### PR TITLE
[Backport stable-26-1] PR #35553: Fix check status of ticket parsing

### DIFF
--- a/ydb/core/base/ticket_parser.h
+++ b/ydb/core/base/ticket_parser.h
@@ -181,18 +181,30 @@ namespace NKikimr {
             TError Error;
             TIntrusiveConstPtr<NACLib::TUserToken> Token;
             const TString SerializedToken;
+            bool IsSuccess = false;
 
             TEvAuthorizeTicketResult(const TString& ticket, const TIntrusiveConstPtr<NACLib::TUserToken>& token)
                 : Ticket(ticket)
                 , Token(token)
                 , SerializedToken(token ? token->GetSerializedToken() : "")
+                , IsSuccess(true)
             {
             }
 
             TEvAuthorizeTicketResult(const TString& ticket, const TError& error)
                 : Ticket(ticket)
                 , Error(error)
+                , IsSuccess(false)
             {}
+
+            void SetError(const TError& error) {
+                Error = error;
+                IsSuccess = false;
+            }
+
+            bool HasError() const {
+                return !IsSuccess;
+            }
         };
 
         struct TEvRefreshTicket : TEventLocal<TEvRefreshTicket, EvRefreshTicket> {

--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -122,7 +122,7 @@ namespace NKikimr::NHttpProxy {
         }
 
         void HandleTicketParser(const TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const TActorContext& ctx) {
-            if (ev->Get()->Error) {
+            if (ev->Get()->HasError()) {
                 return ReplyWithError(ctx, ev->Get()->Error.Retryable ? NYdb::EStatus::UNAVAILABLE : NYdb::EStatus::UNAUTHORIZED, TString{ev->Get()->Error.Message});
             }
             ctx.Send(Sender, new TEvServerlessProxy::TEvToken(ev->Get()->Token->GetUserSID(), "", ev->Get()->SerializedToken, {"", DatabaseId, DatabasePath, CloudId, FolderId}));

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -180,7 +180,7 @@ void TKafkaSaslAuthActor::HandleLoginResult(TEvSasl::TEvSaslScramFinalServerResp
 }
 
 void TKafkaSaslAuthActor::Handle(NKikimr::TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const NActors::TActorContext& ctx) {
-    if (ev->Get()->Error) {
+    if (ev->Get()->HasError()) {
         if (Context->SaslMechanism == "SCRAM-SHA-256") {
             AuthResponse = NLogin::NSasl::BuildErrorMsg(NLogin::NSasl::EScramServerError::OtherError);
         }

--- a/ydb/core/local_pgwire/local_pgwire_auth_actor.cpp
+++ b/ydb/core/local_pgwire/local_pgwire_auth_actor.cpp
@@ -70,7 +70,7 @@ public:
     }
 
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev) {
-        if (ev->Get()->Error) {
+        if (ev->Get()->HasError()) {
             SendResponseAndDie(ev->Get()->Error.Message);
             return;
         }

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider_ut.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider_ut.cpp
@@ -595,7 +595,7 @@ void CheckRequiredLdapSettings(std::function<void(NKikimrProto::TLdapAuthenticat
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, expectedErrorMessage);
 }
 
@@ -617,7 +617,7 @@ void LdapFetchGroupsWithDefaultGroupAttributeGood(const ESecurityConnectionType&
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -659,7 +659,7 @@ Y_UNIT_TEST(CanFetchGroupsWithDefaultGroupAttributeDisableNestedGroups) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -685,7 +685,7 @@ Y_UNIT_TEST(CanFetchGroupsFromAdServer) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -711,7 +711,7 @@ Y_UNIT_TEST(CanFetchGroupsWithDisabledRequestToAD) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -737,7 +737,7 @@ Y_UNIT_TEST(CanFetchGroupsWithDefaultGroupAttributeUseListOfHosts) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -763,7 +763,7 @@ Y_UNIT_TEST(CanFetchGroupsWithCustomGroupAttribute) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -816,7 +816,7 @@ Y_UNIT_TEST(CanFetchGroupsWithDontExistGroupAttribute) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -838,7 +838,7 @@ Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserLogin) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
 }
@@ -856,7 +856,7 @@ Y_UNIT_TEST(CanNotFetchGroupsWithInvalidRobotUserPassword) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
 }
@@ -890,7 +890,7 @@ Y_UNIT_TEST(CanNotFetchGroupsWithRemovedUserCredentials) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, removedUserLogin, removedUserPassword);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
 }
 
@@ -907,7 +907,7 @@ Y_UNIT_TEST(CanNotFetchGroupsUseInvalidSearchFilter) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
 }
 
@@ -930,7 +930,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfo) {
     TAutoPtr<IEventHandle> handle;
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
     const auto& fetchedGroups = ticketParserResult->Token->GetGroupSIDs();
@@ -950,7 +950,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfo) {
     runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(loginResponse.Token)), 0);
     ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + "@ldap");
     const auto& newFetchedGroups = ticketParserResult->Token->GetGroupSIDs();
