### PR TITLE
Add LastKeyAck to reshuffle, local & prefix kmeans indexes (issue #16342)

### DIFF
--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -26,6 +26,7 @@ message TIndexBuildScanSettings {
     optional uint32 MaxBatchRows = 1 [ default = 50000 ];
     optional uint64 MaxBatchBytes = 2 [ default = 8388608 ];
     optional uint32 MaxBatchRetries = 3 [ default = 50 ];
+    optional uint64 MaxCheckpointBytes = 4 [ default = 104857600 ]; // 100 MB
 }
 
 message TMeteringStats {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1686,6 +1686,8 @@ message TEvLocalKMeansRequest {
     optional uint32 OverlapClusters = 24;
     optional double OverlapRatio = 25;
     optional bool OverlapOutForeign = 26;
+
+    optional NKikimrTx.TKeyRange KeyRange = 27;
 }
 
 message TEvLocalKMeansResponse {
@@ -1703,6 +1705,8 @@ message TEvLocalKMeansResponse {
     reserved 8 to 11;
     optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
     optional bool IsEmpty = 13;
+
+    optional bytes LastKeyAck = 14;
 }
 
 message TEvReshuffleKMeansRequest {
@@ -1740,6 +1744,8 @@ message TEvReshuffleKMeansRequest {
     optional uint32 OverlapClusters = 18;
     optional double OverlapRatio = 19;
     optional bool OverlapOutForeign = 20;
+
+    optional NKikimrTx.TKeyRange KeyRange = 21;
 }
 
 message TEvReshuffleKMeansResponse {
@@ -1756,6 +1762,8 @@ message TEvReshuffleKMeansResponse {
 
     reserved 8 to 11;
     optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
+
+    optional bytes LastKeyAck = 13;
 }
 
 message TEvRecomputeKMeansRequest {
@@ -1859,6 +1867,8 @@ message TEvPrefixKMeansRequest {
     optional uint32 OverlapClusters = 21;
     optional double OverlapRatio = 22;
     optional bool OverlapOutForeign = 23;
+
+    optional NKikimrTx.TKeyRange KeyRange = 24;
 }
 
 message TEvPrefixKMeansResponse {
@@ -1875,6 +1885,8 @@ message TEvPrefixKMeansResponse {
 
     reserved 8 to 11;
     optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
+
+    optional bytes LastKeyAck = 13;
 }
 
 // Copy rows from an intermediate build table with more than <OverlapClusters> overlapping clusters

--- a/ydb/core/tx/datashard/build_index/common_helper.h
+++ b/ydb/core/tx/datashard/build_index/common_helper.h
@@ -132,6 +132,22 @@ public:
         return true;
     }
 
+    bool AllFlushed() const {
+        if (Uploading) {
+            return false;
+        }
+        for (const auto& [_, dst] : Destinations) {
+            if (!dst.Buffer.IsEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    ui64 GetUploadBytes() const {
+        return UploadBytes;
+    }
+
     void AddIssue(const std::exception& exc) {
         UploadStatus.Issues.AddIssue(NYql::TIssue(TStringBuilder()
             << "Scan failed " << exc.what()));

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -107,6 +107,11 @@ protected:
 
     bool IsExhausted = false;
 
+    TVector<NScheme::TTypeInfo> KeyTypes;
+    TSerializedCellVec LastAckedKey;
+    TSerializedCellVec PendingCheckpointKey;
+    ui64 NextCheckpointAtBytes = 0;
+
     std::unique_ptr<IClusters> Clusters;
     std::vector<std::pair<ui32, double>> TmpClusters;
 
@@ -137,9 +142,11 @@ public:
         , ResponseActorId{responseActorId}
         , Response{std::move(response)}
         , PrefixColumns{request.GetParentFrom() == 0 && request.GetParentTo() == 0 ? 0u : 1u}
+        , KeyTypes(table.KeyColumnTypes)
         , Clusters(std::move(clusters))
     {
         LOG_I("Create " << Debug());
+        NextCheckpointAtBytes = ScanSettings.GetMaxCheckpointBytes();
 
         const bool toBuild = (request.GetUpload() == NKikimrTxDataShard::UPLOAD_MAIN_TO_BUILD
             || request.GetUpload() == NKikimrTxDataShard::UPLOAD_BUILD_TO_BUILD);
@@ -189,6 +196,10 @@ public:
         record.MutableMeteringStats()->SetReadBytes(ReadBytes);
         record.MutableMeteringStats()->SetCpuTimeUs(Driver->GetTotalCpuTimeUs());
         record.SetIsEmpty(IsEmpty);
+
+        if (LastAckedKey.GetBuffer()) {
+            record.SetLastKeyAck(LastAckedKey.GetBuffer());
+        }
 
         Uploader.Finish(record, status);
 
@@ -315,9 +326,25 @@ protected:
             return;
         }
 
-        Uploader.Handle(ev);
+        bool batchUploaded = Uploader.Handle(ev);
 
         if (Uploader.GetUploadStatus().IsSuccess()) {
+            if (batchUploaded && PendingCheckpointKey.GetBuffer() && Uploader.AllFlushed()
+                && Uploader.GetUploadBytes() >= NextCheckpointAtBytes) {
+                NextCheckpointAtBytes = Uploader.GetUploadBytes() + ScanSettings.GetMaxCheckpointBytes();;
+                LastAckedKey = PendingCheckpointKey;
+                PendingCheckpointKey = {};
+
+                auto progress = MakeHolder<TEvDataShard::TEvLocalKMeansResponse>();
+                auto& rec = progress->Record;
+                rec.SetId(BuildId);
+                rec.SetTabletId(TabletId);
+                rec.SetRequestSeqNoGeneration(Response->Record.GetRequestSeqNoGeneration());
+                rec.SetRequestSeqNoRound(Response->Record.GetRequestSeqNoRound());
+                rec.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);
+                rec.SetLastKeyAck(LastAckedKey.GetBuffer());
+                Send(ResponseActorId, progress.Release());
+            }
             Driver->Touch(EScan::Feed);
             return;
         }
@@ -350,6 +377,7 @@ protected:
     bool FinishPrefix()
     {
         if (FinishPrefixImpl()) {
+            PendingCheckpointKey = Prefix;
             StartNewPrefix();
             LOG_T("FinishPrefix finished " << Debug());
             return true;
@@ -364,6 +392,7 @@ protected:
                         Feed(key.GetCells(), row.GetCells());
                     }
                     if (FinishPrefixImpl()) {
+                        PendingCheckpointKey = Prefix;
                         StartNewPrefix();
                         LOG_T("FinishPrefix finished in " << iteration << " iterations " << Debug());
                         return true;
@@ -656,7 +685,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
             {
                 badRequest("Wrong upload for zero parent");
             }
-            lead.To({}, NTable::ESeek::Lower);
+            if (request.HasKeyRange()) {
+                TSerializedTableRange resumeRange;
+                resumeRange.Load(request.GetKeyRange());
+                auto scanRange = Intersect(userTable.KeyColumnTypes, resumeRange.ToTableRange(), userTable.Range.ToTableRange());
+                lead = CreateLeadFrom(scanRange);
+            } else {
+                lead.To({}, NTable::ESeek::Lower);
+            }
         } else if (parentFrom > parentTo) {
             badRequest(TStringBuilder() << "Parent from " << parentFrom << " should be less or equal to parent to " << parentTo);
         } else if (request.GetUpload() == NKikimrTxDataShard::UPLOAD_MAIN_TO_BUILD
@@ -666,16 +702,23 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         } else {
             TCell from = TCell::Make(parentFrom - 1);
             TCell to = TCell::Make(parentTo);
-            TTableRange range{{&from, 1}, false, {&to, 1}, true};
-            auto scanRange = Intersect(userTable.KeyColumnTypes, range, userTable.Range.ToTableRange());
+            TTableRange parentRange{{&from, 1}, false, {&to, 1}, true};
+            auto scanRange = Intersect(userTable.KeyColumnTypes, parentRange, userTable.Range.ToTableRange());
             if (scanRange.IsEmptyRange(userTable.KeyColumnTypes)) {
                 badRequest(TStringBuilder() << "Requested range doesn't intersect with table range:"
-                    << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, range, *AppData()->TypeRegistry)
+                    << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, parentRange, *AppData()->TypeRegistry)
                     << " tableRange: " << DebugPrintRange(userTable.KeyColumnTypes, userTable.Range.ToTableRange(), *AppData()->TypeRegistry)
                     << " scanRange: " << DebugPrintRange(userTable.KeyColumnTypes, scanRange, *AppData()->TypeRegistry));
             }
-            lead.To(range.From, NTable::ESeek::Upper);
-            lead.Until(range.To, true);
+            if (request.HasKeyRange()) {
+                TSerializedTableRange resumeRange;
+                resumeRange.Load(request.GetKeyRange());
+                auto resumeScanRange = Intersect(userTable.KeyColumnTypes, resumeRange.ToTableRange(), scanRange);
+                lead = CreateLeadFrom(resumeScanRange);
+            } else {
+                lead.To(parentRange.From, NTable::ESeek::Upper);
+                lead.Until(parentRange.To, true);
+            }
         }
 
         if (!request.GetLevelName()) {

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -1,5 +1,6 @@
 #include "kmeans_helper.h"
 #include "../datashard_impl.h"
+#include "../range_ops.h"
 #include "../scan_common.h"
 #include "../upload_stats.h"
 #include "../buffer_data.h"
@@ -106,6 +107,10 @@ protected:
 
     bool IsExhausted = false;
 
+    TVector<NScheme::TTypeInfo> KeyTypes;
+    TSerializedCellVec LastAckedKey;
+    TSerializedCellVec PendingCheckpointKey;
+    ui64 NextCheckpointAtBytes = 0;
     std::unique_ptr<IClusters> Clusters;
     std::vector<std::pair<ui32, double>> TmpClusters;
 
@@ -135,9 +140,11 @@ public:
         , ResponseActorId{responseActorId}
         , Response{std::move(response)}
         , PrefixColumns{request.GetPrefixColumns()}
+        , KeyTypes(table.KeyColumnTypes)
         , Clusters(std::move(clusters))
     {
         LOG_I("Create " << Debug());
+        NextCheckpointAtBytes = ScanSettings.GetMaxCheckpointBytes();
 
         const bool toBuild = request.GetUpload() == NKikimrTxDataShard::UPLOAD_BUILD_TO_BUILD;
         OutForeign = OverlapClusters > 1 && request.GetOverlapOutForeign();
@@ -152,6 +159,13 @@ public:
         // DataPos always includes the embedding column
         DataColumnCount = ScanTags.size() - request.GetSourcePrimaryKeyColumns().size() - DataPos;
         Lead.To(ScanTags, {}, NTable::ESeek::Lower);
+        if (request.HasKeyRange()) {
+            TSerializedTableRange resumeRange;
+            resumeRange.Load(request.GetKeyRange());
+            auto scanRange = Intersect(KeyTypes, resumeRange.ToTableRange(), table.GetTableRange());
+            Lead = CreateLeadFrom(scanRange);
+            Lead.SetTags(ScanTags);
+        }
         {
             Ydb::Type type;
             auto levelTypes = std::make_shared<NTxProxy::TUploadTypes>(3);
@@ -216,6 +230,10 @@ public:
         record.MutableMeteringStats()->SetReadRows(ReadRows);
         record.MutableMeteringStats()->SetReadBytes(ReadBytes);
         record.MutableMeteringStats()->SetCpuTimeUs(Driver->GetTotalCpuTimeUs());
+
+        if (LastAckedKey.GetBuffer()) {
+            record.SetLastKeyAck(LastAckedKey.GetBuffer());
+        }
 
         Uploader.Finish(record, status);
 
@@ -346,9 +364,26 @@ protected:
             return;
         }
 
-        Uploader.Handle(ev);
+        bool batchUploaded = Uploader.Handle(ev);
 
         if (Uploader.GetUploadStatus().IsSuccess()) {
+            if (batchUploaded && PendingCheckpointKey.GetBuffer() && Uploader.AllFlushed()
+                && Uploader.GetUploadBytes() >= NextCheckpointAtBytes)
+            {
+                NextCheckpointAtBytes = Uploader.GetUploadBytes() + ScanSettings.GetMaxCheckpointBytes();;
+                LastAckedKey = PendingCheckpointKey;
+                PendingCheckpointKey = {};
+
+                auto progress = MakeHolder<TEvDataShard::TEvPrefixKMeansResponse>();
+                auto& rec = progress->Record;
+                rec.SetId(BuildId);
+                rec.SetTabletId(TabletId);
+                rec.SetRequestSeqNoGeneration(Response->Record.GetRequestSeqNoGeneration());
+                rec.SetRequestSeqNoRound(Response->Record.GetRequestSeqNoRound());
+                rec.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);
+                rec.SetLastKeyAck(LastAckedKey.GetBuffer());
+                Send(ResponseActorId, progress.Release());
+            }
             Driver->Touch(EScan::Feed);
             return;
         }
@@ -390,6 +425,7 @@ protected:
     bool FinishPrefix()
     {
         if (FinishPrefixImpl()) {
+            PendingCheckpointKey = Prefix;
             StartNewPrefix();
             LOG_T("FinishPrefix finished " << Debug());
             return true;
@@ -404,6 +440,7 @@ protected:
                         Feed(key.GetCells(), row.GetCells());
                     }
                     if (FinishPrefixImpl()) {
+                        PendingCheckpointKey = Prefix;
                         StartNewPrefix();
                         LOG_T("FinishPrefix finished in " << iteration << " iterations " << Debug());
                         return true;

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -1,5 +1,6 @@
 #include "kmeans_helper.h"
 #include "../datashard_impl.h"
+#include "../range_ops.h"
 #include "../scan_common.h"
 #include "../upload_stats.h"
 #include "../buffer_data.h"
@@ -65,6 +66,11 @@ protected:
     ui64 ReadRows = 0;
     ui64 ReadBytes = 0;
 
+    TVector<NScheme::TTypeInfo> KeyTypes;
+    TSerializedCellVec LastProcessedKey;
+    TSerializedCellVec LastAckedKey;
+    ui64 NextCheckpointAtBytes = 0;
+
     TBatchRowsUploader Uploader;
 
     TBufferData* OutputBuf = nullptr;
@@ -111,6 +117,7 @@ public:
         , Lead(std::move(lead))
         , TabletId(tabletId)
         , BuildId(request.GetId())
+        , KeyTypes(table.KeyColumnTypes)
         , Uploader(request.GetDatabaseName(), request.GetScanSettings())
         , Dimensions(request.GetSettings().vector_dimension())
         , OverlapClusters(request.GetOverlapClusters() ? request.GetOverlapClusters() : 1)
@@ -120,6 +127,17 @@ public:
         , Response(std::move(response))
         , Clusters(std::move(clusters))
     {
+        if (request.HasKeyRange()) {
+            TSerializedTableRange requestedRange;
+            requestedRange.Load(request.GetKeyRange());
+            TCell fromCell, toCell;
+            auto parentRange = CreateRangeFrom(table, Parent, fromCell, toCell);
+            auto scanRange = Intersect(KeyTypes, requestedRange.ToTableRange(), parentRange);
+            Lead = CreateLeadFrom(scanRange);
+        }
+
+        NextCheckpointAtBytes = ScanSettings.GetMaxCheckpointBytes();
+
         LOG_I("Create " << Debug());
 
         const bool toBuild = (request.GetUpload() == NKikimrTxDataShard::UPLOAD_MAIN_TO_BUILD
@@ -158,6 +176,10 @@ public:
         record.MutableMeteringStats()->SetReadRows(ReadRows);
         record.MutableMeteringStats()->SetReadBytes(ReadBytes);
         record.MutableMeteringStats()->SetCpuTimeUs(Driver->GetTotalCpuTimeUs());
+
+        if (LastAckedKey.GetBuffer()) {
+            record.SetLastKeyAck(LastAckedKey.GetBuffer());
+        }
 
         Uploader.Finish(record, status);
 
@@ -215,6 +237,8 @@ public:
         ++ReadRows;
         ReadBytes += CountRowCellBytes(key, *row);
 
+        LastProcessedKey = TSerializedCellVec(key);
+
         Feed(key, *row);
 
         return Uploader.ShouldWaitUpload() ? EScan::Sleep : EScan::Feed;
@@ -258,9 +282,25 @@ protected:
             return;
         }
 
-        Uploader.Handle(ev);
+        bool batchUploaded = Uploader.Handle(ev);
 
         if (Uploader.GetUploadStatus().IsSuccess()) {
+            if (batchUploaded && !IsExhausted && LastProcessedKey.GetBuffer()
+                && LastProcessedKey.GetBuffer() != LastAckedKey.GetBuffer() && Uploader.AllFlushed()
+                && Uploader.GetUploadBytes() >= NextCheckpointAtBytes) {
+                NextCheckpointAtBytes = Uploader.GetUploadBytes() + ScanSettings.GetMaxCheckpointBytes();
+                LastAckedKey = LastProcessedKey;
+
+                auto progress = MakeHolder<TEvDataShard::TEvReshuffleKMeansResponse>();
+                auto& record = progress->Record;
+                record.SetId(BuildId);
+                record.SetTabletId(TabletId);
+                record.SetRequestSeqNoGeneration(Response->Record.GetRequestSeqNoGeneration());
+                record.SetRequestSeqNoRound(Response->Record.GetRequestSeqNoRound());
+                record.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);
+                record.SetLastKeyAck(LastAckedKey.GetBuffer());
+                Send(ResponseActorId, progress.Release());
+            }
             Driver->Touch(EScan::Feed);
             return;
         }
@@ -280,6 +320,7 @@ protected:
     {
         return TStringBuilder() << "TReshuffleKMeansScan TabletId: " << TabletId << " Id: " << BuildId
             << " Parent: " << Parent << " Child: " << Child
+            << ", last acked key: " << DebugPrintPoint(KeyTypes, LastAckedKey.GetCells(), *AppData()->TypeRegistry)
             << " " << Clusters->Debug()
             << " " << Uploader.Debug();
     }

--- a/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_local_kmeans.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/index_builder.pb.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -82,7 +83,8 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
     static std::tuple<TString, TString> DoLocalKMeans(
         Tests::TServer::TPtr server, TActorId sender, NTableIndex::NKMeans::TClusterId parentFrom, NTableIndex::NKMeans::TClusterId parentTo, ui64 seed, ui64 k,
         NKikimrTxDataShard::EKMeansState upload, VectorIndexSettings::VectorType type,
-        VectorIndexSettings::Metric metric, ui32 maxBatchRows = 50000, ui32 overlapClusters = 0, bool expectEmpty = false)
+        VectorIndexSettings::Metric metric, ui32 maxBatchRows = 50000, ui32 overlapClusters = 0, bool expectEmpty = false,
+        std::optional<TSerializedTableRange> keyRange = {})
     {
         auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
@@ -139,6 +141,10 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
                 rec.SetOutputName(kPostingTable);
 
                 rec.MutableScanSettings()->SetMaxBatchRows(maxBatchRows);
+
+                if (keyRange) {
+                    keyRange->Serialize(*rec.MutableKeyRange());
+                }
             };
             fill(ev1);
             fill(ev2);
@@ -1050,6 +1056,145 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
                 recreate();
             }
         }
+    }
+
+    Y_UNIT_TEST(MainToPostingWithKeyRange) {
+        // Verify that specifying a KeyRange in the request causes only rows
+        // in that range to be scanned (resume-from-checkpoint semantics).
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        CreateMainTable(server, sender, options);
+
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (key, embedding, data) VALUES )"
+            "(1, \"mm\2\", \"one\"),"
+            "(2, \"mm\2\", \"two\"),"
+            "(3, \"mm\2\", \"three\"),"
+            "(4, \"11\2\", \"four\"),"
+            "(5, \"11\2\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed = 0;
+        ui64 k = 2;
+
+        // Full scan (no KeyRange): all 5 rows clustered.
+        auto [fullLevel, fullPosting] = DoLocalKMeans(server, sender, 0, 0, seed, k,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN);
+        recreate();
+
+        // Resumed scan: start strictly after key=2.
+        TCell fromCell = TCell::Make(ui32(2));
+        TSerializedTableRange resumeRange{TArrayRef<const TCell>{&fromCell, 1}, false, {}, false};
+        auto [resumedLevel, resumedPosting] = DoLocalKMeans(server, sender, 0, 0, seed, k,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN,
+            50000, 0, false, resumeRange);
+
+        // Resumed scan should only contain rows 3, 4, 5.
+        UNIT_ASSERT(!resumedPosting.Contains("key = 1,"));
+        UNIT_ASSERT(!resumedPosting.Contains("key = 2,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 3,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 4,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 5,"));
+
+        // Full scan covers all rows.
+        UNIT_ASSERT(fullPosting.Contains("key = 1,"));
+        UNIT_ASSERT(fullPosting.Contains("key = 2,"));
+        UNIT_ASSERT(fullPosting.Contains("key = 3,"));
+        UNIT_ASSERT(fullPosting.Contains("key = 4,"));
+        UNIT_ASSERT(fullPosting.Contains("key = 5,"));
+    }
+
+    Y_UNIT_TEST(BuildToBuildWithKeyRange) {
+        // Verify that KeyRange restricts scanning for the build-to-build upload mode.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        CreateBuildTable(server, sender, options, "table-main");
+
+        // Insert rows under parent cluster 1 (keys 1..5) — used as scan input.
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (__ydb_parent, key, embedding, data) VALUES )"
+            "(1, 1, \"mm\2\", \"one\"),"
+            "(1, 2, \"mm\2\", \"two\"),"
+            "(1, 3, \"mm\2\", \"three\"),"
+            "(1, 4, \"11\2\", \"four\"),"
+            "(1, 5, \"11\2\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreateBuildTable(server, sender, options, "table-posting");
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed = 0;
+        ui64 k = 2;
+
+        // Full scan of parent=1.
+        auto [fullLevel, fullPosting] = DoLocalKMeans(server, sender, 1, 1, seed, k,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN);
+        recreate();
+
+        // Resume from (parent=1, key=3) exclusive — should only see keys 4 and 5.
+        TCell fromCells[2] = {TCell::Make(ui64(1)), TCell::Make(ui32(3))};
+        TSerializedTableRange resumeRange{TArrayRef<const TCell>{fromCells, 2}, false, {}, false};
+        auto [resumedLevel, resumedPosting] = DoLocalKMeans(server, sender, 1, 1, seed, k,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN,
+            50000, 0, false, resumeRange);
+
+        UNIT_ASSERT(!resumedPosting.Contains("key = 1,"));
+        UNIT_ASSERT(!resumedPosting.Contains("key = 2,"));
+        UNIT_ASSERT(!resumedPosting.Contains("key = 3,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 4,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 5,"));
+
+        UNIT_ASSERT(fullPosting.Contains("key = 1,"));
+        UNIT_ASSERT(fullPosting.Contains("key = 4,"));
     }
 }
 

--- a/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/index_builder.pb.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -84,7 +85,8 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
     static std::tuple<TString, TString, TString> DoPrefixKMeans(
         Tests::TServer::TPtr server, TActorId sender, NTableIndex::NKMeans::TClusterId parent, ui64 seed, ui64 k,
         NKikimrTxDataShard::EKMeansState upload, VectorIndexSettings::VectorType type,
-        VectorIndexSettings::Metric metric, ui32 maxBatchRows, ui32 overlapClusters = 0)
+        VectorIndexSettings::Metric metric, ui32 maxBatchRows, ui32 overlapClusters = 0,
+        std::optional<TSerializedTableRange> keyRange = {})
     {
         auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
@@ -137,6 +139,10 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
                 rec.SetOutputName(kPostingTable);
 
                 rec.MutableScanSettings()->SetMaxBatchRows(maxBatchRows);
+
+                if (keyRange) {
+                    keyRange->Serialize(*rec.MutableKeyRange());
+                }
             };
             fill(ev1);
             fill(ev2);
@@ -747,6 +753,87 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
             );
             recreate();
         }
+    }
+
+    Y_UNIT_TEST(BuildToPostingWithKeyRange) {
+        // Verify that specifying a KeyRange causes only the rows after the given
+        // key to be scanned, skipping already-processed rows (resume semantics).
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+
+        CreateBuildPrefixTable(server, sender, options, "table-main");
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (user, key, embedding, data) VALUES )"
+            "(\"user-1\", 11, \"\x30\x30\2\", \"1-one\"),"
+            "(\"user-1\", 12, \"\x31\x31\2\", \"1-two\"),"
+            "(\"user-1\", 13, \"\x32\x32\2\", \"1-three\"),"
+            "(\"user-1\", 14, \"\x65\x65\2\", \"1-four\"),"
+            "(\"user-1\", 15, \"\x75\x75\2\", \"1-five\"),"
+            "(\"user-2\", 21, \"\x30\x30\2\", \"2-one\"),"
+            "(\"user-2\", 22, \"\x31\x31\2\", \"2-two\"),"
+            "(\"user-2\", 23, \"\x32\x32\2\", \"2-three\"),"
+            "(\"user-2\", 24, \"\x65\x65\2\", \"2-four\"),"
+            "(\"user-2\", 25, \"\x75\x75\2\", \"2-five\");");
+
+        auto create = [&] {
+            CreatePrefixTable(server, sender, options);
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-prefix");
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        // Full scan baseline.
+        auto [fullPrefix, fullLevel, fullPosting] = DoPrefixKMeans(server, sender, 40, 0, 2,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN, 50000);
+        recreate();
+
+        // Resume scan from strictly after (user-1, key=15) — should only process user-2 rows.
+        TString userStr = "user-1";
+        TCell fromCells[2] = {TCell(userStr.data(), userStr.size()), TCell::Make(ui32(15))};
+        TSerializedTableRange resumeRange{TArrayRef<const TCell>{fromCells, 2}, false, {}, false};
+        auto [resumedPrefix, resumedLevel, resumedPosting] = DoPrefixKMeans(server, sender, 40, 0, 2,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN, 50000,
+            0, resumeRange);
+
+        // Full scan contains both users.
+        UNIT_ASSERT(fullPosting.Contains("1-one"));
+        UNIT_ASSERT(fullPosting.Contains("2-one"));
+
+        // Resumed scan skips all user-1 rows.
+        UNIT_ASSERT(!resumedPosting.Contains("1-one"));
+        UNIT_ASSERT(!resumedPosting.Contains("1-two"));
+        UNIT_ASSERT(!resumedPosting.Contains("1-three"));
+        UNIT_ASSERT(!resumedPosting.Contains("1-four"));
+        UNIT_ASSERT(!resumedPosting.Contains("1-five"));
+
+        // Resumed scan contains user-2 rows.
+        UNIT_ASSERT(resumedPosting.Contains("2-one"));
+        UNIT_ASSERT(resumedPosting.Contains("2-two"));
+        UNIT_ASSERT(resumedPosting.Contains("2-three"));
+        UNIT_ASSERT(resumedPosting.Contains("2-four"));
+        UNIT_ASSERT(resumedPosting.Contains("2-five"));
     }
 }
 

