### PR TITLE
async ca/checkpointing: fix stall on full input and empty checkpoint

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -668,6 +668,7 @@ private:
         if (!shouldSkipData) {
             if (asyncData.Checkpoint.Defined()) {
                 ResumeInputsByCheckpoint();
+                ContinueExecute(EResumeSource::CheckpointInject);
             }
 
             for (ui32 i = 0; i < asyncData.Data.size(); i++) {
@@ -768,6 +769,7 @@ private:
         if (checkpoint) {
             CA_LOG_I("Resume inputs");
             ResumeInputsByCheckpoint();
+            ResumeExecution(EResumeSource::CheckpointInject);
         }
 
         sinkInfo.PopStarted = false;

--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -539,8 +539,6 @@ private:
                 MetricsReporter.ReportInjectedToOutputsWatermark(*watermark);
                 WatermarksTracker.PopPendingWatermark();
             }
-            // sources or input channels was unpaused, trigger new poll
-            ResumeExecution(EResumeSource::CAWatermarkInject);
         }
 
         ReadyToCheckpointFlag = (bool) ev->Get()->ProgramState;
@@ -668,7 +666,6 @@ private:
         if (!shouldSkipData) {
             if (asyncData.Checkpoint.Defined()) {
                 ResumeInputsByCheckpoint();
-                ContinueExecute(EResumeSource::CheckpointInject);
             }
 
             for (ui32 i = 0; i < asyncData.Data.size(); i++) {
@@ -769,7 +766,6 @@ private:
         if (checkpoint) {
             CA_LOG_I("Resume inputs");
             ResumeInputsByCheckpoint();
-            ResumeExecution(EResumeSource::CheckpointInject);
         }
 
         sinkInfo.PopStarted = false;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -55,9 +55,10 @@ enum class EResumeSource : ui32 {
     CADataSent,
     CAPendingOutput,
     CATaskRunnerCreated,
-    CAWatermarkInject,
+    CAResumeByWatermark,
     CAWatermarkIdleness,
     CAWakeupCallback,
+    CAResumeByCheckpoint,
 
     Last,
 };

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -823,6 +823,8 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
 
             sourceInfo.ResumeByWatermark(watermark);
         }
+        // sources or input channels was unpaused, trigger new poll
+        ResumeExecution(EResumeSource::CAResumeByWatermark);
     }
 
     void ResumeInputsByCheckpoint() override final {
@@ -831,6 +833,8 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
                 channelInfo.ResumeByCheckpoint();
             }
         }
+        // sources or input channels was unpaused, trigger new poll
+        ResumeExecution(EResumeSource::CAResumeByCheckpoint);
     }
 
 protected:


### PR DESCRIPTION
CA may freeze when checkpoint with empty data was send when input while channels getting full with data (if channels are not full, new data arrival will trigger poll; if data was sent, it would also trigger new poll; but if neither is true, CA would just deadlock)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TODO: test