### PR TITLE
Add ForcedPDiskSpaceColor ICB flag and test helper

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -4,6 +4,7 @@
 #include "blobstorage_pdisk_completion_impl.h"
 #include "blobstorage_pdisk_mon.h"
 #include "blobstorage_pdisk_request_id.h"
+#include "blobstorage_pdisk_util_space_color.h"
 
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/control/lib/dynamic_control_board_impl.h>
@@ -74,6 +75,7 @@ TPDisk::TPDisk(std::shared_ptr<TPDiskCtx> pCtx, const TIntrusivePtr<TPDiskConfig
     // 2 - YellowStop
     SemiStrictSpaceIsolation = TControlWrapper(0, 0, 2);
     SemiStrictSpaceIsolationCached = 0;
+    ForcedPDiskSpaceColor = TControlWrapper(0, 0, 60);
 
     if (Cfg->SectorMap) {
         auto diskModeParams = Cfg->SectorMap->GetDiskModeParams();
@@ -621,6 +623,15 @@ NPDisk::TStatusFlags TPDisk::GetStatusFlags(TOwner ownerId, const EOwnerGroupTyp
     } else {
         TOwner keeperOwner = (ownerGroupType == EOwnerGroupType::Dynamic ? OwnerSystem : OwnerCommonStaticLog);
         res = Keeper.GetSpaceStatusFlags(keeperOwner, &occupancy_);
+    }
+
+    if (i64 forcedColor = ForcedPDiskSpaceColor; forcedColor != 0) {
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+        if (NKikimrBlobStorage::TPDiskSpaceColor_E_IsValid(static_cast<int>(forcedColor))) {
+            res = SpaceColorToStatusFlag(static_cast<TColor::E>(forcedColor));
+        } else {
+            P_LOG(PRI_ERROR, BPD01, "ForcedPDiskSpaceColor has invalid value, ignoring", (ForcedPDiskSpaceColor, forcedColor));
+        }
     }
 
     if (occupancy) {
@@ -2967,6 +2978,9 @@ bool TPDisk::Initialize() {
             TControlBoard::RegisterSharedControl(UseNoopSchedulerSSD, icb->PDiskControls.UseNoopSchedulerSSD);
             REGISTER_LOCAL_CONTROL(ChunkBaseLimitPerMille);
             TControlBoard::RegisterSharedControl(SemiStrictSpaceIsolation, icb->PDiskControls.SemiStrictSpaceIsolation);
+            if (Cfg->FeatureFlags.GetEnablePDiskSpaceColorOverride()) {
+                REGISTER_LOCAL_CONTROL(ForcedPDiskSpaceColor);
+            }
 
             if (Cfg->SectorMap) {
                 auto diskModeParams = Cfg->SectorMap->GetDiskModeParams();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -112,6 +112,7 @@ public:
     TControlWrapper ChunkBaseLimitPerMille;
     TControlWrapper SemiStrictSpaceIsolation;
     i64 SemiStrictSpaceIsolationCached = 0;
+    TControlWrapper ForcedPDiskSpaceColor;
     NKikimrBlobStorage::TPDiskSpaceColor::E GetColorBorderIcb() {
         using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
         switch (SemiStrictSpaceIsolation) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -1360,6 +1360,44 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         }
     }
 
+    Y_UNIT_TEST(SpaceColorDcbOverride) {
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+
+        TActorTestContext testCtx{{ .EnablePDiskSpaceColorOverride = true }};
+        TVDiskMock vdisk(&testCtx);
+        vdisk.InitFull();
+
+        auto& appData = testCtx.GetRuntime()->GetAppData();
+        const ui32 pdiskId = testCtx.GetPDisk()->PCtx->PDiskId;
+        const TString controlName = Sprintf("PDisk_%u_ForcedPDiskSpaceColor", pdiskId);
+
+        auto setColor = [&](i64 color) {
+            TAtomic prev = 0;
+            appData.Dcb->SetValue(controlName, color, prev);
+        };
+
+        auto checkColor = [&](TColor::E expected) {
+            auto space = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
+                new NPDisk::TEvCheckSpace(vdisk.PDiskParams->Owner, vdisk.PDiskParams->OwnerRound),
+                NKikimrProto::OK);
+            UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(space->StatusFlags), expected);
+        };
+
+        checkColor(TColor::GREEN);
+
+        setColor(TColor::YELLOW);
+        checkColor(TColor::YELLOW);
+
+        setColor(TColor::RED);
+        checkColor(TColor::RED);
+
+        setColor(TColor::GREEN);
+        checkColor(TColor::GREEN);
+
+        setColor(0);
+        checkColor(TColor::GREEN);
+    }
+
     Y_UNIT_TEST(DeviceHaltTooLong) {
         TActorTestContext testCtx{{}};
         testCtx.TestCtx.SectorMap->ImitateRandomWait = {TDuration::Seconds(1), TDuration::Seconds(2)};

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
@@ -40,6 +40,7 @@ public:
         std::optional<bool> RandomizeMagic = std::nullopt;
         std::optional<ui64> NonceRandNum = std::nullopt;
         bool UseRdmaAllocator = false;
+        bool EnablePDiskSpaceColorOverride = false;
     };
 
 private:
@@ -105,6 +106,7 @@ public:
         pDiskConfig->FeatureFlags.SetEnableSmallDiskOptimization(Settings.SmallDisk);
         pDiskConfig->FeatureFlags.SetSuppressCompatibilityCheck(Settings.SuppressCompatibilityCheck);
         pDiskConfig->FeatureFlags.SetEnablePDiskLogForSmallDisks(false);
+        pDiskConfig->FeatureFlags.SetEnablePDiskSpaceColorOverride(Settings.EnablePDiskSpaceColorOverride);
         pDiskConfig->ReadOnly = Settings.ReadOnly;
         pDiskConfig->PlainDataChunks = Settings.PlainDataChunks;
         pDiskConfig->NonceRandNum = Settings.NonceRandNum;

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -1269,4 +1269,10 @@ config:
             it->second = value;
         }
     }