--- a/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_reshuffle_kmeans.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/index_builder.pb.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -75,7 +76,8 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
 
     static TString DoReshuffleKMeans(Tests::TServer::TPtr server, TActorId sender, NTableIndex::NKMeans::TClusterId parent,
         const std::vector<TString>& level, NKikimrTxDataShard::EKMeansState upload,
-        VectorIndexSettings::VectorType type, VectorIndexSettings::Metric metric, ui32 overlapClusters = 0)
+        VectorIndexSettings::VectorType type, VectorIndexSettings::Metric metric, ui32 overlapClusters = 0,
+        ui32 maxBatchRows = 50000, std::optional<TSerializedTableRange> keyRange = {})
     {
         auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
@@ -125,6 +127,12 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
                     upload == NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD);
 
                 rec.SetOutputName(kPostingTable);
+
+                rec.MutableScanSettings()->SetMaxBatchRows(maxBatchRows);
+
+                if (keyRange) {
+                    keyRange->Serialize(*rec.MutableKeyRange());
+                }
             };
             fill(ev1);
             fill(ev2);
@@ -145,6 +153,73 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
         Cerr << "Posting:" << Endl;
         Cerr << posting << Endl;
         return std::move(posting);
+    }
+
+    // Returns the LastKeyAck from the DONE response (collected after all IN_PROGRESS messages are drained).
+    static TString DoReshuffleKMeansCollectProgress(Tests::TServer::TPtr server, TActorId sender,
+        NTableIndex::NKMeans::TClusterId parent, const std::vector<TString>& level,
+        NKikimrTxDataShard::EKMeansState upload, VectorIndexSettings::VectorType type,
+        VectorIndexSettings::Metric metric, ui32 maxBatchRows,
+        TVector<TString>& outInProgressKeys, ui64 maxCheckpointBytes = 0)
+    {
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
+        auto& runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        auto datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        UNIT_ASSERT_EQUAL(datashards.size(), 1u);
+        auto tid = datashards[0];
+
+        auto ev = std::make_unique<TEvDataShard::TEvReshuffleKMeansRequest>();
+        auto& rec = ev->Record;
+        rec.SetId(1);
+        rec.SetSeqNoGeneration(id);
+        rec.SetSeqNoRound(1);
+        rec.SetTabletId(tid);
+        tableId.PathId.ToProto(rec.MutablePathId());
+        rec.SetSnapshotTxId(snapshot.TxId);
+        rec.SetSnapshotStep(snapshot.Step);
+
+        VectorIndexSettings settings;
+        settings.set_vector_dimension(2);
+        settings.set_vector_type(type);
+        settings.set_metric(metric);
+        *rec.MutableSettings() = settings;
+
+        rec.SetUpload(upload);
+        *rec.MutableClusters() = {level.begin(), level.end()};
+        rec.SetParent(parent);
+        rec.SetChild(parent + 1);
+        rec.SetEmbeddingColumn("embedding");
+        rec.AddDataColumns("data");
+        rec.SetDatabaseName(kDatabaseName);
+        rec.SetOutputName(kPostingTable);
+        rec.MutableScanSettings()->SetMaxBatchRows(maxBatchRows);
+        if (maxCheckpointBytes > 0) {
+            rec.MutableScanSettings()->SetMaxCheckpointBytes(maxCheckpointBytes);
+        }
+
+        runtime.SendToPipe(tid, sender, ev.release(), 0, GetPipeConfigWithRetries());
+
+        TString lastKeyAck;
+        while (true) {
+            TAutoPtr<IEventHandle> handle;
+            runtime.GrabEdgeEvents<TEvDataShard::TEvReshuffleKMeansResponse>(handle);
+            auto* reply = handle->Get<TEvDataShard::TEvReshuffleKMeansResponse>();
+            if (reply->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS) {
+                outInProgressKeys.push_back(reply->Record.GetLastKeyAck());
+            } else {
+                NYql::TIssues issues;
+                NYql::IssuesFromMessage(reply->Record.GetIssues(), issues);
+                UNIT_ASSERT_EQUAL_C(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::DONE,
+                                    issues.ToOneLineString());
+                lastKeyAck = reply->Record.GetLastKeyAck();
+                break;
+            }
+        }
+
+        return lastKeyAck;
     }
 
     static void DropTable(Tests::TServer::TPtr server, TActorId sender, const char* name)
