### PR TITLE
Portion interval tree simplified

### DIFF
--- a/ydb/core/tx/columnshard/engines/storage/granule/portion_interval_tree.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/portion_interval_tree.h
@@ -14,16 +14,16 @@ namespace NKikimr::NOlap::PortionIntervalTree {
 struct TPortionIntervalTreeValueTraits: NRangeTreap::TDefaultValueTraits<std::shared_ptr<TPortionInfo>> {
     struct TValueHash {
         ui64 operator()(const std::shared_ptr<TPortionInfo>& value) const {
-            return THash<TPortionAddress>()(value->GetAddress());
+            return value->GetPortionId();
         }
     };
 
     static bool Less(const std::shared_ptr<TPortionInfo>& a, const std::shared_ptr<TPortionInfo>& b) noexcept {
-        return a->GetAddress() < b->GetAddress();
+        return a->GetPortionId() < b->GetPortionId();
     }
 
     static bool Equal(const std::shared_ptr<TPortionInfo>& a, const std::shared_ptr<TPortionInfo>& b) noexcept {
-        return a->GetAddress() == b->GetAddress();
+        return a->GetPortionId() == b->GetPortionId();
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Portion interval tree use only PortionId for hashing and comparisons instead of full portion Address, because all pathId's are equal in one capsule.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
