### PR TITLE
Mon CLRF fix - stream-nb-25-1

### DIFF
--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -826,23 +826,23 @@ public:
         PassAway();
     }
 
+    // Mixed-version compatibility: old node may return no-body response without terminating CRLFCRLF.
+    void NormalizeNoBodyResponseHeaders(TString& responseTxt) const {
+        NHttp::THttpResponseParser parser(responseTxt);
+        const bool noBodyExpected = !parser.ExpectedBody();
+        const bool hasIncompleteHeaders = parser.HasHeaders() && !parser.HasCompletedHeaders();
+        if (hasIncompleteHeaders && noBodyExpected && !responseTxt.EndsWith("\r\n\r\n")) {
+            if (!responseTxt.EndsWith("\r\n")) {
+                responseTxt += "\r\n";
+            }
+            responseTxt += "\r\n";
+        }
+    }
+
     void Handle(TEvMon::TEvMonitoringResponse::TPtr& ev) {
         if (ev->Get()->Record.HasHttpResponse()) {
             TString responseTxt = ev->Get()->Record.GetHttpResponse();
-            NHttp::THttpResponseParser initialRawParser(responseTxt);
-            const bool initialRawResponseNoBodyExpected = Event->Get()->Request->Method == "HEAD" || !initialRawParser.ExpectedBody();
-            const bool initialRawResponseHasIncompleteHeaders = initialRawParser.HasHeaders() && !initialRawParser.HasCompletedHeaders();
-            if (initialRawResponseHasIncompleteHeaders && initialRawResponseNoBodyExpected) {
-                // Mixed-version compatibility: old node may return no-body response without terminating CRLFCRLF.
-                if (!responseTxt.EndsWith("\r\n\r\n")) {
-                    if (!responseTxt.EndsWith("\r\n")) {
-                        responseTxt += "\r\n";
-                    }
-                    responseTxt += "\r\n";
-                }
-            }
-
-            NHttp::THttpResponseParser rawParser(responseTxt);
+            NormalizeNoBodyResponseHeaders(responseTxt);
             NHttp::THttpOutgoingResponsePtr responseObj = Event->Get()->Request->CreateResponseString(responseTxt);
 
             if (responseObj->Status == "301" || responseObj->Status == "302") {
@@ -860,19 +860,6 @@ public:
                     responseObj = response;
                 }
             }
-
-            // const bool rawResponseNoBodyExpected = Event->Get()->Request->Method == "HEAD" || !rawParser.ExpectedBody();
-            // const bool rawResponseHasIncompleteHeaders = rawParser.HasHeaders() && !rawParser.HasCompletedHeaders();
-            // if (rawResponseHasIncompleteHeaders && rawResponseNoBodyExpected) {
-            //     // Mixed-version compatibility: older nodes may return a no-body response text
-            //     // without completed headers. Rebuild it into a finalized response object before send.
-            //     NHttp::THeaders headers(responseObj->Headers);
-            //     if (responseObj->Body.empty()) {
-            //         responseObj = Event->Get()->Request->CreateResponse(responseObj->Status, responseObj->Message, headers);
-            //     } else {
-            //         responseObj = Event->Get()->Request->CreateResponse(responseObj->Status, responseObj->Message, headers, responseObj->Body);
-            //     }
-            // }
 
             Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(responseObj), 0, Event->Cookie);
 

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -829,6 +829,20 @@ public:
     void Handle(TEvMon::TEvMonitoringResponse::TPtr& ev) {
         if (ev->Get()->Record.HasHttpResponse()) {
             TString responseTxt = ev->Get()->Record.GetHttpResponse();
+            NHttp::THttpResponseParser initialRawParser(responseTxt);
+            const bool initialRawResponseNoBodyExpected = Event->Get()->Request->Method == "HEAD" || !initialRawParser.ExpectedBody();
+            const bool initialRawResponseHasIncompleteHeaders = initialRawParser.HasHeaders() && !initialRawParser.HasCompletedHeaders();
+            if (initialRawResponseHasIncompleteHeaders && initialRawResponseNoBodyExpected) {
+                // Mixed-version compatibility: old node may return no-body response without terminating CRLFCRLF.
+                if (!responseTxt.EndsWith("\r\n\r\n")) {
+                    if (!responseTxt.EndsWith("\r\n")) {
+                        responseTxt += "\r\n";
+                    }
+                    responseTxt += "\r\n";
+                }
+            }
+
+            NHttp::THttpResponseParser rawParser(responseTxt);
             NHttp::THttpOutgoingResponsePtr responseObj = Event->Get()->Request->CreateResponseString(responseTxt);
 
             if (responseObj->Status == "301" || responseObj->Status == "302") {
@@ -847,10 +861,22 @@ public:
                 }
             }
 
+            // const bool rawResponseNoBodyExpected = Event->Get()->Request->Method == "HEAD" || !rawParser.ExpectedBody();
+            // const bool rawResponseHasIncompleteHeaders = rawParser.HasHeaders() && !rawParser.HasCompletedHeaders();
+            // if (rawResponseHasIncompleteHeaders && rawResponseNoBodyExpected) {
+            //     // Mixed-version compatibility: older nodes may return a no-body response text
+            //     // without completed headers. Rebuild it into a finalized response object before send.
+            //     NHttp::THeaders headers(responseObj->Headers);
+            //     if (responseObj->Body.empty()) {
+            //         responseObj = Event->Get()->Request->CreateResponse(responseObj->Status, responseObj->Message, headers);
+            //     } else {
+            //         responseObj = Event->Get()->Request->CreateResponse(responseObj->Status, responseObj->Message, headers, responseObj->Body);
+            //     }
+            // }
+
             Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(responseObj), 0, Event->Cookie);
 