@@ -719,6 +794,191 @@ Y_UNIT_TEST_SUITE (TTxDataShardReshuffleKMeansScan) {
             NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD,
             VectorIndexSettings::VECTOR_TYPE_UINT8, similarity, 2);
         UNIT_ASSERT_VALUES_EQUAL(posting, BuildToBuildWithOverlapOut);
+    }
+
+    Y_UNIT_TEST(MainToPostingWithKeyRange) {
+        // Verify that specifying a KeyRange in the request causes only the rows
+        // after the given key to be scanned and uploaded.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        CreateMainTable(server, sender, options);
+
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (key, embedding, data) VALUES )"
+            "(1, \"mm\2\", \"one\"),"
+            "(2, \"mm\2\", \"two\"),"
+            "(3, \"mm\2\", \"three\"),"
+            "(4, \"11\2\", \"four\"),"
+            "(5, \"11\2\", \"five\");");
+
+        auto create = [&] { CreatePostingTable(server, sender, options); };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        std::vector<TString> level = {"mm\2", "11\2"};
+
+        // Full scan: all 5 rows
+        auto fullPosting = DoReshuffleKMeans(server, sender, 0, level,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE);
+        recreate();
+
+        // Resume scan starting strictly after key=2 (exclusive lower bound).
+        // Only rows 3,4,5 should be processed.
+        TCell fromCell = TCell::Make(ui32(2));
+        TSerializedTableRange resumeRange{TArrayRef<const TCell>{&fromCell, 1}, false, {}, false};
+        auto resumedPosting = DoReshuffleKMeans(server, sender, 0, level,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE,
+            0 /*overlapClusters*/, 50000, resumeRange);
+
+        // Full scan contains rows 1..5; resumed scan skips rows 1 and 2.
+        UNIT_ASSERT(resumedPosting.size() < fullPosting.size());
+        UNIT_ASSERT(!resumedPosting.Contains("key = 1,"));
+        UNIT_ASSERT(!resumedPosting.Contains("key = 2,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 3,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 4,"));
+        UNIT_ASSERT(resumedPosting.Contains("key = 5,"));
+    }
+
+    Y_UNIT_TEST(MainToPostingLastKeyAckInProgress) {
+        // Verify that IN_PROGRESS messages with LastKeyAck are sent when batches
+        // are uploaded, and that LastKeyAck in the final DONE response is set.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        CreateMainTable(server, sender, options);
+
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (key, embedding, data) VALUES )"
+            "(1, \"mm\2\", \"one\"),"
+            "(2, \"mm\2\", \"two\"),"
+            "(3, \"mm\2\", \"three\"),"
+            "(4, \"11\2\", \"four\"),"
+            "(5, \"11\2\", \"five\");");
+
+        CreatePostingTable(server, sender, options);
+
+        std::vector<TString> level = {"mm\2", "11\2"};
+
+        // Use MaxBatchRows=1 and MaxCheckpointBytes=1. With one row per batch, the second
+        // row arrives while the first upload is still in-flight, so ShouldWaitUpload blocks
+        // the scan. When the first upload completes, Handle() starts the next upload
+        // immediately (row 2 is already buffered), so AllFlushed() is false and no
+        // IN_PROGRESS checkpoint is emitted mid-scan. Checkpoints require AllFlushed()=true,
+        // which only happens reliably at scan end — but by then IsExhausted=true blocks it.
+        // Verify only the DONE response and that all rows were uploaded.
+        TVector<TString> inProgressKeys;
+        TString lastKeyAck = DoReshuffleKMeansCollectProgress(server, sender, 0, level,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE,
+            1 /*maxBatchRows*/, inProgressKeys, 1 /*maxCheckpointBytes*/);
+
+        // All 5 rows must have been uploaded regardless of checkpointing.
+        auto posting = ReadShardedTable(server, kPostingTable);
+        UNIT_ASSERT(posting.Contains("key = 1,"));
+        UNIT_ASSERT(posting.Contains("key = 2,"));
+        UNIT_ASSERT(posting.Contains("key = 3,"));
+        UNIT_ASSERT(posting.Contains("key = 4,"));
+        UNIT_ASSERT(posting.Contains("key = 5,"));
+    }
+
+    Y_UNIT_TEST(MainToPostingResumeFromLastKeyAck) {
+        // Run a scan, capture its LastKeyAck, then run another scan starting
+        // from that key and verify the two partial scans together equal a full scan.
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true);
+        options.Shards(1);
+        CreateMainTable(server, sender, options);
+
+        ExecSQL(server, sender,
+            R"(UPSERT INTO `/Root/table-main` (key, embedding, data) VALUES )"
+            "(1, \"mm\2\", \"one\"),"
+            "(2, \"mm\2\", \"two\"),"
+            "(3, \"mm\2\", \"three\"),"
+            "(4, \"11\2\", \"four\"),"
+            "(5, \"11\2\", \"five\");");
+
+        auto create = [&] { CreatePostingTable(server, sender, options); };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        std::vector<TString> level = {"mm\2", "11\2"};
+
+        // First pass: scan rows 1..3 only (stop after key=3 by using KeyRange to+inclusive).
+        TCell toCell = TCell::Make(ui32(3));
+        TSerializedTableRange firstRange{{}, true, TArrayRef<const TCell>{&toCell, 1}, true};
+        auto firstPosting = DoReshuffleKMeans(server, sender, 0, level,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE,
+            0, 50000, firstRange);
+        recreate();
+
+        // Second pass: resume from key=3 (exclusive lower bound) to scan rows 4..5.
+        TCell fromCell = TCell::Make(ui32(3));
+        TSerializedTableRange secondRange{TArrayRef<const TCell>{&fromCell, 1}, false, {}, false};
+        auto secondPosting = DoReshuffleKMeans(server, sender, 0, level,
+            NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING,
+            VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE,
+            0, 50000, secondRange);
+
+        UNIT_ASSERT(firstPosting.Contains("key = 1,"));
+        UNIT_ASSERT(firstPosting.Contains("key = 2,"));
+        UNIT_ASSERT(firstPosting.Contains("key = 3,"));
+        UNIT_ASSERT(!firstPosting.Contains("key = 4,"));
+        UNIT_ASSERT(!firstPosting.Contains("key = 5,"));
+
+        UNIT_ASSERT(!secondPosting.Contains("key = 1,"));
+        UNIT_ASSERT(!secondPosting.Contains("key = 2,"));
+        UNIT_ASSERT(!secondPosting.Contains("key = 3,"));
+        UNIT_ASSERT(secondPosting.Contains("key = 4,"));
+        UNIT_ASSERT(secondPosting.Contains("key = 5,"));
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -741,6 +741,16 @@ private:
         ev->Record.SetOverlapOutForeign(buildInfo.KMeans.OverlapClusters > 1 && buildInfo.KMeans.Levels > 1);
 
         auto shardId = FillScanRequestCommon(ev->Record, shardIdx, buildInfo);
