### PR TITLE
add minmax index on every column at create column table

### DIFF
--- a/ydb/core/formats/arrow/switch/switch_type.h
+++ b/ydb/core/formats/arrow/switch/switch_type.h
@@ -60,7 +60,7 @@ template <typename TFunc>
         case NScheme::NTypeIds::JsonDocument:
             return callback(TTypeWrapper<arrow::BinaryType>());
         case NScheme::NTypeIds::Timestamp:
-            return callback(TTypeWrapper<arrow::TimestampType>());
+            return callback(TTypeWrapper<arrow::UInt64Type>());
         case NScheme::NTypeIds::Interval:
             return callback(TTypeWrapper<arrow::DurationType>());
         case NScheme::NTypeIds::Decimal:

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -266,4 +266,5 @@ message TFeatureFlags {
     optional bool EnableSQSMigrationTopicCreation = 239 [default = false];
     optional bool EnableSQSMigrationCompatibility = 240 [default = false];
     optional bool EnableSQSMigrationFinished = 241 [default = false];
+    optional bool EnableDefaultMinMaxIndexForColumnTables = 242 [default = true];
 }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/minmax/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/minmax/meta.cpp
@@ -137,6 +137,7 @@ bool TIndexMeta::DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescrip
     }
     return true;
 }
+
 bool TIndexMeta::DoCheckValue(const TString& data, const std::optional<ui64> cat,
     const std::shared_ptr<arrow::Scalar>& requestValue, const NArrow::NSSA::TIndexCheckOperation& op, const TIndexInfo& info) const {
     AFL_VERIFY(!cat.has_value())("error", "category shouldn't be passed to minmax index");
@@ -147,6 +148,7 @@ bool TIndexMeta::DoCheckValue(const TString& data, const std::optional<ui64> cat
 
 bool TIndexMeta::Skip(NArrow::NAccessor::TMinMax chunkValue, const std::shared_ptr<arrow::Scalar>& requestValue,
     const NArrow::NSSA::TIndexCheckOperation& op) const {
+
     switch (op.GetOperation()) {
         case NArrow::NSSA::TIndexCheckOperation::EOperation::Equals:
             return requestValue < chunkValue.Min || requestValue > chunkValue.Max;
@@ -175,5 +177,22 @@ void TIndexMeta::DoSerializeToProto(NKikimrSchemeOp::TOlapIndexDescription& prot
     filterProto->SetColumnId(GetColumnId());
     *filterProto->MutableDataExtractor() = GetDataExtractor().SerializeToProto();
 }
+
+bool TIndexMeta::IsAvailableType(const NScheme::TTypeInfo type) {
+
+    // JSON is not supported for minmax index.
+    if (type.GetTypeId() == NScheme::NTypeIds::Json || type.GetTypeId() == NScheme::NTypeIds::JsonDocument) {
+        return false;
+    }
+
+    auto dataTypeResult = NArrow::GetArrowType(type);
+    if (!dataTypeResult.ok()) {
+        return false;
+    }
+    
+    auto typedId = (*dataTypeResult)->id();
+    return (arrow::is_primitive(typedId) || arrow::is_base_binary_like(typedId));
+}
+
 
 }   // namespace NKikimr::NOlap::NIndexes::NMinMax

--- a/ydb/core/tx/columnshard/engines/storage/indexes/minmax/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/minmax/meta.h
@@ -39,15 +39,7 @@ public:
     {
     }
 
-    static bool IsAvailableType(const NScheme::TTypeInfo type) {
-        auto dataTypeResult = NArrow::GetArrowType(type);
-        if (!dataTypeResult.ok()) {
-            return false;
-        }
-        auto typedId = (*dataTypeResult)->id();
-        return (arrow::is_primitive(typedId) || arrow::is_base_binary_like(typedId)) &&
-               !(typedId == arrow::Type::TIMESTAMP /*not supported yet, see https://github.com/ydb-platform/ydb/issues/35699 */);
-    }
+    static bool IsAvailableType(const NScheme::TTypeInfo type);
 
     virtual TString GetClassName() const override {
         return GetClassNameStatic();

--- a/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
@@ -193,6 +193,12 @@ private:
         }
 
         TableSchema.ParseIndexesFromFullSchema(description.GetSchema());
+
+        if (AppData()->FeatureFlags.GetEnableDefaultMinMaxIndexForColumnTables()) {
+            if (!TableSchema.AddDefaultMinMaxIndexes(errors)) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/ydb/core/tx/schemeshard/olap/schema/schema.cpp
+++ b/ydb/core/tx/schemeshard/olap/schema/schema.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/tx/schemeshard/common/validation.h>
 #include <ydb/core/tx/schemeshard/olap/ttl/validator.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/minmax/meta.h>
 
 namespace NKikimr::NSchemeShard {
 
@@ -81,6 +82,31 @@ bool TOlapSchema::ValidateForStore(const NKikimrSchemeOp::TColumnTableSchema& op
     }
 
     return true;
+}
+
+bool TOlapSchema::AddDefaultMinMaxIndexes(IErrorCollector& errors) {
+    NKikimrSchemeOp::TAlterColumnTableSchema alterSchema;
+    for (auto& [id, col] : Columns.GetColumns()) {
+        if (!NOlap::NIndexes::NMinMax::TIndexMeta::IsAvailableType(col.GetType())) {
+            continue;
+        }
+        const TString indexName = "__minmax_" + col.GetName();
+        if (Indexes.GetByName(indexName)) {
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "skip_default_minmax_index")("index_name", indexName)("reason", "index with " +indexName+ " already exists");
+            continue;
+        }
+        auto* upsertIndex = alterSchema.AddUpsertIndexes();
+        upsertIndex->SetName(indexName);
+        upsertIndex->MutableMinMaxIndex()->SetColumnName(col.GetName());
+    }
+    if (alterSchema.UpsertIndexesSize() == 0) {
+        return true;
+    }
+    TOlapIndexesUpdate indexUpdate;
+    if (!indexUpdate.Parse(alterSchema, errors)) {
+        return false;
+    }
+    return Indexes.ApplyUpdate(*this, indexUpdate, errors, NextColumnId);
 }
 
 void TOlapStoreSchemaPreset::ParseFromLocalDB(const NKikimrSchemeOp::TColumnTableSchemaPreset& presetProto) {

--- a/ydb/core/tx/schemeshard/olap/schema/schema.cpp
+++ b/ydb/core/tx/schemeshard/olap/schema/schema.cpp
@@ -97,6 +97,7 @@ bool TOlapSchema::AddDefaultMinMaxIndexes(IErrorCollector& errors) {
         }
         auto* upsertIndex = alterSchema.AddUpsertIndexes();
         upsertIndex->SetName(indexName);
+        upsertIndex->SetClassName(NOlap::NIndexes::NMinMax::TIndexMeta::GetClassNameStatic());
         upsertIndex->MutableMinMaxIndex()->SetColumnName(col.GetName());
     }
     if (alterSchema.UpsertIndexesSize() == 0) {

--- a/ydb/core/tx/schemeshard/olap/schema/schema.cpp
+++ b/ydb/core/tx/schemeshard/olap/schema/schema.cpp
@@ -86,7 +86,13 @@ bool TOlapSchema::ValidateForStore(const NKikimrSchemeOp::TColumnTableSchema& op
 
 bool TOlapSchema::AddDefaultMinMaxIndexes(IErrorCollector& errors) {
     NKikimrSchemeOp::TAlterColumnTableSchema alterSchema;
+    // Skip minmax index for the first primary key column
+    const ui32 firstPkColumnId = Columns.GetKeyColumnIds()[0];
+
     for (auto& [id, col] : Columns.GetColumns()) {
+        if (id == firstPkColumnId) {
+            continue;
+        }
         if (!NOlap::NIndexes::NMinMax::TIndexMeta::IsAvailableType(col.GetType())) {
             continue;
         }

--- a/ydb/core/tx/schemeshard/olap/schema/schema.h
+++ b/ydb/core/tx/schemeshard/olap/schema/schema.h
@@ -30,6 +30,7 @@ namespace NKikimr::NSchemeShard {
         void Serialize(NKikimrSchemeOp::TColumnTableSchema& tableSchema) const;
         bool ValidateForStore(const NKikimrSchemeOp::TColumnTableSchema& opSchema, IErrorCollector& errors) const;
         bool ValidateTtlSettings(const NKikimrSchemeOp::TColumnDataLifeCycle& ttlSettings, const TOperationContext& context, IErrorCollector& errors) const;
+        bool AddDefaultMinMaxIndexes(IErrorCollector& errors);
     };
 
     class TOlapStoreSchemaPreset: public TOlapSchema {


### PR DESCRIPTION
this pr adds EnableDefaultMinMaxIndexForColumnTables feature flag that, if enabled, adds minmax index on every column on create table
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
