### PR TITLE
Fix cross-database quota interference in Kesus quoter proxy

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2224,6 +2224,15 @@ message TImmediateControlsConfig {
     optional TGroupMapperControls GroupMapperControls = 18;
     optional TBackupControls BackupControls = 19;
     optional TBootstrapperControls BootstrapperControls = 20;
+
+    message TQuoterControls {
+        optional uint64 ProxyProtocolVersion = 1 [(ControlOptions) = {
+            Description: "Quoter proxy protocol version (0 = legacy, 1 = dual channel)",
+            MinValue: 0,
+            MaxValue: 10,
+            DefaultValue: 1 }];
+    }
+    optional TQuoterControls QuoterControls = 21;
 };
 
 message TMeteringConfig {

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -2,8 +2,10 @@
 #include "quoter_service_impl.h"
 #include "debug_info.h"
 
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/control/lib/immediate_control_board_impl.h>
 #include <ydb/core/kesus/tablet/events.h>
 #include <ydb/core/kesus/tablet/quoter_constants.h>
 
@@ -57,6 +59,7 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
         bool SessionIsActive = false;
         bool ProxySessionWasSent = false;
         TInstant LastAllocated = TInstant::Zero();
+        double LastAllocAmount = 0.0; // Last allocation from Kesus, used for sustained rate
         std::pair<TDuration, double> AverageAllocationParams = {TDuration::Zero(), 0.0};
 
         NKikimrKesus::TStreamingQuoterResource Props;
@@ -161,22 +164,58 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
             , Counters(resource, quoterCounters)
         {}
 
-        void AddUpdate(TEvQuota::TEvProxyUpdate& ev) const {
+        void AddUpdate(TEvQuota::TEvProxyUpdate& ev, ui32 version) const {
+            TVector<TEvQuota::TUpdateTick> update;
+            double sustainedRate = 0.0;
+
+            switch (version) {
+            case 1:
+                AddUpdateV1(update, sustainedRate);
+                break;
+            default:
+                AddUpdateV0(update, sustainedRate);
+                break;
+            }
+
+            ev.Resources.emplace_back(ResId, sustainedRate, std::move(update), TEvQuota::EUpdateState::Normal);
+        }
+
+    private:
+        void AddUpdateV0(TVector<TEvQuota::TUpdateTick>& update, double& sustainedRate) const {
             constexpr double rateBurst = 2.0;
             constexpr ui32 ticks = 2;
             constexpr double ticksD = static_cast<double>(ticks);
 
-            TVector<TEvQuota::TUpdateTick> update;
-            double sustainedRate = 0.0;
             if (Available > 0.0) {
                 update.emplace_back(0, ticks, Available * (rateBurst / ticksD), TEvQuota::ETickPolicy::Front);
                 sustainedRate = Available * rateBurst;
             } else {
-                // Ticks > 0 keeps the channel alive (Ticks=0 would erase it)
                 update.emplace_back(0, ticks, 0.0, TEvQuota::ETickPolicy::Front);
             }
-            ev.Resources.emplace_back(ResId, sustainedRate, std::move(update), TEvQuota::EUpdateState::Normal);
         }
+
+        void AddUpdateV1(TVector<TEvQuota::TUpdateTick>& update, double& sustainedRate) const {
+            // Dual-channel: sustained (channel 0) prevents starvation between
+            // Kesus allocations; burst (channel 1) provides immediate availability.
+            const double speed = Props.GetHierarchicalDRRResourceConfig().GetMaxUnitsPerSecond();
+            const double steadyRatePerTick = LastAllocAmount;
+            const double exhaustionThreshold = speed / 2.0;
+
+            if (steadyRatePerTick > 0 && Available > -exhaustionThreshold && speed > 0) {
+                update.emplace_back(0, Max<ui32>(), steadyRatePerTick, TEvQuota::ETickPolicy::Sustained);
+                sustainedRate = steadyRatePerTick * 10.0;
+            } else {
+                update.emplace_back(0, 2, 0.0, TEvQuota::ETickPolicy::Sustained);
+            }
+
+            if (Available > 0.0) {
+                update.emplace_back(1, 2, Available, TEvQuota::ETickPolicy::Front);
+            } else {
+                update.emplace_back(1, 1, 0.0, TEvQuota::ETickPolicy::Front);
+            }
+        }
+
+    public:
 
         void AddConsumed(double consumed) {
             if (ReplicationEnabled) {
@@ -244,6 +283,9 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
             if (!InitedProps) {
                 InitedProps = true;
                 SetAvailable(ResourceBucketMaxSize);
+                // Conservative init: 1% of expected per-tick allocation.
+                // Enough to keep TickRate > 0, adapts on first TEvResourcesAllocated.
+                LastAllocAmount = speed / 1000.0;
             }
             AllocStats.SetProps(Props);
         }
@@ -297,6 +339,7 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
     TInstant DisconnectTime;
     ui64 OfflineAllocationCookie = 0;
     ui64 KesusReconnectCount = 0;
+    TControlWrapper QuoterProxyProtocolVersion{1, 0, 10};
 
     TMap<TString, THolder<TResourceState>> Resources; // Map because iterators are needed to remain valid during insertions.
     THashMap<ui64, decltype(Resources)::iterator> ResIndex;
@@ -513,7 +556,7 @@ private:
             // Already. Resend result.
             resState->ProxySessionWasSent = false;
             SendProxySessionIfNotSent(resState);
-            resState->AddUpdate(GetProxyUpdateEv());
+            AddResourceUpdate(*resState);
         }
     }
 
@@ -556,6 +599,10 @@ private:
             ProxyUpdateEv = CreateUpdateEvent();
         }
         return *ProxyUpdateEv;
