### PR TITLE
Make index build parallelism configurable in ALTER TABLE ADD INDEX (#24182)

### DIFF
--- a/ydb/core/base/fulltext.cpp
+++ b/ydb/core/base/fulltext.cpp
@@ -420,40 +420,39 @@ bool ValidateSettings(const Ydb::Table::FulltextIndexSettings& settings, TString
     return true;
 }
 
-bool FillSetting(Ydb::Table::FulltextIndexSettings& settings, const TString& name, const TString& value, TString& error) {
+bool FillSetting(Ydb::Table::FulltextIndexSettings& settings, const TString& nameLower, const TString& value, TString& error) {
     error = "";
 
     Ydb::Table::FulltextIndexSettings::Analyzers* analyzers = settings.columns().empty()
         ? settings.add_columns()->mutable_analyzers()
         : settings.mutable_columns()->rbegin()->mutable_analyzers();
 
-    const TString nameLower = to_lower(name);
     if (nameLower == "tokenizer") {
         analyzers->set_tokenizer(ParseTokenizer(value, error));
     } else if (nameLower == "language") {
         analyzers->set_language(value);
     } else if (nameLower == "use_filter_lowercase") {
-        analyzers->set_use_filter_lowercase(ParseBool(name, value, error));
+        analyzers->set_use_filter_lowercase(ParseBool(nameLower, value, error));
     } else if (nameLower == "use_filter_stopwords") {
-        analyzers->set_use_filter_stopwords(ParseBool(name, value, error));
+        analyzers->set_use_filter_stopwords(ParseBool(nameLower, value, error));
     } else if (nameLower == "use_filter_ngram") {
-        analyzers->set_use_filter_ngram(ParseBool(name, value, error));
+        analyzers->set_use_filter_ngram(ParseBool(nameLower, value, error));
     } else if (nameLower == "use_filter_edge_ngram") {
-        analyzers->set_use_filter_edge_ngram(ParseBool(name, value, error));
+        analyzers->set_use_filter_edge_ngram(ParseBool(nameLower, value, error));
     } else if (nameLower == "filter_ngram_min_length") {
-        analyzers->set_filter_ngram_min_length(ParseInt32(name, value, error));
+        analyzers->set_filter_ngram_min_length(ParseInt32(nameLower, value, error));
     } else if (nameLower == "filter_ngram_max_length") {
-        analyzers->set_filter_ngram_max_length(ParseInt32(name, value, error));
+        analyzers->set_filter_ngram_max_length(ParseInt32(nameLower, value, error));
     } else if (nameLower == "use_filter_length") {
-        analyzers->set_use_filter_length(ParseBool(name, value, error));
+        analyzers->set_use_filter_length(ParseBool(nameLower, value, error));
     } else if (nameLower == "filter_length_min") {
-        analyzers->set_filter_length_min(ParseInt32(name, value, error));
+        analyzers->set_filter_length_min(ParseInt32(nameLower, value, error));
     } else if (nameLower == "filter_length_max") {
-        analyzers->set_filter_length_max(ParseInt32(name, value, error));
+        analyzers->set_filter_length_max(ParseInt32(nameLower, value, error));
     } else if (nameLower == "use_filter_snowball") {
-        analyzers->set_use_filter_snowball(ParseBool(name, value, error));
+        analyzers->set_use_filter_snowball(ParseBool(nameLower, value, error));
     } else {
-        error = TStringBuilder() << "Unknown index setting: " << name;
+        error = TStringBuilder() << "Unknown index setting: " << nameLower;
         return false;
     }
 

--- a/ydb/core/base/fulltext.h
+++ b/ydb/core/base/fulltext.h
@@ -23,6 +23,6 @@ bool ValidateColumnsMatches(const NProtoBuf::RepeatedPtrField<TString>& columns,
 bool ValidateColumnsMatches(const TVector<TString>& columns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
 
 bool ValidateSettings(const Ydb::Table::FulltextIndexSettings& settings, TString& error);
-bool FillSetting(Ydb::Table::FulltextIndexSettings& settings, const TString& name, const TString& value, TString& error);
+bool FillSetting(Ydb::Table::FulltextIndexSettings& settings, const TString& nameLower, const TString& value, TString& error);
 
 }

--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -658,10 +658,9 @@ bool ValidateSettings(const Ydb::Table::VectorIndexSettings& settings, TString& 
     return true;
 }
 
-bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& name, const TString& value, TString& error) {
+bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& nameLower, const TString& value, TString& error) {
     error = "";
 
-    const TString nameLower = to_lower(name);
     if (nameLower == "distance") {
         if (settings.mutable_settings()->has_metric()) {
             error = "only one of distance or similarity should be set, not both";
@@ -677,17 +676,17 @@ bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& name, 
     } else if (nameLower =="vector_type") {
         settings.mutable_settings()->set_vector_type(ParseVectorType(value, error));
     } else if (nameLower =="vector_dimension") {
-        settings.mutable_settings()->set_vector_dimension(ParseUInt32(name, value, MinVectorDimension, MaxVectorDimension, error));
+        settings.mutable_settings()->set_vector_dimension(ParseUInt32(nameLower, value, MinVectorDimension, MaxVectorDimension, error));
     } else if (nameLower =="clusters") {
-        settings.set_clusters(ParseUInt32(name, value, MinClusters, MaxClusters, error));
+        settings.set_clusters(ParseUInt32(nameLower, value, MinClusters, MaxClusters, error));
     } else if (nameLower =="levels") {
-        settings.set_levels(ParseUInt32(name, value, MinLevels, MaxLevels, error));
+        settings.set_levels(ParseUInt32(nameLower, value, MinLevels, MaxLevels, error));
     } else if (nameLower == "overlap_clusters") {
-        settings.set_overlap_clusters(ParseUInt32(name, value, MinClusters, MaxClusters, error));
+        settings.set_overlap_clusters(ParseUInt32(nameLower, value, MinClusters, MaxClusters, error));
     } else if (nameLower == "overlap_ratio") {
-        settings.set_overlap_ratio(ParseDouble(name, value, error));
+        settings.set_overlap_ratio(ParseDouble(nameLower, value, error));
     } else {
-        error = TStringBuilder() << "Unknown index setting: " << name;
+        error = TStringBuilder() << "Unknown index setting: " << nameLower;
         return false;
     }
 

--- a/ydb/core/base/kmeans_clusters.h
+++ b/ydb/core/base/kmeans_clusters.h
@@ -61,7 +61,7 @@ std::unique_ptr<IClusters> CreateClustersAutoDetect(Ydb::Table::VectorIndexSetti
 
 bool ValidateSettings(const Ydb::Table::VectorIndexSettings& settings, TString& error);
 bool ValidateSettings(const Ydb::Table::KMeansTreeSettings& settings, TString& error);
-bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& name, const TString& value, TString& error);
+bool FillSetting(Ydb::Table::KMeansTreeSettings& settings, const TString& nameLower, const TString& value, TString& error);
 void FilterOverlapRows(TVector<TSerializedCellVec>& rows, size_t distancePos, ui32 overlapClusters, double overlapRatio);
 void FilterOverlapRows(TVector<std::pair<NTableIndex::NKMeans::TClusterId, double>>& rowClusters, ui32 overlapClusters, double overlapRatio);
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -2421,45 +2421,55 @@ public:
                             TIndexDescription::TLocalBloomNgramFilterDescription localBloomNgramFilterDesc;
                             for (const auto& indexSetting : indexSettings.Cast<TCoNameValueTupleList>()) {
                                 YQL_ENSURE(indexSetting.Value().Maybe<TCoAtom>());
-                                const auto& name = indexSetting.Name();
+                                const auto& name = to_lower(indexSetting.Name().StringValue());
                                 const auto& value = indexSetting.Value().Cast<TCoAtom>();
 
                                 TString error;
-                                switch (add_index->type_case()) {
-                                    case Ydb::Table::TableIndex::kGlobalVectorKmeansTreeIndex: {
-                                        NKikimr::NKMeans::FillSetting(
-                                            *add_index->mutable_global_vector_kmeans_tree_index()->mutable_vector_settings(),
-                                            name.StringValue(), value.StringValue(), error);
-                                        break;
+
+                                if (name == "parallel") {
+                                    ui32 result = 0;
+                                    if (TryFromString(value.StringValue(), result) && result > 0) {
+                                        add_index->set_parallel(result);
+                                    } else {
+                                        error = TStringBuilder() << "Invalid " << name << ": " << value.StringValue();
                                     }
-                                    case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex: {
-                                        NKikimr::NFulltext::FillSetting(
-                                            *add_index->mutable_global_fulltext_plain_index()->mutable_fulltext_settings(),
-                                            name.StringValue(), value.StringValue(), error);
-                                        break;
+                                } else {
+                                    switch (add_index->type_case()) {
+                                        case Ydb::Table::TableIndex::kGlobalVectorKmeansTreeIndex: {
+                                            NKikimr::NKMeans::FillSetting(
+                                                *add_index->mutable_global_vector_kmeans_tree_index()->mutable_vector_settings(),
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
+                                        case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex: {
+                                            NKikimr::NFulltext::FillSetting(
+                                                *add_index->mutable_global_fulltext_plain_index()->mutable_fulltext_settings(),
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
+                                        case Ydb::Table::TableIndex::kGlobalFulltextRelevanceIndex: {
+                                            NKikimr::NFulltext::FillSetting(
+                                                *add_index->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings(),
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
+                                        case Ydb::Table::TableIndex::kLocalBloomFilterIndex: {
+                                            FillLocalBloomFilterSetting(
+                                                localBloomFilterDesc,
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
+                                        case Ydb::Table::TableIndex::kLocalBloomNgramFilterIndex: {
+                                            FillLocalBloomNgramFilterSetting(
+                                                localBloomNgramFilterDesc,
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
+                                        default:
+                                            ctx.AddError(TIssue(ctx.GetPosition(nameNode.Pos()), TStringBuilder()
+                                                << "Unknown index setting: " << name));
+                                            return SyncError();
                                     }
-                                    case Ydb::Table::TableIndex::kGlobalFulltextRelevanceIndex: {
-                                        NKikimr::NFulltext::FillSetting(
-                                            *add_index->mutable_global_fulltext_relevance_index()->mutable_fulltext_settings(),
-                                            name.StringValue(), value.StringValue(), error);
-                                        break;
-                                    }
-                                    case Ydb::Table::TableIndex::kLocalBloomFilterIndex: {
-                                        FillLocalBloomFilterSetting(
-                                            localBloomFilterDesc,
-                                            name.StringValue(), value.StringValue(), error);
-                                        break;
-                                    }
-                                    case Ydb::Table::TableIndex::kLocalBloomNgramFilterIndex: {
-                                        FillLocalBloomNgramFilterSetting(
-                                            localBloomNgramFilterDesc,
-                                            name.StringValue(), value.StringValue(), error);
-                                        break;
-                                    }
-                                    default:
-                                        ctx.AddError(TIssue(ctx.GetPosition(nameNode.Pos()), TStringBuilder()
-                                            << "Unknown index setting: " << name.StringValue()));
-                                        return SyncError();
                                 }
 
                                 if (error) {

--- a/ydb/core/kqp/ut/indexes/vector/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/vector/kqp_indexes_vector_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/kqp/gateway/kqp_metadata_loader.h>
 #include <ydb/core/kqp/host/kqp_host_impl.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/schemeshard/index/build_index.h>
 
 #include <ydb/public/sdk/cpp/adapters/issue/issue.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/operation/operation.h>
@@ -1427,6 +1428,40 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
 
         DoOnlyUpsertValuesIntoTable(session);
         DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(VectorIndexBuildParallelOne) {
+        auto serverSettings = TKikimrSettings()
+            // SetUseRealThreads(false) is required to capture events (!) but then you have to do kikimr.RunCall() for everything
+            .SetUseRealThreads(false);
+
+        TKikimrRunner kikimr(serverSettings);
+        auto runtime = kikimr.GetTestServer().GetRuntime();
+
+        auto db = kikimr.RunCall([&] { return kikimr.GetTableClient(); });
+        auto session = kikimr.RunCall([&] { return DoOnlyCreateTableForVectorIndex(db); });
+
+        ui32 capturedParallel = 0;
+        auto captureEvents = [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == NSchemeShard::TEvIndexBuilder::TEvCreateRequest::EventType) {
+                capturedParallel = ev->Get<NSchemeShard::TEvIndexBuilder::TEvCreateRequest>()
+                    ->Record.GetSettings().max_shards_in_flight();
+            }
+            return false;
+        };
+        runtime->SetEventFilter(captureEvents);
+
+        const TString createIndex(Q_(R"(
+            ALTER TABLE `/Root/TestTable`
+                ADD INDEX index1
+                GLOBAL USING vector_kmeans_tree
+                ON (emb)
+                WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2, parallel=1);
+        )"));
+        auto result = kikimr.RunCall([&] { return session.ExecuteSchemeQuery(createIndex).ExtractValueSync(); });
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        UNIT_ASSERT_VALUES_EQUAL(capturedParallel, 1);
     }
 }
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -1975,4 +1975,63 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, txId);
     }
 
+    Y_UNIT_TEST(ParallelOne) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        ui64 tenantSchemeShard = 0;
+        TestCreateServerLessDb(runtime, env, txId, tenantSchemeShard);
+
+        TestCreateTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB", R"(
+            Name: "Table"
+            Columns { Name: "key"       Type: "Uint32" }
+            Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
+        )");
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 50);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 1, 50, 150);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 2, 150, 200);
+
+        // Count SampleK requests dispatched to datashards without blocking them
+        int requestsSeen = 0;
+        TBlockEvents<TEvDataShard::TEvSampleKRequest> requestCounter(runtime, [&](const auto&) {
+            ++requestsSeen;
+            return false;
+        });
+        TBlockEvents<TEvDataShard::TEvSampleKResponse> responseBlocker(runtime, [](const auto&) {
+            return true;
+        });
+
+        const ui64 buildIndexTx = ++txId;
+        {
+            auto sender = runtime.AllocateEdgeActor();
+            auto request = CreateBuildIndexRequest(buildIndexTx, "/MyRoot/ServerLessDB", "/MyRoot/ServerLessDB/Table",
+                TBuildIndexConfig{"index1", NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, {"embedding"}, {}, {}});
+            request->Record.MutableSettings()->set_max_shards_in_flight(1);
+            ForwardToTablet(runtime, tenantSchemeShard, sender, request);
+        }
+
+        // Check that only 1 request is in flight
+        for (int i = 0; i < 3; ++i) {
+            runtime.WaitFor("SampleKResponse", [&]{ return responseBlocker.size() >= 1; });
+            UNIT_ASSERT_VALUES_EQUAL_C(requestsSeen, i + 1,
+                "Expected " << i + 1 << " total requests, got " << requestsSeen << " at shard " << i + 1);
+            responseBlocker.Unblock(1);
+        }
+        responseBlocker.Stop().Unblock();
+
+        env.TestWaitNotification(runtime, buildIndexTx, tenantSchemeShard);
+        TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
+            {NLs::PathExist, NLs::IndexesCount(1)});
+    }
+
 }

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -200,6 +200,10 @@ bool BuildAlterTableAddIndexRequest(const Ydb::Table::AlterTableRequest* req, NK
         settings->set_if_not_exist(true);
     }
 
+    if (desc.parallel()) {
+        settings->set_max_shards_in_flight(desc.parallel());
+    }
+
     settings->set_source_path(req->path());
     auto tableIndex = settings->mutable_index();
     tableIndex->CopyFrom(req->add_indexes(0));

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -358,6 +358,8 @@ message TableIndex {
     }
     // list of columns content to be copied in to index table
     repeated string data_columns = 5;
+    // maximum level of parallelism for index build operation
+    optional uint32 parallel = 13;
 }
 
 // Represent table index with index state

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -442,6 +442,7 @@ public:
     const std::vector<std::string>& GetDataColumns() const;
     const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings>& GetIndexSettings() const;
     uint64_t GetSizeBytes() const;
+    void SetParallel(uint32_t parallel);
 
     static TIndexDescription CreateGlobalIndex(
         const std::string& name,
@@ -521,6 +522,7 @@ private:
     std::vector<TGlobalIndexSettings> GlobalIndexSettings_;
     std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings> SpecializedIndexSettings_;
     uint64_t SizeBytes_ = 0;
+    uint32_t Parallel_ = 0;
 };
 
 struct TRenameIndex {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -2511,6 +2511,10 @@ uint64_t TIndexDescription::GetSizeBytes() const {
     return SizeBytes_;
 }
 
+void TIndexDescription::SetParallel(uint32_t parallel) {
+    Parallel_ = parallel;
+}
+
 TIndexDescription TIndexDescription::CreateGlobalIndex(
     const std::string& name,
     const std::vector<std::string>& indexColumns,
@@ -3055,6 +3059,9 @@ TIndexDescription TIndexDescription::FromProto(const TProto& proto) {
     if constexpr (std::is_same_v<TProto, Ydb::Table::TableIndexDescription>) {
         result.SizeBytes_ = proto.size_bytes();
     }
+    if constexpr (std::is_same_v<TProto, Ydb::Table::TableIndex>) {
+        result.Parallel_ = proto.parallel();
+    }
 
     return result;
 }
@@ -3066,6 +3073,8 @@ void TIndexDescription::SerializeTo(Ydb::Table::TableIndex& proto) const {
     }
 
     *proto.mutable_data_columns() = {DataColumns_.begin(), DataColumns_.end()};
+
+    proto.set_parallel(Parallel_);
 
     switch (IndexType_) {
     case EIndexType::GlobalSync: {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

По итогам обсуждения поменял название опции на WITH (PARALLEL=...).

Также на саппорте договорились переименовать max_shards_in_flight в COMPACT, но это отдельным ПР.

Для векторного и полнотекстового работает сразу, т.к. там есть WITH, а для обычных и JSON нужно поправить YQL, чтобы разрешить WITH.