@@ -984,7 +984,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithDisabledNestedGroups) {
     TAutoPtr<IEventHandle> handle;
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
     const auto& fetchedGroups = ticketParserResult->Token->GetGroupSIDs();
@@ -1004,7 +1004,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithDisabledNestedGroups) {
     runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(loginResponse.Token)), 0);
     ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + "@ldap");
     const auto& newFetchedGroups = ticketParserResult->Token->GetGroupSIDs();
@@ -1043,7 +1043,7 @@ Y_UNIT_TEST(CanNotRefreshRemovedUser) {
     TAutoPtr<IEventHandle> handle;
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -1064,7 +1064,7 @@ Y_UNIT_TEST(CanNotRefreshRemovedUser) {
     runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(loginResponse.Token)), 0);
     ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT_EQUAL(ticketParserResult->Error.Retryable, false);
@@ -1095,7 +1095,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithError) {
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
     // Server is busy, return retryable error
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Expected return error message");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Expected return error message");
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
     UNIT_ASSERT_STRINGS_EQUAL(ticketParserResult->Error.Message, "Could not login via LDAP");
     UNIT_ASSERT_EQUAL(ticketParserResult->Error.Retryable, true);
@@ -1108,7 +1108,7 @@ Y_UNIT_TEST(CanRefreshGroupsInfoWithError) {
     ticketParserResult = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
     // After refresh ticket, server return success
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -1168,7 +1168,7 @@ Y_UNIT_TEST(CanFetchGroupsWithDelayUpdateSecurityState) {
     TAutoPtr<IEventHandle> handle;
     runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -1207,7 +1207,7 @@ Y_UNIT_TEST(CanGetErrorIfAppropriateLoginProviderIsAbsent) {
     TAutoPtr<IEventHandle> handle;
     runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT(!ticketParserResult->Error.empty());
+    UNIT_ASSERT(ticketParserResult->HasError());
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Message, "Login state is not available", ticketParserResult->Error);
     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Retryable, false, ticketParserResult->Error.Retryable);
@@ -1241,7 +1241,7 @@ Y_UNIT_TEST(CanFetchGroupsWithValidCredentialsUseExternalSaslAuth) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(ticketParserResult->Error.empty(), ticketParserResult->Error);
+    UNIT_ASSERT_C(!ticketParserResult->HasError(), ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token != nullptr);
     const TString ldapDomain = "@ldap";
     UNIT_ASSERT_VALUES_EQUAL(ticketParserResult->Token->GetUserSID(), login + ldapDomain);
@@ -1283,7 +1283,7 @@ Y_UNIT_TEST(CanNotFetchGroupsOverSaslExternalWithoutClientCert) {
     ldapServer.Start();
     TAutoPtr<IEventHandle> handle = LdapAuthenticate(ydbServer, login, password);
     TEvTicketParser::TEvAuthorizeTicketResult* ticketParserResult = handle->Get<TEvTicketParser::TEvAuthorizeTicketResult>();
-    UNIT_ASSERT_C(!ticketParserResult->Error.empty(), "Should be error");
+    UNIT_ASSERT_C(ticketParserResult->HasError(), "Should be error");
     UNIT_ASSERT_EQUAL_C(ticketParserResult->Error.Message, "Could not login via LDAP", ticketParserResult->Error);
     UNIT_ASSERT(ticketParserResult->Token == nullptr);
 }

--- a/ydb/core/security/login_page.cpp
+++ b/ydb/core/security/login_page.cpp
@@ -272,7 +272,7 @@ public:
 
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev) {
         const TEvTicketParser::TEvAuthorizeTicketResult& result = *ev->Get();
-        if (result.Error) {
+        if (result.HasError()) {
             return ReplyErrorAndPassAway("403", "Forbidden", result.Error.Message);
         }
         if (result.Token == nullptr) {

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -39,7 +39,7 @@ private:
     }
 
     void ProcessAuthorizeTicketResult(THolder<TEvTicketParser::TEvAuthorizeTicketResult> result, const TActorContext& ctx) {
-        if (!result->Error.empty()) {
+        if (result->HasError()) {
             if (IsTokenRequired()) {
                 return static_cast<TDerived*>(this)->OnAccessDenied(result->Error, ctx);
             }

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -113,7 +113,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
     }
@@ -160,7 +160,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -212,7 +212,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             TAutoPtr<IEventHandle> handle;
 
             TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(!result->HasError());
             UNIT_ASSERT(result->Token != nullptr);
             UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
             UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -243,7 +243,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             TAutoPtr<IEventHandle> handle;
 
             TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT(result->Error.empty());
+            UNIT_ASSERT(!result->HasError());
             UNIT_ASSERT(result->Token != nullptr);
             UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
             UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -294,7 +294,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Token == nullptr);
         UNIT_ASSERT_EQUAL_C(result->Error.Message, "Login state is not available", result->Error);
         UNIT_ASSERT_EQUAL_C(result->Error.Retryable, false, result->Error.Retryable);
@@ -334,7 +334,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Token is not in correct format");
     }
 
@@ -381,7 +381,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -397,7 +397,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -415,7 +415,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -470,7 +470,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(!result->Error.empty(), "Expected return error message");
+        UNIT_ASSERT_C(result->HasError(), "Expected return error message");
         UNIT_ASSERT(result->Token == nullptr);
         UNIT_ASSERT_STRINGS_EQUAL(result->Error.Message, "Security state is empty");
         UNIT_ASSERT_EQUAL(result->Error.Retryable, true);
@@ -483,7 +483,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -533,7 +533,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1");
         UNIT_ASSERT(result->Token->IsExist("group1"));
@@ -549,7 +549,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
 
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT_EQUAL(result->Error.Message, "User not found");
         UNIT_ASSERT(result->Token == nullptr);
     }
@@ -591,7 +591,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         TAutoPtr<IEventHandle> handle;
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Token == nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Ticket is empty");
     }
