### PR TITLE
interconnect: Use TCP_USER_TIMEOUT + SO_KEEPALIVE to check node availability without user level pings NBYDB-1766 (#35559)

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -486,8 +486,31 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     if (config.HasNumPreallocatedBuffers()) {
         result.NumPreallocatedBuffers = config.GetNumPreallocatedBuffers();
     }
-    if (config.HasEnableExternalDataChannel()) {
-        result.EnableExternalDataChannel = config.GetEnableExternalDataChannel();
+    result.EnableExternalDataChannel = config.GetEnableExternalDataChannel();
+    result.EnableKernelLiveness = false;
+    if (config.GetUseKernelKeepAlive()) {
+        result.EnableKernelLiveness = true;
+
+        result.KernelUserTimeout = result.DeadPeer != TDuration::Zero()
+            ? result.DeadPeer
+            : NActors::DEFAULT_DEADPEER_TIMEOUT;
+        // Keep kernel liveness approximately aligned to KernelUserTimeout while keeping the setup simple.
+        // Target budget on idle links is:
+        //   KernelKeepAliveIdle + KernelKeepAliveInterval * KernelKeepAliveProbes ~= KernelUserTimeout.
+        // Interval is derived from timeout and probes are fixed for predictable behavior.
+        result.KernelKeepAliveInterval = Max(result.KernelUserTimeout / 10, TDuration::Seconds(1));
+        constexpr ui32 keepAliveProbes = 5;
+        result.KernelKeepAliveProbes = keepAliveProbes;
+
+        const ui64 userTimeoutMs = result.KernelUserTimeout.MilliSeconds();
+        const ui64 keepAliveIntervalMs = result.KernelKeepAliveInterval.MilliSeconds();
+        const ui64 keepAliveWindowMs = keepAliveIntervalMs * keepAliveProbes;
+        // Use the remaining budget as keepalive idle. If interval*probes already consumes timeout,
+        // clamp idle to 1s to keep socket options valid and avoid disabling kernel mode.
+        const ui64 keepAliveIdleMs = userTimeoutMs > keepAliveWindowMs
+            ? userTimeoutMs - keepAliveWindowMs
+            : TDuration::Seconds(1).MilliSeconds();
+        result.KernelKeepAliveIdle = Max(TDuration::MilliSeconds(keepAliveIdleMs), TDuration::Seconds(1));
     }
     if (config.HasValidateIncomingPeerViaDirectLookup()) {
         result.ValidateIncomingPeerViaDirectLookup = config.GetValidateIncomingPeerViaDirectLookup();

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -488,6 +488,7 @@ message TInterconnectConfig {
     optional bool RdmaChecksum = 54 [default = true];
     optional ERdmaCqMode RdmaCqMode = 55;
     optional uint32 RdmaMemPoolSizeLimitMb = 56 [default = 4096];
+    optional bool UseKernelKeepAlive = 58 [default = false];
 
     // ballast is added to IC handshake frames to ensure correctness of jumbo frames transmission over network
     optional uint32 HandshakeBallastSize = 14;

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -60,6 +60,14 @@ namespace NActors {
         ui32 PreallocatedBufferSize = 8 << 10; // 8 KB
         ui32 NumPreallocatedBuffers = 16;
         bool EnableExternalDataChannel = true;
+        bool EnableKernelLiveness = false;
+        TDuration KernelKeepAliveIdle = TDuration::Seconds(5);
+        TDuration KernelKeepAliveInterval = TDuration::Seconds(1);
+        ui32 KernelKeepAliveProbes = 5;
+        TDuration KernelUserTimeout = TDuration::Seconds(10);
+        // Period for user-space ping/clock probes that keep clock-skew metrics up to date
+        // when kernel keepalive mode disables user-space dead-peer logic.
+        TDuration ClockSkewPingTimeout = TDuration::Minutes(1);
         bool ValidateIncomingPeerViaDirectLookup = false;
         ui32 SocketBacklogSize = 0; // SOMAXCONN if zero
         TDuration FirstErrorSleep = TDuration::MilliSeconds(10);

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -12,11 +12,13 @@
 #include <ydb/library/actors/core/actor_coroutine.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
+#include <util/network/socket.h>
 #include <util/system/getpid.h>
 #include <util/random/entropy.h>
 
 #include <google/protobuf/text_format.h>
 
+#include <limits>
 #include <variant>
 
 namespace NActors {
@@ -94,6 +96,7 @@ namespace NActors {
             THandshakeActor *Actor = nullptr;
             TIntrusivePtr<NInterconnect::TStreamSocket> Socket;
             TPollerToken::TPtr PollerToken;
+            bool KernelLivenessReady = false;
 
         public:
             TConnection(THandshakeActor *actor, TIntrusivePtr<NInterconnect::TStreamSocket> socket)
@@ -147,6 +150,7 @@ namespace NActors {
             void Reset() {
                 Socket.Reset();
                 PollerToken.Reset();
+                KernelLivenessReady = false;
             }
 
             void SetupSocket() {
@@ -162,6 +166,8 @@ namespace NActors {
                 if (const auto& buffer = Actor->Common->Settings.TCPSocketBufferSize) {
                     Socket->SetSendBufferSize(buffer);
                 }
+
+                KernelLivenessReady = SetupKernelLiveness();
             }
 
             void RegisterInPoller() {
@@ -225,8 +231,94 @@ namespace NActors {
                 }
             }
 
+            bool IsKernelLivenessReady() const {
+                return KernelLivenessReady;
+            }
+
             TIntrusivePtr<NInterconnect::TStreamSocket>& GetSocketRef() { return Socket; }
             operator bool() const { return static_cast<bool>(Socket); }
+
+        private:
+            static int ClampSockOptValue(ui64 value) {
+                constexpr ui64 maxValue = static_cast<ui64>(std::numeric_limits<int>::max());
+                return value > maxValue ? std::numeric_limits<int>::max() : static_cast<int>(value);
+            }
+
+            bool SetIntSockOpt(int level, int option, int value, const char *name) {
+                if (SetSockOpt(*Socket, level, option, value) == 0) {
+                    return true;
+                }
+
+                const int err = errno;
+                LOG_LOG(*TlsActivationContext, NLog::PRI_WARN, NActorsServices::INTERCONNECT,
+                    "%s ICH40 Kernel liveness disabled for socket# %d due to setsockopt(%s=%d) failure, errno# %d (%s)",
+                    Actor->LogPrefix.data(), int(*Socket), name, value, err, strerror(err));
+                return false;
+            }
+
+            bool SetupKernelLiveness() {
+                if (!Actor->Common->Settings.EnableKernelLiveness) {
+                    return false;
+                }
+
+#if defined(_linux_)
+#if !defined(TCP_KEEPIDLE) || !defined(TCP_KEEPINTVL) || !defined(TCP_KEEPCNT)
+                LOG_LOG(*TlsActivationContext, NLog::PRI_WARN, NActorsServices::INTERCONNECT,
+                    "%s ICH42 Kernel liveness requested, but TCP keepalive tuning options are unavailable on this platform",
+                    Actor->LogPrefix.data());
+                return false;
+#else
+                auto toSockOptSeconds = [](TDuration value) -> ui64 {
+                    const ui64 ms = value.MilliSeconds();
+                    return ms ? (ms - 1) / 1000 + 1 : 0; // ceil(ms / 1000) for non-zero durations
+                };
+
+                const auto& settings = Actor->Common->Settings;
+                const ui64 keepAliveIdleSec = toSockOptSeconds(settings.KernelKeepAliveIdle);
+                const ui64 keepAliveIntervalSec = toSockOptSeconds(settings.KernelKeepAliveInterval);
+                const ui64 userTimeoutMs = settings.KernelUserTimeout.MilliSeconds();
+                if (!keepAliveIdleSec || !keepAliveIntervalSec || !settings.KernelKeepAliveProbes || !userTimeoutMs) {
+                    LOG_LOG(*TlsActivationContext, NLog::PRI_WARN, NActorsServices::INTERCONNECT,
+                        "%s ICH43 Kernel liveness disabled due to invalid settings KeepAliveIdle# %s KeepAliveInterval# %s KeepAliveProbes# %" PRIu32
+                        " KernelUserTimeout# %s",
+                        Actor->LogPrefix.data(), settings.KernelKeepAliveIdle.ToString().data(),
+                        settings.KernelKeepAliveInterval.ToString().data(), settings.KernelKeepAliveProbes,
+                        settings.KernelUserTimeout.ToString().data());
+                    return false;
+                }
+
+                if (!SetIntSockOpt(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE")) {
+                    return false;
+                }
+                if (!SetIntSockOpt(IPPROTO_TCP, TCP_KEEPIDLE, ClampSockOptValue(keepAliveIdleSec), "TCP_KEEPIDLE")) {
+                    return false;
+                }
+                if (!SetIntSockOpt(IPPROTO_TCP, TCP_KEEPINTVL, ClampSockOptValue(keepAliveIntervalSec), "TCP_KEEPINTVL")) {
+                    return false;
+                }
+                if (!SetIntSockOpt(IPPROTO_TCP, TCP_KEEPCNT, ClampSockOptValue(settings.KernelKeepAliveProbes), "TCP_KEEPCNT")) {
+                    return false;
+                }
+
+#if defined(TCP_USER_TIMEOUT)
+                if (!SetIntSockOpt(IPPROTO_TCP, TCP_USER_TIMEOUT, ClampSockOptValue(userTimeoutMs), "TCP_USER_TIMEOUT")) {
+                    return false;
+                }
+#else
+                LOG_LOG(*TlsActivationContext, NLog::PRI_WARN, NActorsServices::INTERCONNECT,
+                    "%s ICH45 Kernel liveness requested, but TCP_USER_TIMEOUT is unavailable on this platform",
+                    Actor->LogPrefix.data());
+                return false;
+#endif
+
+                return true;
+#endif
+#else
+                LOG_LOG(*TlsActivationContext, NLog::PRI_WARN, NActorsServices::INTERCONNECT,
+                    "%s ICH44 Kernel liveness requested, but this platform is unsupported", Actor->LogPrefix.data());
+                return false;
+#endif
+            }
         };
 
     private:
@@ -893,6 +985,9 @@ namespace NActors {
                 Params.UseExternalDataChannel = success.GetUseExternalDataChannel();
                 Params.UseXxhash = success.GetUseXxhash();
                 Params.UseXdcShuffle = success.GetUseXdcShuffle();
+                // Kernel liveness mode is a local transport decision: it depends on whether this side
+                // configured keepalive/user-timeout on its own socket.
+                Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
                 if (success.HasServerScopeId()) {
                     ParsePeerScopeId(success.GetServerScopeId());
                 }
@@ -938,6 +1033,8 @@ namespace NActors {
             } else {
                 ProgramInfo.ConstructInPlace(); // successful handshake
             }
+
+            Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
         }
 
         std::vector<NInterconnect::TAddress> ResolvePeer() {
@@ -1069,6 +1166,7 @@ namespace NActors {
                     PeerVirtualId = request.Header.SelfVirtualId;
                     NextPacketToPeer = ack->NextPacket;
                     Params = ack->Params;
+                    Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
 
                     // only succeed in case when proxy returned valid SelfVirtualId; otherwise it wants us to terminate
                     // the handshake process and it does not expect the handshake reply
@@ -1177,6 +1275,7 @@ namespace NActors {
                 Params.UseExternalDataChannel = request.GetRequestExternalDataChannel() && Common->Settings.EnableExternalDataChannel;
                 Params.UseXxhash = request.GetRequestXxhash();
                 Params.UseXdcShuffle = request.GetRequestXdcShuffle();
+                Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
 
                 if (Params.UseExternalDataChannel) {
                     if (request.HasHandshakeId()) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -249,7 +249,17 @@ namespace NActors {
 
     void TInputSessionTCP::Bootstrap() {
         SetPrefix(Sprintf("InputSession %s [node %" PRIu32 "]", SelfId().ToString().data(), NodeId));
-        Become(&TThis::WorkingState, DeadPeerTimeout, new TEvCheckDeadPeer);
+
+        // Dead-peer watchdog and session-side periodic ping are a single logical user-space liveness mechanism.
+        // They must be switched off together; otherwise one actor may still assume legacy liveness while the
+        // other already relies on kernel keepalive/user-timeout.
+        //
+        // UseKernelLivenessMode() intentionally mirrors the condition in TInterconnectSessionTCP.
+        if (UseKernelLivenessMode()) {
+            Become(&TThis::WorkingState);
+        } else {
+            Become(&TThis::WorkingState, DeadPeerTimeout, new TEvCheckDeadPeer);
+        }
         if (RdmaQp) {
             LOG_DEBUG_IC_SESSION("ICRDMA", "InputSession created, rdma qp num: %d", RdmaQp->GetQpNum());
         } else {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -34,6 +34,7 @@ namespace NActors {
         , CloseOnIdleWatchdog(GetCloseOnIdleTimeout(), std::bind(&TThis::OnCloseOnIdleTimerHit, this))
         , LostConnectionWatchdog(GetLostConnectionTimeout(), std::bind(&TThis::OnLostConnectionTimerHit, this))
         , Params(std::move(params))
+        , KernelLivenessMode(Params.UseKernelLiveness)
         , TotalOutputQueueSize(0)
         , OutputStuckFlag(false)
         , OutputQueueUtilization(16)
@@ -306,6 +307,9 @@ namespace NActors {
             ZcProcessor.ApplySocketOption(*XdcSocket);
         }
 
+        // Apply kernel-liveness decision for this concrete transport connection.
+        KernelLivenessMode = ev->Get()->Params.UseKernelLiveness;
+
         // there may be a race
         const ui64 nextPacket = Max(LastConfirmed, ev->Get()->NextPacket);
 
@@ -313,7 +317,8 @@ namespace NActors {
         RearmCloseOnIdle();
 
         // reset activity timestamps
-        LastInputActivityTimestamp = LastPayloadActivityTimestamp = TActivationContext::Monotonic();
+        LastInputActivityTimestamp = LastPayloadActivityTimestamp = LastPingTimestamp = TActivationContext::Monotonic();
+        ClockSkewPingTimestamp = TMonotonic::Max();
 
         LOG_INFO_IC_SESSION("ICS10", "traffic start");
 
@@ -326,8 +331,11 @@ namespace NActors {
 
         // create input session actor
         ReceiveContext->UnlockLastPacketSerialToConfirm();
+        // Keep most session params stable, but pass current transport-level liveness mode.
+        TSessionParams inputSessionParams = Params;
+        inputSessionParams.UseKernelLiveness = KernelLivenessMode;
         auto actor = MakeHolder<TInputSessionTCP>(SelfId(), Socket, XdcSocket, ReceiveContext, Proxy->Common,
-            Proxy->Metrics, Proxy->PeerNodeId, nextPacket, GetDeadPeerTimeout(), Params, RdmaQp, std::move(cq));
+            Proxy->Metrics, Proxy->PeerNodeId, nextPacket, GetDeadPeerTimeout(), std::move(inputSessionParams), RdmaQp, std::move(cq));
         ReceiverId = RegisterWithSameMailbox(actor.Release());
 
         // register our socket in poller actor
@@ -872,9 +880,12 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::ScheduleFlush() {
-        if (FlushSchedule.empty() || ForcePacketTimestamp < FlushSchedule.top()) {
-            Schedule(ForcePacketTimestamp, new TEvFlush);
-            FlushSchedule.push(ForcePacketTimestamp);
+        const TMonotonic nextFlushTimestamp = UseKernelLivenessMode()
+            ? Min(ForcePacketTimestamp, ClockSkewPingTimestamp)
+            : ForcePacketTimestamp;
+        if (nextFlushTimestamp != TMonotonic::Max() && (FlushSchedule.empty() || nextFlushTimestamp < FlushSchedule.top())) {
+            Schedule(nextFlushTimestamp, new TEvFlush);
+            FlushSchedule.push(nextFlushTimestamp);
             MaxFlushSchedule = Max(MaxFlushSchedule, FlushSchedule.size());
             ++FlushEventsScheduled;
         }
@@ -890,7 +901,11 @@ namespace NActors {
                 ++ConfirmPacketsForcedByTimeout;
                 ++FlushEventsProcessed;
                 MakePacket(false); // just generate confirmation packet if we have preconditions for this
-            } else if (ForcePacketTimestamp != TMonotonic::Max()) {
+            }
+            const TMonotonic nextFlushTimestamp = UseKernelLivenessMode()
+                ? Min(ForcePacketTimestamp, ClockSkewPingTimestamp)
+                : ForcePacketTimestamp;
+            if (nextFlushTimestamp != TMonotonic::Max() && now < nextFlushTimestamp) {
                 ScheduleFlush();
             }
             GenerateTraffic();
@@ -900,9 +915,20 @@ namespace NActors {
     void TInterconnectSessionTCP::ResetFlushLogic() {
         ForcePacketTimestamp = TMonotonic::Max();
         UnconfirmedBytes = 0;
-        const TDuration ping = Proxy->Common->Settings.PingPeriod;
-        if (ping != TDuration::Zero() && !NumEventsInQueue) {
-            SetForcePacketTimestamp(ping);
+        if (UseKernelLivenessMode()) {
+            const TDuration clockSkewPingTimeout = Proxy->Common->Settings.ClockSkewPingTimeout;
+            if (clockSkewPingTimeout == TDuration::Zero()) {
+                ClockSkewPingTimestamp = TMonotonic::Max();
+            } else {
+                ClockSkewPingTimestamp = LastPingTimestamp + clockSkewPingTimeout;
+                ScheduleFlush();
+            }
+        } else {
+            Y_DEBUG_ABORT_UNLESS(ClockSkewPingTimestamp == TMonotonic::Max());
+            const TDuration ping = Proxy->Common->Settings.PingPeriod;
+            if (ping != TDuration::Zero() && !NumEventsInQueue) {
+                SetForcePacketTimestamp(ping);
+            }
         }
     }
 
@@ -1123,12 +1149,14 @@ namespace NActors {
                 flagState = EFlag::GREEN;
 
                 do {
-                    auto lastInputDelay = TActivationContext::Monotonic() - LastInputActivityTimestamp;
-                    if (lastInputDelay * 4 >= GetDeadPeerTimeout() * 3) {
-                        flagState = EFlag::ORANGE;
-                        break;
-                    } else if (lastInputDelay * 2 >= GetDeadPeerTimeout()) {
-                        flagState = EFlag::YELLOW;
+                    if (!UseKernelLivenessMode()) {
+                        auto lastInputDelay = TActivationContext::Monotonic() - LastInputActivityTimestamp;
+                        if (lastInputDelay * 4 >= GetDeadPeerTimeout() * 3) {
+                            flagState = EFlag::ORANGE;
+                            break;
+                        } else if (lastInputDelay * 2 >= GetDeadPeerTimeout()) {
+                            flagState = EFlag::YELLOW;
+                        }
                     }
 
                     // check utilization
@@ -1216,14 +1244,20 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::IssuePingRequest() {
+        const TDuration period = UseKernelLivenessMode()
+            ? Proxy->Common->Settings.ClockSkewPingTimeout
+            : PingPeriodicity;
+        if (period == TDuration::Zero()) {
+            return;
+        }
         const TMonotonic now = TActivationContext::Monotonic();
-        if (now >= LastPingTimestamp + PingPeriodicity) {
+        if (now >= LastPingTimestamp + period) {
             LOG_DEBUG_IC_SESSION("ICS00", "Issuing ping request");
+            LastPingTimestamp = now;
             if (Socket) {
                 MakePacket(false, GetCycleCountFast() | TTcpPacketBuf::PingRequestMask);
                 MakePacket(false, TInstant::Now().MicroSeconds() | TTcpPacketBuf::ClockMask);
             }
-            LastPingTimestamp = now;
         }
     }
 
@@ -1366,6 +1400,10 @@ namespace NActors {
 
                             MON_VAR(Created)
                             MON_VAR(Params.UseExternalDataChannel)
+                            TABLER() {
+                                TABLED() { str << "Params.UseKernelLiveness"; }
+                                TABLED() { str << UseKernelLivenessMode(); }
+                            }
                             MON_VAR(NewConnectionSet)
                             MON_VAR(ReceiverId)
                             MON_VAR(MessagesGot)

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -283,7 +283,7 @@ namespace NActors {
         XXH3_state_t XxhashState;
         XXH3_state_t XxhashXdcState;
 
-        size_t PayloadSize;
+        size_t PayloadSize = 0;
         ui32 ChecksumExpected, Checksum;
         bool IgnorePayload;
         TRope Payload;
@@ -370,6 +370,13 @@ namespace NActors {
 
         inline ui64 GetMaxCyclesPerEvent() const {
             return DurationToCycles(TDuration::MicroSeconds(500));
+        }
+
+        bool UseKernelLivenessMode() const {
+            // Once kernel liveness is negotiated for this session, user-space liveness checks
+            // are disabled and both actors rely on kernel keepalive/user-timeout.
+            // Keep this condition identical to TInterconnectSessionTCP::UseKernelLivenessMode().
+            return Params.UseKernelLiveness;
         }
 
         const TDuration DeadPeerTimeout;
@@ -561,6 +568,10 @@ namespace NActors {
         TDuration GetLostConnectionTimeout() const;
         ui32 GetTotalInflightAmountOfData() const;
         ui64 GetMaxCyclesPerEvent() const;
+        bool UseKernelLivenessMode() const {
+            // Effective liveness mode for the currently attached transport connection.
+            return KernelLivenessMode;
+        }
 
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -598,7 +609,9 @@ namespace NActors {
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        const TSessionParams Params;
+        const TSessionParams Params; // stable session template used for continuation handshakes
+        // Runtime mode negotiated for the current socket; may differ from Params on reconnect.
+        bool KernelLivenessMode = false;
         std::unique_ptr<TEventHolderPool> Pool;
         TMaybe<TChannelScheduler> ChannelScheduler;
         ui64 TotalOutputQueueSize;
@@ -659,6 +672,7 @@ namespace NActors {
         // time at which we want to send confirmation packet even if there was no outgoing data
         ui64 UnconfirmedBytes = 0;
         TMonotonic ForcePacketTimestamp = TMonotonic::Max();
+        TMonotonic ClockSkewPingTimestamp = TMonotonic::Max();
         TPriorityQueue<TMonotonic, TVector<TMonotonic>, std::greater<TMonotonic>> FlushSchedule;
         size_t MaxFlushSchedule = 0;
         ui64 FlushEventsScheduled = 0;

--- a/ydb/library/actors/interconnect/rdma/ut/ya.make
+++ b/ydb/library/actors/interconnect/rdma/ut/ya.make
@@ -27,4 +27,5 @@ PEERDIR(
     ydb/library/actors/testlib
 )
 
+ENDIF()
 END()

--- a/ydb/library/actors/interconnect/types.h
+++ b/ydb/library/actors/interconnect/types.h
@@ -59,6 +59,7 @@ namespace NActors {
         bool UseExternalDataChannel = {};
         bool UseXxhash = {};
         bool UseXdcShuffle = {};
+        bool UseKernelLiveness = {};
         bool UseRdma = {};
         bool ChecksumRdmaEvent = {};
         TString AuthCN;

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -2,10 +2,120 @@
 #include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/digest/md5/md5.h>
+#include <cstring>
 #include <util/random/fast.h>
+#include <util/string/cast.h>
 #include <util/string/vector.h>
 
 using namespace NActors;
+
+namespace {
+
+ui64 GetSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    return FromString<ui64>(ExtractPattern(cluster, me, peer, start, "<"));
+}
+
+TDuration GetSessionDurationMetric(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    return TDuration::Parse(ExtractPattern(cluster, me, peer, start, "<"));
+}
+
+i64 GetSessionSignedDurationMetricUs(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    const TString value = ExtractPattern(cluster, me, peer, start, "<");
+    TStringBuf metric(value);
+    i64 sign = 1;
+    if (metric && (metric[0] == '+' || metric[0] == '-')) {
+        sign = metric[0] == '-' ? -1 : 1;
+        metric = metric.SubStr(1);
+    }
+    return sign * TDuration::Parse(metric).MicroSeconds();
+}
+
+TString GetSessionTextMetric(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    return ExtractPattern(cluster, me, peer, start, "<");
+}
+
+i64 GetSessionSocketFd(TTestICCluster& cluster, ui32 me, ui32 peer) {
+    return FromString<i64>(ExtractPattern(cluster, me, peer, "<tr><td>Socket</td><td>", "<"));
+}
+
+ui64 WaitForSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name,
+        TDuration timeout = TDuration::Seconds(10)) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        try {
+            return GetSessionCounter(cluster, me, peer, name);
+        } catch (const TPatternNotFound&) {
+            Sleep(TDuration::MilliSeconds(100));
+        }
+    }
+    UNIT_FAIL(TStringBuilder() << "failed to read session counter " << name << " from " << me << " to " << peer);
+    return 0;
+}
+
+template <typename TCallback>
+void WaitForCondition(TDuration timeout, TCallback&& callback, TStringBuf description) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        if (callback()) {
+            return;
+        }
+        Sleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_FAIL(TStringBuilder() << "condition failed: " << description);
+}
+
+class TDropRecipientActor : public TActor<TDropRecipientActor> {
+public:
+    TDropRecipientActor()
+        : TActor(&TThis::StateFunc)
+    {}
+
+    size_t GetReceived() const noexcept {
+        return Received.load(std::memory_order_relaxed);
+    }
+
+private:
+    void HandlePing(TAutoPtr<IEventHandle>&) {
+        Received.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    STRICT_STFUNC(StateFunc,
+        fFunc(TEvents::THelloWorld::Ping, HandlePing);
+    )
+
+private:
+    std::atomic<size_t> Received = 0;
+};
+
+class TBurstSenderActor : public TActorBootstrapped<TBurstSenderActor> {
+public:
+    TBurstSenderActor(TActorId recipient, size_t messages, size_t payloadSize)
+        : Recipient(recipient)
+        , Messages(messages)
+        , PayloadSize(payloadSize)
+    {}
+
+    void Bootstrap() {
+        TString payload = TString::Uninitialized(PayloadSize);
+        memset(payload.Detach(), 'x', payload.size());
+        for (size_t i = 0; i < Messages; ++i) {
+            TActivationContext::Send(new IEventHandle(TEvents::THelloWorld::Ping, 0, Recipient, SelfId(),
+                MakeIntrusive<TEventSerializedData>(TString(payload), TEventSerializationInfo{}), i));
+        }
+        PassAway();
+    }
+
+private:
+    const TActorId Recipient;
+    const size_t Messages;
+    const size_t PayloadSize;
+};
+
+} // namespace
 
 class TSenderActor : public TActorBootstrapped<TSenderActor> {
     const TActorId Recipient;
@@ -124,7 +234,7 @@ class TRecipientActor : public TActor<TRecipientActor> {
 public:
     TRecipientActor()
         : TActor(&TThis::StateFunc)
-        , Recieved(0)
+        , Received(0)
     {}
 
     void HandlePing(TAutoPtr<IEventHandle>& ev) {
@@ -132,19 +242,297 @@ public:
         const TString& response = MD5::CalcRaw(data);
         TActivationContext::Send(new IEventHandle(TEvents::THelloWorld::Pong, 0, ev->Sender, SelfId(),
             MakeIntrusive<TEventSerializedData>(response, TEventSerializationInfo{}), ev->Cookie));
-        Recieved.fetch_add(1, std::memory_order_relaxed);
+        Received.fetch_add(1, std::memory_order_relaxed);
     }
 
-    size_t GetRecieved() const noexcept {
-        return Recieved.load(std::memory_order_relaxed);
+    size_t GetReceived() const noexcept {
+        return Received.load(std::memory_order_relaxed);
     }
 
     STRICT_STFUNC(StateFunc,
         fFunc(TEvents::THelloWorld::Ping, HandlePing);
     )
 private:
-    std::atomic<size_t> Recieved;
+    std::atomic<size_t> Received;
 };
+
+namespace {
+
+TTestICCluster::Flags GetKernelLivenessFlags(bool withRdma) {
+    return withRdma ? TTestICCluster::EMPTY : TTestICCluster::DISABLE_RDMA;
+}
+
+bool SkipIfRdmaUnavailable(bool withRdma, TStringBuf testName) {
+    if (withRdma && NRdmaTest::IsRdmaTestDisabled()) {
+        Cerr << testName << " test skipped" << Endl;
+        return true;
+    }
+    return false;
+}
+
+ui64 MeasureIdleGeneratedPackets(bool enableKernelLiveness, bool withRdma) {
+    auto settingsCustomizer = [enableKernelLiveness](ui32, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = enableKernelLiveness;
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient, 1), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "initial message delivery");
+
+    const ui64 negotiated = WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness");
+    UNIT_ASSERT_VALUES_EQUAL(negotiated, enableKernelLiveness ? 1ULL : 0ULL);
+
+    Sleep(TDuration::Seconds(1));
+    const ui64 packetsBefore = WaitForSessionCounter(cluster, 2, 1, "PacketsGenerated");
+    Sleep(TDuration::Seconds(4));
+    const ui64 packetsAfter = WaitForSessionCounter(cluster, 2, 1, "PacketsGenerated");
+    UNIT_ASSERT_C(packetsAfter >= packetsBefore, "PacketsGenerated counter regressed while measuring idle traffic");
+    return packetsAfter - packetsBefore;
+}
+
+void RunKernelLivenessMixedConfigAsymmetric(bool withRdma, ui32 kernelLivenessNodeId) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessMixedConfigAsymmetricRdma")) {
+        return;
+    }
+
+    auto settingsCustomizer = [kernelLivenessNodeId](ui32 nodeId, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = (nodeId == kernelLivenessNodeId);
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient, 1), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "mixed cluster initial message delivery");
+
+    const ui64 node2Expected = kernelLivenessNodeId == 2 ? 1ULL : 0ULL;
+    const ui64 node1Expected = kernelLivenessNodeId == 1 ? 1ULL : 0ULL;
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), node2Expected);
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), node1Expected);
+}
+
+void RunKernelLivenessSocketSetupFallback(bool withRdma) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessSocketSetupFallbackRdma")) {
+        return;
+    }
+
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = true;
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+        if (nodeId == 2) {
+            settings.KernelKeepAliveProbes = 0; // force local socket setup failure
+        }
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient, 1), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "socket-setup fallback initial message delivery");
+
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 0ULL);
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), 1ULL);
+}
+
+void RunKernelLivenessReducesIdlePackets(bool withRdma) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessReducesIdlePacketsRdma")) {
+        return;
+    }
+
+    const ui64 legacyPackets = MeasureIdleGeneratedPackets(false, withRdma);
+    const ui64 kernelPackets = MeasureIdleGeneratedPackets(true, withRdma);
+    Cerr << "legacyPackets# " << legacyPackets << " kernelPackets# " << kernelPackets << Endl;
+    UNIT_ASSERT_GT(legacyPackets, kernelPackets);
+}
+
+void RunKernelLivenessPreservesFlowControlConfirms(bool withRdma) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessPreservesFlowControlConfirmsRdma")) {
+        return;
+    }
+
+    constexpr size_t messages = 4000;
+    constexpr size_t payloadSize = 256;
+
+    auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = true;
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(2), 64 * 1024, settingsCustomizer);
+
+    auto* recipientPtr = new TDropRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TBurstSenderActor(recipient, messages, payloadSize), 2);
+
+    WaitForCondition(TDuration::Seconds(20), [&] {
+        return recipientPtr->GetReceived() >= messages;
+    }, "bulk one-way delivery in kernel liveness mode");
+
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);
+    const ui64 confirmBySize = WaitForSessionCounter(cluster, 1, 2, "ConfirmPacketsForcedBySize");
+    const ui64 confirmByTimeout = WaitForSessionCounter(cluster, 1, 2, "ConfirmPacketsForcedByTimeout");
+    Cerr << "confirmBySize# " << confirmBySize << " confirmByTimeout# " << confirmByTimeout << Endl;
+    UNIT_ASSERT_GT(confirmBySize + confirmByTimeout, 0ULL);
+}
+
+void RunKernelLivenessClockSkewPingTimeoutUpdatesMetrics(bool withRdma) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessClockSkewPingTimeoutUpdatesMetricsRdma")) {
+        return;
+    }
+
+    auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = true;
+        settings.ClockSkewPingTimeout = TDuration::MilliSeconds(200);
+        settings.PingPeriod = TDuration::Seconds(30);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient, 1), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "initial message delivery for clock-skew metrics");
+
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        try {
+            return GetSessionDurationMetric(cluster, 2, 1, "GetPingRTT()") > TDuration::Zero();
+        } catch (const TPatternNotFound&) {
+            return false;
+        }
+    }, "kernel-liveness ping RTT metric updated");
+
+    const TDuration pingRtt = GetSessionDurationMetric(cluster, 2, 1, "GetPingRTT()");
+    const TDuration sinceLastPing = GetSessionDurationMetric(cluster, 2, 1, "now - LastPingTimestamp");
+    const i64 clockSkewUs = GetSessionSignedDurationMetricUs(cluster, 2, 1, "clockSkew");
+    Cerr << "pingRtt# " << pingRtt << " sinceLastPing# " << sinceLastPing << " clockSkewUs# " << clockSkewUs << Endl;
+
+    UNIT_ASSERT_GT(pingRtt, TDuration::Zero());
+    UNIT_ASSERT_LT(sinceLastPing, TDuration::Seconds(2));
+}
+
+void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
+    if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessReconnectLocalFallbackNotAppliedRdma")) {
+        return;
+    }
+
+    auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = true;
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "initial message delivery for reconnect fallback");
+
+    auto waitKernelMode = [&](ui64 expected, TStringBuf description) {
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            try {
+                return GetSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness") == expected;
+            } catch (const TPatternNotFound&) {
+                return false;
+            }
+        }, description);
+    };
+
+    auto reconnectFromNode2 = [&](TStringBuf description) {
+        const TString handshakeBefore = GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone");
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            try {
+                return GetSessionCounter(cluster, 2, 1, "NumEventsInQueue") > 0;
+            } catch (const TPatternNotFound&) {
+                return false;
+            }
+        }, "session has pending output before forced reconnect");
+        cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvClosePeerSocket);
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            try {
+                return GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone") != handshakeBefore &&
+                    GetSessionSocketFd(cluster, 2, 1) >= 0;
+            } catch (const TPatternNotFound&) {
+                return false;
+            } catch (const TFromStringException&) {
+                return false;
+            }
+        }, description);
+    };
+
+    waitKernelMode(1ULL, "initial kernel liveness negotiated");
+
+    bool exercisedSameSessionContinuation = false;
+    for (ui32 attempt = 0; attempt < 5; ++attempt) {
+        const TString createdBefore = GetSessionTextMetric(cluster, 2, 1, "Created");
+
+        // Force local fallback on reconnect.
+        cluster.GetNode(2)->MutableInterconnectSettings().EnableKernelLiveness = false;
+        reconnectFromNode2("session reconnected with local kernel liveness disabled");
+
+        const TString createdAfter = GetSessionTextMetric(cluster, 2, 1, "Created");
+        if (createdAfter == createdBefore) {
+            exercisedSameSessionContinuation = true;
+            break;
+        }
+
+        // Session was recreated while local kernel mode was disabled, so this new session template now carries
+        // UseKernelLiveness=false. Force another session recreation after restoring local settings to avoid
+        // continuation within the stale template.
+        cluster.GetNode(2)->MutableInterconnectSettings().EnableKernelLiveness = true;
+        const TString restoreCreatedBefore = GetSessionTextMetric(cluster, 2, 1, "Created");
+        cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvPoisonSession);
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            try {
+                return GetSessionTextMetric(cluster, 2, 1, "Created") != restoreCreatedBefore &&
+                    GetSessionSocketFd(cluster, 2, 1) >= 0;
+            } catch (const TPatternNotFound&) {
+                return false;
+            } catch (const TFromStringException&) {
+                return false;
+            }
+        }, "restore baseline session after forced recreation");
+        waitKernelMode(1ULL, "baseline kernel liveness restored");
+    }
+
+    UNIT_ASSERT_C(exercisedSameSessionContinuation,
+        "failed to exercise continuation within the same session instance");
+
+    // Expected behavior: resumed continuation should apply local fallback and disable kernel liveness.
+    // Buggy behavior: existing session keeps stale Params.UseKernelLiveness from initial connect.
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 0ULL);
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(Interconnect) {
 
@@ -186,6 +574,62 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         }
     }
 