+    }
+
+    void AddResourceUpdate(TResourceState& res) {
+        res.AddUpdate(GetProxyUpdateEv(), static_cast<ui32>(static_cast<i64>(QuoterProxyProtocolVersion)));
     }
 
     void InitUpdateEv() {
@@ -757,7 +804,7 @@ private:
                 }
                 KESUS_PROXY_LOG_TRACE("Set info for resource \"" << res.Resource << "\": { Available: " << res.Available << ", QueueWeight: " << res.QueueWeight << " }");
                 CheckState(res);
-                res.AddUpdate(GetProxyUpdateEv());
+                AddResourceUpdate(res);
             }
         }
     }
@@ -862,7 +909,7 @@ private:
                             resourceIt->second->SetAvailable(resResult.GetInitialAvailable());
                         }
                         resState->AllocStats.OnConnected();
-                        resourceIt->second->AddUpdate(GetProxyUpdateEv());
+                        AddResourceUpdate(*resourceIt->second);
                         SendProxySessionIfNotSent(resState);
                     } else {
                         // TODO: make cache with error results.
@@ -890,11 +937,12 @@ private:
                 }
                 res->SetAvailable(res->Available + amount);
                 res->LastAllocated = now;
+                res->LastAllocAmount = amount;
                 res->AllocStats.OnResourceAllocated(now, amount);
                 res->TotalAllocated += amount;
                 res->Counters.ReceivedFromKesus += amount;
                 CheckState(*res);
-                res->AddUpdate(GetProxyUpdateEv());
+                AddResourceUpdate(*res);
             } else {
                 KESUS_PROXY_LOG_WARN("Resource [" << res->Resource << "] is broken: " << KesusErrorToString(allocatedInfo.GetStateNotification()));
                 BreakResource(*res, GetProxyUpdateEv());
@@ -919,7 +967,7 @@ private:
             res->SetAvailable(res->Available + allocatedInfo.Amount);
             res->LastAllocated = now;
             CheckState(*res);
-            res->AddUpdate(GetProxyUpdateEv());
+            AddResourceUpdate(*res);
             if (wasActive) {
                 MarkResourceForOfflineAllocation(*res, now);
             }
@@ -950,7 +998,7 @@ private:
             res->SetAvailable(available - consumedLagCompensation + allocatedLagCompensation);
             res->LastAllocated = now;
             CheckState(*res);
-            res->AddUpdate(GetProxyUpdateEv());
+            AddResourceUpdate(*res);
         }
     }
 
@@ -1095,6 +1143,10 @@ public:
     void Bootstrap() {
         KESUS_PROXY_LOG_INFO("Created kesus quoter proxy. Tablet id: " << GetKesusTabletId());
         Counters.Init(CanonizePath(Path));
+        if (AppData()->Icb) {
+            TControlBoard::RegisterSharedControl(QuoterProxyProtocolVersion,
+                AppData()->Icb->QuoterControls.ProxyProtocolVersion);
+        }
         Become(&TThis::StateFunc);
         ConnectToKesus(false);
     }

--- a/ydb/core/quoter/kesus_quoter_ut.cpp
+++ b/ydb/core/quoter/kesus_quoter_ut.cpp
@@ -2,6 +2,8 @@
 #include "kesus_quoter_proxy.h"
 #include "ut_helpers.h"
 
