### PR TITLE
Fix OOM in select * limit 1

### DIFF
--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
@@ -234,6 +234,24 @@ private:
     bool DqHashOperatorsUseBlocks;
 };
 
+class TKqpPeepholeBlockPackUnpackTransformer : public TOptimizeTransformerBase {
+public:
+    TKqpPeepholeBlockPackUnpackTransformer(TTypeAnnotationContext& ctx)
+        : TOptimizeTransformerBase(&ctx, NYql::NLog::EComponent::ProviderKqp, {})
+    {
+#define HNDL(name) "KqpPeepholeBlockPackUnpack-"#name, Hndl(&TKqpPeepholeBlockPackUnpackTransformer::name)
+        AddHandler(0, &TCoWideMap::Match, HNDL(EliminateWideMapPackUnpack));
+#undef HNDL
+    }
+
+private:
+    TMaybeNode<TExprBase> EliminateWideMapPackUnpack(TExprBase node, TExprContext& ctx) {
+        TExprBase output = KqpEliminateWideMapPackUnpack(node, ctx, *GetTypes());
+        DumpAppliedRule(__func__, node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+};
+
 class TKqpPeepholeFinalTransformer : public TOptimizeTransformerBase {
 public:
     TKqpPeepholeFinalTransformer(TTypeAnnotationContext& ctx, TKikimrConfiguration::TPtr config)
@@ -272,6 +290,7 @@ struct TKqpPeepholePipelineFinalConfigurator : IPipelineConfigurator {
         if (WithFinalStageRules) {
             pipeline->Add(new TKqpPeepholeNewOperatorTransformer(*pipeline->GetTypeAnnotationContext(), Config), "KqpPeepholeNewOperator");
         }
+        pipeline->Add(new TKqpPeepholeBlockPackUnpackTransformer(*pipeline->GetTypeAnnotationContext()), "KqpPeepholeBlockPackUnpack");
     }
 
 private:

--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole_rules.h
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole_rules.h
@@ -14,5 +14,6 @@ namespace NKikimr::NKqp::NOpt {
 NYql::NNodes::TExprBase KqpBuildWideReadTable(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, NYql::TTypeAnnotationContext& typesCtx);
 NYql::NNodes::TExprBase KqpRewriteWriteConstraint(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx);
 NYql::NNodes::TExprBase KqpEliminateWideMapForLargeOlapTable(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, NYql::TTypeAnnotationContext& typesCtx);
+NYql::NNodes::TExprBase KqpEliminateWideMapPackUnpack(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, NYql::TTypeAnnotationContext& typesCtx);
 
 } // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole_wide_read.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole_wide_read.cpp
@@ -26,6 +26,66 @@ bool IsValidBlockAsStruct(const TExprNode *node) {
 }
 } // namespace
 
+TExprBase KqpEliminateWideMapPackUnpack(const TExprBase& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx) {
+    Y_UNUSED(typesCtx);
+    if (!node.Maybe<TCoWideMap>()) {
+        return node;
+    }
+
+    auto wideMap = node.Cast<TCoWideMap>();
+    auto lambda = wideMap.Lambda();
+    const auto& args = lambda.Ptr()->Head();
+    const auto bodyCount = lambda.Ptr()->ChildrenSize() - 1;
+
+    // Match unpack lambda: (struct, count) → (BlockMember(struct, col1), ..., count)
+    if (args.ChildrenSize() != 2 || bodyCount < 2 ||
+        lambda.Ptr()->Child(bodyCount) != args.Child(1)) {
+        return node;
+    }
+
+    TVector<TStringBuf> unpackColumns;
+    for (ui32 i = 1; i < bodyCount; ++i) {
+        const auto* c = lambda.Ptr()->Child(i);
+        if (!c->IsCallable("BlockMember") || c->Child(0) != args.Child(0)) {
+            return node;
+        }
+        unpackColumns.push_back(c->Child(1)->Content());
+    }
+
+    // Match input: WideTakeBlocks(WideMap(X, packLambda), n)
+    const auto& inp = wideMap.Input().Ref();
+    if (!inp.IsCallable("WideTakeBlocks") || !inp.Head().IsCallable("WideMap")) {
+        return node;
+    }
+
+    const auto packLambda = inp.Head().ChildPtr(1);
+    if (packLambda->ChildrenSize() != 3 ||
+        !packLambda->Child(1)->IsCallable("BlockAsStruct") ||
+        packLambda->Child(2) != packLambda->Head().Child(packLambda->Head().ChildrenSize() - 1)) {
+        return node;
+    }
+
+    const auto* bas = packLambda->Child(1);
+    if (bas->ChildrenSize() != unpackColumns.size()) {
+        return node;
+    }
+
+    if (bas->ChildrenSize() != packLambda->Head().ChildrenSize() - 1) {
+        return node;
+    }
+
+    for (ui32 i = 0; i < bas->ChildrenSize(); ++i) {
+        if (bas->Child(i)->Child(0)->Content() != unpackColumns[i]) {
+            return node;
+        }
+        if (bas->Child(i)->Child(1) != packLambda->Head().Child(i)) {
+            return node;
+        }
+    }
+
+    return TExprBase(ctx.ChangeChild(inp, 0, inp.Head().HeadPtr()));
+}
+
 TExprBase KqpEliminateWideMapForLargeOlapTable(const TExprBase& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx) {
     Y_UNUSED(typesCtx);
     if (!node.Maybe<TCoWideMap>()) {

--- a/ydb/core/kqp/ut/olap/peephole_ut.cpp
+++ b/ydb/core/kqp/ut/olap/peephole_ut.cpp
@@ -1,0 +1,50 @@
+#include "helpers/local.h"
+
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/tx/columnshard/hooks/testing/controller.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp {
+
+using namespace NYdb;
+
+Y_UNIT_TEST_SUITE(KqpOlapPeephole) {
+
+    Y_UNIT_TEST(EliminateWideMapPackUnpackOnSelectStarLimit) {
+        auto settings = TKikimrSettings().SetWithSampleTables(false);
+        settings.AppConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        TKikimrRunner kikimr(settings);
+
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/TestTable` (
+                    id Uint64 NOT NULL, c1 String, c2 String, c3 String,
+                    PRIMARY KEY (id)
+                )
+                PARTITION BY HASH(id)
+                WITH (STORE = COLUMN, PARTITION_COUNT = 1)
+            )").GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto client = kikimr.GetQueryClient();
+        NQuery::TExecuteQuerySettings explainSettings;
+        explainSettings.ExecMode(NQuery::EExecMode::Explain);
+        auto it = client.StreamExecuteQuery(
+            "SELECT * FROM `/Root/TestTable` LIMIT 1",
+            NQuery::TTxControl::BeginTx().CommitTx(), explainSettings).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+        auto plan = CollectStreamResult(it);
+        UNIT_ASSERT(plan.QueryStats.Defined());
+        const auto& ast = plan.QueryStats->Getquery_ast();
+
+        UNIT_ASSERT_C(ast.Contains("(WideTakeBlocks (FromFlow"),
+            "Scan stage: expected WideTakeBlocks directly on FromFlow "
+            "(WideMap pack/unpack roundtrip should be eliminated). AST: " + ast);
+    }
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/olap/ya.make
+++ b/ydb/core/kqp/ut/olap/ya.make
@@ -19,6 +19,7 @@ SRCS(
     dictionary_ut.cpp
     locks_ut.cpp
     optimizer_ut.cpp
+    peephole_ut.cpp
     sys_view_ut.cpp
     tiering_ut.cpp
 )

--- a/ydb/core/kqp/ut/opt/kqp_peephole_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_peephole_ut.cpp
@@ -1,0 +1,142 @@
+#include <yql/essentials/ast/yql_expr.h>
+#include <yql/essentials/core/expr_nodes_gen/yql_expr_nodes_gen.h>
+#include <yql/essentials/core/yql_type_annotation.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp::NOpt {
+NYql::NNodes::TExprBase KqpEliminateWideMapPackUnpack(
+    const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx,
+    NYql::TTypeAnnotationContext& typesCtx);
+}
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+enum class EPackKind {
+    Identity,       // (a, b, count) -> BlockAsStruct('c1':a, 'c2':b), count
+    Computation,    // (a, b, count) -> BlockAsStruct('c1':Inc(a), 'c2':Inc(b)), count
+    Reorder,        // (a, b, count) -> BlockAsStruct('c1':b, 'c2':a), count -- swapped
+    Projection,     // (a, b, c, count) -> BlockAsStruct('c1':a, 'c2':b), count -- c dropped
+};
+
+NYql::TExprNode::TPtr BuildPackUnpackWideMap(NYql::TExprContext& ctx, EPackKind kind) {
+    auto pos = NYql::TPositionHandle();
+
+    auto packArgA = ctx.NewArgument(pos, "a");
+    auto packArgB = ctx.NewArgument(pos, "b");
+    auto packArgCount = ctx.NewArgument(pos, "count");
+
+    NYql::TExprNode::TListType packArgs = {packArgA, packArgB, packArgCount};
+
+    NYql::TExprNode::TPtr valA, valB;
+
+    switch (kind) {
+        case EPackKind::Identity:
+            valA = packArgA;
+            valB = packArgB;
+            break;
+        case EPackKind::Computation:
+            valA = ctx.NewCallable(pos, "Increment", {packArgA});
+            valB = ctx.NewCallable(pos, "Increment", {packArgB});
+            break;
+        case EPackKind::Reorder:
+            valA = packArgB;  // swapped: c1 gets b
+            valB = packArgA;  // swapped: c2 gets a
+            break;
+        case EPackKind::Projection: {
+            auto packArgC = ctx.NewArgument(pos, "c");
+            packArgs = {packArgA, packArgB, packArgC, packArgCount};
+            valA = packArgA;
+            valB = packArgB;
+            break;
+        }
+    }
+
+    auto bas = ctx.NewCallable(pos, "BlockAsStruct", {
+        ctx.NewList(pos, {ctx.NewAtom(pos, "c1"), valA}),
+        ctx.NewList(pos, {ctx.NewAtom(pos, "c2"), valB}),
+    });
+
+    auto packLambda = ctx.NewLambda(pos,
+        ctx.NewArguments(pos, std::move(packArgs)),
+        {bas, packArgCount});
+
+    auto input = ctx.NewCallable(pos, "TestInput", {});
+    auto innerWideMap = ctx.NewCallable(pos, "WideMap", {input, packLambda});
+
+    auto limit = ctx.NewCallable(pos, "Uint64", {ctx.NewAtom(pos, "1")});
+    auto wideTake = ctx.NewCallable(pos, "WideTakeBlocks", {innerWideMap, limit});
+
+    auto unpackArgStruct = ctx.NewArgument(pos, "struct");
+    auto unpackArgCount = ctx.NewArgument(pos, "ucount");
+
+    auto unpackLambda = ctx.NewLambda(pos,
+        ctx.NewArguments(pos, {unpackArgStruct, unpackArgCount}),
+        {
+            ctx.NewCallable(pos, "BlockMember", {unpackArgStruct, ctx.NewAtom(pos, "c1")}),
+            ctx.NewCallable(pos, "BlockMember", {unpackArgStruct, ctx.NewAtom(pos, "c2")}),
+            unpackArgCount,
+        });
+
+    return ctx.NewCallable(pos, "WideMap", {wideTake, unpackLambda});
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(KqpPeepholeRules) {
+
+    Y_UNIT_TEST(IdentityPackUnpackIsEliminated) {
+        NYql::TExprContext ctx;
+        NYql::TTypeAnnotationContext typesCtx;
+
+        auto node = BuildPackUnpackWideMap(ctx, EPackKind::Identity);
+        auto result = NOpt::KqpEliminateWideMapPackUnpack(NYql::NNodes::TExprBase(node), ctx, typesCtx);
+
+        UNIT_ASSERT_C(result.Ptr() != node,
+            "Identity pack/unpack roundtrip should be eliminated");
+        UNIT_ASSERT_C(result.Ref().IsCallable("WideTakeBlocks"),
+            "Result should be WideTakeBlocks(input)");
+        UNIT_ASSERT_C(result.Ref().Head().IsCallable("TestInput"),
+            "WideTakeBlocks input should be the original TestInput");
+    }
+
+    Y_UNIT_TEST(PackWithComputationIsPreserved) {
+        NYql::TExprContext ctx;
+        NYql::TTypeAnnotationContext typesCtx;
+
+        // (a, b) -> BlockAsStruct('c1': Increment(a), 'c2': Increment(b))
+        auto node = BuildPackUnpackWideMap(ctx, EPackKind::Computation);
+        auto result = NOpt::KqpEliminateWideMapPackUnpack(NYql::NNodes::TExprBase(node), ctx, typesCtx);
+
+        UNIT_ASSERT_C(result.Ptr() == node,
+            "Pack with computation (a+1) should NOT be eliminated");
+    }
+
+    Y_UNIT_TEST(PackWithReorderIsPreserved) {
+        NYql::TExprContext ctx;
+        NYql::TTypeAnnotationContext typesCtx;
+
+        // (a, b) -> BlockAsStruct('c1': b, 'c2': a) -- columns swapped
+        auto node = BuildPackUnpackWideMap(ctx, EPackKind::Reorder);
+        auto result = NOpt::KqpEliminateWideMapPackUnpack(NYql::NNodes::TExprBase(node), ctx, typesCtx);
+
+        UNIT_ASSERT_C(result.Ptr() == node,
+            "Pack with reordered columns should NOT be eliminated");
+    }
+
+    Y_UNIT_TEST(PackWithProjectionIsPreserved) {
+        NYql::TExprContext ctx;
+        NYql::TTypeAnnotationContext typesCtx;
+
+        // (a, b, c) -> BlockAsStruct('c1': a, 'c2': b) -- column c dropped
+        auto node = BuildPackUnpackWideMap(ctx, EPackKind::Projection);
+        auto result = NOpt::KqpEliminateWideMapPackUnpack(NYql::NNodes::TExprBase(node), ctx, typesCtx);
+
+        UNIT_ASSERT_C(result.Ptr() == node,
+            "Pack with projection (dropped column) should NOT be eliminated");
+    }
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/opt/ya.make
+++ b/ydb/core/kqp/ut/opt/ya.make
@@ -25,6 +25,7 @@ SRCS(
     kqp_sort_ut.cpp
     kqp_sqlin_ut.cpp
     kqp_union_ut.cpp
+    kqp_peephole_ut.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Fixed oom in queries like `select * from table limit 1` by removing redundant heavy WideMap.

Incident ticket: https://nda.ya.ru/t/vt2wx2h77XQP6M
...

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