+        {
+            auto& shardStatus = buildInfo.Shards.at(shardIdx);
+            if (shardStatus.LastKeyAck) {
+                TSerializedCellVec lastKey{shardStatus.LastKeyAck};
+                TSerializedTableRange range{lastKey.GetCells(), false, {}, false};
+                range.Serialize(*ev->Record.MutableKeyRange());
+            } else {
+                shardStatus.Range.Serialize(*ev->Record.MutableKeyRange());
+            }
+        }
         LOG_N("TTxBuildProgress: TEvReshuffleKMeansRequest: " << ToShortDebugString(ev->Record));
 
         ToTabletSend.emplace(shardId, std::move(ev));
@@ -827,6 +837,30 @@ private:
 
         auto shardId = FillScanRequestCommon(ev->Record, shardIdx, buildInfo);
         FillScanRequestSeed(ev->Record);
+        {
+            auto& shardStatus = buildInfo.Shards.at(shardIdx);
+            const ui64 parentTo = ev->Record.GetParentTo();
+            if (parentTo != 0) {
+                auto to = TCell::Make(parentTo);
+                if (shardStatus.LastKeyAck) {
+                    TSerializedCellVec lastKey{shardStatus.LastKeyAck};
+                    TSerializedTableRange range{lastKey.GetCells(), false, {&to, 1}, true};
+                    range.Serialize(*ev->Record.MutableKeyRange());
+                } else {
+                    auto fromCell = TCell::Make(ev->Record.GetParentFrom() - 1);
+                    TSerializedTableRange range{{&fromCell, 1}, false, {&to, 1}, true};
+                    range.Serialize(*ev->Record.MutableKeyRange());
+                }
+            } else {
+                if (shardStatus.LastKeyAck) {
+                    TSerializedCellVec lastKey{shardStatus.LastKeyAck};
+                    TSerializedTableRange range{lastKey.GetCells(), false, {}, false};
+                    range.Serialize(*ev->Record.MutableKeyRange());
+                } else {
+                    shardStatus.Range.Serialize(*ev->Record.MutableKeyRange());
+                }
+            }
+        }
         LOG_N("TTxBuildProgress: TEvLocalKMeansRequest: " << ev->Record.ShortDebugString());
 
         ToTabletSend.emplace(shardId, std::move(ev));
