### PR TITLE
Make scans do not prevent portions and tables, which they do not use, from deleting

### DIFF
--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -21,7 +21,7 @@ bool TTxBlobsWritingFinished::DoExecute(TTransactionContext& txc, const TActorCo
         NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_BLOBS)("tablet_id", Self->TabletID())("tx_state", "execute");
     ACFL_DEBUG("event", "start_execute");
     auto& index = Self->MutableIndexAs<NOlap::TColumnEngineForLogs>();
-    const auto minReadSnapshot = Self->GetMinReadSnapshot();
+    const auto minReadSnapshot = Self->GetMinShapshotForNewReads();
 
     for (auto&& writeResult : Pack.GetWriteResults()) {
         const auto& writeMeta = writeResult.GetWriteMeta();

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -198,15 +198,18 @@ NOlap::TSnapshot TColumnShard::GetMinReadSnapshot() const {
     ui64 delayMillisec = NYDBTest::TControllers::GetColumnShardController()->GetMaxReadStaleness().MilliSeconds();
     ui64 passedStep = GetOutdatedStep();
     ui64 minReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
-
-    if (auto ssClean = InFlightReadsTracker.GetSnapshotToClean()) {
-        if (ssClean->GetPlanStep() < minReadStep) {
-            Counters.GetRequestsTracingCounters()->OnDefaultMinSnapshotInstant(TInstant::MilliSeconds(ssClean->GetPlanStep()));
-            return *ssClean;
-        }
-    }
     Counters.GetRequestsTracingCounters()->OnDefaultMinSnapshotInstant(TInstant::MilliSeconds(minReadStep));
     return NOlap::TSnapshot::MaxForPlanStep(minReadStep);
+}
+
+NOlap::TSnapshotHolders TColumnShard::GetSnapshotHolders() const {
+    auto minReadSnapshot = GetMinReadSnapshot();
+    // all snapshots younger than minReadSnapshot may be considered as "potentially in flight".
+    // meaning that at any moment a scan may come with any snapshot in [minScanSnapshot, maxScapSnapshot],
+    // so we will get a live snapshot at that moment.
+    // that is said, we need here only snapshots that are older than minReadSnapshot.
+    auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(minReadSnapshot);
+    return NOlap::TSnapshotHolders(minReadSnapshot, std::move(inFlightTxs));
 }
 
 void TColumnShard::UpdateSchemaSeqNo(const TMessageSeqNo& seqNo, NTabletFlatExecutor::TTransactionContext& txc) {
@@ -808,10 +811,10 @@ void TColumnShard::SetupCleanupPortions() {
         return;
     }
 
-    const NOlap::TSnapshot minReadSnapshot = GetMinReadSnapshot();
-    const auto& pathsToDrop = TablesManager.GetPathsToDrop(minReadSnapshot);
+    const auto snapshotHolders = GetSnapshotHolders();
+    const auto& pathsToDrop = TablesManager.GetPathsToDrop(snapshotHolders);
 
-    auto changes = TablesManager.MutablePrimaryIndex().StartCleanupPortions(minReadSnapshot, pathsToDrop, DataLocksManager);
+    auto changes = TablesManager.MutablePrimaryIndex().StartCleanupPortions(snapshotHolders, pathsToDrop, DataLocksManager);
     if (!changes) {
         ACFL_DEBUG("background", "cleanup")("skip_reason", "no_changes");
         return;
@@ -838,8 +841,9 @@ void TColumnShard::SetupCleanupTables() {
         return;
     }
 
+    const auto snapshotHolders = GetSnapshotHolders();
     THashSet<TInternalPathId> pathIdsEmptyInInsertTable;
-    for (auto&& i : TablesManager.GetPathsToDrop(GetMinReadSnapshot())) {
+    for (auto&& i : TablesManager.GetPathsToDrop(snapshotHolders)) {
         pathIdsEmptyInInsertTable.emplace(i);
     }
 

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -205,7 +205,7 @@ NOlap::TSnapshot TColumnShard::GetMinReadSnapshot() const {
 NOlap::TSnapshotHolders TColumnShard::GetSnapshotHolders() const {
     auto minReadSnapshot = GetMinReadSnapshot();
     // all snapshots younger than minReadSnapshot may be considered as "potentially in flight".
-    // meaning that at any moment a scan may come with any snapshot in [minScanSnapshot, maxScapSnapshot],
+    // meaning that at any moment a scan may come with any snapshot in [minScanSnapshot, maxScanSnapshot],
     // so we will get a live snapshot at that moment.
     // that is said, we need here only snapshots that are older than minReadSnapshot.
     auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(minReadSnapshot);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -194,7 +194,7 @@ ui64 TColumnShard::GetOutdatedStep() const {
     return step;
 }
 
-NOlap::TSnapshot TColumnShard::GetMinReadSnapshot() const {
+NOlap::TSnapshot TColumnShard::GetMinShapshotForNewReads() const {
     ui64 delayMillisec = NYDBTest::TControllers::GetColumnShardController()->GetMaxReadStaleness().MilliSeconds();
     ui64 passedStep = GetOutdatedStep();
     ui64 minReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
@@ -203,13 +203,13 @@ NOlap::TSnapshot TColumnShard::GetMinReadSnapshot() const {
 }
 
 NOlap::TSnapshotHolders TColumnShard::GetSnapshotHolders() const {
-    auto minReadSnapshot = GetMinReadSnapshot();
-    // all snapshots younger than minReadSnapshot may be considered as "potentially in flight".
+    auto minSnapshotForNewReads = GetMinShapshotForNewReads();
+    // all snapshots younger than minSnapshotForNewReads may be considered as "potentially in flight".
     // meaning that at any moment a scan may come with any snapshot in [minScanSnapshot, maxScanSnapshot],
     // so we will get a live snapshot at that moment.
-    // that is said, we need here only snapshots that are older than minReadSnapshot.
-    auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(minReadSnapshot);
-    return NOlap::TSnapshotHolders(minReadSnapshot, std::move(inFlightTxs));
+    // that is said, we need here only snapshots that are older than minSnapshotForNewReads.
+    auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(minSnapshotForNewReads);
+    return NOlap::TSnapshotHolders(minSnapshotForNewReads, std::move(inFlightTxs));
 }
 
 void TColumnShard::UpdateSchemaSeqNo(const TMessageSeqNo& seqNo, NTabletFlatExecutor::TTransactionContext& txc) {

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -576,6 +576,7 @@ private:
     void RescheduleWaitingReads();
     NOlap::TSnapshot GetMaxReadVersion() const;
     NOlap::TSnapshot GetMinReadSnapshot() const;
+    NOlap::TSnapshotHolders GetSnapshotHolders() const;
     ui64 GetOutdatedStep() const;
     TDuration GetTxCompleteLag() const {
         ui64 mediatorTime = MediatorTimeCastEntry ? MediatorTimeCastEntry->Get(TabletID()) : 0;

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -575,7 +575,7 @@ private:
     void SendWaitPlanStep(ui64 step);
     void RescheduleWaitingReads();
     NOlap::TSnapshot GetMaxReadVersion() const;
-    NOlap::TSnapshot GetMinReadSnapshot() const;
+    NOlap::TSnapshot GetMinShapshotForNewReads() const;
     NOlap::TSnapshotHolders GetSnapshotHolders() const;
     ui64 GetOutdatedStep() const;
     TDuration GetTxCompleteLag() const {

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -5,6 +5,7 @@
 #include "changes/abstract/settings.h"
 #include "predicate/filter.h"
 #include "scheme/snapshot_scheme.h"
+#include "snapshot_holders.h"
 #include "scheme/versions/versioned_index.h"
 
 #include <ydb/core/tx/columnshard/common/path_id.h>
@@ -14,8 +15,6 @@
 #include <ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/container.h>
 #include <ydb/core/tx/columnshard/tx_reader/abstract.h>
-#include <algorithm>
-
 namespace NKikimr::NColumnShard {
 class TTiersManager;
 }   // namespace NKikimr::NColumnShard
@@ -83,56 +82,6 @@ public:
         , Processor(processor) {
         AFL_VERIFY(Request);
         AFL_VERIFY(Processor);
-    }
-};
-
-class TSnapshotHolders {
-    const TSnapshot minReadSnapshot;
-    // sorted from older to younger
-    const std::vector<TSnapshot> txInFlight;
-
-    public:
-    TSnapshotHolders(TSnapshot minReadSnapshot, std::vector<TSnapshot> txInFlight)
-        : minReadSnapshot(std::move(minReadSnapshot))
-        , txInFlight(std::move(txInFlight)) {
-        AFL_VERIFY(std::is_sorted(this->txInFlight.begin(), this->txInFlight.end()));
-        if (!txInFlight.empty()) {
-            AFL_VERIFY(txInFlight.back() < minReadSnapshot);
-        }
-    }
-
-    const TSnapshot GetMinReadSnapshot() const {
-        return minReadSnapshot;
-    }
-
-    bool CouldUsePortion(const TPortionInfo::TConstPtr& portion) const {
-        return CouldUse(
-            [&portion](const TSnapshot& snapshot) { return portion->IsRemovedFor(snapshot); },
-            [&portion](const TSnapshot& snapshot) { return portion->IsVisible(snapshot, true); }
-        );
-    }
-
-    template <class TIsRemovedFor, class TIsVisible>
-    bool CouldUse(const TIsRemovedFor& isRemovedFor, const TIsVisible& isVisible) const {
-        // the portion can be used by new scans
-        if (!isRemovedFor(minReadSnapshot)) {
-            return true;
-        }
-
-        // loop invariant: all txs older than curTx couldn't use the portion
-        for (const auto& txSnapshot : txInFlight) {
-            // this and all younger txs cannot see the portion
-            if (isRemovedFor(txSnapshot)) {
-                return false;
-            }
-            // the tx could use this portion
-            if (isVisible(txSnapshot)) {
-                return true;
-            }
-            // cur tx could not use the portion, but maybe the next tx could
-        }
-        // we have not found any txs that could use the portion
-        return false;
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -14,6 +14,7 @@
 #include <ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/container.h>
 #include <ydb/core/tx/columnshard/tx_reader/abstract.h>
+#include <algorithm>
 
 namespace NKikimr::NColumnShard {
 class TTiersManager;
@@ -82,6 +83,56 @@ public:
         , Processor(processor) {
         AFL_VERIFY(Request);
         AFL_VERIFY(Processor);
+    }
+};
+
+class TSnapshotHolders {
+    const TSnapshot minReadSnapshot;
+    // sorted from older to younger
+    const std::vector<TSnapshot> txInFlight;
+
+    public:
+    TSnapshotHolders(TSnapshot minReadSnapshot, std::vector<TSnapshot> txInFlight)
+        : minReadSnapshot(std::move(minReadSnapshot))
+        , txInFlight(std::move(txInFlight)) {
+        AFL_VERIFY(std::is_sorted(this->txInFlight.begin(), this->txInFlight.end()));
+        if (!txInFlight.empty()) {
+            AFL_VERIFY(txInFlight.back() < minReadSnapshot);
+        }
+    }
+
+    const TSnapshot GetMinReadSnapshot() const {
+        return minReadSnapshot;
+    }
+
+    bool CouldUsePortion(const TPortionInfo::TConstPtr& portion) const {
+        return CouldUse(
+            [&portion](const TSnapshot& snapshot) { return portion->IsRemovedFor(snapshot); },
+            [&portion](const TSnapshot& snapshot) { return portion->IsVisible(snapshot, true); }
+        );
+    }
+
+    template <class TIsRemovedFor, class TIsVisible>
+    bool CouldUse(const TIsRemovedFor& isRemovedFor, const TIsVisible& isVisible) const {
+        // the portion can be used by new scans
+        if (!isRemovedFor(minReadSnapshot)) {
+            return true;
+        }
+
+        // loop invariant: all txs older than curTx couldn't use the portion
+        for (const auto& txSnapshot : txInFlight) {
+            // this and all younger txs cannot see the portion
+            if (isRemovedFor(txSnapshot)) {
+                return false;
+            }
+            // the tx could use this portion
+            if (isVisible(txSnapshot)) {
+                return true;
+            }
+            // cur tx could not use the portion, but maybe the next tx could
+        }
+        // we have not found any txs that could use the portion
+        return false;
     }
 };
 
@@ -164,7 +215,7 @@ public:
     virtual std::vector<std::shared_ptr<TColumnEngineChanges>> StartCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept = 0;
     virtual ui64 GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager, const std::set<TInternalPathId>& pathIds,
         const std::optional<ui64> waitingPriority) const noexcept = 0;
-    virtual std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshot& snapshot,
+    virtual std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshotHolders& snapshotHolders,
         const THashSet<TInternalPathId>& pathsToDrop, const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept = 0;
     virtual std::shared_ptr<TCleanupTablesColumnEngineChanges> StartCleanupTables(const THashSet<TInternalPathId>& pathsToDrop) noexcept = 0;
     virtual std::vector<std::shared_ptr<TTTLColumnEngineChanges>> StartTtl(const THashMap<TInternalPathId, TTiering>& pathEviction,

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -428,7 +428,7 @@ std::shared_ptr<TCleanupTablesColumnEngineChanges> TColumnEngineForLogs::StartCl
     return changes;
 }
 
-std::shared_ptr<TCleanupPortionsColumnEngineChanges> TColumnEngineForLogs::StartCleanupPortions(const TSnapshot& snapshot,
+std::shared_ptr<TCleanupPortionsColumnEngineChanges> TColumnEngineForLogs::StartCleanupPortions(const TSnapshotHolders& snapshotHolders,
     const THashSet<TInternalPathId>& pathsToDrop, const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept {
     AFL_VERIFY(dataLocksManager);
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "StartCleanup")("portions_count", CleanupPortions.size());
@@ -441,43 +441,41 @@ std::shared_ptr<TCleanupPortionsColumnEngineChanges> TColumnEngineForLogs::Start
     bool limitExceeded = false;
     const ui32 maxChunksCount = 500000;
     const ui32 maxPortionsCount = 1000;
-    const TInstant snapshotInstant = snapshot.GetPlanInstant();
+    const TInstant minReadPlanStep = snapshotHolders.GetMinReadSnapshot().GetPlanInstant();
     for (auto it = CleanupPortions.begin(); !limitExceeded && it != CleanupPortions.end();) {
-        if (it->first > snapshotInstant) {
-            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "StartCleanupStop")("snapshot", snapshot.DebugString())(
-                "current_snapshot_ts", it->first.MilliSeconds());
+        auto& [removePlanStep, portions] = *it;
+        if (removePlanStep > minReadPlanStep) {
+            // no point to proceed, we do not delete portions that are younger than minReadSnapshot
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "StartCleanupStop")("min_read_snapshot", snapshotHolders.GetMinReadSnapshot().DebugString())("remove_planstep", removePlanStep.MilliSeconds());
             break;
         }
-        for (ui32 i = 0; i < it->second.size();) {
-            if (dataLocksManager->IsLocked(it->second[i], NDataLocks::ELockCategory::Cleanup)) {
+        for (ui32 i = 0; i < portions.size();) {
+            auto portion = portions[i];
+            if (dataLocksManager->IsLocked(portion, NDataLocks::ELockCategory::Cleanup)) {
                 ++skipLocked;
                 ++i;
                 continue;
             }
-            // TODO: fix this
-            // AFL_VERIFY(it->second[i]->CheckForCleanup(snapshot))("p_snapshot", it->second[i]->GetRemoveSnapshotOptional())("snapshot", snapshot);
-            if (!it->second[i]->CheckForCleanup(snapshot)) {
-                AFL_EMERG(NKikimrServices::TX_COLUMNSHARD)("error", "check for cleanup failed")("portion", it->second[i]->DebugString())("snapshot", snapshot);
+            if (snapshotHolders.CouldUsePortion(portion)) {
                 ++i;
                 continue;
             }
             ++portionsCount;
-            chunksCount += it->second[i]->GetApproxChunksCount(it->second[i]->GetSchema(GetVersionedIndex())->GetColumnsCount());
-            if ((portionsCount < maxPortionsCount && chunksCount < maxChunksCount) || changes->GetPortionsToDrop().empty()) {
-            } else {
+            chunksCount += portion->GetApproxChunksCount(portion->GetSchema(GetVersionedIndex())->GetColumnsCount());
+            if ((portionsCount >= maxPortionsCount || chunksCount >= maxChunksCount) && changes->GetPortionsToDrop().size() > 0) {
                 limitExceeded = true;
                 break;
             }
-            changes->AddPortionToDrop(it->second[i]);
-            if (i + 1 < it->second.size()) {
-                it->second[i] = std::move(it->second.back());
+            changes->AddPortionToDrop(portion);
+            if (i + 1 < portions.size()) {
+                portions[i] = std::move(portions.back());
             }
-            it->second.pop_back();
+            portions.pop_back();
         }
         if (limitExceeded) {
             break;
         }
-        if (it->second.empty()) {
+        if (portions.empty()) {
             it = CleanupPortions.erase(it);
         } else {
             ++it;

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -441,12 +441,12 @@ std::shared_ptr<TCleanupPortionsColumnEngineChanges> TColumnEngineForLogs::Start
     bool limitExceeded = false;
     const ui32 maxChunksCount = 500000;
     const ui32 maxPortionsCount = 1000;
-    const TInstant minReadPlanStep = snapshotHolders.GetMinReadSnapshot().GetPlanInstant();
+    const TInstant minPlanStepForNewReads = snapshotHolders.GetMinSnapshotForNewReads().GetPlanInstant();
     for (auto it = CleanupPortions.begin(); !limitExceeded && it != CleanupPortions.end();) {
         auto& [removePlanStep, portions] = *it;
-        if (removePlanStep > minReadPlanStep) {
+        if (minPlanStepForNewReads < removePlanStep) {
             // no point to proceed, we do not delete portions that are younger than minReadSnapshot
-            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "StartCleanupStop")("min_read_snapshot", snapshotHolders.GetMinReadSnapshot().DebugString())("remove_planstep", removePlanStep.MilliSeconds());
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "StartCleanupStop")("min_snapshot_for_new_reads", snapshotHolders.GetMinSnapshotForNewReads().DebugString())("remove_planstep", removePlanStep.MilliSeconds());
             break;
         }
         for (ui32 i = 0; i < portions.size();) {

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.h
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.h
@@ -152,7 +152,7 @@ public:
     ui64 GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager, const std::set<TInternalPathId>& pathIds,
         const std::optional<ui64> waitingPriority) const noexcept override;
     std::vector<std::shared_ptr<TColumnEngineChanges>> StartCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept override;
-    std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshot& snapshot,
+    std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshotHolders& snapshotHolders,
         const THashSet<TInternalPathId>& pathsToDrop, const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept override;
     std::shared_ptr<TCleanupTablesColumnEngineChanges> StartCleanupTables(const THashSet<TInternalPathId>& pathsToDrop) noexcept override;
     std::vector<std::shared_ptr<TTTLColumnEngineChanges>> StartTtl(const THashMap<TInternalPathId, TTiering>& pathEviction,

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
@@ -26,9 +26,9 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
         return std::shared_ptr<TReadMetadataBase>();
     }
 
-    if (read.GetSnapshot().GetPlanInstant() < self->GetMinReadSnapshot().GetPlanInstant()) {
+    if (read.GetSnapshot().GetPlanInstant() < self->GetMinShapshotForNewReads().GetPlanInstant()) {
         return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
-                                                        << self->GetMinReadSnapshot() << ". now: " << TInstant::Now());
+                                                        << self->GetMinShapshotForNewReads() << ". now: " << TInstant::Now());
     }
 
     auto readCopy = read;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
@@ -30,9 +30,9 @@ TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructor::DoBuil
         schemas = &defaultSchemas;
     }
     if (read.TableMetadataAccessor->NeedStalenessChecker()) {
-        if (read.GetSnapshot().GetPlanInstant() < self->GetMinReadSnapshot().GetPlanInstant()) {
+        if (read.GetSnapshot().GetPlanInstant() < self->GetMinShapshotForNewReads().GetPlanInstant()) {
             return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
-                                                            << self->GetMinReadSnapshot() << ". now: " << TInstant::Now());
+                                                            << self->GetMinShapshotForNewReads() << ". now: " << TInstant::Now());
         }
     }
 

--- a/ydb/core/tx/columnshard/engines/snapshot_holders.h
+++ b/ydb/core/tx/columnshard/engines/snapshot_holders.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "portions/portion_info.h"
+
+#include <algorithm>
+
+namespace NKikimr::NOlap {
+
+class TSnapshotHolders {
+    const TSnapshot MinReadSnapshot;
+    // Sorted from older to younger.
+    const std::vector<TSnapshot> TxInFlight;
+
+public:
+    TSnapshotHolders(TSnapshot minReadSnapshot, std::vector<TSnapshot> txInFlight)
+        : MinReadSnapshot(std::move(minReadSnapshot))
+        , TxInFlight(std::move(txInFlight)) {
+        AFL_VERIFY(std::is_sorted(TxInFlight.begin(), TxInFlight.end()));
+        if (!TxInFlight.empty()) {
+            AFL_VERIFY(TxInFlight.back() < MinReadSnapshot);
+        }
+    }
+
+    TSnapshot GetMinReadSnapshot() const {
+        return MinReadSnapshot;
+    }
+
+    bool CouldUsePortion(const TPortionInfo::TConstPtr& portion) const {
+        return CouldUse(
+            [&portion](const TSnapshot& snapshot) { return portion->IsRemovedFor(snapshot); },
+            [&portion](const TSnapshot& snapshot) { return portion->IsVisible(snapshot, true); });
+    }
+
+    template <class TIsRemovedFor, class TIsVisible>
+    bool CouldUse(const TIsRemovedFor& isRemovedFor, const TIsVisible& isVisible) const {
+        // The object can be used by new scans.
+        if (!isRemovedFor(MinReadSnapshot)) {
+            return true;
+        }
+
+        // Loop invariant: all txs older than txSnapshot couldn't use the object.
+        for (const auto& txSnapshot : TxInFlight) {
+            // This and all younger txs cannot see it.
+            if (isRemovedFor(txSnapshot)) {
+                return false;
+            }
+            // This tx could use it.
+            if (isVisible(txSnapshot)) {
+                return true;
+            }
+            // Current tx could not use it, maybe the next tx could.
+        }
+        // We have not found txs that could use it.
+        return false;
+    }
+};
+
+}   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/snapshot_holders.h
+++ b/ydb/core/tx/columnshard/engines/snapshot_holders.h
@@ -6,23 +6,33 @@
 
 namespace NKikimr::NOlap {
 
+/**
+The life looks like this:
+time ---------[----------------------------------------]--------->
+        ^scan1  ^minSnapshotForNewReads  ^scan2 ^scan3   ^now
+
+In this class, we need only minSnapshotForNewReads and scan1.
+We do not need scan2 and scan3 because we consider the whole range [minSnapshotForNewReads, now] as "in flight",
+because any number of new scans may come there.
+*/
 class TSnapshotHolders {
-    const TSnapshot MinReadSnapshot;
-    // Sorted from older to younger.
+    // It is the oldest snapshot new scans can start at
+    const TSnapshot MinSnapshotForNewReads;
+    // Sorted from older to younger
     const std::vector<TSnapshot> TxInFlight;
 
 public:
-    TSnapshotHolders(TSnapshot minReadSnapshot, std::vector<TSnapshot> txInFlight)
-        : MinReadSnapshot(std::move(minReadSnapshot))
+    TSnapshotHolders(TSnapshot minSnapshotForNewReads, std::vector<TSnapshot> txInFlight)
+        : MinSnapshotForNewReads(std::move(minSnapshotForNewReads))
         , TxInFlight(std::move(txInFlight)) {
         AFL_VERIFY(std::is_sorted(TxInFlight.begin(), TxInFlight.end()));
         if (!TxInFlight.empty()) {
-            AFL_VERIFY(TxInFlight.back() < MinReadSnapshot);
+            AFL_VERIFY(TxInFlight.back() < MinSnapshotForNewReads);
         }
     }
 
-    TSnapshot GetMinReadSnapshot() const {
-        return MinReadSnapshot;
+    TSnapshot GetMinSnapshotForNewReads() const {
+        return MinSnapshotForNewReads;
     }
 
     bool CouldUsePortion(const TPortionInfo::TConstPtr& portion) const {
@@ -34,7 +44,7 @@ public:
     template <class TIsRemovedFor, class TIsVisible>
     bool CouldUse(const TIsRemovedFor& isRemovedFor, const TIsVisible& isVisible) const {
         // The object can be used by new scans.
-        if (!isRemovedFor(MinReadSnapshot)) {
+        if (!isRemovedFor(MinSnapshotForNewReads)) {
             return true;
         }
 

--- a/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
@@ -1,0 +1,107 @@
+#include <ydb/core/tx/columnshard/engines/snapshot_holders.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace NKikimr::NOlap {
+
+Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
+    TSnapshot Step(const ui64 planStep) {
+        return TSnapshot(planStep, 1);
+    }
+
+    struct TMyPortion {
+        TSnapshot Appeared;
+        TSnapshot Removed;
+
+        TMyPortion(const ui64 appearedPlanStep, const ui64 removedPlanStep)
+            : Appeared(appearedPlanStep, 1)
+            , Removed(removedPlanStep, 1)
+        {}
+    };
+
+    bool CouldUse(const TSnapshotHolders& holders, const TMyPortion& portion) {
+        return holders.CouldUse(
+            [&portion](const TSnapshot& heldSnapshot) { return portion.Removed <= heldSnapshot; },
+            [&portion](const TSnapshot& heldSnapshot) { return portion.Appeared <= heldSnapshot; }
+        );
+    }
+
+    Y_UNIT_TEST(PortionsCouldBeUsedAfterMinReadSnapshot) {
+        // time        0--1--------------------------------10---11
+        //                                                 ^ minReadSnapshot
+        // p1             [.....................................)
+        // p2                                                   [11....................20)
+        // p3             [................................)
+        const TSnapshotHolders holders(Step(10), {});
+        const TMyPortion p1(1, 11);
+        const TMyPortion p2(11, 20);
+        const TMyPortion p3(1, 10);
+
+        UNIT_ASSERT(CouldUse(holders, p1));
+        UNIT_ASSERT(CouldUse(holders, p2));
+        UNIT_ASSERT(!CouldUse(holders, p3));
+    }
+
+    Y_UNIT_TEST(TxCouldUseAPortions) {
+        // time      0--1---------5-------------10-------------20
+        //                        ^ tx                         ^ minReadSnapshot
+        // portion1     [.......................)
+        // portion2              [5.............)
+        const TSnapshotHolders holders(Step(20), { Step(5) });
+        const TMyPortion portion1(1, 10);
+        const TMyPortion portion2(5, 10);
+
+        UNIT_ASSERT(CouldUse(holders, portion1));
+        UNIT_ASSERT(CouldUse(holders, portion2));
+    }
+
+    Y_UNIT_TEST(TxsCouldNotUsePortions) {
+        // time        0--1-----4-5-6-----10----12-13----18----20
+        //                        ^ tx1         ^ tx2          ^ minReadSnapshot
+        // portion1       [1......5)
+        // portion2                 [6....10)
+        // portion3                                [13..18)
+        const TSnapshotHolders holders(Step(20), { Step(5), Step(12) });
+        const TMyPortion portion1(1, 5);
+        const TMyPortion portion2(6, 10);
+        const TMyPortion portion3(13, 18);
+
+        UNIT_ASSERT(!CouldUse(holders, portion1));
+        UNIT_ASSERT(!CouldUse(holders, portion2));
+        UNIT_ASSERT(!CouldUse(holders, portion3));
+    }
+
+    template <class TCallback>
+    int RunInChild(const TCallback& callback) {
+        const pid_t pid = fork();
+        UNIT_ASSERT_C(pid >= 0, "fork() failed");
+        if (pid == 0) {
+            callback();
+            _exit(0);
+        }
+
+        int status = 0;
+        UNIT_ASSERT_VALUES_EQUAL(waitpid(pid, &status, 0), pid);
+        return status;
+    }
+
+    Y_UNIT_TEST(ConstructorVerifiesInvariants) {
+        const int unsortedTxs = RunInChild([] {
+            [[maybe_unused]] TSnapshotHolders holders(Step(20), { Step(12), Step(5) });
+        });
+        UNIT_ASSERT_C(!WIFEXITED(unsortedTxs) || WEXITSTATUS(unsortedTxs) != 0,
+            "unsorted tx list must fail constructor checks");
+
+        const int tooYoungTx = RunInChild([] {
+            [[maybe_unused]] TSnapshotHolders holders(Step(20), { Step(20) });
+        });
+        UNIT_ASSERT_C(!WIFEXITED(tooYoungTx) || WEXITSTATUS(tooYoungTx) != 0,
+            "tx snapshot >= minReadSnapshot must fail constructor checks");
+    }
+
+}
+
+}   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
@@ -2,8 +2,11 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#ifndef _win_
+#include <cerrno>
 #include <sys/wait.h>
 #include <unistd.h>
+#endif
 
 namespace NKikimr::NOlap {
 
@@ -74,6 +77,7 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
         UNIT_ASSERT(!CouldUse(holders, portion3));
     }
 
+#ifndef _win_
     template <class TCallback>
     int RunInChild(const TCallback& callback) {
         const pid_t pid = fork();
@@ -84,11 +88,19 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
         }
 
         int status = 0;
-        UNIT_ASSERT_VALUES_EQUAL(waitpid(pid, &status, 0), pid);
+        while (true) {
+            const pid_t waitResult = waitpid(pid, &status, 0);
+            if (waitResult == pid) {
+                break;
+            }
+            UNIT_ASSERT_C(waitResult != -1 || errno == EINTR, "waitpid() failed");
+        }
         return status;
     }
+#endif
 
     Y_UNIT_TEST(ConstructorVerifiesInvariants) {
+#ifndef _win_
         const int unsortedTxs = RunInChild([] {
             [[maybe_unused]] TSnapshotHolders holders(Step(20), { Step(12), Step(5) });
         });
@@ -100,6 +112,9 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
         });
         UNIT_ASSERT_C(!WIFEXITED(tooYoungTx) || WEXITSTATUS(tooYoungTx) != 0,
             "tx snapshot >= minReadSnapshot must fail constructor checks");
+#else
+        UNIT_ASSERT_C(true, "POSIX-only test is skipped on Windows");
+#endif
     }
 
 }

--- a/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_snapshot_holders.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
 
     Y_UNIT_TEST(PortionsCouldBeUsedAfterMinReadSnapshot) {
         // time        0--1--------------------------------10---11
-        //                                                 ^ minReadSnapshot
+        //                                                 ^ minSnapshotForNewReads
         // p1             [.....................................)
         // p2                                                   [11....................20)
         // p3             [................................)
@@ -50,7 +50,7 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
 
     Y_UNIT_TEST(TxCouldUseAPortions) {
         // time      0--1---------5-------------10-------------20
-        //                        ^ tx                         ^ minReadSnapshot
+        //                        ^ tx                         ^ minSnapshotForNewReads
         // portion1     [.......................)
         // portion2              [5.............)
         const TSnapshotHolders holders(Step(20), { Step(5) });
@@ -63,7 +63,7 @@ Y_UNIT_TEST_SUITE(TSnapshotHoldersTests) {
 
     Y_UNIT_TEST(TxsCouldNotUsePortions) {
         // time        0--1-----4-5-6-----10----12-13----18----20
-        //                        ^ tx1         ^ tx2          ^ minReadSnapshot
+        //                        ^ tx1         ^ tx2          ^ minSnapshotForNewReads
         // portion1       [1......5)
         // portion2                 [6....10)
         // portion3                                [13..18)

--- a/ydb/core/tx/columnshard/engines/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/ut/ya.make
@@ -32,6 +32,7 @@ YQL_LAST_ABI_VERSION()
 
 SRCS(
     ut_program.cpp
+    ut_snapshot_holders.cpp
     ut_script.cpp
     helper.cpp
 )

--- a/ydb/core/tx/columnshard/inflight_request_tracker.h
+++ b/ydb/core/tx/columnshard/inflight_request_tracker.h
@@ -101,6 +101,16 @@ public:
         }
     }
 
+    std::vector<NOlap::TSnapshot> GetLiveSnapshots(const NOlap::TSnapshot until) const {
+        std::vector<NOlap::TSnapshot> result;
+        for (auto&& [snapshot, liveInfo] : SnapshotsLive) {
+            if (snapshot >= until) break;
+
+            result.push_back(snapshot);
+        }
+        return result;
+    }
+
     bool LoadFromDatabase(NTable::TDatabase& db);
 
     [[nodiscard]] std::unique_ptr<NTabletFlatExecutor::ITransaction> Ping(

--- a/ydb/core/tx/columnshard/inflight_request_tracker.h
+++ b/ydb/core/tx/columnshard/inflight_request_tracker.h
@@ -103,7 +103,7 @@ public:
 
     std::vector<NOlap::TSnapshot> GetLiveSnapshots(const NOlap::TSnapshot until) const {
         std::vector<NOlap::TSnapshot> result;
-        for (auto&& [snapshot, liveInfo] : SnapshotsLive) {
+        for (auto&& [snapshot, _] : SnapshotsLive) {
             if (snapshot >= until) break;
 
             result.push_back(snapshot);

--- a/ydb/core/tx/columnshard/tables_manager.cpp
+++ b/ydb/core/tx/columnshard/tables_manager.cpp
@@ -389,8 +389,8 @@ bool TTablesManager::HasPreset(const ui32 presetId) const {
     return SchemaPresetsIds.contains(presetId);
 }
 
-const TTableInfo& TTablesManager::GetTable(const TInternalPathId pathId) const {
-    Y_ABORT_UNLESS(HasTable(pathId));
+const TTableInfo& TTablesManager::GetTable(const TInternalPathId pathId, const bool withDeleted) const {
+    Y_ABORT_UNLESS(HasTable(pathId, withDeleted));
     return Tables.at(pathId);
 }
 

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -465,7 +465,7 @@ public:
         THashSet<TInternalPathId> result;
         for (auto& [dropSnapshot, tableIds] : PathsToDrop) {
             // new transactions may come to any snapshot younger than minReadSnapshot, so we cannot drop there anything
-            if (snapshotHolders.GetMinReadSnapshot() < dropSnapshot) {
+            if (snapshotHolders.GetMinSnapshotForNewReads() < dropSnapshot) {
                 break;
             }
             for (const auto& tableId : tableIds) {

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -115,6 +115,23 @@ public:
         return InternalPathId;
     }
 
+    bool CanBeUsedAt(const NOlap::TSnapshot& snapshot) const {
+        if (Versions.empty()) {
+            return false;
+        }
+        const NOlap::TSnapshot minVersion = *Versions.begin();
+        for (const auto& [_, pathInfo] : SchemeShardLocalPathIds) {
+            const NOlap::TSnapshot appearVersion = pathInfo.CopyVersion.value_or(minVersion);
+            if (snapshot < appearVersion) {
+                continue;
+            }
+            if (!pathInfo.DropVersion || snapshot < *pathInfo.DropVersion) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     std::set<TUnifiedPathId> GetPathIds() const {
         std::set<NColumnShard::TUnifiedPathId> paths;
         for (const auto& [schemeShardLocalPathId, _]: SchemeShardLocalPathIds) {
@@ -444,13 +461,24 @@ public:
         return PathsToDrop;
     }
 
-    THashSet<TInternalPathId> GetPathsToDrop(const NOlap::TSnapshot& minReadSnapshot) const {
+    THashSet<TInternalPathId> GetPathsToDrop(const NOlap::TSnapshotHolders& snapshotHolders) const {
         THashSet<TInternalPathId> result;
-        for (auto&& i : PathsToDrop) {
-            if (minReadSnapshot < i.first) {
+        for (auto& [dropSnapshot, tableIds] : PathsToDrop) {
+            // new transactions may come to any snapshot younger than minReadSnapshot, so we cannot drop there anything
+            if (snapshotHolders.GetMinReadSnapshot() < dropSnapshot) {
                 break;
             }
-            result.insert(i.second.begin(), i.second.end());
+            for (const auto& tableId : tableIds) {
+                auto& table = GetTable(tableId, true);
+                if (!snapshotHolders.CouldUse(
+                    // isRemovedFor
+                    [&dropSnapshot](const NOlap::TSnapshot& heldSnapshot) { return dropSnapshot <= heldSnapshot;},
+                    // isVisibleAt
+                    [&table](const NOlap::TSnapshot& heldSnapshot) { return table.CanBeUsedAt(heldSnapshot); }
+                )) {
+                    result.insert(tableId);
+                }
+            }
         }
         return result;
     }
@@ -536,7 +564,7 @@ public:
     void Init(NIceDb::TNiceDb& db, const TSchemeShardLocalPathId tabletSchemeShardLocalPathId, const TTabletStorageInfo* info);
     bool InitFromDB(NIceDb::TNiceDb& db, const TTabletStorageInfo* info);
 
-    const TTableInfo& GetTable(const TInternalPathId pathId) const;
+    const TTableInfo& GetTable(const TInternalPathId pathId, const bool withDeleted = false) const;
     ui64 GetMemoryUsage() const;
     TInternalPathId GetOrCreateInternalPathId(const TSchemeShardLocalPathId schemShardLocalPathId);
     THashMap<TSchemeShardLocalPathId, TInternalPathId> ResolveInternalPathIds(


### PR DESCRIPTION
fixes #35486

# How it was

Previously the following logic decided if a portion/table (which have a remove snapshot) can be physically deleted:
1. minReadSnapshot was defined as = min(now - readStaleness, min(in flight transaction snapshots))
2. everything that has remove_snapshot younger than minReadSnapshot can not be deleted.

So, if we have a long scan (2 hours), we could not delete all the data that came and was compacted during those 2 hours. That effectively blocks data ingesting. So, reads block writes.

```
time ----------------------------------------------
                          ^ tx                    ^ (now - readStaleness)
portion1   [............)
portion2                         [..............)
```

[ - portion appeared (appearance_snapshot) 
) - portion removed (remove_snapshot)

We can delete portion1 here. But we cannot delete portion2 despite the fact than nobody can/could see it.

The problem - we take only remove_snapshot into account and ignore appearance_snapshot.

# How it is now

The solution - take appearance_snapshot into account too.

Now, the following logic decides if a portion/table (which have a remove snapshot) can be physically deleted:
1. minReadSnapshot = now - readStaleness
2. txInFlight = snapshot of all active transactions
3. if a portion/table is removed before minReadSnapshot and none of txInFlight could see it, the portion/table can be safely physically deleted.

```
time ----------------------------------------------
                          ^ tx                    ^ (now - readStaleness)
portion1   [............)
portion2                         [..............)
```

We can delete both portions here because none of existing and future transaction can see them.

# What jepsen thinks about it

1 hour jepsen run thinks the changes are fine
<img width="1111" height="867" alt="image" src="https://github.com/user-attachments/assets/84f0cc75-a1ea-4414-bc33-e7cab9fae108" />
