### PR TITLE
YQL-20977: Migrate to ExtendedTranslationFlags

### DIFF
--- a/ydb/library/benchmarks/runner/runner/test-gateways.conf
+++ b/ydb/library/benchmarks/runner/runner/test-gateways.conf
@@ -138,6 +138,13 @@ YqlCore {
 }
 
 SqlCore {
-    TranslationFlags: ["FlexibleTypes", "DisableAnsiOptionalAs", "EmitAggApply"]
+    ExtendedTranslationFlags: {
+        Name: "FlexibleTypes"
+    }
+    ExtendedTranslationFlags: {
+        Name: "DisableAnsiOptionalAs"
+    }
+    ExtendedTranslationFlags: {
+        Name: "EmitAggApply"
+    }
 }
-

--- a/ydb/library/yql/tools/dqrun/examples/gateways.conf
+++ b/ydb/library/yql/tools/dqrun/examples/gateways.conf
@@ -133,7 +133,15 @@ YqlCore {
 }
 
 SqlCore {
-    TranslationFlags: ["FlexibleTypes", "DisableAnsiOptionalAs", "EmitAggApply"]
+    ExtendedTranslationFlags: {
+        Name: "FlexibleTypes"
+    }
+    ExtendedTranslationFlags: {
+        Name: "DisableAnsiOptionalAs"
+    }
+    ExtendedTranslationFlags: {
+        Name: "EmitAggApply"
+    }
 }
 
 Pq {
@@ -147,4 +155,3 @@ Pq {
         ReadGroup: "read_group"
     }
 }
-


### PR DESCRIPTION

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `ExtendedTranslationFlags` allow conditional and randomized activation. They are going to replace legacy `TranslationFlags` completely.