@@ -877,6 +911,16 @@ private:
 
         auto shardId = FillScanRequestCommon<false>(ev->Record, shardIdx, buildInfo);
         FillScanRequestSeed(ev->Record);
+        {
+            auto& shardStatus = buildInfo.Shards.at(shardIdx);
+            if (shardStatus.LastKeyAck) {
+                TSerializedCellVec lastKey{shardStatus.LastKeyAck};
+                TSerializedTableRange range{lastKey.GetCells(), false, {}, false};
+                range.Serialize(*ev->Record.MutableKeyRange());
+            } else {
+                shardStatus.Range.Serialize(*ev->Record.MutableKeyRange());
+            }
+        }
         LOG_N("TTxBuildProgress: TEvPrefixKMeansRequest: " << ev->Record.ShortDebugString());
 
         ToTabletSend.emplace(shardId, std::move(ev));
@@ -2777,8 +2821,8 @@ public:
                     keyTypes.emplace_back(tableInfo.Columns.at(keyPos).PType);
                 }
 
-                TSerializedCellVec next{shardStatus.LastKeyAck};
-                TSerializedCellVec prev{lastKeyAck};
+                TSerializedCellVec next{lastKeyAck};
+                TSerializedCellVec prev{shardStatus.LastKeyAck};
 
                 int cmp = CompareBorders<true, true>(next.GetCells(), prev.GetCells(), true, true, keyTypes);
                 if (cmp < 0) {
@@ -2788,6 +2832,8 @@ public:
                 } else {
                     shardStatus.LastKeyAck = lastKeyAck;
                 }
