### PR TITLE
[EXT-2041] Meta: support links, added grafana dashboard source

### DIFF
--- a/ydb/mvp/core/core_ydb.cpp
+++ b/ydb/mvp/core/core_ydb.cpp
@@ -58,7 +58,7 @@ NYdb::NScheme::TSchemeClient TYdbLocation::GetSchemeClient(const TRequest& reque
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    if (TString database = TYdbLocation::BuildMetaDatabasePath(request)) {
+    if (TString database = TYdbLocation::GetDatabaseName(request)) {
         clientSettings.Database(database);
     }
     return NYdb::NScheme::TSchemeClient(GetDriver(), clientSettings);
@@ -117,7 +117,7 @@ NYdb::NTable::TTableClient TYdbLocation::GetTableClient(const TRequest& request,
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    if (TString database = TYdbLocation::BuildMetaDatabasePath(request)) {
+    if (TString database = TYdbLocation::GetDatabaseName(request)) {
         clientSettings.Database(database);
     }
     return GetTableClient(clientSettings);
@@ -127,21 +127,15 @@ NYdb::NTable::TTableClient TYdbLocation::GetTableClient(const NYdb::NTable::TCli
     return NYdb::NTable::TTableClient(GetDriver(), clientSettings);
 }
 
-TString TYdbLocation::BuildMetaDatabasePath(const TRequest& request, TStringBuf databaseParameterName) const {
-    if (databaseParameterName.empty()) {
-        return {};
+TString TYdbLocation::GetDatabaseName(const TRequest& request) const {
+    TString database = request.Parameters["database"];
+    if (database) {
+        if (!database.StartsWith('/')) {
+            database.insert(database.begin(), '/');
+        }
+        database.insert(0, RootDomain);
     }
-
-    TString database = request.Parameters[databaseParameterName];
-    if (database.empty()) {
-        return {};
-    }
-
-    if (!database.StartsWith('/')) {
-        database = "/" + database;
-    }
-
-    return RootDomain + database;
+    return database;
 }
 
 NYdb::NScripting::TScriptingClient TYdbLocation::GetScriptingClient(const TRequest& request) const {
@@ -150,7 +144,7 @@ NYdb::NScripting::TScriptingClient TYdbLocation::GetScriptingClient(const TReque
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    TString database = BuildMetaDatabasePath(request);
+    TString database = GetDatabaseName(request);
     if (database) {
         clientSettings.Database(database);
     }

--- a/ydb/mvp/core/core_ydb.cpp
+++ b/ydb/mvp/core/core_ydb.cpp
@@ -58,7 +58,7 @@ NYdb::NScheme::TSchemeClient TYdbLocation::GetSchemeClient(const TRequest& reque
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    if (TString database = TYdbLocation::GetDatabaseName(request)) {
+    if (TString database = TYdbLocation::BuildMetaDatabasePath(request)) {
         clientSettings.Database(database);
     }
     return NYdb::NScheme::TSchemeClient(GetDriver(), clientSettings);
@@ -117,7 +117,7 @@ NYdb::NTable::TTableClient TYdbLocation::GetTableClient(const TRequest& request,
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    if (TString database = TYdbLocation::GetDatabaseName(request)) {
+    if (TString database = TYdbLocation::BuildMetaDatabasePath(request)) {
         clientSettings.Database(database);
     }
     return GetTableClient(clientSettings);
@@ -127,15 +127,21 @@ NYdb::NTable::TTableClient TYdbLocation::GetTableClient(const NYdb::NTable::TCli
     return NYdb::NTable::TTableClient(GetDriver(), clientSettings);
 }
 
-TString TYdbLocation::GetDatabaseName(const TRequest& request) const {
-    TString database = request.Parameters["database"];
-    if (database) {
-        if (!database.StartsWith('/')) {
-            database.insert(database.begin(), '/');
-        }
-        database.insert(0, RootDomain);
+TString TYdbLocation::BuildMetaDatabasePath(const TRequest& request, TStringBuf databaseParameterName) const {
+    if (databaseParameterName.empty()) {
+        return {};
     }
-    return database;
+
+    TString database = request.Parameters[databaseParameterName];
+    if (database.empty()) {
+        return {};
+    }
+
+    if (!database.StartsWith('/')) {
+        database = "/" + database;
+    }
+
+    return RootDomain + database;
 }
 
 NYdb::NScripting::TScriptingClient TYdbLocation::GetScriptingClient(const TRequest& request) const {
@@ -144,7 +150,7 @@ NYdb::NScripting::TScriptingClient TYdbLocation::GetScriptingClient(const TReque
     if (authToken) {
         clientSettings.AuthToken(authToken);
     }
-    TString database = GetDatabaseName(request);
+    TString database = BuildMetaDatabasePath(request);
     if (database) {
         clientSettings.Database(database);
     }

--- a/ydb/mvp/core/core_ydb.h
+++ b/ydb/mvp/core/core_ydb.h
@@ -355,7 +355,7 @@ struct TYdbLocation {
         return name;
     }
 
-    TString GetDatabaseName(const TRequest& request) const;
+    TString BuildMetaDatabasePath(const TRequest& request, TStringBuf databaseParameterName = "database") const;
     TString GetServerlessProxyUrl(const TString& database) const;
 
 private:

--- a/ydb/mvp/core/core_ydb.h
+++ b/ydb/mvp/core/core_ydb.h
@@ -323,39 +323,7 @@ struct TYdbLocation {
     std::unique_ptr<NYdb::NScripting::TScriptingClient> GetScriptingClientPtr(TStringBuf endpoint, TStringBuf scheme, const NYdb::TCommonClientSettings& settings = NYdb::TCommonClientSettings()) const;
     std::unique_ptr<NYdb::NQuery::TQueryClient> GetQueryClientPtr(TStringBuf endpoint, TStringBuf scheme, const NYdb::NQuery::TClientSettings& settings = NYdb::NQuery::TClientSettings()) const;
 
-    TString GetPath(const TRequest& request) const {
-        TString path = request.Parameters["path"];
-        if (!path.StartsWith('/')) {
-            path.insert(path.begin(), '/');
-        }
-        TString database = request.Parameters["database"];
-        if (!database.empty()) {
-            path = RootDomain + '/' + database + path;
-        } else {
-            path = RootDomain + path;
-        }
-        if (path.EndsWith('/')) {
-            path.resize(path.size() - 1);
-        }
-        if (path.find_first_of("]") != TString::npos) {
-            return TString();
-        }
-        return path;
-    }
-
-    TString GetName(const TRequest& request) const {
-        TString name = request.Parameters["name"];
-        if (!name.StartsWith('/')) {
-            name.insert(name.begin(), '/');
-        }
-        name = RootDomain + name;
-        if (name.find_first_of("]") != TString::npos) {
-            return TString();
-        }
-        return name;
-    }
-
-    TString BuildMetaDatabasePath(const TRequest& request, TStringBuf databaseParameterName = "database") const;
+    TString GetDatabaseName(const TRequest& request) const;
     TString GetServerlessProxyUrl(const TString& database) const;
 
 private:

--- a/ydb/mvp/core/ya.make
+++ b/ydb/mvp/core/ya.make
@@ -1,7 +1,3 @@
-RECURSE_FOR_TESTS(
-    ut
-)
-
 LIBRARY()
 
 SRCS(
@@ -63,3 +59,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -22,8 +22,6 @@ meta:
 
   grafana:
     endpoint: https://grafana.example.net
-    # Name of secret from generic.auth.tokens.secret_info used as Grafana API token.
-    secret_name: "secret-name"
 
   support_links:
     cluster:

--- a/ydb/mvp/meta/meta.cpp
+++ b/ydb/mvp/meta/meta.cpp
@@ -155,15 +155,18 @@ TString TMVP::GetMetaDatabaseAuthToken(const TRequest& request) {
     return authToken;
 }
 
-NYdb::NTable::TClientSettings TMVP::GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location, TStringBuf databaseParameterName) {
+NYdb::NTable::TClientSettings TMVP::GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location) {
+    NYdb::NTable::TClientSettings clientSettings = GetStrictMetaDatabaseClientSettings(request, location);
+    if (TString database = location.GetDatabaseName(request)) {
+        clientSettings.Database(database);
+    }
+    return clientSettings;
+}
+
+NYdb::NTable::TClientSettings TMVP::GetStrictMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location) {
     NYdb::NTable::TClientSettings clientSettings;
     clientSettings.AuthToken(GetMetaDatabaseAuthToken(request));
     clientSettings.Database(location.RootDomain);
-    if (!databaseParameterName.empty()) {
-        if (TString metaDatabasePath = location.BuildMetaDatabasePath(request, databaseParameterName)) {
-            clientSettings.Database(metaDatabasePath);
-        }
-    }
     return clientSettings;
 }
 

--- a/ydb/mvp/meta/meta.cpp
+++ b/ydb/mvp/meta/meta.cpp
@@ -155,12 +155,14 @@ TString TMVP::GetMetaDatabaseAuthToken(const TRequest& request) {
     return authToken;
 }
 
-NYdb::NTable::TClientSettings TMVP::GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location) {
+NYdb::NTable::TClientSettings TMVP::GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location, TStringBuf databaseParameterName) {
     NYdb::NTable::TClientSettings clientSettings;
     clientSettings.AuthToken(GetMetaDatabaseAuthToken(request));
     clientSettings.Database(location.RootDomain);
-    if (TString database = location.GetDatabaseName(request)) {
-        clientSettings.Database(database);
+    if (!databaseParameterName.empty()) {
+        if (TString metaDatabasePath = location.BuildMetaDatabasePath(request, databaseParameterName)) {
+            clientSettings.Database(metaDatabasePath);
+        }
     }
     return clientSettings;
 }

--- a/ydb/mvp/meta/meta_cluster_info.cpp
+++ b/ydb/mvp/meta/meta_cluster_info.cpp
@@ -1,0 +1,32 @@
+#include "meta_cluster_info.h"
+
+#include <ydb/mvp/core/core_ydb_impl.h>
+
+namespace NMVP {
+
+TString BuildClusterInfoQuery(TStringBuf rootDomain) {
+    return TStringBuilder() << "DECLARE $name AS Utf8; SELECT * FROM `" << rootDomain << "/ydb/MasterClusterExt.db` WHERE name=$name";
+}
+
+NYdb::TParams BuildClusterInfoQueryParams(TStringBuf clusterName) {
+    NYdb::TParamsBuilder params;
+    params.AddParam("$name", NYdb::TValueBuilder().Utf8(TString(clusterName)).Build());
+    return params.Build();
+}
+
+bool TryExtractClusterInfo(const NYdb::TResultSet& resultSet, THashMap<TString, TString>& clusterInfo) {
+    const auto& columnsMeta = resultSet.GetColumnsMeta();
+    NYdb::TResultSetParser rsParser(resultSet);
+    if (!rsParser.TryNextRow()) {
+        return false;
+    }
+
+    for (size_t columnNum = 0; columnNum < columnsMeta.size(); ++columnNum) {
+        const NYdb::TColumn& columnMeta = columnsMeta[columnNum];
+        clusterInfo[columnMeta.Name] = THandlerActorYdb::ColumnValueToString(rsParser.ColumnParser(columnNum));
+    }
+
+    return true;
+}
+
+} // namespace NMVP

--- a/ydb/mvp/meta/meta_cluster_info.h
+++ b/ydb/mvp/meta/meta_cluster_info.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <util/generic/hash.h>
+
+namespace NMVP {
+
+TString BuildClusterInfoQuery(TStringBuf rootDomain);
+NYdb::TParams BuildClusterInfoQueryParams(TStringBuf clusterName);
+bool TryExtractClusterInfo(const NYdb::TResultSet& resultSet, THashMap<TString, TString>& clusterInfo);
+
+} // namespace NMVP

--- a/ydb/mvp/meta/meta_settings.cpp
+++ b/ydb/mvp/meta/meta_settings.cpp
@@ -1,0 +1,43 @@
+#include "meta_settings.h"
+
+#include <ydb/mvp/meta/support_links/source.h>
+#include <ydb/mvp/core/utils.h>
+
+#include <util/generic/yexception.h>
+
+namespace NMVP {
+
+TMetaSettings BuildMetaSettings(const NMvp::NMeta::TMetaConfig& config, NMvp::EAccessServiceType accessServiceType) {
+    TMetaSettings settings;
+    settings.MetaApiEndpoint = config.GetMetaApiEndpoint();
+    settings.MetaDatabase = config.GetMetaDatabase();
+    settings.AccessServiceType = accessServiceType;
+
+    if (settings.MetaApiEndpoint.empty()) {
+        ythrow yexception() << CONFIG_ERROR_PREFIX << "meta.meta_api_endpoint must be specified";
+    }
+    if (settings.MetaDatabase.empty()) {
+        ythrow yexception() << CONFIG_ERROR_PREFIX << "meta.meta_database must be specified";
+    }
+
+    if (config.HasGrafana()) {
+        settings.SupportLinks.GrafanaEndpoint = config.GetGrafana().GetEndpoint();
+    }
+
+    if (config.HasSupportLinks()) {
+        const auto& supportLinks = config.GetSupportLinks();
+        ValidateSupportLinksConfig(supportLinks, settings);
+        settings.SupportLinks.ClusterLinks.reserve(supportLinks.GetCluster().size());
+        for (int i = 0; i < supportLinks.GetCluster().size(); ++i) {
+            settings.SupportLinks.ClusterLinks.push_back(supportLinks.GetCluster(i));
+        }
+        settings.SupportLinks.DatabaseLinks.reserve(supportLinks.GetDatabase().size());
+        for (int i = 0; i < supportLinks.GetDatabase().size(); ++i) {
+            settings.SupportLinks.DatabaseLinks.push_back(supportLinks.GetDatabase(i));
+        }
+    }
+
+    return settings;
+}
+
+} // namespace NMVP

--- a/ydb/mvp/meta/meta_settings.h
+++ b/ydb/mvp/meta/meta_settings.h
@@ -5,23 +5,25 @@
 
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
-#include <memory>
 
 namespace NMVP {
 
 using TSupportLinkEntryConfig = NMvp::NMeta::TMetaConfig::TSupportLinksConfig::TSupportLinkEntry;
 using TSupportLinksConfig = NMvp::NMeta::TMetaConfig::TSupportLinksConfig;
 
-class ILinkSource;
+struct TSupportLinksSettings {
+    TString GrafanaEndpoint;
+    TVector<TSupportLinkEntryConfig> ClusterLinks;
+    TVector<TSupportLinkEntryConfig> DatabaseLinks;
+};
 
 struct TMetaSettings {
     TString MetaApiEndpoint;
     TString MetaDatabase;
     NMvp::EAccessServiceType AccessServiceType = NMvp::yandex_v2;
-    TString GrafanaEndpoint;
-    TString GrafanaSecretName;
-    TVector<std::shared_ptr<ILinkSource>> ClusterLinkSources;
-    TVector<std::shared_ptr<ILinkSource>> DatabaseLinkSources;
+    TSupportLinksSettings SupportLinks;
 };
+
+TMetaSettings BuildMetaSettings(const NMvp::NMeta::TMetaConfig& config, NMvp::EAccessServiceType accessServiceType);
 
 } // namespace NMVP

--- a/ydb/mvp/meta/meta_support_links.h
+++ b/ydb/mvp/meta/meta_support_links.h
@@ -119,7 +119,7 @@ public:
                 NYdb::NTable::TTxSettings::OnlineRO(
                     NYdb::NTable::TTxOnlineSettings().AllowInconsistentReads(true))).CommitTx(),
             params)
-            .Subscribe([actorId, actorSystem, session = Session](const NYdb::NTable::TAsyncDataQueryResult& result) {
+            .Subscribe([actorId, actorSystem](const NYdb::NTable::TAsyncDataQueryResult& result) {
                 SendDataQueryResult(actorId, actorSystem, result);
             });
     }

--- a/ydb/mvp/meta/meta_support_links.h
+++ b/ydb/mvp/meta/meta_support_links.h
@@ -28,8 +28,6 @@
 
 namespace NMVP {
 
-using namespace NKikimr;
-
 inline constexpr TStringBuf SOURCE_META = "meta";
 
 class TMetaSupportLinksGetHandlerActor : private THandlerActorYdb, public NActors::TActorBootstrapped<TMetaSupportLinksGetHandlerActor> {
@@ -75,7 +73,7 @@ public:
     }
 
     bool ValidateAndInitEntityType() {
-        const TString cluster = GetClusterName();
+        const TString cluster = Request.Parameters["cluster"];
         const TString database = Request.Parameters["database"];
 
         if (cluster.empty()) {
@@ -89,7 +87,7 @@ public:
     virtual void RequestClusterInfo() {
         NActors::TActorSystem* actorSystem = NActors::TActivationContext::ActorSystem();
         NActors::TActorId actorId = SelfId();
-        Location.GetTableClient(TMVP::GetMetaDatabaseClientSettings(Request, Location, "metadb"))
+        Location.GetTableClient(TMVP::GetStrictMetaDatabaseClientSettings(Request, Location))
             .CreateSession()
             .Subscribe([actorId, actorSystem](const NYdb::NTable::TAsyncCreateSessionResult& result) {
                 SendCreateSessionResult(actorId, actorSystem, result);
@@ -109,7 +107,7 @@ public:
 
     void RequestClusterInfoRows() {
         TString query = BuildClusterInfoQuery(Location.RootDomain);
-        NYdb::TParams params = BuildClusterInfoQueryParams(GetClusterName());
+        NYdb::TParams params = BuildClusterInfoQueryParams(Request.Parameters["cluster"]);
 
         NActors::TActorSystem* actorSystem = NActors::TActivationContext::ActorSystem();
         NActors::TActorId actorId = SelfId();
@@ -133,10 +131,6 @@ public:
         actorSystem->Send(actorId, new TEvPrivate::TEvCreateSessionResult(res.ExtractValue()));
     }
 
-    TString GetClusterName() const {
-        return Request.Parameters["cluster"];
-    }
-
     static void SendDataQueryResult(
         const NActors::TActorId& actorId,
         NActors::TActorSystem* actorSystem,
@@ -154,7 +148,7 @@ public:
         }
 
         if (!TryExtractClusterInfo(result.GetResultSet(0), ClusterInfo)) {
-            AddCommonError(TStringBuilder() << "Cluster '" << GetClusterName() << "' is not found in MasterClusterExt.db");
+            AddCommonError(TStringBuilder() << "Cluster '" << Request.Parameters["cluster"] << "' is not found in MasterClusterExt.db");
         }
         ResolveSupportLinks();
     }

--- a/ydb/mvp/meta/meta_support_links.h
+++ b/ydb/mvp/meta/meta_support_links.h
@@ -2,8 +2,10 @@
 
 #include <ydb/mvp/core/core_ydb.h>
 #include <ydb/mvp/core/core_ydb_impl.h>
+#include <ydb/mvp/meta/meta_cluster_info.h>
 #include <ydb/mvp/meta/mvp.h>
 #include <ydb/mvp/meta/support_links/events.h>
+#include <ydb/mvp/meta/support_links/response.h>
 #include <ydb/mvp/meta/support_links/source.h>
 #include <ydb/mvp/meta/support_links/support_links_resolver.h>
 
@@ -41,7 +43,7 @@ protected:
     const TMetaSettings Settings;
     TRequest Request;
     EEntityType EntityType = EEntityType::Cluster;
-    THashMap<TString, TString> ClusterColumns;
+    THashMap<TString, TString> ClusterInfo;
 
 private:
     TMaybe<NYdb::NTable::TSession> Session;
@@ -49,7 +51,6 @@ private:
     TVector<NSupportLinks::TSupportError> PendingErrors;
 
 public:
-
     TMetaSupportLinksGetHandlerActor(
         const NActors::TActorId& httpProxyId,
         const TYdbLocation& location,
@@ -65,7 +66,7 @@ public:
     void Bootstrap() {
         Become(&TMetaSupportLinksGetHandlerActor::StateWork, GetTimeout(Request, TDuration::Seconds(60)), new NActors::TEvents::TEvWakeup());
 
-        if (!InitEntityType()) {
+        if (!ValidateAndInitEntityType()) {
             ReplyBadRequestAndDie();
             return;
         }
@@ -73,8 +74,8 @@ public:
         RequestClusterInfo();
     }
 
-    bool InitEntityType() {
-        const TString cluster = Request.Parameters["cluster"];
+    bool ValidateAndInitEntityType() {
+        const TString cluster = GetClusterName();
         const TString database = Request.Parameters["database"];
 
         if (cluster.empty()) {
@@ -88,26 +89,27 @@ public:
     virtual void RequestClusterInfo() {
         NActors::TActorSystem* actorSystem = NActors::TActivationContext::ActorSystem();
         NActors::TActorId actorId = SelfId();
-        Location.GetTableClient(TMVP::GetMetaDatabaseClientSettings(Request, Location))
+        Location.GetTableClient(TMVP::GetMetaDatabaseClientSettings(Request, Location, "metadb"))
             .CreateSession()
             .Subscribe([actorId, actorSystem](const NYdb::NTable::TAsyncCreateSessionResult& result) {
-                NYdb::NTable::TAsyncCreateSessionResult res(result);
-                actorSystem->Send(actorId, new TEvPrivate::TEvCreateSessionResult(res.ExtractValue()));
+                SendCreateSessionResult(actorId, actorSystem, result);
             });
     }
 
     void Handle(TEvPrivate::TEvCreateSessionResult::TPtr event) {
         const NYdb::NTable::TCreateSessionResult& result(event->Get()->Result);
         if (!result.IsSuccess()) {
-            Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(CreateStatusResponse(Request.Request, result)));
-            PassAway();
+            ReplyStatusAndDie(result);
             return;
         }
 
         Session = result.GetSession();
-        TString query = TStringBuilder() << "DECLARE $name AS Utf8; SELECT * FROM `" << Location.RootDomain << "/ydb/MasterClusterExt.db` WHERE name=$name";
-        NYdb::TParamsBuilder params;
-        params.AddParam("$name", NYdb::TValueBuilder().Utf8(Request.Parameters["cluster"]).Build());
+        RequestClusterInfoRows();
+    }
+
+    void RequestClusterInfoRows() {
+        TString query = BuildClusterInfoQuery(Location.RootDomain);
+        NYdb::TParams params = BuildClusterInfoQueryParams(GetClusterName());
 
         NActors::TActorSystem* actorSystem = NActors::TActivationContext::ActorSystem();
         NActors::TActorId actorId = SelfId();
@@ -116,70 +118,91 @@ public:
             NYdb::NTable::TTxControl::BeginTx(
                 NYdb::NTable::TTxSettings::OnlineRO(
                     NYdb::NTable::TTxOnlineSettings().AllowInconsistentReads(true))).CommitTx(),
-            params.Build())
+            params)
             .Subscribe([actorId, actorSystem, session = Session](const NYdb::NTable::TAsyncDataQueryResult& result) {
-                NYdb::NTable::TAsyncDataQueryResult res(result);
-                actorSystem->Send(actorId, new TEvPrivate::TEvDataQueryResult(res.ExtractValue()));
+                SendDataQueryResult(actorId, actorSystem, result);
             });
+    }
+
+    static void SendCreateSessionResult(
+        const NActors::TActorId& actorId,
+        NActors::TActorSystem* actorSystem,
+        const NYdb::NTable::TAsyncCreateSessionResult& result)
+    {
+        NYdb::NTable::TAsyncCreateSessionResult res(result);
+        actorSystem->Send(actorId, new TEvPrivate::TEvCreateSessionResult(res.ExtractValue()));
+    }
+
+    TString GetClusterName() const {
+        return Request.Parameters["cluster"];
+    }
+
+    static void SendDataQueryResult(
+        const NActors::TActorId& actorId,
+        NActors::TActorSystem* actorSystem,
+        const NYdb::NTable::TAsyncDataQueryResult& result)
+    {
+        NYdb::NTable::TAsyncDataQueryResult res(result);
+        actorSystem->Send(actorId, new TEvPrivate::TEvDataQueryResult(res.ExtractValue()));
     }
 
     void Handle(TEvPrivate::TEvDataQueryResult::TPtr event) {
         NYdb::NTable::TDataQueryResult& result(event->Get()->Result);
         if (!result.IsSuccess()) {
-            Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(CreateStatusResponse(Request.Request, result)));
-            PassAway();
+            ReplyStatusAndDie(result);
             return;
         }
 
-        auto resultSet = result.GetResultSet(0);
-        const auto& columnsMeta = resultSet.GetColumnsMeta();
-        NYdb::TResultSetParser rsParser(resultSet);
-        if (!rsParser.TryNextRow()) {
-            AddCommonError(TStringBuilder() << "Cluster '" << Request.Parameters["cluster"] << "' is not found in MasterClusterExt.db");
-        } else {
-            for (size_t columnNum = 0; columnNum < columnsMeta.size(); ++columnNum) {
-                const NYdb::TColumn& columnMeta = columnsMeta[columnNum];
-                ClusterColumns[columnMeta.Name] = ColumnValueToString(rsParser.ColumnParser(columnNum));
-            }
+        if (!TryExtractClusterInfo(result.GetResultSet(0), ClusterInfo)) {
+            AddCommonError(TStringBuilder() << "Cluster '" << GetClusterName() << "' is not found in MasterClusterExt.db");
         }
-
         ResolveSupportLinks();
     }
 
     void ResolveSupportLinks() {
         SupportLinksResolver = CreateSupportLinksResolver();
         SupportLinksResolver->Start();
-        if (SupportLinksResolver->IsFinished()) {
-            ReplyOkAndDie();
+        if (TryReplyResolvedSupportLinks()) {
             return;
         }
         Become(&TMetaSupportLinksGetHandlerActor::StateResolveSources);
     }
 
-    virtual std::unique_ptr<TSupportLinksResolver> CreateSupportLinksResolver() {
-        return std::make_unique<TSupportLinksResolver>(TSupportLinksResolver::TParams{
+    TSupportLinksResolver::TParams BuildSupportLinksResolverParams() const {
+        return TSupportLinksResolver::TParams{
             .EntityType = EntityType,
             .Settings = &Settings,
-            .ClusterColumns = ClusterColumns,
+            .ClusterInfo = ClusterInfo,
             .UrlParameters = Request.Parameters.UrlParameters,
-            .Parent = SelfId(),
+            .Owner = SelfId(),
             .HttpProxyId = HttpProxyId,
-        });
+        };
     }
 
-    void Handle(NSupportLinks::TEvPrivate::TEvSourceResponse::TPtr event) {
-        SupportLinksResolver->OnSourceResponse(event);
-        if (SupportLinksResolver->IsFinished()) {
-            ReplyOkAndDie();
+    virtual std::unique_ptr<TSupportLinksResolver> CreateSupportLinksResolver() {
+        return std::make_unique<TSupportLinksResolver>(BuildSupportLinksResolverParams());
+    }
+
+    bool TryReplyResolvedSupportLinks() {
+        if (!SupportLinksResolver->IsFinished()) {
+            return false;
         }
+        ReplyOkAndDie();
+        return true;
+    }
+
+    void HandleSourceResponse(NSupportLinks::TEvPrivate::TEvSourceResponse::TPtr event) {
+        SupportLinksResolver->OnSourceResponse(event);
+        TryReplyResolvedSupportLinks();
     }
 
     void HandleTimeout() {
         if (SupportLinksResolver) {
             SupportLinksResolver->HandleTimeout();
-        } else {
-            AddCommonError("Timeout while querying cluster info from MasterClusterExt.db");
+            ReplyOkAndDie();
+            return;
         }
+        AddCommonError("Timeout while querying cluster info from MasterClusterExt.db");
         ReplyOkAndDie();
     }
 
@@ -190,63 +213,32 @@ public:
         });
     }
 
-    void ReplyOkAndDie() {
-        auto response = CreateResponseOK(Request.Request, BuildResponseBody(), "application/json; charset=utf-8");
+    void ReplyStatusAndDie(const NYdb::NTable::TCreateSessionResult& result) {
+        Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(CreateStatusResponse(Request.Request, result)));
+        PassAway();
+    }
+
+    void ReplyStatusAndDie(const NYdb::NTable::TDataQueryResult& result) {
+        Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(CreateStatusResponse(Request.Request, result)));
+        PassAway();
+    }
+
+    void SendJsonResponseAndDie(const NHttp::THttpOutgoingResponsePtr& response) {
         Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
         PassAway();
+    }
+
+    void ReplyOkAndDie() {
+        SendJsonResponseAndDie(CreateResponseOK(Request.Request, BuildResponseBody(), "application/json; charset=utf-8"));
     }
 
     void ReplyBadRequestAndDie() {
-        auto response = CreateResponseBadRequest(Request.Request, BuildResponseBody(), "application/json; charset=utf-8");
-        Send(Request.Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
-        PassAway();
-    }
-
-    static void AppendErrorJson(NJson::TJsonValue& errorsJson, const NSupportLinks::TSupportError& error) {
-        NJson::TJsonValue& item = errorsJson.AppendValue(NJson::TJsonValue());
-        item["source"] = error.Source;
-        if (error.Status) {
-            item["status"] = *error.Status;
-        }
-        if (!error.Reason.empty()) {
-            item["reason"] = error.Reason;
-        }
-        if (!error.Message.empty()) {
-            item["message"] = error.Message;
-        }
+        SendJsonResponseAndDie(CreateResponseBadRequest(Request.Request, BuildResponseBody(), "application/json; charset=utf-8"));
     }
 
     TString BuildResponseBody() const {
-        NJson::TJsonValue root;
-        NJson::TJsonValue& linksJson = root["links"];
-        linksJson.SetType(NJson::JSON_ARRAY);
-
-        NJson::TJsonValue errorsJson;
-        errorsJson.SetType(NJson::JSON_ARRAY);
-
-        if (SupportLinksResolver) {
-            for (const auto& sourceOutput : SupportLinksResolver->GetSourceOutput()) {
-                for (const auto& link : sourceOutput.Links) {
-                    NJson::TJsonValue& linkItem = linksJson.AppendValue(NJson::TJsonValue());
-                    if (!link.Title.empty()) {
-                        linkItem["title"] = link.Title;
-                    }
-                    linkItem["url"] = link.Url;
-                }
-                for (const auto& error : sourceOutput.Errors) {
-                    AppendErrorJson(errorsJson, error);
-                }
-            }
-        }
-
-        for (const auto& error : PendingErrors) {
-            AppendErrorJson(errorsJson, error);
-        }
-
-        if (!errorsJson.GetArray().empty()) {
-            root["errors"] = std::move(errorsJson);
-        }
-        return NJson::WriteJson(root, false);
+        const auto* sourceOutputs = SupportLinksResolver ? &SupportLinksResolver->GetSourceOutput() : nullptr;
+        return NSupportLinks::BuildResponseBody(sourceOutputs, PendingErrors);
     }
 
     STFUNC(StateWork) {
@@ -260,7 +252,7 @@ public:
     // Separate state to avoid mixing event IDs from THandlerActorYdb::TEvPrivate and NSupportLinks::TEvPrivate.
     STFUNC(StateResolveSources) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(NSupportLinks::TEvPrivate::TEvSourceResponse, Handle);
+            hFunc(NSupportLinks::TEvPrivate::TEvSourceResponse, HandleSourceResponse);
             cFunc(NActors::TEvents::TSystem::Wakeup, HandleTimeout);
         }
     }

--- a/ydb/mvp/meta/meta_support_links_ut.cpp
+++ b/ydb/mvp/meta/meta_support_links_ut.cpp
@@ -9,7 +9,20 @@
 
 #include <google/protobuf/text_format.h>
 #include <memory>
-#include <mutex>
+
+namespace {
+
+    std::shared_ptr<NMVP::ILinkSource> MakeTestLinkSource(NMVP::TSupportLinkEntryConfig config, const NMVP::TMetaSettings& settings) {
+        if (config.GetSource() == "mock/sync") {
+            return NMVP::NTest::MakeMockLinkSourceSync(std::move(config));
+        }
+        if (config.GetSource() == "mock/async") {
+            return NMVP::NTest::MakeMockLinkSourceAsync(std::move(config));
+        }
+        return NMVP::MakeLinkSource(std::move(config), settings);
+    }
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(MetaSupportLinks) {
     class TTestActorRuntime : public NActors::TTestActorRuntimeBase {
@@ -37,6 +50,18 @@ Y_UNIT_TEST_SUITE(MetaSupportLinks) {
         void RequestClusterInfo() override {
             Send(SelfId(), new NMVP::THandlerActorYdb::TEvPrivate::TEvDataQueryResult(std::move(Result)));
         }
+
+        std::unique_ptr<NMVP::TSupportLinksResolver> CreateSupportLinksResolver() override {
+            return std::make_unique<NMVP::TSupportLinksResolver>(NMVP::TSupportLinksResolver::TParams{
+                .EntityType = EntityType,
+                .Settings = &Settings,
+                .ClusterInfo = ClusterInfo,
+                .UrlParameters = Request.Parameters.UrlParameters,
+                .Owner = SelfId(),
+                .HttpProxyId = HttpProxyId,
+                .LinkSourceFactory = MakeTestLinkSource,
+            });
+        }
     };
 
     struct TSupportLinksTestContext {
@@ -44,17 +69,13 @@ Y_UNIT_TEST_SUITE(MetaSupportLinks) {
         const TYdbLocation Location = TYdbLocation("meta", "meta", {}, "/Root");
 
         explicit TSupportLinksTestContext(const NMVP::TSupportLinksConfig& config) {
-            static std::once_flag once;
-            std::call_once(once, [] {
-                NMVP::NTest::RegisterMockLinkSources();
-            });
-            Settings.ClusterLinkSources.reserve(config.GetCluster().size());
+            Settings.SupportLinks.ClusterLinks.reserve(config.GetCluster().size());
             for (int i = 0; i < config.GetCluster().size(); ++i) {
-                Settings.ClusterLinkSources.push_back(NMVP::MakeLinkSource(config.GetCluster(i)));
+                Settings.SupportLinks.ClusterLinks.push_back(config.GetCluster(i));
             }
-            Settings.DatabaseLinkSources.reserve(config.GetDatabase().size());
+            Settings.SupportLinks.DatabaseLinks.reserve(config.GetDatabase().size());
             for (int i = 0; i < config.GetDatabase().size(); ++i) {
-                Settings.DatabaseLinkSources.push_back(NMVP::MakeLinkSource(config.GetDatabase(i)));
+                Settings.SupportLinks.DatabaseLinks.push_back(config.GetDatabase(i));
             }
         }
 
@@ -157,7 +178,7 @@ columns {
         TAutoPtr<NActors::IEventHandle> handle;
 
         auto sender = runtime.AllocateEdgeActor();
-        TSupportLinksTestContext context(MakeConfig("mock/sourceSync"));
+        TSupportLinksTestContext context(MakeConfig("mock/sync"));
 
         auto request = BuildHttpRequest("/meta/support_links?database=/root/test");
         auto result = MakeClusterInfoResult();
@@ -216,7 +237,7 @@ columns {
         TAutoPtr<NActors::IEventHandle> handle;
 
         auto sender = runtime.AllocateEdgeActor();
-        TSupportLinksTestContext context(MakeConfig("mock/sourceSync"));
+        TSupportLinksTestContext context(MakeConfig("mock/sync"));
 
         auto request = BuildHttpRequest("/meta/support_links?cluster=testing-global");
         auto result = MakeClusterInfoResult();
@@ -232,7 +253,7 @@ columns {
         TAutoPtr<NActors::IEventHandle> handle;
 
         auto sender = runtime.AllocateEdgeActor();
-        TSupportLinksTestContext context(MakeConfig("mock/sourceAsync"));
+        TSupportLinksTestContext context(MakeConfig("mock/async"));
 
         auto request = BuildHttpRequest("/meta/support_links?cluster=testing-global");
         auto result = MakeClusterInfoResult();
@@ -270,7 +291,7 @@ columns {
         TAutoPtr<NActors::IEventHandle> handle;
 
         auto sender = runtime.AllocateEdgeActor();
-        TSupportLinksTestContext context(MakeConfig("mock/sourceSync"));
+        TSupportLinksTestContext context(MakeConfig("mock/sync"));
 
         auto request = BuildHttpRequest("/meta/support_links?cluster=missing-cluster");
         auto result = MakeEmptyClusterInfoResult();

--- a/ydb/mvp/meta/meta_ut.cpp
+++ b/ydb/mvp/meta/meta_ut.cpp
@@ -122,7 +122,7 @@ meta:
         UNIT_ASSERT_EXCEPTION_CONTAINS(mvp.TryGetMetaOptionsFromConfig(appConfig), yexception, "source is required");
     }
 
-    Y_UNIT_TEST(UnsupportedSourceInConfigDoesNotThrow) {
+    Y_UNIT_TEST(UnsupportedSourceInConfigThrows) {
         const TString yaml = R"(
 generic:
   access_service_type: "yandex_v2"
@@ -136,25 +136,11 @@ meta:
         url: "https://example.test"
 )";
         const NMvp::NMeta::TMetaAppConfig appConfig = ParseConfig(yaml);
-
-        UNIT_ASSERT(appConfig.HasMeta());
-        UNIT_ASSERT(appConfig.GetMeta().HasSupportLinks());
-        UNIT_ASSERT_VALUES_EQUAL(appConfig.GetMeta().GetSupportLinks().GetCluster().size(), 1);
-
-        auto source = NMVP::MakeLinkSource(appConfig.GetMeta().GetSupportLinks().GetCluster(0));
-        THashMap<TString, TString> clusterColumns;
-        NHttp::TUrlParameters urlParameters("");
-        const NMVP::ILinkSource::TResolveInput input{
-            .Place = 0,
-            .ClusterColumns = clusterColumns,
-            .UrlParameters = urlParameters,
-            .Parent = NActors::TActorId{},
-            .HttpProxyId = NActors::TActorId{},
-        };
-        const NMVP::TResolveOutput output = source->Resolve(input);
-        UNIT_ASSERT_VALUES_EQUAL(output.Name, "unknown/source");
-        UNIT_ASSERT_VALUES_EQUAL(output.Errors.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(output.Errors.front().Source, "unknown/source");
-        UNIT_ASSERT(output.Errors.front().Message.Contains("unsupported support_links source"));
+        auto mvp = MakeTestMvp();
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            mvp.TryGetMetaOptionsFromConfig(appConfig),
+            yexception,
+            "unsupported support_links source: unknown/source"
+        );
     }
 }

--- a/ydb/mvp/meta/meta_ut.cpp
+++ b/ydb/mvp/meta/meta_ut.cpp
@@ -1,6 +1,10 @@
 #include <ydb/mvp/meta/mvp.h>
+#include <ydb/mvp/core/core_ydb.h>
+#include <ydb/mvp/core/mvp_test_runtime.h>
 #include <ydb/mvp/meta/support_links/source.h>
 #include <ydb/mvp/core/utils.h>
+
+#include <ydb/library/actors/http/http.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -143,4 +147,5 @@ meta:
             "unsupported support_links source: unknown/source"
         );
     }
+
 }

--- a/ydb/mvp/meta/mvp.cpp
+++ b/ydb/mvp/meta/mvp.cpp
@@ -18,368 +18,126 @@
 #include <ydb/library/actors/protos/services_common.pb.h>
 
 #include <google/protobuf/text_format.h>
+#include <library/cpp/deprecated/atomic/atomic.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/string_utils/quote/quote.h>
-#include <library/cpp/deprecated/atomic/atomic.h>
 #include <yaml-cpp/yaml.h>
 
 #include <util/datetime/base.h>
-#include <util/string/cast.h>
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
+#include <util/string/cast.h>
 #include <util/system/hostname.h>
 #include <util/system/mlock.h>
 
 using namespace NMVP;
 
-NMVP::TMVP* NMVP::InstanceMVP;
+NMVP::TMVP *NMVP::InstanceMVP;
 
-namespace {
-
-class TGrafanaDashboardSearchResolveActor final : public NActors::TActorBootstrapped<TGrafanaDashboardSearchResolveActor> {
-public:
-    TGrafanaDashboardSearchResolveActor(
-        NMVP::TSupportLinkEntryConfig config,
-        TString grafanaEndpoint,
-        TString grafanaTokenName,
-        NActors::TActorId owner,
-        NActors::TActorId httpProxyId,
-        size_t place,
-        THashMap<TString, TString> clusterColumns,
-        NHttp::TUrlParameters urlParameters)
-        : Config(std::move(config))
-        , GrafanaEndpoint(std::move(grafanaEndpoint))
-        , GrafanaTokenName(std::move(grafanaTokenName))
-        , Owner(owner)
-        , HttpProxyId(httpProxyId)
-        , Place(place)
-        , ClusterColumns(std::move(clusterColumns))
-        , UrlParameters(std::move(urlParameters))
-    {}
-
-    void Bootstrap() {
-        const TString authHeaderValue = FindAuthorizationHeaderValue();
-        if (authHeaderValue.empty()) {
-            ReplyAndDie();
-            return;
-        }
-
-        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet(BuildSearchUrl());
-        request->Set("Authorization", authHeaderValue);
-
-        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
-        event->Timeout = TDuration::Seconds(30);
-        Send(HttpProxyId, event.Release());
-
-        Become(&TGrafanaDashboardSearchResolveActor::StateWork, TDuration::Seconds(30), new NActors::TEvents::TEvWakeup());
-    }
-
-    STFUNC(StateWork) {
-        switch (ev->GetTypeRewrite()) {
-            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
-            cFunc(NActors::TEvents::TSystem::Wakeup, HandleTimeout);
-        }
-    }
-
-private:
-    static bool IsAbsoluteUrl(const TString& url) {
-        return url.StartsWith("http://") || url.StartsWith("https://");
-    }
-
-    static TString JoinUrl(const TString& endpoint, const TString& path) {
-        const bool endpointHasSlash = endpoint.EndsWith('/');
-        const bool pathHasSlash = path.StartsWith('/');
-        if (endpointHasSlash && pathHasSlash) {
-            return endpoint.substr(0, endpoint.size() - 1) + path;
-        }
-        if (!endpointHasSlash && !pathHasSlash) {
-            return endpoint + "/" + path;
-        }
-        return endpoint + path;
-    }
-
-    static TString AppendQueryParam(const TString& url, TStringBuf key, TStringBuf value) {
-        TStringBuilder result;
-        result << url << (url.Contains('?') ? '&' : '?') << key << "=" << CGIEscapeRet(value);
-        return result;
-    }
-
-    TString ResolveGrafanaUrl(const TString& configuredUrl) const {
-        if (IsAbsoluteUrl(configuredUrl)) {
-            return configuredUrl;
-        }
-        return JoinUrl(GrafanaEndpoint, configuredUrl);
-    }
-
-    TString BuildSearchUrl() const {
-        TString url = Config.GetUrl().empty() ? TString("/api/search") : Config.GetUrl();
-        url = ResolveGrafanaUrl(url);
-        if (Config.HasTag() && Config.GetTag()) {
-            url = AppendQueryParam(url, "tag", Config.GetTag());
-        }
-        if (Config.HasFolder() && Config.GetFolder()) {
-            url = AppendQueryParam(url, "folderUIDs", Config.GetFolder());
-        }
-        return url;
-    }
-
-    TString FindAuthorizationHeaderValue() {
-        if (GrafanaTokenName.empty()) {
-            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-                .Source = Config.GetSource(),
-                .Message = TStringBuilder() << "meta.meta_database_token_name is required for source=" << Config.GetSource(),
-            });
-            return {};
-        }
-
-        auto* appData = NMVP::MVPAppData();
-        if (!appData || !appData->Tokenator) {
-            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-                .Source = Config.GetSource(),
-                .Message = "Tokenator is unavailable",
-            });
-            return {};
-        }
-
-        const TString authHeaderValue = appData->Tokenator->GetToken(GrafanaTokenName);
-        if (!authHeaderValue.empty()) {
-            return authHeaderValue;
-        }
-
-        Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-            .Source = Config.GetSource(),
-            .Message = TStringBuilder() << "IAM token '" << GrafanaTokenName << "' is not available from tokenator",
-        });
-        return {};
-    }
-
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
-        if (!event->Get()->Error.empty() || !event->Get()->Response || event->Get()->Response->Status != "200") {
-            NMVP::NSupportLinks::TSupportError error;
-            error.Source = Config.GetSource();
-            if (!event->Get()->Error.empty()) {
-                error.Message = event->Get()->Error;
-            } else if (event->Get()->Response) {
-                ui32 status = 0;
-                if (TryFromString<ui32>(event->Get()->Response->Status, status)) {
-                    error.Status = status;
-                }
-                error.Reason = TString(event->Get()->Response->Message);
-                error.Message = TStringBuilder() << event->Get()->Response->Status << " " << event->Get()->Response->Message;
-            } else {
-                error.Message = "Unknown Grafana request error";
-            }
-            Errors.push_back(std::move(error));
-            ReplyAndDie();
-            return;
-        }
-
-        NJson::TJsonValue dashboardsJson;
-        NJson::TJsonReaderConfig jsonReaderConfig;
-        if (!NJson::ReadJsonTree(event->Get()->Response->Body, &jsonReaderConfig, &dashboardsJson)
-            || dashboardsJson.GetType() != NJson::JSON_ARRAY)
-        {
-            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-                .Source = Config.GetSource(),
-                .Message = "Invalid JSON from Grafana Search API",
-            });
-            ReplyAndDie();
-            return;
-        }
-
-        for (const auto& item : dashboardsJson.GetArray()) {
-            if (item.GetType() != NJson::JSON_MAP) {
-                continue;
-            }
-
-            TString title;
-            TString dashboardPath;
-            if (item.Has("title") && item["title"].GetType() == NJson::JSON_STRING) {
-                title = item["title"].GetStringRobust();
-            }
-            if (item.Has("url") && item["url"].GetType() == NJson::JSON_STRING) {
-                dashboardPath = item["url"].GetStringRobust();
-            } else if (item.Has("uri") && item["uri"].GetType() == NJson::JSON_STRING) {
-                dashboardPath = item["uri"].GetStringRobust();
-            }
-
-            if (dashboardPath.empty()) {
-                continue;
-            }
-
-            Links.emplace_back(NMVP::NSupportLinks::TResolvedLink{
-                .Title = std::move(title),
-                .Url = ResolveDashboardUrl(dashboardPath),
-            });
-        }
-
-        ReplyAndDie();
-    }
-
-    TString ResolveDashboardUrl(const TString& dashboardPath) {
-        TString url = ResolveGrafanaUrl(dashboardPath);
-
-        static constexpr TStringBuf WorkspaceColumn = "k8s_namespace";
-        static constexpr TStringBuf DatasourceColumn = "datasource";
-
-        const auto workspaceIt = ClusterColumns.find(WorkspaceColumn);
-        if (workspaceIt == ClusterColumns.end() || workspaceIt->second.empty()) {
-            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-                .Source = "meta",
-                .Message = TStringBuilder() << "Cluster metadata column '" << WorkspaceColumn << "' is missing or empty",
-            });
-        } else {
-            url = AppendQueryParam(url, "var-workspace", workspaceIt->second);
-        }
-
-        const auto datasourceIt = ClusterColumns.find(DatasourceColumn);
-        if (datasourceIt == ClusterColumns.end() || datasourceIt->second.empty()) {
-            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-                .Source = "meta",
-                .Message = TStringBuilder() << "Cluster metadata column '" << DatasourceColumn << "' is missing or empty",
-            });
-        } else {
-            url = AppendQueryParam(url, "var-ds", datasourceIt->second);
-        }
-
-        for (const auto& [name, value] : UrlParameters.Parameters) {
-            Y_UNUSED(value);
-            url = AppendQueryParam(url, TStringBuilder() << "var-" << name, UrlParameters[name]);
-        }
-        return url;
-    }
-
-    void HandleTimeout() {
-        Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
-            .Source = Config.GetSource(),
-            .Message = "Timeout while resolving support links source",
-        });
-        ReplyAndDie();
-    }
-
-    void ReplyAndDie() {
-        Send(Owner, new NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse(Place, std::move(Links), std::move(Errors)));
-        PassAway();
-    }
-
-private:
-    NMVP::TSupportLinkEntryConfig Config;
-    TString GrafanaEndpoint;
-    TString GrafanaTokenName;
-    NActors::TActorId Owner;
-    NActors::TActorId HttpProxyId;
-    size_t Place = 0;
-    THashMap<TString, TString> ClusterColumns;
-    NHttp::TUrlParameters UrlParameters;
-    TVector<NMVP::NSupportLinks::TResolvedLink> Links;
-    TVector<NMVP::NSupportLinks::TSupportError> Errors;
-};
-
-} // namespace
-
-const TString& NMVP::GetEServiceName(NActors::NLog::EComponent component) {
-    static const TString loggerName("LOGGER");
-    static const TString mvpName("MVP");
-    static const TString grpcName("GRPC");
-    static const TString queryName("QUERY");
-    static const TString unknownName("UNKNOW");
-    switch (component) {
-    case EService::Logger:
-        return loggerName;
-    case EService::MVP:
-        return mvpName;
-    case EService::GRPC:
-        return grpcName;
-    case EService::QUERY:
-        return queryName;
-    default:
-        return unknownName;
-    }
+const TString &NMVP::GetEServiceName(NActors::NLog::EComponent component) {
+  static const TString loggerName("LOGGER");
+  static const TString mvpName("MVP");
+  static const TString grpcName("GRPC");
+  static const TString queryName("QUERY");
+  static const TString unknownName("UNKNOW");
+  switch (component) {
+  case EService::Logger:
+    return loggerName;
+  case EService::MVP:
+    return mvpName;
+  case EService::GRPC:
+    return grpcName;
+  case EService::QUERY:
+    return queryName;
+  default:
+    return unknownName;
+  }
 }
 
-void TMVP::OnTerminate(int) {
-    AtomicSet(Quit, true);
-}
+void TMVP::OnTerminate(int) { AtomicSet(Quit, true); }
 
 int TMVP::Init() {
-    ActorSystem.Start();
+  ActorSystem.Start();
 
-    ActorSystem.Register(NActors::CreateProcStatCollector(TDuration::Seconds(5), AppData.MetricRegistry = std::make_shared<NMonitoring::TMetricRegistry>()));
+  ActorSystem.Register(NActors::CreateProcStatCollector(
+      TDuration::Seconds(5),
+      AppData.MetricRegistry =
+          std::make_shared<NMonitoring::TMetricRegistry>()));
 
-    HttpProxyId = ActorSystem.Register(NHttp::CreateHttpProxy(AppData.MetricRegistry));
-    ActorSystem.Register(AppData.Tokenator = TMvpTokenator::CreateTokenator(TokensConfig, HttpProxyId));
+  HttpProxyId =
+      ActorSystem.Register(NHttp::CreateHttpProxy(AppData.MetricRegistry));
+  ActorSystem.Register(AppData.Tokenator = TMvpTokenator::CreateTokenator(
+                           TokensConfig, HttpProxyId));
 
-    if (StartupOptions.HttpPort) {
-        auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(StartupOptions.HttpPort, TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpPort);
-        ev->CompressContentTypes = {
-            "text/plain",
-            "text/html",
-            "text/css",
-            "text/javascript",
-            "application/json",
-        };
-        ActorSystem.Send(HttpProxyId, ev);
-    }
-    if (StartupOptions.HttpsPort) {
-        auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(StartupOptions.HttpsPort, TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpsPort);
-        ev->Secure = true;
-        ev->SslCertificatePem = TYdbLocation::SslCertificate;
-        ev->CompressContentTypes = {
-            "text/plain",
-            "text/html",
-            "text/css",
-            "text/javascript",
-            "application/json",
-        };
-        ActorSystem.Send(HttpProxyId, ev);
-    }
+  if (StartupOptions.HttpPort) {
+    auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
+        StartupOptions.HttpPort,
+        TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpPort);
+    ev->CompressContentTypes = {
+        "text/plain",      "text/html",        "text/css",
+        "text/javascript", "application/json",
+    };
+    ActorSystem.Send(HttpProxyId, ev);
+  }
+  if (StartupOptions.HttpsPort) {
+    auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
+        StartupOptions.HttpsPort,
+        TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpsPort);
+    ev->Secure = true;
+    ev->SslCertificatePem = TYdbLocation::SslCertificate;
+    ev->CompressContentTypes = {
+        "text/plain",      "text/html",        "text/css",
+        "text/javascript", "application/json",
+    };
+    ActorSystem.Send(HttpProxyId, ev);
+  }
 
-    InitMeta();
+  InitMeta();
 
-    return 0;
+  return 0;
 }
 
 int TMVP::Run() {
-    try {
-        int res = Init();
-        if (res != 0) {
-            return res;
-        }
-#ifndef NDEBUG
-        Cout << "Started" << Endl;
-#endif
-        while (!AtomicGet(Quit)) {
-            Sleep(TDuration::MilliSeconds(100));
-        }
-#ifndef NDEBUG
-        Cout << Endl << "Finished" << Endl;
-#endif
-        Shutdown();
+  try {
+    int res = Init();
+    if (res != 0) {
+      return res;
     }
-    catch (const yexception& e) {
-        Cerr << e.what() << Endl;
-        return 1;
+#ifndef NDEBUG
+    Cout << "Started" << Endl;
+#endif
+    while (!AtomicGet(Quit)) {
+      Sleep(TDuration::MilliSeconds(100));
     }
-    return 0;
+#ifndef NDEBUG
+    Cout << Endl << "Finished" << Endl;
+#endif
+    Shutdown();
+  } catch (const yexception &e) {
+    Cerr << e.what() << Endl;
+    return 1;
+  }
+  return 0;
 }
 
 int TMVP::Shutdown() {
-    ActorSystem.Stop();
-    AppData.GRpcClientLow->Stop(true);
-    ActorSystem.Cleanup();
-    return 0;
+  ActorSystem.Stop();
+  AppData.GRpcClientLow->Stop(true);
+  ActorSystem.Cleanup();
+  return 0;
 }
 
-TString TMVP::GetAppropriateEndpoint(const NHttp::THttpIncomingRequestPtr& req) {
-    const bool secure = req->Endpoint->Secure;
-    const ui16 port = secure ? StartupOptions.HttpsPort : StartupOptions.HttpPort;
+TString
+TMVP::GetAppropriateEndpoint(const NHttp::THttpIncomingRequestPtr &req) {
+  const bool secure = req->Endpoint->Secure;
+  const ui16 port = secure ? StartupOptions.HttpsPort : StartupOptions.HttpPort;
 
-    TStringBuilder b;
-    b << (secure ? "https://[::1]" : "http://[::1]");
-    if (port) {
-        b << ":" << port;
-    }
-    return b;
+  TStringBuilder b;
+  b << (secure ? "https://[::1]" : "http://[::1]");
+  if (port) {
+    b << ":" << port;
+  }
+  return b;
 }
 
 NMvp::TTokensConfig TMVP::TokensConfig;
@@ -387,111 +145,122 @@ TString TMVP::MetaDatabaseTokenName;
 
 bool TMVP::DbUserTokenSource = false;
 
-TMVP::TMVP(int argc, const char* argv[])
-    : StartupOptions(TMvpStartupOptions::Build(argc, argv))
-    , LoggerSettings(BuildLoggerSettings())
-    , ActorSystemSetup(BuildActorSystemSetup())
-    , ActorSystem(ActorSystemSetup, &AppData, LoggerSettings)
-{
-    InstanceMVP = this;
+TMVP::TMVP(int argc, const char *argv[])
+    : StartupOptions(TMvpStartupOptions::Build(argc, argv)),
+      LoggerSettings(BuildLoggerSettings()),
+      ActorSystemSetup(BuildActorSystemSetup()),
+      ActorSystem(ActorSystemSetup, &AppData, LoggerSettings) {
+  InstanceMVP = this;
 }
 
 TIntrusivePtr<NActors::NLog::TSettings> TMVP::BuildLoggerSettings() {
-    const NActors::TActorId loggerActorId = NActors::TActorId(1, "logger");
-    TIntrusivePtr<NActors::NLog::TSettings> loggerSettings = new NActors::NLog::TSettings(loggerActorId, EService::Logger, NActors::NLog::PRI_WARN);
-    loggerSettings->Append(
-        NActorsServices::EServiceCommon_MIN,
-        NActorsServices::EServiceCommon_MAX,
-        NActorsServices::EServiceCommon_Name
-    );
-    loggerSettings->Append(
-        EService::MIN,
-        EService::MAX,
-        GetEServiceName
-    );
-    TString explanation;
-    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, NActorsServices::HTTP, explanation);
-    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::MVP, explanation);
-    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::GRPC, explanation);
-    loggerSettings->SetLevel(NActors::NLog::PRI_INFO, EService::QUERY, explanation);
-    return loggerSettings;
+  const NActors::TActorId loggerActorId = NActors::TActorId(1, "logger");
+  TIntrusivePtr<NActors::NLog::TSettings> loggerSettings =
+      new NActors::NLog::TSettings(loggerActorId, EService::Logger,
+                                   NActors::NLog::PRI_WARN);
+  loggerSettings->Append(NActorsServices::EServiceCommon_MIN,
+                         NActorsServices::EServiceCommon_MAX,
+                         NActorsServices::EServiceCommon_Name);
+  loggerSettings->Append(EService::MIN, EService::MAX, GetEServiceName);
+  TString explanation;
+  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, NActorsServices::HTTP,
+                           explanation);
+  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::MVP,
+                           explanation);
+  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::GRPC,
+                           explanation);
+  loggerSettings->SetLevel(NActors::NLog::PRI_INFO, EService::QUERY,
+                           explanation);
+  return loggerSettings;
 }
 
-void TMVP::TryGetMetaOptionsFromConfig(const NMvp::NMeta::TMetaAppConfig& appConfig) {
-    if (!appConfig.HasMeta()) {
-        ythrow yexception() << "Check that `meta` section exists and is on the same indentation as `generic` section";
-    }
+void TMVP::TryGetMetaOptionsFromConfig(
+    const NMvp::NMeta::TMetaAppConfig &appConfig) {
+  if (!appConfig.HasMeta()) {
+    ythrow yexception() << "Check that `meta` section exists and is on the "
+                           "same indentation as `generic` section";
+  }
 
-    const auto& config = appConfig.GetMeta();
+  const auto &config = appConfig.GetMeta();
 
-    MetaCache = config.GetMetaCache();
-    MetaDatabaseTokenName = config.GetMetaDatabaseTokenName();
-    DbUserTokenSource = config.GetDbUserTokenAccess();
-    MetaSettings = BuildMetaSettings(config, StartupOptions.AccessServiceType);
-    MetaApiEndpoint = MetaSettings.MetaApiEndpoint;
-    MetaDatabase = MetaSettings.MetaDatabase;
+  MetaCache = config.GetMetaCache();
+  MetaDatabaseTokenName = config.GetMetaDatabaseTokenName();
+  DbUserTokenSource = config.GetDbUserTokenAccess();
+  MetaSettings = BuildMetaSettings(config, StartupOptions.AccessServiceType);
+  MetaApiEndpoint = MetaSettings.MetaApiEndpoint;
+  MetaDatabase = MetaSettings.MetaDatabase;
 }
 
 void TMVP::TryGetMetaOptionsFromConfig() {
-    if (StartupOptions.GetYamlConfigPath().empty()) {
-        return;
-    }
-    try {
-        YAML::Node config = YAML::LoadFile(StartupOptions.GetYamlConfigPath());
-        NMvp::NMeta::TMetaAppConfig appConfig;
-        MergeYamlNodeToProto(config, appConfig);
-        TryGetMetaOptionsFromConfig(appConfig);
-    } catch (const YAML::Exception& e) {
-        ythrow yexception() << "Error parsing YAML configuration file: " << e.what();
-    }
+  if (StartupOptions.GetYamlConfigPath().empty()) {
+    return;
+  }
+  try {
+    YAML::Node config = YAML::LoadFile(StartupOptions.GetYamlConfigPath());
+    NMvp::NMeta::TMetaAppConfig appConfig;
+    MergeYamlNodeToProto(config, appConfig);
+    TryGetMetaOptionsFromConfig(appConfig);
+  } catch (const YAML::Exception &e) {
+    ythrow yexception() << "Error parsing YAML configuration file: "
+                        << e.what();
+  }
 }
 
 THolder<NActors::TActorSystemSetup> TMVP::BuildActorSystemSetup() {
-    TString defaultMetaDatabase = "/Root";
-    TString defaultMetaApiEndpoint = "grpc://meta.ydb.yandex.net:2135";
+  TString defaultMetaDatabase = "/Root";
+  TString defaultMetaApiEndpoint = "grpc://meta.ydb.yandex.net:2135";
 
-    TryGetMetaOptionsFromConfig();
+  TryGetMetaOptionsFromConfig();
 
-    if (MetaApiEndpoint.empty()) {
-        MetaApiEndpoint = defaultMetaApiEndpoint;
-    }
+  if (MetaApiEndpoint.empty()) {
+    MetaApiEndpoint = defaultMetaApiEndpoint;
+  }
 
-    if (MetaDatabase.empty()) {
-        MetaDatabase = defaultMetaDatabase;
-    }
+  if (MetaDatabase.empty()) {
+    MetaDatabase = defaultMetaDatabase;
+  }
 
-    MetaSettings.AccessServiceType = StartupOptions.AccessServiceType;
+  MetaSettings.AccessServiceType = StartupOptions.AccessServiceType;
 
-    if (StartupOptions.Mlock) {
-        LockAllMemory(LockCurrentMemory);
-    }
+  if (StartupOptions.Mlock) {
+    LockAllMemory(LockCurrentMemory);
+  }
 
-    TYdbLocation::UserToken = StartupOptions.UserToken;
-    TYdbLocation::CaCertificate = StartupOptions.CaCertificate;
-    TYdbLocation::SslCertificate = StartupOptions.SslCertificate;
+  TYdbLocation::UserToken = StartupOptions.UserToken;
+  TYdbLocation::CaCertificate = StartupOptions.CaCertificate;
+  TYdbLocation::SslCertificate = StartupOptions.SslCertificate;
 
-    TokensConfig = StartupOptions.Tokens;
+  TokensConfig = StartupOptions.Tokens;
 
-    NActors::TLoggerActor* loggerActor = new NActors::TLoggerActor(
-                LoggerSettings,
-                StartupOptions.LogToStderr ? NActors::CreateStderrBackend() : NActors::CreateSysLogBackend("mvp", false, true),
-                new NMonitoring::TDynamicCounters());
-    THolder<NActors::TActorSystemSetup> setup = MakeHolder<NActors::TActorSystemSetup>();
-    setup->NodeId = 1;
-    setup->Executors.Reset(new TAutoPtr<NActors::IExecutorPool>[3]);
-    setup->ExecutorsCount = 3;
-    setup->Executors[0] = new NActors::TBasicExecutorPool(0, 4, 10);
-    // For UI v2 Logbroker RPCs. We use separate thread pools for RPCs so CPU heavy
-    // and slow requests don't interfere with requests that communicate with
-    // Logbroker Configuration manager only and suppose to work fast
-    setup->Executors[1] = new NActors::TBasicExecutorPool(1, 4, 10);
-    // For JSON Merger used by  UI v2 dynamic Logbroker RPCs
-    setup->Executors[2] = new NActors::TBasicExecutorPool(2, 4, 10);
+  NActors::TLoggerActor *loggerActor = new NActors::TLoggerActor(
+      LoggerSettings,
+      StartupOptions.LogToStderr
+          ? NActors::CreateStderrBackend()
+          : NActors::CreateSysLogBackend("mvp", false, true),
+      new NMonitoring::TDynamicCounters());
+  THolder<NActors::TActorSystemSetup> setup =
+      MakeHolder<NActors::TActorSystemSetup>();
+  setup->NodeId = 1;
+  setup->Executors.Reset(new TAutoPtr<NActors::IExecutorPool>[3]);
+  setup->ExecutorsCount = 3;
+  setup->Executors[0] = new NActors::TBasicExecutorPool(0, 4, 10);
+  // For UI v2 Logbroker RPCs. We use separate thread pools for RPCs so CPU
+  // heavy and slow requests don't interfere with requests that communicate with
+  // Logbroker Configuration manager only and suppose to work fast
+  setup->Executors[1] = new NActors::TBasicExecutorPool(1, 4, 10);
+  // For JSON Merger used by  UI v2 dynamic Logbroker RPCs
+  setup->Executors[2] = new NActors::TBasicExecutorPool(2, 4, 10);
 
-    setup->Scheduler = new NActors::TBasicSchedulerThread(NActors::TSchedulerConfig(512, 100));
-    setup->LocalServices.emplace_back(LoggerSettings->LoggerActorId, NActors::TActorSetupCmd(loggerActor, NActors::TMailboxType::HTSwap, 0));
-    setup->LocalServices.emplace_back(NActors::MakePollerActorId(), NActors::TActorSetupCmd(NActors::CreatePollerActor(), NActors::TMailboxType::HTSwap, 0));
-    return setup;
+  setup->Scheduler =
+      new NActors::TBasicSchedulerThread(NActors::TSchedulerConfig(512, 100));
+  setup->LocalServices.emplace_back(
+      LoggerSettings->LoggerActorId,
+      NActors::TActorSetupCmd(loggerActor, NActors::TMailboxType::HTSwap, 0));
+  setup->LocalServices.emplace_back(
+      NActors::MakePollerActorId(),
+      NActors::TActorSetupCmd(NActors::CreatePollerActor(),
+                              NActors::TMailboxType::HTSwap, 0));
+  return setup;
 }
 
 TAtomic TMVP::Quit = false;

--- a/ydb/mvp/meta/mvp.cpp
+++ b/ydb/mvp/meta/mvp.cpp
@@ -4,6 +4,8 @@
 #include <ydb/mvp/core/core_ydbc.h>
 #include <ydb/mvp/core/protos/mvp.pb.h>
 #include <ydb/mvp/core/utils.h>
+#include <ydb/mvp/meta/support_links/events.h>
+#include <ydb/mvp/meta/support_links/grafana_dashboard_source.h>
 #include <ydb/mvp/meta/support_links/source.h>
 
 #include <ydb/library/actors/core/executor_pool_basic.h>
@@ -16,10 +18,13 @@
 #include <ydb/library/actors/protos/services_common.pb.h>
 
 #include <google/protobuf/text_format.h>
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
 #include <yaml-cpp/yaml.h>
 
 #include <util/datetime/base.h>
+#include <util/string/cast.h>
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
 #include <util/system/hostname.h>
@@ -28,6 +33,249 @@
 using namespace NMVP;
 
 NMVP::TMVP* NMVP::InstanceMVP;
+
+namespace {
+
+class TGrafanaDashboardSearchResolveActor final : public NActors::TActorBootstrapped<TGrafanaDashboardSearchResolveActor> {
+public:
+    TGrafanaDashboardSearchResolveActor(
+        NMVP::TSupportLinkEntryConfig config,
+        TString grafanaEndpoint,
+        TString grafanaTokenName,
+        NActors::TActorId owner,
+        NActors::TActorId httpProxyId,
+        size_t place,
+        THashMap<TString, TString> clusterColumns,
+        NHttp::TUrlParameters urlParameters)
+        : Config(std::move(config))
+        , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , GrafanaTokenName(std::move(grafanaTokenName))
+        , Owner(owner)
+        , HttpProxyId(httpProxyId)
+        , Place(place)
+        , ClusterColumns(std::move(clusterColumns))
+        , UrlParameters(std::move(urlParameters))
+    {}
+
+    void Bootstrap() {
+        const TString authHeaderValue = FindAuthorizationHeaderValue();
+        if (authHeaderValue.empty()) {
+            ReplyAndDie();
+            return;
+        }
+
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet(BuildSearchUrl());
+        request->Set("Authorization", authHeaderValue);
+
+        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
+        event->Timeout = TDuration::Seconds(30);
+        Send(HttpProxyId, event.Release());
+
+        Become(&TGrafanaDashboardSearchResolveActor::StateWork, TDuration::Seconds(30), new NActors::TEvents::TEvWakeup());
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
+            cFunc(NActors::TEvents::TSystem::Wakeup, HandleTimeout);
+        }
+    }
+
+private:
+    static bool IsAbsoluteUrl(const TString& url) {
+        return url.StartsWith("http://") || url.StartsWith("https://");
+    }
+
+    static TString JoinUrl(const TString& endpoint, const TString& path) {
+        const bool endpointHasSlash = endpoint.EndsWith('/');
+        const bool pathHasSlash = path.StartsWith('/');
+        if (endpointHasSlash && pathHasSlash) {
+            return endpoint.substr(0, endpoint.size() - 1) + path;
+        }
+        if (!endpointHasSlash && !pathHasSlash) {
+            return endpoint + "/" + path;
+        }
+        return endpoint + path;
+    }
+
+    static TString AppendQueryParam(const TString& url, TStringBuf key, TStringBuf value) {
+        TStringBuilder result;
+        result << url << (url.Contains('?') ? '&' : '?') << key << "=" << CGIEscapeRet(value);
+        return result;
+    }
+
+    TString ResolveGrafanaUrl(const TString& configuredUrl) const {
+        if (IsAbsoluteUrl(configuredUrl)) {
+            return configuredUrl;
+        }
+        return JoinUrl(GrafanaEndpoint, configuredUrl);
+    }
+
+    TString BuildSearchUrl() const {
+        TString url = Config.GetUrl().empty() ? TString("/api/search") : Config.GetUrl();
+        url = ResolveGrafanaUrl(url);
+        if (Config.HasTag() && Config.GetTag()) {
+            url = AppendQueryParam(url, "tag", Config.GetTag());
+        }
+        if (Config.HasFolder() && Config.GetFolder()) {
+            url = AppendQueryParam(url, "folderUIDs", Config.GetFolder());
+        }
+        return url;
+    }
+
+    TString FindAuthorizationHeaderValue() {
+        if (GrafanaTokenName.empty()) {
+            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+                .Source = Config.GetSource(),
+                .Message = TStringBuilder() << "meta.meta_database_token_name is required for source=" << Config.GetSource(),
+            });
+            return {};
+        }
+
+        auto* appData = NMVP::MVPAppData();
+        if (!appData || !appData->Tokenator) {
+            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+                .Source = Config.GetSource(),
+                .Message = "Tokenator is unavailable",
+            });
+            return {};
+        }
+
+        const TString authHeaderValue = appData->Tokenator->GetToken(GrafanaTokenName);
+        if (!authHeaderValue.empty()) {
+            return authHeaderValue;
+        }
+
+        Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+            .Source = Config.GetSource(),
+            .Message = TStringBuilder() << "IAM token '" << GrafanaTokenName << "' is not available from tokenator",
+        });
+        return {};
+    }
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
+        if (!event->Get()->Error.empty() || !event->Get()->Response || event->Get()->Response->Status != "200") {
+            NMVP::NSupportLinks::TSupportError error;
+            error.Source = Config.GetSource();
+            if (!event->Get()->Error.empty()) {
+                error.Message = event->Get()->Error;
+            } else if (event->Get()->Response) {
+                ui32 status = 0;
+                if (TryFromString<ui32>(event->Get()->Response->Status, status)) {
+                    error.Status = status;
+                }
+                error.Reason = TString(event->Get()->Response->Message);
+                error.Message = TStringBuilder() << event->Get()->Response->Status << " " << event->Get()->Response->Message;
+            } else {
+                error.Message = "Unknown Grafana request error";
+            }
+            Errors.push_back(std::move(error));
+            ReplyAndDie();
+            return;
+        }
+
+        NJson::TJsonValue dashboardsJson;
+        NJson::TJsonReaderConfig jsonReaderConfig;
+        if (!NJson::ReadJsonTree(event->Get()->Response->Body, &jsonReaderConfig, &dashboardsJson)
+            || dashboardsJson.GetType() != NJson::JSON_ARRAY)
+        {
+            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+                .Source = Config.GetSource(),
+                .Message = "Invalid JSON from Grafana Search API",
+            });
+            ReplyAndDie();
+            return;
+        }
+
+        for (const auto& item : dashboardsJson.GetArray()) {
+            if (item.GetType() != NJson::JSON_MAP) {
+                continue;
+            }
+
+            TString title;
+            TString dashboardPath;
+            if (item.Has("title") && item["title"].GetType() == NJson::JSON_STRING) {
+                title = item["title"].GetStringRobust();
+            }
+            if (item.Has("url") && item["url"].GetType() == NJson::JSON_STRING) {
+                dashboardPath = item["url"].GetStringRobust();
+            } else if (item.Has("uri") && item["uri"].GetType() == NJson::JSON_STRING) {
+                dashboardPath = item["uri"].GetStringRobust();
+            }
+
+            if (dashboardPath.empty()) {
+                continue;
+            }
+
+            Links.emplace_back(NMVP::NSupportLinks::TResolvedLink{
+                .Title = std::move(title),
+                .Url = ResolveDashboardUrl(dashboardPath),
+            });
+        }
+
+        ReplyAndDie();
+    }
+
+    TString ResolveDashboardUrl(const TString& dashboardPath) {
+        TString url = ResolveGrafanaUrl(dashboardPath);
+
+        static constexpr TStringBuf WorkspaceColumn = "k8s_namespace";
+        static constexpr TStringBuf DatasourceColumn = "datasource";
+
+        const auto workspaceIt = ClusterColumns.find(WorkspaceColumn);
+        if (workspaceIt == ClusterColumns.end() || workspaceIt->second.empty()) {
+            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+                .Source = "meta",
+                .Message = TStringBuilder() << "Cluster metadata column '" << WorkspaceColumn << "' is missing or empty",
+            });
+        } else {
+            url = AppendQueryParam(url, "var-workspace", workspaceIt->second);
+        }
+
+        const auto datasourceIt = ClusterColumns.find(DatasourceColumn);
+        if (datasourceIt == ClusterColumns.end() || datasourceIt->second.empty()) {
+            Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+                .Source = "meta",
+                .Message = TStringBuilder() << "Cluster metadata column '" << DatasourceColumn << "' is missing or empty",
+            });
+        } else {
+            url = AppendQueryParam(url, "var-ds", datasourceIt->second);
+        }
+
+        for (const auto& [name, value] : UrlParameters.Parameters) {
+            Y_UNUSED(value);
+            url = AppendQueryParam(url, TStringBuilder() << "var-" << name, UrlParameters[name]);
+        }
+        return url;
+    }
+
+    void HandleTimeout() {
+        Errors.emplace_back(NMVP::NSupportLinks::TSupportError{
+            .Source = Config.GetSource(),
+            .Message = "Timeout while resolving support links source",
+        });
+        ReplyAndDie();
+    }
+
+    void ReplyAndDie() {
+        Send(Owner, new NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse(Place, std::move(Links), std::move(Errors)));
+        PassAway();
+    }
+
+private:
+    NMVP::TSupportLinkEntryConfig Config;
+    TString GrafanaEndpoint;
+    TString GrafanaTokenName;
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+    size_t Place = 0;
+    THashMap<TString, TString> ClusterColumns;
+    NHttp::TUrlParameters UrlParameters;
+    TVector<NMVP::NSupportLinks::TResolvedLink> Links;
+    TVector<NMVP::NSupportLinks::TSupportError> Errors;
+};
+
+} // namespace
 
 const TString& NMVP::GetEServiceName(NActors::NLog::EComponent component) {
     static const TString loggerName("LOGGER");
@@ -176,41 +424,12 @@ void TMVP::TryGetMetaOptionsFromConfig(const NMvp::NMeta::TMetaAppConfig& appCon
 
     const auto& config = appConfig.GetMeta();
 
-    MetaApiEndpoint = config.GetMetaApiEndpoint();
-    MetaDatabase = config.GetMetaDatabase();
     MetaCache = config.GetMetaCache();
     MetaDatabaseTokenName = config.GetMetaDatabaseTokenName();
     DbUserTokenSource = config.GetDbUserTokenAccess();
-    MetaSettings.MetaApiEndpoint = MetaApiEndpoint;
-    MetaSettings.MetaDatabase = MetaDatabase;
-    if (MetaSettings.MetaApiEndpoint.empty()) {
-        ythrow yexception() << NMVP::CONFIG_ERROR_PREFIX << "meta.meta_api_endpoint must be specified";
-    }
-    if (MetaSettings.MetaDatabase.empty()) {
-        ythrow yexception() << NMVP::CONFIG_ERROR_PREFIX << "meta.meta_database must be specified";
-    }
-
-    if (config.HasGrafana()) {
-        MetaSettings.GrafanaEndpoint = config.GetGrafana().GetEndpoint();
-        MetaSettings.GrafanaSecretName = config.GetGrafana().GetSecretName();
-    } else {
-        MetaSettings.GrafanaEndpoint.clear();
-        MetaSettings.GrafanaSecretName.clear();
-    }
-
-    if (config.HasSupportLinks()) {
-        const auto& supportLinks = config.GetSupportLinks();
-        MetaSettings.ClusterLinkSources.clear();
-        MetaSettings.ClusterLinkSources.reserve(supportLinks.GetCluster().size());
-        for (int i = 0; i < supportLinks.GetCluster().size(); ++i) {
-            MetaSettings.ClusterLinkSources.push_back(MakeLinkSource(supportLinks.GetCluster(i)));
-        }
-        MetaSettings.DatabaseLinkSources.clear();
-        MetaSettings.DatabaseLinkSources.reserve(supportLinks.GetDatabase().size());
-        for (int i = 0; i < supportLinks.GetDatabase().size(); ++i) {
-            MetaSettings.DatabaseLinkSources.push_back(MakeLinkSource(supportLinks.GetDatabase(i)));
-        }
-    }
+    MetaSettings = BuildMetaSettings(config, StartupOptions.AccessServiceType);
+    MetaApiEndpoint = MetaSettings.MetaApiEndpoint;
+    MetaDatabase = MetaSettings.MetaDatabase;
 }
 
 void TMVP::TryGetMetaOptionsFromConfig() {

--- a/ydb/mvp/meta/mvp.cpp
+++ b/ydb/mvp/meta/mvp.cpp
@@ -4,9 +4,6 @@
 #include <ydb/mvp/core/core_ydbc.h>
 #include <ydb/mvp/core/protos/mvp.pb.h>
 #include <ydb/mvp/core/utils.h>
-#include <ydb/mvp/meta/support_links/events.h>
-#include <ydb/mvp/meta/support_links/grafana_dashboard_source.h>
-#include <ydb/mvp/meta/support_links/source.h>
 
 #include <ydb/library/actors/core/executor_pool_basic.h>
 #include <ydb/library/actors/core/log.h>
@@ -17,127 +14,123 @@
 #include <ydb/library/actors/interconnect/poller/poller_actor.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 
-#include <google/protobuf/text_format.h>
 #include <library/cpp/deprecated/atomic/atomic.h>
-#include <library/cpp/json/json_reader.h>
-#include <library/cpp/string_utils/quote/quote.h>
 #include <yaml-cpp/yaml.h>
 
 #include <util/datetime/base.h>
 #include <util/generic/yexception.h>
 #include <util/stream/file.h>
-#include <util/string/cast.h>
 #include <util/system/hostname.h>
 #include <util/system/mlock.h>
 
 using namespace NMVP;
 
-NMVP::TMVP *NMVP::InstanceMVP;
+NMVP::TMVP* NMVP::InstanceMVP;
 
-const TString &NMVP::GetEServiceName(NActors::NLog::EComponent component) {
-  static const TString loggerName("LOGGER");
-  static const TString mvpName("MVP");
-  static const TString grpcName("GRPC");
-  static const TString queryName("QUERY");
-  static const TString unknownName("UNKNOW");
-  switch (component) {
-  case EService::Logger:
-    return loggerName;
-  case EService::MVP:
-    return mvpName;
-  case EService::GRPC:
-    return grpcName;
-  case EService::QUERY:
-    return queryName;
-  default:
-    return unknownName;
-  }
+const TString& NMVP::GetEServiceName(NActors::NLog::EComponent component) {
+    static const TString loggerName("LOGGER");
+    static const TString mvpName("MVP");
+    static const TString grpcName("GRPC");
+    static const TString queryName("QUERY");
+    static const TString unknownName("UNKNOW");
+    switch (component) {
+    case EService::Logger:
+        return loggerName;
+    case EService::MVP:
+        return mvpName;
+    case EService::GRPC:
+        return grpcName;
+    case EService::QUERY:
+        return queryName;
+    default:
+        return unknownName;
+    }
 }
 
 void TMVP::OnTerminate(int) { AtomicSet(Quit, true); }
 
 int TMVP::Init() {
-  ActorSystem.Start();
+    ActorSystem.Start();
 
-  ActorSystem.Register(NActors::CreateProcStatCollector(
-      TDuration::Seconds(5),
-      AppData.MetricRegistry =
-          std::make_shared<NMonitoring::TMetricRegistry>()));
+    ActorSystem.Register(NActors::CreateProcStatCollector(
+        TDuration::Seconds(5),
+        AppData.MetricRegistry =
+            std::make_shared<NMonitoring::TMetricRegistry>()));
 
-  HttpProxyId =
-      ActorSystem.Register(NHttp::CreateHttpProxy(AppData.MetricRegistry));
-  ActorSystem.Register(AppData.Tokenator = TMvpTokenator::CreateTokenator(
-                           TokensConfig, HttpProxyId));
+    HttpProxyId =
+        ActorSystem.Register(NHttp::CreateHttpProxy(AppData.MetricRegistry));
+    ActorSystem.Register(AppData.Tokenator = TMvpTokenator::CreateTokenator(
+                             TokensConfig, HttpProxyId));
 
-  if (StartupOptions.HttpPort) {
-    auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
-        StartupOptions.HttpPort,
-        TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpPort);
-    ev->CompressContentTypes = {
-        "text/plain",      "text/html",        "text/css",
-        "text/javascript", "application/json",
-    };
-    ActorSystem.Send(HttpProxyId, ev);
-  }
-  if (StartupOptions.HttpsPort) {
-    auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
-        StartupOptions.HttpsPort,
-        TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpsPort);
-    ev->Secure = true;
-    ev->SslCertificatePem = TYdbLocation::SslCertificate;
-    ev->CompressContentTypes = {
-        "text/plain",      "text/html",        "text/css",
-        "text/javascript", "application/json",
-    };
-    ActorSystem.Send(HttpProxyId, ev);
-  }
+    if (StartupOptions.HttpPort) {
+        auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
+            StartupOptions.HttpPort,
+            TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpPort);
+        ev->CompressContentTypes = {
+            "text/plain",      "text/html",        "text/css",
+            "text/javascript", "application/json",
+        };
+        ActorSystem.Send(HttpProxyId, ev);
+    }
+    if (StartupOptions.HttpsPort) {
+        auto ev = new NHttp::TEvHttpProxy::TEvAddListeningPort(
+            StartupOptions.HttpsPort,
+            TStringBuilder() << FQDNHostName() << ':' << StartupOptions.HttpsPort);
+        ev->Secure = true;
+        ev->SslCertificatePem = TYdbLocation::SslCertificate;
+        ev->CompressContentTypes = {
+            "text/plain",      "text/html",        "text/css",
+            "text/javascript", "application/json",
+        };
+        ActorSystem.Send(HttpProxyId, ev);
+    }
 
-  InitMeta();
+    InitMeta();
 
-  return 0;
+    return 0;
 }
 
 int TMVP::Run() {
-  try {
-    int res = Init();
-    if (res != 0) {
-      return res;
-    }
+    try {
+        int res = Init();
+        if (res != 0) {
+            return res;
+        }
 #ifndef NDEBUG
-    Cout << "Started" << Endl;
+        Cout << "Started" << Endl;
 #endif
-    while (!AtomicGet(Quit)) {
-      Sleep(TDuration::MilliSeconds(100));
-    }
+        while (!AtomicGet(Quit)) {
+            Sleep(TDuration::MilliSeconds(100));
+        }
 #ifndef NDEBUG
-    Cout << Endl << "Finished" << Endl;
+        Cout << Endl << "Finished" << Endl;
 #endif
-    Shutdown();
-  } catch (const yexception &e) {
-    Cerr << e.what() << Endl;
-    return 1;
-  }
-  return 0;
+        Shutdown();
+    } catch (const yexception& e) {
+        Cerr << e.what() << Endl;
+        return 1;
+    }
+    return 0;
 }
 
 int TMVP::Shutdown() {
-  ActorSystem.Stop();
-  AppData.GRpcClientLow->Stop(true);
-  ActorSystem.Cleanup();
-  return 0;
+    ActorSystem.Stop();
+    AppData.GRpcClientLow->Stop(true);
+    ActorSystem.Cleanup();
+    return 0;
 }
 
 TString
