### PR TITLE
There are too many TTopicClient instances

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -17,12 +17,14 @@ TTopicWorkloadWriterWorker::TTopicWorkloadWriterWorker(const TTopicWorkloadWrite
     Producers = std::vector<std::shared_ptr<TTopicWorkloadWriterProducer>>();
     Producers.reserve(Params.PartitionCount);
 
+    NTopic::TTopicClient topicClient(Params.Driver);
+
     for (ui32 i = 0; i < Params.PartitionCount; ++i) {
         // write to random partition, cause workload CLI tool can be launched in several instances
         // and they need to load test different partitions of the topic
         ui32 partitionId = (Params.PartitionSeed + i) % Params.PartitionCount;
 
-        Producers.push_back(CreateProducer(partitionId));
+        Producers.push_back(CreateProducer(partitionId, topicClient));
     }
 
     WRITE_LOG(Params.Log, ELogPriority::TLOG_DEBUG, TStringBuilder()
@@ -128,7 +130,8 @@ void TTopicWorkloadWriterWorker::Process(TInstant endTime) {
     );
 }
 
-std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::CreateProducer(ui64 partitionId) {
+std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::CreateProducer(ui64 partitionId,
+                                                                                         NTopic::TTopicClient& topicClient) {
     auto clock = NUnifiedAgent::TClock();
     auto producerId = TGUID::CreateTimebased().AsGuidString();
 
@@ -163,7 +166,7 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
 
     settings.DirectWriteToPartition(Params.Direct);
 
-    producer->SetWriteSession(NYdb::NTopic::TTopicClient(Params.Driver).CreateWriteSession(settings));
+    producer->SetWriteSession(topicClient.CreateWriteSession(settings));
 
     return producer;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -70,7 +70,8 @@ namespace NYdb {
             void Close();
             void CloseProducers();
 
-            std::shared_ptr<TTopicWorkloadWriterProducer> CreateProducer(ui64 partitionId);
+            std::shared_ptr<TTopicWorkloadWriterProducer> CreateProducer(ui64 partitionId,
+                                                                         NTopic::TTopicClient& topicClient);
 
             void WaitTillNextMessageExpectedCreateTimeAndContinuationToken(std::shared_ptr<TTopicWorkloadWriterProducer> producer);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

For each CreateProducer call, a TTopicClient instance was created. This is unnecessary, you can use a single instance.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
