### PR TITLE
Add retries for uncovered HTTP response codes in s3 import/export

### DIFF
--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -648,7 +648,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
             UploadId.Clear(); // force getting info after restart
             Retry();
         } else {
-            Error = error.GetMessage().c_str();
+            Error = TStringBuilder() << error;
             this->PassAway();
         }
     }

--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -704,7 +704,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
         if (CanRetry(error)) {
             Retry();
         } else {
-            Finish(false, TStringBuilder() << "S3 error: " << error.GetMessage().c_str());
+            Finish(false, TStringBuilder() << "S3 error: " << error);
         }
     }
 

--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -648,7 +648,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
             UploadId.Clear(); // force getting info after restart
             Retry();
         } else {
-            Error = TStringBuilder() << error;
+            Error = TStringBuilder() << "S3 error: " << error;
             this->PassAway();
         }
     }

--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -671,7 +671,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
         } else {
             Y_ENSURE(Error);
             Error = TStringBuilder() << *Error << " Additionally, 'AbortMultipartUpload' has failed: "
-                << error.GetMessage();
+                << error;
             this->PassAway();
         }
     }

--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -1023,7 +1023,7 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
         } else {
             if constexpr (std::is_same_v<T, Aws::S3::S3Error>) {
                 Finish(false, TStringBuilder() << Settings.GetDataKey(DataFormat, CompressionCodec)
-                    << ": S3 error: " << error.GetMessage().c_str());
+                    << ": S3 error: " << error);
             } else {
                 Finish(false, TStringBuilder() << Settings.GetDataKey(DataFormat, CompressionCodec)
                     << ": " << error);

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -154,7 +154,7 @@ protected:
             Delay = Min(Delay * ++Attempt, MaxDelay);
             this->Schedule(Delay, new TEvents::TEvWakeup());
         } else {
-            Reply(shouldRetry ? Ydb::StatusIds::EXTERNAL_ERROR : Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "S3 error: " << error.GetMessage().c_str());
+            Reply(shouldRetry ? Ydb::StatusIds::EXTERNAL_ERROR : Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "S3 error: " << error);
         }
     }
 

--- a/ydb/core/wrappers/events/s3_out.cpp
+++ b/ydb/core/wrappers/events/s3_out.cpp
@@ -56,7 +56,7 @@ void OutOutcome(IOutputStream& out, const Aws::Utils::Outcome<T, Aws::S3::S3Erro
     if (outcome.IsSuccess()) {
         out << outcome.GetResult();
     } else {
-        out << outcome.GetError().GetMessage().c_str();
+        out << outcome.GetError();
     }
 }
 
@@ -218,6 +218,10 @@ void Out(IOutputStream& out, const CompletedPart& part) {
 
 void Out(IOutputStream& out, const TStringOutcome& outcome) {
     OutOutcome(out, outcome);
+}
+
+void Out(IOutputStream& out, const Aws::S3::S3Error& error) {
+    out << static_cast<int>(error.GetResponseCode()) << " " << error.GetMessage().c_str();
 }
 
 } // NKikimr::NWrappers

--- a/ydb/core/wrappers/events/s3_out.cpp
+++ b/ydb/core/wrappers/events/s3_out.cpp
@@ -221,7 +221,11 @@ void Out(IOutputStream& out, const TStringOutcome& outcome) {
 }
 
 void Out(IOutputStream& out, const Aws::S3::S3Error& error) {
-    out << static_cast<int>(error.GetResponseCode()) << " " << error.GetMessage().c_str();
+    const auto responseCode = error.GetResponseCode();
+    if (responseCode != Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
+        out << static_cast<int>(responseCode) << " ";
+    }
+    out << error.GetMessage().c_str();
 }
 
 } // NKikimr::NWrappers

--- a/ydb/core/wrappers/events/s3_out.h
+++ b/ydb/core/wrappers/events/s3_out.h
@@ -66,6 +66,7 @@ void Out(IOutputStream& out, const Aws::S3::Model::CompletedPart& part);
 
 using TStringOutcome = Aws::Utils::Outcome<Aws::String, Aws::S3::S3Error>;
 void Out(IOutputStream& out, const TStringOutcome& outcome);