+
+    void SetPDiskStatusFlags(ui32 nodeId, ui32 pdiskId, NKikimrBlobStorage::TPDiskSpaceColor::E color) {
+        auto it = PDiskMockStates.find({nodeId, pdiskId});
+        UNIT_ASSERT_C(it != PDiskMockStates.end(), "PDisk not found: nodeId# " << nodeId << " pdiskId# " << pdiskId);
+        it->second->SetStatusFlags(color);
+    }
 };

--- a/ydb/core/blobstorage/ut_blobstorage/pdisk_status_flags.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/pdisk_status_flags.cpp
@@ -1,0 +1,61 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_space_color.h>
+
+Y_UNIT_TEST_SUITE(PDiskStatusFlags) {
+
+    Y_UNIT_TEST(SetPDiskStatusFlagsHelper) {
+        TEnvironmentSetup env(TEnvironmentSetup::TSettings{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        });
+        env.CreateBoxAndPool(1, 1);
+        env.Sim(TDuration::Seconds(30));
+
+        auto groups = env.GetGroups();
+        UNIT_ASSERT_C(!groups.empty(), "No groups created");
+
+        auto groupInfo = env.GetGroupInfo(groups[0]);
+        UNIT_ASSERT(groupInfo);
+
+        const TVDiskID vdiskId = groupInfo->GetVDiskId(0);
+        const TActorId vdiskActorId = groupInfo->GetActorId(0);
+        ui32 nodeId, pdiskId;
+        std::tie(nodeId, pdiskId, std::ignore) = DecomposeVDiskServiceId(vdiskActorId);
+
+        auto getStatusFlags = [&]() -> ui32 {
+            ui32 flags = 0;
+            env.WithQueueId(vdiskId, NKikimrBlobStorage::EVDiskQueueId::PutTabletLog, [&](TActorId queueId) {
+                const TActorId edge = env.Runtime->AllocateEdgeActor(queueId.NodeId(), __FILE__, __LINE__);
+                env.Runtime->Send(new IEventHandle(queueId, edge, new TEvBlobStorage::TEvVStatus(vdiskId)), queueId.NodeId());
+                auto r = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVStatusResult>(edge);
+                flags = r->Get()->Record.GetStatusFlags();
+            });
+            return flags;
+        };
+
+        // before: no YELLOW flag
+        ui32 flagsBefore = getStatusFlags();
+        UNIT_ASSERT_C(
+            !(flagsBefore & ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop)),
+            "Expected no YELLOW flag before SetPDiskStatusFlags, got: " << flagsBefore);
+
+        // set YELLOW — flag must appear in status
+        env.SetPDiskStatusFlags(nodeId, pdiskId, NKikimrBlobStorage::TPDiskSpaceColor::YELLOW);
+        env.Sim(TDuration::Seconds(5));
+
+        ui32 flagsYellow = getStatusFlags();
+        UNIT_ASSERT_C(
+            flagsYellow & ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop),
+            "Expected YELLOW flag after SetPDiskStatusFlags(YELLOW), got: " << flagsYellow);
+
+        // set RED — status flags must reflect RED
+        env.SetPDiskStatusFlags(nodeId, pdiskId, NKikimrBlobStorage::TPDiskSpaceColor::RED);
+        env.Sim(TDuration::Seconds(5));
+
+        ui32 flagsRed = getStatusFlags();
+        UNIT_ASSERT_C(
+            flagsRed & ui32(NKikimrBlobStorage::StatusDiskSpaceRed),
+            "Expected RED flag after SetPDiskStatusFlags(RED), got: " << flagsRed);
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -53,6 +53,7 @@ SRCS(
     vdisk_internals.cpp
     vdisk_malfunction.cpp
     group_size_in_units.cpp
+    pdisk_status_flags.cpp
 )
 
 PEERDIR(

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -266,4 +266,5 @@ message TFeatureFlags {
     optional bool EnableSQSMigrationTopicCreation = 239 [default = false];
     optional bool EnableSQSMigrationCompatibility = 240 [default = false];
     optional bool EnableSQSMigrationFinished = 241 [default = false];
+    optional bool EnablePDiskSpaceColorOverride = 242 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add ForcedPDiskSpaceColor ICB flag and test helper

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- For testing purposes only
- Only visible with feature flag enabled:

```
feature_flags:
  enable_pdisk_space_color_override: true
```
