### PR TITLE
use correct VDisk parameters when tiny disks are enabled (#34781)

### DIFF
--- a/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
@@ -228,7 +228,7 @@ class THugeModuleRecoveryActor : public TActorBootstrapped<THugeModuleRecoveryAc
                         HmCtx->PDiskCtx->Dsk->OwnerRound,
                         HmCtx->LsnMngr->GetLsn(),
                         HmCtx->Counters));
-        TLogCutterCtx logCutterCtx = {HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr, HmCtx->Config, HmCtx->LoggerID};
+        TLogCutterCtx logCutterCtx = {HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr, HmCtx->Config, HmCtx->LoggerID, false};
         HmCtx->LogCutterID = ctx.Register(CreateRecoveryLogCutter(std::move(logCutterCtx)));
         RepairedHuge->FinishRecovery(ctx);
         auto hugeKeeperCtx = std::make_shared<THugeKeeperCtx>(HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr,

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
@@ -199,7 +199,7 @@ class TSyncLogTestWriteActor : public TActorBootstrapped<TSyncLogTestWriteActor>
                     Db->VCtx->VDiskCounters));
 
         // RecoveryLogCutter
-        TLogCutterCtx logCutterCtx = {VCtx, TestCtx->PDiskCtx, TestCtx->LsnMngr, VDiskConfig, TestCtx->LoggerId};
+        TLogCutterCtx logCutterCtx = {VCtx, TestCtx->PDiskCtx, TestCtx->LsnMngr, VDiskConfig, TestCtx->LoggerId, false};
         LogCutterId = ctx.Register(CreateRecoveryLogCutter(std::move(logCutterCtx)));
 
         // Repaired SyncLog State

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
@@ -128,7 +128,7 @@ namespace NKikimr {
             ui64 curLsn = Min(HullLsnToKeep, SyncLogLsnToKeep, SyncerLsnToKeep,
                 HugeKeeperLsnToKeep, ScrubLsnToKeep, ChunkKeeperLsnToKeep);
 
-            if (AppData(ctx)->FeatureFlags.GetEnableTinyDisks()) {
+            if (LogCutterCtx.WriteMetadata) {
                 curLsn = Min(curLsn, MetadataLsnToKeep);
             }
 

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h
@@ -49,6 +49,7 @@ namespace NKikimr {
         TIntrusivePtr<TLsnMngr> LsnMngr;
         TIntrusivePtr<TVDiskConfig> Config;
         TActorId LoggerId;
+        bool WriteMetadata = false;
     };
 
     IActor* CreateRecoveryLogCutter(TLogCutterCtx &&logCutterCtx);

--- a/ydb/core/blobstorage/vdisk/common/vdisk_log_context.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_log_context.cpp
@@ -6,12 +6,14 @@ TVDiskLogContext::TVDiskLogContext(TIntrusivePtr<TVDiskContext> vctx,
         TIntrusivePtr<TLsnMngr> lsnMngr,
         TPDiskCtxPtr pdiskCtx,
         const TActorId& loggerId,
-        const TActorId& logCutterId)
+        const TActorId& logCutterId,
+        bool writeMetadata)
     : VCtx(std::move(vctx))
     , LsnMngr(std::move(lsnMngr))
     , PDiskCtx(std::move(pdiskCtx))
     , LoggerId(loggerId)
     , LogCutterId(logCutterId)
+    , WriteMetadata(writeMetadata)
 {}
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_log_context.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_log_context.h
@@ -13,12 +13,14 @@ public:
     const TPDiskCtxPtr PDiskCtx;
     const TActorId LoggerId;
     const TActorId LogCutterId;
+    const bool WriteMetadata = false;
 
     TVDiskLogContext(TIntrusivePtr<TVDiskContext> vctx,
             TIntrusivePtr<TLsnMngr> lsnMngr,
             TPDiskCtxPtr pdiskCtx,
             const TActorId& loggerId,
-            const TActorId& logCutterId);
+            const TActorId& logCutterId,
+            bool writeMetadata);
 };
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.h
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.h
@@ -54,6 +54,7 @@ namespace NKikimr {
         ui64 ScrubEntrypointLsn;
         NKikimrVDiskData::TMetadataEntryPoint MetadataEntryPoint;
         std::unique_ptr<TChunkKeeperData> ChunkKeeperData;
+        bool HasMetadata = false;
 
         TEvLocalRecoveryDone(NKikimrProto::EReplyStatus status,
                              TIntrusivePtr<TLocalRecoveryInfo> recovInfo,
@@ -70,7 +71,8 @@ namespace NKikimr {
                              NKikimrVDiskData::TScrubEntrypoint scrubEntrypoint,
                              ui64 scrubEntrypointLsn,
                              NKikimrVDiskData::TMetadataEntryPoint metadataEntryPoint,
-                             std::unique_ptr<TChunkKeeperData>&& chunkKeeperData);
+                             std::unique_ptr<TChunkKeeperData>&& chunkKeeperData,
+                             bool hasMetadata);
         ~TEvLocalRecoveryDone();
     };
 

--- a/ydb/core/blobstorage/vdisk/metadata/metadata_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/metadata/metadata_actor.cpp
@@ -38,7 +38,7 @@ class TMetadataActor : public TActor<TMetadataActor> {
     }
 
     void Handle(TEvCommitVDiskMetadata::TPtr& ev) {
-        if (!AppData()->FeatureFlags.GetEnableTinyDisks()) {
+        if (!LogCtx->WriteMetadata) {
             Send(ev->Sender, new TEvCommitVDiskMetadataDone);
             return;
         }
@@ -63,7 +63,7 @@ class TMetadataActor : public TActor<TMetadataActor> {
     }
 
     void Handle(NPDisk::TEvCutLog::TPtr& ev) {
-        if (!AppData()->FeatureFlags.GetEnableTinyDisks()) {
+        if (!LogCtx->WriteMetadata) {
             return;
         }
 

--- a/ydb/core/protos/blobstorage_vdisk_internal.proto
+++ b/ydb/core/protos/blobstorage_vdisk_internal.proto
@@ -279,10 +279,10 @@ message THugeKeeperEntryPoint {
 }
 
 message TMetadataEntryPoint {
-    optional bool IsTinyDisk = 1;
+    reserved 1;
     optional uint32 HullCompLevel0MaxSstsAtOnce = 2;
     optional uint32 HullCompSortedPartsNum = 3;
-    optional uint32 HugeBlobOverhead = 4;
+    reserved 4;
 }
 
 message TChunkKeeperEntryPoint {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)