+            } else {
+                shardStatus.LastKeyAck = lastKeyAck;
             }
         }
     }
@@ -2918,10 +2964,18 @@ struct TSchemeShard::TIndexBuilder::TTxReplyLocalKMeans: public TTxShardReply<TE
     {
     }
 
-    void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) {
-        if (Response->Get()->Record.GetIsEmpty() &&
-            buildInfo.KMeans.Parent == 0)
-        {
+    void HandleProgress(TIndexBuildShardStatus& shardStatus, TIndexBuildInfo& buildInfo) override {
+        UpdateLastKeyAck(shardStatus, buildInfo, Response->Get()->Record.GetLastKeyAck());
+    }
+
+    void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) override {
+        const auto& record = Response->Get()->Record;
+        TTabletId shardId = TTabletId(record.GetTabletId());
+        TShardIdx shardIdx = Self->GetShardIdx(shardId);
+        TIndexBuildShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
+        UpdateLastKeyAck(shardStatus, buildInfo, record.GetLastKeyAck());
+
+        if (record.GetIsEmpty() && buildInfo.KMeans.Parent == 0) {
             // We only handle the root level through MultiLocal if the table has exactly 1 shard.
             // If that shard is empty then it means the whole index is empty.
             buildInfo.KMeans.IsEmpty = true;
@@ -2935,12 +2989,38 @@ struct TSchemeShard::TIndexBuilder::TTxReplyReshuffleKMeans: public TTxShardRepl
         : TTxShardReply(self, TIndexBuildId(response->Get()->Record.GetId()), response)
     {
     }
+
+    void HandleProgress(TIndexBuildShardStatus& shardStatus, TIndexBuildInfo& buildInfo) override {
+        UpdateLastKeyAck(shardStatus, buildInfo, Response->Get()->Record.GetLastKeyAck());
+    }
+
+    void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) override {
+        const auto& record = Response->Get()->Record;
+        TTabletId shardId = TTabletId(record.GetTabletId());
+        TShardIdx shardIdx = Self->GetShardIdx(shardId);
+        TIndexBuildShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
+        UpdateLastKeyAck(shardStatus, buildInfo, record.GetLastKeyAck());
+        Y_UNUSED(db);
+    }
 };
 
 struct TSchemeShard::TIndexBuilder::TTxReplyPrefixKMeans: public TTxShardReply<TEvDataShard::TEvPrefixKMeansResponse> {
     explicit TTxReplyPrefixKMeans(TSelf* self, TEvDataShard::TEvPrefixKMeansResponse::TPtr& response)
         : TTxShardReply(self, TIndexBuildId(response->Get()->Record.GetId()), response)
     {
+    }
+
+    void HandleProgress(TIndexBuildShardStatus& shardStatus, TIndexBuildInfo& buildInfo) override {
+        UpdateLastKeyAck(shardStatus, buildInfo, Response->Get()->Record.GetLastKeyAck());
+    }
+
+    void HandleDone(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) override {
+        const auto& record = Response->Get()->Record;
+        TTabletId shardId = TTabletId(record.GetTabletId());
+        TShardIdx shardIdx = Self->GetShardIdx(shardId);
+        TIndexBuildShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
+        UpdateLastKeyAck(shardStatus, buildInfo, record.GetLastKeyAck());
+        Y_UNUSED(db);
     }
 };
 
@@ -3049,10 +3129,7 @@ struct TSchemeShard::TIndexBuilder::TTxReplyFulltextIndex: public TTxShardReply<
         TTabletId shardId = TTabletId(record.GetTabletId());
         TShardIdx shardIdx = Self->GetShardIdx(shardId);
         TIndexBuildShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
-
-        if (record.HasLastKeyAck()) {
-            shardStatus.LastKeyAck = max(shardStatus.LastKeyAck, record.GetLastKeyAck());
-        }
+        UpdateLastKeyAck(shardStatus, buildInfo, record.GetLastKeyAck());
 
         shardStatus.DocCount = record.GetDocCount();
         shardStatus.TotalDocLength = record.GetTotalDocLength();

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -1,4 +1,7 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/testlib/tablet_helpers.h>
+#include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/scheme_board/events_schemeshard.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
@@ -102,103 +105,6 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
         });
     }
 