+#include <ydb/core/control/lib/immediate_control_board_impl.h>
+
 namespace NKikimr {
 
 Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
@@ -68,6 +70,20 @@ Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
         TKesusQuoterTestSetup setup;
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, TKesusQuoterTestSetup::DEFAULT_KESUS_RESOURCE); // stabilization
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, TKesusQuoterTestSetup::DEFAULT_KESUS_RESOURCE, 40, TDuration::MilliSeconds(500), TEvQuota::TEvClearance::EResult::Deadline); // default rate is 10
+    }
+
+    Y_UNIT_TEST(DualChannelPreventsStarvationAfterBurstConsumption) {
+        // Without dual-channel fix, consuming 2*BucketMax drains Available negative,
+        // channel expires, TickRate=0, requests stuck. With fix, Sustained channel
+        // keeps TickRate > 0 and the request succeeds.
+        TKesusQuoterTestSetup setup;
+        const auto& path = TKesusQuoterTestSetup::DEFAULT_KESUS_PATH;
+        const auto& resource = TKesusQuoterTestSetup::DEFAULT_KESUS_RESOURCE;
+
+        setup.GetQuota(path, resource); // stabilization
+        setup.GetQuota(path, resource, 4, TDuration::Seconds(10)); // consume 2*BucketMax
+        setup.GetQuota(path, resource, 1, TDuration::Seconds(2),
+                       TEvQuota::TEvClearance::EResult::Success); // must not starve
     }
 
     Y_UNIT_TEST(PrefetchCoefficient) {
@@ -672,9 +688,12 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 25.0, {}, 1, 25.0, 0, 0)});
         setup.WaitEvent<TEvQuota::TEvProxyStats>();
 
-        // Drain update after consumption (zero-rate channel, Available=-5)
         auto update = setup.GetProxyUpdate();
-        UNIT_ASSERT_DOUBLES_EQUAL(update->Get()->Resources[0].Update[0].Rate, 0.0, 0.001);
+        // Sustained channel (channel 0) must be active with positive rate
+        UNIT_ASSERT_GE(update->Get()->Resources[0].Update.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources[0].Update[0].Channel, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources[0].Update[0].Policy, TEvQuota::ETickPolicy::Sustained);
+        UNIT_ASSERT_GT(update->Get()->Resources[0].Update[0].Rate, 0.0);
 
         // Now double the speed: 100 -> 200
         // ResourceBucketMaxSize goes from 20 to 40, scale = 2.0
@@ -735,9 +754,7 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         const auto& res = update->Get()->Resources[0];
         UNIT_ASSERT_GT(res.Update.size(), 0);
         const auto& tick = res.Update[0];
-        // After Bug 4 fix: even with Available <= 0, Ticks should be > 0
         UNIT_ASSERT_GT(tick.Ticks, 0u);
-        UNIT_ASSERT_DOUBLES_EQUAL(tick.Rate, 0.0, 0.001);
     }
 
     Y_UNIT_TEST(ProxyRecoversFromZeroAvailable) {
@@ -765,12 +782,14 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 25.0, {}, 1, 25.0, 0, 0)});
         setup.WaitEvent<TEvQuota::TEvProxyStats>();
 
-        // Verify we get a zero-rate (but non-erasing) channel
+        // Sustained channel must still be active with positive rate
         auto update = setup.GetProxyUpdate();
         UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources.size(), 1);
-        UNIT_ASSERT_GT(update->Get()->Resources[0].Update.size(), 0);
+        UNIT_ASSERT_GE(update->Get()->Resources[0].Update.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources[0].Update[0].Channel, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources[0].Update[0].Policy, TEvQuota::ETickPolicy::Sustained);
         UNIT_ASSERT_GT(update->Get()->Resources[0].Update[0].Ticks, 0u);
-        UNIT_ASSERT_DOUBLES_EQUAL(update->Get()->Resources[0].Update[0].Rate, 0.0, 0.001);
+        UNIT_ASSERT_GT(update->Get()->Resources[0].Update[0].Rate, 0.0);
 
         // Now Kesus allocates new quota — Available becomes positive again
         // Available was -5, +10 = +5
@@ -811,17 +830,15 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 25.0, {}, 1, 25.0, 0, 0)});
         setup.WaitEvent<TEvQuota::TEvProxyStats>();
 
