### PR TITLE
Fix race condition in dynamic node subscription logic

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -583,13 +583,14 @@ namespace NKikimr::NStorage {
         TActorId StaticNodeSessionId;
         bool ReconnectScheduled = false;
         THashSet<ui32> ConnectedDynamicNodes;
+        ui64 StaticNodeSubscriptionCookie = 0;
 
         // these are used on the dynamic nodes
         void ApplyStaticNodeIds(const std::vector<ui32>& nodeIds);
         void ConnectToStaticNode();
         void HandleReconnect();
-        void OnStaticNodeConnected(ui32 nodeId, TActorId sessionId);
-        void OnStaticNodeDisconnected(ui32 nodeId, TActorId sessionId);
+        void OnStaticNodeConnected(ui32 nodeId, TActorId sessionId, ui64 cookie);
+        void OnStaticNodeDisconnected(ui32 nodeId, TActorId sessionId, ui64 cookie);
         void Handle(TEvNodeWardenDynamicConfigPush::TPtr ev);
 
         // these are used on the static nodes

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -223,7 +223,7 @@ namespace NKikimr::NStorage {
             (SubscriptionExists, SubscribedSessions.contains(nodeId)));
 
         if (!IsSelfStatic) {
-            return OnStaticNodeConnected(nodeId, sessionId);
+            return OnStaticNodeConnected(nodeId, sessionId, cookie);
         }
 
         // check subscription map, do we really have this subscription in flight
@@ -269,7 +269,7 @@ namespace NKikimr::NStorage {
         STLOG(PRI_DEBUG, BS_NODE, NWDC07, "TEvNodeDisconnected", (NodeId, nodeId), (SessionId, sessionId), (Cookie, cookie));
 
         if (!IsSelfStatic) {
-            return OnStaticNodeDisconnected(nodeId, sessionId);
+            return OnStaticNodeDisconnected(nodeId, sessionId, cookie);
         }
 
         const auto it = SubscribedSessions.find(nodeId);

--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -18,7 +18,7 @@ namespace NKikimr::NStorage {
             ConnectedToStaticNode = *nodeId;
             TActivationContext::Send(new IEventHandle(TEvBlobStorage::EvNodeWardenDynamicConfigSubscribe,
                 IEventHandle::FlagSubscribeOnSession, MakeBlobStorageNodeWardenID(ConnectedToStaticNode), SelfId(),
-                nullptr, 0));
+                nullptr, ++StaticNodeSubscriptionCookie));
         } else if (timestamp != TMonotonic::Max()) {
             if (!ReconnectScheduled) {
                 TActivationContext::Schedule(timestamp, new IEventHandle(TEvPrivate::EvReconnect, 0, SelfId(), {}, nullptr, 0));
@@ -33,16 +33,19 @@ namespace NKikimr::NStorage {
         ConnectToStaticNode();
     }
 
-    void TDistributedConfigKeeper::OnStaticNodeConnected(ui32 nodeId, TActorId sessionId) {
-        Y_ABORT_UNLESS(nodeId == ConnectedToStaticNode);
-        Y_ABORT_UNLESS(!StaticNodeSessionId);
-        StaticNodeSessionId = sessionId;
+    void TDistributedConfigKeeper::OnStaticNodeConnected(ui32 nodeId, TActorId sessionId, ui64 cookie) {
+        if (cookie == StaticNodeSubscriptionCookie) {
+            Y_ABORT_UNLESS(nodeId == ConnectedToStaticNode);
+            Y_ABORT_UNLESS(!StaticNodeSessionId);
+            StaticNodeSessionId = sessionId;
+        }
     }
 
-    void TDistributedConfigKeeper::OnStaticNodeDisconnected(ui32 nodeId, TActorId sessionId) {
-        if (nodeId != ConnectedToStaticNode || (StaticNodeSessionId && StaticNodeSessionId != sessionId)) {
+    void TDistributedConfigKeeper::OnStaticNodeDisconnected(ui32 nodeId, TActorId sessionId, ui64 cookie) {
+        if ((StaticNodeSessionId && sessionId != StaticNodeSessionId) || cookie != StaticNodeSubscriptionCookie) {
             return; // possible race with unsubscription
         }
+        Y_ABORT_UNLESS(nodeId == ConnectedToStaticNode);
         ConnectedToStaticNode = 0;
         StaticNodeSessionId = {};
         ConnectToStaticNode();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix race condition in dynamic node subscription logic

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes #35937 sometimes leading to false-positive assertion failure.