-TMVP::GetAppropriateEndpoint(const NHttp::THttpIncomingRequestPtr &req) {
-  const bool secure = req->Endpoint->Secure;
-  const ui16 port = secure ? StartupOptions.HttpsPort : StartupOptions.HttpPort;
+TMVP::GetAppropriateEndpoint(const NHttp::THttpIncomingRequestPtr& req) {
+    const bool secure = req->Endpoint->Secure;
+    const ui16 port = secure ? StartupOptions.HttpsPort : StartupOptions.HttpPort;
 
-  TStringBuilder b;
-  b << (secure ? "https://[::1]" : "http://[::1]");
-  if (port) {
-    b << ":" << port;
-  }
-  return b;
+    TStringBuilder b;
+    b << (secure ? "https://[::1]" : "http://[::1]");
+    if (port) {
+        b << ":" << port;
+    }
+    return b;
 }
 
 NMvp::TTokensConfig TMVP::TokensConfig;
@@ -145,122 +138,122 @@ TString TMVP::MetaDatabaseTokenName;
 
 bool TMVP::DbUserTokenSource = false;
 
-TMVP::TMVP(int argc, const char *argv[])
+TMVP::TMVP(int argc, const char* argv[])
     : StartupOptions(TMvpStartupOptions::Build(argc, argv)),
       LoggerSettings(BuildLoggerSettings()),
       ActorSystemSetup(BuildActorSystemSetup()),
       ActorSystem(ActorSystemSetup, &AppData, LoggerSettings) {
-  InstanceMVP = this;
+    InstanceMVP = this;
 }
 
 TIntrusivePtr<NActors::NLog::TSettings> TMVP::BuildLoggerSettings() {
-  const NActors::TActorId loggerActorId = NActors::TActorId(1, "logger");
-  TIntrusivePtr<NActors::NLog::TSettings> loggerSettings =
-      new NActors::NLog::TSettings(loggerActorId, EService::Logger,
-                                   NActors::NLog::PRI_WARN);
-  loggerSettings->Append(NActorsServices::EServiceCommon_MIN,
-                         NActorsServices::EServiceCommon_MAX,
-                         NActorsServices::EServiceCommon_Name);
-  loggerSettings->Append(EService::MIN, EService::MAX, GetEServiceName);
-  TString explanation;
-  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, NActorsServices::HTTP,
-                           explanation);
-  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::MVP,
-                           explanation);
-  loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::GRPC,
-                           explanation);
-  loggerSettings->SetLevel(NActors::NLog::PRI_INFO, EService::QUERY,
-                           explanation);
-  return loggerSettings;
+    const NActors::TActorId loggerActorId = NActors::TActorId(1, "logger");
+    TIntrusivePtr<NActors::NLog::TSettings> loggerSettings =
+        new NActors::NLog::TSettings(loggerActorId, EService::Logger,
+                                     NActors::NLog::PRI_WARN);
+    loggerSettings->Append(NActorsServices::EServiceCommon_MIN,
+                           NActorsServices::EServiceCommon_MAX,
+                           NActorsServices::EServiceCommon_Name);
+    loggerSettings->Append(EService::MIN, EService::MAX, GetEServiceName);
+    TString explanation;
+    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, NActorsServices::HTTP,
+                             explanation);
+    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::MVP,
+                             explanation);
+    loggerSettings->SetLevel(NActors::NLog::PRI_DEBUG, EService::GRPC,
+                             explanation);
+    loggerSettings->SetLevel(NActors::NLog::PRI_INFO, EService::QUERY,
+                             explanation);
+    return loggerSettings;
 }
 
 void TMVP::TryGetMetaOptionsFromConfig(
-    const NMvp::NMeta::TMetaAppConfig &appConfig) {
-  if (!appConfig.HasMeta()) {
-    ythrow yexception() << "Check that `meta` section exists and is on the "
-                           "same indentation as `generic` section";
-  }
+    const NMvp::NMeta::TMetaAppConfig& appConfig) {
+    if (!appConfig.HasMeta()) {
+        ythrow yexception() << "Check that `meta` section exists and is on the "
+                               "same indentation as `generic` section";
+    }
 
-  const auto &config = appConfig.GetMeta();
+    const auto& config = appConfig.GetMeta();
 
-  MetaCache = config.GetMetaCache();
-  MetaDatabaseTokenName = config.GetMetaDatabaseTokenName();
-  DbUserTokenSource = config.GetDbUserTokenAccess();
-  MetaSettings = BuildMetaSettings(config, StartupOptions.AccessServiceType);
-  MetaApiEndpoint = MetaSettings.MetaApiEndpoint;
-  MetaDatabase = MetaSettings.MetaDatabase;
+    MetaCache = config.GetMetaCache();
+    MetaDatabaseTokenName = config.GetMetaDatabaseTokenName();
+    DbUserTokenSource = config.GetDbUserTokenAccess();
+    MetaSettings = BuildMetaSettings(config, StartupOptions.AccessServiceType);
+    MetaApiEndpoint = MetaSettings.MetaApiEndpoint;
+    MetaDatabase = MetaSettings.MetaDatabase;
 }
 
 void TMVP::TryGetMetaOptionsFromConfig() {
-  if (StartupOptions.GetYamlConfigPath().empty()) {
-    return;
-  }
-  try {
-    YAML::Node config = YAML::LoadFile(StartupOptions.GetYamlConfigPath());
-    NMvp::NMeta::TMetaAppConfig appConfig;
-    MergeYamlNodeToProto(config, appConfig);
-    TryGetMetaOptionsFromConfig(appConfig);
-  } catch (const YAML::Exception &e) {
-    ythrow yexception() << "Error parsing YAML configuration file: "
-                        << e.what();
-  }
+    if (StartupOptions.GetYamlConfigPath().empty()) {
+        return;
+    }
+    try {
+        YAML::Node config = YAML::LoadFile(StartupOptions.GetYamlConfigPath());
+        NMvp::NMeta::TMetaAppConfig appConfig;
+        MergeYamlNodeToProto(config, appConfig);
+        TryGetMetaOptionsFromConfig(appConfig);
+    } catch (const YAML::Exception& e) {
+        ythrow yexception() << "Error parsing YAML configuration file: "
+                            << e.what();
+    }
 }
 
 THolder<NActors::TActorSystemSetup> TMVP::BuildActorSystemSetup() {
-  TString defaultMetaDatabase = "/Root";
-  TString defaultMetaApiEndpoint = "grpc://meta.ydb.yandex.net:2135";
+    TString defaultMetaDatabase = "/Root";
+    TString defaultMetaApiEndpoint = "grpc://meta.ydb.yandex.net:2135";
 
-  TryGetMetaOptionsFromConfig();
+    TryGetMetaOptionsFromConfig();
 
-  if (MetaApiEndpoint.empty()) {
-    MetaApiEndpoint = defaultMetaApiEndpoint;
-  }
+    if (MetaApiEndpoint.empty()) {
+        MetaApiEndpoint = defaultMetaApiEndpoint;
+    }
 
-  if (MetaDatabase.empty()) {
-    MetaDatabase = defaultMetaDatabase;
-  }
+    if (MetaDatabase.empty()) {
+        MetaDatabase = defaultMetaDatabase;
+    }
 
-  MetaSettings.AccessServiceType = StartupOptions.AccessServiceType;
+    MetaSettings.AccessServiceType = StartupOptions.AccessServiceType;
 
-  if (StartupOptions.Mlock) {
-    LockAllMemory(LockCurrentMemory);
-  }
+    if (StartupOptions.Mlock) {
+        LockAllMemory(LockCurrentMemory);
+    }
 
-  TYdbLocation::UserToken = StartupOptions.UserToken;
-  TYdbLocation::CaCertificate = StartupOptions.CaCertificate;
-  TYdbLocation::SslCertificate = StartupOptions.SslCertificate;
+    TYdbLocation::UserToken = StartupOptions.UserToken;
+    TYdbLocation::CaCertificate = StartupOptions.CaCertificate;
+    TYdbLocation::SslCertificate = StartupOptions.SslCertificate;
 
-  TokensConfig = StartupOptions.Tokens;
+    TokensConfig = StartupOptions.Tokens;
 
-  NActors::TLoggerActor *loggerActor = new NActors::TLoggerActor(
-      LoggerSettings,
-      StartupOptions.LogToStderr
-          ? NActors::CreateStderrBackend()
-          : NActors::CreateSysLogBackend("mvp", false, true),
-      new NMonitoring::TDynamicCounters());
-  THolder<NActors::TActorSystemSetup> setup =
-      MakeHolder<NActors::TActorSystemSetup>();
-  setup->NodeId = 1;
-  setup->Executors.Reset(new TAutoPtr<NActors::IExecutorPool>[3]);
-  setup->ExecutorsCount = 3;
-  setup->Executors[0] = new NActors::TBasicExecutorPool(0, 4, 10);
-  // For UI v2 Logbroker RPCs. We use separate thread pools for RPCs so CPU
-  // heavy and slow requests don't interfere with requests that communicate with
-  // Logbroker Configuration manager only and suppose to work fast
-  setup->Executors[1] = new NActors::TBasicExecutorPool(1, 4, 10);
-  // For JSON Merger used by  UI v2 dynamic Logbroker RPCs
-  setup->Executors[2] = new NActors::TBasicExecutorPool(2, 4, 10);
+    NActors::TLoggerActor* loggerActor = new NActors::TLoggerActor(
+        LoggerSettings,
+        StartupOptions.LogToStderr
+            ? NActors::CreateStderrBackend()
+            : NActors::CreateSysLogBackend("mvp", false, true),
+        new NMonitoring::TDynamicCounters());
+    THolder<NActors::TActorSystemSetup> setup =
+        MakeHolder<NActors::TActorSystemSetup>();
+    setup->NodeId = 1;
+    setup->Executors.Reset(new TAutoPtr<NActors::IExecutorPool>[3]);
+    setup->ExecutorsCount = 3;
+    setup->Executors[0] = new NActors::TBasicExecutorPool(0, 4, 10);
+    // For UI v2 Logbroker RPCs. We use separate thread pools for RPCs so CPU
+    // heavy and slow requests don't interfere with requests that communicate with
+    // Logbroker Configuration manager only and suppose to work fast
+    setup->Executors[1] = new NActors::TBasicExecutorPool(1, 4, 10);
+    // For JSON Merger used by  UI v2 dynamic Logbroker RPCs
+    setup->Executors[2] = new NActors::TBasicExecutorPool(2, 4, 10);
 
-  setup->Scheduler =
-      new NActors::TBasicSchedulerThread(NActors::TSchedulerConfig(512, 100));
-  setup->LocalServices.emplace_back(
-      LoggerSettings->LoggerActorId,
-      NActors::TActorSetupCmd(loggerActor, NActors::TMailboxType::HTSwap, 0));
-  setup->LocalServices.emplace_back(
-      NActors::MakePollerActorId(),
-      NActors::TActorSetupCmd(NActors::CreatePollerActor(),
-                              NActors::TMailboxType::HTSwap, 0));
-  return setup;
+    setup->Scheduler =
+        new NActors::TBasicSchedulerThread(NActors::TSchedulerConfig(512, 100));
+    setup->LocalServices.emplace_back(
+        LoggerSettings->LoggerActorId,
+        NActors::TActorSetupCmd(loggerActor, NActors::TMailboxType::HTSwap, 0));
+    setup->LocalServices.emplace_back(
+        NActors::MakePollerActorId(),
+        NActors::TActorSetupCmd(NActors::CreatePollerActor(),
+                                NActors::TMailboxType::HTSwap, 0));
+    return setup;
 }
 
 TAtomic TMVP::Quit = false;