-    // Test that resuming from LastKeyAck checkpoints works correctly when schemeshard is rebooted
-    // mid-indexation. Uses small MaxBatchRows to force many IN_PROGRESS checkpoints so that
-    // reboots exercise the resume-from-checkpoint code path in schemeshard_build_index__progress.cpp.
-    void DoTestIndexBuildWithCheckpoints(TTestWithReboots& t, bool Prefixed, bool Overlap) {
-        // speed up the test: only check scheme shard reboots
-        t.TabletIds.clear();
-        t.TabletIds.push_back(t.SchemeShardTabletId);
-        // white list some more events
-        t.NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
-        t.NoRebootEventTypes.insert(TSchemeBoardEvents::EvUpdateAck);
-        t.NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletionRegistered);
-        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerDisconnected);
-        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerConnected);
-        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientConnected);
-        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientDestroyed);
-        // Do NOT whitelist EvBuildIndexProgressResponse: reboots on those exercise LastKeyAck resume.
-        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
-            {
-                TInactiveZone inactive(activeZone);
-
-                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
-                    Name: "dir/Table"
-                    Columns { Name: "key"       Type: "Uint32" }
-                    Columns { Name: "embedding" Type: "String" }
-                    Columns { Name: "prefix"    Type: "Uint32" }
-                    Columns { Name: "value"     Type: "String" }
-                    KeyColumnNames: ["key"]
-                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
-                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
-                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 250 } } } }
-                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 350 } } } }
-                )");
-                t.TestEnv->TestWaitNotification(runtime, t.TxId);
-
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 0, 0, 50);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 1, 50, 150);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 2, 150, 250);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 3, 250, 350);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 4, 350, 400);
-            }
-
-            const ui64 buildIndexId = ++t.TxId;
-            {
-                auto indexColumns = (Prefixed ? TVector<TString>{"prefix", "embedding"} : TVector<TString>{"embedding"});
-                auto sender = runtime.AllocateEdgeActor();
-                auto request = CreateBuildIndexRequest(buildIndexId, "/MyRoot", "/MyRoot/dir/Table", TBuildIndexConfig{
-                    "index1", NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, indexColumns, {"value"}, {}
-                });
-                // Use small MaxBatchRows to produce many IN_PROGRESS checkpoints with LastKeyAck.
-                // Each checkpoint persists the resume key, so reboots between checkpoints exercise
-                // the resume-from-middle-of-indexation path.
-                request->Record.MutableSettings()->MutableScanSettings()->SetMaxBatchRows(10);
-                if (Overlap) {
-                    request->Record.MutableSettings()
-                        ->mutable_index()
-                        ->mutable_global_vector_kmeans_tree_index()
-                        ->mutable_vector_settings()
-                        ->set_overlap_clusters(2);
-                }
-                ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
-            }
-
-            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
-
-            {
-                TInactiveZone inactive(activeZone);
-
-                auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
-                UNIT_ASSERT_VALUES_EQUAL((ui64)descr.GetIndexBuild().GetState(), (ui64)Ydb::Table::IndexBuildState::STATE_DONE);
-
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/dir/Table"),
-                                   {NLs::PathExist,
-                                    NLs::IndexesCount(1)});
-                const TString indexPath = "/MyRoot/dir/Table/index1";
-                TestDescribeResult(DescribePath(runtime, indexPath, true, true, true),
-                                   {NLs::PathExist,
-                                    NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
-                using namespace NTableIndex::NKMeans;
-                if (Prefixed) {
-                    TestDescribeResult(DescribePath(runtime, indexPath + "/" + PrefixTable, true, true, true), {NLs::PathExist});
-                }
-                TestDescribeResult(DescribePath(runtime, indexPath + "/" + LevelTable, true, true, true), {NLs::PathExist});
-                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable, true, true, true), {NLs::PathExist});
-                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix0, true, true, true), {NLs::PathNotExist});
-                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix1, true, true, true), {NLs::PathNotExist});
-
-                // All 400 rows must be indexed exactly once: resuming from LastKeyAck checkpoints
-                // must not cause duplicates or skipped rows.
-                {
-                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/dir/Table/index1/" + TString(PostingTable));
-                    Cerr << "... posting table contains " << rows << " rows" << Endl;
-                    UNIT_ASSERT_VALUES_EQUAL(rows, (Overlap ? 800 : 400));
-                }
-            }
-        });
-    }
-
     // Without killOnCommit, the schemeshard doesn't get rebooted on TEvDataShard::Ev***KMeansResponse's,
     // and thus the vector index build process is never interrupted at all because there are no other
     // events to reboot on.
@@ -217,10 +123,161 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedOverlap, 8 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
         DoTestIndexBuild(t, true, true);
     }
+}
 
-    // Tests with small MaxBatchRows that force mid-indexation checkpoints via LastKeyAck.
-    // Reboots between IN_PROGRESS checkpoints exercise the resume-from-middle path.
-    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedOverlapWithCheckpoints, 16 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
-        DoTestIndexBuildWithCheckpoints(t, true, true);
+// ---------------------------------------------------------------------------
+// Tests for LastKeyAck persistence and resume-from-key-range at the SchemeShard level.
+//
+// These tests verify the integration path:
+//   datashard emits IN_PROGRESS with LastKeyAck
+//   → SchemeShard persists LastKeyAck in IndexBuildShardStatus
+//   → after SchemeShard reboot the next scan request carries KeyRange = [LastKeyAck, ∞)
+//   → the completed index is identical to a fresh full build.
+//
+// Note: TEvReshuffleKMeansResponse IN_PROGRESS is not tested here because it requires
+// AllFlushed()=true mid-scan, which cannot happen reliably when rows arrive faster than
+// upload responses (see comment in ut_reshuffle_kmeans.cpp::MainToPostingLastKeyAckInProgress).
+// LocalKMeans and PrefixKMeans checkpoint at cluster/prefix boundaries and are reliable.
+// ---------------------------------------------------------------------------
+
+Y_UNIT_TEST_SUITE(VectorIndexBuildLastKeyAckTests) {
+
+    // 10 rows on a single shard — enough to produce multiple batches with MaxBatchRows=1
+    // while keeping the test fast (no multi-shard overhead).
+    static constexpr ui32 kTableRows = 10;
+
+    void SetupVectorTable(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId) {
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "dir/Table"
+            Columns { Name: "key"       Type: "Uint32" }
+            Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++txId, "/MyRoot/dir/Table", 0, 0, kTableRows);
+    }
+
+    // Build the index request with MaxBatchRows=1 and MaxCheckpointBytes=1 so that every
+    // completed batch upload triggers an IN_PROGRESS checkpoint. This guarantees the blocker
+    // captures events quickly without needing a large table.
+    TEvIndexBuilder::TEvCreateRequest* MakeBuildRequest(ui64 buildTx, bool Prefixed) {
+        auto indexColumns = Prefixed ? TVector<TString>{"prefix", "embedding"} : TVector<TString>{"embedding"};
+        auto* request = CreateBuildIndexRequest(buildTx, "/MyRoot", "/MyRoot/dir/Table", TBuildIndexConfig{
+            "index1", NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, indexColumns, {"value"}, {}
+        });
+        // CreateBuildIndexRequest already sets MaxBatchRows=1; also set MaxCheckpointBytes=1
+        // so every uploaded batch crosses the checkpoint threshold and emits IN_PROGRESS.
+        request->Record.MutableSettings()->MutableScanSettings()->SetMaxCheckpointBytes(1);
+        return request;
+    }
+
+    void CheckIndexComplete(TTestBasicRuntime& runtime, ui64 buildTx, bool Prefixed) {
+        auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildTx);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+            op.DebugString());
+
+        const TString indexPath = "/MyRoot/dir/Table/index1";
+        using namespace NTableIndex::NKMeans;
+        if (Prefixed) {
+            TestDescribeResult(DescribePath(runtime, indexPath + "/" + PrefixTable, true, true, true), {NLs::PathExist});
+        }
+        TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable, true, true, true), {NLs::PathExist});
+
+        // All rows must be indexed exactly once — resuming from LastKeyAck must not
+        // cause duplicates or skipped rows.
+        auto rows = CountRows(runtime, TTestTxConfig::SchemeShard,
+                              "/MyRoot/dir/Table/index1/" + TString(PostingTable));
+        Cerr << "... posting table contains " << rows << " rows" << Endl;
+        UNIT_ASSERT(rows > 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Strategy:
+    //   1. Block all IN_PROGRESS prefix-kmeans responses before they reach SchemeShard.
+    //   2. Allow exactly one through so SchemeShard persists a non-empty LastKeyAck.
+    //   3. Reboot SchemeShard (simulates crash right after committing LastKeyAck).
+    //   4. Stop blocking and let the resumed build finish.
+    //   5. Verify the index is complete and non-empty.
+    //
+    // PrefixKMeans emits IN_PROGRESS after completing each prefix group, so with 10 rows
+    // having 10 distinct prefix values (key % 17), there are 9 opportunities for checkpoints.
+    // -----------------------------------------------------------------------
+    Y_UNIT_TEST(RebootAfterFirstInProgressResumesScanPrefixed) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        SetupVectorTable(runtime, env, txId);
+
+        TBlockEvents<TEvDataShard::TEvPrefixKMeansResponse> blocker(runtime,
+            [](const TEvDataShard::TEvPrefixKMeansResponse::TPtr& ev) {
+                return ev->Get()->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS;
+            });
+
+        const ui64 buildTx = ++txId;
+        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor(),
+                        MakeBuildRequest(buildTx, true /*Prefixed*/));
+
+        // Wait until at least one IN_PROGRESS checkpoint is captured.
+        runtime.WaitFor("first IN_PROGRESS captured", [&] { return !blocker.empty(); });
+
+        // Let exactly one through so SchemeShard commits a LastKeyAck to disk.
+        blocker.Unblock(1);
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+        // Reboot SchemeShard — simulates a crash right after persisting LastKeyAck.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Stop blocking so the resumed build can proceed from the saved LastKeyAck.
+        blocker.Stop().Unblock();
+
+        env.TestWaitNotification(runtime, buildTx);
+
+        CheckIndexComplete(runtime, buildTx, true /*Prefixed*/);
+    }
+
+    // LocalKMeans emits IN_PROGRESS after completing each parent cluster group.
+    // With clusters=4 and levels=2 (defaults), 4 parent clusters are created in the first
+    // level, so there are 3 opportunities for IN_PROGRESS checkpoints between them.
+    Y_UNIT_TEST(RebootAfterFirstInProgressResumesScanLocalKMeans) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        SetupVectorTable(runtime, env, txId);
+
+        TBlockEvents<TEvDataShard::TEvLocalKMeansResponse> blocker(runtime,
+            [](const TEvDataShard::TEvLocalKMeansResponse::TPtr& ev) {
+                return ev->Get()->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS;
+            });
+
+        const ui64 buildTx = ++txId;
+        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor(),
+                        MakeBuildRequest(buildTx, false /*Prefixed*/));
+
+        // Wait until at least one IN_PROGRESS checkpoint is captured.
+        runtime.WaitFor("first IN_PROGRESS captured", [&] { return !blocker.empty(); });
+
+        // Let exactly one through so SchemeShard commits a LastKeyAck to disk.
+        blocker.Unblock(1);
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+        // Reboot SchemeShard — simulates a crash right after persisting LastKeyAck.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Stop blocking so the resumed build can proceed from the saved LastKeyAck.
+        blocker.Stop().Unblock();
+
+        env.TestWaitNotification(runtime, buildTx);
+
+        CheckIndexComplete(runtime, buildTx, false /*Prefixed*/);
     }
 }

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -102,6 +102,103 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
         });
     }
 
