### PR TITLE
YQ-5128 added retry for streaming query cancelled status

### DIFF
--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -373,7 +373,7 @@ struct TEvScriptFinalizeRequest : public TEventLocal<TEvScriptFinalizeRequest, T
     struct TDescription {
         TDescription(EFinalizationStatus finalizationStatus, const TString& executionId, const TString& database,
         Ydb::StatusIds::StatusCode operationStatus, Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, std::optional<NKqpProto::TKqpStatsQuery> queryStats,
-        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration)
+        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration, bool cancelledByUser = false)
             : FinalizationStatus(finalizationStatus)
             , ExecutionId(executionId)
             , Database(database)
@@ -384,6 +384,7 @@ struct TEvScriptFinalizeRequest : public TEventLocal<TEvScriptFinalizeRequest, T
             , QueryPlan(std::move(queryPlan))
             , QueryAst(std::move(queryAst))
             , LeaseGeneration(leaseGeneration)
+            , CancelledByUser(cancelledByUser)
         {}
 
         EFinalizationStatus FinalizationStatus;
@@ -396,14 +397,15 @@ struct TEvScriptFinalizeRequest : public TEventLocal<TEvScriptFinalizeRequest, T
         std::optional<TString> QueryPlan;
         std::optional<TString> QueryAst;
         i64 LeaseGeneration;
