### PR TITLE
Fix unknown server error when rows are delited by ttl

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -879,8 +879,14 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
         return;
     }
 
-    if (!groupStatus->Exists || groupStatus->Generation != GenerationId || groupStatus->State != GROUP_STATE_WORKING) {
+    if (!groupStatus->Exists ||
+        groupStatus->Exists && groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING ||
+        groupStatus->State != GROUP_STATE_WORKING) {
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
+        return;
+    }
+    if (groupStatus->Generation != GenerationId) {
+        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::ILLEGAL_GENERATION, "Old or unknown group generation");
         return;
     }
 
@@ -1123,7 +1129,7 @@ bool TKafkaBalancerActor::ParseDeadsAndSessionTimeout(
     auto& resp = record.GetResponse();
 
     if (resp.GetYdbResults().size() < 2) {
-        return false;
+        return true;
     }
 
     {
@@ -1141,9 +1147,10 @@ bool TKafkaBalancerActor::ParseDeadsAndSessionTimeout(
     {
         NYdb::TResultSetParser parser(resp.GetYdbResults(1));
         if (!parser.TryNextRow()) {
-            return false;
+            sessionTimeoutMs = DEFAULT_SESSION_TIMEOUT_MS;
+        } else {
+            sessionTimeoutMs = parser.ColumnParser("session_timeout_ms").GetOptionalUint32().value_or(DEFAULT_SESSION_TIMEOUT_MS);
         }
-        sessionTimeoutMs = parser.ColumnParser("session_timeout_ms").GetOptionalUint32().value_or(DEFAULT_SESSION_TIMEOUT_MS);
         if (parser.TryNextRow()) {
             return false;
         }

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -880,7 +880,7 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     }
 
     if (!groupStatus->Exists ||
-        (groupStatus->Generation != GenerationId && groupStatus->State != GROUP_STATE_WORKING)) {
+        (groupStatus->Generation != GenerationId + 1) && (groupStatus->State != GROUP_STATE_WORKING)) {
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
         return;
     }

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -882,10 +882,12 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     if (!groupStatus->Exists ||
         groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING ||
         groupStatus->State != GROUP_STATE_WORKING) {
+        KAFKA_LOG_D("REBALANCE_IN_PROGRESS, oldGen=" << GenerationId << ", newGen=" << groupStatus->Generation << ", groupState=" << groupStatus->State);
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
         return;
     }
     if (groupStatus->Generation != GenerationId) {
+        KAFKA_LOG_D("ILLEGAL_GENERATION, oldGen=" << GenerationId << ", newGen=" << groupStatus->Generation << ", groupState=" << groupStatus->State);
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::ILLEGAL_GENERATION, TStringBuilder() << "Old or unknown group generation: " << GenerationId << ". Group generationId=" << groupStatus->Generation);
         return;
     }

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -880,7 +880,7 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     }
 
     if (!groupStatus->Exists ||
-        groupStatus->Exists && groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING ||
+        groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING ||
         groupStatus->State != GROUP_STATE_WORKING) {
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
         return;

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -880,7 +880,7 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     }
 
     if (!groupStatus->Exists ||
-        groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING ||
+        groupStatus->Generation == GenerationId + 1 ||
         groupStatus->State != GROUP_STATE_WORKING) {
         KAFKA_LOG_D("REBALANCE_IN_PROGRESS, oldGen=" << GenerationId << ", newGen=" << groupStatus->Generation << ", groupState=" << groupStatus->State);
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -886,7 +886,7 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
         return;
     }
     if (groupStatus->Generation != GenerationId) {
-        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::ILLEGAL_GENERATION, "Old or unknown group generation");
+        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::ILLEGAL_GENERATION, TStringBuilder() << "Old or unknown group generation: " << GenerationId << ". Group generationId=" << groupStatus->Generation);
         return;
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -880,7 +880,7 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     }
 
     if (!groupStatus->Exists ||
-        groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING) {
+        (groupStatus->Generation != GenerationId && groupStatus->State != GROUP_STATE_WORKING)) {
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
         return;
     }

--- a/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_balancer_actor.cpp
@@ -842,7 +842,7 @@ void TKafkaBalancerActor::HeartbeatStepCommitTx(NKqp::TEvKqp::TEvQueryResponse::
     }
 
     if (deadsCount > 0) {
-        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Deads members found. Rejoin required.");
+        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::FENCED_INSTANCE_ID, "Deads members found. Rejoin required.");
         return;
     }
 
