### PR TITLE
Use mutex-guarded deterministic random provider in testlib

### DIFF
--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -13,6 +13,7 @@
 #include <ydb/library/actors/interconnect/interconnect_tcp_proxy.h>
 #include <ydb/library/actors/interconnect/interconnect_proxy_wrapper.h>
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
+#include <ydb/library/actors/util/mutex_guarded_deterministic_random_provider.h>
 #include <ydb/library/actors/util/queue_oneone_inplace.h>
 
 #include <util/generic/maybe.h>
@@ -524,7 +525,7 @@ namespace NActors {
         , DispatchCyclesCount(0)
         , DispatchedEventsCount(0)
         , NeedMonitoring(false)
-        , RandomProvider(CreateDeterministicRandomProvider(DefaultRandomSeed))
+        , RandomProvider(CreateMutexGuardedDeterministicRandomProvider(DefaultRandomSeed))
         , TimeProvider(new TTimeProvider(*this))
         , MonotonicTimeProvider(new TMonotonicTimeProvider(*this))
         , ShouldContinue()

--- a/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.cpp
+++ b/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.cpp
@@ -1,32 +1,31 @@
-#pragma once
-
 #include <mutex>
 
-#include <library/cpp/random/random_provider.h>
+#include "mutex_guarded_deterministic_random_provider.h"
 
-class TMutexGuardedDeterministicRandomProvider : public TDeterministicRandomProvider {
+class TMutexGuardedDeterministicRandomProvider : public IRandomProvider {
 public:
     TMutexGuardedDeterministicRandomProvider(ui64 seed)
-        : TDeterministicRandomProvider(seed)
+        : Impl(CreateDeterministicRandomProvider(seed))
     {}
 
     ui64 GenRand() noexcept override {
-        std::lock_guard guard(mutex);
-        return TDeterministicRandomProvider::GenRand();
+        std::lock_guard guard(Mutex);
+        return Impl->GenRand();
     }
 
     TGUID GenGuid() noexcept override {
-        std::lock_guard guard(mutex);
-        return TDeterministicRandomProvider::GenGuid();
+        std::lock_guard guard(Mutex);
+        return Impl->GenGuid();
     }
 
     TGUID GenUuid4() noexcept override {
-        std::lock_guard guard(mutex);
-        return TDeterministicRandomProvider::GenUuid4();
+        std::lock_guard guard(Mutex);
+        return Impl->GenUuid4();
     }
 
 private:
     std::mutex Mutex;
+    TIntrusivePtr<IRandomProvider> Impl;
 };
 
 TIntrusivePtr<IRandomProvider> CreateMutexGuardedDeterministicRandomProvider(ui64 seed) {

--- a/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.cpp
+++ b/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.cpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mutex>
+
+#include <library/cpp/random/random_provider.h>
+
+class TMutexGuardedDeterministicRandomProvider : public TDeterministicRandomProvider {
+public:
+    TMutexGuardedDeterministicRandomProvider(ui64 seed)
+        : TDeterministicRandomProvider(seed)
+    {}
+
+    ui64 GenRand() noexcept override {
+        std::lock_guard guard(mutex);
+        return TDeterministicRandomProvider::GenRand();
+    }
+
+    TGUID GenGuid() noexcept override {
+        std::lock_guard guard(mutex);
+        return TDeterministicRandomProvider::GenGuid();
+    }
+
+    TGUID GenUuid4() noexcept override {
+        std::lock_guard guard(mutex);
+        return TDeterministicRandomProvider::GenUuid4();
+    }
+
+private:
+    std::mutex Mutex;
+};
+
+TIntrusivePtr<IRandomProvider> CreateMutexGuardedDeterministicRandomProvider(ui64 seed) {
+    return TIntrusivePtr<IRandomProvider>(new TMutexGuardedDeterministicRandomProvider(seed));
+}

--- a/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.h
+++ b/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <library/cpp/random/random_provider.h>
+#include <library/cpp/random_provider/random_provider.h>
 
 TIntrusivePtr<IRandomProvider> CreateMutexGuardedDeterministicRandomProvider(ui64 seed);

--- a/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.h
+++ b/ydb/library/actors/util/mutex_guarded_deterministic_random_provider.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <library/cpp/random/random_provider.h>
+
+TIntrusivePtr<IRandomProvider> CreateMutexGuardedDeterministicRandomProvider(ui64 seed);

--- a/ydb/library/actors/util/ya.make
+++ b/ydb/library/actors/util/ya.make
@@ -18,6 +18,8 @@ SRCS(
     memory_track.h
     memory_tracker.cpp
     memory_tracker.h
+    mutex_guarded_deterministic_random_provider.cpp
+    mutex_guarded_deterministic_random_provider.h
     recentwnd.h
     rope.cpp
     rope.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add mutex-guarded deterministic random provider to prevent dataraces on TMersenne in UT

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)