-        // Get the zero-rate channel update
         auto update = setup.GetProxyUpdate();
         UNIT_ASSERT_VALUES_EQUAL(update->Get()->Resources.size(), 1);
+        UNIT_ASSERT_GE(update->Get()->Resources[0].Update.size(), 1);
         const auto& tick = update->Get()->Resources[0].Update[0];
-        // Channel has Ticks=2, Rate=0 — it will expire after 2 FeedResource cycles
-        UNIT_ASSERT_VALUES_EQUAL(tick.Ticks, 2u);
-        UNIT_ASSERT_DOUBLES_EQUAL(tick.Rate, 0.0, 0.001);
+        // Sustained channel stays alive with positive rate after drain
         UNIT_ASSERT_VALUES_EQUAL(tick.Channel, 0u);
-        // Ticks=2 means: after 2 feed cycles without a new update, the channel
-        // is naturally removed by FeedResource (Ticks counts down: 2 -> 1 -> erase).
-        // This ensures no permanent channel leak if the proxy stops updating.
+        UNIT_ASSERT_VALUES_EQUAL(tick.Policy, TEvQuota::ETickPolicy::Sustained);
+        UNIT_ASSERT_GT(tick.Ticks, 0u);
+        UNIT_ASSERT_GT(tick.Rate, 0.0);
     }
 
     Y_UNIT_TEST(ConnectsDuringOfflineAllocation) {
@@ -851,6 +868,192 @@ Y_UNIT_TEST_SUITE(KesusProxyTest) {
         setup.SendConnected(pipe2);
 
         UNIT_ASSERT(setup.ConsumeResourceAllocateByKesus(pipe2, 42, 60.0, session->Get()->TickSize, 2));
+    }
+
+    Y_UNIT_TEST(SteadyChannelPreventsStarvationBetweenAllocations) {
+        // After consuming all Available, the Sustained channel must still
+        // report rate > 0 to prevent service starvation between allocations.
+        TKesusProxyTestSetup setup;
+        auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
+        EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
+            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+                UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
+                NKikimrKesus::TEvSubscribeOnResourcesResult ans;
+                FillResult(ans.AddResults(), 42, 100.0); // speed=100, BucketMax=20
+                pipe->SendSubscribeOnResourceResult(ans, cookie);
+            }));
+        EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
+            .Times(AnyNumber());
+
+        auto session = setup.ProxyRequest("res");
+        setup.GetProxyUpdate();
+
+        // Service consumes all available quota
+        setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 20.0, {}, 0, 0, 0, 0)});
+        setup.WaitEvent<TEvQuota::TEvProxyStats>();
+
+        auto update = setup.GetProxyUpdate();
+
+        // The steady channel (Sustained) should still have rate > 0
+        // even though Available is now 0.
+        bool hasSteadyRate = false;
+        for (const auto& tick : update->Get()->Resources[0].Update) {
+            if (tick.Policy == TEvQuota::ETickPolicy::Sustained && tick.Rate > 0.0) {
+                hasSteadyRate = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(hasSteadyRate,
+            "Steady channel should maintain positive rate after consumption. "
+            "This prevents the starvation gap between Kesus allocations.");
+    }
+
+    Y_UNIT_TEST(SteadyChannelRateMatchesLastAllocation) {
+        // Sustained rate = LastAllocAmount (what Kesus actually gave).
+        // speed=100, prefetch=0.2. Allocate 10 units → sustained rate = 10.
+        TKesusProxyTestSetup setup;
+        auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
+        EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
+            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+                UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
+                NKikimrKesus::TEvSubscribeOnResourcesResult ans;
+                FillResult(ans.AddResults(), 42, 100.0);
+                pipe->SendSubscribeOnResourceResult(ans, cookie);
+            }));
+        EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
+            .Times(AnyNumber());
+
+        auto session = setup.ProxyRequest("res");
+        setup.GetProxyUpdate();
+
+        // Drain Available
+        setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 25.0, {}, 1, 25.0, 0, 0)});
+        setup.WaitEvent<TEvQuota::TEvProxyStats>();
+        setup.GetProxyUpdate();
+
+        // Allocate 10 units — sustained rate should become 10
+        setup.SendResourcesAllocated(pipe, 42, 10.0);
+        auto update = setup.GetProxyUpdate();
+        for (const auto& tick : update->Get()->Resources[0].Update) {
+            if (tick.Policy == TEvQuota::ETickPolicy::Sustained) {
+                UNIT_ASSERT_DOUBLES_EQUAL(tick.Rate, 10.0, 0.01);
+                UNIT_ASSERT_VALUES_EQUAL(tick.Ticks, Max<ui32>());
+                break;
+            }
+        }
+    }
+
+    Y_UNIT_TEST(SteadyChannelAdaptsToSmallerAllocation) {
+        // When DRR gives us less (sibling activated), sustained rate drops.
+        TKesusProxyTestSetup setup;
+        auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
+        EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
+            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+                UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
+                NKikimrKesus::TEvSubscribeOnResourcesResult ans;
+                FillResult(ans.AddResults(), 42, 100.0);
+                pipe->SendSubscribeOnResourceResult(ans, cookie);
+            }));
+        EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
+            .Times(AnyNumber());
+
+        auto session = setup.ProxyRequest("res");
+        setup.GetProxyUpdate();
+
+        // Allocate 10 → sustained = 10
+        setup.SendResourcesAllocated(pipe, 42, 10.0);
+        setup.GetProxyUpdate();
+
+        // Drain
+        setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 30.0, {}, 1, 30.0, 0, 0)});
+        setup.WaitEvent<TEvQuota::TEvProxyStats>();
+        setup.GetProxyUpdate();
+
+        // Allocate only 5 (DRR half) → sustained should drop to 5
+        setup.SendResourcesAllocated(pipe, 42, 5.0);
+        auto update = setup.GetProxyUpdate();
+        for (const auto& tick : update->Get()->Resources[0].Update) {
+            if (tick.Policy == TEvQuota::ETickPolicy::Sustained) {
+                UNIT_ASSERT_DOUBLES_EQUAL(tick.Rate, 5.0, 0.01);
+                break;
+            }
+        }
+    }
+
+    Y_UNIT_TEST(SteadyChannelInitFromBucket) {
+        // Before any Kesus allocation, LastAllocAmount is initialized from
+        // BucketMaxSize. Sustained rate = BucketMax = speed * prefetch.
+        // speed=100, prefetch=0.2 → BucketMax=20 → sustained=20/tick.
+        TKesusProxyTestSetup setup;
+        auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
+        EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
+            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+                UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
+                NKikimrKesus::TEvSubscribeOnResourcesResult ans;
+                FillResult(ans.AddResults(), 42, 100.0);
+                pipe->SendSubscribeOnResourceResult(ans, cookie);
+            }));
+        EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
+            .Times(AnyNumber());
+
+        auto session = setup.ProxyRequest("res");
+        auto update = setup.GetProxyUpdate();
+
+        bool hasSustained = false;
+        bool hasBurst = false;
+        for (const auto& tick : update->Get()->Resources[0].Update) {
+            if (tick.Policy == TEvQuota::ETickPolicy::Sustained && tick.Rate > 0) {
+                // Initial sustained = speed/1000 = 0.1
+                UNIT_ASSERT_DOUBLES_EQUAL(tick.Rate, 0.1, 0.01);
+                hasSustained = true;
+            }
+            if (tick.Policy == TEvQuota::ETickPolicy::Front && tick.Rate > 0) {
+                hasBurst = true;
+            }
+        }
+        UNIT_ASSERT(hasSustained);
+        UNIT_ASSERT(hasBurst);
+    }
+
+    Y_UNIT_TEST(V0FallbackUsesSingleFrontChannel) {
+        // Verify ICB runtime switch to V0 (legacy single Front channel).
+        // First update arrives as V1 (default). Then switch ICB to V0,
+        // trigger another update via ProxyStats, verify it's V0.
+        TKesusProxyTestSetup setup;
+        auto* pipe = setup.GetPipeFactory().ExpectTabletPipeConnection();
+        EXPECT_CALL(*pipe, OnSubscribeOnResources(_, _))
+            .WillOnce(Invoke([&](const NKikimrKesus::TEvSubscribeOnResources& record, ui64 cookie) {
+                UNIT_ASSERT_VALUES_EQUAL(record.ResourcesSize(), 1);
+                NKikimrKesus::TEvSubscribeOnResourcesResult ans;
+                FillResult(ans.AddResults(), 42, 100.0);
+                pipe->SendSubscribeOnResourceResult(ans, cookie);
+            }));
+        EXPECT_CALL(*pipe, OnUpdateConsumptionState(_, _))
+            .Times(AnyNumber());
+
+        auto session = setup.ProxyRequest("res");
+
+        // First update: V1 (dual channel) — drain it
+        auto update1 = setup.GetProxyUpdate();
+        UNIT_ASSERT_GE(update1->Get()->Resources[0].Update.size(), 2); // V1: two channels
+
+        // Switch to V0 via ICB
+        auto& icb = *setup.GetRuntime().GetAppData().Icb;
+        TControlWrapper ctrl;
+        TControlBoard::RegisterSharedControl(ctrl, icb.QuoterControls.ProxyProtocolVersion);
+        ctrl = 0;
+
+        // Trigger another AddResourceUpdate via consumption stats
+        setup.SendProxyStats({TEvQuota::TProxyStat(42, 1, 1.0, {}, 0, 0, 0, 0)});
+        setup.WaitEvent<TEvQuota::TEvProxyStats>();
+        auto update2 = setup.GetProxyUpdate();
+
+        // V0: single channel, Front policy
+        UNIT_ASSERT_VALUES_EQUAL(update2->Get()->Resources[0].Update.size(), 1);
+        const auto& tick = update2->Get()->Resources[0].Update[0];
+        UNIT_ASSERT_VALUES_EQUAL(tick.Policy, TEvQuota::ETickPolicy::Front);
+        UNIT_ASSERT_VALUES_EQUAL(tick.Channel, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(tick.Ticks, 2u);
     }
 }
 