@@ -880,15 +880,12 @@ void TKafkaBalancerActor::HeartbeatStepUpdateHeartbeatDeadlines(NKqp::TEvKqp::TE
     }
 
     if (!groupStatus->Exists ||
-        groupStatus->Generation == GenerationId + 1 ||
-        groupStatus->State != GROUP_STATE_WORKING) {
-        KAFKA_LOG_D("REBALANCE_IN_PROGRESS, oldGen=" << GenerationId << ", newGen=" << groupStatus->Generation << ", groupState=" << groupStatus->State);
+        groupStatus->Generation == GenerationId + 1 && groupStatus->State != GROUP_STATE_WORKING) {
         SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::REBALANCE_IN_PROGRESS, "Group state changed. Rejoin required");
         return;
     }
     if (groupStatus->Generation != GenerationId) {
-        KAFKA_LOG_D("ILLEGAL_GENERATION, oldGen=" << GenerationId << ", newGen=" << groupStatus->Generation << ", groupState=" << groupStatus->State);
-        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::ILLEGAL_GENERATION, TStringBuilder() << "Old or unknown group generation: " << GenerationId << ". Group generationId=" << groupStatus->Generation);
+        SendHeartbeatResponseFail(ctx, CorrelationId, EKafkaErrors::FENCED_INSTANCE_ID, TStringBuilder() << "Old or unknown group generation: " << GenerationId << ". Group generationId=" << groupStatus->Generation);
         return;
     }
 

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -362,7 +362,7 @@ void TKafkaTestClient::WaitRebalance(TString& memberId, ui64 generationId, TStri
         heartbeatStatus = Heartbeat(memberId, generationId, groupId)->ErrorCode;
     } while (heartbeatStatus == static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
 
-    UNIT_ASSERT_VALUES_EQUAL(heartbeatStatus, static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS));
+    UNIT_ASSERT(heartbeatStatus == static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS) || heartbeatStatus == static_cast<TKafkaInt16>(EKafkaErrors::FENCED_INSTANCE_ID));
 }
 
 TReadInfo TKafkaTestClient::JoinAndSyncGroupAndWaitPartitions(std::vector<TString>& topics, TString& groupId, ui32 expectedPartitionsCount, TString& protocolName, ui32 totalPartitionsCount, ui32 hartbeatTimeout) {

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -4234,20 +4234,20 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         auto syncRespA = clientA.ReadResponse<TSyncGroupResponseData>(hdrSyncA);
 
-        UNIT_ASSERT_EQUAL(syncRespA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION));
+        UNIT_ASSERT_VALUES_EQUAL(syncRespA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION));
         syncReqA.GenerationId  = joinRespA->GenerationId;
         clientA.WriteToSocket(hdrSyncA, syncReqA);
         auto syncRespA1 = clientA.ReadResponse<TSyncGroupResponseData>(hdrSyncA);