--- a/ydb/mvp/meta/mvp.h
+++ b/ydb/mvp/meta/mvp.h
@@ -47,10 +47,8 @@ public:
     void InitMeta();
 
     TString static GetMetaDatabaseAuthToken(const TRequest& request);
-    NYdb::NTable::TClientSettings static GetMetaDatabaseClientSettings(
-        const TRequest& request,
-        const TYdbLocation& location,
-        TStringBuf databaseParameterName = {});
+    NYdb::NTable::TClientSettings static GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location);
+    NYdb::NTable::TClientSettings static GetStrictMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location);
 
     void TryGetMetaOptionsFromConfig();
     void TryGetMetaOptionsFromConfig(const NMvp::NMeta::TMetaAppConfig& appConfig);

--- a/ydb/mvp/meta/mvp.h
+++ b/ydb/mvp/meta/mvp.h
@@ -47,19 +47,22 @@ public:
     void InitMeta();
 
     TString static GetMetaDatabaseAuthToken(const TRequest& request);
-    NYdb::NTable::TClientSettings static GetMetaDatabaseClientSettings(const TRequest& request, const TYdbLocation& location);
+    NYdb::NTable::TClientSettings static GetMetaDatabaseClientSettings(
+        const TRequest& request,
+        const TYdbLocation& location,
+        TStringBuf databaseParameterName = {});
 
     void TryGetMetaOptionsFromConfig();
     void TryGetMetaOptionsFromConfig(const NMvp::NMeta::TMetaAppConfig& appConfig);
 
     TMVPAppData AppData;
     const TMvpStartupOptions StartupOptions;