@@ -627,7 +627,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("C=RU,ST=MSK,L=MSK,O=YA,OU=UtTest,CN=localhost@cert"), result->Token->ShortDebugString());
         const auto& groups = result->Token->GetGroupSIDs();
         const std::unordered_set<TString> groupsSet(groups.cbegin(), groups.cend());
@@ -666,7 +666,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(!result->Error.empty(), "Expected return error message");
+        UNIT_ASSERT_C(result->HasError(), "Expected return error message");
         UNIT_ASSERT_STRINGS_EQUAL(result->Error.Message, "Cannot create token from certificate. Client`s certificate and server`s certificate have different issuers");
         UNIT_ASSERT(result->Token == nullptr);
     }
@@ -717,7 +717,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("C=RU,ST=MSK,L=MSK,O=YA,OU=UtTest,CN=localhost@cert"), result->Token->ShortDebugString());
         const auto& groups = result->Token->GetGroupSIDs();
         const std::unordered_set<TString> groupsSet(groups.cbegin(), groups.cend());
@@ -770,7 +770,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("C=RU,ST=MSK,L=MSK,O=YA,OU=UtTest,CN=localhost@cert"), result->Token->ShortDebugString());
         const auto& groups = result->Token->GetGroupSIDs();
         const std::unordered_set<TString> groupsSet(groups.cbegin(), groups.cend());