+        bool CancelledByUser = false; // User cancel API; false when status is CANCELLED from execution (e.g. streaming retry).
         std::optional<TString> QueryPlanCompressionMethod;
         std::optional<TString> QueryAstCompressionMethod;
     };
 
     TEvScriptFinalizeRequest(EFinalizationStatus finalizationStatus, const TString& executionId, const TString& database,
         Ydb::StatusIds::StatusCode operationStatus, Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, std::optional<NKqpProto::TKqpStatsQuery> queryStats,
-        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration)
-        : Description(finalizationStatus, executionId, database, operationStatus, execStatus, issues, queryStats, queryPlan, queryAst, leaseGeneration)
+        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration, bool cancelledByUser = false)
+        : Description(finalizationStatus, executionId, database, operationStatus, execStatus, issues, queryStats, queryPlan, queryAst, leaseGeneration, cancelledByUser)
     {}
 
     TDescription Description;

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1874,14 +1874,14 @@ private:
     }
 
     static std::vector<NKikimrKqp::TScriptExecutionRetryState::TMapping> CreateDefaultRetryMapping() {
-        // Retried all statuses except of SUCCESS, CANCELLED
+        // Retried all statuses except SUCCESS (user cancel clears retry policy in finalize).
 
         NKikimrKqp::TScriptExecutionRetryState::TMapping mapping;
 
         const auto* statusDescriptor = Ydb::StatusIds::StatusCode_descriptor();
         for (int i = 0; i < statusDescriptor->value_count(); ++i) {
             const auto status = static_cast<Ydb::StatusIds::StatusCode>(statusDescriptor->value(i)->number());
-            if (!IsIn({Ydb::StatusIds::SUCCESS, Ydb::StatusIds::CANCELLED}, status)) {
+            if (status != Ydb::StatusIds::SUCCESS) {
                 mapping.AddStatusCode(status);
             }
         }

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -1787,7 +1787,7 @@ private:
     }
 
     void Handle(TEvKqp::TEvListSessionsRequest::TPtr& ev) {
-        KQP_PROXY_LOG_D("incoming list sessions request " << ev->Get()->Record.ShortUtf8DebugString());
+        KQP_PROXY_LOG_D("incoming list sessions request " << ev->Get()->Record.ShortUtf8DebugString() << ", local sessions #" << LocalSessions->size());
 
         auto result = std::make_unique<TEvKqp::TEvListSessionsResponse>();
 
@@ -1796,7 +1796,7 @@ private:
 
         auto startIt = LocalSessions->GetOrderedLowerBound(tenant, ev->Get()->Record.GetSessionIdStart());
         auto endIt = LocalSessions->GetOrderedEnd();
-        i32 freeSpace = ev->Get()->Record.GetFreeSpace();
+        i64 freeSpace = ev->Get()->Record.GetFreeSpace();
 
         TKqpSessionInfo::TFieldsMap fieldsMap(ev->Get()->Record.GetColumns());
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -4237,6 +4237,10 @@ public:
             WHERE database = $database AND execution_id = $execution_id;
         )";
 
+        if (Request.CancelledByUser) {
+            RetryState.ClearRetryPolicyMapping();
+        }
+
         TInstant retryDeadline = TInstant::Now();
         ELeaseState leaseState = ELeaseState::ScriptFinalizing;
         if (!Response->ApplicateScriptExternalEffectRequired) {

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -349,9 +349,10 @@ private:
         if (!FinalStatusIsSaved) {
             FinalStatusIsSaved = true;
             WaitFinalizationRequest = true;
+            const bool cancelledByUser = (RunState == ERunState::Cancelling);
             RunState = IsExecuting() ? ERunState::Finishing : RunState;
 
-            if (RunState == ERunState::Cancelling) {
+            if (cancelledByUser) {
                 NYql::TIssue cancelIssue("Request was canceled by user");
                 cancelIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
                 Issues.AddIssue(std::move(cancelIssue));
@@ -361,7 +362,7 @@ private:
 
             auto scriptFinalizeRequest = std::make_unique<TEvScriptFinalizeRequest>(
                 GetFinalizationStatusFromRunState(), ExecutionId, Database, Status, GetExecStatusFromStatusCode(Status),
-                Issues, std::move(QueryStats), std::move(QueryPlan), std::move(QueryAst), LeaseGeneration
+                Issues, std::move(QueryStats), std::move(QueryPlan), std::move(QueryAst), LeaseGeneration, cancelledByUser
             );
             Send(MakeKqpFinalizeScriptServiceId(SelfId().NodeId()), scriptFinalizeRequest.release());
             return;

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/federated_query/common/common.h>
+#include <ydb/core/sys_view/common/registry.h>
 #include <ydb/core/testlib/test_pq_client.h>
 #include <ydb/library/testlib/common/test_utils.h>
 #include <ydb/library/testlib/pq_helpers/mock_pq_gateway.h>
@@ -4997,6 +4998,73 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             const auto result = results[i].ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
         }
+    }
+
+    Y_UNIT_TEST_F(StreamingQueryRestartAfterShutdown, TStreamingTestFixture) {
+        ExecQuery("GRANT ALL ON `/Root` TO `" BUILTIN_ACL_ROOT "`");
+
+        constexpr char inputTopicName[] = "streamingQueryRestartAfterShutdownInputTopic";
+        constexpr char outputTopicName[] = "streamingQueryRestartAfterShutdownOutputTopic";
+        CreateTopic(inputTopicName, NTopic::TCreateTopicSettings().PartitioningSettings(2, 2));
+        CreateTopic(outputTopicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        constexpr char queryName[] = "streamingQuery";
+        ExecQuery(fmt::format(R"(
+            CREATE STREAMING QUERY `{query_name}` AS
+            DO BEGIN
+                INSERT INTO `{pq_source}`.`{output_topic}`
+                SELECT * FROM `{pq_source}`.`{input_topic}`
+            END DO;)",
+            "query_name"_a = queryName,
+            "pq_source"_a = pqSourceName,
+            "input_topic"_a = inputTopicName,
+            "output_topic"_a = outputTopicName
+        ));
+
+        CheckScriptExecutionsCount(1, 1);
+        Sleep(TDuration::Seconds(1));
+
+        WriteTopicMessage(inputTopicName, "key1value1");
+        ReadTopicMessage(outputTopicName, "key1value1");
+
+        // Finish query like shutdown
+        {
+            const auto& edgeActor = GetRuntime().AllocateEdgeActor();
+            const auto& proxyId = MakeKqpProxyID(GetRuntime().GetFirstNodeId());
+
+            auto listRequest = std::make_unique<TEvKqp::TEvListSessionsRequest>();
+            auto& listRequestProto = listRequest->Record;
+            listRequestProto.AddColumns(NSysView::Schema::QuerySessions::SessionId::ColumnId);
+            listRequestProto.SetFreeSpace(std::numeric_limits<i64>::max());
+            listRequestProto.SetTenantName(GetRuntime().GetAppData().TenantName);
+            GetRuntime().Send(proxyId, edgeActor, listRequest.release());
+            auto sessionsEv = GetRuntime().GrabEdgeEvent<TEvKqp::TEvListSessionsResponse>(edgeActor, TEST_OPERATION_TIMEOUT);
+            UNIT_ASSERT(sessionsEv);
+
+            const auto& sessionsProto = sessionsEv->Get()->Record.GetSessions();
+            UNIT_ASSERT_GE(sessionsProto.size(), 1);
+
+            for (const auto& session : sessionsProto) {
+                auto closeRequest = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
+                closeRequest->Record.MutableRequest()->SetSessionId(session.GetSessionId());
+                GetRuntime().Send(proxyId, edgeActor, closeRequest.release());
+            }
+
+            Sleep(TDuration::Seconds(2));
+        }
+
+        const auto& result = ExecQuery("SELECT RetryCount FROM `.sys/streaming_queries`");
+        UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
+        CheckScriptResult(result[0], 1, 1, [&](TResultSetParser& resultSet) {
+            UNIT_ASSERT_VALUES_EQUAL(*resultSet.ColumnParser("RetryCount").GetOptionalUint64(), 1);
+        });
+
+        const auto disposition = TInstant::Now();
+        WriteTopicMessage(inputTopicName, "key2value2");
+        ReadTopicMessage(outputTopicName, "key2value2", disposition);
     }
 }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     ydb/core/kqp
     ydb/core/kqp/ut/common
     ydb/core/kqp/ut/federated_query/common
+    ydb/core/sys_view/common
     ydb/core/testlib
     ydb/library/testlib/common
     ydb/library/testlib/pq_helpers


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added retry for streaming query cancelled status

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Bugfix ticket: https://st.yandex-team.ru/YQ-5128
