### PR TITLE
Make long scans work on columnshards

### DIFF
--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -21,7 +21,7 @@ bool TTxBlobsWritingFinished::DoExecute(TTransactionContext& txc, const TActorCo
         NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD_BLOBS)("tablet_id", Self->TabletID())("tx_state", "execute");
     ACFL_DEBUG("event", "start_execute");
     auto& index = Self->MutableIndexAs<NOlap::TColumnEngineForLogs>();
-    const auto minReadSnapshot = Self->GetMinShapshotForNewReads();
+    const auto minReadSnapshot = Self->GetMinSnapshotForNewReads();
 
     for (auto&& writeResult : Pack.GetWriteResults()) {
         const auto& writeMeta = writeResult.GetWriteMeta();

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -637,12 +637,12 @@ public:
 };
 
 void TColumnShard::StartCompaction(const std::shared_ptr<NPrioritiesQueue::TAllocationGuard>& guard) {
-    Counters.GetCSCounters().OnSetupCompaction();
-    BackgroundController.ResetWaitingPriority();
     if (BackgroundController.GetCompactionsCount()) {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "skip_start_compaction")("reason", "compaction_in_progress");
         return;
     }
+    Counters.GetCSCounters().OnSetupCompaction();
+    BackgroundController.ResetWaitingPriority();
 
     auto indexChangesList = TablesManager.MutablePrimaryIndex().StartCompaction(DataLocksManager);
 

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -199,7 +199,7 @@ NOlap::TSnapshot TColumnShard::GetMinSnapshotForNewReads() const {
     ui64 passedStep = GetOutdatedStep();
     ui64 minReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
     Counters.GetRequestsTracingCounters()->OnDefaultMinSnapshotInstant(TInstant::MilliSeconds(minReadStep));
-    return NOlap::TSnapshot::MaxForPlanStep(minReadStep);
+    return NOlap::TSnapshot(minReadStep, 0);
 }
 
 bool TColumnShard::MayStartScanAt(const NOlap::TSnapshot& snapshot) const {

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -202,6 +202,10 @@ NOlap::TSnapshot TColumnShard::GetMinSnapshotForNewReads() const {
     return NOlap::TSnapshot::MaxForPlanStep(minReadStep);
 }
 
+bool TColumnShard::MayStartScanAt(const NOlap::TSnapshot& snapshot) const {
+    return GetMinSnapshotForNewReads() <= snapshot || InFlightReadsTracker.HasLiveSnapshot(snapshot);
+}
+
 NOlap::TSnapshotHolders TColumnShard::GetSnapshotHolders() const {
     auto minSnapshotForNewReads = GetMinSnapshotForNewReads();
     // all snapshots younger than minSnapshotForNewReads may be considered as "potentially in flight".

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -194,7 +194,7 @@ ui64 TColumnShard::GetOutdatedStep() const {
     return step;
 }
 
-NOlap::TSnapshot TColumnShard::GetMinShapshotForNewReads() const {
+NOlap::TSnapshot TColumnShard::GetMinSnapshotForNewReads() const {
     ui64 delayMillisec = NYDBTest::TControllers::GetColumnShardController()->GetMaxReadStaleness().MilliSeconds();
     ui64 passedStep = GetOutdatedStep();
     ui64 minReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
@@ -203,7 +203,7 @@ NOlap::TSnapshot TColumnShard::GetMinShapshotForNewReads() const {
 }
 
 NOlap::TSnapshotHolders TColumnShard::GetSnapshotHolders() const {
-    auto minSnapshotForNewReads = GetMinShapshotForNewReads();
+    auto minSnapshotForNewReads = GetMinSnapshotForNewReads();
     // all snapshots younger than minSnapshotForNewReads may be considered as "potentially in flight".
     // meaning that at any moment a scan may come with any snapshot in [minScanSnapshot, maxScanSnapshot],
     // so we will get a live snapshot at that moment.

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -511,7 +511,7 @@ void TColumnShard::SetupCompaction(const std::set<TInternalPathId>& pathIds) {
     if (BackgroundController.GetCompactionsCount()) {
         return;
     }
-    const ui64 priority = TablesManager.GetPrimaryIndexSafe().GetCompactionPriority(DataLocksManager, pathIds, BackgroundController.GetWaitingPriorityOptional());
+    const ui64 priority = TablesManager.GetPrimaryIndexSafe().GetCompactionPriority(pathIds, BackgroundController.GetWaitingPriorityOptional());
     if (priority) {
         BackgroundController.UpdateWaitingPriority(priority);
         if (pathIds.size()) {

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -653,6 +653,7 @@ void TColumnShard::StartCompaction(const std::shared_ptr<NPrioritiesQueue::TAllo
 
     const ui64 compactionStageMemoryLimit = HasAppData() ? AppDataVerified().ColumnShardConfig.GetCompactionStageMemoryLimit() : NOlap::TGlobalLimits::GeneralCompactionMemoryLimit;
     for (const auto& indexChanges : indexChangesList) {
+        AFL_VERIFY(indexChanges);
         auto& compaction = *VerifyDynamicCast<NOlap::NCompaction::TGeneralCompactColumnEngineChanges*>(indexChanges.get());
         compaction.SetActivityFlag(GetTabletActivity());
         compaction.SetQueueGuard(guard);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -639,6 +639,10 @@ public:
 void TColumnShard::StartCompaction(const std::shared_ptr<NPrioritiesQueue::TAllocationGuard>& guard) {
     Counters.GetCSCounters().OnSetupCompaction();
     BackgroundController.ResetWaitingPriority();
+    if (BackgroundController.GetCompactionsCount()) {
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "skip_start_compaction")("reason", "compaction_in_progress");
+        return;
+    }
 
     auto indexChangesList = TablesManager.MutablePrimaryIndex().StartCompaction(DataLocksManager);
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -575,7 +575,7 @@ private:
     void SendWaitPlanStep(ui64 step);
     void RescheduleWaitingReads();
     NOlap::TSnapshot GetMaxReadVersion() const;
-    NOlap::TSnapshot GetMinShapshotForNewReads() const;
+    NOlap::TSnapshot GetMinSnapshotForNewReads() const;
     NOlap::TSnapshotHolders GetSnapshotHolders() const;
     ui64 GetOutdatedStep() const;
     TDuration GetTxCompleteLag() const {

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -576,6 +576,7 @@ private:
     void RescheduleWaitingReads();
     NOlap::TSnapshot GetMaxReadVersion() const;
     NOlap::TSnapshot GetMinSnapshotForNewReads() const;
+    bool MayStartScanAt(const NOlap::TSnapshot& snapshot) const;
     NOlap::TSnapshotHolders GetSnapshotHolders() const;
     ui64 GetOutdatedStep() const;
     TDuration GetTxCompleteLag() const {

--- a/ydb/core/tx/columnshard/engines/changes/compaction.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction.h
@@ -30,8 +30,7 @@ protected:
         return NDataLocks::ELockCategory::Compaction;
     }
     virtual std::shared_ptr<NDataLocks::ILock> DoBuildDataLockImpl() const override {
-        const THashSet<TInternalPathId> pathIds = { GranuleMeta->GetPathId() };
-        return std::make_shared<NDataLocks::TListTablesLock>(TypeString() + "::" + GetTaskIdentifier(), pathIds, GetLockCategory());
+        return nullptr;
     }
 
     virtual void OnDataAccessorsInitialized(const TDataAccessorsInitializationContext& context) override {

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -162,7 +162,7 @@ public:
     virtual std::vector<TSelectedPortionInfo> Select(
         TInternalPathId pathId, TSnapshot snapshot, const TPKRangesFilter& pkRangesFilter, const bool withNonconflicting, const bool withConflicting, const std::optional<THashSet<TInsertWriteId>>& ownPortions) const = 0;
     virtual std::vector<std::shared_ptr<TColumnEngineChanges>> StartCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept = 0;
-    virtual ui64 GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager, const std::set<TInternalPathId>& pathIds,
+    virtual ui64 GetCompactionPriority(const std::set<TInternalPathId>& pathIds,
         const std::optional<ui64> waitingPriority) const noexcept = 0;
     virtual std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshotHolders& snapshotHolders,
         const THashSet<TInternalPathId>& pathsToDrop, const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept = 0;

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -402,7 +402,6 @@ std::vector<std::shared_ptr<TColumnEngineChanges>> TColumnEngineForLogs::StartCo
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "cannot build optimization task for granule that need compaction")("weight", orderedG.GetPriority().DebugString())("path_id", granule->GetPathId());
         } else {
             granuleToCompact = granule;
-            granuleToCompact->OnStartCompaction();
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "found granule for compaction")("weight", orderedG.GetPriority().DebugString())("path_id", granule->GetPathId());
             break;
         }

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -379,29 +379,37 @@ ui64 TColumnEngineForLogs::GetCompactionPriority(
     const std::set<TInternalPathId>& pathIds,
     const std::optional<ui64> waitingPriority
 ) const noexcept {
-    auto priority = GranulesStorage->GetCompactionPriority(pathIds, waitingPriority);
-    if (!priority) {
+    auto granules = GranulesStorage->GetGranulesForCompaction(pathIds, waitingPriority);
+    if (granules.empty()) {
         return 0;
     } else {
-        return priority->GetGeneralPriority();
+        return granules.front().GetPriority().GetGeneralPriority();
     }
 }
 
-std::vector<std::shared_ptr<TColumnEngineChanges>> TColumnEngineForLogs::StartCompaction(
-    const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept {
+std::vector<std::shared_ptr<TColumnEngineChanges>> TColumnEngineForLogs::StartCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept {
     AFL_VERIFY(dataLocksManager);
-    auto granule = GranulesStorage->GetGranuleForCompaction();
-    if (!granule) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "no granules for start compaction");
-        return {};
+    auto granulesSortedDesc = GranulesStorage->GetGranulesForCompaction();
+
+    std::shared_ptr<TGranuleMeta> granuleToCompact = nullptr;
+    std::vector<std::shared_ptr<TColumnEngineChanges>> changes;
+    for (auto& orderedG: granulesSortedDesc) {
+        auto granule = orderedG.GetGranule();
+        TMonotonic startTime = TMonotonic::Now();
+        changes = granule->GetOptimizationTasks(granule, dataLocksManager);
+        NChanges::TGeneralCompactionCounters::OnTasksGeneratred((TMonotonic::Now() - startTime).MicroSeconds(), changes.size());
+        if (changes.empty()) {
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "cannot build optimization task for granule that need compaction")("weight", orderedG.GetPriority().DebugString())("path_id", granule->GetPathId());
+        } else {
+            granuleToCompact = granule;
+            granuleToCompact->OnStartCompaction();
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "found granule for compaction")("weight", orderedG.GetPriority().DebugString())("path_id", granule->GetPathId());
+            break;
+        }
     }
-    granule->OnStartCompaction();
-    TMonotonic startTime = TMonotonic::Now();
-    auto changes = granule->GetOptimizationTasks(granule, dataLocksManager);
-    NChanges::TGeneralCompactionCounters::OnTasksGeneratred((TMonotonic::Now() - startTime).MicroSeconds(), changes.size());
-    if (changes.empty()) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "cannot build optimization task for granule that need compaction")(
-            "weight", granule->GetCompactionPriority().DebugString());
+    if (!granuleToCompact) {
+        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "no granules to start compaction");
+        return {};
     }
     return changes;
 }

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -375,9 +375,11 @@ bool TColumnEngineForLogs::FinishLoading() {
     return true;
 }
 
-ui64 TColumnEngineForLogs::GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager,
-    const std::set<TInternalPathId>& pathIds, const std::optional<ui64> waitingPriority) const noexcept {
-    auto priority = GranulesStorage->GetCompactionPriority(dataLocksManager, pathIds, waitingPriority);
+ui64 TColumnEngineForLogs::GetCompactionPriority(
+    const std::set<TInternalPathId>& pathIds,
+    const std::optional<ui64> waitingPriority
+) const noexcept {
+    auto priority = GranulesStorage->GetCompactionPriority(pathIds, waitingPriority);
     if (!priority) {
         return 0;
     } else {
@@ -388,7 +390,7 @@ ui64 TColumnEngineForLogs::GetCompactionPriority(const std::shared_ptr<NDataLock
 std::vector<std::shared_ptr<TColumnEngineChanges>> TColumnEngineForLogs::StartCompaction(
     const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept {
     AFL_VERIFY(dataLocksManager);
-    auto granule = GranulesStorage->GetGranuleForCompaction(dataLocksManager);
+    auto granule = GranulesStorage->GetGranuleForCompaction();
     if (!granule) {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "no granules for start compaction");
         return {};

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.h
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.h
@@ -149,7 +149,7 @@ public:
     virtual std::vector<TCSMetadataRequest> CollectMetadataRequests() const override {
         return GranulesStorage->CollectMetadataRequests();
     }
-    ui64 GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager, const std::set<TInternalPathId>& pathIds,
+    ui64 GetCompactionPriority(const std::set<TInternalPathId>& pathIds,
         const std::optional<ui64> waitingPriority) const noexcept override;
     std::vector<std::shared_ptr<TColumnEngineChanges>> StartCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) noexcept override;
     std::shared_ptr<TCleanupPortionsColumnEngineChanges> StartCleanupPortions(const TSnapshotHolders& snapshotHolders,

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
@@ -26,7 +26,7 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
         return std::shared_ptr<TReadMetadataBase>();
     }
 
-    if (read.GetSnapshot().GetPlanInstant() < self->GetMinSnapshotForNewReads().GetPlanInstant()) {
+    if (!self->MayStartScanAt(read.GetSnapshot())) {
         return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
                                                         << self->GetMinSnapshotForNewReads() << ". now: " << TInstant::Now());
     }

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
@@ -26,9 +26,9 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
         return std::shared_ptr<TReadMetadataBase>();
     }
 
-    if (read.GetSnapshot().GetPlanInstant() < self->GetMinShapshotForNewReads().GetPlanInstant()) {
+    if (read.GetSnapshot().GetPlanInstant() < self->GetMinSnapshotForNewReads().GetPlanInstant()) {
         return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
-                                                        << self->GetMinShapshotForNewReads() << ". now: " << TInstant::Now());
+                                                        << self->GetMinSnapshotForNewReads() << ". now: " << TInstant::Now());
     }
 
     auto readCopy = read;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
@@ -30,7 +30,7 @@ TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructor::DoBuil
         schemas = &defaultSchemas;
     }
     if (read.TableMetadataAccessor->NeedStalenessChecker()) {
-        if (read.GetSnapshot().GetPlanInstant() < self->GetMinSnapshotForNewReads().GetPlanInstant()) {
+        if (!self->MayStartScanAt(read.GetSnapshot())) {
             return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
                                                             << self->GetMinSnapshotForNewReads() << ". now: " << TInstant::Now());
         }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
@@ -30,9 +30,9 @@ TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructor::DoBuil
         schemas = &defaultSchemas;
     }
     if (read.TableMetadataAccessor->NeedStalenessChecker()) {
-        if (read.GetSnapshot().GetPlanInstant() < self->GetMinShapshotForNewReads().GetPlanInstant()) {
+        if (read.GetSnapshot().GetPlanInstant() < self->GetMinSnapshotForNewReads().GetPlanInstant()) {
             return TConclusionStatus::Fail(TStringBuilder() << "Snapshot too old: " << read.GetSnapshot() << ". CS min read snapshot: "
-                                                            << self->GetMinShapshotForNewReads() << ". now: " << TInstant::Now());
+                                                            << self->GetMinSnapshotForNewReads() << ". now: " << TInstant::Now());
         }
     }
 

--- a/ydb/core/tx/columnshard/engines/storage/granule/granule.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/granule.h
@@ -148,7 +148,6 @@ private:
     void OnAfterChangePortion(const std::shared_ptr<TPortionInfo> portionAfter,
         NStorageOptimizer::IOptimizerPlanner::TModificationGuard* modificationGuard, const bool onLoad = false);
     void OnAdditiveSummaryChange() const;
-    YDB_READONLY(TMonotonic, LastCompactionInstant, TMonotonic::Zero());
 
     TConclusion<std::shared_ptr<TPortionInfo>> GetInnerPortion(const TPortionInfo::TConstPtr& portion) const {
         if (!portion) {
@@ -281,10 +280,6 @@ public:
 
     NArrow::NMerger::TIntervalPositions GetBucketPositions() const {
         return OptimizerPlanner->GetBucketPositions();
-    }
-
-    void OnStartCompaction() {
-        LastCompactionInstant = TMonotonic::Now();
     }
 
     void BuildActualizationTasks(NActualizer::TTieringProcessContext& context, const TDuration actualizationLag) const;

--- a/ydb/core/tx/columnshard/engines/storage/granule/storage.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/granule/storage.cpp
@@ -27,8 +27,10 @@ public:
 }   // namespace
 
 std::optional<NStorageOptimizer::TOptimizationPriority> TGranulesStorage::GetCompactionPriority(
-    const std::shared_ptr<NDataLocks::TManager>& dataLocksManager, const std::set<TInternalPathId>& pathIds, const std::optional<ui64> waitingPriority,
-    std::shared_ptr<TGranuleMeta>* granuleResult) const {
+    const std::set<TInternalPathId>& pathIds, 
+    const std::optional<ui64> waitingPriority,
+    std::shared_ptr<TGranuleMeta>* granuleResult
+) const {
     const TInstant now = HasAppData() ? AppDataVerified().TimeProvider->Now() : TInstant::Now();
     std::vector<TGranuleOrdered> granulesSorted;
     std::optional<NStorageOptimizer::TOptimizationPriority> priorityChecker;
@@ -57,16 +59,9 @@ std::optional<NStorageOptimizer::TOptimizationPriority> TGranulesStorage::GetCom
         }
     }
     std::sort(granulesSorted.begin(), granulesSorted.end());
-    while (granulesSorted.size()) {
-        auto lockName = dataLocksManager->IsLocked(*granulesSorted.back().GetGranule(), NDataLocks::ELockCategory::Compaction);
-        if (!lockName) {
-            priorityChecker = granulesSorted.back().GetPriority();
-            maxPriorityGranule = granulesSorted.back().GetGranule();
-            break;
-        }
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "granule_locked")("path_id", granulesSorted.back().GetGranule()->GetPathId())(
-            "lock_id", *lockName);
-        granulesSorted.pop_back();
+    if (!granulesSorted.empty()) {
+        priorityChecker = granulesSorted.back().GetPriority();
+        maxPriorityGranule = granulesSorted.back().GetGranule();
     }
     if (granuleResult) {
         *granuleResult = maxPriorityGranule;
@@ -74,16 +69,14 @@ std::optional<NStorageOptimizer::TOptimizationPriority> TGranulesStorage::GetCom
     return priorityChecker;
 }
 
-std::shared_ptr<TGranuleMeta> TGranulesStorage::GetGranuleForCompaction(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const {
+std::shared_ptr<TGranuleMeta> TGranulesStorage::GetGranuleForCompaction() const {
     std::shared_ptr<TGranuleMeta> granuleMaxPriority;
-    std::optional<NStorageOptimizer::TOptimizationPriority> priorityChecker =
-        GetCompactionPriority(dataLocksManager, {}, std::nullopt, &granuleMaxPriority);
+    std::optional<NStorageOptimizer::TOptimizationPriority> priorityChecker = GetCompactionPriority({}, std::nullopt, &granuleMaxPriority);
     if (!granuleMaxPriority) {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "no_granules");
         return nullptr;
     }
     NActors::TLogContextGuard lGuard = NActors::TLogContextBuilder::Build()("path_id", granuleMaxPriority->GetPathId());
-    AFL_VERIFY(!dataLocksManager->IsLocked(*granuleMaxPriority, NDataLocks::ELockCategory::Compaction));
     AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "granule_compaction_weight")("priority", priorityChecker->DebugString());
     return granuleMaxPriority;
 }

--- a/ydb/core/tx/columnshard/engines/storage/granule/storage.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/granule/storage.cpp
@@ -4,40 +4,14 @@
 
 namespace NKikimr::NOlap {
 
-namespace {
-class TGranuleOrdered {
-private:
-    NStorageOptimizer::TOptimizationPriority Priority;
-    YDB_READONLY_DEF(std::shared_ptr<TGranuleMeta>, Granule);
-
-public:
-    const NStorageOptimizer::TOptimizationPriority& GetPriority() const {
-        return Priority;
-    }
-
-    TGranuleOrdered(const NStorageOptimizer::TOptimizationPriority& priority, const std::shared_ptr<TGranuleMeta>& meta)
-        : Priority(priority)
-        , Granule(meta) {
-    }
-
-    bool operator<(const TGranuleOrdered& item) const {
-        return Priority < item.Priority;
-    }
-};
-}   // namespace
-
-std::optional<NStorageOptimizer::TOptimizationPriority> TGranulesStorage::GetCompactionPriority(
+std::vector<TGranuleOrdered> TGranulesStorage::GetGranulesForCompaction(
     const std::set<TInternalPathId>& pathIds, 
-    const std::optional<ui64> waitingPriority,
-    std::shared_ptr<TGranuleMeta>* granuleResult
+    const std::optional<ui64> waitingPriority
 ) const {
     const TInstant now = HasAppData() ? AppDataVerified().TimeProvider->Now() : TInstant::Now();
     std::vector<TGranuleOrdered> granulesSorted;
-    std::optional<NStorageOptimizer::TOptimizationPriority> priorityChecker;
-    std::shared_ptr<TGranuleMeta> maxPriorityGranule;
     const TDuration actualizationLag = NYDBTest::TControllers::GetColumnShardController()->GetCompactionActualizationLag();
     const auto actor = [&](const TInternalPathId /*pathId*/, const std::shared_ptr<TGranuleMeta>& granule) {
-        //        NActors::TLogContextGuard lGuard = NActors::TLogContextBuilder::Build()("path_id", i.first);
         if (pathIds.empty()) {
             granule->ActualizeOptimizer(now, actualizationLag);
         }
@@ -58,27 +32,11 @@ std::optional<NStorageOptimizer::TOptimizationPriority> TGranulesStorage::GetCom
             actor(i.first, i.second);
         }
     }
-    std::sort(granulesSorted.begin(), granulesSorted.end());
-    if (!granulesSorted.empty()) {
-        priorityChecker = granulesSorted.back().GetPriority();
-        maxPriorityGranule = granulesSorted.back().GetGranule();
-    }
-    if (granuleResult) {
-        *granuleResult = maxPriorityGranule;
-    }
-    return priorityChecker;
-}
-
-std::shared_ptr<TGranuleMeta> TGranulesStorage::GetGranuleForCompaction() const {
-    std::shared_ptr<TGranuleMeta> granuleMaxPriority;
-    std::optional<NStorageOptimizer::TOptimizationPriority> priorityChecker = GetCompactionPriority({}, std::nullopt, &granuleMaxPriority);
-    if (!granuleMaxPriority) {
-        AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "no_granules");
-        return nullptr;
-    }
-    NActors::TLogContextGuard lGuard = NActors::TLogContextBuilder::Build()("path_id", granuleMaxPriority->GetPathId());
-    AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "granule_compaction_weight")("priority", priorityChecker->DebugString());
-    return granuleMaxPriority;
+    // descending order
+    std::sort(granulesSorted.begin(), granulesSorted.end(),
+        [](const TGranuleOrdered& a, const TGranuleOrdered& b) { return b < a; }
+    );
+    return granulesSorted;
 }
 
 }   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/storage/granule/storage.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/storage.h
@@ -212,10 +212,12 @@ public:
         return Counters;
     }
 
-    std::shared_ptr<TGranuleMeta> GetGranuleForCompaction(const std::shared_ptr<NDataLocks::TManager>& locksManager) const;
-    std::optional<NStorageOptimizer::TOptimizationPriority> GetCompactionPriority(const std::shared_ptr<NDataLocks::TManager>& locksManager,
-        const std::set<TInternalPathId>& pathIds = Default<std::set<TInternalPathId>>(), const std::optional<ui64> waitingPriority = std::nullopt,
-        std::shared_ptr<TGranuleMeta>* granuleResult = nullptr) const;
+    std::shared_ptr<TGranuleMeta> GetGranuleForCompaction() const;
+    std::optional<NStorageOptimizer::TOptimizationPriority> GetCompactionPriority(
+        const std::set<TInternalPathId>& pathIds = Default<std::set<TInternalPathId>>(), 
+        const std::optional<ui64> waitingPriority = std::nullopt,
+        std::shared_ptr<TGranuleMeta>* granuleResult = nullptr
+    ) const;
 };
 
 }   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/storage/granule/storage.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/storage.h
@@ -106,6 +106,26 @@ public:
     }
 };
 
+class TGranuleOrdered {
+private:
+    NStorageOptimizer::TOptimizationPriority Priority;
+    YDB_READONLY_DEF(std::shared_ptr<TGranuleMeta>, Granule);
+
+public:
+    const NStorageOptimizer::TOptimizationPriority& GetPriority() const {
+        return Priority;
+    }
+
+    TGranuleOrdered(const NStorageOptimizer::TOptimizationPriority& priority, const std::shared_ptr<TGranuleMeta>& meta)
+        : Priority(priority)
+        , Granule(meta) {
+    }
+
+    bool operator<(const TGranuleOrdered& item) const {
+        return Priority < item.Priority;
+    }
+};
+
 class TGranulesStorage {
 private:
     const NColumnShard::TEngineLogsCounters Counters;
@@ -212,11 +232,12 @@ public:
         return Counters;
     }
 
-    std::shared_ptr<TGranuleMeta> GetGranuleForCompaction() const;
-    std::optional<NStorageOptimizer::TOptimizationPriority> GetCompactionPriority(
+    /**
+    Returns granules for compaction in descending order of priority
+    */
+    std::vector<TGranuleOrdered> GetGranulesForCompaction(
         const std::set<TInternalPathId>& pathIds = Default<std::set<TInternalPathId>>(), 
-        const std::optional<ui64> waitingPriority = std::nullopt,
-        std::shared_ptr<TGranuleMeta>* granuleResult = nullptr
+        const std::optional<ui64> waitingPriority = std::nullopt
     ) const;
 };
 

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/abstract/optimizer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/abstract/optimizer.h
@@ -131,7 +131,6 @@ protected:
     virtual NJson::TJsonValue DoSerializeToJsonVisual() const {
         return NJson::JSON_NULL;
     }
-    virtual bool DoIsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const = 0;
     virtual std::vector<TTaskDescription> DoGetTasksDescription() const = 0;
     virtual TConclusionStatus DoCheckWriteData() const {
         return TConclusionStatus::Success();

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lbuckets/planner/optimizer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lbuckets/planner/optimizer.h
@@ -213,30 +213,6 @@ public:
         }
     }
 