@@ -821,7 +821,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(!result->Error.empty(), "Expected return error message");
+        UNIT_ASSERT_C(result->HasError(), "Expected return error message");
         UNIT_ASSERT_STRINGS_EQUAL(result->Error.Message, "Cannot create token from certificate. Client certificate failed verification");
         UNIT_ASSERT(result->Token == nullptr);
     }
@@ -865,7 +865,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("C=RU,ST=MSK,L=MSK,O=YA,OU=UtTest,CN=localhost@cert"), result->Token->ShortDebugString());
         const auto& groups = result->Token->GetGroupSIDs();
         const std::unordered_set<TString> groupsSet(groups.cbegin(), groups.cend());
@@ -909,7 +909,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(!result->Error.empty(), "Expected return error message");
+        UNIT_ASSERT_C(result->HasError(), "Expected return error message");
         UNIT_ASSERT_STRINGS_EQUAL(result->Error.Message, "Cannot create token from certificate. Client certificate failed verification");
         UNIT_ASSERT(result->Token == nullptr);
     }
@@ -954,7 +954,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(!result->Error.empty(), "Expected return error message");
+        UNIT_ASSERT_C(result->HasError(), "Expected return error message");
         UNIT_ASSERT_STRINGS_EQUAL(result->Error.Message, "Cannot create token from certificate. Client certificate failed verification");
         UNIT_ASSERT(result->Token == nullptr);
     }
@@ -997,7 +997,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_VALUES_EQUAL(accessServiceMock.AuthorizeCount.load(), 0);
         UNIT_ASSERT_VALUES_EQUAL(accessServiceMock.AuthenticateCount.load(), 1);
         UNIT_ASSERT_VALUES_EQUAL(result->Ticket, userToken);
@@ -1051,7 +1051,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         TAutoPtr<IEventHandle> handle;
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
     }
 
     Y_UNIT_TEST(AuthenticationWithUserAccount) {
@@ -1104,7 +1104,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(userToken)), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "login1@passport");
     }
 
@@ -1149,7 +1149,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         accessServiceMock.UnavailableTokens.insert(userToken);
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(userToken)), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
         UNIT_ASSERT_VALUES_EQUAL(accessServiceMock.AuthorizeCount.load(), 0);
@@ -1213,7 +1213,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket("user1")), 0);
         }
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
 
@@ -1227,7 +1227,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket("user1")), 0);
         }
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1@as");
         UNIT_ASSERT_VALUES_EQUAL(accessServiceMock.AuthorizeCount.load(), 0);
@@ -1291,7 +1291,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(TString("user1"))), 0);
         }
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
 
@@ -1303,7 +1303,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
             runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(TString("user1"))), 0);
         }
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1@as");
         UNIT_ASSERT_VALUES_EQUAL(accessServiceMock.AuthorizeCount.load(), 0);
@@ -1374,7 +1374,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         }
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
 
@@ -1389,7 +1389,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         }
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1@as");
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
@@ -1464,7 +1464,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         }
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
 
@@ -1477,7 +1477,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         }
 
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token != nullptr);
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "user1@as");
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
@@ -1537,7 +1537,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         accessServiceMock.UnavailableTokens.insert(userToken);
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(userToken)), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Token is not supported");
     }
@@ -1584,7 +1584,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(std::move(signature), "", {})), 0);
 
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access key signature is not supported");
     }
@@ -1629,7 +1629,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         accessServiceMock.UnavailableTokens.insert(userToken);
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(userToken)), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Unknown token");
     }
@@ -1685,7 +1685,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            attrs,
                                            {"something.read"})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
         UNIT_ASSERT_C(!result->Token->IsExist("something.write-bbbb4554@as"), result->Token->ShortDebugString());
@@ -1696,7 +1696,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            attrs,
                                            {"something.read", "something.connect", "something.list", "something.update"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
         UNIT_ASSERT_C(result->Token->IsExist("something.connect-bbbb4554@as"), result->Token->ShortDebugString());
@@ -1710,7 +1710,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             attrs,
                                             {"something.read"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(!result->HasError(), result->Error);
             UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
             UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
             UNIT_ASSERT_C(!result->Token->IsExist("something.write-bbbb4554@as"), result->Token->ShortDebugString());
@@ -1724,7 +1724,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            attrs,
                                            {"something.read", "read.something", "something.connect", "something.list", "something.update"})), 0);
             TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(!result->Error.empty(), result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->HasError(), result->Token->ShortDebugString());
 
             // switch off this check
             accessServiceMock.ContainerId = "";