-        UNIT_ASSERT_EQUAL(syncRespA1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(syncRespA1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
 
-        UNIT_ASSERT_EQUAL(
+        UNIT_ASSERT_VALUES_EQUAL(
             clientA.Heartbeat(joinRespA->MemberId.value(),
                              illegalGeneration,
                              groupId)->ErrorCode,
             static_cast<TKafkaInt16>(EKafkaErrors::FENCED_INSTANCE_ID)
         );
 
-        UNIT_ASSERT_EQUAL(clientA.Heartbeat(joinRespA->MemberId.value(),
+        UNIT_ASSERT_VALUES_EQUAL(clientA.Heartbeat(joinRespA->MemberId.value(),
                              joinRespA->GenerationId,
                              groupId)->ErrorCode,
             static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR)

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -4087,11 +4087,11 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         );
 
         Sleep(TDuration::Seconds(25));
+        {
+            auto errorCode = clientA.Heartbeat(joinRespA2->MemberId.value(), joinRespA2->GenerationId, groupId)->ErrorCode;
+             UNIT_ASSERT(errorCode == static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS) || errorCode == static_cast<TKafkaInt16>(EKafkaErrors::FENCED_INSTANCE_ID));
+        }
 
-        UNIT_ASSERT_VALUES_EQUAL(
-            clientA.Heartbeat(joinRespA2->MemberId.value(), joinRespA2->GenerationId, groupId)->ErrorCode,
-            static_cast<TKafkaInt16>(EKafkaErrors::REBALANCE_IN_PROGRESS)
-        );
 
         // LAST READER GETS ALL PARTITIONS
         clientA.JoinAndSyncGroupAndWaitPartitions(topics, groupId, totalPartitions, protocolName, totalPartitions, heartbeatTimeout);
@@ -4244,7 +4244,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             clientA.Heartbeat(joinRespA->MemberId.value(),
                              illegalGeneration,
                              groupId)->ErrorCode,
-            static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION)
+            static_cast<TKafkaInt16>(EKafkaErrors::FENCED_INSTANCE_ID)
         );
 
         UNIT_ASSERT_EQUAL(clientA.Heartbeat(joinRespA->MemberId.value(),

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -4139,6 +4139,121 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         }
     }
 
+    Y_UNIT_TEST(HeartbeatWithTTLGenerationsScenario) {
+        TInsecureTestServer testServer("1", false, true);
+
+        TString topicName = "/Root/topic-0";
+        ui64 totalPartitions = 24;
+        TString groupId = "consumer-0";
+
+        TString protocolType = "consumer";
+        TString protocolName = "range";
+
+        {
+            NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
+            auto result = pqClient
+                .CreateTopic(
+                    topicName,
+                    NYdb::NTopic::TCreateTopicSettings()
+                        .PartitioningSettings(totalPartitions, 100)
+                        .BeginAddConsumer(groupId).EndAddConsumer()
+                )
+                .ExtractValueSync();
+            UNIT_ASSERT_C(
+                result.IsSuccess(),
+                "CreateTopic failed, issues: " << result.GetIssues().ToString()
+            );
+        }
+
+        TKafkaTestClient clientA(testServer.Port, "ClientA");
+
+        {
+            auto rA = clientA.ApiVersions();
+            UNIT_ASSERT_VALUES_EQUAL(rA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+                    }
+        {
+            auto rA = clientA.SaslHandshake("PLAIN");
+            UNIT_ASSERT_VALUES_EQUAL(rA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        }
+        {
+            TString user = "ouruser@/Root";
+            TString pass = "ourUserPassword";
+            auto rA = clientA.SaslPlainAuthenticate(user, pass);
+            UNIT_ASSERT_VALUES_EQUAL(rA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        }
+
+        std::vector<TString> topics = {topicName};
+        i32 heartbeatTimeout = 15000;
+        i32 rebalanceTimeout = 5000;
+        i32 illegalGeneration = 10001;
+
+        TRequestHeaderData headerAJoin = clientA.Header(NKafka::EApiKey::JOIN_GROUP, 9);
+        TJoinGroupRequestData joinReq;
+        joinReq.GroupId = groupId;
+        joinReq.ProtocolType = protocolType;
+        joinReq.SessionTimeoutMs = heartbeatTimeout;
+        joinReq.RebalanceTimeoutMs = rebalanceTimeout;
+
+        NKafka::TJoinGroupRequestData::TJoinGroupRequestProtocol protocol;
+        protocol.Name = protocolName;
+
+        TConsumerProtocolSubscription subscribtion;
+        for (auto& topic : topics) {
+            subscribtion.Topics.push_back(topic);
+        }
+        TKafkaVersion version = 3;
+        TWritableBuf buf(nullptr, subscribtion.Size(version) + sizeof(version));
+        TKafkaWritable writable(buf);
+        writable << version;
+        subscribtion.Write(writable, version);
+        protocol.Metadata = TKafkaRawBytes(buf.GetFrontBuffer().data(), buf.GetFrontBuffer().size());
+
+        joinReq.Protocols.push_back(protocol);
+
+        TJoinGroupRequestData joinReqA = joinReq;
+        joinReqA.GroupInstanceId = "instanceA";
+
+        clientA.WriteToSocket(headerAJoin, joinReqA);
+
+        auto joinRespA = clientA.ReadResponse<TJoinGroupResponseData>(headerAJoin);
+
+        UNIT_ASSERT_VALUES_EQUAL(joinRespA->ErrorCode, (TKafkaInt16)EKafkaErrors::NONE_ERROR);
+        const std::vector<TSyncGroupRequestData::TSyncGroupRequestAssignment> assignments = clientA.MakeRangeAssignment(joinRespA, totalPartitions);
+
+        TRequestHeaderData hdrSyncA = clientA.Header(NKafka::EApiKey::SYNC_GROUP, 5);
+
+        TSyncGroupRequestData syncReqA;
+        syncReqA.GroupId       = groupId;
+        syncReqA.ProtocolType  = protocolType;
+        syncReqA.ProtocolName  = protocolName;
+        syncReqA.GenerationId  = illegalGeneration;
+        syncReqA.MemberId      = joinRespA->MemberId.value();
+        syncReqA.Assignments = assignments;
+
+        clientA.WriteToSocket(hdrSyncA, syncReqA);
+
+        auto syncRespA = clientA.ReadResponse<TSyncGroupResponseData>(hdrSyncA);
+
+        UNIT_ASSERT_EQUAL(syncRespA->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION));
+        syncReqA.GenerationId  = joinRespA->GenerationId;
+        clientA.WriteToSocket(hdrSyncA, syncReqA);
+        auto syncRespA1 = clientA.ReadResponse<TSyncGroupResponseData>(hdrSyncA);
+        UNIT_ASSERT_EQUAL(syncRespA1->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+
+        UNIT_ASSERT_EQUAL(
+            clientA.Heartbeat(joinRespA->MemberId.value(),
+                             illegalGeneration,
+                             groupId)->ErrorCode,
+            static_cast<TKafkaInt16>(EKafkaErrors::ILLEGAL_GENERATION)
+        );
+
+        UNIT_ASSERT_EQUAL(clientA.Heartbeat(joinRespA->MemberId.value(),
+                             joinRespA->GenerationId,
+                             groupId)->ErrorCode,
+            static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR)
+        );
+    }
+
     Y_UNIT_TEST(InitProducerId_withoutTransactionalIdShouldReturnRandomInt) {
         TInsecureTestServer testServer;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Change UNKNOWN_SERVER_ERROR to expected ILLEGAL_GENERATION when .metadata table info is deleted by TTL

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
