### PR TITLE
SchemeShard: Fix batch processing for forced compactions

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -5705,7 +5705,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 auto compactionId = shardsRowset.GetValue<Schema::WaitingForcedCompactionShards::ForcedCompactionId>();
 
-                Self->AddForcedCompactionShard(shardIdx, Self->ForcedCompactions.at(compactionId));
+                if (auto* info = Self->ForcedCompactions.FindPtr(compactionId)) {
+                    Self->AddForcedCompactionShard(shardIdx, *info);
+                } else {
+                    LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                            "unknown forced compaction id " << compactionId
+                            << " for shardIdx: " << shardIdx
+                            << ", at schemeshard: " << Self->TabletID());
+                }
 
                 if (!shardsRowset.Next()) {
                     return false;

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
@@ -18,18 +18,22 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
     }
 
     void DoExecute(TTransactionContext &txc, const TActorContext &ctx) override {
-        LOG_N("TForcedCompaction::TTxProgress DoExecute, CompactionsToPersist size: " << CompactionsToPersist.size());
+        LOG_N("TForcedCompaction::TTxProgress DoExecute"
+            << ", DoneShardsToPersist size: " << Self->DoneShardsToPersist.size()
+            << ", CancellingForcedCompactions size: " << Self->CancellingForcedCompactions.size());
+        THashSet<TForcedCompactionInfo::TPtr> compactionsToPersist;
+        compactionsToPersist.reserve(Self->DoneShardsToPersist.size() + Self->CancellingForcedCompactions.size());
         NIceDb::TNiceDb db(txc.DB);
         for (auto& [shardIdx, forcedCompactionInfo] : Self->DoneShardsToPersist) {
             if (Self->InProgressForcedCompactionsByShard.erase(shardIdx)) {
                 forcedCompactionInfo->DoneShardCount++;
             }
-            CompactionsToPersist.emplace(forcedCompactionInfo, false);
+            compactionsToPersist.emplace(forcedCompactionInfo);
             Self->PersistForcedCompactionDoneShard(db, shardIdx);
         }
 
         for (auto cancelling : Self->CancellingForcedCompactions) {
-            CompactionsToPersist.emplace(cancelling.Info, false);
+            compactionsToPersist.emplace(cancelling.Info);
             if (cancelling.Waiter) {
                 auto cancelResponse = MakeHolder<TEvForcedCompaction::TEvCancelResponse>(cancelling.Waiter->TxId);
                 cancelResponse->Record.SetStatus(Ydb::StatusIds::SUCCESS);
@@ -41,11 +45,10 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
             }
         }
 
-        for (auto& [forcedCompactionInfo, completed] : CompactionsToPersist) {
+        for (auto& forcedCompactionInfo : compactionsToPersist) {
             const auto* shardsQueue = Self->ForcedCompactionShardsByTable.FindPtr(forcedCompactionInfo->TablePathId);
             bool compactionCompleted = (!shardsQueue || shardsQueue->Empty()) && forcedCompactionInfo->ShardsInFlight.empty();
             if (compactionCompleted) {
-                completed = true;
                 if (!shardsQueue || shardsQueue->Empty()) {
                     Self->ForcedCompactionShardsByTable.erase(forcedCompactionInfo->TablePathId);
                     Self->ForcedCompactionTablesQueue.Remove(forcedCompactionInfo->TablePathId);
@@ -53,25 +56,20 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
                 Self->InProgressForcedCompactionsByTable.erase(forcedCompactionInfo->TablePathId);
                 forcedCompactionInfo->EndTime = ctx.Now();
 
-                // Persist copy with final state. In-memory state will be changed in DoComplete
-                auto infoCopy = *forcedCompactionInfo;
-                TransitToFinalState(infoCopy);
-                Self->PersistForcedCompactionState(db, infoCopy);
-                SendNotificationsIfFinished(infoCopy, ctx);
+                TransitToFinalState(*forcedCompactionInfo);
             }
+            Self->PersistForcedCompactionState(db, *forcedCompactionInfo);
+            SendNotificationsIfFinished(*forcedCompactionInfo, ctx);
         }
+        Self->DoneShardsToPersist.clear();
+        Self->CancellingForcedCompactions.clear();
         SideEffects.ApplyOnExecute(Self, txc, ctx);
     }
 
     void DoComplete(const TActorContext &ctx) override {
-        LOG_N("TForcedCompaction::TTxProgress DoComplete, CompactionsToPersist size: " << CompactionsToPersist.size());
-        for (auto& [info, completed] : CompactionsToPersist) {
-            if (completed) {
-                TransitToFinalState(*info);
-            }
-        }
-        Self->DoneShardsToPersist.clear();
-        Self->CancellingForcedCompactions.clear();
+        LOG_N("TForcedCompaction::TTxProgress DoComplete"
+            << ", DoneShardsToPersist size: " << Self->DoneShardsToPersist.size()
+            << ", CancellingForcedCompactions size: " << Self->CancellingForcedCompactions.size());
         SideEffects.ApplyOnComplete(Self, ctx);
     }
 
@@ -107,7 +105,6 @@ private:
 
 private:
     TSideEffects SideEffects;
-    THashMap<TForcedCompactionInfo::TPtr, bool> CompactionsToPersist;
 };
 
 ITransaction* TSchemeShard::CreateTxProgressForcedCompaction() {

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -2123,6 +2123,28 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         }
     }
 
+    Y_UNIT_TEST(CheckGetOperationShardsCounting) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        Setup(runtime, env);
+
+        ui64 txId = 1000;
+
+        CreateTableWithData(runtime, env, "/MyRoot", "Simple", 10, ++txId);
+
+        {
+            TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", 10);
+            ui64 compactionId = txId;
+            env.SimulateSleep(runtime, TDuration::Seconds(1));
+            auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetId(), compactionId);
+            UNIT_ASSERT_DOUBLES_EQUAL(response.GetForcedCompaction().GetProgress(), 100.0, 1e-7);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetState(), Ydb::Table::CompactState::STATE_DONE);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetShardsTotal(), 10);
+            UNIT_ASSERT_VALUES_EQUAL(response.GetForcedCompaction().GetShardsDone(), 10);
+        }
+    }
+
     Y_UNIT_TEST(CheckOperationFailures) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Update CompactionsToPersist state in DoExecute to prevent losing updates between DoExecute and DoComplete.
- Don't abort on schemeshard init if there are orphan shard states in local db, just log them.