@@ -1736,7 +1736,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.write"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
         UNIT_ASSERT(!result->Error.Retryable);
 
@@ -1746,7 +1746,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
         UNIT_ASSERT_C(!result->Token->IsExist("something.write-bbbb4554@as"), result->Token->ShortDebugString());
@@ -1757,7 +1757,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
 
@@ -1767,7 +1767,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
 
@@ -1778,7 +1778,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "XXXXXXXX"}, {"database_id", "XXXXXXXX"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
 
@@ -1792,7 +1792,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "XXXXXXXX"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-XXXXXXXX@as"), result->Token->ShortDebugString());
 
@@ -1809,7 +1809,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "XXXXXXXX"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(!result->HasError(), result->Error);
         UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
 
@@ -1822,7 +1822,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             {{"gizmo_id", "gizmo"}, },
                                             {"monitoring.view"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(!result->HasError(), result->Error);
             UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
             UNIT_ASSERT_VALUES_EQUAL_C(result->Token->GetGroupSIDs().size(), 4, result->Token->ShortDebugString());
             UNIT_ASSERT_C(result->Token->IsExist("all-users@well-known"), result->Token->ShortDebugString());
@@ -1838,7 +1838,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             {{"folder_id", "folder"}, },
                                             {"monitoring.view"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(!result->HasError(), result->Error);
             UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
             UNIT_ASSERT_VALUES_EQUAL_C(result->Token->GetGroupSIDs().size(), 3, result->Token->ShortDebugString());
             UNIT_ASSERT_C(result->Token->IsExist("all-users@well-known"), result->Token->ShortDebugString());
@@ -1866,7 +1866,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             serviceAttrs,
                                             {"something.write"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(!result->HasError(), result->Error);
             UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_SERVICE);
             UNIT_ASSERT_C(result->Token->IsExist("service1@as"), result->Token->ShortDebugString());
 
@@ -1882,7 +1882,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             serviceAttrs,
                                             {"something.write"})), 0);
                 result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-                UNIT_ASSERT_C(result->Error.empty(), result->Error);
+                UNIT_ASSERT_C(!result->HasError(), result->Error);
                 UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_SERVICE);
                 UNIT_ASSERT_C(result->Token->IsExist("service2@as"), result->Token->ShortDebugString());
 
@@ -1901,7 +1901,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             serviceAttrs,
                                             {"something.write"})), 0);
                 result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-                UNIT_ASSERT_C(result->Error.empty(), result->Error);
+                UNIT_ASSERT_C(!result->HasError(), result->Error);
                 UNIT_ASSERT_EQUAL(result->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_SERVICE_IMPERSONATED_FROM_USER);
                 UNIT_ASSERT_C(result->Token->IsExist("service3@as"), result->Token->ShortDebugString());
             }
@@ -1968,7 +1968,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            TVector<TEvTicketParser::TEvAuthorizeTicket::TPermission>{TEvTicketParser::TEvAuthorizeTicket::Optional("something.read"), TEvTicketParser::TEvAuthorizeTicket::Optional("something.write")})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(!result->Token->IsExist("something.write-bbbb4554@as"));
 
@@ -1978,7 +1978,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            TVector<TEvTicketParser::TEvAuthorizeTicket::TPermission>{TEvTicketParser::TEvAuthorizeTicket::Optional("something.read"), TEvTicketParser::TEvAuthorizeTicket::Required("something.write")})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_STRING_CONTAINS(result->Error.Message, "something.write for ");
         UNIT_ASSERT_STRING_CONTAINS(result->Error.Message, "aaaa1234");
@@ -2055,7 +2055,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(!result->Token->IsExist("something.write-bbbb4554@as"));
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "login1@passport");
@@ -2066,7 +2066,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.write"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(!result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Access Denied");
 