+void Out(IOutputStream& out, const Aws::S3::S3Error& error);
 
 } // NKikimr::NWrappers
 
@@ -206,6 +207,10 @@ Y_DECLARE_OUT_SPEC(inline, Aws::S3::Model::CompletedMultipartUpload, out, value)
 }
 
 Y_DECLARE_OUT_SPEC(inline, Aws::S3::Model::CompletedPart, out, value) {
+    NKikimr::NWrappers::Out(out, value);
+}
+
+Y_DECLARE_OUT_SPEC(inline, Aws::S3::S3Error, out, value) {
     NKikimr::NWrappers::Out(out, value);
 }
 

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -19,9 +19,8 @@ bool ShouldRetry(const Aws::S3::S3Error& error) {
         return true;
     }
 
-    // Unexpected response code (connection failure, DNS, TLS, etc.)
-    const int code = static_cast<int>(error.GetResponseCode());
-    if (code < 200) {
+    // No response (connection failure, DNS, TLS, etc.)
+    if (error.GetResponseCode() == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
         return true;
     }
 

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -19,20 +19,9 @@ bool ShouldRetry(const Aws::S3::S3Error& error) {
         return true;
     }
 
-    const int code = static_cast<int>(error.GetResponseCode());
-
     // Unexpected response code (connection failure, DNS, TLS, etc.)
+    const int code = static_cast<int>(error.GetResponseCode());
     if (code < 200) {
-        return true;
-    }
-
-    // Server errors
-    if (code >= 500) {
-        return true;
-    }
-
-    // Request Timeout, Conflict, or Too Many Requests
-    if (code == 408 || code == 409 || code == 429) {
         return true;
     }
 

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -5,7 +5,6 @@
 #include "retry_policy.h"
 
 #include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3/include/aws/s3/S3Errors.h>
-#include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h>
 
 namespace NKikimr::NWrappers {
 

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -19,9 +19,12 @@ bool ShouldRetry(const Aws::S3::S3Error& error) {
         return true;
     }
 
-    // No response (connection failure, DNS, TLS, etc.)
-    if (error.GetResponseCode() == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
-        return true;
+    switch (error.GetResponseCode()) {
+        case Aws::Http::HttpResponseCode::REQUEST_NOT_MADE:
+        case Aws::Http::HttpResponseCode::BAD_GATEWAY:
+            return true;
+        default:
+            break;
     }
 
     return false;

--- a/ydb/core/wrappers/retry_policy.cpp
+++ b/ydb/core/wrappers/retry_policy.cpp
@@ -5,6 +5,7 @@
 #include "retry_policy.h"
 
 #include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3/include/aws/s3/S3Errors.h>
+#include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h>
 
 namespace NKikimr::NWrappers {
 
@@ -16,6 +17,23 @@ bool ShouldRetry(const Aws::S3::S3Error& error) {
     const auto& exceptionName = error.GetExceptionName();
     if (exceptionName == "TooManyRequests" ||
         exceptionName == "OperationAborted") {
+        return true;
+    }
+
+    const int code = static_cast<int>(error.GetResponseCode());
+
+    // Unexpected response code (connection failure, DNS, TLS, etc.)
+    if (code < 200) {
+        return true;
+    }
+
+    // Server errors
+    if (code >= 500) {
+        return true;
+    }
+
+    // Request Timeout, Conflict, or Too Many Requests
+    if (code == 408 || code == 409 || code == 429) {
         return true;
     }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add retries for HTTP response codes that are not covered by AWS CPP SDK:
- `REQUEST_NOT_MADE` – default status, may be [encountered](https://github.com/aws/aws-sdk-cpp/issues/1363).
- `BAD_GATEWAY` – covered only in [new versions](https://github.com/aws/aws-sdk-cpp/blame/d3185f95dc6432a36b1665145059085cda0a1d1b/src/aws-cpp-sdk-core/include/aws/core/http/HttpResponse.h#L119).
