### PR TITLE
Add x-user-ip header for AccessService request + tests

### DIFF
--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -55,6 +55,7 @@ namespace NKikimr::NHttpProxy {
             , Authorize(!context.Driver)
             , DatabasePath(CanonizePath(context.DatabasePath))
             , StreamName(context.StreamName)
+            , SourceAddress(context.SourceAddress)
         {
         }
 
@@ -179,12 +180,12 @@ namespace NKikimr::NHttpProxy {
 
                     ctx.Send(MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({.Signature = std::move(signature),
                                                                                                      .Database = DatabasePath,
-                                                                                                     .PeerName = "",
+                                                                                                     .PeerName = SourceAddress,
                                                                                                      .Entries = entries}));
                 } else {
                     ctx.Send(MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({.Ticket = IamToken,
                                                                                                      .Database = DatabasePath,
-                                                                                                     .PeerName = "",
+                                                                                                     .PeerName = SourceAddress,
                                                                                                      .Entries = entries}));
                 }
                 return;
@@ -312,6 +313,7 @@ namespace NKikimr::NHttpProxy {
         TString DatabaseId;
         TString DatabasePath;
         TString StreamName;
+        TString SourceAddress;
     };
 
     NActors::IActor* CreateIamAuthActor(const TActorId sender, THttpRequestContext& context, THolder<NKikimr::NSQS::TAwsRequestSignV4> signature)

--- a/ydb/core/http_proxy/ya.make
+++ b/ydb/core/http_proxy/ya.make
@@ -39,7 +39,6 @@ PEERDIR(
     yql/essentials/public/issue
     ydb/library/http_proxy/authorization
     ydb/library/http_proxy/error
-    ydb/library/testlib/service_mocks
     ydb/library/ycloud/api
     ydb/library/ycloud/impl
     ydb/library/naming_conventions

--- a/ydb/core/http_proxy/ya.make
+++ b/ydb/core/http_proxy/ya.make
@@ -39,6 +39,7 @@ PEERDIR(
     yql/essentials/public/issue
     ydb/library/http_proxy/authorization
     ydb/library/http_proxy/error
+    ydb/library/testlib/service_mocks
     ydb/library/ycloud/api
     ydb/library/ycloud/impl
     ydb/library/naming_conventions

--- a/ydb/core/kafka_proxy/ut/ya.make
+++ b/ydb/core/kafka_proxy/ut/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     ydb/core/kafka_proxy
     ydb/core/persqueue/ut/common
     ydb/core/testlib/default
+    ydb/library/testlib/service_mocks
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
 
 )

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -427,9 +427,12 @@ private:
             }
         }
 
+        auto& headers = request->Headers;
         if (record.IsLowRequestPriority) {
-            auto& headers = request->Headers;
             headers["x-ya-priority"] = "low";
+        }
+        if (!record.PeerName.empty()) {
+            headers["x-user-ip"] = record.PeerName;
         }
 
         return request;
