### PR TITLE
log fallback reason in the federated cpp sdk

### DIFF
--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.cpp
@@ -135,6 +135,9 @@ void TFederatedDbObserverImpl::OnFederationDiscovery(TStatus&& status, Ydb::Fede
         //   1) The request was meant for a non-federated topic: fall back to single db mode.
         //   2) The database path in the request is simply wrong: the client should get the BAD_REQUEST status.
         if (status.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED || status.GetStatus() == EStatus::BAD_REQUEST) {
+            LOG_LAZY(DbDriverState_->Log, TLOG_DEBUG, TStringBuilder()
+                << "OnFederationDiscovery: Got error. Status: " << status.GetStatus()
+                << ". Description: " << status.GetIssues().ToOneLineString());
             LOG_LAZY(DbDriverState_->Log, TLOG_INFO, TStringBuilder()
                 << "OnFederationDiscovery fall back to single mode, database=" << DbDriverState_->Database);
             FederatedDbState->Status = TPlainStatus{};  // SUCCESS


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Иногда неверное имя БД — это ошибка в пользовательском коде, и тогда сообщение полезно для отладки:

```
OnFederationDiscovery: Got error. Status: BAD_REQUEST.
Description: { <main>: Error: Bad database path in request: should be '<federation_prefix>/<user_name>' }
```