-    bool IsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const {
-        for (auto&& f : Futures) {
-            for (auto&& p : f.second) {
-                if (auto lockInfo = dataLocksManager->IsLocked(*p.second, NDataLocks::ELockCategory::Compaction)) {
-                    AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "optimization_locked")("reason", *lockInfo);
-                    return true;
-                }
-            }
-        }
-        for (auto&& i : PreActuals) {
-            if (auto lockInfo = dataLocksManager->IsLocked(*i.second, NDataLocks::ELockCategory::Compaction)) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "optimization_locked")("reason", *lockInfo);
-                return true;
-            }
-        }
-        for (auto&& i : Actuals) {
-            if (auto lockInfo = dataLocksManager->IsLocked(*i.second, NDataLocks::ELockCategory::Compaction)) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "optimization_locked")("reason", *lockInfo);
-                return true;
-            }
-        }
-        return false;
-    }
-
     bool Validate(const std::shared_ptr<TPortionInfo>& portion) const {
         if (portion) {
             AFL_VERIFY(!PreActuals.contains(portion->GetPortionId()));
@@ -750,16 +726,6 @@ public:
         }
     };
 
-    bool IsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const {
-        if (MainPortion) {
-            if (auto lockInfo = dataLocksManager->IsLocked(*MainPortion, NDataLocks::ELockCategory::Compaction)) {
-                AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "optimization_locked")("reason", *lockInfo);
-                return true;
-            }
-        }
-        return Others.IsLocked(dataLocksManager);
-    }
-
     bool IsEmpty() const {
         return !MainPortion && Others.IsEmpty();
     }
