### PR TITLE
Don't write entry point of ChunkKeeper in disabled state when there are no chunks

### DIFF
--- a/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
@@ -44,8 +44,12 @@ public:
         if (IsActive) {
             Become(&TThis::StateAccepting);
         } else {
-            if (!ReadOnly && !Committed->Chunks.empty()) {
-                DropAllChunks();
+            if (!ReadOnly) {
+                if (!Committed->Chunks.empty()) {
+                    DropAllChunks();
+                } else {
+                    Send(LogCtx->LogCutterId, new TEvVDiskCutLog(TEvVDiskCutLog::ChunkKeeper, Max<ui64>()));
+                }
             }
             Become(&TThis::StateError);
         }

--- a/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
@@ -49,7 +49,7 @@ public:
                 if (!Committed->Chunks.empty()) {
                     DropAllChunks();
                 } else {
-                    Send(Ctx.gLogCtx->LogCutterId, new TEvVDiskCutLog(TEvVDiskCutLog::ChunkKeeper, Max<ui64>()));
+                    Send(Ctx.LogCtx->LogCutterId, new TEvVDiskCutLog(TEvVDiskCutLog::ChunkKeeper, Max<ui64>()));
                 }
             }
             Become(&TThis::StateError);

--- a/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
@@ -40,7 +40,8 @@ public:
     void Bootstrap() {
         STLOG(PRI_DEBUG, BS_CHUNK_KEEPER, BSCK07, VDISKP(Ctx.LogCtx->VCtx, "Bootstrap TChunkKeeperActor"),
                 (CommittedData, PrintCommittedData()),
-                (IsActive, IsActive));
+                (IsActive, IsActive),
+                (ReadOnly, ReadOnly));
         if (IsActive) {
             Become(&TThis::StateAccepting);
         } else {
@@ -48,7 +49,7 @@ public:
                 if (!Committed->Chunks.empty()) {
                     DropAllChunks();
                 } else {
-                    Send(LogCtx->LogCutterId, new TEvVDiskCutLog(TEvVDiskCutLog::ChunkKeeper, Max<ui64>()));
+                    Send(Ctx.gLogCtx->LogCutterId, new TEvVDiskCutLog(TEvVDiskCutLog::ChunkKeeper, Max<ui64>()));
                 }
             }
             Become(&TThis::StateError);

--- a/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/chunk_keeper/chunk_keeper_actor.cpp
@@ -44,7 +44,7 @@ public:
         if (IsActive) {
             Become(&TThis::StateAccepting);
         } else {
-            if (!ReadOnly) {
+            if (!ReadOnly && !Committed->Chunks.empty()) {
                 DropAllChunks();
             }
             Become(&TThis::StateError);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't write entrypoint of ChunkKeeper when there are no chunks.
Fixes https://github.com/ydb-platform/ydb/issues/35053

### Changelog category <!-- remove all except one -->

* Bugfix