### PR TITLE
Fixed topic partition quota wait time

### DIFF
--- a/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
@@ -33,7 +33,7 @@ namespace NKikimr::NPQ {
             QuotedTime += diff;
         }
 
-        AvailableSize = Min<i64>(AvailableSize + QuotaSpeed * diff.MicroSeconds(), MaxBurst);
+        AvailableSize = Min<i64>(AvailableSize + static_cast<i64>(QuotaSpeed) * static_cast<i64>(diff.MicroSeconds()), MaxBurst);
     }
 
     bool TQuotaTracker::CanExaust(const TInstant timestamp) {

--- a/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
@@ -1,19 +1,26 @@
 #include "quota_tracker.h"
+#include <util/string/builder.h>
 
 
 namespace NKikimr::NPQ {
+    namespace {
+        constexpr size_t MicroSecondsPerSecond = 1000000;
+    }
+
     TQuotaTracker::TQuotaTracker(const ui64 maxBurst, const ui64 speedPerSecond, const TInstant timestamp)
-        : AvailableSize(maxBurst)
-        , SpeedPerSecond(speedPerSecond)
+        : AvailableSize(maxBurst * MicroSecondsPerSecond)
+        , QuotaSpeed(speedPerSecond)
+        , MaxBurst(maxBurst * MicroSecondsPerSecond)
         , LastUpdateTime(timestamp)
-        , MaxBurst(maxBurst)
     {}
 
     bool TQuotaTracker::UpdateConfigIfChanged(const ui64 maxBurst, const ui64 speedPerSecond) {
-        if (maxBurst != MaxBurst || speedPerSecond != SpeedPerSecond) {
-            SpeedPerSecond = speedPerSecond;
-            MaxBurst = maxBurst;
-            AvailableSize = maxBurst;
+        const auto newMaxBurst = maxBurst * MicroSecondsPerSecond;
+        const auto newQuotaSpeed = speedPerSecond;
+        if (newMaxBurst != MaxBurst || newQuotaSpeed != QuotaSpeed) {
+            AvailableSize = newMaxBurst;
+            QuotaSpeed = newQuotaSpeed;
+            MaxBurst = newMaxBurst;
             return true;
         }
         return false;
@@ -27,17 +34,17 @@ namespace NKikimr::NPQ {
             QuotedTime += diff;
         }
 
-        AvailableSize = Min<i64>(AvailableSize + (ui64)SpeedPerSecond * diff.MicroSeconds() / 1000'000, MaxBurst);
+        AvailableSize = Min<i64>(AvailableSize + QuotaSpeed * diff.MicroSeconds(), MaxBurst);
     }
 
     bool TQuotaTracker::CanExaust(const TInstant timestamp) {
         Update(timestamp);
-        return AvailableSize > 0;
+        return AvailableSize >= (i64)MicroSecondsPerSecond; // a whole quota unit has become available
     }
 
     void TQuotaTracker::Exaust(const ui64 size, const TInstant timestamp) {
         Update(timestamp);
-        AvailableSize -= (i64)size;
+        AvailableSize -= (i64)size * MicroSecondsPerSecond;
         Update(timestamp);
     }
 
@@ -47,7 +54,7 @@ namespace NKikimr::NPQ {
     }
 
     ui64 TQuotaTracker::GetTotalSpeed() const {
-        return SpeedPerSecond;
+        return QuotaSpeed;
     }
 
 } // NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quota_tracker.cpp
@@ -1,5 +1,4 @@
 #include "quota_tracker.h"
-#include <util/string/builder.h>
 
 
 namespace NKikimr::NPQ {

--- a/ydb/core/persqueue/pqtablet/quota/quota_tracker.h
+++ b/ydb/core/persqueue/pqtablet/quota/quota_tracker.h
@@ -19,10 +19,10 @@ namespace NKikimr::NPQ {
 
     private:
         i64 AvailableSize;
-        ui64 SpeedPerSecond;
-        TInstant LastUpdateTime;
+        ui64 QuotaSpeed;
         ui64 MaxBurst;
 
+        TInstant LastUpdateTime;
         TDuration QuotedTime;
     };
 

--- a/ydb/core/persqueue/pqtablet/quota/quota_tracker_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quota_tracker_ut.cpp
@@ -26,8 +26,8 @@ Y_UNIT_TEST(TestSmallMessages) {
         ts += TDuration::MicroSeconds(100);
     }
     Cerr << "processed_blobs=" << processedBlobs << " quoted_time=" << quota.GetQuotedTime(ts) << Endl;
-    UNIT_ASSERT_EQUAL(processedBlobs, 41800);
-    UNIT_ASSERT_EQUAL(quota.GetQuotedTime(ts), TDuration::MilliSeconds(9980));
+    UNIT_ASSERT_VALUES_EQUAL(processedBlobs, 41943); // ( 2 MB/sec * 10 sec ) / 500 bytes/message = 41943,04 messages
+    UNIT_ASSERT_VALUES_EQUAL(quota.GetQuotedTime(ts), TDuration::MilliSeconds(9980));
 }
 
 Y_UNIT_TEST(TestBigMessages) {

--- a/ydb/core/persqueue/pqtablet/quota/quoter_base.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quoter_base.cpp
@@ -133,7 +133,6 @@ bool TPartitionQuoterBase::CanExaust(TInstant now) {
 
 void TPartitionQuoterBase::ProcessPartitionTotalQuotaQueue() {
     if (!PartitionTotalQuotaTracker) {
-        LOG_T("PartitionTotalQuotaTracker is not defined");
         return;
     }
     LOG_D("Waiting for the quota of partition " << WaitingTotalPartitionQuotaRequests.size() << " of the request");

--- a/ydb/core/persqueue/pqtablet/quota/quoter_base.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/quoter_base.cpp
@@ -132,8 +132,11 @@ bool TPartitionQuoterBase::CanExaust(TInstant now) {
 }
 
 void TPartitionQuoterBase::ProcessPartitionTotalQuotaQueue() {
-    if (!PartitionTotalQuotaTracker)
+    if (!PartitionTotalQuotaTracker) {
+        LOG_T("PartitionTotalQuotaTracker is not defined");
         return;
+    }
+    LOG_D("Waiting for the quota of partition " << WaitingTotalPartitionQuotaRequests.size() << " of the request");
     while (!WaitingTotalPartitionQuotaRequests.empty() && CanExaust(ActorContext().Now())) {
         auto& request = WaitingTotalPartitionQuotaRequests.front();
         ApproveQuota(request);

--- a/ydb/core/persqueue/pqtablet/quota/quoter_base.h
+++ b/ydb/core/persqueue/pqtablet/quota/quoter_base.h
@@ -46,7 +46,7 @@ public:
 class TPartitionQuoterBase : public TBaseTabletActor<TPartitionQuoterBase>
                            , private TConstantLogPrefix {
 
-const TDuration WAKE_UP_TIMEOUT = TDuration::Seconds(1);
+const TDuration WAKE_UP_TIMEOUT = TDuration::MilliSeconds(50);
 
 public:
     TPartitionQuoterBase(

--- a/ydb/core/persqueue/ut/counters_ut.cpp
+++ b/ydb/core/persqueue/ut/counters_ut.cpp
@@ -762,7 +762,7 @@ void ConsumerDetailedMetrics(const TConsumerDetailedPartitionLevelMetricsTestPar
             histogram->OutputHtml(histogramStr);
             Cerr << "**** Total histogram: **** \n " << histogramStr.Str() << "**** **** **** ****" << Endl;
             auto instant = histogram->FindNamedCounter("Interval", "0ms")->Val();
-            auto oneSec = histogram->FindNamedCounter("Interval", "1000ms")->Val();
+            auto oneSec = histogram->FindNamedCounter("Interval", "100ms")->Val();
             auto twoSec = histogram->FindNamedCounter("Interval", "2500ms")->Val();
             UNIT_ASSERT_VALUES_EQUAL(oneSec + twoSec, 5);
             UNIT_ASSERT(twoSec >= 2);

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -1964,7 +1964,7 @@ Y_UNIT_TEST_F(UserActCount, TPartitionFixture)
 
     CreatePartition();
 
-    Ctx->Runtime->SetScheduledLimit(6000);
+    Ctx->Runtime->SetScheduledLimit(60000);
 
     SendCreateSession(1, "client", "session-id", 2, 3);
     WaitCmdWrite({.Count=2, .UserInfos={{0, {.Session="session-id", .Offset=0, .Generation=2, .Step=3}}}});

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -318,7 +318,7 @@ Y_UNIT_TEST(TestPartitionTotalQuota) {
         TFinalizer finalizer(tc);
         tc.Prepare(dispatchName, setup, activeZone);
         activeZone = false;
-        tc.Runtime->SetScheduledLimit(1000);
+        tc.Runtime->SetScheduledLimit(10000);
 
         tc.Runtime->GetAppData(0).PQConfig.MutableQuotingConfig()->SetPartitionReadQuotaIsTwiceWriteQuota(true);
         tc.Runtime->GetAppData(0).PQConfig.MutableQuotingConfig()->SetMaxParallelConsumersPerPartition(1); //total partition quota is equal to quota per consumer. Very low.

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -306,7 +306,7 @@ public:
             }
 
             Cerr << "DURATION " << (TInstant::Now() - start) << "\n";
-            UNIT_ASSERT(TInstant::Now() - start > minTime);
+            UNIT_ASSERT_GT(TInstant::Now() - start, minTime);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Из-за редкой проверки квоты на запись в партицию топика часть запросов на запись могли "притормаживаться" до 1 сек. не смотря на то, что квота в на запись в партицию не израсходована.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