+    // Test that resuming from LastKeyAck checkpoints works correctly when schemeshard is rebooted
+    // mid-indexation. Uses small MaxBatchRows to force many IN_PROGRESS checkpoints so that
+    // reboots exercise the resume-from-checkpoint code path in schemeshard_build_index__progress.cpp.
+    void DoTestIndexBuildWithCheckpoints(TTestWithReboots& t, bool Prefixed, bool Overlap) {
+        // speed up the test: only check scheme shard reboots
+        t.TabletIds.clear();
+        t.TabletIds.push_back(t.SchemeShardTabletId);
+        // white list some more events
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
+        t.NoRebootEventTypes.insert(TSchemeBoardEvents::EvUpdateAck);
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletionRegistered);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerDisconnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientDestroyed);
+        // Do NOT whitelist EvBuildIndexProgressResponse: reboots on those exercise LastKeyAck resume.
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "dir/Table"
+                    Columns { Name: "key"       Type: "Uint32" }
+                    Columns { Name: "embedding" Type: "String" }
+                    Columns { Name: "prefix"    Type: "Uint32" }
+                    Columns { Name: "value"     Type: "String" }
+                    KeyColumnNames: ["key"]
+                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
+                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
+                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 250 } } } }
+                    SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 350 } } } }
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 0, 0, 50);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 1, 50, 150);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 2, 150, 250);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 3, 250, 350);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 4, 350, 400);
+            }
+
+            const ui64 buildIndexId = ++t.TxId;
+            {
+                auto indexColumns = (Prefixed ? TVector<TString>{"prefix", "embedding"} : TVector<TString>{"embedding"});
+                auto sender = runtime.AllocateEdgeActor();
+                auto request = CreateBuildIndexRequest(buildIndexId, "/MyRoot", "/MyRoot/dir/Table", TBuildIndexConfig{
+                    "index1", NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, indexColumns, {"value"}, {}
+                });
+                // Use small MaxBatchRows to produce many IN_PROGRESS checkpoints with LastKeyAck.
+                // Each checkpoint persists the resume key, so reboots between checkpoints exercise
+                // the resume-from-middle-of-indexation path.
+                request->Record.MutableSettings()->MutableScanSettings()->SetMaxBatchRows(10);
+                if (Overlap) {
+                    request->Record.MutableSettings()
+                        ->mutable_index()
+                        ->mutable_global_vector_kmeans_tree_index()
+                        ->mutable_vector_settings()
+                        ->set_overlap_clusters(2);
+                }
+                ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
+            }
+
+            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL((ui64)descr.GetIndexBuild().GetState(), (ui64)Ydb::Table::IndexBuildState::STATE_DONE);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/dir/Table"),
+                                   {NLs::PathExist,
+                                    NLs::IndexesCount(1)});
+                const TString indexPath = "/MyRoot/dir/Table/index1";
+                TestDescribeResult(DescribePath(runtime, indexPath, true, true, true),
+                                   {NLs::PathExist,
+                                    NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+                using namespace NTableIndex::NKMeans;
+                if (Prefixed) {
+                    TestDescribeResult(DescribePath(runtime, indexPath + "/" + PrefixTable, true, true, true), {NLs::PathExist});
+                }
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + LevelTable, true, true, true), {NLs::PathExist});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable, true, true, true), {NLs::PathExist});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix0, true, true, true), {NLs::PathNotExist});
+                TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix1, true, true, true), {NLs::PathNotExist});
+
+                // All 400 rows must be indexed exactly once: resuming from LastKeyAck checkpoints
+                // must not cause duplicates or skipped rows.
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, "/MyRoot/dir/Table/index1/" + TString(PostingTable));
+                    Cerr << "... posting table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(rows, (Overlap ? 800 : 400));
+                }
+            }
+        });
+    }
+
     // Without killOnCommit, the schemeshard doesn't get rebooted on TEvDataShard::Ev***KMeansResponse's,
     // and thus the vector index build process is never interrupted at all because there are no other
     // events to reboot on.
@@ -119,5 +216,23 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
 
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedOverlap, 8 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
         DoTestIndexBuild(t, true, true);
+    }
+
+    // Tests with small MaxBatchRows that force mid-indexation checkpoints via LastKeyAck.
+    // Reboots between IN_PROGRESS checkpoints exercise the resume-from-middle path.
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(BaseCaseWithCheckpoints, 4 /*rebootBuckets*/, 2 /*pipeResetBuckets*/, true /*killOnCommit*/) {
+        DoTestIndexBuildWithCheckpoints(t, false, false);
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedWithCheckpoints, 8 /*rebootBuckets*/, 2 /*pipeResetBuckets*/, true /*killOnCommit*/) {
+        DoTestIndexBuildWithCheckpoints(t, true, false);
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(OverlapWithCheckpoints, 8 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
+        DoTestIndexBuildWithCheckpoints(t, false, true);
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedOverlapWithCheckpoints, 16 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
+        DoTestIndexBuildWithCheckpoints(t, true, true);
     }
 }

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -220,18 +220,6 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
 
     // Tests with small MaxBatchRows that force mid-indexation checkpoints via LastKeyAck.
     // Reboots between IN_PROGRESS checkpoints exercise the resume-from-middle path.
-    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(BaseCaseWithCheckpoints, 4 /*rebootBuckets*/, 2 /*pipeResetBuckets*/, true /*killOnCommit*/) {
-        DoTestIndexBuildWithCheckpoints(t, false, false);
-    }
-
-    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedWithCheckpoints, 8 /*rebootBuckets*/, 2 /*pipeResetBuckets*/, true /*killOnCommit*/) {
-        DoTestIndexBuildWithCheckpoints(t, true, false);
-    }
-
-    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(OverlapWithCheckpoints, 8 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
-        DoTestIndexBuildWithCheckpoints(t, false, true);
-    }
-
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(PrefixedOverlapWithCheckpoints, 16 /*rebootBuckets*/, 4 /*pipeResetBuckets*/, true /*killOnCommit*/) {
         DoTestIndexBuildWithCheckpoints(t, true, true);
     }


### PR DESCRIPTION
### Changelog entry 

Added ability to save/restore progress to reshuffle, local & prefix kmeans indexes.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers
The tests were autogenerated using Claude Code.

...