@@ -2076,7 +2076,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(!result->Token->IsExist("something.write-bbbb4554@as"));
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetUserSID(), "login1@passport");
@@ -2089,7 +2089,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            TVector<TString>{"something.read", "something.write"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         // placemark 1
         UNIT_ASSERT(result->Token->IsExist("something.write-bbbb4554@as"));
@@ -2164,7 +2164,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.list", "something.read", "something.write", "something.eat", "somewhere.sleep"})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(!result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(!result->Token->IsExist("something.list-bbbb4554@as"));
         UNIT_ASSERT(result->Token->IsExist("something.write-bbbb4554@as"));
@@ -2226,7 +2226,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            TVector<TString>{"something.read", "something.write"})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(!result->Error.empty());
+        UNIT_ASSERT(result->HasError());
         UNIT_ASSERT(result->Error.Retryable);
         UNIT_ASSERT_VALUES_EQUAL(result->Error.Message, "Service Unavailable");
     }
@@ -2288,7 +2288,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            {"something.read"})), 0);
         TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(!result->Token->IsExist("something.write-bbbb4554@as"));
 
@@ -2301,7 +2301,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                            {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
                                            TVector<TString>{"something.read", "something.write"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT(result->Error.empty());
+        UNIT_ASSERT(!result->HasError());
         UNIT_ASSERT(result->Token->IsExist("something.read-bbbb4554@as"));
         UNIT_ASSERT(result->Token->IsExist("something.write-bbbb4554@as"));
     }
@@ -2316,6 +2316,58 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
     Y_UNIT_TEST(NebiusAuthorizationModify) {
         AuthorizationModify<NKikimr::TNebiusAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(CanProperHandleErrorWithEmptyMessage) {
+        using namespace Tests;
+
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        ui16 servicePort = tp.GetPort(4284);
+        TString accessServiceEndpoint = "localhost:" + ToString(servicePort);
+        NKikimrProto::TAuthConfig authConfig;
+        authConfig.SetUseBlackBox(false);
+        SetUseAccessService<TAccessServiceMock>(authConfig);
+        authConfig.SetUseAccessServiceTLS(false);
+        authConfig.SetAccessServiceEndpoint(accessServiceEndpoint);
+        authConfig.SetUseStaff(false);
+        auto settings = TServerSettings(port, authConfig);
+        settings.SetEnableAccessServiceBulkAuthorization(true);
+        settings.SetDomainName("Root");
+        settings.CreateTicketParser = NKikimr::CreateTicketParser;
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TICKET_PARSER, NLog::PRI_TRACE);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
+        TClient client(settings);
+        NClient::TKikimr kikimr(client.GetClientConfig());
+        client.InitRootScheme();
+
+        TString userToken = "user1";
+
+        // Access Server Mock
+        TTicketParserAccessServiceMockV2 accessServiceMock;
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
+        std::unique_ptr<grpc::Server> accessServer(builder.BuildAndStart());
+
+        accessServiceMock.isUserAuthenticated = false;
+        accessServiceMock.UnauthenticatedErrorMessage = ""; // Empty error message
+
+        TTestActorRuntime* runtime = server.GetRuntime();
+        TActorId sender = runtime->AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+
+        // Authorization unsuccessfull.
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
+                                           userToken,
+                                           {{"folder_id", "aaaa1234"}, {"database_id", "bbbb4554"}},
+                                           TVector<TString>{"something.read", "something.write"})), 0);
+        TEvTicketParser::TEvAuthorizeTicketResult* result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT_C(result->HasError(), result->Error.Message);
+        UNIT_ASSERT_STRINGS_EQUAL_C(result->Error.Message, "", result->Error.Message);
+        UNIT_ASSERT(!result->Error.Retryable);
     }
 }
 
@@ -2478,7 +2530,7 @@ Y_UNIT_TEST(CanAuthorizeYdbInAccessService) {
                                         {"something.read"})));
         authorizeTicketResultEv = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
     }