+    Y_UNIT_TEST(KernelLivenessMixedConfigFallback) {
+        RunKernelLivenessMixedConfigAsymmetric(false, 2);
+    }
+
+    Y_UNIT_TEST(KernelLivenessMixedConfigFallbackReverse) {
+        RunKernelLivenessMixedConfigAsymmetric(false, 1);
+    }
+
+    Y_UNIT_TEST(KernelLivenessSocketSetupFallback) {
+        RunKernelLivenessSocketSetupFallback(false);
+    }
+
+    Y_UNIT_TEST(KernelLivenessReducesIdlePackets) {
+        RunKernelLivenessReducesIdlePackets(false);
+    }
+
+    Y_UNIT_TEST(KernelLivenessPreservesFlowControlConfirms) {
+        RunKernelLivenessPreservesFlowControlConfirms(false);
+    }
+
+    Y_UNIT_TEST(KernelLivenessClockSkewPingTimeoutUpdatesMetrics) {
+        RunKernelLivenessClockSkewPingTimeoutUpdatesMetrics(false);
+    }
+
+    Y_UNIT_TEST(KernelLivenessMixedConfigFallbackRdma) {
+        RunKernelLivenessMixedConfigAsymmetric(true, 2);
+    }
+
+    Y_UNIT_TEST(KernelLivenessMixedConfigFallbackReverseRdma) {
+        RunKernelLivenessMixedConfigAsymmetric(true, 1);
+    }
+
+    Y_UNIT_TEST(KernelLivenessSocketSetupFallbackRdma) {
+        RunKernelLivenessSocketSetupFallback(true);
+    }
+
+    Y_UNIT_TEST(KernelLivenessReducesIdlePacketsRdma) {
+        RunKernelLivenessReducesIdlePackets(true);
+    }
+
+    Y_UNIT_TEST(KernelLivenessPreservesFlowControlConfirmsRdma) {
+        RunKernelLivenessPreservesFlowControlConfirms(true);
+    }
+
+    Y_UNIT_TEST(KernelLivenessClockSkewPingTimeoutUpdatesMetricsRdma) {
+        RunKernelLivenessClockSkewPingTimeoutUpdatesMetrics(true);
+    }
+
+    Y_UNIT_TEST(KernelLivenessReconnectLocalFallbackNotApplied) {
+        RunKernelLivenessReconnectLocalFallbackNotApplied(false);
+    }
+
+    Y_UNIT_TEST(KernelLivenessReconnectLocalFallbackNotAppliedRdma) {
+        RunKernelLivenessReconnectLocalFallbackNotApplied(true);
+    }
+
     Y_UNIT_TEST(SetupRdmaSession) {
         if (NRdmaTest::IsRdmaTestDisabled()) {
             Cerr << "SetupRdmaSession test skipped" << Endl;
@@ -198,7 +642,7 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         auto senderPtr = new TSenderActor(recipient, limit);
         cluster.RegisterActor(senderPtr, 2);
 
-        while (recieverPtr->GetRecieved() < limit) {
+        while (recieverPtr->GetReceived() < limit) {
             Sleep(TDuration::MilliSeconds(100));
         }
 

--- a/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
+++ b/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
@@ -23,7 +23,10 @@ public:
         USE_ZC = 1,
         USE_TLS = 1 << 1,
         RDMA_POLLING_CQ = 1 << 2,
+        DISABLE_RDMA = 1 << 3,
     };
+
+    using TCheckerFactory = std::function<IActor*(ui32)>;
 
 private:
     const ui32 NumNodes;
@@ -32,6 +35,7 @@ private:
     NMonitoring::TDynamicCounterPtr Counters;
     THashMap<ui32, THolder<TNode>> Nodes;
     TList<TTrafficInterrupter> interrupters;
+    THashMap<ui32, TTrafficInterrupter*> InterrupterByNode;
     NActors::TChannelsConfig ChannelsConfig;
     NInterconnectTest::IPortManager::TPtr PortManager;
     TIntrusivePtr<NLog::TSettings> LoggerSettings;
@@ -39,7 +43,8 @@ private:
 public:
     TTestICCluster(ui32 numNodes = 1, NActors::TChannelsConfig channelsConfig = NActors::TChannelsConfig(),
                    TTrafficInterrupterSettings* tiSettings = nullptr, TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, Flags flags = EMPTY,
-                   TDuration deadPeerTimeout = TDuration::Seconds(2), ui32 inflight = TNode::DefaultInflight())
+                   TCheckerFactory checkerFactory = {}, TDuration deadPeerTimeout = TDuration::Seconds(2), ui32 inflight = TNode::DefaultInflight(),
+                   std::function<void(ui32, NActors::TInterconnectSettings&)> settingsCustomizer = {})
         : NumNodes(numNodes)
         , DeadPeerTimeout(deadPeerTimeout)
         , Counters(new NMonitoring::TDynamicCounters)
@@ -66,7 +71,9 @@ public:
                 specificNodePortMap[nodeId] = nodeToPortMap;
                 specificNodePortMap[nodeId].at(nodeId) = forwardPort;
                 interrupters.emplace_back(Address, listenPort, forwardPort, tiSettings->RejectingTrafficTimeout, tiSettings->BandWidth, tiSettings->Disconnect);
-                interrupters.back().Start();
+                TTrafficInterrupter& interrupter = interrupters.back();
+                InterrupterByNode.emplace(nodeId, &interrupter);
+                interrupter.Start();
             }
         }
 