@@ -525,6 +528,9 @@ private:
     template <typename TTokenRecord>
     void NebiusAccessServiceAuthorize(const TString& key, TTokenRecord& record) const {
         auto request = MakeHolder<TEvNebiusAccessServiceAuthorizeRequest>(key);
+        if (!record.PeerName.empty()) {
+            request->Headers["x-user-ip"] = record.PeerName;
+        }
         TStringBuilder requestForPermissions;
         i64 i = 0;
         for (const auto& [permissionName, permissionRecord] : record.Permissions) {
@@ -561,6 +567,9 @@ private:
     void NebiusAccessServiceAuthenticate(const TString& key, TTokenRecord& record) const {
         auto request = MakeHolder<TEvNebiusAccessServiceAuthenticateRequest>(key);
         request->Request.set_iam_token(record.Ticket);
+        if (!record.PeerName.empty()) {
+            request->Headers["x-user-ip"] = record.PeerName;
+        }
         Send(NebiusAccessServiceValidator, request.Release());
     }
 

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -2458,7 +2458,106 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_C(expireTimeCalledFlag,
             "Token expire time was not taken from the parser subclass override");
     }
-}
+
+    template <typename TAccessServiceMock, bool EnableBulkAuthorization = false>
+    void AuthorizationWithPeerName() {
+        using namespace Tests;
+
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        ui16 servicePort = tp.GetPort(4284);
+        TString accessServiceEndpoint = "localhost:" + ToString(servicePort);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        SetUseAccessService<TAccessServiceMock>(authConfig);
+        authConfig.SetUseAccessServiceApiKey(IsApiKeySupported<TAccessServiceMock>());
+        authConfig.SetUseAccessServiceTLS(false);
+        authConfig.SetAccessServiceEndpoint(accessServiceEndpoint);
+        authConfig.SetUseStaff(false);
+        auto settings = TServerSettings(port, authConfig);
+        settings.SetEnableAccessServiceBulkAuthorization(EnableBulkAuthorization);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+
+        TString userToken = "user1";
+        TString testPeerName = "192.168.1.100";
+
+        // Access Server Mock
+        TAccessServiceMock accessServiceMock;
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
+        std::unique_ptr<grpc::Server> accessServer(builder.BuildAndStart());
+
+        TTestActorRuntime* runtime = server.GetRuntime();
+        TActorId sender = runtime->AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+
+        if constexpr (IsNebiusAccessService<TAccessServiceMock>()) {
+            accessServiceMock.ContainerId = "aaaa1234";
+        }
+
+        // Authorization successful.
+        TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> entries = {
+            {{"something.read"}, {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}}}
+        };
+        runtime->Send(new IEventHandle(
+            MakeTicketParserID(), 
+            sender, 
+            new TEvTicketParser::TEvAuthorizeTicket(userToken, testPeerName, entries)
+        ), 0);
+        TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT(!result->HasError());
+        UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
+        UNIT_ASSERT(!result->Token->IsExist("something.write-bbbb4554@as"));
+        UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1@as");
+
+        // Verify that x-user-ip header was set with the correct value
+        UNIT_ASSERT_VALUES_EQUAL_C(accessServiceMock.CapturedXUserIP, testPeerName,
+                                   "Expected x-user-ip header to be '" << testPeerName 
+                                   << "' but got '" << accessServiceMock.CapturedXUserIP << "'");
+
+        accessServiceMock.CapturedXUserIP.clear();
+
+        // Authorization failure with not enough permissions.
+        entries = {
+            {{"something.write"}, {{"folder_id", "test_folder"}, {"database_id", "test_db"}}}
+        };
+        runtime->Send(new IEventHandle(
+            MakeTicketParserID(), 
+            sender, 
+            new TEvTicketParser::TEvAuthorizeTicket(userToken, testPeerName, entries)
+        ), 0);
+        result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT(result->HasError());
+        UNIT_ASSERT(!result->Error.Retryable);
+        UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
+
+        // Verify that x-user-ip header was set with the correct value
+        UNIT_ASSERT_VALUES_EQUAL_C(accessServiceMock.CapturedXUserIP, testPeerName,
+                                   "Expected x-user-ip header to be '" << testPeerName 
+                                   << "' but got '" << accessServiceMock.CapturedXUserIP << "'");
+    }
+
+    Y_UNIT_TEST(XUserIPHeaderIsSetInTicketParserAuthorization) {
+        AuthorizationWithPeerName<NKikimr::TAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(XUserIPHeaderIsSetInTicketParserBulkAuthorization) {
+        AuthorizationWithPeerName<TTicketParserAccessServiceMockV2, true>();
+    }
+
+    Y_UNIT_TEST(XUserIPHeaderIsSetInTicketParserNebiusAuthorization) {
+        AuthorizationWithPeerName<NKikimr::TNebiusAccessServiceMock>();
+    }
+} // Test suite TTicketParserTest
 
 Y_UNIT_TEST_SUITE(AuthorizeRequestToAccessService) {
 

--- a/ydb/library/ncloud/impl/ut/ya.make
+++ b/ydb/library/ncloud/impl/ut/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     ydb/core/testlib
     ydb/core/testlib/actors
     yql/essentials/sql/pg_dummy
+    ydb/library/testlib/service_mocks
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -78,7 +78,6 @@ public:
             const yandex::cloud::priv::servicecontrol::v1::AuthorizeRequest* request,
             yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse* response) override {
 
-        // Capture x-user-ip header
         CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         const TString& lastResourceId = request->resource_path(request->resource_path_size() - 1).id();
@@ -180,7 +179,6 @@ public:
 
         // Do not use authentication for "Authorize" handler
 
-        // Capture x-user-ip header
         CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         ++AuthorizeCount;
@@ -248,7 +246,6 @@ public:
                                  const ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeRequest* request,
                                  ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeResponse* response) {
 
-        // Capture x-user-ip header
         CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         if (!IsServiceAuthenticated(AllowedServiceAuthTokens, ctx)) {

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ydb/library/testlib/service_mocks/common.h"
+
 #include <ydb/public/api/client/yc_private/servicecontrol/access_service.grpc.pb.h>
 #include <ydb/public/api/client/yc_private/accessservice/access_service.grpc.pb.h>
 
@@ -38,6 +40,7 @@ public:
 
     THashMap<TString, TResponse<yandex::cloud::priv::servicecontrol::v1::AuthenticateResponse>> AuthenticateData;
     THashMap<TString, TResponse<yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse>> AuthorizeData;
+    TString CapturedXUserIP;
 
     template <class TResonseProto>
     void CheckRequestId(grpc::ServerContext* ctx, const TResponse<TResonseProto>& resp, const TString& token) {
@@ -74,6 +77,10 @@ public:
             grpc::ServerContext* ctx,
             const yandex::cloud::priv::servicecontrol::v1::AuthorizeRequest* request,
             yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse* response) override {
+
+        // Capture x-user-ip header
+        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+
         const TString& lastResourceId = request->resource_path(request->resource_path_size() - 1).id();
         const TString& token = request->signature().access_key_id() + request->iam_token() + "-" + request->permission() + "-" + lastResourceId;
         auto it = AuthorizeData.find(token);
@@ -164,13 +171,17 @@ public:
     THashMap<TString, TString> AllowedServicePermissions = {{"service1-something.write", "root1/folder1"}};
     THashSet<TString> AllowedResourceIds = {};
     THashSet<TString> UnavailableUserPermissions;
+    TString CapturedXUserIP;
 
     grpc::Status Authorize(
-            grpc::ServerContext*,
+            grpc::ServerContext* ctx,
             const yandex::cloud::priv::servicecontrol::v1::AuthorizeRequest* request,
             yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse* response) override {
 
         // Do not use authentication for "Authorize" handler
+
+        // Capture x-user-ip header
+        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         ++AuthorizeCount;
         if (request->has_signature()) {
@@ -230,13 +241,17 @@ public:
         "user1-monitoring.view"
     };
     THashMap<TString, TString> AllowedServicePermissions = {{"service1-something.write", "root1/folder1"}};
+    TString CapturedXUserIP;
 
 public:
-    ::grpc::Status BulkAuthorize(::grpc::ServerContext* context,
+    ::grpc::Status BulkAuthorize(::grpc::ServerContext* ctx,
                                  const ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeRequest* request,
                                  ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeResponse* response) {
 
-        if (!IsServiceAuthenticated(AllowedServiceAuthTokens, context)) {
+        // Capture x-user-ip header
+        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+
+        if (!IsServiceAuthenticated(AllowedServiceAuthTokens, ctx)) {
             return grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Unauthenticated service");
         }
 

--- a/ydb/library/testlib/service_mocks/common.cpp
+++ b/ydb/library/testlib/service_mocks/common.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+
+#include <grpcpp/server_context.h>
+
+namespace NTestUtils {
+
+TString CaptureXUserIP(grpc::ServerContext* ctx) {
+    const auto& meta = ctx->client_metadata();
+    const auto xUserIPHeaderRange = meta.equal_range("x-user-ip");
+    TString xUserIP;
+    for (auto it = xUserIPHeaderRange.first; it != xUserIPHeaderRange.second; ++it) {
+        xUserIP = TString(it->second.cbegin(), it->second.cend());
+    }
+    return xUserIP;
+}
+
+}  // namespace NTestUtils

--- a/ydb/library/testlib/service_mocks/common.h
+++ b/ydb/library/testlib/service_mocks/common.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+
+namespace NTestUtils {
+
+TString CaptureXUserIP(grpc::ServerContext* ctx);
+
+}  // namespace NTestUtils

--- a/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
@@ -52,7 +52,6 @@ public:
             const nebius::iam::v1::AuthorizeRequest* request,
             nebius::iam::v1::AuthorizeResponse* response) override {
         
-        // Capture x-user-ip header
         CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         UNIT_ASSERT_VALUES_EQUAL_C(request->checks_size(), 1, "Nebius access service mock does not support multiple checks yet");
@@ -207,7 +206,6 @@ public:
              << request->Utf8DebugString()
              << Endl;
 
-        // Capture x-user-ip header
         CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         ++AuthorizeCount;

--- a/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ydb/library/testlib/service_mocks/common.h"
+
 #include <ydb/public/api/client/nc_private/iam/v1/access_service.grpc.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -17,6 +19,7 @@ public:
 
     THashMap<TString, TResponse<nebius::iam::v1::AuthenticateResponse>> AuthenticateData;
     THashMap<TString, TResponse<nebius::iam::v1::AuthorizeResponse>> AuthorizeData;
+    TString CapturedXUserIP;
 
     template <class TResonseProto>
     void CheckRequestId(grpc::ServerContext* ctx, const TResponse<TResonseProto>& resp, const TString& token) {
@@ -48,6 +51,10 @@ public:
             grpc::ServerContext* ctx,
             const nebius::iam::v1::AuthorizeRequest* request,
             nebius::iam::v1::AuthorizeResponse* response) override {
+        
+        // Capture x-user-ip header
+        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+
         UNIT_ASSERT_VALUES_EQUAL_C(request->checks_size(), 1, "Nebius access service mock does not support multiple checks yet");
         const auto checkIt = request->checks().find(0);
         UNIT_ASSERT(checkIt != request->checks().end());
@@ -190,14 +197,18 @@ public:
     THashSet<TString> AllowedResourceIds;
     THashSet<TString> UnavailableUserPermissions;
     TString ContainerId;
+    TString CapturedXUserIP;
 
     grpc::Status Authorize(
-            grpc::ServerContext*,
+            grpc::ServerContext* ctx,
             const nebius::iam::v1::AuthorizeRequest* request,
             nebius::iam::v1::AuthorizeResponse* response) override {
         Cerr << "NebiusAccessService::Authorize request\n"
              << request->Utf8DebugString()
              << Endl;
+
+        // Capture x-user-ip header
+        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
 
         ++AuthorizeCount;
 

--- a/ydb/library/testlib/service_mocks/ya.make
+++ b/ydb/library/testlib/service_mocks/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 
 SRCS(
     access_service_mock.h
+    common.cpp
     datastreams_service_mock.h
     folder_service_transitional_mock.h
     folder_service_mock.h

--- a/ydb/library/ycloud/impl/ut/ya.make
+++ b/ydb/library/ycloud/impl/ut/ya.make
@@ -7,6 +7,7 @@ SIZE(MEDIUM)
 PEERDIR(
     library/cpp/retry
     ydb/core/testlib/default
+    ydb/library/testlib/service_mocks
 )
 
 YQL_LAST_ABI_VERSION()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add new X-user-IP header for AccessService requests. Also add this header for NebiusAS

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/34769