-    UNIT_ASSERT_C(authorizeTicketResultEv->Error.empty(), authorizeTicketResultEv->Error);
+    UNIT_ASSERT_C(!authorizeTicketResultEv->HasError(), authorizeTicketResultEv->Error);
     UNIT_ASSERT_EQUAL_C(authorizeTicketResultEv->Token->GetUserSID(), "user1@as", authorizeTicketResultEv->Token->GetUserSID());
     UNIT_ASSERT_EQUAL(authorizeTicketResultEv->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
     UNIT_ASSERT_C(authorizeTicketResultEv->Token->IsExist("something.read-bbbb4554@as"), authorizeTicketResultEv->Token->ShortDebugString());
@@ -2561,7 +2613,7 @@ Y_UNIT_TEST(CanRefreshTokenForAccessService) {
                                             {"something.read"})));
             authorizeTicketResultEv = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         }
-        UNIT_ASSERT_C(authorizeTicketResultEv->Error.empty(), authorizeTicketResultEv->Error);
+        UNIT_ASSERT_C(!authorizeTicketResultEv->HasError(), authorizeTicketResultEv->Error);
         UNIT_ASSERT_EQUAL_C(authorizeTicketResultEv->Token->GetUserSID(), "user1@as", authorizeTicketResultEv->Token->GetUserSID());
         UNIT_ASSERT_EQUAL(authorizeTicketResultEv->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(authorizeTicketResultEv->Token->IsExist("something.read-bbbb4554@as"), authorizeTicketResultEv->Token->ShortDebugString());
@@ -2594,7 +2646,7 @@ Y_UNIT_TEST(CanRefreshTokenForAccessService) {
                                             {"something.read"})));
             authorizeTicketResultEv = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         }
-        UNIT_ASSERT_C(authorizeTicketResultEv->Error.empty(), authorizeTicketResultEv->Error);
+        UNIT_ASSERT_C(!authorizeTicketResultEv->HasError(), authorizeTicketResultEv->Error);
         UNIT_ASSERT_EQUAL_C(authorizeTicketResultEv->Token->GetUserSID(), "user2@as", authorizeTicketResultEv->Token->GetUserSID());
         UNIT_ASSERT_EQUAL(authorizeTicketResultEv->Token->GetSubjectType(), NACLibProto::ESubjectType::SUBJECT_TYPE_USER);
         UNIT_ASSERT_C(authorizeTicketResultEv->Token->IsExist("something.read-bbbb4554@as"), authorizeTicketResultEv->Token->ShortDebugString());

--- a/ydb/core/tx/tx_proxy/schemereq_ut.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq_ut.cpp
@@ -322,7 +322,7 @@ void CreateLocalUser2(TTestEnv& env, const TString& database, const TString& nam
         auto event = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         Cerr << __FUNCTION__ << " grab ticket_parser result" << Endl;
 
-        UNIT_ASSERT_C(event->Error.empty(), event->Error);
+        UNIT_ASSERT_C(!event->HasError(), event->Error);
         UNIT_ASSERT(event->Token != nullptr);
         userToken = event->Token->SerializeAsString();
     }
@@ -370,7 +370,7 @@ void CreateLocalGroup2(TTestEnv& env, const TString& database, const TString& na
         auto event = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         Cerr << __FUNCTION__ << " grab ticket_parser result" << Endl;
 
-        UNIT_ASSERT_C(event->Error.empty(), event->Error);
+        UNIT_ASSERT_C(!event->HasError(), event->Error);
         UNIT_ASSERT(event->Token != nullptr);
         userToken = event->Token->SerializeAsString();
     }