@@ -1089,15 +1055,6 @@ public:
         AddBucketToRating(LeftBucket);
     }
 
-    bool IsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const {
-        if (BucketsByWeight.empty()) {
-            return false;
-        }
-        AFL_VERIFY(BucketsByWeight.begin()->second.size());
-        const TPortionsBucket* bucketForOptimization = *BucketsByWeight.begin()->second.begin();
-        return bucketForOptimization->IsLocked(dataLocksManager);
-    }
-
     bool IsEmpty() const {
         return Buckets.empty() && LeftBucket->IsEmpty();
     }
@@ -1227,10 +1184,6 @@ private:
     }
 
 protected:
-    virtual bool DoIsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const override {
-        return Buckets.IsLocked(dataLocksManager);
-    }
-
     virtual void DoModifyPortions(const std::vector<TPortionInfo::TPtr>& add, const std::vector<TPortionInfo::TPtr>& remove) override {
         const TInstant now = TInstant::Now();
         for (auto&& i : remove) {

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
@@ -110,7 +110,7 @@ public:
         return NotIncludedNextPortion;
     }
 
-    bool GetConsistBlockedPortions() const {
+    bool HasBlockedPortions() const {
         return ConsistBlockedPortions;
     }
 

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
@@ -546,9 +546,6 @@ public:
     std::vector<TCompactionTaskData> GetOptimizationTasks(const TMayUsePortion& mayUsePortion) const {
         AFL_VERIFY(NextLevel);
         std::vector<TCompactionTaskData> result = DoGetOptimizationTasks(mayUsePortion);
-        for (const auto& compactionTaskData: result) {
-            AFL_VERIFY(!compactionTaskData.IsEmpty());
-        }
         return result;
     }
 };

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
@@ -8,7 +8,11 @@
 #include <ydb/library/formats/arrow/replace_key.h>
 #include <ydb/services/bg_tasks/abstract/interface.h>
 
+#include <functional>
+
 namespace NKikimr::NOlap::NStorageOptimizer::NLCBuckets {
+
+using TMayUsePortion = std::function<bool(const TPortionInfo::TConstPtr&)>;
 
 class TOrderedPortion {
 private:
@@ -359,8 +363,9 @@ private:
     virtual ui64 DoGetWeight(bool highPriority) const = 0;
     virtual TInstant DoGetWeightExpirationInstant() const = 0;
     virtual NArrow::NMerger::TIntervalPositions DoGetBucketPositions(const std::shared_ptr<arrow::Schema>& pkSchema) const = 0;
-    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks() const = 0;
-    virtual std::optional<TPortionsChain> DoGetAffectedPortions(const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to) const = 0;
+    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const = 0;
+    virtual std::optional<TPortionsChain> DoGetAffectedPortions(
+        const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to, const TMayUsePortion& mayUsePortion) const = 0;
     virtual ui64 DoGetAffectedPortionBytes(const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to) const = 0;
 
     virtual NJson::TJsonValue DoSerializeToJson() const {
@@ -482,8 +487,9 @@ public:
         return DoDebugString();
     }
 
-    std::optional<TPortionsChain> GetAffectedPortions(const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to) const {
-        return DoGetAffectedPortions(from, to);
+    std::optional<TPortionsChain> GetAffectedPortions(
+        const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to, const TMayUsePortion& mayUsePortion) const {
+        return DoGetAffectedPortions(from, to, mayUsePortion);
     }
 
     ui64 GetAffectedPortionBytes(const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to) const {
@@ -534,10 +540,9 @@ public:
         return DoGetBucketPositions(pkSchema);
     }
 
-    std::vector<TCompactionTaskData> GetOptimizationTasks() const {
+    std::vector<TCompactionTaskData> GetOptimizationTasks(const TMayUsePortion& mayUsePortion) const {
         AFL_VERIFY(NextLevel);
-        std::vector<TCompactionTaskData> result = DoGetOptimizationTasks();
-        AFL_VERIFY(!result.empty());
+        std::vector<TCompactionTaskData> result = DoGetOptimizationTasks(mayUsePortion);
         for (const auto& compactionTaskData: result) {
             AFL_VERIFY(!compactionTaskData.IsEmpty());
         }

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
@@ -98,8 +98,8 @@ public:
 class TPortionsChain {
 private:
     std::vector<TPortionInfo::TConstPtr> Portions;
-
     TPortionInfo::TConstPtr NotIncludedNextPortion;
+    bool ConsistBlockedPortions;
 
 public:
     const std::vector<TPortionInfo::TConstPtr>& GetPortions() const {
@@ -108,6 +108,10 @@ public:
 
     const TPortionInfo::TConstPtr& GetNotIncludedNextPortion() const {
         return NotIncludedNextPortion;
+    }
+
+    bool GetConsistBlockedPortions() const {
+        return ConsistBlockedPortions;
     }
 
     TChainAddress GetAddress() const {
@@ -120,10 +124,16 @@ public:
         }
     }
 
-    TPortionsChain(const std::vector<TPortionInfo::TConstPtr>& portions, const TPortionInfo::TConstPtr& notIncludedNextPortion)
-        : Portions(portions)
-        , NotIncludedNextPortion(notIncludedNextPortion) {
-        AFL_VERIFY(Portions.size() || !!NotIncludedNextPortion);
+    TPortionsChain(
+        const std::vector<TPortionInfo::TConstPtr>& portions, 
+        const TPortionInfo::TConstPtr& notIncludedNextPortion,
+        const bool consistBlockedPortions
+    ): 
+        Portions(portions), 
+        NotIncludedNextPortion(notIncludedNextPortion),
+        ConsistBlockedPortions(consistBlockedPortions)
+    {
+        AFL_VERIFY(Portions.size() || !!NotIncludedNextPortion || ConsistBlockedPortions);
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/abstract.h
@@ -193,13 +193,6 @@ public:
         } else {
             return Portions;
         }
-        auto moveIds = GetMovePortionIds();
-        for (auto&& i : Portions) {
-            if (!moveIds.contains(i->GetPortionId())) {
-                result.emplace_back(i);
-            }
-        }
-        return result;
     }
 
     std::vector<TPortionInfo::TConstPtr> GetMovePortions() const {

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
@@ -60,7 +60,7 @@ void TOneLayerPortions::TryAddPortionToTask(
         return;
     }
     auto affectedPortions = GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion);
-    if (affectedPortions.has_value() && affectedPortions->GetConsistBlockedPortions()) {
+    if (affectedPortions.has_value() && affectedPortions->HasBlockedPortions()) {
         return;
     }
     compactedData += portion->GetTotalBlobBytes();

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
@@ -50,7 +50,7 @@ std::vector<TPortionInfo::TPtr> TOneLayerPortions::DoModifyPortions(
     return problems;
 }
 
-std::vector<TCompactionTaskData> TOneLayerPortions::DoGetOptimizationTasks() const {
+std::vector<TCompactionTaskData> TOneLayerPortions::DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const {
     AFL_VERIFY(GetNextLevel());
     ui64 compactedData = 0;
     TCompactionTaskData result(GetNextLevel()->GetLevelId());
@@ -65,14 +65,26 @@ std::vector<TCompactionTaskData> TOneLayerPortions::DoGetOptimizationTasks() con
         if (itFwd != Portions.end() &&
             (itBkwd == Portions.begin() || itBkwd->GetPortion()->GetTotalBlobBytes() <= itFwd->GetPortion()->GetTotalBlobBytes())) {
             auto portion = itFwd->GetPortion();
-            compactedData += portion->GetTotalBlobBytes();
-            result.AddCurrentLevelPortion(portion, GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd()), false);
+            if (mayUsePortion(portion)) {
+                compactedData += portion->GetTotalBlobBytes();
+                result.AddCurrentLevelPortion(
+                    portion, 
+                    GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion), 
+                    false
+                );
+            }
             ++itFwd;
         } else if (itBkwd != Portions.begin() &&
                    (itFwd == Portions.end() || itFwd->GetPortion()->GetTotalBlobBytes() < itBkwd->GetPortion()->GetTotalBlobBytes())) {
             auto portion = itBkwd->GetPortion();
-            compactedData += portion->GetTotalBlobBytes();
-            result.AddCurrentLevelPortion(portion, GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd()), false);
+            if (mayUsePortion(portion)) {
+                compactedData += portion->GetTotalBlobBytes();
+                result.AddCurrentLevelPortion(
+                    portion, 
+                    GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion), 
+                    false
+                );
+            }
             --itBkwd;
         }
     }

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.cpp
@@ -50,6 +50,23 @@ std::vector<TPortionInfo::TPtr> TOneLayerPortions::DoModifyPortions(
     return problems;
 }
 
+void TOneLayerPortions::TryAddPortionToTask(
+    const TPortionInfo::TConstPtr& portion,
+    TCompactionTaskData& task,
+    ui64& compactedData,
+    const TMayUsePortion& mayUsePortion
+) const {
+    if (!mayUsePortion(portion)) {
+        return;
+    }
+    auto affectedPortions = GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion);
+    if (affectedPortions.has_value() && affectedPortions->GetConsistBlockedPortions()) {
+        return;
+    }
+    compactedData += portion->GetTotalBlobBytes();
+    task.AddCurrentLevelPortion(portion, std::move(affectedPortions), false);
+}
+
 std::vector<TCompactionTaskData> TOneLayerPortions::DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const {
     AFL_VERIFY(GetNextLevel());
     ui64 compactedData = 0;
@@ -64,27 +81,11 @@ std::vector<TCompactionTaskData> TOneLayerPortions::DoGetOptimizationTasks(const
            (itBkwd != Portions.begin() || itFwd != Portions.end()) && result.CanTakeMore()) {
         if (itFwd != Portions.end() &&
             (itBkwd == Portions.begin() || itBkwd->GetPortion()->GetTotalBlobBytes() <= itFwd->GetPortion()->GetTotalBlobBytes())) {
-            auto portion = itFwd->GetPortion();
-            if (mayUsePortion(portion)) {
-                compactedData += portion->GetTotalBlobBytes();
-                result.AddCurrentLevelPortion(
-                    portion, 
-                    GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion), 
-                    false
-                );
-            }
+            TryAddPortionToTask(itFwd->GetPortion(), result, compactedData, mayUsePortion);
             ++itFwd;
         } else if (itBkwd != Portions.begin() &&
                    (itFwd == Portions.end() || itFwd->GetPortion()->GetTotalBlobBytes() < itBkwd->GetPortion()->GetTotalBlobBytes())) {
-            auto portion = itBkwd->GetPortion();
-            if (mayUsePortion(portion)) {
-                compactedData += portion->GetTotalBlobBytes();
-                result.AddCurrentLevelPortion(
-                    portion, 
-                    GetNextLevel()->GetAffectedPortions(portion->IndexKeyStart(), portion->IndexKeyEnd(), mayUsePortion), 
-                    false
-                );
-            }
+            TryAddPortionToTask(itBkwd->GetPortion(), result, compactedData, mayUsePortion);
             --itBkwd;
         }
     }

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.h
@@ -33,7 +33,8 @@ private:
         return result;
     }
 
-    virtual std::optional<TPortionsChain> DoGetAffectedPortions(const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to) const override {
+    virtual std::optional<TPortionsChain> DoGetAffectedPortions(
+        const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to, const TMayUsePortion& mayUsePortion) const override {
         if (Portions.empty()) {
             return std::nullopt;
         }
@@ -43,20 +44,30 @@ private:
         if (itFrom != Portions.begin()) {
             auto it = itFrom;
             --it;
-            if (from <= it->GetPortion()->IndexKeyEnd()) {
+            if (from <= it->GetPortion()->IndexKeyEnd() && mayUsePortion(it->GetPortion())) {
                 result.insert(result.begin(), it->GetPortion());
             }
         }
         for (auto it = itFrom; it != itTo; ++it) {
-            result.emplace_back(it->GetPortion());
+            if (mayUsePortion(it->GetPortion())) {
+                result.emplace_back(it->GetPortion());
+            }
         }
+        TPortionInfo::TConstPtr next = nullptr;
         if (itTo != Portions.end()) {
-            return TPortionsChain(std::move(result), itTo->GetPortion());
-        } else if (result.size()) {
-            return TPortionsChain(std::move(result), nullptr);
-        } else {
-            return std::nullopt;
+            auto itNext = itTo;
+            while (itNext != Portions.end() && !mayUsePortion(itNext->GetPortion())) {
+                ++itNext;
+            }
+            if (itNext != Portions.end()) {
+                next = itNext->GetPortion();
+            }
         }
+
+        if (result.size() || next) {
+            return TPortionsChain(std::move(result), next);
+        }
+        return std::nullopt;
     }
 
     virtual ui64 DoGetWeight(bool) const override {
@@ -146,7 +157,7 @@ public:
     virtual std::vector<TPortionInfo::TPtr> DoModifyPortions(
         const std::vector<TPortionInfo::TPtr>& add, const std::vector<TPortionInfo::TPtr>& remove) override;
 
-    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks() const override;
+    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const override;
 
     virtual NArrow::NMerger::TIntervalPositions DoGetBucketPositions(const std::shared_ptr<arrow::Schema>& /*pkSchema*/) const override {
         NArrow::NMerger::TIntervalPositions result;

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/one_layer.h
@@ -34,7 +34,10 @@ private:
     }
 
     virtual std::optional<TPortionsChain> DoGetAffectedPortions(
-        const NArrow::TSimpleRow& from, const NArrow::TSimpleRow& to, const TMayUsePortion& mayUsePortion) const override {
+        const NArrow::TSimpleRow& from, 
+        const NArrow::TSimpleRow& to,
+        const TMayUsePortion& mayUsePortion
+    ) const override {
         if (Portions.empty()) {
             return std::nullopt;
         }
@@ -44,28 +47,38 @@ private:
         if (itFrom != Portions.begin()) {
             auto it = itFrom;
             --it;
-            if (from <= it->GetPortion()->IndexKeyEnd() && mayUsePortion(it->GetPortion())) {
-                result.insert(result.begin(), it->GetPortion());
+            if (from <= it->GetPortion()->IndexKeyEnd()) {
+                itFrom = it;
             }
         }
         for (auto it = itFrom; it != itTo; ++it) {
-            if (mayUsePortion(it->GetPortion())) {
-                result.emplace_back(it->GetPortion());
-            }
+            result.emplace_back(it->GetPortion());
         }
         TPortionInfo::TConstPtr next = nullptr;
         if (itTo != Portions.end()) {
-            auto itNext = itTo;
-            while (itNext != Portions.end() && !mayUsePortion(itNext->GetPortion())) {
-                ++itNext;
-            }
-            if (itNext != Portions.end()) {
-                next = itNext->GetPortion();
+            next = itTo->GetPortion();
+        }
+
+        // We should not compact the portions that intersect with blocked portions
+        // on a "one layer" level. Because one layer requires all portions not to intersect
+        // with each other. So, if we just skip blocked portions, there will be a chance that
+        // new compacted portions will intersect with those blocked portions, that is we will
+        // break this requirement.
+        // So, that is why here we check all the portions if they are blocked, so that the client's
+        // code can skip this [from, to] part completely.
+        bool consistBlockedPortions = false;
+        for (auto& it: result) {
+            if (!mayUsePortion(it)) {
+                consistBlockedPortions = true;
+                break;
             }
         }
 
+        if (consistBlockedPortions) {
+            return TPortionsChain(std::vector<TPortionInfo::TConstPtr>(), nullptr, true);
+        }
         if (result.size() || next) {
-            return TPortionsChain(std::move(result), next);
+            return TPortionsChain(std::move(result), next, false);
         }
         return std::nullopt;
     }
@@ -100,6 +113,13 @@ private:
     virtual TInstant DoGetWeightExpirationInstant() const override {
         return TInstant::Max();
     }
+
+    void TryAddPortionToTask(
+        const TPortionInfo::TConstPtr& portion, 
+        TCompactionTaskData& task, 
+        ui64& compactedData,
+        const TMayUsePortion& mayUsePortion
+    ) const;
 
 public:
     TOneLayerPortions(const ui64 levelId, const double bytesLimitFraction, const ui64 expectedPortionSize,

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
@@ -11,8 +11,11 @@ std::vector<TCompactionTaskData> TZeroLevelPortions::DoGetOptimizationTasks(cons
         if (!mayUsePortion(i.GetPortion())) {
             continue;
         }
-        result.back().AddCurrentLevelPortion(
-            i.GetPortion(), NextLevel->GetAffectedPortions(i.GetPortion()->IndexKeyStart(), i.GetPortion()->IndexKeyEnd(), mayUsePortion), true);
+        auto affectedPortions = NextLevel->GetAffectedPortions(i.GetPortion()->IndexKeyStart(), i.GetPortion()->IndexKeyEnd(), mayUsePortion);
+        if (affectedPortions.has_value() && affectedPortions->GetConsistBlockedPortions()) {
+            continue;
+        }
+        result.back().AddCurrentLevelPortion(i.GetPortion(), std::move(affectedPortions), true);
         if (!result.back().CanTakeMore()) {
             //            result.SetStopSeparation(i.GetPortion()->IndexKeyStart());
             if (--tasksLeft <= 0) {

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
@@ -12,7 +12,7 @@ std::vector<TCompactionTaskData> TZeroLevelPortions::DoGetOptimizationTasks(cons
             continue;
         }
         auto affectedPortions = NextLevel->GetAffectedPortions(i.GetPortion()->IndexKeyStart(), i.GetPortion()->IndexKeyEnd(), mayUsePortion);
-        if (affectedPortions.has_value() && affectedPortions->GetConsistBlockedPortions()) {
+        if (affectedPortions.has_value() && affectedPortions->HasBlockedPortions()) {
             continue;
         }
         result.back().AddCurrentLevelPortion(i.GetPortion(), std::move(affectedPortions), true);

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.cpp
@@ -2,14 +2,17 @@
 
 namespace NKikimr::NOlap::NStorageOptimizer::NLCBuckets {
 
-std::vector<TCompactionTaskData> TZeroLevelPortions::DoGetOptimizationTasks() const {
+std::vector<TCompactionTaskData> TZeroLevelPortions::DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const {
     std::vector<TCompactionTaskData> result;
     AFL_VERIFY(Portions.size());
     result.emplace_back(NextLevel->GetLevelId(), CompactionTaskMemoryLimit, CompactionTaskPortionsCountLimit, CompactAtLevel ? NextLevel->GetExpectedPortionSize() : std::optional<ui64>());
     i64 tasksLeft = GetMaxConcurrency();
     for (auto&& i : Portions) {
+        if (!mayUsePortion(i.GetPortion())) {
+            continue;
+        }
         result.back().AddCurrentLevelPortion(
-            i.GetPortion(), NextLevel->GetAffectedPortions(i.GetPortion()->IndexKeyStart(), i.GetPortion()->IndexKeyEnd()), true);
+            i.GetPortion(), NextLevel->GetAffectedPortions(i.GetPortion()->IndexKeyStart(), i.GetPortion()->IndexKeyEnd(), mayUsePortion), true);
         if (!result.back().CanTakeMore()) {
             //            result.SetStopSeparation(i.GetPortion()->IndexKeyStart());
             if (--tasksLeft <= 0) {
@@ -22,7 +25,9 @@ std::vector<TCompactionTaskData> TZeroLevelPortions::DoGetOptimizationTasks() co
     if (result.back().IsEmpty()) {
         result.pop_back();
     }
-    AFL_VERIFY(!result.empty());
+    if (result.empty()) {
+        return result;
+    }
 
     if (result.back().CanTakeMore()) {
         PredOptimization = TInstant::Now();

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/level/zero_level.h
@@ -23,7 +23,7 @@ private:
     }
 
     virtual std::optional<TPortionsChain> DoGetAffectedPortions(
-        const NArrow::TSimpleRow& /*from*/, const NArrow::TSimpleRow& /*to*/) const override {
+        const NArrow::TSimpleRow& /*from*/, const NArrow::TSimpleRow& /*to*/, const TMayUsePortion& /*mayUsePortion*/) const override {
         return std::nullopt;
     }
 
@@ -76,7 +76,7 @@ private:
     virtual ui64 DoGetWeight(bool highPriority) const override;
     virtual TInstant DoGetWeightExpirationInstant() const override;
 
-    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks() const override;
+    virtual std::vector<TCompactionTaskData> DoGetOptimizationTasks(const TMayUsePortion& mayUsePortion) const override;
     virtual ui64 GetExpectedPortionSize() const override {
         return ExpectedBlobsSize;
     }

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.cpp
@@ -1,9 +1,6 @@
 #include "optimizer.h"
 
 #include "level/one_layer.h"
-#include "level/zero_level.h"
-#include "selector/snapshot.h"
-#include "selector/transparent.h"
 
 #include <ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/constructor/constructor.h>
 
@@ -40,28 +37,36 @@ std::vector<std::shared_ptr<TColumnEngineChanges>> TOptimizerPlanner::DoGetOptim
             if (data.IsEmpty()) {
                 continue;
             }
+            // filter out locked portions
+            auto notLockedPortions = data.GetRepackPortions(level->GetLevelId());
+            size_t i = 0;
+            while (i < notLockedPortions.size()) {
+                if (!locksManager->IsLocked(notLockedPortions[i], NDataLocks::ELockCategory::Compaction)) {
+                    i++;
+                    continue;
+                }
+                if (i + 1 == notLockedPortions.size()) {
+                    notLockedPortions.pop_back();
+                    break;
+                }
+                notLockedPortions[i] = notLockedPortions.back();
+                notLockedPortions.pop_back();
+            }
+            if (notLockedPortions.size() < 2) {
+                continue;
+            }
             hasOneLayer |= dynamic_pointer_cast<TOneLayerPortions>(level) != nullptr;
-            if (!results.empty() && hasOneLayer) {
+            if (hasOneLayer && !results.empty()) {
                 return results;
             }
-            std::shared_ptr<NCompaction::TGeneralCompactColumnEngineChanges> result;
-            //    if (level->GetLevelId() == 0) {
-            result =
-                std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(granule, data.GetRepackPortions(level->GetLevelId()), saverContext);
-            //    } else {
-            //        result = std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(
-            //            granule, data.GetRepackPortions(level->GetLevelId()), saverContext);
-            //        result->AddMovePortions(data.GetMovePortions());
-            //    }
+
+            auto result = std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(granule, notLockedPortions, saverContext);
             result->SetTargetCompactionLevel(data.GetTargetCompactionLevel());
             result->SetPortionExpectedSize(Levels[data.GetTargetCompactionLevel()]->GetExpectedPortionSize());
             auto positions = data.GetCheckPositions(PrimaryKeysSchema, level->GetLevelId() > 1);
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("task_id", result->GetTaskIdentifier())("positions", positions.DebugString())(
                 "level", level->GetLevelId())("target", data.GetTargetCompactionLevel())("data", data.DebugString());
             result->SetCheckPoints(std::move(positions));
-            for (auto&& i : result->GetSwitchedPortions()) {
-                AFL_VERIFY(!locksManager->IsLocked(i, NDataLocks::ELockCategory::Compaction));
-            }
             results.push_back(result);
             if (!AppDataVerified().ColumnShardConfig.GetEnableParallelCompaction()) {
                 return results;

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.cpp
@@ -28,31 +28,16 @@ std::vector<std::shared_ptr<TColumnEngineChanges>> TOptimizerPlanner::DoGetOptim
     TSaverContext saverContext(StoragesManager);
     std::vector<std::shared_ptr<TColumnEngineChanges>> results;
     bool hasOneLayer = false;
+    const auto mayUsePortion = [&](const TPortionInfo::TConstPtr& p) {
+        return !locksManager->IsLocked(p, NDataLocks::ELockCategory::Compaction);
+    };
     for (const auto& [weight, level]: LevelsByWeight) {
         if (weight == 0) {
             break;
         }
-        auto tasks = level->GetOptimizationTasks();
+        auto tasks = level->GetOptimizationTasks(mayUsePortion);
         for (auto& data: tasks) {
             if (data.IsEmpty()) {
-                continue;
-            }
-            // filter out locked portions
-            auto notLockedPortions = data.GetRepackPortions(level->GetLevelId());
-            size_t i = 0;
-            while (i < notLockedPortions.size()) {
-                if (!locksManager->IsLocked(notLockedPortions[i], NDataLocks::ELockCategory::Compaction)) {
-                    i++;
-                    continue;
-                }
-                if (i + 1 == notLockedPortions.size()) {
-                    notLockedPortions.pop_back();
-                    break;
-                }
-                notLockedPortions[i] = notLockedPortions.back();
-                notLockedPortions.pop_back();
-            }
-            if (notLockedPortions.size() < 2) {
                 continue;
             }
             hasOneLayer |= dynamic_pointer_cast<TOneLayerPortions>(level) != nullptr;
@@ -60,7 +45,7 @@ std::vector<std::shared_ptr<TColumnEngineChanges>> TOptimizerPlanner::DoGetOptim
                 return results;
             }
 
-            auto result = std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(granule, notLockedPortions, saverContext);
+            auto result = std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(granule, data.GetRepackPortions(level->GetLevelId()), saverContext);
             result->SetTargetCompactionLevel(data.GetTargetCompactionLevel());
             result->SetPortionExpectedSize(Levels[data.GetTargetCompactionLevel()]->GetExpectedPortionSize());
             auto positions = data.GetCheckPositions(PrimaryKeysSchema, level->GetLevelId() > 1);

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lcbuckets/planner/optimizer.h
@@ -58,15 +58,6 @@ private:
     }
 
 protected:
-    virtual bool DoIsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const override {
-        for (auto&& i : Levels) {
-            if (i->IsLocked(dataLocksManager)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     virtual void DoModifyPortions(const std::vector<TPortionInfo::TPtr>& add, const std::vector<TPortionInfo::TPtr>& remove) override {
         std::vector<std::vector<TPortionInfo::TPtr>> removePortionsByLevel;
         removePortionsByLevel.resize(Levels.size());

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
@@ -566,12 +566,6 @@ private:
         return {};
     }
 
-    bool DoIsLocked(const std::shared_ptr<NDataLocks::TManager>& dataLocksManager) const override {
-        // This method is never used
-        Y_UNUSED(dataLocksManager);
-        return false;
-    }
-
     bool IsAccumulatorPortion(const TPortionInfo::TPtr& p) {
         if (p->GetTotalBlobBytes() <= MaxAccumulatePortionSize && InternalLevel[p->GetPortionId()] < 3) {
             return true; // portion is too small

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
@@ -806,10 +806,15 @@ private:
         }
 
         if (isLevel) {
-            return { GetCompactLevelTask(granule, locksManager, *maxLevel) };
+            if (auto result = GetCompactLevelTask(granule, locksManager, *maxLevel)) {
+                return { result };
+            }
+        } else {
+            if (auto result = GetCompactAccumulatorTask(granule, locksManager, *maxLevel)) {
+                return { result };
+            }
         }
-
-        return { GetCompactAccumulatorTask(granule, locksManager, *maxLevel) };
+        return {};
     }
 
     void DoActualize(const TInstant currentInstant) override {

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
@@ -496,7 +496,7 @@ class TOptimizerPlanner : public IOptimizerPlanner, private TSettings {
     using TBase = IOptimizerPlanner;
     std::shared_ptr<TCounters> Counters;
     std::shared_ptr<TSimplePortionsGroupInfo> PortionsInfo;
-    mutable bool Busy = false;
+    mutable bool LastTaskWasImportant = false;
     size_t MaxPortionPromotion = 100;
     TDuration PromoteTime = TDuration::Seconds(180);
 
@@ -722,7 +722,7 @@ private:
     }
 
     void PromotePortions(const TInstant currentInstant) {
-        if (Busy) {
+        if (LastTaskWasImportant) {
             return;
         }
 
@@ -750,13 +750,13 @@ private:
 
     std::vector<std::shared_ptr<TColumnEngineChanges>> DoGetOptimizationTasks(std::shared_ptr<TGranuleMeta> granule, const std::shared_ptr<NDataLocks::TManager>& locksManager) const override {
         // Check compactions, top to bottom
-        Busy = true;
+        LastTaskWasImportant = true;
 
         for (size_t level = 0; level < Max(Accumulator.size(), Levels.size()); ++level) {
             if (level < Accumulator.size()) {
                 if (NeedAccumulatorCompaction(level).IsCritical()) {
                     if (auto result = GetCompactAccumulatorTask(granule, locksManager, level)) {
-                        Busy = false;
+                        // keep LastTaskWasImportant true
                         return { result };
                     }
                 }
@@ -764,14 +764,14 @@ private:
             if (level < Levels.size()) {
                 if (NeedLevelCompaction(level).IsCritical()) {
                     if (auto result = GetCompactLevelTask(granule, locksManager, level)) {
-                        Busy = false;
+                        // keep LastTaskWasImportant true
                         return { result };
                     }
                 }
             }
         }
 
-        Busy = false;
+        LastTaskWasImportant = false;
 
         TOptimizationPriority maxPriority = TOptimizationPriority::Zero();
         bool isLevel = false;

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/tiling/tiling.cpp
@@ -762,6 +762,7 @@ private:
             if (level < Accumulator.size()) {
                 if (NeedAccumulatorCompaction(level).IsCritical()) {
                     if (auto result = GetCompactAccumulatorTask(granule, locksManager, level)) {
+                        Busy = false;
                         return { result };
                     }
                 }
@@ -769,6 +770,7 @@ private:
             if (level < Levels.size()) {
                 if (NeedLevelCompaction(level).IsCritical()) {
                     if (auto result = GetCompactLevelTask(granule, locksManager, level)) {
+                        Busy = false;
                         return { result };
                     }
                 }

--- a/ydb/core/tx/columnshard/inflight_request_tracker.cpp
+++ b/ydb/core/tx/columnshard/inflight_request_tracker.cpp
@@ -21,7 +21,7 @@ NOlap::NReader::TReadMetadataBase::TConstPtr TInFlightReadsTracker::ExtractInFli
         AFL_VERIFY(it != SnapshotsLive.end());
         Y_UNUSED(it->second.DelRequest(cookie, now));
     }
-    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetSnapshotToClean());
+    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetOldestLiveSnapshot());
 
     RequestsMeta.erase(cookie);
     return readMetaBase;
@@ -84,7 +84,7 @@ std::unique_ptr<NTabletFlatExecutor::ITransaction> TInFlightReadsTracker::Ping(
     for (auto&& i : snapshotsToFreeInMem) {
         SnapshotsLive.erase(i);
     }
-    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetSnapshotToClean());
+    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetOldestLiveSnapshot());
     if (snapshotsToFreeInDB.size() || snapshotsToSave.size()) {
         NYDBTest::TControllers::GetColumnShardController()->OnRequestTracingChanges(snapshotsToSave, snapshotsToFreeInMem);
         return std::make_unique<TTransactionSavePersistentSnapshots>(self, std::move(snapshotsToSave), std::move(snapshotsToFreeInDB));
@@ -109,7 +109,7 @@ bool TInFlightReadsTracker::LoadFromDatabase(NTable::TDatabase& tableDB) {
             return false;
         }
     }
-    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetSnapshotToClean());
+    Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetOldestLiveSnapshot());
     return true;
 }
 
@@ -118,7 +118,7 @@ ui64 TInFlightReadsTracker::AddInFlightRequest(NOlap::NReader::TReadMetadataBase
     auto it = SnapshotsLive.find(readMeta->GetRequestSnapshot());
     if (it == SnapshotsLive.end()) {
         it = SnapshotsLive.emplace(readMeta->GetRequestSnapshot(), TSnapshotLiveInfo::BuildFromRequest(readMeta->GetRequestSnapshot())).first;
-        Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetSnapshotToClean());
+        Counters->OnSnapshotsInfo(SnapshotsLive.size(), GetOldestLiveSnapshot());
     }
     it->second.AddRequest(cookie);
     AddToInFlightRequest(cookie, readMeta, index);

--- a/ydb/core/tx/columnshard/inflight_request_tracker.h
+++ b/ydb/core/tx/columnshard/inflight_request_tracker.h
@@ -93,7 +93,7 @@ private:
     NOlap::TSelectInfo::TStats SelectStatsDelta;
 
 public:
-    std::optional<NOlap::TSnapshot> GetSnapshotToClean() const {
+    std::optional<NOlap::TSnapshot> GetOldestLiveSnapshot() const {
         if (SnapshotsLive.empty()) {
             return std::nullopt;
         } else {
@@ -109,6 +109,10 @@ public:
             result.push_back(snapshot);
         }
         return result;
+    }
+
+    bool HasLiveSnapshot(const NOlap::TSnapshot& snapshot) const {
+        return SnapshotsLive.contains(snapshot);
     }
 
     bool LoadFromDatabase(NTable::TDatabase& db);


### PR DESCRIPTION
Fixes #36332

1. Long scans may proceed after the shard move. The snapshot checking logic checks both the new scan window (now - read staleness) + active scan snapshots. So if a new scan has an old snapshot (older than now - read staleness), but the columnshard has its snapshot among active snapshots, the scan is allowed to read/work.
2. Compaction does not take the lock for the whole table anymore. Now it only takes locks only for portions it works with. In the same fashion ttl and cleanup work.