### PR TITLE
Fix test_alter_tiering.py::TestAlterTiering::test[many_tables]

### DIFF
--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -273,7 +273,6 @@ class TestAlterTiering(TieringTestBase):
             )
             time.sleep((datetime.datetime.now() - begin).total_seconds())
 
-
     def _loop_set_ttl(
         self,
         ctx: TestContext,
@@ -285,7 +284,6 @@ class TestAlterTiering(TieringTestBase):
         sth = ScenarioTestHelper(ctx)
 
         for _ in loop:
-            begin = datetime.datetime.now()
             for source in sources:
                 LOGGER.info(f'setting eviction to `{source}`')
                 sth.execute_scheme_query(

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -32,6 +32,7 @@ import boto3
 import datetime
 import random
 import os
+import time
 from typing import Iterable
 from string import ascii_lowercase
 
@@ -54,10 +55,12 @@ class TestLoop:
 
 class S3:
     def __init__(self):
+        self.port_manager = library.python.port_manager.PortManager()
         self._server = None
 
     def start_server(self) -> str:
-        port = yatest.common.network.PortManager().get_port()
+        port = self.port_manager.get_port()
+
         self._server = ThreadedMotoServer(port=port)
         self._server.start()
         return f'http://localhost:{port}'
@@ -97,7 +100,7 @@ class S3:
 class TieringTestBase(BaseTestSet):
     @classmethod
     def _get_cluster_config(cls):
-        return KikimrConfigGenerator(
+        cfg = KikimrConfigGenerator(
             extra_feature_flags=[
                 'enable_external_data_sources',
                 'enable_tiering_in_column_shard',
@@ -120,6 +123,19 @@ class TieringTestBase(BaseTestSet):
                 available_external_data_sources=["ObjectStorage"]
             ),
         )
+        # aws_client_config lives at the top-level app config (not inside column_shard_config).
+        cfg.yaml_config['aws_client_config'] = {
+            # executor_threads_count controls TS3ThreadsPoolByEndpoint — a SHARED thread pool
+            # across ALL S3 clients for the same endpoint (moto). This is the effective global
+            # limit on concurrent S3 operations from ALL column-shard tablets combined.
+            # - Too low: eviction PUTs starve when scan GETs occupy all threads
+            #   → write buffer overflow → "Cannot write data (TIMEOUT)"
+            # - Too high: moto overwhelmed with concurrent connections
+            #   → "curlCode: 28, Timeout was reached"
+            # 6 threads allows enough eviction throughput while keeping moto load manageable.
+            'executor_threads_count': 8,
+        }
+        return cfg
 
     def _setup_tiering_test(self, ctx):
         random.seed(0)
@@ -216,6 +232,7 @@ class TestAlterTiering(TieringTestBase):
         sth = ScenarioTestHelper(ctx)
 
         for _ in loop:
+            begin = datetime.datetime.now()
             sth.bulk_upsert(
                 table,
                 dg.DataGeneratorPerColumn(self.schema1, 1000)
@@ -230,6 +247,8 @@ class TestAlterTiering(TieringTestBase):
                     dg.ColumnValueGeneratorConst(random.randbytes(1024)),
                 ),
             )
+            # do 3 times less writes so that moto server can handle all writes.
+            time.sleep((datetime.datetime.now() - begin).total_seconds()*2)
 
     def _loop_scan(
         self,
@@ -245,11 +264,15 @@ class TestAlterTiering(TieringTestBase):
 
         for _ in loop:
             LOGGER.info('executing SELECT')
+            begin = datetime.datetime.now()
+
             sth.execute_query(
                 f'SELECT MIN(writer) FROM `{sth.get_full_path(table)}`',
                 expected_status=expected_scan_status,
                 ignore_error={"Query invalidated on scheme/internal error during Data execution"}  # https://github.com/ydb-platform/ydb/issues/12854
             )
+            time.sleep((datetime.datetime.now() - begin).total_seconds())
+
 
     def _loop_set_ttl(
         self,
@@ -262,6 +285,7 @@ class TestAlterTiering(TieringTestBase):
         sth = ScenarioTestHelper(ctx)
 
         for _ in loop:
+            begin = datetime.datetime.now()
             for source in sources:
                 LOGGER.info(f'setting eviction to `{source}`')
                 sth.execute_scheme_query(
@@ -306,8 +330,8 @@ class TestAlterTiering(TieringTestBase):
         self._setup_tiering_test(ctx)
 
         self.test_duration = self._get_test_duration(get_external_param('test-class', 'SMALL'))
-        self.n_tables = 4
-        self.n_writers = 4
+        self.n_tables = 2
+        self.n_writers = 2
 
         sth = ScenarioTestHelper(ctx)
 

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -25,7 +25,7 @@ from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 
 from ydb import PrimitiveType, StatusCode
-import yatest.common
+import yatest.common.network
 from moto.server import ThreadedMotoServer
 
 import boto3
@@ -55,7 +55,7 @@ class TestLoop:
 
 class S3:
     def __init__(self):
-        self.port_manager = library.python.port_manager.PortManager()
+        self.port_manager = yatest.common.network.PortManager()
         self._server = None
 
     def start_server(self) -> str:


### PR DESCRIPTION
muted in #32098

also fixed incorrect usage of raii PortManager class 

original error was:
Scan failed at tablet 72075186224037903, reason: task_error:Error reading blob range for columns: { Blob: DS:4294967295:[72075186224037903:1:1:255:1:3920:0] Offset: 352 Size: 224 }, error: cannot get blob: curlCode: 28, Timeout was reached, detailed error: , curlCode: 28, Timeout was reached, status: ERROR

this error was caused by s3 mock server(moto) overload. i've fixed it by adding `'executor_threads_count': 8` to aws config. this limits parallelism of s3 requests by 8(default value is 32), and accordingly reduces the load on the server by 4 times

then another error occurred:
Cannot write data (TIMEOUT) into shard 72075186224037892 in longTx ydb://long-tx/01kkbpvvkw5hp7ftphnbpp42wg?node_id=1

This error was caused by all 8 threads (the limit from the previous fix) being busy with reads. As a result, writes were timing out due to a lack of execution time. I fixed this by reducing the number of reads and writes.


...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
