### PR TITLE
Fix bad atomic access in VDiskIOTest::HugeBlobIOCount UT

### DIFF
--- a/ydb/core/blobstorage/ut_vdisk_io/vdisk_io.cpp
+++ b/ydb/core/blobstorage/ut_vdisk_io/vdisk_io.cpp
@@ -37,9 +37,9 @@ Y_UNIT_TEST_SUITE(VDiskIOTest) {
             auto device = rot->GetSubgroup("subsystem", "device");
             auto pDisk = rot->GetSubgroup("subsystem", "pdisk");
 
-            ui64 deviceWrites = device->FindCounter("DeviceWrites")->GetAtomic();
-            ui64 writesLog = pDisk->GetSubgroup("req", "WriteLog")->FindCounter("Requests")->GetAtomic();
-            ui64 writesHugeUser = pDisk->GetSubgroup("req", "WriteHugeUser")->FindCounter("Requests")->GetAtomic();
+            ui64 deviceWrites = AtomicGet(device->FindCounter("DeviceWrites")->GetAtomic());
+            ui64 writesLog = AtomicGet(pDisk->GetSubgroup("req", "WriteLog")->FindCounter("Requests")->GetAtomic());
+            ui64 writesHugeUser = AtomicGet(pDisk->GetSubgroup("req", "WriteHugeUser")->FindCounter("Requests")->GetAtomic());
 
             return std::make_tuple(deviceWrites, writesLog, writesHugeUser);
         };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix bad atomic access in UT which leads to datarace, https://github.com/ydb-platform/ydb/issues/33890

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)