+    TMetaSettings MetaSettings;
     TIntrusivePtr<NActors::NLog::TSettings> LoggerSettings;
     THolder<NActors::TActorSystemSetup> ActorSystemSetup;
     NActors::TActorSystem ActorSystem;
     NActors::TActorId HttpProxyId;
     NActors::TActorId HandlerId;
-    TMetaSettings MetaSettings;
 
     static NMvp::TTokensConfig TokensConfig;
 };

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -8,8 +8,6 @@ message TMetaConfig {
     message TGrafanaConfig {
         // Grafana base URL used to resolve relative Grafana links.
         optional string Endpoint = 1;
-        // Name of secret in auth token config with Grafana API token.
-        optional string SecretName = 2;
     }
 
     message TSupportLinksConfig {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_common.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_common.h
@@ -3,7 +3,32 @@
 #include "source_common.h"
 #include "types.h"
 
+#include <library/cpp/cgiparam/cgiparam.h>
+
 namespace NMVP::NSupportLinks {
+
+inline void ApplyGrafanaDashboardBindingPolicy(
+    TCgiParameters& queryParameters,
+    const THashMap<TString, TString>& clusterInfo,
+    const NHttp::TUrlParameters& requestUrlParameters)
+{
+    static constexpr TStringBuf WorkspaceKey = "k8s_namespace";
+    static constexpr TStringBuf DatasourceKey = "datasource";
+
+    const auto workspaceIt = clusterInfo.find(WorkspaceKey);
+    if (workspaceIt != clusterInfo.end() && !workspaceIt->second.empty()) {
+        queryParameters.InsertUnescaped("var-workspace", workspaceIt->second);
+    }
+
+    const auto datasourceIt = clusterInfo.find(DatasourceKey);
+    if (datasourceIt != clusterInfo.end() && !datasourceIt->second.empty()) {
+        queryParameters.InsertUnescaped("var-ds", datasourceIt->second);
+    }
+
+    for (const auto& parameter : requestUrlParameters.Parameters) {
+        queryParameters.InsertUnescaped(TStringBuilder() << "var-" << parameter.first, requestUrlParameters[parameter.first]);
+    }
+}
 
 inline TString BuildGrafanaDashboardUrl(
     TStringBuf grafanaEndpoint,
@@ -11,26 +36,21 @@ inline TString BuildGrafanaDashboardUrl(
     const THashMap<TString, TString>& clusterInfo,
     const NHttp::TUrlParameters& requestUrlParameters)
 {
-    static constexpr TStringBuf WorkspaceKey = "k8s_namespace";
-    static constexpr TStringBuf DatasourceKey = "datasource";
-
     TString resolvedUrl = IsAbsoluteUrl(url)
         ? TString(url)
         : JoinUrl(grafanaEndpoint, url);
-    const auto workspaceIt = clusterInfo.find(WorkspaceKey);
-    if (workspaceIt != clusterInfo.end() && !workspaceIt->second.empty()) {
-        resolvedUrl = AppendQueryParam(resolvedUrl, "var-workspace", workspaceIt->second);
-    }
+    const TStringBuf path = TStringBuf(resolvedUrl).Before('?');
+    const TStringBuf queryString = TStringBuf(resolvedUrl).After('?');
 
-    const auto datasourceIt = clusterInfo.find(DatasourceKey);
-    if (datasourceIt != clusterInfo.end() && !datasourceIt->second.empty()) {
-        resolvedUrl = AppendQueryParam(resolvedUrl, "var-ds", datasourceIt->second);
+    TCgiParameters queryParameters;
+    if (!queryString.empty()) {
+        queryParameters.Scan(queryString);
     }
+    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestUrlParameters);
 
-    for (const auto& [name, _] : requestUrlParameters.Parameters) {
-        resolvedUrl = AppendQueryParam(resolvedUrl, TStringBuilder() << "var-" << name, requestUrlParameters[name]);
-    }
-    return resolvedUrl;
+    return queryParameters.empty()
+        ? TString(path)
+        : TStringBuilder() << path << '?' << queryParameters.Print();
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_common.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_common.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "source_common.h"
+#include "types.h"
+
+namespace NMVP::NSupportLinks {
+
+inline TString BuildGrafanaDashboardUrl(
+    TStringBuf grafanaEndpoint,
+    TStringBuf url,
+    const THashMap<TString, TString>& clusterInfo,
+    const NHttp::TUrlParameters& requestUrlParameters)
+{
+    static constexpr TStringBuf WorkspaceKey = "k8s_namespace";
+    static constexpr TStringBuf DatasourceKey = "datasource";
+
+    TString resolvedUrl = IsAbsoluteUrl(url)
+        ? TString(url)
+        : JoinUrl(grafanaEndpoint, url);
+    const auto workspaceIt = clusterInfo.find(WorkspaceKey);
+    if (workspaceIt != clusterInfo.end() && !workspaceIt->second.empty()) {
+        resolvedUrl = AppendQueryParam(resolvedUrl, "var-workspace", workspaceIt->second);
+    }
+
+    const auto datasourceIt = clusterInfo.find(DatasourceKey);
+    if (datasourceIt != clusterInfo.end() && !datasourceIt->second.empty()) {
+        resolvedUrl = AppendQueryParam(resolvedUrl, "var-ds", datasourceIt->second);
+    }
+
+    for (const auto& [name, _] : requestUrlParameters.Parameters) {
+        resolvedUrl = AppendQueryParam(resolvedUrl, TStringBuilder() << "var-" << name, requestUrlParameters[name]);
+    }
+    return resolvedUrl;
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source.h
@@ -48,8 +48,7 @@ inline void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& 
     }
 }
 
-inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings)
-{
+inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
     ValidateGrafanaDashboardSourceConfig(config, metaSettings);
     return std::make_shared<TGrafanaDashboardSource>(
         config.GetSource(),

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "source_common.h"
+#include "grafana_dashboard_common.h"
+
+#include <ydb/mvp/meta/support_links/source.h>
+
+#include <util/generic/yexception.h>
+
+namespace NMVP {
+
+class TGrafanaDashboardSource : public ILinkSource {
+public:
+    TGrafanaDashboardSource(TString sourceName, TString title, TString url, TString grafanaEndpoint)
+        : SourceName(std::move(sourceName))
+        , Title(std::move(title))
+        , Url(std::move(url))
+        , GrafanaEndpoint(std::move(grafanaEndpoint))
+    {}
+
+    TResolveOutput Resolve(const TLinkResolveInput& input, const TResolveContext&) const override {
+        TString resolvedUrl = NSupportLinks::BuildGrafanaDashboardUrl(GrafanaEndpoint, Url, input.ClusterInfo, input.UrlParameters);
+        TResolveOutput result{
+            .Name = SourceName,
+        };
+        if (!resolvedUrl.empty()) {
+            result.Links.emplace_back(NSupportLinks::TResolvedLink{
+                .Title = Title,
+                .Url = std::move(resolvedUrl),
+            });
+        }
+        return result;
+    }
+
+private:
+    TString SourceName;
+    TString Title;
+    TString Url;
+    TString GrafanaEndpoint;
+};
+
+inline void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
+    if (config.GetUrl().empty()) {
+        ythrow yexception() << "url is required for source=" << config.GetSource();
+    }
+    if (!NSupportLinks::IsAbsoluteUrl(config.GetUrl()) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
+        ythrow yexception() << "grafana.endpoint is required for relative url";
+    }
+}
+
+inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings)
+{
+    ValidateGrafanaDashboardSourceConfig(config, metaSettings);
+    return std::make_shared<TGrafanaDashboardSource>(
+        config.GetSource(),
+        config.GetTitle(),
+        config.GetUrl(),
+        metaSettings.SupportLinks.GrafanaEndpoint
+    );
+}
+
+} // namespace NMVP

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
@@ -106,6 +106,7 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSource) {
         context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=root_test");
         auto result = context.Resolve();
 
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(result.Links[0].Title, "CPU");
         AssertSingleResolvedLink(
             result,

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
@@ -1,4 +1,5 @@
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/cgiparam/cgiparam.h>
 
 #include <ydb/library/actors/http/http.h>
 #include <ydb/mvp/meta/support_links/grafana_dashboard_source.h>
@@ -33,7 +34,15 @@ NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
 
 void AssertSingleResolvedLink(const NMVP::TResolveOutput& result, TStringBuf expectedUrl) {
     UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1);
-    UNIT_ASSERT_VALUES_EQUAL(result.Links[0].Url, expectedUrl);
+    const TStringBuf actualUrl = result.Links[0].Url;
+    UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedUrl.Before('?'));
+
+    TCgiParameters actualQuery;
+    TCgiParameters expectedQuery;
+    actualQuery.Scan(actualUrl.After('?'));
+    expectedQuery.Scan(expectedUrl.After('?'));
+
+    UNIT_ASSERT_VALUES_EQUAL(actualQuery.Print(), expectedQuery.Print());
     UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0);
 }
 

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
@@ -1,0 +1,227 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/library/actors/http/http.h>
+#include <ydb/mvp/meta/support_links/grafana_dashboard_source.h>
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+namespace {
+
+NMVP::TMetaSettings MakeMetaSettings(TStringBuf grafanaEndpoint) {
+    NMVP::TMetaSettings settings;
+    settings.SupportLinks.GrafanaEndpoint = TString(grafanaEndpoint);
+    return settings;
+}
+
+NMVP::TSupportLinkEntryConfig ParseGrafanaDashboardConfig(TStringBuf url) {
+    NMVP::TSupportLinkEntryConfig config;
+    config.SetSource("grafana/dashboard");
+    config.SetTitle("CPU");
+    config.SetUrl(TString(url));
+    return config;
+}
+
+NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
+    NHttp::TUrlParametersBuilder builder;
+    for (TStringBuf param = query.NextTok('&'); !param.empty(); param = query.NextTok('&')) {
+        TStringBuf name = param.NextTok('=');
+        builder.Set(name, param);
+    }
+    return builder;
+}
+
+void AssertSingleResolvedLink(const NMVP::TResolveOutput& result, TStringBuf expectedUrl) {
+    UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(result.Links[0].Url, expectedUrl);
+    UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0);
+}
+
+struct TGrafanaDashboardTestContext {
+    NMVP::TSupportLinkEntryConfig Config;
+    NMVP::TMetaSettings Settings;
+    THashMap<TString, TString> ClusterInfo;
+    NHttp::TUrlParametersBuilder UrlParameters;
+    NMVP::ILinkSource::TLinkResolveInput Input;
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+    NMVP::ILinkSource::TResolveContext Context;
+
+    explicit TGrafanaDashboardTestContext(TStringBuf url = "/d/cpu")
+        : Config(ParseGrafanaDashboardConfig(url))
+        , Settings(MakeMetaSettings("https://grafana.example.net"))
+        , UrlParameters("")
+        , Input{
+            .ClusterInfo = ClusterInfo,
+            .UrlParameters = UrlParameters,
+        }
+        , Owner(1, "ow")
+        , HttpProxyId(2, "hp")
+        , Context{
+            .Place = 0,
+            .Owner = Owner,
+            .HttpProxyId = HttpProxyId,
+        }
+    {}
+
+    std::shared_ptr<NMVP::ILinkSource> CreateSource() const {
+        return NMVP::MakeGrafanaDashboardSource(Config, Settings);
+    }
+
+    void SetDefaultClusterInfo() {
+        ClusterInfo["k8s_namespace"] = "ydb-workspace";
+        ClusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+    }
+
+    NMVP::TResolveOutput Resolve() const {
+        return CreateSource()->Resolve(Input, Context);
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSource) {
+    Y_UNIT_TEST(ValidationRejectsEmptyUrl) {
+        TGrafanaDashboardTestContext context("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "url is required for source=grafana/dashboard"
+        );
+    }
+
+    Y_UNIT_TEST(ValidationRejectsRelativeUrlWithoutGrafanaEndpoint) {
+        TGrafanaDashboardTestContext context;
+        context.Settings = MakeMetaSettings("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "grafana.endpoint is required for relative url"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveBuildsFullUrl) {
+        TGrafanaDashboardTestContext context;
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=root_test");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links[0].Title, "CPU");
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global&var-database=root_test"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveSkipsMissingDatasource) {
+        TGrafanaDashboardTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-workspace";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=%2Froot%2Ftest");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-cluster=ydb-global&var-database=/root/test"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveSkipsEmptyDatasource) {
+        TGrafanaDashboardTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-workspace";
+        context.ClusterInfo["datasource"] = "";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=%2Froot%2Ftest");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-cluster=ydb-global&var-database=/root/test"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveSkipsMissingWorkspace) {
+        TGrafanaDashboardTestContext context;
+        context.ClusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesAbsoluteUrlWithoutGrafanaEndpoint) {
+        TGrafanaDashboardTestContext context("https://external.example.net/d/cpu");
+        context.Settings = MakeMetaSettings("");
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://external.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesAbsoluteUrlWithGrafanaEndpoint) {
+        TGrafanaDashboardTestContext context("https://external.example.net/d/cpu");
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://external.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveJoinsRelativeUrlWithTrailingSlashInGrafanaEndpoint) {
+        TGrafanaDashboardTestContext context("/d/cpu");
+        context.Settings = MakeMetaSettings("https://grafana.example.net/");
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveJoinsRelativeUrlWithoutLeadingSlash) {
+        TGrafanaDashboardTestContext context("d/cpu");
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveJoinsRelativeUrlWithoutLeadingSlashWithTrailingSlashInGrafanaEndpoint) {
+        TGrafanaDashboardTestContext context("d/cpu");
+        context.Settings = MakeMetaSettings("https://grafana.example.net/");
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveEncodesQueryParameters) {
+        TGrafanaDashboardTestContext context;
+        context.SetDefaultClusterInfo();
+        context.UrlParameters = MakeUrlParameters("database=root%26x%3Dy");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=root%26x%3Dy"
+        );
+    }
+}

--- a/ydb/mvp/meta/support_links/response.cpp
+++ b/ydb/mvp/meta/support_links/response.cpp
@@ -1,0 +1,64 @@
+#include "response.h"
+
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+
+namespace NMVP::NSupportLinks {
+
+namespace {
+
+void AppendErrorJson(NJson::TJsonValue& errorsJson, const TSupportError& error) {
+    NJson::TJsonValue& item = errorsJson.AppendValue(NJson::TJsonValue());
+    item["source"] = error.Source;
+    if (error.Status) {
+        item["status"] = *error.Status;
+    }
+    if (!error.Reason.empty()) {
+        item["reason"] = error.Reason;
+    }
+    if (!error.Message.empty()) {
+        item["message"] = error.Message;
+    }
+}
+
+void AppendSourceOutputJson(NJson::TJsonValue& linksJson, NJson::TJsonValue& errorsJson, const TResolveOutput& sourceOutput) {
+    for (const auto& link : sourceOutput.Links) {
+        NJson::TJsonValue& linkItem = linksJson.AppendValue(NJson::TJsonValue());
+        if (!link.Title.empty()) {
+            linkItem["title"] = link.Title;
+        }
+        linkItem["url"] = link.Url;
+    }
+    for (const auto& error : sourceOutput.Errors) {
+        AppendErrorJson(errorsJson, error);
+    }
+}
+
+} // namespace
+
+TString BuildResponseBody(const TVector<TResolveOutput>* sourceOutputs, const TVector<TSupportError>& pendingErrors) {
+    NJson::TJsonValue root;
+    NJson::TJsonValue& linksJson = root["links"];
+    linksJson.SetType(NJson::JSON_ARRAY);
+
+    NJson::TJsonValue errorsJson;
+    errorsJson.SetType(NJson::JSON_ARRAY);
+
+    if (sourceOutputs) {
+        for (const auto& sourceOutput : *sourceOutputs) {
+            AppendSourceOutputJson(linksJson, errorsJson, sourceOutput);
+        }
+    }
+
+    for (const auto& error : pendingErrors) {
+        AppendErrorJson(errorsJson, error);
+    }
+
+    if (!errorsJson.GetArray().empty()) {
+        root["errors"] = std::move(errorsJson);
+    }
+
+    return NJson::WriteJson(root, false);
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/response.h
+++ b/ydb/mvp/meta/support_links/response.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "types.h"
+
+namespace NMVP::NSupportLinks {
+
+TString BuildResponseBody(const TVector<TResolveOutput>* sourceOutputs, const TVector<TSupportError>& pendingErrors);
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/source.cpp
+++ b/ydb/mvp/meta/support_links/source.cpp
@@ -1,82 +1,40 @@
 #include "source.h"
+#include "grafana_dashboard_source.h"
 
 #include <util/generic/yexception.h>
-#include <mutex>
 
 namespace NMVP {
 
-namespace {
-
-THashMap<TString, TLinkSourceFactory>& LinkSourceFactories() {
-    static THashMap<TString, TLinkSourceFactory> factories;
-    return factories;
+void ValidateSupportLinksConfig(const TSupportLinksConfig& supportLinks, const TMetaSettings& metaSettings) {
+    for (int i = 0; i < supportLinks.GetCluster().size(); ++i) {
+        ValidateLinkSourceConfig(supportLinks.GetCluster(i), metaSettings);
+    }
+    for (int i = 0; i < supportLinks.GetDatabase().size(); ++i) {
+        ValidateLinkSourceConfig(supportLinks.GetDatabase(i), metaSettings);
+    }
 }
 
-std::mutex& LinkSourceFactoriesMutex() {
-    static std::mutex mutex;
-    return mutex;
-}
-
-} // namespace
-
-class TUnsupportedLinkSource final : public ILinkSource {
-public:
-    explicit TUnsupportedLinkSource(TSupportLinkEntryConfig config)
-        : SourceConfig(std::move(config))
-    {}
-
-    const TSupportLinkEntryConfig& Config() const override {
-        return SourceConfig;
-    }
-
-    TResolveOutput Resolve(const TResolveInput&) const override {
-        TResolveOutput output;
-        output.Name = SourceConfig.GetSource();
-        output.Ready = true;
-        output.Errors.emplace_back(NSupportLinks::TSupportError{
-            .Source = SourceConfig.GetSource(),
-            .Message = TStringBuilder() << "unsupported support_links source: " << SourceConfig.GetSource(),
-        });
-        return output;
-    }
-
-private:
-    TSupportLinkEntryConfig SourceConfig;
-};
-
-void RegisterLinkSource(TString source, TLinkSourceFactory factory) {
-    if (source.empty()) {
-        ythrow yexception() << "support_links source name is required";
-    }
-    if (!factory) {
-        ythrow yexception() << "support_links source factory is required for " << source;
-    }
-
-    std::lock_guard guard(LinkSourceFactoriesMutex());
-    auto& factories = LinkSourceFactories();
-    if (factories.contains(source)) {
-        ythrow yexception() << "support_links source factory is already registered for " << source;
-    }
-    factories.emplace(std::move(source), factory);
-}
-
-std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config) {
+void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
     if (config.GetSource().empty()) {
         ythrow yexception() << "source is required";
     }
 
-    TLinkSourceFactory factory = nullptr;
-    {
-        std::lock_guard guard(LinkSourceFactoriesMutex());
-        if (const auto it = LinkSourceFactories().find(config.GetSource()); it != LinkSourceFactories().end()) {
-            factory = it->second;
-        }
-    }
-    if (factory) {
-        return factory(std::move(config));
+    if (config.GetSource() == "grafana/dashboard") {
+        ValidateGrafanaDashboardSourceConfig(config, metaSettings);
+        return;
     }
 
-    return std::make_shared<TUnsupportedLinkSource>(std::move(config));
+    ythrow yexception() << "unsupported support_links source: " << config.GetSource();
+}
+
+std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
+    ValidateLinkSourceConfig(config, metaSettings);
+
+    if (config.GetSource() == "grafana/dashboard") {
+        return MakeGrafanaDashboardSource(std::move(config), metaSettings);
+    }
+
+    ythrow yexception() << "unsupported support_links source: " << config.GetSource();
 }
 
 } // namespace NMVP

--- a/ydb/mvp/meta/support_links/source.h
+++ b/ydb/mvp/meta/support_links/source.h
@@ -13,22 +13,25 @@ namespace NMVP {
 
 class ILinkSource {
 public:
-    struct TResolveInput {
-        size_t Place = 0;
-        const THashMap<TString, TString>& ClusterColumns;
+    struct TLinkResolveInput {
+        const THashMap<TString, TString>& ClusterInfo;
         const NHttp::TUrlParameters& UrlParameters;
-        const NActors::TActorId& Parent;
+    };
+
+    struct TResolveContext {
+        size_t Place = 0;
+        const NActors::TActorId& Owner;
         const NActors::TActorId& HttpProxyId;
     };
 
     virtual ~ILinkSource() = default;
-    virtual const TSupportLinkEntryConfig& Config() const = 0;
-    virtual TResolveOutput Resolve(const TResolveInput& input) const = 0;
+    virtual TResolveOutput Resolve(const TLinkResolveInput& input, const TResolveContext& context) const = 0;
 };
 
-using TLinkSourceFactory = std::shared_ptr<ILinkSource> (*)(TSupportLinkEntryConfig);
+using TLinkSourceFactory = std::shared_ptr<ILinkSource> (*)(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings);
 
-void RegisterLinkSource(TString source, TLinkSourceFactory factory);
-std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config);
+void ValidateSupportLinksConfig(const TSupportLinksConfig& supportLinks, const TMetaSettings& metaSettings);
+void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings);
+std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings);
 
 } // namespace NMVP

--- a/ydb/mvp/meta/support_links/source_common.h
+++ b/ydb/mvp/meta/support_links/source_common.h
@@ -1,13 +1,7 @@
 #pragma once
 
-#include <ydb/mvp/meta/meta_settings.h>
-
-#include <ydb/library/actors/core/actorid.h>
-#include <ydb/library/actors/http/http.h>
-
 #include <library/cpp/string_utils/quote/quote.h>
 
-#include <util/generic/hash.h>
 #include <util/string/builder.h>
 
 namespace NMVP::NSupportLinks {

--- a/ydb/mvp/meta/support_links/source_common.h
+++ b/ydb/mvp/meta/support_links/source_common.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ydb/mvp/meta/meta_settings.h>
+
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/http/http.h>
+
+#include <library/cpp/string_utils/quote/quote.h>
+
+#include <util/generic/hash.h>
+#include <util/string/builder.h>
+
+namespace NMVP::NSupportLinks {
+
+inline constexpr TStringBuf SOURCE_META = "meta";
+
+struct TLinkResolveContext {
+    size_t Place = 0;
+    TString SourceName;
+    TSupportLinkEntryConfig LinkConfig;
+    THashMap<TString, TString> ClusterColumns;
+    NHttp::TUrlParameters UrlParameters = NHttp::TUrlParameters("");
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+};
+
+inline bool IsAbsoluteUrl(TStringBuf url) {
+    return url.StartsWith("http://") || url.StartsWith("https://");
+}
+
+inline TString JoinUrl(TStringBuf endpoint, TStringBuf path) {
+    const bool endpointHasSlash = endpoint.EndsWith('/');
+    const bool pathHasSlash = path.StartsWith('/');
+    if (endpointHasSlash && pathHasSlash) {
+        return TString(endpoint.SubStr(0, endpoint.size() - 1)) + TString(path);
+    }
+    if (!endpointHasSlash && !pathHasSlash) {
+        return TString(endpoint) + "/" + TString(path);
+    }
+    return TString(endpoint) + TString(path);
+}
+
+inline TString AppendQueryParam(const TString& url, TStringBuf key, TStringBuf value) {
+    TStringBuilder result;
+    result << url << (url.Contains('?') ? '&' : '?') << key << "=" << CGIEscapeRet(value);
+    return result;
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/source_common.h
+++ b/ydb/mvp/meta/support_links/source_common.h
@@ -14,16 +14,6 @@ namespace NMVP::NSupportLinks {
 
 inline constexpr TStringBuf SOURCE_META = "meta";
 
-struct TLinkResolveContext {
-    size_t Place = 0;
-    TString SourceName;
-    TSupportLinkEntryConfig LinkConfig;
-    THashMap<TString, TString> ClusterColumns;
-    NHttp::TUrlParameters UrlParameters = NHttp::TUrlParameters("");
-    NActors::TActorId Owner;
-    NActors::TActorId HttpProxyId;
-};
-
 inline bool IsAbsoluteUrl(TStringBuf url) {
     return url.StartsWith("http://") || url.StartsWith("https://");
 }

--- a/ydb/mvp/meta/support_links/support_links_resolver.cpp
+++ b/ydb/mvp/meta/support_links/support_links_resolver.cpp
@@ -1,5 +1,4 @@
 #include "support_links_resolver.h"
-#include <ydb/mvp/meta/support_links/source.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/events.h>

--- a/ydb/mvp/meta/support_links/support_links_resolver.cpp
+++ b/ydb/mvp/meta/support_links/support_links_resolver.cpp
@@ -15,9 +15,14 @@ TVector<std::shared_ptr<ILinkSource>> BuildSources(const TSupportLinksResolver::
     if (!params.Settings) {
         ythrow yexception() << "support links settings are required";
     }
-    const auto& linkSources = params.EntityType == TSupportLinksResolver::EEntityType::Database
-        ? params.Settings->DatabaseLinkSources
-        : params.Settings->ClusterLinkSources;
+    const auto& linkConfigs = params.EntityType == TSupportLinksResolver::EEntityType::Database
+        ? params.Settings->SupportLinks.DatabaseLinks
+        : params.Settings->SupportLinks.ClusterLinks;
+    TVector<std::shared_ptr<ILinkSource>> linkSources;
+    linkSources.reserve(linkConfigs.size());
+    for (const auto& linkConfig : linkConfigs) {
+        linkSources.push_back(params.LinkSourceFactory(linkConfig, *params.Settings));
+    }
     return linkSources;
 }
 
@@ -25,73 +30,93 @@ TVector<std::shared_ptr<ILinkSource>> BuildSources(const TSupportLinksResolver::
 
 TSupportLinksResolver::TSupportLinksResolver(TParams params)
     : Sources(BuildSources(params))
-    , ClusterColumns(std::move(params.ClusterColumns))
+    , ClusterInfo(std::move(params.ClusterInfo))
     , UrlParameters(std::move(params.UrlParameters))
-    , Parent(std::move(params.Parent))
+    , Owner(std::move(params.Owner))
     , HttpProxyId(std::move(params.HttpProxyId))
 {}
 
-auto TSupportLinksResolver::MakeResolveInput(size_t place) const {
-    return ILinkSource::TResolveInput{
-        .Place = place,
-        .ClusterColumns = ClusterColumns,
+ILinkSource::TLinkResolveInput TSupportLinksResolver::MakeResolveInput() const {
+    return ILinkSource::TLinkResolveInput{
+        .ClusterInfo = ClusterInfo,
         .UrlParameters = UrlParameters,
-        .Parent = Parent,
+    };
+}
+
+ILinkSource::TResolveContext TSupportLinksResolver::MakeResolveContext(size_t place) const {
+    return ILinkSource::TResolveContext{
+        .Place = place,
+        .Owner = Owner,
         .HttpProxyId = HttpProxyId,
     };
 }
 
-void TSupportLinksResolver::Start() {
+void TSupportLinksResolver::ResetState() {
     SourceOutputs.clear();
     SourceOutputs.resize(Sources.size());
     SourceActors.clear();
     SourceActors.resize(Sources.size());
+}
+
+TResolveOutput TSupportLinksResolver::ResolveSource(size_t place) const {
+    return Sources[place]->Resolve(MakeResolveInput(), MakeResolveContext(place));
+}
+
+void TSupportLinksResolver::SaveSourceOutput(size_t place, TResolveOutput sourceOutput) {
+    SourceActors[place] = sourceOutput.Actor;
+    SourceOutputs[place] = std::move(sourceOutput);
+}
+
+void TSupportLinksResolver::ApplySourceResponse(size_t place, const NSupportLinks::TEvPrivate::TEvSourceResponse& response) {
+    TResolveOutput& slot = SourceOutputs[place];
+    slot.Links = response.Links;
+    slot.Errors.insert(slot.Errors.end(), response.Errors.begin(), response.Errors.end());
+    SourceActors[place].Clear();
+}
+
+void TSupportLinksResolver::HandleSourceTimeout(size_t place, NActors::TActorSystem* actorSystem) {
+    auto& sourceOutput = SourceOutputs[place];
+    actorSystem->Send(new NActors::IEventHandle(
+        *SourceActors[place],
+        Owner,
+        new NActors::TEvents::TEvPoisonPill()));
+    SourceActors[place].Clear();
+    sourceOutput.Errors.emplace_back(NSupportLinks::TSupportError{
+        .Source = sourceOutput.Name,
+        .Message = "Timeout while resolving support links source"
+    });
+}
+
+void TSupportLinksResolver::Start() {
+    ResetState();
 
     for (size_t i = 0; i < Sources.size(); ++i) {
-        const auto& source = Sources[i];
-        TResolveOutput sourceOutput = source->Resolve(MakeResolveInput(i));
-        sourceOutput.Name = source->Config().GetSource();
-        SourceActors[i] = sourceOutput.Actor;
-        SourceOutputs[i] = std::move(sourceOutput);
+        TResolveOutput sourceOutput = ResolveSource(i);
+        SaveSourceOutput(i, std::move(sourceOutput));
     }
 }
 
 void TSupportLinksResolver::OnSourceResponse(const NSupportLinks::TEvPrivate::TEvSourceResponse::TPtr& event) {
     const auto* msg = event->Get();
-    if (msg->Place < SourceOutputs.size()) {
-        TResolveOutput& slot = SourceOutputs[msg->Place];
-        slot.Ready = true;
-        slot.Links = msg->Links;
-        slot.Errors.insert(slot.Errors.end(), msg->Errors.begin(), msg->Errors.end());
-        SourceActors[msg->Place].Clear();
+    if (msg->Place >= SourceOutputs.size()) {
+        return;
     }
+    ApplySourceResponse(msg->Place, *msg);
 }
 
 void TSupportLinksResolver::HandleTimeout() {
     auto* actorSystem = NActors::TActivationContext::ActorSystem();
 
     for (size_t place = 0; place < SourceOutputs.size(); ++place) {
-        auto& sourceOutput = SourceOutputs[place];
-        if (!sourceOutput.Ready) {
-            if (SourceActors[place]) {
-                actorSystem->Send(new NActors::IEventHandle(
-                    *SourceActors[place],
-                    Parent,
-                    new NActors::TEvents::TEvPoisonPill()));
-            }
-            SourceActors[place].Clear();
-            sourceOutput.Errors.emplace_back(NSupportLinks::TSupportError{
-                .Source = sourceOutput.Name,
-                .Message = "Timeout while resolving support links source"
-            });
-            sourceOutput.Ready = true;
+        if (SourceActors[place]) {
+            HandleSourceTimeout(place, actorSystem);
         }
     }
 }
 
 bool TSupportLinksResolver::IsFinished() const {
-    for (const auto& sourceOutput : SourceOutputs) {
-        if (!sourceOutput.Ready) {
+    for (const auto& sourceActor : SourceActors) {
+        if (sourceActor) {
             return false;
         }
     }

--- a/ydb/mvp/meta/support_links/support_links_resolver.h
+++ b/ydb/mvp/meta/support_links/support_links_resolver.h
@@ -2,7 +2,6 @@
 
 #include "events.h"
 #include "source.h"
-#include "types.h"
 
 #include <ydb/mvp/meta/meta_settings.h>
 #include <ydb/library/actors/http/http.h>

--- a/ydb/mvp/meta/support_links/support_links_resolver.h
+++ b/ydb/mvp/meta/support_links/support_links_resolver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "events.h"
+#include "source.h"
 #include "types.h"
 
 #include <ydb/mvp/meta/meta_settings.h>
@@ -10,8 +11,6 @@
 #include <memory>
 
 namespace NMVP {
-
-class ILinkSource;
 
 class TSupportLinksResolver {
 public:
@@ -23,10 +22,11 @@ public:
     struct TParams {
         EEntityType EntityType = EEntityType::Cluster;
         const TMetaSettings* Settings = nullptr;
-        THashMap<TString, TString> ClusterColumns;
+        THashMap<TString, TString> ClusterInfo;
         NHttp::TUrlParameters UrlParameters;
-        NActors::TActorId Parent;
+        NActors::TActorId Owner;
         NActors::TActorId HttpProxyId;
+        TLinkSourceFactory LinkSourceFactory = MakeLinkSource;
     };
 
     explicit TSupportLinksResolver(TParams params);
@@ -38,14 +38,20 @@ public:
     bool IsFinished() const;
 
 private:
-    auto MakeResolveInput(size_t place) const;
+    void ResetState();
+    ILinkSource::TLinkResolveInput MakeResolveInput() const;
+    ILinkSource::TResolveContext MakeResolveContext(size_t place) const;
+    TResolveOutput ResolveSource(size_t place) const;
+    void SaveSourceOutput(size_t place, TResolveOutput sourceOutput);
+    void ApplySourceResponse(size_t place, const NSupportLinks::TEvPrivate::TEvSourceResponse& response);
+    void HandleSourceTimeout(size_t place, NActors::TActorSystem* actorSystem);
 
     TVector<std::shared_ptr<ILinkSource>> Sources;
     TVector<TResolveOutput> SourceOutputs;
     TVector<TMaybe<NActors::TActorId>> SourceActors;
-    THashMap<TString, TString> ClusterColumns;
+    THashMap<TString, TString> ClusterInfo;
     NHttp::TUrlParameters UrlParameters;
-    NActors::TActorId Parent;
+    NActors::TActorId Owner;
     NActors::TActorId HttpProxyId;
 };
 

--- a/ydb/mvp/meta/support_links/types.h
+++ b/ydb/mvp/meta/support_links/types.h
@@ -35,10 +35,6 @@ struct TResolveOutput {
     // Source id from config ("source" field), used in result/error reporting.
     TString Name;
 
-    // false: source is still resolving.
-    // true: source resolving is finished for this entry.
-    bool Ready = false;
-
     // Links produced by this source.
     TVector<NSupportLinks::TResolvedLink> Links;
 

--- a/ydb/mvp/meta/support_links/ut/mock_link_source.h
+++ b/ydb/mvp/meta/support_links/ut/mock_link_source.h
@@ -28,14 +28,9 @@ public:
         : SourceConfig(std::move(config))
     {}
 
-    const TSupportLinkEntryConfig& Config() const override {
-        return SourceConfig;
-    }
-
-    TResolveOutput Resolve(const TResolveInput&) const override {
+    TResolveOutput Resolve(const TLinkResolveInput&, const TResolveContext&) const override {
         TResolveOutput out;
         out.Name = SourceConfig.GetSource();
-        out.Ready = true;
         out.Links = MakeMockLinks();
         return out;
     }
@@ -46,13 +41,13 @@ private:
 
 class TMockReplyActor final : public NActors::TActorBootstrapped<TMockReplyActor> {
 public:
-    TMockReplyActor(NActors::TActorId parent, size_t place)
-        : Parent(parent)
+    TMockReplyActor(NActors::TActorId owner, size_t place)
+        : Owner(owner)
         , Place(place)
     {}
 
     void Bootstrap() {
-        Send(Parent, new NSupportLinks::TEvPrivate::TEvSourceResponse(
+        Send(Owner, new NSupportLinks::TEvPrivate::TEvSourceResponse(
             Place,
             MakeMockLinks(),
             {}));
@@ -60,7 +55,7 @@ public:
     }
 
 private:
-    NActors::TActorId Parent;
+    NActors::TActorId Owner;
     size_t Place = 0;
 };
 
@@ -70,17 +65,12 @@ public:
         : SourceConfig(std::move(config))
     {}
 
-    const TSupportLinkEntryConfig& Config() const override {
-        return SourceConfig;
-    }
-
-    TResolveOutput Resolve(const TResolveInput& input) const override {
+    TResolveOutput Resolve(const TLinkResolveInput&, const TResolveContext& context) const override {
         TResolveOutput out;
         out.Name = SourceConfig.GetSource();
-        out.Ready = false;
         auto actorId = NActors::TActivationContext::Register(
-            new TMockReplyActor(input.Parent, input.Place),
-            input.Parent);
+            new TMockReplyActor(context.Owner, context.Place),
+            context.Owner);
         out.Actor = actorId;
         return out;
     }
@@ -95,11 +85,6 @@ inline std::shared_ptr<ILinkSource> MakeMockLinkSourceSync(TSupportLinkEntryConf
 
 inline std::shared_ptr<ILinkSource> MakeMockLinkSourceAsync(TSupportLinkEntryConfig config) {
     return std::make_shared<TMockLinkSourceAsync>(std::move(config));
-}
-
-inline void RegisterMockLinkSources() {
-    RegisterLinkSource("mock/sourceSync", &MakeMockLinkSourceSync);
-    RegisterLinkSource("mock/sourceAsync", &MakeMockLinkSourceAsync);
 }
 
 } // namespace NMVP::NTest

--- a/ydb/mvp/meta/support_links/ut/ya.make
+++ b/ydb/mvp/meta/support_links/ut/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(ydb/mvp/meta/support_links)
+
+SIZE(SMALL)
+
+SRCS(
+    grafana_dashboard_source_ut.cpp
+)
+
+PEERDIR(
+    ydb/mvp/core
+    ydb/mvp/meta
+    ydb/core/testlib/actors
+)
+
+END()

--- a/ydb/mvp/meta/support_links/ya.make
+++ b/ydb/mvp/meta/support_links/ya.make
@@ -5,15 +5,15 @@ RECURSE_FOR_TESTS(
 LIBRARY()
 
 SRCS(
-	response.cpp
-	source.cpp
-	support_links_resolver.cpp
+    response.cpp
+    source.cpp
+    support_links_resolver.cpp
 )
 
 PEERDIR(
-	ydb/mvp/core
-	ydb/mvp/meta/protos
-	library/cpp/json
+    ydb/mvp/core
+    ydb/mvp/meta/protos
+    library/cpp/json
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/mvp/meta/support_links/ya.make
+++ b/ydb/mvp/meta/support_links/ya.make
@@ -1,7 +1,3 @@
-RECURSE_FOR_TESTS(
-    ut
-)
-
 LIBRARY()
 
 SRCS(
@@ -19,3 +15,7 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/mvp/meta/support_links/ya.make
+++ b/ydb/mvp/meta/support_links/ya.make
@@ -1,13 +1,21 @@
+RECURSE_FOR_TESTS(
+    ut
+)
+
 LIBRARY()
 
 SRCS(
-    source.cpp
-    support_links_resolver.cpp
+	response.cpp
+	source.cpp
+	support_links_resolver.cpp
 )
 
 PEERDIR(
-    ydb/mvp/core
-    ydb/mvp/meta/protos
+	ydb/mvp/core
+	ydb/mvp/meta/protos
+	library/cpp/json
 )
+
+YQL_LAST_ABI_VERSION()
 
 END()

--- a/ydb/mvp/meta/ya.make
+++ b/ydb/mvp/meta/ya.make
@@ -5,8 +5,10 @@ RECURSE_FOR_TESTS(
 LIBRARY()
 
 SRCS(
+    meta_cluster_info.cpp
     meta.cpp
     meta_cache.cpp
+    meta_settings.cpp
     meta_versions.cpp
     mvp.cpp
 )
@@ -32,4 +34,5 @@ END()
 
 RECURSE(
     bin
+    support_links
 )

--- a/ydb/mvp/meta/ya.make
+++ b/ydb/mvp/meta/ya.make
@@ -1,7 +1,3 @@
-RECURSE_FOR_TESTS(
-    ut
-)
-
 LIBRARY()
 
 SRCS(
@@ -35,4 +31,8 @@ END()
 RECURSE(
     bin
     support_links
+)
+
+RECURSE_FOR_TESTS(
+    ut
 )

--- a/ydb/mvp/oidc_proxy/ya.make
+++ b/ydb/mvp/oidc_proxy/ya.make
@@ -1,7 +1,3 @@
-RECURSE_FOR_TESTS(
-    ut
-)
-
 LIBRARY()
 
 SRCS(
@@ -42,4 +38,8 @@ END()
 
 RECURSE(
     bin
+)
+
+RECURSE_FOR_TESTS(
+    ut
 )

--- a/ydb/tests/functional/mvp/meta/conftest.py
+++ b/ydb/tests/functional/mvp/meta/conftest.py
@@ -1,5 +1,12 @@
 import pytest
+import yatest.common
 from support_links_env import started_meta_support_links_env
+
+
+@pytest.fixture(autouse=True)
+def skip_meta_functional_tests_under_asan():
+    if yatest.common.context.sanitize == "address":
+        pytest.skip("KiKiMR startup via ydbd is not supported under address sanitizer in this suite")
 
 
 @pytest.fixture

--- a/ydb/tests/functional/mvp/meta/conftest.py
+++ b/ydb/tests/functional/mvp/meta/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from support_links_env import started_meta_support_links_env
+
+
+@pytest.fixture
+def meta_support_links_env():
+    with started_meta_support_links_env() as env:
+        yield env

--- a/ydb/tests/functional/mvp/meta/support_links_env.py
+++ b/ydb/tests/functional/mvp/meta/support_links_env.py
@@ -1,0 +1,228 @@
+import os
+import textwrap
+from contextlib import contextmanager
+
+import requests
+import yatest.common
+
+from library.python.port_manager import PortManager
+
+from ydb.tests.library.common.wait_for import wait_for
+from ydb.tests.library.harness.daemon import Daemon
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+CLUSTER_NAME = "ydb-global"
+WORKSPACE_NAME = "ydb-workspace"
+DATASOURCE_ID = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63"
+ROOT_DATABASE = "/Root"
+META_TABLE_PATH = "/Root/ydb/MasterClusterExt.db"
+GRAFANA_DASHBOARD_PATH = "/d/ydb/overview"
+ABSOLUTE_GRAFANA_DASHBOARD_URL = "https://external.example.test/d/ydb/overview"
+DATABASE_NAME = "/Root/db1"
+MISSING_CLUSTER_NAME = "missing-cluster"
+MISSING_CLUSTER_ERROR = f"Cluster '{MISSING_CLUSTER_NAME}' is not found in MasterClusterExt.db"
+MISSING_CLUSTER_PARAMETER_ERROR = (
+    "Invalid identity parameters. Supported entities: cluster requires 'cluster'; "
+    "database requires 'cluster' and 'database'."
+)
+
+
+def mvp_meta_bin():
+    return yatest.common.binary_path("ydb/mvp/meta/bin/mvp_meta")
+
+
+class MetaService:
+    def __init__(self, config_path, http_port):
+        self.http_port = http_port
+        self._daemon = Daemon(
+            command=[
+                mvp_meta_bin(),
+                "--config",
+                config_path,
+                "--http-port",
+                str(http_port),
+                "--stderr",
+            ],
+            cwd=yatest.common.output_path(),
+            timeout=30,
+            stdout_file=os.path.join(yatest.common.output_path(), "mvp_meta.stdout"),
+            stderr_file=os.path.join(yatest.common.output_path(), "mvp_meta.stderr"),
+            stderr_on_error_lines=100,
+        )
+
+    @property
+    def endpoint(self):
+        return f"http://localhost:{self.http_port}"
+
+    def _is_ready(self):
+        try:
+            return requests.get(f"{self.endpoint}/ping", timeout=1).status_code == 200
+        except requests.RequestException:
+            return False
+
+    def start(self):
+        self._daemon.start()
+        ready = wait_for(
+            self._is_ready,
+            timeout_seconds=30,
+            step_seconds=0.5,
+        )
+        if not ready:
+            if self._daemon.is_alive():
+                self._daemon.stop()
+        assert ready, "mvp_meta did not become ready on /ping"
+        return self
+
+    def stop(self):
+        self._daemon.stop()
+
+
+def start_cluster_with_meta_table(
+    cluster_name=CLUSTER_NAME,
+    k8s_namespace=WORKSPACE_NAME,
+    datasource=DATASOURCE_ID,
+):
+    cluster = KiKiMR()
+    cluster.start()
+
+    driver = ydb.Driver(
+        ydb.DriverConfig(
+            database=ROOT_DATABASE,
+            endpoint=f"{cluster.nodes[1].host}:{cluster.nodes[1].port}",
+        )
+    )
+    driver.wait()
+
+    session = ydb.retry_operation_sync(lambda: driver.table_client.session().create())
+    session.execute_scheme(textwrap.dedent("""
+        CREATE TABLE `{table_path}` (
+            name Utf8,
+            k8s_namespace Utf8,
+            datasource Utf8,
+            PRIMARY KEY (name)
+        );
+    """).format(table_path=META_TABLE_PATH))
+
+    session.transaction().execute(textwrap.dedent(f"""
+        UPSERT INTO `{META_TABLE_PATH}` (name, k8s_namespace, datasource)
+        VALUES ("{cluster_name}", "{k8s_namespace}", "{datasource}");
+    """), commit_tx=True)
+
+    return cluster, driver
+
+
+class MetaSupportLinksEnv:
+    def __init__(self, meta_service):
+        self.meta_service = meta_service
+
+    @property
+    def endpoint(self):
+        return self.meta_service.endpoint
+
+    def get_support_links(self, cluster_name=None, database=None):
+        params = {}
+        if cluster_name is not None:
+            params["cluster"] = cluster_name
+        if database is not None:
+            params["database"] = database
+        return requests.get(
+            f"{self.endpoint}/meta/support_links",
+            params=params,
+            timeout=10,
+        )
+
+    def get_ok_support_links_payload(self, cluster_name=None, database=None):
+        response = self.get_support_links(cluster_name=cluster_name, database=database)
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    def get_bad_request_support_links_payload(self, cluster_name=None, database=None):
+        response = self.get_support_links(cluster_name=cluster_name, database=database)
+        assert response.status_code == 400, response.text
+        return response.json()
+
+
+def write_meta_support_links_config(
+    config_path,
+    http_port,
+    grpc_endpoint,
+    url=GRAFANA_DASHBOARD_PATH,
+    include_grafana_endpoint=True,
+):
+    config_lines = [
+        "generic:",
+        '  access_service_type: "nebius_v1"',
+        "  logging:",
+        "    stderr: true",
+        "  server:",
+        f"    http_port: {http_port}",
+        "",
+        "meta:",
+        f'  meta_api_endpoint: "grpc://{grpc_endpoint}"',
+        f'  meta_database: "{ROOT_DATABASE}"',
+        "",
+    ]
+    if include_grafana_endpoint:
+        config_lines.extend([
+            "  grafana:",
+            '    endpoint: "https://grafana.example.test"',
+            "",
+        ])
+    config_lines.extend([
+        "  support_links:",
+        "    cluster:",
+        '      - source: "grafana/dashboard"',
+        '        title: "Overview"',
+        f'        url: "{url}"',
+        "    database:",
+        '      - source: "grafana/dashboard"',
+        '        title: "Overview"',
+        f'        url: "{url}"',
+        "",
+    ])
+    with open(config_path, "w") as config:
+        config.write("\n".join(config_lines))
+
+
+def start_meta_support_links_service(cluster, http_port, url=GRAFANA_DASHBOARD_PATH, include_grafana_endpoint=True):
+    config_path = os.path.join(yatest.common.output_path(), "meta_support_links.yaml")
+    write_meta_support_links_config(
+        config_path=config_path,
+        http_port=http_port,
+        grpc_endpoint=f"{cluster.nodes[1].host}:{cluster.nodes[1].port}",
+        url=url,
+        include_grafana_endpoint=include_grafana_endpoint,
+    )
+    return MetaService(config_path=config_path, http_port=http_port).start()
+
+
+@contextmanager
+def started_meta_support_links_env(
+    cluster_name=CLUSTER_NAME,
+    k8s_namespace=WORKSPACE_NAME,
+    datasource=DATASOURCE_ID,
+    url=GRAFANA_DASHBOARD_PATH,
+    include_grafana_endpoint=True,
+):
+    cluster, driver = start_cluster_with_meta_table(
+        cluster_name=cluster_name,
+        k8s_namespace=k8s_namespace,
+        datasource=datasource,
+    )
+    try:
+        with PortManager() as port_manager:
+            http_port = port_manager.get_port()
+            meta = start_meta_support_links_service(
+                cluster,
+                http_port,
+                url=url,
+                include_grafana_endpoint=include_grafana_endpoint,
+            )
+            try:
+                yield MetaSupportLinksEnv(meta)
+            finally:
+                meta.stop()
+    finally:
+        driver.stop()
+        cluster.stop()

--- a/ydb/tests/functional/mvp/meta/test_support_links.py
+++ b/ydb/tests/functional/mvp/meta/test_support_links.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from urllib.parse import parse_qsl, urlsplit
 
 import pytest
 from library.python.port_manager import PortManager
@@ -31,10 +32,11 @@ class SupportLinksConfigCase:
 
 
 def assert_support_links_response(payload, expected_url):
-    assert payload["links"] == [{
-        "title": "Overview",
-        "url": expected_url,
-    }]
+    assert len(payload["links"]) == 1
+    assert payload["links"][0]["title"] == "Overview"
+
+    actual_url = payload["links"][0]["url"]
+    assert_urls_match(actual_url, expected_url)
     assert "errors" not in payload
 
 
@@ -46,10 +48,11 @@ def assert_support_links_error(payload, message_substring):
 
 
 def assert_support_links_response_with_error(payload, expected_url, message_substring):
-    assert payload["links"] == [{
-        "title": "Overview",
-        "url": expected_url,
-    }]
+    assert len(payload["links"]) == 1
+    assert payload["links"][0]["title"] == "Overview"
+
+    actual_url = payload["links"][0]["url"]
+    assert_urls_match(actual_url, expected_url)
     assert len(payload["errors"]) == 1
     assert payload["errors"][0]["source"] == "meta"
     assert message_substring in payload["errors"][0]["message"]
@@ -60,6 +63,18 @@ def assert_bad_request_response(payload, message_substring):
     assert len(payload["errors"]) == 1
     assert payload["errors"][0]["source"] == "meta"
     assert message_substring in payload["errors"][0]["message"]
+
+
+def assert_urls_match(actual_url, expected_url):
+    actual_split = urlsplit(actual_url)
+    expected_split = urlsplit(expected_url)
+
+    assert actual_split.scheme == expected_split.scheme
+    assert actual_split.netloc == expected_split.netloc
+    assert actual_split.path == expected_split.path
+    assert sorted(parse_qsl(actual_split.query, keep_blank_values=True)) == sorted(
+        parse_qsl(expected_split.query, keep_blank_values=True)
+    )
 
 
 def grafana_url_with_cluster(cluster_name=CLUSTER_NAME, extra_query=""):

--- a/ydb/tests/functional/mvp/meta/test_support_links.py
+++ b/ydb/tests/functional/mvp/meta/test_support_links.py
@@ -1,0 +1,178 @@
+from dataclasses import dataclass
+
+import pytest
+from library.python.port_manager import PortManager
+
+from support_links_env import (
+    ABSOLUTE_GRAFANA_DASHBOARD_URL,
+    CLUSTER_NAME,
+    DATABASE_NAME,
+    DATASOURCE_ID,
+    MISSING_CLUSTER_ERROR,
+    MISSING_CLUSTER_NAME,
+    MISSING_CLUSTER_PARAMETER_ERROR,
+    WORKSPACE_NAME,
+    start_cluster_with_meta_table,
+    start_meta_support_links_service,
+    started_meta_support_links_env,
+)
+
+
+@dataclass(frozen=True)
+class SupportLinksRequestCase:
+    database: str | None
+    expected_url: str
+
+
+@dataclass(frozen=True)
+class SupportLinksConfigCase:
+    env_kwargs: dict
+    expected_url: str
+
+
+def assert_support_links_response(payload, expected_url):
+    assert payload["links"] == [{
+        "title": "Overview",
+        "url": expected_url,
+    }]
+    assert "errors" not in payload
+
+
+def assert_support_links_error(payload, message_substring):
+    assert payload["links"] == []
+    assert len(payload["errors"]) == 1
+    assert payload["errors"][0]["source"] == "meta"
+    assert message_substring in payload["errors"][0]["message"]
+
+
+def assert_support_links_response_with_error(payload, expected_url, message_substring):
+    assert payload["links"] == [{
+        "title": "Overview",
+        "url": expected_url,
+    }]
+    assert len(payload["errors"]) == 1
+    assert payload["errors"][0]["source"] == "meta"
+    assert message_substring in payload["errors"][0]["message"]
+
+
+def assert_bad_request_response(payload, message_substring):
+    assert payload["links"] == []
+    assert len(payload["errors"]) == 1
+    assert payload["errors"][0]["source"] == "meta"
+    assert message_substring in payload["errors"][0]["message"]
+
+
+def grafana_url_with_cluster(cluster_name=CLUSTER_NAME, extra_query=""):
+    url = (
+        "https://grafana.example.test/d/ydb/overview"
+        f"?var-workspace={WORKSPACE_NAME}"
+        f"&var-ds={DATASOURCE_ID}"
+        f"&var-cluster={cluster_name}"
+    )
+    if extra_query:
+        url += f"&{extra_query}"
+    return url
+
+
+def external_grafana_url(extra_query=""):
+    url = (
+        "https://external.example.test/d/ydb/overview"
+        f"?var-workspace={WORKSPACE_NAME}"
+        f"&var-ds={DATASOURCE_ID}"
+        f"&var-cluster={CLUSTER_NAME}"
+    )
+    if extra_query:
+        url += f"&{extra_query}"
+    return url
+
+
+def grafana_url_with_cluster_only(cluster_name):
+    return "https://grafana.example.test/d/ydb/overview" f"?var-cluster={cluster_name}"
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            SupportLinksRequestCase(
+                database=None,
+                expected_url=grafana_url_with_cluster(),
+            ),
+            id="cluster-links",
+        ),
+        pytest.param(
+            SupportLinksRequestCase(
+                database=DATABASE_NAME,
+                expected_url=grafana_url_with_cluster(extra_query=f"var-database={DATABASE_NAME}"),
+            ),
+            id="database-links",
+        ),
+    ],
+)
+def test_meta_support_links_returns_grafana_link(meta_support_links_env, case):
+    assert_support_links_response(
+        meta_support_links_env.get_ok_support_links_payload(CLUSTER_NAME, database=case.database),
+        case.expected_url,
+    )
+
+
+def test_meta_support_links_returns_error_for_missing_cluster(meta_support_links_env):
+    assert_support_links_response_with_error(
+        meta_support_links_env.get_ok_support_links_payload(MISSING_CLUSTER_NAME),
+        grafana_url_with_cluster_only(MISSING_CLUSTER_NAME),
+        MISSING_CLUSTER_ERROR,
+    )
+
+
+def test_meta_support_links_does_not_start_with_invalid_config():
+    cluster, driver = start_cluster_with_meta_table()
+    try:
+        with PortManager() as port_manager:
+            http_port = port_manager.get_port()
+            with pytest.raises(AssertionError, match="mvp_meta did not become ready on /ping"):
+                start_meta_support_links_service(
+                    cluster,
+                    http_port,
+                    include_grafana_endpoint=False,
+                )
+    finally:
+        driver.stop()
+        cluster.stop()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            SupportLinksConfigCase(
+                env_kwargs={"url": ABSOLUTE_GRAFANA_DASHBOARD_URL},
+                expected_url=external_grafana_url(),
+            ),
+            id="absolute-url",
+        ),
+        pytest.param(
+            SupportLinksConfigCase(
+                env_kwargs={"datasource": ""},
+                expected_url=(
+                    "https://grafana.example.test/d/ydb/overview"
+                    f"?var-workspace={WORKSPACE_NAME}"
+                    f"&var-cluster={CLUSTER_NAME}"
+                ),
+            ),
+            id="empty-datasource",
+        ),
+    ],
+)
+def test_meta_support_links_returns_expected_link_for_config(case):
+    with started_meta_support_links_env(**case.env_kwargs) as env:
+        assert_support_links_response(
+            env.get_ok_support_links_payload(CLUSTER_NAME),
+            case.expected_url,
+        )
+
+
+def test_meta_support_links_requires_cluster_parameter(meta_support_links_env):
+    assert_bad_request_response(
+        meta_support_links_env.get_bad_request_support_links_payload(database=DATABASE_NAME),
+        MISSING_CLUSTER_PARAMETER_ERROR,
+    )

--- a/ydb/tests/functional/mvp/meta/ya.make
+++ b/ydb/tests/functional/mvp/meta/ya.make
@@ -1,0 +1,25 @@
+PY3TEST()
+
+FORK_TEST_FILES()
+SIZE(MEDIUM)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+
+TEST_SRCS(
+    conftest.py
+    support_links_env.py
+    test_support_links.py
+)
+
+DEPENDS(
+    ydb/mvp/meta/bin
+)
+
+PEERDIR(
+    contrib/python/requests
+    ydb/tests/library
+    ydb/tests/library/fixtures
+    ydb/tests/oss/ydb_sdk_import
+)
+
+END()

--- a/ydb/tests/functional/mvp/ya.make
+++ b/ydb/tests/functional/mvp/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    meta
+)

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -18,6 +18,7 @@ RECURSE(
     large_serializable
     limits
     minidumps
+    mvp/meta_support_links
     nbs
     postgresql
     query_cache

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -18,7 +18,7 @@ RECURSE(
     large_serializable
     limits
     minidumps
-    mvp/meta_support_links
+    mvp
     nbs
     postgresql
     query_cache


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds a new Grafana “dashboard” support-links source to the MVP Meta service, refactors support-links configuration/settings handling, and introduces both C++ unit tests and Python functional tests to validate the generated links and error behavior.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Implement grafana/dashboard support-links source with URL resolution and JSON response building.
- Refactor meta settings loading/validation (including support-links config validation) and cluster-info query extraction.
- Add unit tests for the Grafana dashboard source and Python functional tests for /meta/support_links.