--- a/ydb/core/ymq/actor/action.h
+++ b/ydb/core/ymq/actor/action.h
@@ -736,7 +736,7 @@ private:
 
     void HandleTicketParserResponse(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev) {
         const TEvTicketParser::TEvAuthorizeTicketResult& result(*ev->Get());
-        if (!result.Error.empty()) {
+        if (result.HasError()) {
             RLOG_SQS_ERROR("Got ticket parser error: " << result.Error << ". " << Action_ << " was rejected");
             MakeError(MutableErrorDesc(), NErrors::ACCESS_DENIED);
             SendReplyAndDie();

--- a/ydb/core/ymq/actor/auth_multi_factory.cpp
+++ b/ydb/core/ymq/actor/auth_multi_factory.cpp
@@ -250,7 +250,7 @@ void TBaseCloudAuthRequestProxy::ProcessAuthorizationResult(const TEvTicketParse
         Counters_.AuthorizeDuration->Collect((TActivationContext::Now() - AuthorizeRequestStartTimestamp_).MilliSeconds());
     });
 
-    if (result.Error) {
+    if (result.HasError()) {
         if (CanRetry() && result.Error.Retryable) {
             ScheduleAuthorizationRetry();
         } else {
@@ -411,11 +411,15 @@ void TBaseCloudAuthRequestProxy::Authorize() {
     } else {
         TEvTicketParser::TEvAuthorizeTicketResult result("fake_token", nullptr);
         if (AccessKeySignature_ && AccessKeySignature_->AccessKeyId.empty()) {
-            result.Error.Message = "mocked_auth_error: empty access key";
-            result.Error.Retryable = false;
+            result.SetError({
+                .Message = "mocked_auth_error: empty access key",
+                .Retryable = false
+            });
         } else if (AccessKeySignature_ && AccessKeySignature_->AccessKeyId == "TEST_ID_FOR_RETRYIES") {
-            result.Error.Message = "mocked_auth_error: correct process retries";
-            result.Error.Retryable = true;
+            result.SetError({
+                .Message = "mocked_auth_error: correct process retries",
+                .Retryable = true
+            });
         } else {
             result.Token = MakeIntrusive<NACLib::TUserToken>("fake_user_sid@as", TVector<TString>());
         }

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -220,6 +220,7 @@ public:
     bool ShouldGenerateOneRetryableError = false;
     bool isUserAuthenticated = true;
 
+    TString UnauthenticatedErrorMessage = "User is unauthenticated";
     THashSet<TString> AllowedServiceAuthTokens;
     THashSet<TString> UnavailableUserPermissions;
     THashSet<TString> AllowedResourceIds;
@@ -234,6 +235,7 @@ public:
     ::grpc::Status BulkAuthorize(::grpc::ServerContext* context,
                                  const ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeRequest* request,
                                  ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeResponse* response) {
+
         if (!IsServiceAuthenticated(AllowedServiceAuthTokens, context)) {
             return grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Unauthenticated service");
         }
@@ -253,7 +255,7 @@ public:
         } else {
             if (!isUserAuthenticated) {
                 auto error = response->mutable_unauthenticated_error();
-                error->set_message("User is unauthenticated");
+                error->set_message(UnauthenticatedErrorMessage);
                 return grpc::Status(grpc::StatusCode::OK, "OK");
             }
             TString token = request->has_iam_token() ? request->iam_token() : request->api_key();

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -812,9 +812,9 @@ void TReadSessionActor::Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& 
     TString ticket = ev->Get()->Ticket;
     TString maskedTicket = ticket.size() > 5 ? (ticket.substr(0, 5) + "***" + ticket.substr(ticket.size() - 5)) : "***";
     LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, "CheckACL ticket " << maskedTicket << " got result from TICKET_PARSER response: error: " << ev->Get()->Error << " user: "
-                            << (ev->Get()->Error.empty() ? ev->Get()->Token->GetUserSID() : ""));
+                            << (!ev->Get()->HasError() ? ev->Get()->Token->GetUserSID() : ""));
 
-    if (!ev->Get()->Error.empty()) {
+    if (ev->Get()->HasError()) {
         CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
         return;
     }

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_write_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_write_actor.cpp
@@ -451,9 +451,9 @@ void TWriteSessionActor::Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr&
     TString maskedTicket = ticket.size() > 5 ? (ticket.substr(0, 5) + "***" + ticket.substr(ticket.size() - 5)) : "***";
     LOG_INFO_S(ctx, NKikimrServices::PQ_WRITE_PROXY, "CheckACL ticket " << maskedTicket << " got result from TICKET_PARSER response: error: "
                             << ev->Get()->Error << " user: "
-                            << (ev->Get()->Error.empty() ? ev->Get()->Token->GetUserSID() : ""));
+                            << (!ev->Get()->HasError() ? ev->Get()->Token->GetUserSID() : ""));
 
-    if (!ev->Get()->Error.empty()) {
+    if (ev->Get()->HasError()) {
         CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
         return;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed that EvAuthorizeTicketRelust::Error is considered an error only if there is a text Message

### Changelog category <!-- remove all except one -->

* Improvement 

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/32788