### PR TITLE
YDB options for topic stress tests

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -416,4 +416,22 @@ bool TTopicOperationsScenario::AnyOutgoingMessages() const
     return false;
 }
 
+void TTopicOperationsScenario::ConfigMetadataMonitoringOptions(TClientCommand::TConfig& config)
+{
+    config.Opts->AddLongOption("configure-consumers", "Number of consumers to continuously add and remove from the topic")
+        .Optional()
+        .Hidden()
+        .DefaultValue(0)
+        .StoreResult(&ConfigConsumerCount);
+    config.Opts->AddLongOption("describe-topic", "Continuously call DescribeTopic method to monitor topic metadata")
+        .Optional()
+        .Hidden()
+        .DefaultValue(false)
+        .StoreTrue(&NeedDescribeTopic);
+    config.Opts->AddLongOption("describe-consumer", "Consumer name for which DescribeConsumer method will be called continuously")
+        .Optional()
+        .Hidden()
+        .StoreResult(&DescribeConsumerName);
+}
+
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -206,7 +206,9 @@ void TTopicOperationsScenario::CreateTopic(const TString& topic,
         settings.AddAttribute("_cleanup_policy", "compact");
     }
 
-    settings.AddAttribute("_partitions_per_tablet", ToString(PartitionsPerTablet));
+    if (PartitionsPerTablet.Defined()) {
+        settings.AddAttribute("_partitions_per_tablet", ToString(*PartitionsPerTablet));
+    }
 
     for (unsigned consumerIdx = 0; consumerIdx < consumerCount; ++consumerIdx) {
         settings

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -206,6 +206,8 @@ void TTopicOperationsScenario::CreateTopic(const TString& topic,
         settings.AddAttribute("_cleanup_policy", "compact");
     }
 
+    settings.AddAttribute("_partitions_per_tablet", ToString(PartitionsPerTablet));
+
     for (unsigned consumerIdx = 0; consumerIdx < consumerCount; ++consumerIdx) {
         settings
             .BeginAddConsumer(TCommandWorkloadTopicDescribe::GenerateConsumerName(ConsumerPrefix, consumerIdx))

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -96,7 +96,7 @@ public:
     size_t ConfigConsumerCount = 0;
     bool NeedDescribeTopic = false;
     TString DescribeConsumerName;
-    ui32 PartitionsPerTablet = 1;
+    TMaybe<ui32> PartitionsPerTablet;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -48,6 +48,8 @@ public:
 
     ui32 GetTopicMaxPartitionCount() const;
 
+    void ConfigMetadataMonitoringOptions(TClientCommand::TConfig& config);
+
     TDuration TotalSec;
     TDuration WindowSec;
     TDuration WarmupSec;

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -94,6 +94,7 @@ public:
     size_t ConfigConsumerCount = 0;
     bool NeedDescribeTopic = false;
     TString DescribeConsumerName;
+    ui32 PartitionsPerTablet = 1;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
@@ -22,6 +22,8 @@ int TTopicReadWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
+    StartConfiguratorThread(threads, config.Database);
+    StartDescriberThread(threads, config.Database);
 
     StatsCollector->PrintWindowStatsLoop();
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_init.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_init.cpp
@@ -4,6 +4,7 @@
 #include "topic_workload_describe.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
+#include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 
 using namespace NYdb::NConsoleClient;
@@ -66,7 +67,7 @@ void TCommandWorkloadTopicInit::Config(TConfig& config)
     config.Opts->AddLongOption("partitions-per-tablet", "Partitions per PQ tablet")
         .Optional()
         .Hidden()
-        .StoreResult(&Scenario.PartitionsPerTablet);
+        .StoreMappedResult(&Scenario.PartitionsPerTablet, ParsePartitionPerTabletValue);
 }
 
 void TCommandWorkloadTopicInit::Parse(TConfig& config)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_init.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_init.cpp
@@ -62,6 +62,11 @@ void TCommandWorkloadTopicInit::Config(TConfig& config)
         .Optional()
         .Hidden()
         .StoreTrue(&Scenario.CleanupPolicyCompact);
+
+    config.Opts->AddLongOption("partitions-per-tablet", "Partitions per PQ tablet")
+        .Optional()
+        .Hidden()
+        .StoreResult(&Scenario.PartitionsPerTablet);
 }
 
 void TCommandWorkloadTopicInit::Parse(TConfig& config)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -122,22 +122,7 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
         .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NYdb::SizeFromString);
 
