### PR TITLE
use port manager from library to remove deprecation warning

### DIFF
--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import abc
+import library.python.port_manager
 import os
 import yatest
-import yatest.common.network
 
 
 class KikimrNodePortAllocatorInterface(object):
@@ -152,7 +152,7 @@ class KikimrPortManagerNodePortAllocator(KikimrNodePortAllocatorInterface):
 class KikimrPortManagerPortAllocator(KikimrPortAllocatorInterface):
     def __init__(self, port_manager=None):
         super(KikimrPortManagerPortAllocator, self).__init__()
-        self.__port_manager = yatest.common.network.PortManager() if port_manager is None else port_manager
+        self.__port_manager = library.python.port_manager.PortManager() if port_manager is None else port_manager
         self.__nodes_allocators = []
         self.__slots_allocators = []
 

--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -2,7 +2,6 @@
 import abc
 import library.python.port_manager
 import os
-import yatest
 
 
 class KikimrNodePortAllocatorInterface(object):

--- a/ydb/tests/library/ya.make
+++ b/ydb/tests/library/ya.make
@@ -74,6 +74,7 @@ PEERDIR(
     contrib/python/PyYAML
     contrib/python/cryptography
     contrib/python/importlib-resources
+    contrib/python/port_manager
     contrib/python/protobuf
     contrib/python/pytest
     contrib/python/requests

--- a/ydb/tests/library/ya.make
+++ b/ydb/tests/library/ya.make
@@ -74,13 +74,13 @@ PEERDIR(
     contrib/python/PyYAML
     contrib/python/cryptography
     contrib/python/importlib-resources
-    contrib/python/port_manager
     contrib/python/protobuf
     contrib/python/pytest
     contrib/python/requests
     contrib/python/setuptools
     contrib/python/six
     ydb/public/sdk/python
+    library/python/port_manager
     library/python/svn_version
     library/python/testing/yatest_common
     ydb/core/protos

--- a/ydb/tests/olap/common/s3_client.py
+++ b/ydb/tests/olap/common/s3_client.py
@@ -4,7 +4,6 @@ from typing import Tuple, Optional
 
 import boto3
 import library.python.port_manager
-import yatest.common
 from library.recipes import common as recipes_common
 
 

--- a/ydb/tests/olap/common/s3_client.py
+++ b/ydb/tests/olap/common/s3_client.py
@@ -3,6 +3,7 @@ import requests
 from typing import Tuple, Optional
 
 import boto3
+import library.python.port_manager
 import yatest.common
 from library.recipes import common as recipes_common
 
@@ -11,7 +12,7 @@ class S3Mock:
     def __init__(self, moto_server_path: str):
         self.moto_server_path = moto_server_path
         self.s3_pid_file = "s3.pid"
-        self.port_manager = yatest.common.network.PortManager()
+        self.port_manager = library.python.port_manager.PortManager()
 
         self.endpoint: Optional[str] = None
         self.s3_pid: Optional[int] = None

--- a/ydb/tests/olap/common/ya.make
+++ b/ydb/tests/olap/common/ya.make
@@ -14,6 +14,7 @@ PY3_LIBRARY()
         contrib/python/boto3
         contrib/python/numpy
         contrib/python/requests
+        library/python/port_manager
         library/recipes/common
         ydb/public/sdk/python
     )

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -25,7 +25,7 @@ from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 
 from ydb import PrimitiveType, StatusCode
-import yatest.common.network
+import library.python.port_manager
 from moto.server import ThreadedMotoServer
 
 import boto3
@@ -55,7 +55,7 @@ class TestLoop:
 
 class S3:
     def __init__(self):
-        self.port_manager = yatest.common.network.PortManager()
+        self.port_manager = library.python.port_manager.PortManager()
         self._server = None
 
     def start_server(self) -> str:

--- a/ydb/tests/olap/scenario/ya.make
+++ b/ydb/tests/olap/scenario/ya.make
@@ -26,6 +26,7 @@ PY3TEST()
         contrib/python/boto3
         contrib/python/moto
         contrib/python/requests
+        library/python/port_manager
         library/python/testing/yatest_common
         library/recipes/common
         ydb/public/sdk/python

--- a/ydb/tests/sql/lib/test_s3.py
+++ b/ydb/tests/sql/lib/test_s3.py
@@ -1,5 +1,6 @@
 import pytest
 from library.recipes import common as recipes_common
+import library.python.port_manager
 import yatest.common
 import moto
 import requests
@@ -20,7 +21,7 @@ class S3Base(object):
         s3_pid_file = "s3.pid"
         moto_server_path = os.environ["MOTO_SERVER_PATH"]
 
-        port_manager = yatest.common.network.PortManager()
+        port_manager = library.python.port_manager.PortManager()
         s3_port = port_manager.get_port()
         s3_endpoint = "http://localhost:{port}".format(port=s3_port)
         self.s3base_setup_classmethod(s3_endpoint)

--- a/ydb/tests/sql/lib/ya.make
+++ b/ydb/tests/sql/lib/ya.make
@@ -10,6 +10,7 @@ PY_SRCS(
 PEERDIR(
     ydb/tests/library
     ydb/tests/library/test_meta
+    library/python/port_manager
     library/python/testing/recipe
     library/recipes/common
     contrib/python/moto

--- a/ydb/tests/stress/kafka/tests/test_kafka_streams.py
+++ b/ydb/tests/stress/kafka/tests/test_kafka_streams.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import pytest
+import library.python.port_manager
 import yatest
 
 from ydb.tests.library.stress.fixtures import StressFixture
@@ -9,7 +10,7 @@ from ydb.tests.library.stress.fixtures import StressFixture
 class TestYdbTopicWorkload(StressFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
-        port_manager = yatest.common.network.PortManager()
+        port_manager = library.python.port_manager.PortManager()
         self.kafka_api_port = port_manager.get_port()
         yield from self.setup_cluster(
             kafka_api_port=self.kafka_api_port,

--- a/ydb/tests/stress/kafka/tests/ya.make
+++ b/ydb/tests/stress/kafka/tests/ya.make
@@ -17,6 +17,7 @@ DEPENDS(
 )
 
 PEERDIR(
+    library/python/port_manager
     ydb/tests/library
     ydb/tests/library/stress
     ydb/tests/stress/kafka/workload


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

переключаемся с легаси yatest.common.network.PortManager на library.python.port_manager.PortManager