### PR TITLE
Fix confusing dstool error message

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -745,7 +745,7 @@ def invoke_nbs_request(request_type, request):
 def print_nbs_request_result(args, request, response):
     success = response.operation.ready and response.operation.status == StatusIds.SUCCESS
     error_reason = 'Request has failed: \n{0}\n{1}\n'.format(request, response)
-    print_status_if_verbose(args, success, error_reason)
+    print_status(args, success, error_reason)
 
 
 @inmemcache('base_config_and_storage_pools', cache_enable_param='cache')
@@ -1317,19 +1317,7 @@ def print_result(format: str, status: str, description: str = None, file=None):
 def print_request_result(args, request, response):
     success = is_successful_bsc_response(response)
     error_reason = 'Request has failed: \n{0}\n{1}\n'.format(request, response)
-    print_status_if_verbose(args, success, error_reason)
-
-
-def print_status_if_verbose(args, success, error_reason):
-    format = getattr(args, 'format', 'pretty')
-    verbose = getattr(args, 'verbose', False)
-    if success:
-        print_result(format, 'success')
-    else:
-        if verbose:
-            print_result(format, 'error', error_reason)
-        else:
-            print_result(format, 'error', 'add --verbose for more info')
+    print_status(args, success, error_reason)
 
 
 def print_status_if_not_quiet(args, success, error_reason):


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
E   AssertionError: Command
E   ['/home/runner/.ya/build/build_root/g6zg/000b63/ydb/apps/dstool/ydb-dstool', '--endpoint', 'grpc://localhost:1252', 'vdisk', 'evict', '--vdisk-ids', '[82000000:1:0:0:0]', '--ignore-degraded-group-check', '--ignore-failure-model-group-check']
E    finished with exit code 1, stderr:
E   
E   error, add --verbose for more info
E   
E   
```

Happy debugging the above CI failure