-    config.Opts->AddLongOption("configure-consumers", "The number of consumers to change the topic configuration. "
-                                                      "If the value is greater than 0, the program will continuously "
-                                                      "change the topic configuration.")
-        .Optional()
-        .Hidden()
-        .DefaultValue(0)
-        .StoreResult(&Scenario.ConfigConsumerCount);
-    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescribeTopic method")
-        .Optional()
-        .Hidden()
-        .DefaultValue(false)
-        .StoreTrue(&Scenario.NeedDescribeTopic);
-    config.Opts->AddLongOption("describe-consumer", "The program constantly calls the DescribeConsumer method")
-        .Optional()
-        .Hidden()
-        .StoreResult(&Scenario.DescribeConsumerName);
+    Scenario.ConfigMetadataMonitoringOptions(config);
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -121,6 +121,24 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
     config.Opts->AddLongOption("max-memory-usage-per-producer", "Max memory usage per producer in bytes.")
         .DefaultValue(HumanReadableSize(15_MB, SF_BYTES))
         .StoreMappedResult(&Scenario.ProducerMaxMemoryUsageBytes, NYdb::SizeFromString);
+
+    config.Opts->AddLongOption("configure-consumers", "The number of consumers to change the topic configuration. "
+                                                      "If the value is greater than 0, the program will continuously "
+                                                      "change the topic configuration.")
+        .Optional()
+        .Hidden()
+        .DefaultValue(0)
+        .StoreResult(&Scenario.ConfigConsumerCount);
+    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescribeTopic method")
+        .Optional()
+        .Hidden()
+        .DefaultValue(false)
+        .StoreTrue(&Scenario.NeedDescribeTopic);
+    config.Opts->AddLongOption("describe-consumer", "The program constantly calls the DescribeConsumer method")
+        .Optional()
+        .Hidden()
+        .StoreResult(&Scenario.DescribeConsumerName);
+
     config.IsNetworkIntensive = true;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -118,22 +118,7 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .Hidden()
         .StoreResult(&Scenario.ProducerKeysCount);
 
-    config.Opts->AddLongOption("configure-consumers", "The number of consumers to change the topic configuration. "
-                                                      "If the value is greater than 0, the program will continuously "
-                                                      "change the topic configuration.")
-        .Optional()
-        .Hidden()
-        .DefaultValue(0)
-        .StoreResult(&Scenario.ConfigConsumerCount);
-    config.Opts->AddLongOption("describe-topic", "The program constantly calls the DescribeTopic method")
-        .Optional()
-        .Hidden()
-        .DefaultValue(false)
-        .StoreTrue(&Scenario.NeedDescribeTopic);
-    config.Opts->AddLongOption("describe-consumer", "The program constantly calls the DescribeConsumer method")
-        .Optional()
-        .Hidden()
-        .StoreResult(&Scenario.DescribeConsumerName);
+    Scenario.ConfigMetadataMonitoringOptions(config);
 
     config.IsNetworkIntensive = true;
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -156,6 +156,15 @@ namespace NYdb::NConsoleClient {
         return description.Str();
     }
 
+    ui32 ParsePartitionPerTabletValue(TStringBuf s)
+    {
+        auto v = FromString<ui32>(s);
+        if ((v < 1) || (v > 20)) {
+            throw TMisuseException() << "Incorrect number of partitions in PQ tablet (" << v << "). Expected value from 1 to 20";
+        }
+        return v;
+    }
+
     namespace {
         NTopic::ECodec ParseCodec(const TString& codecStr, const TVector<NTopic::ECodec>& allowedCodecs) {
             auto exists = ExistingCodecs.find(to_lower(codecStr));
@@ -384,7 +393,7 @@ namespace NYdb::NConsoleClient {
         config.Opts->AddLongOption("partitions-per-tablet", "Partitions per PQ tablet")
             .Optional()
             .Hidden()
-            .StoreResult(&PartitionsPerTablet_);
+            .StoreMappedResult(&PartitionsPerTablet_, ParsePartitionPerTabletValue);
 
         config.Opts->MutuallyExclusive("retention-period-hours", "retention-period");
     }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
@@ -14,6 +14,7 @@ namespace NYdb::NConsoleClient {
     TVector<NTopic::ECodec> InitAllowedCodecs();
     const TVector<NTopic::ECodec> AllowedCodecs = InitAllowedCodecs();
     std::function<void(const TString& opt)> TimestampOptionHandler(TMaybe<TInstant>* destination); // parses timestamp in the following formats: unix time, ISO-8601
+    ui32 ParsePartitionPerTabletValue(TStringBuf s);
 
     class TCommandWithSupportedCodecs {
     protected:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Опция `--partitions-per-tablet`. Позволяет с помощью команды `ydb workload topic init` создавать таблетки PQ, обслуживающие несколько партиций. Такая конфигурация используется в федерации.

Опция `--configure-consumers`. Позволяет в командах `ydb workload topic run write|full` задавать количество консьюмеров для конфигурационных транзакций. Программа будет постоянно создавать и удалять этих консьюмеров.

Опция `--describe-topic`. Позволяет командам `ydb workload topic run write|full` постоянно вызывать метод `DescribeTopic`.

Опция `--describe-consumer`. Позволяет в командах `ydb workload topic run write|full` задавать имя консьюмера для DescribeConsumer. Программа будет постоянно вызывать метод DescribeConsumer для этого консьюмера.

Опции нужно только для стресс-тестов топиков. Поэтому сделаны скрытыми.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
