### PR TITLE
Make retries when committing static group syncer updates in Bridge mode

### DIFF
--- a/ydb/core/mind/bscontroller/bridge.cpp
+++ b/ydb/core/mind/bscontroller/bridge.cpp
@@ -441,26 +441,7 @@ void TBlobStorageController::ApplySyncerState(TNodeId nodeId, const NKikimrBlobS
             updates.emplace_back(targetGroupId, TTxUpdateBridgeSyncState::TChangeStage{});
 
             if (staticGroup) {
-                NKikimrBlobStorage::TEvNodeConfigInvokeOnRoot request;
-                auto *cmd = request.MutableUpdateBridgeGroupInfo();
-                groupId.CopyToProto(cmd, &std::decay_t<decltype(*cmd)>::SetGroupId);
-                cmd->SetGroupGeneration(generation);
-                cmd->MutableBridgeGroupInfo()->Swap(&bridgeGroupInfo);
-                InvokeOnRoot(std::move(request), [=](NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult& result) {
-                    if (result.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
-                        Y_DEBUG_ABORT("UpdateBridgeGroupInfo has unexpectedly failed");
-                        STLOG(PRI_ERROR, BS_CONTROLLER, BSCBR08, "UpdateBridgeGroupInfo has unexpectedly failed",
-                            (Result, result));
-                    }
-                    if (const auto it = TargetGroupToSyncerState.find(targetGroupId); it != TargetGroupToSyncerState.end()) {
-                        TSyncerState& syncerState = it->second;
-                        Y_ABORT_UNLESS(syncerState.InCommit);
-                        syncerState.InCommit = false;
-                        if (!syncerState.NodeIds) {
-                            SyncersRequiringAction.PushBack(&syncerState);
-                        }
-                    }
-                });
+                UpdateStaticGroupBridgeGroupInfo(groupId, generation, std::move(bridgeGroupInfo), targetGroupId);
             } else {
                 Execute(std::make_unique<TTxUpdateBridgeGroupInfo>(this, groupId, generation,
                     std::move(bridgeGroupInfo), targetGroupId));
@@ -488,6 +469,30 @@ void TBlobStorageController::ApplySyncerState(TNodeId nodeId, const NKikimrBlobS
         nodesToUpdate.insert(nodeId);
     }
     ProcessSyncers(std::move(nodesToUpdate));
+}
+
+void TBlobStorageController::UpdateStaticGroupBridgeGroupInfo(TGroupId groupId, ui32 generation,
+        NKikimrBlobStorage::TGroupInfo bridgeGroupInfo, TGroupId targetGroupId) {
+    NKikimrBlobStorage::TEvNodeConfigInvokeOnRoot request;
+    auto *cmd = request.MutableUpdateBridgeGroupInfo();
+    groupId.CopyToProto(cmd, &std::decay_t<decltype(*cmd)>::SetGroupId);
+    cmd->SetGroupGeneration(generation);
+    cmd->MutableBridgeGroupInfo()->CopyFrom(bridgeGroupInfo);
+    InvokeOnRoot(std::move(request), [=](NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult& result) {
+        if (result.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
+            STLOG(PRI_ERROR, BS_CONTROLLER, BSCBR08, "UpdateBridgeGroupInfo has unexpectedly failed",
+                (Result, result));
+            return UpdateStaticGroupBridgeGroupInfo(groupId, generation, std::move(bridgeGroupInfo), targetGroupId);
+        }
+        if (const auto it = TargetGroupToSyncerState.find(targetGroupId); it != TargetGroupToSyncerState.end()) {
+            TSyncerState& syncerState = it->second;
+            Y_ABORT_UNLESS(syncerState.InCommit);
+            syncerState.InCommit = false;
+            if (!syncerState.NodeIds) {
+                SyncersRequiringAction.PushBack(&syncerState);
+            }
+        }
+    });
 }
 
 void TBlobStorageController::CheckSyncerDisconnectedNodes() {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -2050,6 +2050,9 @@ private:
     void ApplySyncerState(TNodeId nodeId, const NKikimrBlobStorage::TEvControllerUpdateSyncerState& update,
         TSet<TGroupId>& groupIdsToRead, bool comprehensive);
 
+    void UpdateStaticGroupBridgeGroupInfo(TGroupId groupId, ui32 generation, NKikimrBlobStorage::TGroupInfo bridgeGroupInfo,
+        TGroupId targetGroupId);
+
     void CheckSyncerDisconnectedNodes();
 
     void ProcessSyncers(THashSet<TNodeId> nodesToUpdate = {});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make retries when committing static group syncer updates in Bridge mode

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes #35935 failing when there is not enough nodes to make quorum while committing static group syncer state.
