### PR TITLE
Backport stable 25 4 watermark idle channels

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -185,6 +185,9 @@ private:
 
         html << "<h3>Watermarks</h3>";
         DUMP(WatermarksTracker, GetPendingWatermark, ());
+        html << "<pre>";
+        DUMP((*this), WatermarksTracker);
+        html << "</pre>";
 
         html << "<h3>CPU Quota</h3>";
         html << "QuoterServiceActorId: " << QuoterServiceActorId.ToString() << "<br />";

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -1585,7 +1585,16 @@ protected:
     void HandleCheckIdleness(const TEvPrivate::TEvCheckIdleness::TPtr& ev) {
         auto checkTime = Max(ev->Get()->CheckTime, TInstant::Now());
         if (WatermarksTracker.ProcessIdlenessCheck(checkTime)) {
-            auto idleWatermark = WatermarksTracker.HandleIdleness(checkTime);
+            TMaybe<TInstant> idleWatermark;
+            if constexpr (!std::is_same_v<TDerived, TDqAsyncComputeActor>) {
+                for (const auto& [id, _]: InputTransformsMap) {
+                    auto transformWatermarksTracker = GetInputTransformWatermarksTracker(id);
+                    if (transformWatermarksTracker) {
+                        idleWatermark = Max(idleWatermark, transformWatermarksTracker->HandleIdleness(checkTime));
+                    }
+                }
+            }
+            idleWatermark = Max(idleWatermark, WatermarksTracker.HandleIdleness(checkTime));
             if (idleWatermark) {
                 CA_LOG_T("Idleness watermark " << idleWatermark);
                 ResumeExecution(EResumeSource::CAWatermarkIdleness);
@@ -1595,7 +1604,23 @@ protected:
     }
 
     void ScheduleIdlenessCheck() {
-        if (auto checkTime = WatermarksTracker.PrepareIdlenessCheck()) {
+        TMaybe<TInstant> checkTime = WatermarksTracker.GetNextIdlenessCheckAt();
+        if constexpr (!std::is_same_v<TDerived, TDqAsyncComputeActor>) {
+            for (const auto& [id, _]: InputTransformsMap) {
+                auto transformWatermarksTracker = GetInputTransformWatermarksTracker(id);
+                if (transformWatermarksTracker) {
+                    auto transformCheckTime = transformWatermarksTracker->GetNextIdlenessCheckAt();
+                    if (transformCheckTime) {
+                        if (checkTime) {
+                            checkTime = Min(*checkTime, *transformCheckTime);
+                        } else {
+                            checkTime = *transformCheckTime;
+                        }
+                    }
+                }
+            }
+        }
+        if (checkTime && WatermarksTracker.AddScheduledIdlenessCheck(*checkTime)) {
             CA_LOG_T("Schedule next idleness check at " << checkTime);
             this->Schedule(*checkTime, new TEvPrivate::TEvCheckIdleness(*checkTime));
         }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -201,7 +201,7 @@ protected:
         , FunctionRegistry(functionRegistry)
         , CheckpointingMode(GetTaskCheckpointingMode(Task))
         , State(Task.GetCreateSuspended() ? NDqProto::COMPUTE_STATE_UNKNOWN : NDqProto::COMPUTE_STATE_EXECUTING)
-        , WatermarksTracker(LogPrefix)
+        , WatermarksTracker(LogPrefix, taskCounters)
         , TaskCounters(taskCounters)
         , MetricsReporter(taskCounters)
         , ComputeActorSpan(NKikimr::TWilsonKqp::ComputeActor, std::move(traceId), "ComputeActor")

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -19,8 +19,10 @@ namespace NYql::NDq {
 
 using namespace NActors;
 
-TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TString& logPrefix)
-    : LogPrefix(logPrefix), Impl(logPrefix) {
+TDqComputeActorWatermarks::TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters)
+    : LogPrefix(logPrefix)
+    , Impl(logPrefix, counters)
+{
 }
 
 void TDqComputeActorWatermarks::RegisterInputChannel(ui64 inputId, TDuration idleTimeout, TInstant systemTime) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -34,7 +34,7 @@ void TDqComputeActorWatermarks::RegisterAsyncInput(ui64 inputId, TDuration idleT
 void TDqComputeActorWatermarks::RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout, TInstant systemTime)
 {
     LOG_D("Register " << (isChannel ? "channel" : "async input") << " " << inputId << ", idle timeout: " << idleTimeout);
-    auto registered = Impl.RegisterInput(std::make_pair(inputId, isChannel), systemTime, idleTimeout);
+    auto registered = Impl.RegisterInput(TInputKey {inputId, isChannel}, systemTime, idleTimeout);
     if (!registered) {
         LOG_E("Repeated registration " << inputId <<" " << (isChannel ? "channel" : "async input"));
     }
@@ -51,7 +51,7 @@ void TDqComputeActorWatermarks::UnregisterAsyncInput(ui64 inputId, bool silent) 
 }
 
 void TDqComputeActorWatermarks::UnregisterInput(ui64 inputId, bool isChannel, bool silent) {
-    auto result = Impl.UnregisterInput(std::make_pair(inputId, isChannel));
+    auto result = Impl.UnregisterInput(TInputKey {inputId, isChannel});
     if (!result && !silent) {
         LOG_E("Unregistered " << (isChannel ? "input channel" : "async input") << " " << inputId << " was not found");
     }
@@ -70,7 +70,7 @@ bool TDqComputeActorWatermarks::NotifyInputWatermarkReceived(ui64 inputId, bool 
     if (MaxWatermark < watermark) {
         MaxWatermark = watermark;
     }
-    auto [nextWatermark, updated] = Impl.NotifyNewWatermark(std::make_pair(inputId, isChannel), watermark, systemTime);
+    auto [nextWatermark, updated] = Impl.NotifyNewWatermark(TInputKey {inputId, isChannel}, watermark, systemTime);
     if (nextWatermark) {
         PendingWatermark = nextWatermark;
     }
@@ -141,4 +141,18 @@ void TDqComputeActorWatermarks::SetLogPrefix(const TString& logPrefix) {
     LogPrefix = logPrefix;
 }
 
+void TDqComputeActorWatermarks::Out(IOutputStream& str) const {
+    Impl.Out(str);
+}
+
 } // namespace NYql::NDq
+
+template<>
+void Out<NYql::NDq::NDqComputeActorWatermarksImpl::TInputKey>(IOutputStream& str, const NYql::NDq::NDqComputeActorWatermarksImpl::TInputKey& x) {
+    str << "[" << (x.IsChannel ? "Channel " : "Input ") << x.InputId << "]";
+}
+
+template<>
+void Out<NYql::NDq::TDqComputeActorWatermarks>(IOutputStream& str, const NYql::NDq::TDqComputeActorWatermarks& x) {
+    x.Out(str);
+}

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <ydb/library/yql/dq/common/dq_common.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h>
@@ -24,7 +25,7 @@ namespace NYql::NDq {
 class TDqComputeActorWatermarks
 {
 public:
-    TDqComputeActorWatermarks(const TString& logPrefix);
+    explicit TDqComputeActorWatermarks(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {});
 
     void RegisterAsyncInput(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
     void RegisterInputChannel(ui64 inputId, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -4,8 +4,23 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h>
 
-namespace NYql::NDq {
+namespace NYql::NDq::NDqComputeActorWatermarksImpl {
+    struct TInputKey {
+        ui64 InputId;
+        bool IsChannel;
 
+        constexpr auto operator<=> (const TInputKey&) const = default;
+    };
+} // namespace NYql::NDq::NDqComputeActorWatermarksImpl
+
+template<>
+struct THash<NYql::NDq::NDqComputeActorWatermarksImpl::TInputKey> {
+    constexpr size_t operator() (const auto& x) const noexcept {
+        return (x.InputId << 1) ^ x.IsChannel; // better than CombineHashes for this particular purpose
+    }
+};
+
+namespace NYql::NDq {
 class TDqComputeActorWatermarks
 {
 public:
@@ -42,6 +57,8 @@ public:
 
     void SetLogPrefix(const TString& logPrefix);
 
+    void Out(IOutputStream& str) const;
+
     void RegisterInput(ui64 inputId, bool isChannel, TDuration idleTimeout = TDuration::Max(), TInstant systemTime = TInstant::Now());
     void UnregisterInput(ui64 inputId, bool isChannel, bool silent = false);
     bool NotifyInputWatermarkReceived(ui64 inputId, bool isChannel, TInstant watermark, TInstant systemTime = TInstant::Now());
@@ -49,7 +66,7 @@ public:
 private:
     TString LogPrefix;
 
-    using TInputKey = std::pair<ui64, bool>;
+    using TInputKey = NDqComputeActorWatermarksImpl::TInputKey;
     TDqWatermarkTrackerImpl<TInputKey> Impl;
 
     TMaybe<TInstant> PendingWatermark;

--- a/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
+++ b/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
@@ -61,6 +61,10 @@ public:
         return Impl_.GetWatermarkDiscrepancy();
     }
 
+    void Out(IOutputStream& str) const {
+        Impl_.Out(str);
+    }
+
 private:
     TInstant ToDiscreteTime(TInstant time) const {
         return TInstant::MicroSeconds(time.MicroSeconds() - time.MicroSeconds() % Granularity_.MicroSeconds());
@@ -79,4 +83,4 @@ private:
     TDqWatermarkTrackerImpl<TPartitionKey> Impl_;
 };
 
-}
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
+++ b/ydb/library/yql/dq/actors/compute/dq_source_watermark_tracker.h
@@ -17,12 +17,13 @@ public:
         bool idlePartitionsEnabled,
         TDuration lateArrivalDelay,
         TDuration idleTimeout,
-        const TString& logPrefix)
+        const TString& logPrefix,
+        const ::NMonitoring::TDynamicCounterPtr& counters = {})
         : Granularity_(granularity)
         , IdlePartitionsEnabled_(idlePartitionsEnabled)
         , LateArrivalDelay_(lateArrivalDelay)
         , IdleTimeout_(idleTimeout)
-        , Impl_(logPrefix)
+        , Impl_(logPrefix, counters)
     {}
 
     [[nodiscard]] TMaybe<TInstant> NotifyNewPartitionTime(

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -266,6 +266,11 @@ protected:
             TaskRunner->SetSpillerFactory(std::make_shared<TDqSpillerFactory>(execCtx.GetTxId(), NActors::TActivationContext::ActorSystem(), execCtx.GetWakeupCallback(), execCtx.GetErrorCallback()));
         }
 
+        this->WatermarksTracker.SetNotifyHandler([this]() {
+            // This code is called from TaskRunner (either directly or from input transform/helper code), which is owned by sync CA, so `*this` must be alive at that point
+            this->ScheduleIdlenessCheck();
+        });
+
         TaskRunner->Prepare(this->Task, limits, execCtx, &this->WatermarksTracker);
 
         for (auto& [channelId, channel] : this->InputChannelsMap) {

--- a/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <util/datetime/base.h>
 #include <util/generic/maybe.h>
 #include <util/system/types.h>
@@ -16,9 +17,21 @@ namespace NYql::NDq {
 template <typename TInputKey>
 struct TDqWatermarkTrackerImpl {
 public:
-    explicit TDqWatermarkTrackerImpl(const TString& logPrefix)
+    explicit TDqWatermarkTrackerImpl(const TString& logPrefix, const ::NMonitoring::TDynamicCounterPtr& counters = {})
         : LogPrefix_(logPrefix)
+        , Counters_(counters)
     {}
+
+    ~TDqWatermarkTrackerImpl() {
+        if (IdleInputs_) {
+            size_t idleableCount = 0;
+            for (auto& [_, data]: Data_) {
+                idleableCount += (data.IdleTimeout != TDuration::Max());
+            }
+            Y_DEBUG_ABORT_UNLESS(idleableCount >= ExpiresQueue_.size());
+            IdleInputs_->Sub(idleableCount - ExpiresQueue_.size());
+        }
+    }
 
     void SetLogPrefix(const TString& logPrefix) {
         LogPrefix_ = logPrefix;
@@ -58,6 +71,9 @@ public:
             if (rec.empty()) {
                 WATERMARK_LOG_T("Unidle " << it->first << " got " << watermark << " > " << data.Watermark);
                 WatermarksQueue_.emplace(watermark, it);
+                if (IdleInputs_) {
+                    IdleInputs_->Dec();
+                }
             } else {
                 WATERMARK_LOG_T("Update " << it->first << " watermark from " << rec.value().Time << " to " << watermark);
                 rec.value().Time = watermark;
@@ -70,6 +86,9 @@ public:
             if (inserted) {
                 //updated = true;
                 WATERMARK_LOG_T("Unidle " << it->first << " got " << watermark << " <= " << data.Watermark);
+                if (IdleInputs_) {
+                    IdleInputs_->Dec();
+                }
             }
         } else {
             Y_DEBUG_ABORT_UNLESS(WatermarksQueue_.contains(TWatermarksQueueItem { data.Watermark, it }));
@@ -89,6 +108,10 @@ public:
             data.ExpiresAt = systemTime + idleTimeout;
             auto [_, inserted] = ExpiresQueue_.emplace(data.ExpiresAt, it);
             Y_DEBUG_ABORT_UNLESS(inserted);
+            if (Counters_ && !IdleInputs_) {
+                IdleEvents_ = Counters_->GetCounter("WatermarksIdleEvents", true);
+                IdleInputs_ = Counters_->GetCounter("WatermarksIdleInputs");
+            }
         }
         {
             auto [_, inserted] = WatermarksQueue_.emplace(Nothing(), it);
@@ -106,7 +129,10 @@ public:
         WatermarksQueue_.erase(TWatermarksQueueItem { data.Watermark, it });
         // note: erases nothing if input was idle
         if (data.IdleTimeout != TDuration::Max()) {
-            ExpiresQueue_.erase(TExpiresQueueItem { data.ExpiresAt, it });
+            auto removed = ExpiresQueue_.erase(TExpiresQueueItem { data.ExpiresAt, it });
+            if (!removed && IdleInputs_) {
+                IdleInputs_->Dec();
+            }
             // note: erases nothing if input was idle
         }
         Data_.erase(it);
@@ -125,6 +151,11 @@ public:
            auto removed = WatermarksQueue_.erase(TWatermarksQueueItem { data.Watermark, it->Iterator } );
            Y_DEBUG_ABORT_UNLESS(removed); // any partition in ExpiresQueue_ must have matching record in WatermarksQueue_
            it = ExpiresQueue_.erase(it);
+           if (IdleInputs_) {
+               IdleInputs_->Inc();
+               Y_DEBUG_ABORT_UNLESS(IdleEvents_);
+               IdleEvents_->Inc();
+           }
         }
 
         return RecalcWatermark();
@@ -255,6 +286,10 @@ private:
     TMaybe<TInstant> Watermark_;
     TString LogPrefix_;
     std::deque<TInstant> InflyIdlenessChecks_;
+
+    const NMonitoring::TDynamicCounterPtr Counters_;
+    NMonitoring::TDynamicCounters::TCounterPtr IdleEvents_;
+    NMonitoring::TDynamicCounters::TCounterPtr IdleInputs_;
 };
 #undef WATERMARK_LOG_T
 #undef WATERMARK_LOG_D

--- a/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_watermark_tracker_impl.h
@@ -4,6 +4,7 @@
 #include <util/generic/maybe.h>
 #include <util/system/types.h>
 #include <util/string/builder.h>
+#include <util/string/join.h>
 #include <util/generic/set.h>
 #include <algorithm>
 #include <deque>
@@ -169,6 +170,30 @@ public:
         return true;
     }
 
+    void Out(IOutputStream& str) const {
+        if (!Data_.empty()) {
+            str << "Watermarks: {";
+            for (auto it = Data_.cbegin(); it != Data_.cend(); ++it) {
+                const auto& [key, data] = *it;
+                str << "\n    " << key << ": {" << " watermark: " << data.Watermark;
+                if (data.IdleTimeout != TDuration::Max()) {
+                    str << ", expires: " << data.ExpiresAt << ", timeout: " << data.IdleTimeout;
+                    if (!WatermarksQueue_.contains(TWatermarksQueueItem { data.Watermark, it })) {
+                        str << ", expired";
+                    }
+                }
+                str << " },";
+            }
+            str << "};\n";
+        }
+        if (Watermark_) {
+            str << "Watermark: " << Watermark_ << ";\n";
+        }
+        if (!InflyIdlenessChecks_.empty()) {
+            str << "InflyIdlenessChecks: [ " << JoinSeq(", ", InflyIdlenessChecks_) << " ];\n";
+        }
+    }
+
 private:
     TMaybe<TInstant> RecalcWatermark() {
         if (WatermarksQueue_.empty()) {
@@ -197,7 +222,7 @@ private:
 
     template <typename TTimeType, typename TMapType>
     struct TTimeState {
-        using TDataIterator = typename TMapType::iterator;
+        using TDataIterator = typename TMapType::const_iterator;
         TTimeType Time;
         TDataIterator Iterator;
         bool operator< (const TTimeState& other) const noexcept {
@@ -234,4 +259,4 @@ private:
 #undef WATERMARK_LOG_T
 #undef WATERMARK_LOG_D
 
-}
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/runtime/dq_input_producer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_producer.cpp
@@ -72,6 +72,8 @@ private:
 
         // wait for drain only if watermarks enabled
         if (WatermarksEnabled() && WatermarksTracker->HasPendingWatermark()) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
+            WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return NUdf::EFetchStatus::Yield;
         }
 
@@ -113,6 +115,8 @@ private:
 
         // wait for drain only if watermarks enabled
         if (WatermarksEnabled() && WatermarksTracker->HasPendingWatermark()) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
+            WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return NUdf::EFetchStatus::Yield;
         }
 
@@ -192,8 +196,11 @@ private:
         auto hasPendingWatermark = WatermarksTracker->NotifyInputWatermarkReceived(InputKey.InputId, InputKey.IsChannel, *Watermark) && WatermarksTracker->HasPendingWatermark();
         Watermark.Clear();
         if (hasPendingWatermark) {
+            Y_DEBUG_ABORT_UNLESS(WatermarkStorage->WatermarkIn <= *WatermarksTracker->GetPendingWatermark());
             WatermarkStorage->WatermarkIn = WatermarksTracker->GetPendingWatermark();
             return true;
+        } else {
+            Y_DEBUG_ABORT_UNLESS(!WatermarksTracker->HasPendingWatermark());
         }
         return false;
     }

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -637,8 +637,8 @@ public:
                 if (inputDesc.GetSource().GetWatermarksMode() != NDqProto::WATERMARKS_MODE_DISABLED) {
                     inputUsesWatermarks = true;
                     if (transform && WatermarksTracker) {
-                        transform->WatermarksTracker.emplace(/*logPrefix=*/"");
-                        transform->WatermarksTracker->RegisterAsyncInput(i/*TODO: , idleTimeout */);
+                        transform->WatermarksTracker.emplace(*WatermarksTracker, true);
+                        transform->WatermarksTracker->TransferInput(*WatermarksTracker, i, false);
                     }
                 }
             } else {
@@ -653,17 +653,16 @@ public:
                     if (inputChannelDesc.GetWatermarksMode() != NDqProto::WATERMARKS_MODE_DISABLED) {
                         inputUsesWatermarks = true;
                         if (transform && WatermarksTracker) {
-                            WatermarksTracker->UnregisterInputChannel(channelId);
                             if (!transform->WatermarksTracker) {
-                                transform->WatermarksTracker.emplace(/*logPrefix=*/"");
+                                transform->WatermarksTracker.emplace(*WatermarksTracker, true);
                             }
-                            transform->WatermarksTracker->RegisterInputChannel(channelId/*TODO: , idleTimeout */);
+                            transform->WatermarksTracker->TransferInput(*WatermarksTracker, channelId, true);
                         }
                     }
                 }
-                if (inputUsesWatermarks && transform && WatermarksTracker) {
-                    WatermarksTracker->RegisterAsyncInput(i/*TODO: , idleTimeout */);
-                }
+            }
+            if (inputUsesWatermarks && transform && WatermarksTracker) {
+                WatermarksTracker->RegisterAsyncInput(i, transform->WatermarksTracker->GetMaxIdleTimeout());
             }
 
             auto entryNode = AllocatedHolder->ProgramParsed.CompGraph->GetEntryPoint(i, false);

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -847,6 +847,7 @@ void TDqPqRdReadActor::SchedulePartitionIdlenessCheck(TInstant at) {
 }
 
 void TDqPqRdReadActor::InitWatermarkTracker() {
+    Y_DEBUG_ABORT_UNLESS(Parent == this); // called on Parent
     auto lateArrivalDelayUs = SourceParams.GetWatermarks().GetLateArrivalDelayUs();
     auto idleTimeoutUs = // TODO remove fallback
         SourceParams.GetWatermarks().HasIdleTimeoutUs() ?
@@ -854,7 +855,8 @@ void TDqPqRdReadActor::InitWatermarkTracker() {
         lateArrivalDelayUs;
     TDqPqReadActorBase::InitWatermarkTracker(
             TDuration::Zero(), // lateArrivalDelay is embedded into calculation of WatermarkExpr
-            TDuration::MicroSeconds(idleTimeoutUs));
+            TDuration::MicroSeconds(idleTimeoutUs),
+            Metrics.Counters ? Metrics.Source : nullptr);
 }
 
 std::vector<ui64> TDqPqRdReadActor::GetPartitionsToRead() const {

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1291,6 +1291,11 @@ TString TDqPqRdReadActor::GetInternalState() {
         }
         str << "\n";
     }
+    if (Parent->WatermarkTracker) {
+        str << "WatermarksTracker:";
+        Parent->WatermarkTracker->Out(str);
+        str << "\n";
+    }
     return str.Str();
 }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -654,7 +654,7 @@ private:
             SourceParams.GetWatermarks().HasIdleTimeoutUs() ?
             SourceParams.GetWatermarks().GetIdleTimeoutUs() :
             lateArrivalDelayUs;
-        TDqPqReadActorBase::InitWatermarkTracker(TDuration::MicroSeconds(lateArrivalDelayUs), TDuration::MicroSeconds(idleTimeoutUs));
+        TDqPqReadActorBase::InitWatermarkTracker(TDuration::MicroSeconds(lateArrivalDelayUs), TDuration::MicroSeconds(idleTimeoutUs), Metrics.Counters ? Metrics.Source : nullptr);
     }
 
     void SchedulePartitionIdlenessCheck(TInstant at) override {

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.cpp
@@ -144,7 +144,7 @@ const NYql::NDq::TDqAsyncStats& TDqPqReadActorBase::GetIngressStats() const {
     return IngressStats;
 }
 
-void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDuration idleTimeout) {
+void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDuration idleTimeout, const ::NMonitoring::TDynamicCounterPtr& counters) {
     const auto granularity = TDuration::MicroSeconds(SourceParams.GetWatermarks().GetGranularityUs());
     SRC_LOG_D("SessionId: " << GetSessionId() << " Watermarks enabled: " << SourceParams.GetWatermarks().GetEnabled() << " granularity: " << granularity
         << " late arrival delay: " << lateArrivalDelay
@@ -161,7 +161,8 @@ void TDqPqReadActorBase::InitWatermarkTracker(TDuration lateArrivalDelay, TDurat
         SourceParams.GetWatermarks().GetIdlePartitionsEnabled(),
         lateArrivalDelay,
         idleTimeout,
-        LogPrefix
+        LogPrefix,
+        counters
     );
 }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor_base.h
@@ -44,7 +44,7 @@ public:
     virtual void SchedulePartitionIdlenessCheck(TInstant) = 0;
 
     virtual void InitWatermarkTracker() = 0;
-    void InitWatermarkTracker(TDuration, TDuration);
+    void InitWatermarkTracker(TDuration, TDuration, const ::NMonitoring::TDynamicCounterPtr& counters = {});
     void MaybeSchedulePartitionIdlenessCheck(TInstant systemTime);
 
     virtual TString GetSessionId() const {

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import json
 import sys
+import time
 from collections import Counter
 from operator import itemgetter
 from itertools import chain, islice
@@ -870,10 +871,8 @@ class TestJoinStreaming(TestYdsBase):
         fq_client: FederatedQueryClient,
         yq_version,
     ):
-        self.init_topics(
-            f"slj_{partitions_count}{streamlookup}{testcase}{ca}_{yq_version}",
-            partitions_count=partitions_count,
-        )
+        title = f"slj_{partitions_count}{str(streamlookup)[:1]}{testcase}{ca[:1]}{yq_version}"
+        self.init_topics(title, partitions_count=partitions_count)
         fq_client.create_yds_connection("myyds", os.getenv("YDB_DATABASE"), os.getenv("YDB_ENDPOINT"))
 
         table_name = 'join_table'
@@ -895,11 +894,7 @@ class TestJoinStreaming(TestYdsBase):
 
         one_time_waiter.wait()
 
-        query_id = fq_client.create_query(
-            f"slj_{partitions_count}{streamlookup}{testcase}{ca}",
-            sql,
-            type=fq.QueryContent.QueryType.STREAMING,
-        ).result.query_id
+        query_id = fq_client.create_query(title, sql, type=fq.QueryContent.QueryType.STREAMING).result.query_id
 
         if not streamlookup and "MultiGet true" in sql:
             fq_client.wait_query_status(query_id, fq.QueryMeta.FAILED)
@@ -950,12 +945,12 @@ class TestJoinStreaming(TestYdsBase):
         "mvp_external_ydb_endpoint", [{"endpoint": "tests-fq-generic-streaming-ydb:2136"}], indirect=True
     )
     @pytest.mark.parametrize("fq_client", [{"folder_id": "my_folder_slj"}], indirect=True)
-    @pytest.mark.parametrize("partitions_count", [1])
-    @pytest.mark.parametrize("tasks", [1])
+    @pytest.mark.parametrize("partitions_count", [1, 2])
+    @pytest.mark.parametrize("tasks", [1, 2])
     @pytest.mark.parametrize("streamlookup", [True, False])
     @pytest.mark.parametrize("ca", ["sync", "async"])
     @pytest.mark.parametrize("limit", [6, 7, 8, 9, None])
-    def test_streamlookup_with_watermarks(
+    def test_streamlookup_watermarks(
         self,
         kikimr,
         ca,
@@ -966,10 +961,8 @@ class TestJoinStreaming(TestYdsBase):
         fq_client: FederatedQueryClient,
         yq_version,
     ):
-        self.init_topics(
-            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}_{yq_version}",
-            partitions_count=partitions_count,
-        )
+        title = f"slj_wm_{partitions_count}{str(streamlookup)[:1]}{limit}{ca[:1]}{tasks}"
+        self.init_topics(title, partitions_count=partitions_count)
         fq_client.create_yds_connection(
             "wmyds",
             os.getenv("YDB_DATABASE"),
@@ -1053,15 +1046,18 @@ class TestJoinStreaming(TestYdsBase):
 
         one_time_waiter.wait()
 
-        query_id = fq_client.create_query(
-            f"slj_wm_{partitions_count}{streamlookup}{limit}{ca}{tasks}", sql, type=fq.QueryContent.QueryType.STREAMING
-        ).result.query_id
+        query_id = fq_client.create_query(title, sql, type=fq.QueryContent.QueryType.STREAMING).result.query_id
 
         fq_client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
         kikimr.compute_plane.wait_zero_checkpoint(query_id)
 
         for offset in range(0, len(messages), MAX_WRITE_STREAM_SIZE):
-            self.write_stream(map(lambda x: x[0], messages[offset : offset + MAX_WRITE_STREAM_SIZE]))
+            self.write_stream(
+                map(lambda x: x[0], messages[offset : offset + MAX_WRITE_STREAM_SIZE]),
+                partition_key=b'1',
+            )
+        if partitions_count > 1 or tasks > 1:
+            time.sleep(5.0)
 
         expected_len = sum(map(len, messages)) - len(messages)
         read_data = self.read_stream(expected_len)

--- a/ydb/tests/fq/streaming/test_watermarks.py
+++ b/ydb/tests/fq/streaming/test_watermarks.py
@@ -10,15 +10,17 @@ logger = logging.getLogger(__name__)
 
 class TestWatermarksInYdb(StreamingTestBase):
     @pytest.mark.parametrize("kikimr", [{"enable_watermarks": True}], indirect=["kikimr"])
-    @pytest.mark.parametrize("shared_reading", [False], ids=["no_shared"])
-    @pytest.mark.parametrize("tasks", [1])
+    @pytest.mark.parametrize("shared_reading", [False, True], ids=["no_shared", "shared"])
+    @pytest.mark.parametrize("tasks", [1, 2])
     def test_watermarks(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], shared_reading: bool, tasks: int) -> None:
-        query_name = f"test_watermarks_{shared_reading}_{tasks}"
+        query_name = f"test_watermarks_{shared_reading}{tasks}{local_topics}"
         source_name = entity_name(query_name)
         self.init_topics(source_name, partitions_count=tasks)
         self.create_source(kikimr, source_name, shared_reading)
 
         ts = "CAST(ts AS Timestamp)" if shared_reading else "SystemMetadata('write_time')"
+        idleness_clause = ', WATERMARK_IDLE_TIMEOUT = "PT5S"' if tasks > 1 else ''
+
         sql = f'''
             CREATE STREAMING QUERY `{query_name}` AS
             DO BEGIN
@@ -37,8 +39,8 @@ class TestWatermarksInYdb(StreamingTestBase):
                             pass Uint64
                         )
                         , WATERMARK AS ({ts} - Interval('PT5S'))
-                        , WATERMARK_IDLE_TIMEOUT = "PT10S"
                         , WATERMARK_GRANULARITY = "PT1S"
+                        {idleness_clause}
                     )
                 );
 
@@ -73,11 +75,15 @@ class TestWatermarksInYdb(StreamingTestBase):
         kikimr.ydb_client.query(sql)
         self.wait_completed_checkpoints(kikimr, f"/Root/{query_name}")
 
-        self.write_stream(['{"ts": "1970-01-01T00:00:40Z", "pass": 1}'])
-        time.sleep(10)
-        self.write_stream(['{"ts": "1970-01-01T00:00:50Z", "pass": 1}'])
-        time.sleep(10)
-        self.write_stream(['{"ts": "1970-01-01T00:01:00Z", "pass": 0}'])
+        self.write_stream(['{"ts": "1970-01-01T00:00:40Z", "pass": 1}'], partition_key=b'1')
+        if not shared_reading:
+            time.sleep(10)
+        self.write_stream(['{"ts": "1970-01-01T00:00:50Z", "pass": 1}'], partition_key=b'1')
+        if not shared_reading:
+            time.sleep(10)
+        self.write_stream(['{"ts": "1970-01-01T00:01:00Z", "pass": 0}'], partition_key=b'1')
+        if shared_reading and tasks > 1:
+            time.sleep(10)  # leave a bit more time to fire up idle timeout
 
         expected = [
             '[["1970-01-01T00:00:40Z"]]',

--- a/ydb/tests/fq/streaming/test_watermarks.py
+++ b/ydb/tests/fq/streaming/test_watermarks.py
@@ -13,7 +13,7 @@ class TestWatermarksInYdb(StreamingTestBase):
     @pytest.mark.parametrize("shared_reading", [False, True], ids=["no_shared", "shared"])
     @pytest.mark.parametrize("tasks", [1, 2])
     def test_watermarks(self: StreamingTestBase, kikimr: Kikimr, entity_name: Callable[[str], str], shared_reading: bool, tasks: int) -> None:
-        query_name = f"test_watermarks_{shared_reading}{tasks}{local_topics}"
+        query_name = f"test_watermarks_{shared_reading}{tasks}"
         source_name = entity_name(query_name)
         self.init_topics(source_name, partitions_count=tasks)
         self.create_source(kikimr, source_name, shared_reading)

--- a/ydb/tests/tools/datastreams_helpers/data_plane.py
+++ b/ydb/tests/tools/datastreams_helpers/data_plane.py
@@ -44,7 +44,7 @@ def write_stream(path, data, partition_key=None, database=None, endpoint=None):
 
 
 #  Data plane grpc API is not implemented in datastreams.
-def read_stream(path, messages_count, commit_after_processing=True, consumer_name="test_client", timeout=READ_TOOL_TIMEOUT, database=None, endpoint=None):
+def read_stream(path, messages_count, commit_after_processing=True, consumer_name="test_client", timeout=None, database=None, endpoint=None):
     result_file_name = "{}-{}-read-result-{}-{}-out".format(
         os.getenv("PYTEST_CURRENT_TEST").replace(":", "_").replace(" (call)", ""),
         path.replace("/", "_"),
@@ -55,6 +55,8 @@ def read_stream(path, messages_count, commit_after_processing=True, consumer_nam
         database = os.getenv("YDB_DATABASE")
     if endpoint is None:
         endpoint = os.getenv("YDB_ENDPOINT")
+    if timeout is None:
+        timeout = READ_TOOL_TIMEOUT
     result_file = yatest.common.output_path(result_file_name)
     cmd = [
         yatest.common.binary_path("ydb/tests/tools/pq_read/pq_read"),

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -25,9 +25,9 @@ class TestYdsBase(object):
         topic = topic_path if topic_path else self.input_topic
         write_stream(topic, data, partition_key=partition_key, database=database, endpoint=endpoint)
 
-    def read_stream(self, messages_count, commit_after_processing=True, topic_path=None, database=None, endpoint=None):
+    def read_stream(self, messages_count, commit_after_processing=True, topic_path=None, database=None, endpoint=None, timeout=None):
         topic = topic_path if topic_path else self.output_topic
-        return read_stream(topic, messages_count, commit_after_processing, self.consumer_name, database=database, endpoint=endpoint)
+        return read_stream(topic, messages_count, commit_after_processing, self.consumer_name, database=database, endpoint=endpoint, timeout=timeout)
 
     def wait_until(self, predicate, wait_time=plain_or_under_sanitizer(10, 50)):
         deadline = time.time() + wait_time


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Note: mon-pages changes will be useless in 25-4 (mon page is not hooked in kqp, and it was not available in sync ca), this change was only added as idle channel code depends on watermark tracker refactoring that was integrated in this pr