### PR TITLE
Default fail-fast mode for IC

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -585,7 +585,7 @@ namespace NActors {
     void TInterconnectProxyTCP::EnqueueSessionEvent(STATEFN_SIG) {
         ICPROXY_PROFILED;
 
-        if (ev->Flags & IEventHandle::FlagFailFastWhenDisconnected) {
+        if (InErrorState) {
             return DropSessionEvent(ev);
         }
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
@@ -175,6 +175,7 @@ namespace NActors {
 
         const char* State = nullptr;
         TInstant StateSwitchTime;
+        bool InErrorState = false;
 
         template <typename... TArgs>
         void SwitchToState(int line, const char* name, TArgs&&... args) {
@@ -194,6 +195,11 @@ namespace NActors {
                         {}, nullptr, 0));
                     PassAwayScheduled = true;
                 }
+            }
+            if (CurrentStateFunc() == &TThis::HoldByError) {
+                InErrorState = true;
+            } else if (CurrentStateFunc() == &TThis::StateWork || CurrentStateFunc() == &TThis::PendingActivation) {
+                InErrorState = false;
             }
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Default fail-fast mode for IC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch prevents IC messages from stalling when they arrive during reconnection after unsuccessful attempt.