--- a/ydb/core/quoter/ut_helpers.cpp
+++ b/ydb/core/quoter/ut_helpers.cpp
@@ -1,5 +1,6 @@
 #include "ut_helpers.h"
 
+#include <ydb/core/control/lib/immediate_control_board_impl.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 
@@ -181,7 +182,11 @@ TKesusProxyTestSetup::TKesusProxyTestSetup() {
 }
 
 TTestActorRuntime::TEgg MakeEgg() {
-    return { new TAppData(0, 0, 0, 0, { }, nullptr, nullptr, nullptr, nullptr), nullptr, nullptr, {} };
+    auto* appData = new TAppData(0, 0, 0, 0, { }, nullptr, nullptr, nullptr, nullptr);
+    auto icb = MakeIntrusive<TControlBoard>();
+    icb->CreateConfigControls(true);
+    appData->Icb = icb;
+    return { appData, nullptr, nullptr, {} };
 }
 
 void TKesusProxyTestSetup::Start() {
@@ -372,15 +377,20 @@ bool TKesusProxyTestSetup::ConsumeResource(ui64 resId, double amount, TDuration 
                     found = true;
                     UNIT_ASSERT_VALUES_EQUAL(res.ResourceState, TEvQuota::EUpdateState::Normal);
 
-                    UNIT_ASSERT_VALUES_EQUAL(res.Update.size(), 1);
-                    const auto& updateTick = res.Update.front();
-                    UNIT_ASSERT_VALUES_EQUAL(updateTick.Channel, 0);
-                    UNIT_ASSERT_VALUES_EQUAL(updateTick.Policy, TEvQuota::ETickPolicy::Front);
-                    const bool noAmount = updateTick.Rate <= 0.0;
-                    if (noAmount) {
-                        // Zero-rate channel (keep-alive with Ticks > 0) — no quota available yet, keep trying
+                    UNIT_ASSERT_GT(res.Update.size(), 0);
+                    // Find the burst channel (Front policy with positive rate).
+                    const TEvQuota::TUpdateTick* burstTick = nullptr;
+                    for (const auto& tick : res.Update) {
+                        if (tick.Policy == TEvQuota::ETickPolicy::Front && tick.Rate > 0.0) {
+                            burstTick = &tick;
+                            break;
+                        }
+                    }
+                    if (!burstTick) {
+                        // No burst channel with positive rate — no Available quota yet, keep trying
                         continue;
                     }
+                    const auto& updateTick = *burstTick;
 
                     UNIT_ASSERT(res.SustainedRate > 0);
                     UNIT_ASSERT_VALUES_EQUAL(updateTick.Ticks, 2);


### PR DESCRIPTION
When two databases share the same Kesus quoter tree (same cloud), one database hitting its RU quota causes the other's partitions to experience write throttling.

Front-policy burst-starvation. The proxy reported Available (a bucket level snapshot) as a channel rate using Front policy with ticks=2. After consumption, rate dropped to 0 for ~98ms until the next Kesus allocation, causing partition write bursts.

Fix: Dual-channel architecture. Channel 0 (Sustained, long-lived) provides steady flow at configured speed. Channel 1 (Front, short- lived) provides immediate burst of Available. The steady channel prevents starvation gaps between Kesus allocations.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
