### PR TITLE
refactor Out<TDLQMessage> specializations

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.cpp
@@ -107,3 +107,8 @@ ui64 GetCookie(const TEvPQ::TEvProxyResponse::TPtr& ev) {
 }
 
 }
+
+template<>
+void Out<NKikimr::NPQ::NMLP::TDLQMessage>(IOutputStream& o, const NKikimr::NPQ::NMLP::TDLQMessage& p) {
+    o << "(" << p.Offset << ", " << p.SeqNo << ")";
+}

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_common.h
@@ -10,6 +10,10 @@ struct TDLQMessage {
     ui64 SeqNo;
 };
 
+inline TDLQMessage AsTDLQMessage(const std::pair<ui64, ui64> p) {
+    return TDLQMessage{p.first, p.second};
+}
+
 struct TResult {
     TResult(const NActors::TActorId& sender, ui64 cookie)
         : Sender(sender)
@@ -82,18 +86,3 @@ struct TDLQMoverSettings {
 NActors::IActor* CreateDLQMover(TDLQMoverSettings&& settings);
 
 } // namespace NKikimr::NPQ::NMLP
-
-template<>
-inline void Out<std::pair<ui64 const, ui64>>(IOutputStream& o, const std::pair<ui64 const, ui64>& p) {
-    o << "(" << p.first << ", " << p.second << ")";
-}
-
-template<>
-inline void Out<std::pair<ui64, ui64>>(IOutputStream& o, const std::pair<ui64, ui64>& p) {
-    o << "(" << p.first << ", " << p.second << ")";
-}
-
-template<>
-inline void Out<NKikimr::NPQ::NMLP::TDLQMessage>(IOutputStream& o, const NKikimr::NPQ::NMLP::TDLQMessage& p) {
-    o << "(" << p.Offset << ", " << p.SeqNo << ")";
-}

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -6,6 +6,8 @@
 #include <ydb/core/protos/grpc_pq_old.pb.h>
 #include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
+#include <ranges>
+
 namespace NKikimr::NPQ::NMLP {
 
 namespace {
@@ -935,7 +937,7 @@ void TConsumerActor::Handle(TEvPQ::TEvMLPDLQMoverResponse::TPtr& ev) {
     }
 
     auto& moved = ev->Get()->MovedMessages;
-    LOG_D("Moved to the DLQ: " << JoinRange(", ", moved.begin(), moved.end()));
+    LOG_D("Moved to the DLQ: " << JoinSeq(", ", moved | std::views::transform(AsTDLQMessage)));
 
     DLQMoverActorId = {};
     for (auto [offset, seqNo] : moved) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -915,7 +915,7 @@ void TConsumerActor::MoveToDLQIfPossible() {
 
     auto messages = Storage->GetDLQMessages();
     if (!messages.empty()) {
-        LOG_D("Move to DLQ: " << JoinRange(", ", messages.begin(), messages.end()));
+        LOG_D("Move to DLQ: " << JoinSeq(", ", messages));
         DLQMoverActorId = RegisterWithSameMailbox(CreateDLQMover({
             .ParentActorId = SelfId(),
             .Database = Database,

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -6,6 +6,8 @@
 
 #include <util/string/join.h>
 
+#include <ranges>
+
 namespace NKikimr::NPQ::NMLP {
 
 namespace {
@@ -666,7 +668,7 @@ ui64 TStorage::NormalizeDeadline(TInstant deadline) {
 
 ui64 TStorage::DoLock(ui64 offset, TMessage& message, TInstant& deadline) {
     auto now = TimeProvider->Now();
-    
+
     AFL_VERIFY(message.GetStatus() == EMessageStatus::Unprocessed)("status", message.GetStatus());
     message.SetStatus(EMessageStatus::Locked);
     message.DeadlineDelta = NormalizeDeadline(deadline);
@@ -1005,7 +1007,7 @@ TString TStorage::DebugString() const {
 
     sb << "] LockedGroups [" << JoinRange(", ", LockedMessageGroupsId.begin(), LockedMessageGroupsId.end()) << "]";
     sb << " DLQQueue [" << JoinRange(", ", DLQQueue.begin(), DLQQueue.end()) << "]";
-    sb << " DLQMessages [" << JoinRange(", ", DLQMessages.begin(), DLQMessages.end()) << "]";
+    sb << " DLQMessages [" << JoinSeq(", ", DLQMessages | std::views::transform(AsTDLQMessage)) << "]";
     sb << " Metrics {"
         << "Inflight: " << Metrics.InflightMessageCount << ", "
         << "Unprocessed: " << Metrics.UnprocessedMessageCount << ", "

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -1005,8 +1005,8 @@ TString TStorage::DebugString() const {
         dump(FirstOffset + i, Messages[i], 'f');
     }
 
-    sb << "] LockedGroups [" << JoinRange(", ", LockedMessageGroupsId.begin(), LockedMessageGroupsId.end()) << "]";
-    sb << " DLQQueue [" << JoinRange(", ", DLQQueue.begin(), DLQQueue.end()) << "]";
+    sb << "] LockedGroups [" << JoinSeq(", ", LockedMessageGroupsId) << "]";
+    sb << " DLQQueue [" << JoinSeq(", ", DLQQueue) << "]";
     sb << " DLQMessages [" << JoinSeq(", ", DLQMessages | std::views::transform(AsTDLQMessage)) << "]";
     sb << " Metrics {"
         << "Inflight: " << Metrics.InflightMessageCount << ", "

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -666,7 +666,7 @@ ui64 TStorage::NormalizeDeadline(TInstant deadline) {
     return deadlineDelta;
 }
 
-ui64 TStorage::DoLock(ui64 offset, TMessage& message, TInstant& deadline) {
+ui64 TStorage::DoLock(ui64 offset, TMessage& message, const TInstant deadline) {
     auto now = TimeProvider->Now();
 
     AFL_VERIFY(message.GetStatus() == EMessageStatus::Unprocessed)("status", message.GetStatus());

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -217,7 +217,7 @@ private:
     std::pair<TMessage*, bool> GetMessageInt(ui64 offset, EMessageStatus expectedStatus);
     ui64 NormalizeDeadline(TInstant deadline);
 
-    ui64 DoLock(ui64 offset, TMessage& message, TInstant& deadline);
+    ui64 DoLock(ui64 offset, TMessage& message, TInstant deadline);
     bool DoCommit(ui64 offset, size_t& totalMetrics);
     bool DoUnlock(ui64 offset);
     void DoUnlock(ui64 offset, TMessage& message);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* Remove specialization of `Out<>` for non-user types. This could lead to an ODR violation or interfere with behavior of unrelated code.
* Move `Out<TDLQMessage>` toa  cpp file, so it is compiled only once.
* Use JoinSeq instead of JoinRange, as it is shorter.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