-            const bool noBodyExpected = !responseObj->IsNeedBody();
-            if (responseObj->IsDone() || noBodyExpected) {
+            if (responseObj->IsDone()) {
                 return PassAway();
             } else {
                 CurrentResponse = responseObj;

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -827,11 +827,11 @@ public:
     }
 
     // Mixed-version compatibility: old node may return no-body response without terminating CRLFCRLF.
-    void NormalizeNoBodyResponseHeaders(TString& responseTxt) const {
+    void FixupLegacyNoBodyResponseHeaders(TString& responseTxt) const {
         NHttp::THttpResponseParser parser(responseTxt);
+        const bool headersIncomplete = parser.HasHeaders() && !parser.HasCompletedHeaders();
         const bool noBodyExpected = !parser.ExpectedBody();
-        const bool hasIncompleteHeaders = parser.HasHeaders() && !parser.HasCompletedHeaders();
-        if (hasIncompleteHeaders && noBodyExpected && !responseTxt.EndsWith("\r\n\r\n")) {
+        if (headersIncomplete && noBodyExpected && !responseTxt.EndsWith("\r\n\r\n")) {
             if (!responseTxt.EndsWith("\r\n")) {
                 responseTxt += "\r\n";
             }
@@ -842,7 +842,7 @@ public:
     void Handle(TEvMon::TEvMonitoringResponse::TPtr& ev) {
         if (ev->Get()->Record.HasHttpResponse()) {
             TString responseTxt = ev->Get()->Record.GetHttpResponse();
-            NormalizeNoBodyResponseHeaders(responseTxt);
+            FixupLegacyNoBodyResponseHeaders(responseTxt);
             NHttp::THttpOutgoingResponsePtr responseObj = Event->Get()->Request->CreateResponseString(responseTxt);
 
             if (responseObj->Status == "301" || responseObj->Status == "302") {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -849,7 +849,8 @@ public:
 
             Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(responseObj), 0, Event->Cookie);
 
-            if (responseObj->IsDone()) {
+            const bool noBodyExpected = !responseObj->IsNeedBody();
+            if (responseObj->IsDone() || noBodyExpected) {
                 return PassAway();
             } else {
                 CurrentResponse = responseObj;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix a potential hang when processing `OPTIONS` requests via `/node/<id>/` in mixed-version clusters.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

In the scenario where a storage node (newer version) forwards an `OPTIONS` request to an older dynnode, the dynnode may return a `204` response without the terminating `CRLFCRLF` in headers. After recent changes in response handling, the storage node may treat such responses as incomplete and wait for additional data that will
never arrive.

This patch normalizes headers for no-body responses by ensuring the terminating `CRLFCRLF` when headers are incomplete and no body is expected. This prevents the proxy from waiting for a continuation that will never be sent.
