### PR TITLE
rules for remove unneeded file from index for account with limit of indexed files

### DIFF
--- a/.cursorindexingignore-personal
+++ b/.cursorindexingignore-personal
@@ -1,0 +1,38 @@
+# This file contains cursorindexingignore rules for accounts where
+# the indexing limit is lower than the project size.
+#
+# If you hit the Cursor indexing file limit, create a symlink:
+#   ln -sf .cursorindexingignore-personal .cursorindexingignore
+
+# .cpp/.cc/.c files from directories forbidden for modification (see AGENTS.md).
+# .h/.hpp files are kept so the agent can see types and interfaces.
+/library/**/*.cpp
+/library/**/*.cc
+/library/**/*.c
+/util/**/*.cpp
+/util/**/*.cc
+/util/**/*.c
+
+# Go dependencies
+/contrib/go/
+/vendor/
+
+# Python dependencies
+/contrib/python/
+!/contrib/python/ydb/
+
+# Large dependencies
+/contrib/libs/llvm16/
+/contrib/tools/
+/contrib/libs/linux-headers/
+/contrib/restricted/grpc_py2/
+/contrib/libs/cxxsupp/	
+/contrib/restricted/boost/	
+
+# Test and temporary files
+**/canondata/
+*.yqls
+*.result
+*.out
+*.err
+*.report

--- a/.cursorindexingignore-personal
+++ b/.cursorindexingignore-personal
@@ -17,9 +17,10 @@
 /contrib/go/
 /vendor/
 
-# Python dependencies
-/contrib/python/
-!/contrib/python/ydb/
+# Python dependencies, exclude files with extension only for prevent ignore directories
+# and allow return some dependencies to index with ! pattern
+/contrib/python/**/*.* 
+!/contrib/python/ydb/**
 
 # Large dependencies
 /contrib/libs/llvm16/

--- a/.cursorindexingignore-personal
+++ b/.cursorindexingignore-personal
@@ -4,7 +4,7 @@
 # If you hit the Cursor indexing file limit, create a symlink:
 #   ln -sf .cursorindexingignore-personal .cursorindexingignore
 
-# .cpp/.cc/.c files from directories forbidden for modification (see AGENTS.md).
+# .cpp/.cc/.c files from library/util implementation directories are excluded from indexing.
 # .h/.hpp files are kept so the agent can see types and interfaces.
 /library/**/*.cpp
 /library/**/*.cc
@@ -26,8 +26,8 @@
 /contrib/tools/
 /contrib/libs/linux-headers/
 /contrib/restricted/grpc_py2/
-/contrib/libs/cxxsupp/	
-/contrib/restricted/boost/	
+/contrib/libs/cxxsupp/
+/contrib/restricted/boost/
 
 # Test and temporary files
 **/canondata/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 
 /CHANGELOG.md @ydb-platform/changelog-reviewers
 
+/.cursorindexingignore-personal @ydb-platform/ai-reviewers
 /AGENTS.md @ydb-platform/ai-reviewers
 
 /BUILD.md @ydb-platform/ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,13 @@
 
 /CHANGELOG.md @ydb-platform/changelog-reviewers
 
-/.cursorindexingignore-personal @ydb-platform/ai-reviewers
 /AGENTS.md @ydb-platform/ai-reviewers
 
 /BUILD.md @ydb-platform/ci
 
 /CLAUDE.md @ydb-platform/ai-reviewers
 
+/.cursorindexingignore-personal @ydb-platform/ai-reviewers
 /.github/docker @ydb-platform/appteam
 
 /build @ydb-platform/ci

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ path.bash.inc
 # Cursor ignore
 .cursor/
 .cursorignore
+.cursorindexingignore
 
 # Claude Code
 .claude/


### PR DESCRIPTION
### Changelog entry

Added a template to exclude unimportant files from the Cursor index.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers 

Cursor plans for individual users are limited to 100,000 files for codebase indexing. The YDB repository contains about 140,000 files. This template allows excluding low-priority files from indexing, so search can focus on the main YDB codebase. 

`.cursorindexignore` skips these files during indexing but still allows agents to read them, unlike `.cursorignore`.  https://cursor.com/docs/reference/ignore-file#cursorindexingignore