@@ -75,12 +82,36 @@ public:
             Nodes.emplace(i, MakeHolder<TNode>(i, NumNodes, portMap, Address, Counters, DeadPeerTimeout, ChannelsConfig,
                 /*numDynamicNodes=*/0, /*numThreads=*/1, LoggerSettings, inflight,
                 flags & USE_ZC ? ESocketSendOptimization::IC_MSG_ZEROCOPY : ESocketSendOptimization::DISABLED,
-                flags & USE_TLS, flags & RDMA_POLLING_CQ ? NInterconnect::NRdma::ECqMode::POLLING : NInterconnect::NRdma::ECqMode::EVENT));
+                flags & USE_TLS, checkerFactory, flags & RDMA_POLLING_CQ ? NInterconnect::NRdma::ECqMode::POLLING : NInterconnect::NRdma::ECqMode::EVENT,
+                !(flags & DISABLE_RDMA),
+                settingsCustomizer));
         }
     }
 
+    // Backward-compatible overload with legacy argument order:
+    // ... flags, deadPeerTimeout, inflight, settingsCustomizer.
+    TTestICCluster(ui32 numNodes, NActors::TChannelsConfig channelsConfig,
+                   TTrafficInterrupterSettings* tiSettings, TIntrusivePtr<NLog::TSettings> loggerSettings, Flags flags,
+                   TDuration deadPeerTimeout, ui32 inflight = TNode::DefaultInflight(),
+                   std::function<void(ui32, NActors::TInterconnectSettings&)> settingsCustomizer = {})
+        : TTestICCluster(numNodes, std::move(channelsConfig), tiSettings, std::move(loggerSettings), flags,
+            {}, deadPeerTimeout, inflight, std::move(settingsCustomizer))
+    {}
+
     TNode* GetNode(ui32 id) {
         return Nodes[id].Get();
+    }
+
+    void StartBlackhole(ui32 nodeId) {
+        auto it = InterrupterByNode.find(nodeId);
+        Y_ABORT_UNLESS(it != InterrupterByNode.end());
+        it->second->StartBlackhole();
+    }
+
+    void StopBlackhole(ui32 nodeId) {
+        auto it = InterrupterByNode.find(nodeId);
+        Y_ABORT_UNLESS(it != InterrupterByNode.end());
+        it->second->StopBlackhole();
     }
 
     ~TTestICCluster() {
@@ -139,10 +170,13 @@ struct TPatternNotFound : public yexception {};
 
 inline TString ExtractPattern(TTestICCluster& testCluster, ui32 me, ui32 peer, TString patternStart, TString patternEnd) {
     auto httpResp = testCluster.GetSessionDbg(me, peer);
+    if (!httpResp.Wait(TDuration::Seconds(2))) {
+        ythrow TPatternNotFound() << "session debug page request timed out";
+    }
     const TString& resp = httpResp.GetValueSync();
     auto pos = resp.find(patternStart);
     if (pos == std::string::npos) {
-        ythrow TPatternNotFound() << "pattern was not found: " << httpResp.GetValueSync();
+        ythrow TPatternNotFound() << "pattern was not found";
     }
     pos += patternStart.size();
     size_t end = resp.find(patternEnd, pos);

--- a/ydb/library/actors/interconnect/ut/lib/interrupter.h
+++ b/ydb/library/actors/interconnect/ut/lib/interrupter.h
@@ -101,6 +101,24 @@ public:
         this->Join();
     }
 
+    // Force full traffic blackhole on this interrupter: no polling, no forwarding, sockets stay open.
+    // This is used by tests that need deterministic "no progress" TCP states (e.g. TCP_USER_TIMEOUT checks).
+    void StartBlackhole() {
+        ManualRejectingTraffic.store(true, std::memory_order_release);
+        ManualRejectingTrafficOverride.store(true, std::memory_order_release);
+    }
+
+    // Disable forced blackhole and resume normal mode (random reject mode if configured, otherwise pass-through).
+    void StopBlackhole() {
+        ManualRejectingTraffic.store(false, std::memory_order_release);
+        ManualRejectingTrafficOverride.store(true, std::memory_order_release);
+    }
+
+    // Drop manual override and return to legacy random reject toggling (when timeout is configured).
+    void ClearBlackholeOverride() {
+        ManualRejectingTrafficOverride.store(false, std::memory_order_release);
+    }
+
 private:
     std::atomic<bool> Running = true;
     TVector<char> Buf;
@@ -117,6 +135,8 @@ private:
     const bool Disconnect;
     bool RejectingTraffic;
     bool DelayTraffic;
+    std::atomic<bool> ManualRejectingTrafficOverride = false;
+    std::atomic<bool> ManualRejectingTraffic = false;
 
     void UpdateRejectingState() {
         if (TDuration::Seconds(std::abs(RejectingStateTimer.Passed())) > CurrentRejectingTimeout) {
@@ -147,7 +167,9 @@ private:
         Events.resize(10);
 
         while (Running.load(std::memory_order_acquire)) {
-            if (RejectingTrafficTimeout != TDuration::Zero()) {
+            if (ManualRejectingTrafficOverride.load(std::memory_order_acquire)) {
+                RejectingTraffic = ManualRejectingTraffic.load(std::memory_order_acquire);
+            } else if (RejectingTrafficTimeout != TDuration::Zero()) {
                 UpdateRejectingState();
             }
             if (Disconnect) {
@@ -175,7 +197,7 @@ private:
                     DroppedConnections.clear();
                 }
             }
-            if (DelayTraffic) { // process packets from DelayQueues
+            if (DelayTraffic && !RejectingTraffic) { // process packets from DelayQueues
                 auto processDelayedPackages = [](TDirectedConnection& conn) {
                     while (!conn.DelayedQueue.empty()) {
                         auto& frontPackage = conn.DelayedQueue.top();
@@ -194,6 +216,9 @@ private:
                     processDelayedPackages(it.ForwardConnection);
                     processDelayedPackages(it.BackwardConnection);
                 }
+            } else if (RejectingTraffic) {
+                // In rejecting mode with no delayed forwarding, avoid a hot spin loop.
+                NanoSleep(1'000'000); // 1 ms
             }
         }
         ListenSocket.Close();

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -21,6 +21,7 @@ using namespace NActors;
 class TNode {
     THolder<TActorSystem> ActorSystem;
     TString CaPath;
+    TInterconnectProxyCommon::TPtr Common;
 
 public:
     static constexpr ui32 DefaultInflight() { return 512 * 1024; }
@@ -30,8 +31,10 @@ public:
           ui32 numDynamicNodes = 0, ui32 numThreads = 1,
           TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, ui32 inflight = DefaultInflight(),
           ESocketSendOptimization sendOpt = ESocketSendOptimization::DISABLED,
-          bool withTls = false,
-          NInterconnect::NRdma::ECqMode rdmaCqMode = NInterconnect::NRdma::ECqMode::EVENT) {
+          bool withTls = false, std::function<IActor*(ui32)> checkerFactory = {},
+          NInterconnect::NRdma::ECqMode rdmaCqMode = NInterconnect::NRdma::ECqMode::EVENT,
+          bool withRdma = true,
+          std::function<void(ui32, TInterconnectSettings&)> settingsCustomizer = {}) {
         TActorSystemSetup setup;
         setup.NodeId = nodeId;
         setup.ExecutorsCount = 2;
@@ -41,7 +44,8 @@ public:
         setup.Scheduler.Reset(new TBasicSchedulerThread());
         const ui32 interconnectPoolId = 0;
 
-        auto common = MakeIntrusive<TInterconnectProxyCommon>();
+        Common = MakeIntrusive<TInterconnectProxyCommon>();
+        auto& common = Common;
         common->NameserviceId = GetNameserviceActorId();
         common->MonCounters = counters->GetSubgroup("nodeId", ToString(nodeId));
         common->ChannelsConfig = channelsSettings;
@@ -56,9 +60,16 @@ public:
         common->Settings.TCPSocketBufferSize = 2048 * 1024;
         common->Settings.SocketSendOptimization = sendOpt;
         common->OutgoingHandshakeInflightLimit = 3;
+        if (settingsCustomizer) {
+            settingsCustomizer(nodeId, common->Settings);
+        }
 
         #if !defined(_msan_enabled_)
-        common->RdmaMemPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
+        if (withRdma) {
+            common->RdmaMemPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
+        }
+        #else
+            Y_UNUSED(withRdma);
         #endif
 
         if (withTls) {
@@ -67,6 +78,12 @@ public:
             CaPath = NInterconnect::GetTempCaPathForTest();
             common->Settings.CaFilePath = CaPath;
             common->Settings.EncryptionMode = EEncryptionMode::REQUIRED;
+        }
+
+        if (checkerFactory) {
+            TActorId checkerId(0, TStringBuf("CHECKER_____", 12));
+            setup.LocalServices.emplace_back(checkerId, TActorSetupCmd(checkerFactory(nodeId), TMailboxType::ReadAsFilled, 0));
+            common->ConnectionCheckerActorIds.push_back(checkerId);
         }
 
         setup.Interconnect.ProxyActors.resize(numNodes + 1 - numDynamicNodes);
@@ -171,5 +188,9 @@ public:
 
     TActorSystem *GetActorSystem() const {
         return ActorSystem.Get();
+    }
+
+    TInterconnectSettings& MutableInterconnectSettings() {
+        return Common->Settings;
     }
 };

--- a/ydb/library/actors/interconnect/ut/lib/test_actors.h
+++ b/ydb/library/actors/interconnect/ut/lib/test_actors.h
@@ -48,6 +48,13 @@ namespace NActors {
         void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& /*ev*/, const TActorContext& /*ctx*/) {
         }
 
+        // Retry connect from this sender actor so TEvNodeConnected is delivered back here;
+        // if another actor issues TEvConnectNode, this sender may never start sending traffic.
+        virtual void Handle(TEvents::TEvWakeup::TPtr& /*ev*/, const TActorContext& ctx) {
+            ctx.Send(ctx.ActorSystem()->InterconnectProxy(RecipientActorId.NodeId()),
+                new TEvInterconnect::TEvConnectNode);
+        }
+
         virtual void Handle(TEvents::TEvPoisonPill::TPtr& /*ev*/, const TActorContext& ctx) {
             Die(ctx);
         }
@@ -55,6 +62,7 @@ namespace NActors {
         virtual STRICT_STFUNC(StateFunc,
             HFunc(TEvTestResponse, Handle)
             HFunc(TEvents::TEvUndelivered, Handle)
+            HFunc(TEvents::TEvWakeup, Handle)
             HFunc(TEvents::TEvPoisonPill, Handle)
             HFunc(TEvInterconnect::TEvNodeConnected, Handle)
             HFunc(TEvInterconnect::TEvNodeDisconnected, Handle)

--- a/ydb/library/actors/interconnect/ut_fat/main.cpp
+++ b/ydb/library/actors/interconnect/ut_fat/main.cpp
@@ -182,9 +182,15 @@ Y_UNIT_TEST_SUITE(InterconnectUnstableConnection) {
         TReceiverActor* receiverActor = new TReceiverActor(testCluster.GetNode(1));
         const TActorId recipient = testCluster.RegisterActor(receiverActor, 2);
         TSenderActor* senderActor = new TSenderActor(recipient, flags, true);
-        testCluster.RegisterActor(senderActor, 1);
+        const TActorId senderActorId = testCluster.RegisterActor(senderActor, 1);
 
-        NanoSleep(30ULL * 1000 * 1000 * 1000);
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline && receiverActor->GetReceivedCount() == 0) {
+            // Re-arm connection request in case the initial TLS/XDC handshake attempt
+            // fails before sender receives TEvNodeConnected.
+            testCluster.GetNode(1)->Send(senderActorId, new TEvents::TEvWakeup);
+            Sleep(TDuration::MilliSeconds(100));
+        }
 
         UNIT_ASSERT_C(receiverActor->GetReceivedCount() > 0, "no traffic detected!");
     }

--- a/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
@@ -1,0 +1,440 @@
+#include <ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <cstring>
+#include <limits>
+
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
+using namespace NActors;
+
+namespace {
+
+ui64 GetSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    return FromString<ui64>(ExtractPattern(cluster, me, peer, start, "<"));
+}
+
+ui64 WaitForSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name,
+        TDuration timeout = TDuration::Seconds(10)) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        try {
+            return GetSessionCounter(cluster, me, peer, name);
+        } catch (const TPatternNotFound&) {
+            Sleep(TDuration::MilliSeconds(100));
+        }
+    }
+    UNIT_FAIL(TStringBuilder() << "failed to read session counter " << name << " from " << me << " to " << peer);
+    return 0;
+}
+
+i64 GetSessionSocketFd(TTestICCluster& cluster, ui32 me, ui32 peer) {
+    return FromString<i64>(ExtractPattern(cluster, me, peer, "<tr><td>Socket</td><td>", "<"));
+}
+
+i64 TryGetSessionSocketFd(TTestICCluster& cluster, ui32 me, ui32 peer) {
+    try {
+        return GetSessionSocketFd(cluster, me, peer);
+    } catch (const TPatternNotFound&) {
+        return -1;
+    }
+}
+
+template <typename TCallback>
+void WaitForCondition(TDuration timeout, TCallback&& callback, TStringBuf description) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        if (callback()) {
+            return;
+        }
+        Sleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_FAIL(TStringBuilder() << "condition failed: " << description);
+}
+
+class TDropRecipientActor : public TActor<TDropRecipientActor> {
+public:
+    TDropRecipientActor()
+        : TActor(&TThis::StateFunc)
+    {}
+
+    size_t GetReceived() const noexcept {
+        return Received.load(std::memory_order_relaxed);
+    }
+
+private:
+    void HandlePing(TAutoPtr<IEventHandle>& ev) {
+        Received.fetch_add(1, std::memory_order_relaxed);
+        TActivationContext::Send(new IEventHandle(TEvents::THelloWorld::Pong, 0, ev->Sender, SelfId(), nullptr, ev->Cookie));
+    }
+
+    STRICT_STFUNC(StateFunc,
+        fFunc(TEvents::THelloWorld::Ping, HandlePing);
+    )
+
+private:
+    std::atomic<size_t> Received = 0;
+};
+
+class TBlackholeFloodSenderActor : public TActorBootstrapped<TBlackholeFloodSenderActor> {
+public:
+    TBlackholeFloodSenderActor(TActorId recipient, size_t messages, size_t payloadSize)
+        : Recipient(recipient)
+        , Messages(messages)
+        , CookieState(messages + 1, 0)
+        , Payload(TString::Uninitialized(payloadSize))
+    {
+        memset(Payload.Detach(), 'x', Payload.size());
+    }
+
+    bool IsConnected() const noexcept {
+        return Connected.load(std::memory_order_relaxed);
+    }
+
+    size_t GetSent() const noexcept {
+        return Sent.load(std::memory_order_relaxed);
+    }
+
+    size_t GetConnects() const noexcept {
+        return Connects.load(std::memory_order_relaxed);
+    }
+
+    size_t GetUndelivered() const noexcept {
+        return Undelivered.load(std::memory_order_relaxed);
+    }
+
+    size_t GetDelivered() const noexcept {
+        return Delivered.load(std::memory_order_relaxed);
+    }
+
+    size_t GetObservedUnion() const noexcept {
+        return ObservedUnion.load(std::memory_order_relaxed);
+    }
+
+    size_t GetDisconnects() const noexcept {
+        return Disconnects.load(std::memory_order_relaxed);
+    }
+
+    TDuration GetFirstUndeliveredDelay() const noexcept {
+        const ui64 start = FloodStartedAtUs.load(std::memory_order_relaxed);
+        const ui64 first = FirstUndeliveredAtUs.load(std::memory_order_relaxed);
+        if (!start || !first || first < start) {
+            return TDuration::Zero();
+        }
+        return TDuration::MicroSeconds(first - start);
+    }
+
+    TDuration GetFirstDisconnectDelay() const noexcept {
+        const ui64 start = FloodStartedAtUs.load(std::memory_order_relaxed);
+        const ui64 first = FirstDisconnectAtUs.load(std::memory_order_relaxed);
+        if (!start || !first || first < start) {
+            return TDuration::Zero();
+        }
+        return TDuration::MicroSeconds(first - start);
+    }
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+        Send(TActivationContext::InterconnectProxy(Recipient.NodeId()), new TEvents::TEvSubscribe);
+    }
+
+private:
+    static constexpr ui8 DeliveredBit = 1u << 0;
+    static constexpr ui8 UndeliveredBit = 1u << 1;
+
+    void MarkCookie(ui64 cookie, ui8 bit, std::atomic<size_t>& metric) {
+        Y_ABORT_UNLESS(0 < cookie && cookie <= Messages);
+        ui8& state = CookieState[cookie];
+        if (state & bit) {
+            return;
+        }
+        if (!state) {
+            ObservedUnion.fetch_add(1, std::memory_order_relaxed);
+        }
+        state |= bit;
+        metric.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void HandleNodeConnected(TEvInterconnect::TEvNodeConnected::TPtr&) {
+        Connected.store(true, std::memory_order_relaxed);
+        Connects.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void HandleNodeDisconnected(TEvInterconnect::TEvNodeDisconnected::TPtr&) {
+        Connected.store(false, std::memory_order_relaxed);
+        Disconnects.fetch_add(1, std::memory_order_relaxed);
+        const ui64 nowUs = TInstant::Now().MicroSeconds();
+        ui64 expected = 0;
+        FirstDisconnectAtUs.compare_exchange_strong(expected, nowUs, std::memory_order_relaxed);
+    }
+
+    void HandleUndelivered(TEvents::TEvUndelivered::TPtr& ev) {
+        MarkCookie(ev->Cookie, UndeliveredBit, Undelivered);
+        const ui64 nowUs = TInstant::Now().MicroSeconds();
+        ui64 expected = 0;
+        FirstUndeliveredAtUs.compare_exchange_strong(expected, nowUs, std::memory_order_relaxed);
+    }
+
+    void HandlePong(TAutoPtr<IEventHandle>& ev) {
+        MarkCookie(ev->Cookie, DeliveredBit, Delivered);
+    }
+
+    void HandleStartFlood() {
+        if (FloodStarted) {
+            return;
+        }
+        FloodStarted = true;
+        FloodStartedAtUs.store(TInstant::Now().MicroSeconds(), std::memory_order_relaxed);
+        const ui32 flags = IEventHandle::FlagTrackDelivery | IEventHandle::FlagGenerateUnsureUndelivered;
+        for (size_t i = 0; i < Messages; ++i) {
+            TActivationContext::Send(new IEventHandle(TEvents::THelloWorld::Ping, flags, Recipient,
+                SelfId(), MakeIntrusive<TEventSerializedData>(TString(Payload), TEventSerializationInfo{}), i + 1));
+            Sent.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvInterconnect::TEvNodeConnected, HandleNodeConnected)
+        hFunc(TEvInterconnect::TEvNodeDisconnected, HandleNodeDisconnected)
+        hFunc(TEvents::TEvUndelivered, HandleUndelivered)
+        fFunc(TEvents::THelloWorld::Pong, HandlePong)
+        cFunc(TEvents::TSystem::Wakeup, HandleStartFlood)
+    )
+
+private:
+    const TActorId Recipient;
+    const size_t Messages;
+    TVector<ui8> CookieState;
+    TString Payload;
+
+    std::atomic<bool> Connected = false;
+    std::atomic<size_t> Connects = 0;
+    std::atomic<size_t> Sent = 0;
+    std::atomic<size_t> Undelivered = 0;
+    std::atomic<size_t> Delivered = 0;
+    std::atomic<size_t> ObservedUnion = 0;
+    std::atomic<size_t> Disconnects = 0;
+    std::atomic<ui64> FloodStartedAtUs = 0;
+    std::atomic<ui64> FirstUndeliveredAtUs = 0;
+    std::atomic<ui64> FirstDisconnectAtUs = 0;
+    bool FloodStarted = false;
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
+
+    Y_UNIT_TEST(TcpUserTimeoutBlackholeDisconnectsSession) {
+        constexpr size_t messages = 512;
+        constexpr size_t payloadSize = 64 * 1024;
+        constexpr TDuration userTimeout = TDuration::Seconds(3);
+
+        auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+            settings.EnableKernelLiveness = true;
+            settings.KernelKeepAliveIdle = TDuration::Seconds(30);
+            settings.KernelKeepAliveInterval = TDuration::Seconds(1);
+            settings.KernelKeepAliveProbes = 3;
+            settings.KernelUserTimeout = TDuration::Seconds(3);
+
+            // Keep this large so that the test observes transport timeout rather than session watchdog timeout.
+            settings.LostConnection = TDuration::Seconds(60);
+        };
+
+        TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+            .RejectingTrafficTimeout = TDuration::Zero(),
+            .BandWidth = 0.0,
+            .Disconnect = false,
+        };
+
+        TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::DISABLE_RDMA,
+            {}, TDuration::Seconds(30), 128 * 1024 * 1024, settingsCustomizer);
+
+        auto* recipient12 = new TDropRecipientActor;
+        const TActorId recipient12Id = cluster.RegisterActor(recipient12, 1);
+        auto* sender12 = new TBlackholeFloodSenderActor(recipient12Id, messages, payloadSize);
+        const TActorId sender12Id = cluster.RegisterActor(sender12, 2);
+
+        auto* recipient21 = new TDropRecipientActor;
+        const TActorId recipient21Id = cluster.RegisterActor(recipient21, 2);
+        auto* sender21 = new TBlackholeFloodSenderActor(recipient21Id, messages, payloadSize);
+        const TActorId sender21Id = cluster.RegisterActor(sender21, 1);
+
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            // NodeConnected notifications can briefly flap around reconnect races.
+            // Require that each sender has observed at least one connect and the current
+            // interconnect sockets are established on both directions.
+            return sender12->GetConnects() > 0 &&
+                sender21->GetConnects() > 0 &&
+                TryGetSessionSocketFd(cluster, 1, 2) >= 0 &&
+                TryGetSessionSocketFd(cluster, 2, 1) >= 0;
+        }, "senders connected to peer");
+
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), 1ULL);
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);
+
+        // Freeze the proxy path to force zero-window/persist behavior on sender-side TCP.
+        // Connection direction is not deterministic in tests; force blackhole on both interrupters.
+        cluster.StartBlackhole(1);
+        cluster.StartBlackhole(2);
+        const TInstant floodStart = TInstant::Now();
+        cluster.GetNode(2)->Send(sender12Id, new TEvents::TEvWakeup);
+        cluster.GetNode(1)->Send(sender21Id, new TEvents::TEvWakeup);
+
+        TDuration earliestDisconnect = TDuration::Zero();
+        const TInstant deadline = floodStart + TDuration::Seconds(20);
+        while (TInstant::Now() < deadline) {
+            bool disconnected = false;
+            try {
+                disconnected = GetSessionSocketFd(cluster, 1, 2) < 0 || GetSessionSocketFd(cluster, 2, 1) < 0;
+            } catch (const TPatternNotFound&) {
+            }
+            if (disconnected) {
+                earliestDisconnect = TInstant::Now() - floodStart;
+                break;
+            }
+            Sleep(TDuration::MilliSeconds(200));
+        }
+
+        // Reestablish path may keep session alive without immediate undelivered notifications.
+        // Force session termination to flush unsure-undelivered for in-flight tracked events.
+        cluster.GetNode(1)->Send(cluster.InterconnectProxy(2, 1), new TEvInterconnect::TEvPoisonSession);
+        cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvPoisonSession);
+
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            return sender12->GetObservedUnion() == messages && sender21->GetObservedUnion() == messages;
+        }, "each sent cookie is either delivered or undelivered");
+
+        i64 socket12 = std::numeric_limits<i64>::max();
+        i64 socket21 = std::numeric_limits<i64>::max();
+        try {
+            socket12 = GetSessionSocketFd(cluster, 1, 2);
+        } catch (const TPatternNotFound&) {
+        }
+        try {
+            socket21 = GetSessionSocketFd(cluster, 2, 1);
+        } catch (const TPatternNotFound&) {
+        }
+        Cerr << "tcpUserTimeout# " << userTimeout
+            << " earliestDisconnect# " << earliestDisconnect
+            << " socket12# " << socket12
+            << " socket21# " << socket21
+            << " sent12# " << sender12->GetSent()
+            << " sent21# " << sender21->GetSent()
+            << " delivered12# " << sender12->GetDelivered()
+            << " delivered21# " << sender21->GetDelivered()
+            << " undelivered12# " << sender12->GetUndelivered()
+            << " undelivered21# " << sender21->GetUndelivered()
+            << " observed12# " << sender12->GetObservedUnion()
+            << " observed21# " << sender21->GetObservedUnion()
+            << " received12# " << recipient12->GetReceived()
+            << " received21# " << recipient21->GetReceived()
+            << "\n";
+
+        UNIT_ASSERT_VALUES_EQUAL(sender12->GetSent(), messages);
+        UNIT_ASSERT_VALUES_EQUAL(sender21->GetSent(), messages);
+        UNIT_ASSERT_C(earliestDisconnect != TDuration::Zero(),
+            "first disconnect delay is not captured");
+        UNIT_ASSERT_C(earliestDisconnect < TDuration::Seconds(20),
+            TStringBuilder() << "disconnect was too late, delay# " << earliestDisconnect);
+        UNIT_ASSERT_VALUES_EQUAL(sender12->GetObservedUnion(), messages);
+        UNIT_ASSERT_VALUES_EQUAL(sender21->GetObservedUnion(), messages);
+        UNIT_ASSERT_C(sender12->GetUndelivered() > 0 || sender21->GetUndelivered() > 0,
+            "expected at least one undelivered event after forced termination");
+    }
+
+    Y_UNIT_TEST(TcpUserTimeoutNoReconnectGeneratesUndelivered) {
+        constexpr size_t messages = 512;
+        constexpr size_t payloadSize = 64 * 1024;
+        constexpr TDuration userTimeout = TDuration::Seconds(3);
+        constexpr TDuration lostConnection = TDuration::Seconds(8);
+
+        auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+            settings.EnableKernelLiveness = true;
+            settings.KernelKeepAliveIdle = TDuration::Seconds(30);
+            settings.KernelKeepAliveInterval = TDuration::Seconds(1);
+            settings.KernelKeepAliveProbes = 3;
+            settings.KernelUserTimeout = TDuration::Seconds(3);
+
+            // Keep this above KernelUserTimeout to observe socket-level timeout first,
+            // but still short enough to naturally terminate the session during this test.
+            settings.LostConnection = TDuration::Seconds(8);
+        };
+
+        TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+            .RejectingTrafficTimeout = TDuration::Zero(),
+            .BandWidth = 0.0,
+            .Disconnect = false,
+        };
+
+        TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::DISABLE_RDMA,
+            {}, TDuration::Seconds(30), 128 * 1024 * 1024, settingsCustomizer);
+
+        auto* recipient = new TDropRecipientActor;
+        const TActorId recipientId = cluster.RegisterActor(recipient, 1);
+        auto* sender = new TBlackholeFloodSenderActor(recipientId, messages, payloadSize);
+        const TActorId senderId = cluster.RegisterActor(sender, 2);
+
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            return sender->IsConnected();
+        }, "sender connected to peer");
+
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), 1ULL);
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);
+
+        const size_t connectsBeforeFlood = sender->GetConnects();
+
+        // Keep the transport blackholed after the first timeout-driven disconnect,
+        // so that handshake/reconnect cannot progress.
+        cluster.StartBlackhole(1);
+        cluster.StartBlackhole(2);
+        Sleep(TDuration::MilliSeconds(200));
+
+        const TInstant floodStart = TInstant::Now();
+        cluster.GetNode(2)->Send(senderId, new TEvents::TEvWakeup);
+
+        TDuration earliestDisconnect = TDuration::Zero();
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            const bool disconnected = TryGetSessionSocketFd(cluster, 1, 2) < 0 || TryGetSessionSocketFd(cluster, 2, 1) < 0;
+            if (disconnected && earliestDisconnect == TDuration::Zero()) {
+                earliestDisconnect = TInstant::Now() - floodStart;
+            }
+            return disconnected;
+        }, "session disconnected by tcp user timeout");
+
+        const TInstant waitUndeliveredDeadline = floodStart + TDuration::Seconds(35);
+        while (TInstant::Now() < waitUndeliveredDeadline && sender->GetObservedUnion() < messages) {
+            Sleep(TDuration::MilliSeconds(200));
+        }
+
+        const size_t connectsAfterWait = sender->GetConnects();
+        const i64 socket12 = TryGetSessionSocketFd(cluster, 1, 2);
+        const i64 socket21 = TryGetSessionSocketFd(cluster, 2, 1);
+        Cerr << "tcpUserTimeoutNoReconnect# " << userTimeout
+            << " lostConnection# " << lostConnection
+            << " earliestDisconnect# " << earliestDisconnect
+            << " socket12# " << socket12
+            << " socket21# " << socket21
+            << " connectsBeforeFlood# " << connectsBeforeFlood
+            << " connectsAfterWait# " << connectsAfterWait
+            << " sent# " << sender->GetSent()
+            << " delivered# " << sender->GetDelivered()
+            << " undelivered# " << sender->GetUndelivered()
+            << " observed# " << sender->GetObservedUnion()
+            << " received# " << recipient->GetReceived()
+            << "\n";
+
+        UNIT_ASSERT_VALUES_EQUAL(sender->GetSent(), messages);
+        UNIT_ASSERT_C(earliestDisconnect != TDuration::Zero(),
+            "first disconnect delay is not captured");
+        UNIT_ASSERT_C(earliestDisconnect < lostConnection,
+            TStringBuilder() << "disconnect was too late, delay# " << earliestDisconnect);
+        UNIT_ASSERT_VALUES_EQUAL(sender->GetObservedUnion(), messages);
+        UNIT_ASSERT_VALUES_EQUAL(sender->GetUndelivered(), messages);
+        UNIT_ASSERT_VALUES_EQUAL(connectsAfterWait, connectsBeforeFlood);
+    }
+
+}

--- a/ydb/library/actors/interconnect/ut_kernel_liveness/ya.make
+++ b/ydb/library/actors/interconnect/ut_kernel_liveness/ya.make
@@ -1,0 +1,25 @@
+UNITTEST()
+
+IF (OS_LINUX)
+
+SIZE(LARGE)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+
+SRCS(
+    tcp_user_timeout_ut.cpp
+)
+
+PEERDIR(
+    ydb/library/actors/core
+    ydb/library/actors/interconnect
+    ydb/library/actors/interconnect/mock
+    ydb/library/actors/interconnect/ut/lib
+    ydb/library/actors/interconnect/ut/lib/port_manager
+    ydb/library/actors/interconnect/ut/protos
+    library/cpp/testing/unittest
+)
+
+ENDIF()
+
+END()

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -95,4 +95,5 @@ RECURSE_FOR_TESTS(
     ut
     ut_fat
     ut_huge_cluster
+    ut_kernel_liveness
 )


### PR DESCRIPTION
16e94e8b996a969d15a1e2d61ab8edadfd3dd4dc

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
