### PR TITLE
Fix build on windows

### DIFF
--- a/ydb/core/load_test/ya.make
+++ b/ydb/core/load_test/ya.make
@@ -75,6 +75,12 @@ IF (OS_LINUX)
     )
 ENDIF()
 
+# Make NBS protos available for include checking on all platforms
+# even though they're only used on Linux
+PEERDIR(
+    ydb/core/nbs/cloud/storage/core/protos
+)
+
 GENERATE_ENUM_SERIALIZATION(percentile.h)
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix windows build for driver_lib. Add nbs protos to non-linux platforms to fix headers resolve issue.

ya make -DAUTOCHECK=yes contrib/ydb/core/driver_lib/run --target-platform default-win-x86_64
```
{default-win-x86_64,relwithdebinfo,tests,test-size=small,test-type=gtest,test-type=unittest,DEBUGINFO_LINES_ONLY=yes,NO_DEBUGINFO=yes}: could not resolve include file: contrib/ydb/core/nbs/cloud/storage/core/protos/error.pb.h included from here: $S/contrib/ydb/core/nbs/cloud/storage/core/libs/common/error.h
```

[arc sync build](https://a.yandex-team.ru/review/12118726/details?checkId=17600000023919&dialogId=CiCard&filter=suiteCategory%28CATEGORY_CHANGED%29%3Binclude%28INCLUDE_AFFECTED%29&iterationType=FULL&number=1&openedItems=6429415912315789030%3ART_CONFIGURE&snippetViewMode=word-wrap&status=STATUS_FAILED)
