### PR TITLE
schemeshard: remove Grab* copies from TSplitMerge::Propose

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
@@ -1032,19 +1032,13 @@ public:
         /// Accept operation
         ///
 
-        auto guard = context.DbGuard();
-        context.MemChanges.GrabNewTxState(context.SS, OperationId);
-        context.MemChanges.GrabDomain(context.SS, path.GetPathIdForDomain());
-        context.MemChanges.GrabPath(context.SS, path->PathId);
-        context.MemChanges.GrabTable(context.SS, path->PathId);
-
+        //NOTE: No MemChanges.Grab* calls are made here: TSplitMerge::Propose() has no
+        // failure paths after this point, so AbortOperationPropose / UnDo() will
+        // never be triggered for these objects.
+        // AbortUnsafe() (triggered by TDropForceUnsafe) handles its own rollback
+        // by performing the inverse in-memory operations directly.
         context.DbChanges.PersistTxState(OperationId);
         for (const auto& shard : op.Shards) {
-            if (shard.Operation == TTxState::CreateParts) {
-                context.MemChanges.GrabNewShard(context.SS, shard.Idx);
-            } else {
-                context.MemChanges.GrabShard(context.SS, shard.Idx);
-            }
             context.DbChanges.PersistShard(shard.Idx);
         }
 


### PR DESCRIPTION
Remove expensive Grab* copies from `TSplitMerge::Propose()`.

`TSplitMerge::Propose()` called `TMemoryChanges::Grab*` to deep-copy `TTableInfo`, `TSubDomainInfo`, and `TPathElement` on every split/merge. These copies support aborting suboperation `Propose()` phase (`UnDo()` rollback via `AbortOperationPropose()`), but `TSplitMerge` never fails by itself and never combines with other scheme suboperations (no other suboperation's fail can trigger `TSplitMerge`'s abort), so AbortPropose path can never happen for `TSplitMerge`. The copies were always wasted.

**Changes:**
- Remove all `Grab*` calls from `TSplitMerge::Propose()`.

**Experimental results:**
- `TTxPartitionHistogram` speedup is around 1000x (~100ms -> 100μs). 
- Total gain in schemeshard cpu time is around 25% (it gets used by something else though).

(Part about `AbortUnsafe()` was separated into [schemeshard: more correct cleanup in TSplitMerge::AbortUnsafe #36461](https://github.com/ydb-platform/ydb/pull/36461))
