### PR TITLE
OIDC X-Request-Id header

### DIFF
--- a/ydb/mvp/core/mvp_log.h
+++ b/ydb/mvp/core/mvp_log.h
@@ -16,7 +16,7 @@ enum EService : NActors::NLog::EComponent {
     MAX
 };
 
-inline TString GetLogPrefix() {
+inline TStringBuf GetLogPrefix() {
     return {};
 }
 
@@ -29,6 +29,22 @@ using NMVP::GetLogPrefix;
 #define BLOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
 #define BLOG_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
 #define BLOG_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_CRIT(stream) LOG_CRIT_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_TRACE(stream) LOG_TRACE_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+
 #define BLOG_GRPC_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
-#define BLOG_GRPC_DC(context, stream) LOG_DEBUG_S(context, EService::GRPC, stream)
+#define BLOG_GRPC_DC(context, stream) LOG_DEBUG_S(context, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_CRIT(stream) LOG_CRIT_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_TRACE(stream) LOG_TRACE_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+
+#define BLOG_QUERY_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
 #define BLOG_QUERY_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
+#define BLOG_QUERY_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
+#define BLOG_QUERY_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
+#define BLOG_QUERY_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
+#define BLOG_QUERY_CRIT(stream) LOG_CRIT_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)
+#define BLOG_QUERY_TRACE(stream) LOG_TRACE_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)

--- a/ydb/mvp/core/mvp_log.h
+++ b/ydb/mvp/core/mvp_log.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mvp_log_context.h"
+
 #include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 
@@ -14,13 +16,19 @@ enum EService : NActors::NLog::EComponent {
     MAX
 };
 
-#define BLOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::MVP, stream)
-#define BLOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::MVP, stream)
-#define BLOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, EService::MVP, stream)
-#define BLOG_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, EService::MVP, stream)
-#define BLOG_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, EService::MVP, stream)
-#define BLOG_GRPC_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::GRPC, stream)
-#define BLOG_GRPC_DC(context, stream) LOG_DEBUG_S(context, EService::GRPC, stream)
-#define BLOG_QUERY_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::QUERY, stream)
+inline TString GetLogPrefix() {
+    return {};
+}
 
 }
+
+using NMVP::GetLogPrefix;
+
+#define BLOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, EService::MVP, GetLogPrefix() << stream)
+#define BLOG_GRPC_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, EService::GRPC, GetLogPrefix() << stream)
+#define BLOG_GRPC_DC(context, stream) LOG_DEBUG_S(context, EService::GRPC, stream)
+#define BLOG_QUERY_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, EService::QUERY, GetLogPrefix() << stream)

--- a/ydb/mvp/core/mvp_log_context.h
+++ b/ydb/mvp/core/mvp_log_context.h
@@ -7,13 +7,41 @@
 namespace NMVP {
 
 constexpr TStringBuf REQUEST_ID_HEADER = "X-Request-Id";
-constexpr size_t MAX_REQUEST_ID_LENGTH = 256;
+constexpr size_t MAX_REQUEST_ID_LENGTH = 64;
 
-struct TMvpLogContext {
+inline bool IsValidRequestId(TStringBuf requestId) {
+    return !requestId.empty()
+        && requestId.size() <= MAX_REQUEST_ID_LENGTH
+        && NHttp::IsValidHeaderData(requestId);
+}
+
+inline TString NormalizeRequestId(TStringBuf requestId) {
+    if (IsValidRequestId(requestId)) {
+        return TString(requestId);
+    }
+    return CreateGuidAsString();
+}
+
+class TMvpLogContext {
+private:
     TString RequestId;
+
+public:
+    TMvpLogContext()
+        : RequestId(NormalizeRequestId({}))
+    {}
+
+    explicit TMvpLogContext(TStringBuf requestId)
+        : RequestId(NormalizeRequestId(requestId))
+    {}
+
+    TStringBuf GetRequestId() const {
+        return RequestId;
+    }
 };
 
 TString GetLogPrefix(const TMvpLogContext* context);
+TStringBuf GetRequestId(const TMvpLogContext* context);
 TMvpLogContext CreateMvpLogContext(const NHttp::THttpIncomingRequestPtr& request);
 
 class TMvpLogContextProvider {
@@ -35,15 +63,20 @@ public:
         return NMVP::GetLogPrefix(GetLogContext());
     }
 
-    void SetLogContext(const TMvpLogContext& logContext) {
-        LogContext = logContext;
+    TStringBuf GetRequestId() const {
+        return NMVP::GetRequestId(GetLogContext());
+    }
+
+    void SetLogContext(const TMvpLogContext* logContext) {
+        LogContext = logContext ? *logContext : TMvpLogContext();
     }
 };
 
-inline bool IsValidRequestId(TStringBuf requestId) {
-    return !requestId.empty()
-        && requestId.size() <= MAX_REQUEST_ID_LENGTH
-        && NHttp::IsValidHeaderData(requestId);
+inline TStringBuf GetRequestId(const TMvpLogContext* context) {
+    if (!context) {
+        return {};
+    }
+    return context->GetRequestId();
 }
 
 inline TString GetRequestId(const NHttp::THttpIncomingRequestPtr& request) {
@@ -58,25 +91,18 @@ inline TString GetRequestId(const NHttp::THttpIncomingRequestPtr& request) {
 }
 
 inline TMvpLogContext CreateMvpLogContext(const NHttp::THttpIncomingRequestPtr& request) {
-    TString requestId = GetRequestId(request);
-    if (requestId.empty()) {
-        requestId = CreateGuidAsString();
-    }
-    return {.RequestId = std::move(requestId)};
+    return TMvpLogContext(GetRequestId(request));
 }
 
 inline TString GetLogPrefix(const TMvpLogContext* context) {
-    if (!context || context->RequestId.empty()) {
+    if (!context) {
         return {};
     }
-    return TStringBuilder() << "X-Request-Id: " << context->RequestId << ", ";
+    return TStringBuilder() << "X-Request-Id: " << context->GetRequestId() << ", ";
 }
 
-inline void SetRequestIdHeader(NHttp::THeadersBuilder* headers, const TMvpLogContext* context) {
-    if (!headers || !context || !IsValidRequestId(context->RequestId)) {
-        return;
-    }
-    headers->Set(REQUEST_ID_HEADER, context->RequestId);
+inline void SetRequestIdHeader(NHttp::THeadersBuilder& headers, TStringBuf requestId) {
+    headers.Set(REQUEST_ID_HEADER, requestId);
 }
 
 } // namespace NMVP

--- a/ydb/mvp/core/mvp_log_context.h
+++ b/ydb/mvp/core/mvp_log_context.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <ydb/library/actors/http/http.h>
+
+#include <util/generic/guid.h>
+
+namespace NMVP {
+
+constexpr TStringBuf REQUEST_ID_HEADER = "X-Request-Id";
+constexpr size_t MAX_REQUEST_ID_LENGTH = 256;
+
+struct TMvpLogContext {
+    TString RequestId;
+};
+
+TString GetLogPrefix(const TMvpLogContext* context);
+TMvpLogContext CreateMvpLogContext(const NHttp::THttpIncomingRequestPtr& request);
+
+class TMvpLogContextProvider {
+protected:
+    TMvpLogContext LogContext;
+
+public:
+    TMvpLogContextProvider() = default;
+    explicit TMvpLogContextProvider(const TMvpLogContext& logContext)
+        : LogContext(logContext)
+    {}
+
+    virtual ~TMvpLogContextProvider() = default;
+    virtual const TMvpLogContext* GetLogContext() const {
+        return &LogContext;
+    }
+
+    TString GetLogPrefix() const {
+        return NMVP::GetLogPrefix(GetLogContext());
+    }
+
+    void SetLogContext(const TMvpLogContext& logContext) {
+        LogContext = logContext;
+    }
+};
+
+inline bool IsValidRequestId(TStringBuf requestId) {
+    return !requestId.empty()
+        && requestId.size() <= MAX_REQUEST_ID_LENGTH
+        && NHttp::IsValidHeaderData(requestId);
+}
+
+inline TString GetRequestId(const NHttp::THttpIncomingRequestPtr& request) {
+    if (!request) {
+        return {};
+    }
+    NHttp::THeaders headers(request->Headers);
+    if (TStringBuf requestId = headers.Get(REQUEST_ID_HEADER); IsValidRequestId(requestId)) {
+        return TString(requestId);
+    }
+    return {};
+}
+
+inline TMvpLogContext CreateMvpLogContext(const NHttp::THttpIncomingRequestPtr& request) {
+    TString requestId = GetRequestId(request);
+    if (requestId.empty()) {
+        requestId = CreateGuidAsString();
+    }
+    return {.RequestId = std::move(requestId)};
+}
+
+inline TString GetLogPrefix(const TMvpLogContext* context) {
+    if (!context || context->RequestId.empty()) {
+        return {};
+    }
+    return TStringBuilder() << "X-Request-Id: " << context->RequestId << ", ";
+}
+
+inline void SetRequestIdHeader(NHttp::THeadersBuilder* headers, const TMvpLogContext* context) {
+    if (!headers || !context || !IsValidRequestId(context->RequestId)) {
+        return;
+    }
+    headers->Set(REQUEST_ID_HEADER, context->RequestId);
+}
+
+} // namespace NMVP

--- a/ydb/mvp/oidc_proxy/extension.cpp
+++ b/ydb/mvp/oidc_proxy/extension.cpp
@@ -8,12 +8,12 @@ void TExtensionContext::Reply(NHttp::THttpOutgoingResponsePtr httpResponse) {
 
 void TExtensionContext::Reply() {
     if (!Params.StatusOverride.empty()) {
-        SetRequestIdHeader(Params.HeadersOverride.Get(), GetLogContext());
+        SetRequestIdHeader(*Params.HeadersOverride, GetRequestId());
         return Reply(Params.Request->CreateResponse(Params.StatusOverride, Params.MessageOverride, *Params.HeadersOverride, Params.BodyOverride));
     } else {
         static constexpr size_t MAX_LOGGED_SIZE = 1024;
         BLOG_D("Can not process request to protected resource:\n" << Params.Request->GetObfuscatedData().substr(0, MAX_LOGGED_SIZE));
-        return Reply(CreateResponseForNotExistingResponseFromProtectedResource(Params.Request, Params.ResponseError, GetLogContext()));
+        return Reply(CreateResponseForNotExistingResponseFromProtectedResource(Params.Request, Params.ResponseError, GetRequestId()));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/extension.cpp
+++ b/ydb/mvp/oidc_proxy/extension.cpp
@@ -8,11 +8,12 @@ void TExtensionContext::Reply(NHttp::THttpOutgoingResponsePtr httpResponse) {
 
 void TExtensionContext::Reply() {
     if (!Params.StatusOverride.empty()) {
+        SetRequestIdHeader(Params.HeadersOverride.Get(), GetLogContext());
         return Reply(Params.Request->CreateResponse(Params.StatusOverride, Params.MessageOverride, *Params.HeadersOverride, Params.BodyOverride));
     } else {
         static constexpr size_t MAX_LOGGED_SIZE = 1024;
         BLOG_D("Can not process request to protected resource:\n" << Params.Request->GetObfuscatedData().substr(0, MAX_LOGGED_SIZE));
-        return Reply(CreateResponseForNotExistingResponseFromProtectedResource(Params.Request, Params.ResponseError));
+        return Reply(CreateResponseForNotExistingResponseFromProtectedResource(Params.Request, Params.ResponseError, GetLogContext()));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/extension.h
+++ b/ydb/mvp/oidc_proxy/extension.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/mvp/core/mvp_log.h>
 #include "openid_connect.h"
 #include <ydb/mvp/core/cracked_page.h>
 
@@ -29,7 +30,7 @@ struct TExtensionsSteps : public TQueue<std::unique_ptr<IExtension>> {
     std::unique_ptr<IExtension> Next();
 };
 
-struct TExtensionContext : public TThrRefBase {
+struct TExtensionContext : public TThrRefBase, public TMvpLogContextProvider {
     NActors::TActorId Sender;
     TExtensionsSteps Steps;
     TProxiedResponseParams Params;

--- a/ydb/mvp/oidc_proxy/extension_manager.cpp
+++ b/ydb/mvp/oidc_proxy/extension_manager.cpp
@@ -24,8 +24,15 @@ void TExtensionManager::SetExtensionTimeout(TDuration timeout) {
     Timeout = timeout;
 }
 
+void TExtensionManager::SetLogContext(const TMvpLogContext& logContext) {
+    ExtensionCtx->SetLogContext(logContext);
+}
+
 void TExtensionManager::SetRequest(NHttp::THttpIncomingRequestPtr request) {
     ExtensionCtx->Params.Request = std::move(request);
+    if (ExtensionCtx->GetLogContext()->RequestId.empty()) {
+        ExtensionCtx->SetLogContext(CreateMvpLogContext(ExtensionCtx->Params.Request));
+    }
 }
 
 void TExtensionManager::SetOverrideResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {

--- a/ydb/mvp/oidc_proxy/extension_manager.cpp
+++ b/ydb/mvp/oidc_proxy/extension_manager.cpp
@@ -24,15 +24,12 @@ void TExtensionManager::SetExtensionTimeout(TDuration timeout) {
     Timeout = timeout;
 }
 
-void TExtensionManager::SetLogContext(const TMvpLogContext& logContext) {
+void TExtensionManager::SetLogContext(const TMvpLogContext* logContext) {
     ExtensionCtx->SetLogContext(logContext);
 }
 
 void TExtensionManager::SetRequest(NHttp::THttpIncomingRequestPtr request) {
     ExtensionCtx->Params.Request = std::move(request);
-    if (ExtensionCtx->GetLogContext()->RequestId.empty()) {
-        ExtensionCtx->SetLogContext(CreateMvpLogContext(ExtensionCtx->Params.Request));
-    }
 }
 
 void TExtensionManager::SetOverrideResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {

--- a/ydb/mvp/oidc_proxy/extension_manager.h
+++ b/ydb/mvp/oidc_proxy/extension_manager.h
@@ -16,6 +16,7 @@ public:
                       const TCrackedPage& protectedPage,
                       const TString authHeader);
     void SetExtensionTimeout(TDuration timeout);
+    void SetLogContext(const TMvpLogContext& logContext);
     void ArrangeExtensions(const NHttp::THttpIncomingRequestPtr& request);
     void StartExtensionProcess(NHttp::THttpIncomingRequestPtr request,
                                NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event = nullptr);

--- a/ydb/mvp/oidc_proxy/extension_manager.h
+++ b/ydb/mvp/oidc_proxy/extension_manager.h
@@ -16,7 +16,7 @@ public:
                       const TCrackedPage& protectedPage,
                       const TString authHeader);
     void SetExtensionTimeout(TDuration timeout);
-    void SetLogContext(const TMvpLogContext& logContext);
+    void SetLogContext(const TMvpLogContext* logContext);
     void ArrangeExtensions(const NHttp::THttpIncomingRequestPtr& request);
     void StartExtensionProcess(NHttp::THttpIncomingRequestPtr request,
                                NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event = nullptr);

--- a/ydb/mvp/oidc_proxy/extension_whoami.cpp
+++ b/ydb/mvp/oidc_proxy/extension_whoami.cpp
@@ -5,6 +5,10 @@
 
 namespace NMVP::NOIDC {
 
+const TMvpLogContext* TExtensionWhoamiWorker::GetLogContext() const {
+    return Context ? Context->TMvpLogContextProvider::GetLogContext() : nullptr;
+}
+
 void TExtensionWhoamiWorker::Bootstrap() {
     auto connection = CreateGRpcServiceConnection<TProfileService>(Settings.WhoamiExtendedInfoEndpoint);
     RequestContext = MVPAppData()->GRpcClientLow->CreateContext();

--- a/ydb/mvp/oidc_proxy/extension_whoami.h
+++ b/ydb/mvp/oidc_proxy/extension_whoami.h
@@ -6,7 +6,7 @@
 
 namespace NMVP::NOIDC {
 
-class TExtensionWhoamiWorker : public NActors::TActorBootstrapped<TExtensionWhoamiWorker> {
+class TExtensionWhoamiWorker : public NActors::TActorBootstrapped<TExtensionWhoamiWorker>, public TMvpLogContextProvider {
     using TBase = IExtension;
     using TProfileService = nebius::iam::v1::ProfileService;
 
@@ -41,6 +41,7 @@ public:
     }
 
 private:
+    const TMvpLogContext* GetLogContext() const override;
     void PatchResponse(NJson::TJsonValue& json, NJson::TJsonValue& errorJson);
     void ApplyIfReady();
     void ApplyExtension();

--- a/ydb/mvp/oidc_proxy/oidc_cleanup_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_cleanup_page.cpp
@@ -1,6 +1,7 @@
-#include "openid_connect.h"
-#include "oidc_session_create.h"
 #include "oidc_cleanup_page.h"
+
+#include "oidc_session_create.h"
+#include "openid_connect.h"
 
 namespace NMVP::NOIDC {
 
@@ -9,7 +10,8 @@ THandlerCleanup::THandlerCleanup(const NActors::TActorId& sender,
                                  const NActors::TActorId& httpProxyId,
                                  const TOpenIdConnectSettings& settings,
                                  const TString& cookieName)
-    : Sender(sender)
+    : TMvpLogContextProvider(CreateMvpLogContext(request))
+    , Sender(sender)
     , Request(request)
     , HttpProxyId(httpProxyId)
     , Settings(settings)
@@ -22,6 +24,7 @@ void THandlerCleanup::Bootstrap() {
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Set-Cookie", ClearSecureCookie(CookieName));
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
 
     ReplyAndPassAway(Request->CreateResponse("200", "OK", responseHeaders));
 }

--- a/ydb/mvp/oidc_proxy/oidc_cleanup_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_cleanup_page.cpp
@@ -24,7 +24,7 @@ void THandlerCleanup::Bootstrap() {
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Set-Cookie", ClearSecureCookie(CookieName));
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
 
     ReplyAndPassAway(Request->CreateResponse("200", "OK", responseHeaders));
 }

--- a/ydb/mvp/oidc_proxy/oidc_cleanup_page.h
+++ b/ydb/mvp/oidc_proxy/oidc_cleanup_page.h
@@ -1,12 +1,19 @@
 #pragma once
 
+#include <ydb/mvp/core/mvp_log.h>
+
 #include "oidc_settings.h"
 #include "context.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/http/http_proxy.h>
 
 namespace NMVP::NOIDC {
 
-class THandlerCleanup : public NActors::TActorBootstrapped<THandlerCleanup> {
+class THandlerCleanup
+    : public NActors::TActorBootstrapped<THandlerCleanup>
+    , protected TMvpLogContextProvider {
 private:
     using TBase = NActors::TActorBootstrapped<THandlerCleanup>;
 

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
@@ -96,7 +96,7 @@ void THandlerImpersonateStart::ProcessImpersonatedToken(const NJson::TJsonValue&
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Set-Cookie", CreateSecureCookie(impersonatedCookieName, impersonatedCookieValue, expiresIn));
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     ReplyAndPassAway(Request->CreateResponse("200", "OK", responseHeaders));
 }
 
@@ -118,7 +118,7 @@ void THandlerImpersonateStart::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRespon
                 responseHeaders.Set("Content-Type", headers.Get("Content-Type"));
             }
             SetCORS(Request, &responseHeaders);
-            SetRequestIdHeader(&responseHeaders, GetLogContext());
+            SetRequestIdHeader(responseHeaders, GetRequestId());
             return ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
         }
     }
@@ -135,7 +135,7 @@ void THandlerImpersonateStart::ReplyBadRequestAndPassAway(const TString& errorMe
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Content-Type", "text/plain");
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage));
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
@@ -1,6 +1,7 @@
-#include "openid_connect.h"
-#include "oidc_session_create.h"
 #include "oidc_impersonate_start_page_nebius.h"
+
+#include "oidc_session_create.h"
+#include "openid_connect.h"
 
 #include <ydb/mvp/core/mvp_log.h>
 #include <ydb/mvp/core/mvp_tokens.h>
@@ -16,7 +17,8 @@ THandlerImpersonateStart::THandlerImpersonateStart(const NActors::TActorId& send
                                                    const NHttp::THttpIncomingRequestPtr& request,
                                                    const NActors::TActorId& httpProxyId,
                                                    const TOpenIdConnectSettings& settings)
-    : Sender(sender)
+    : TMvpLogContextProvider(CreateMvpLogContext(request))
+    , Sender(sender)
     , Request(request)
     , HttpProxyId(httpProxyId)
     , Settings(settings)
@@ -94,6 +96,7 @@ void THandlerImpersonateStart::ProcessImpersonatedToken(const NJson::TJsonValue&
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Set-Cookie", CreateSecureCookie(impersonatedCookieName, impersonatedCookieValue, expiresIn));
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     ReplyAndPassAway(Request->CreateResponse("200", "OK", responseHeaders));
 }
 
@@ -115,6 +118,7 @@ void THandlerImpersonateStart::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRespon
                 responseHeaders.Set("Content-Type", headers.Get("Content-Type"));
             }
             SetCORS(Request, &responseHeaders);
+            SetRequestIdHeader(&responseHeaders, GetLogContext());
             return ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
         }
     }
@@ -131,6 +135,7 @@ void THandlerImpersonateStart::ReplyBadRequestAndPassAway(const TString& errorMe
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Content-Type", "text/plain");
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage));
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include <ydb/mvp/core/mvp_log.h>
 #include "oidc_settings.h"
 #include "context.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/http/http_proxy.h>
 
 namespace NMVP::NOIDC {
 
-class THandlerImpersonateStart : public NActors::TActorBootstrapped<THandlerImpersonateStart> {
+class THandlerImpersonateStart
+    : public NActors::TActorBootstrapped<THandlerImpersonateStart>
+    , protected TMvpLogContextProvider {
 private:
     using TBase = NActors::TActorBootstrapped<THandlerImpersonateStart>;
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
@@ -12,7 +12,8 @@ THandlerSessionServiceCheck::THandlerSessionServiceCheck(const NActors::TActorId
                                                          const NHttp::THttpIncomingRequestPtr& request,
                                                          const NActors::TActorId& httpProxyId,
                                                          const TOpenIdConnectSettings& settings)
-    : Sender(sender)
+    : TMvpLogContextProvider(CreateMvpLogContext(request))
+    , Sender(sender)
     , Request(request)
     , HttpProxyId(httpProxyId)
     , Settings(settings)
@@ -22,7 +23,7 @@ THandlerSessionServiceCheck::THandlerSessionServiceCheck(const NActors::TActorId
 void THandlerSessionServiceCheck::Bootstrap(const NActors::TActorContext& ctx) {
     Send(Sender, new NHttp::TEvHttpProxy::TEvSubscribeForCancel(), NActors::IEventHandle::FlagTrackDelivery);
     if (!ProtectedPage.IsHttpSchemeAllowed() || !ProtectedPage.IsRequestedHostAllowed(Settings.AllowedProxyHosts)) {
-        return ReplyAndPassAway(CreateResponseForbiddenHost(Request, ProtectedPage));
+        return ReplyAndPassAway(CreateResponseForbiddenHost(Request, ProtectedPage, GetLogContext()));
     }
     NHttp::THeaders headers(Request->Headers);
     TStringBuf authHeader = headers.Get(AUTHORIZATION_HEADER);
@@ -50,6 +51,8 @@ void THandlerSessionServiceCheck::HandleIncompleteProxy(NHttp::TEvHttpProxy::TEv
         NHttp::THttpIncomingResponsePtr response = std::move(event->Get()->Response);
         BLOG_D("Incoming incomplete response for protected resource: " << response->Status);
 
+        // Do not add X-Request-Id to streaming response headers for now.
+        // This path forwards an incomplete upstream response without rebuilding headers.
         StreamResponse = Request->CreateResponseString(response->AsString());
         StreamConnection = event->Sender;
 
@@ -57,7 +60,7 @@ void THandlerSessionServiceCheck::HandleIncompleteProxy(NHttp::TEvHttpProxy::TEv
     } else {
         static constexpr size_t MAX_LOGGED_SIZE = 1024;
         BLOG_D("Can not process incomplete request to protected resource:\n" << event->Get()->Request->GetObfuscatedData().substr(0, MAX_LOGGED_SIZE));
-        ReplyAndPassAway(CreateResponseForNotExistingResponseFromProtectedResource(Request, "Failed to process streaming response"));
+        ReplyAndPassAway(CreateResponseForNotExistingResponseFromProtectedResource(Request, "Failed to process streaming response", GetLogContext()));
     }
 }
 
@@ -121,6 +124,7 @@ void THandlerSessionServiceCheck::ForwardUserRequest(TStringBuf authHeader, bool
     auto timeout = GetRequestTimeout();
     ExtensionManager = MakeHolder<TExtensionManager>(Sender, Settings, ProtectedPage, TString(authHeader));
     ExtensionManager->SetExtensionTimeout(timeout);
+    ExtensionManager->SetLogContext(*GetLogContext());
     ExtensionManager->ArrangeExtensions(Request);
 
     TProxiedRequestParams params(Request, authHeader, secure, ProtectedPage, Settings);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
@@ -23,7 +23,7 @@ THandlerSessionServiceCheck::THandlerSessionServiceCheck(const NActors::TActorId
 void THandlerSessionServiceCheck::Bootstrap(const NActors::TActorContext& ctx) {
     Send(Sender, new NHttp::TEvHttpProxy::TEvSubscribeForCancel(), NActors::IEventHandle::FlagTrackDelivery);
     if (!ProtectedPage.IsHttpSchemeAllowed() || !ProtectedPage.IsRequestedHostAllowed(Settings.AllowedProxyHosts)) {
-        return ReplyAndPassAway(CreateResponseForbiddenHost(Request, ProtectedPage, GetLogContext()));
+        return ReplyAndPassAway(CreateResponseForbiddenHost(Request, ProtectedPage, GetRequestId()));
     }
     NHttp::THeaders headers(Request->Headers);
     TStringBuf authHeader = headers.Get(AUTHORIZATION_HEADER);
@@ -60,7 +60,7 @@ void THandlerSessionServiceCheck::HandleIncompleteProxy(NHttp::TEvHttpProxy::TEv
     } else {
         static constexpr size_t MAX_LOGGED_SIZE = 1024;
         BLOG_D("Can not process incomplete request to protected resource:\n" << event->Get()->Request->GetObfuscatedData().substr(0, MAX_LOGGED_SIZE));
-        ReplyAndPassAway(CreateResponseForNotExistingResponseFromProtectedResource(Request, "Failed to process streaming response", GetLogContext()));
+        ReplyAndPassAway(CreateResponseForNotExistingResponseFromProtectedResource(Request, "Failed to process streaming response", GetRequestId()));
     }
 }
 
@@ -124,7 +124,7 @@ void THandlerSessionServiceCheck::ForwardUserRequest(TStringBuf authHeader, bool
     auto timeout = GetRequestTimeout();
     ExtensionManager = MakeHolder<TExtensionManager>(Sender, Settings, ProtectedPage, TString(authHeader));
     ExtensionManager->SetExtensionTimeout(timeout);
-    ExtensionManager->SetLogContext(*GetLogContext());
+    ExtensionManager->SetLogContext(GetLogContext());
     ExtensionManager->ArrangeExtensions(Request);
 
     TProxiedRequestParams params(Request, authHeader, secure, ProtectedPage, Settings);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "extension_manager.h"
+#include <ydb/mvp/core/mvp_log.h>
 
 #include <util/generic/string.h>
 #include <util/generic/strbuf.h>
@@ -11,7 +12,9 @@
 
 namespace NMVP::NOIDC {
 
-class THandlerSessionServiceCheck : public NActors::TActorBootstrapped<THandlerSessionServiceCheck> {
+class THandlerSessionServiceCheck
+    : public NActors::TActorBootstrapped<THandlerSessionServiceCheck>
+    , protected TMvpLogContextProvider {
 protected:
     using TBase = NActors::TActorBootstrapped<THandlerSessionServiceCheck>;
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.cpp
@@ -45,6 +45,7 @@ void THandlerSessionServiceCheckNebius::HandleExchange(NHttp::TEvHttpProxy::TEvH
         BLOG_D("Getting access token: Bad Request");
         NHttp::THeadersBuilder responseHeaders;
         SetCORS(Request, &responseHeaders);
+        SetRequestIdHeader(&responseHeaders, GetLogContext());
         responseHeaders.Set("Content-Type", "text/plain");
         return ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, event->Get()->Error));
     }
@@ -72,6 +73,7 @@ void THandlerSessionServiceCheckNebius::HandleExchange(NHttp::TEvHttpProxy::TEvH
     // don't know what to do, just forward response
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Parse(response->Headers);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
 }
 
@@ -121,6 +123,7 @@ void THandlerSessionServiceCheckNebius::ClearImpersonatedCookie() {
     BLOG_D("Clear impersonated cookie (" << impersonatedCookieName << ") and retry");
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     responseHeaders.Set("Set-Cookie", ClearSecureCookie(impersonatedCookieName));
     responseHeaders.Set("Location", Request->URL);
     ReplyAndPassAway(Request->CreateResponse("307", "Temporary Redirect", responseHeaders));
@@ -128,7 +131,7 @@ void THandlerSessionServiceCheckNebius::ClearImpersonatedCookie() {
 
 void THandlerSessionServiceCheckNebius::RequestAuthorizationCode() {
     BLOG_D("Request authorization code");
-    NHttp::THttpOutgoingResponsePtr httpResponse = GetHttpOutgoingResponsePtr(Request, Settings);
+    NHttp::THttpOutgoingResponsePtr httpResponse = GetHttpOutgoingResponsePtr(Request, Settings, GetLogContext());
     ReplyAndPassAway(std::move(httpResponse));
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.cpp
@@ -45,7 +45,7 @@ void THandlerSessionServiceCheckNebius::HandleExchange(NHttp::TEvHttpProxy::TEvH
         BLOG_D("Getting access token: Bad Request");
         NHttp::THeadersBuilder responseHeaders;
         SetCORS(Request, &responseHeaders);
-        SetRequestIdHeader(&responseHeaders, GetLogContext());
+        SetRequestIdHeader(responseHeaders, GetRequestId());
         responseHeaders.Set("Content-Type", "text/plain");
         return ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, event->Get()->Error));
     }
@@ -73,7 +73,7 @@ void THandlerSessionServiceCheckNebius::HandleExchange(NHttp::TEvHttpProxy::TEvH
     // don't know what to do, just forward response
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Parse(response->Headers);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
 }
 
@@ -123,7 +123,7 @@ void THandlerSessionServiceCheckNebius::ClearImpersonatedCookie() {
     BLOG_D("Clear impersonated cookie (" << impersonatedCookieName << ") and retry");
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     responseHeaders.Set("Set-Cookie", ClearSecureCookie(impersonatedCookieName));
     responseHeaders.Set("Location", Request->URL);
     ReplyAndPassAway(Request->CreateResponse("307", "Temporary Redirect", responseHeaders));
@@ -131,7 +131,7 @@ void THandlerSessionServiceCheckNebius::ClearImpersonatedCookie() {
 
 void THandlerSessionServiceCheckNebius::RequestAuthorizationCode() {
     BLOG_D("Request authorization code");
-    NHttp::THttpOutgoingResponsePtr httpResponse = GetHttpOutgoingResponsePtr(Request, Settings, GetLogContext());
+    NHttp::THttpOutgoingResponsePtr httpResponse = GetHttpOutgoingResponsePtr(Request, Settings, GetRequestId());
     ReplyAndPassAway(std::move(httpResponse));
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
@@ -1,5 +1,5 @@
-#include "context.h"
 #include "oidc_protected_page_yandex.h"
+#include "context.h"
 
 #include <ydb/mvp/core/appdata.h>
 #include <ydb/mvp/core/mvp_log.h>
@@ -35,9 +35,12 @@ void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvErrorResponse::TPt
     BLOG_D("SessionService.Check(): " << event->Get()->Status);
     NHttp::THttpOutgoingResponsePtr httpResponse;
     if (event->Get()->Status == "400") {
-        return ReplyAndPassAway(GetHttpOutgoingResponsePtr(Request, Settings));
+        return ReplyAndPassAway(GetHttpOutgoingResponsePtr(Request, Settings, GetLogContext()));
     } else {
-        return ReplyAndPassAway(Request->CreateResponse( event->Get()->Status, event->Get()->Message, "text/plain", event->Get()->Details));
+        NHttp::THeadersBuilder responseHeaders;
+        responseHeaders.Set("Content-Type", "text/plain");
+        SetRequestIdHeader(&responseHeaders, GetLogContext());
+        return ReplyAndPassAway(Request->CreateResponse(event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
@@ -35,11 +35,11 @@ void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvErrorResponse::TPt
     BLOG_D("SessionService.Check(): " << event->Get()->Status);
     NHttp::THttpOutgoingResponsePtr httpResponse;
     if (event->Get()->Status == "400") {
-        return ReplyAndPassAway(GetHttpOutgoingResponsePtr(Request, Settings, GetLogContext()));
+        return ReplyAndPassAway(GetHttpOutgoingResponsePtr(Request, Settings, GetRequestId()));
     } else {
         NHttp::THeadersBuilder responseHeaders;
         responseHeaders.Set("Content-Type", "text/plain");
-        SetRequestIdHeader(&responseHeaders, GetLogContext());
+        SetRequestIdHeader(responseHeaders, GetRequestId());
         return ReplyAndPassAway(Request->CreateResponse(event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details));
     }
 }

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -527,7 +527,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             UNIT_ASSERT_STRINGS_EQUAL("true", headers.Get(accessControlAllowCredentials));
 
             UNIT_ASSERT(headers.Has(accessControlAllowHeaders));
-            UNIT_ASSERT_STRINGS_EQUAL("Content-Type,Authorization,Origin,Accept,X-Request-Id,X-Trace-Verbosity,X-Want-Trace,traceparent", headers.Get(accessControlAllowHeaders));
+            UNIT_ASSERT_STRINGS_EQUAL("Content-Type,Authorization,Origin,Accept,X-Trace-Verbosity,X-Want-Trace,traceparent", headers.Get(accessControlAllowHeaders));
 
             UNIT_ASSERT(headers.Has(accessControlAllowMethods));
             UNIT_ASSERT_STRINGS_EQUAL("OPTIONS,GET,POST,PUT,DELETE", headers.Get(accessControlAllowMethods));

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -20,22 +20,26 @@
 using namespace NMVP::NOIDC;
 using namespace NActors;
 
-const TString ALLOWED_PROXY_HOST {"ydb.viewer.page"};
+namespace {
 
-static TOpenIdConnectSettings BuildBaseSettings(TPortManager& tp, NMvp::EAccessServiceType accessServiceType = NMvp::yandex_v2) {
-    ui16 sessionServicePort = tp.GetPort(8655);
-    ui16 profilePort = tp.GetPort(8766);
+    const TString ALLOWED_PROXY_HOST {"ydb.viewer.page"};
 
-    TOpenIdConnectSettings s;
-    s.AccessServiceType = accessServiceType;
-    s.ClientId = "client_id";
-    s.AuthorizationServerAddress = "https://auth.test.net";
-    s.AllowedProxyHosts = {ALLOWED_PROXY_HOST};
-    s.SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort);
-    s.WhoamiExtendedInfoEndpoint = "localhost:" + ToString(profilePort);
-    s.ClientSecret = "0123456789abcdef";
-    return s;
-}
+    static TOpenIdConnectSettings BuildBaseSettings(TPortManager& tp, NMvp::EAccessServiceType accessServiceType = NMvp::yandex_v2) {
+        ui16 sessionServicePort = tp.GetPort(8655);
+        ui16 profilePort = tp.GetPort(8766);
+
+        TOpenIdConnectSettings s;
+        s.AccessServiceType = accessServiceType;
+        s.ClientId = "client_id";
+        s.AuthorizationServerAddress = "https://auth.test.net";
+        s.AllowedProxyHosts = {ALLOWED_PROXY_HOST};
+        s.SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort);
+        s.WhoamiExtendedInfoEndpoint = "localhost:" + ToString(profilePort);
+        s.ClientSecret = "0123456789abcdef";
+        return s;
+    }
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(Mvp) {
     void OpenIdConnectRequestWithIamTokenTest(NMvp::EAccessServiceType profile) {
@@ -523,7 +527,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
             UNIT_ASSERT_STRINGS_EQUAL("true", headers.Get(accessControlAllowCredentials));
 
             UNIT_ASSERT(headers.Has(accessControlAllowHeaders));
-            UNIT_ASSERT_STRINGS_EQUAL("Content-Type,Authorization,Origin,Accept,X-Trace-Verbosity,X-Want-Trace,traceparent", headers.Get(accessControlAllowHeaders));
+            UNIT_ASSERT_STRINGS_EQUAL("Content-Type,Authorization,Origin,Accept,X-Request-Id,X-Trace-Verbosity,X-Want-Trace,traceparent", headers.Get(accessControlAllowHeaders));
 
             UNIT_ASSERT(headers.Has(accessControlAllowMethods));
             UNIT_ASSERT_STRINGS_EQUAL("OPTIONS,GET,POST,PUT,DELETE", headers.Get(accessControlAllowMethods));
@@ -577,6 +581,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         const TString state = urlParameters["state"];
 
         const NHttp::THeaders headers(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(headers.Has("X-Request-Id"));
         UNIT_ASSERT(headers.Has("Set-Cookie"));
         TStringBuf setCookie = headers.Get("Set-Cookie");
         UNIT_ASSERT_STRING_CONTAINS(setCookie, TOpenIdConnectSettings::YDB_OIDC_COOKIE);
@@ -607,6 +612,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
         UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
         const NHttp::THeaders protectedPageHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(protectedPageHeaders.Has("X-Request-Id"));
         UNIT_ASSERT(protectedPageHeaders.Has("Location"));
         redirectStrategy.CheckLocationHeader(protectedPageHeaders.Get("Location"), hostProxy, protectedPage);
         UNIT_ASSERT(protectedPageHeaders.Has("Set-Cookie"));
@@ -632,6 +638,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
 
         outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
         UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "200");
+        UNIT_ASSERT(NHttp::THeaders(outgoingResponseEv->Response->Headers).Has("X-Request-Id"));
         UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Body, "this is test.");
     }
 

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -1,6 +1,6 @@
-#include "openid_connect.h"
 #include "oidc_session_create.h"
 #include "oidc_settings.h"
+#include "openid_connect.h"
 
 #include <ydb/mvp/core/mvp_log.h>
 
@@ -14,7 +14,8 @@ THandlerSessionCreate::THandlerSessionCreate(const NActors::TActorId& sender,
                                              const NHttp::THttpIncomingRequestPtr& request,
                                              const NActors::TActorId& httpProxyId,
                                              const TOpenIdConnectSettings& settings)
-    : Sender(sender)
+    : TMvpLogContextProvider(CreateMvpLogContext(request))
+    , Sender(sender)
     , Request(request)
     , HttpProxyId(httpProxyId)
     , Settings(settings)
@@ -64,6 +65,7 @@ void THandlerSessionCreate::Bootstrap() {
 void THandlerSessionCreate::ReplyBadRequestAndPassAway(TString errorMessage) {
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     responseHeaders.Set("Content-Type", "text/plain");
     return ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage));
 }
@@ -82,6 +84,7 @@ void THandlerSessionCreate::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse:
         } else {
             NHttp::THeadersBuilder responseHeaders;
             responseHeaders.Parse(response->Headers);
+            SetRequestIdHeader(&responseHeaders, GetLogContext());
             return ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
         }
     }
@@ -109,6 +112,7 @@ void THandlerSessionCreate::RetryRequestToProtectedResourceAndDie() {
 
 void THandlerSessionCreate::RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders) {
     SetCORS(Request, responseHeaders);
+    SetRequestIdHeader(responseHeaders, GetLogContext());
     responseHeaders->Set("Location", Context.GetRequestedAddress());
     ReplyAndPassAway(Request->CreateResponse("302", "Found", *responseHeaders));
 }
@@ -117,6 +121,7 @@ void THandlerSessionCreate::SendUnknownErrorResponseAndDie() {
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Content-Type", "text/html");
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     const static TStringBuf BAD_REQUEST_HTML_PAGE = "<html>"
                                                         "<head>"
                                                             "<title>"

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -65,7 +65,7 @@ void THandlerSessionCreate::Bootstrap() {
 void THandlerSessionCreate::ReplyBadRequestAndPassAway(TString errorMessage) {
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     responseHeaders.Set("Content-Type", "text/plain");
     return ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage));
 }
@@ -84,7 +84,7 @@ void THandlerSessionCreate::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse:
         } else {
             NHttp::THeadersBuilder responseHeaders;
             responseHeaders.Parse(response->Headers);
-            SetRequestIdHeader(&responseHeaders, GetLogContext());
+            SetRequestIdHeader(responseHeaders, GetRequestId());
             return ReplyAndPassAway(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body));
         }
     }
@@ -112,7 +112,7 @@ void THandlerSessionCreate::RetryRequestToProtectedResourceAndDie() {
 
 void THandlerSessionCreate::RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders) {
     SetCORS(Request, responseHeaders);
-    SetRequestIdHeader(responseHeaders, GetLogContext());
+    SetRequestIdHeader(*responseHeaders, GetRequestId());
     responseHeaders->Set("Location", Context.GetRequestedAddress());
     ReplyAndPassAway(Request->CreateResponse("302", "Found", *responseHeaders));
 }
@@ -121,7 +121,7 @@ void THandlerSessionCreate::SendUnknownErrorResponseAndDie() {
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Content-Type", "text/html");
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     const static TStringBuf BAD_REQUEST_HTML_PAGE = "<html>"
                                                         "<head>"
                                                             "<title>"

--- a/ydb/mvp/oidc_proxy/oidc_session_create.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ydb/mvp/core/mvp_log.h>
+
 #include <util/generic/string.h>
 #include <util/generic/strbuf.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -11,7 +13,9 @@
 
 namespace NMVP::NOIDC {
 
-class THandlerSessionCreate : public NActors::TActorBootstrapped<THandlerSessionCreate> {
+class THandlerSessionCreate
+    : public NActors::TActorBootstrapped<THandlerSessionCreate>
+    , protected TMvpLogContextProvider {
 private:
     using TBase = NActors::TActorBootstrapped<THandlerSessionCreate>;
 

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.cpp
@@ -68,6 +68,7 @@ void THandlerSessionCreateNebius::ProcessSessionToken(const NJson::TJsonValue& j
 
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
+    SetRequestIdHeader(&responseHeaders, GetLogContext());
     responseHeaders.Set("Set-Cookie", CreateSecureCookie(sessionCookieName, sessionCookieValue, expiresIn));
     responseHeaders.Set("Location", Context.GetRequestedAddress());
     ReplyAndPassAway(Request->CreateResponse("302", "Cookie set", responseHeaders));

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.cpp
@@ -68,7 +68,7 @@ void THandlerSessionCreateNebius::ProcessSessionToken(const NJson::TJsonValue& j
 
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(Request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, GetLogContext());
+    SetRequestIdHeader(responseHeaders, GetRequestId());
     responseHeaders.Set("Set-Cookie", CreateSecureCookie(sessionCookieName, sessionCookieValue, expiresIn));
     responseHeaders.Set("Location", Context.GetRequestedAddress());
     ReplyAndPassAway(Request->CreateResponse("302", "Cookie set", responseHeaders));

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
@@ -86,7 +86,8 @@ void THandlerSessionCreateYandex::HandleError(TEvPrivate::TEvErrorResponse::TPtr
         NHttp::THeadersBuilder responseHeaders;
         responseHeaders.Set("Content-Type", "text/plain");
         SetCORS(Request, &responseHeaders);
-        ReplyAndPassAway(Request->CreateResponse( event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details));
+        SetRequestIdHeader(&responseHeaders, GetLogContext());
+        ReplyAndPassAway(Request->CreateResponse(event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
@@ -86,7 +86,7 @@ void THandlerSessionCreateYandex::HandleError(TEvPrivate::TEvErrorResponse::TPtr
         NHttp::THeadersBuilder responseHeaders;
         responseHeaders.Set("Content-Type", "text/plain");
         SetCORS(Request, &responseHeaders);
-        SetRequestIdHeader(&responseHeaders, GetLogContext());
+        SetRequestIdHeader(responseHeaders, GetRequestId());
         ReplyAndPassAway(Request->CreateResponse(event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details));
     }
 }

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -16,7 +16,6 @@ const TVector<TStringBuf> TOpenIdConnectSettings::REQUEST_HEADERS_WHITE_LIST = {
     "Upgrade-Insecure-Requests",
     "Content-Type",
     "Origin",
-    "X-Request-Id",
     "X-Trace-Verbosity",
     "X-Want-Trace",
     "traceparent"

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -16,6 +16,7 @@ const TVector<TStringBuf> TOpenIdConnectSettings::REQUEST_HEADERS_WHITE_LIST = {
     "Upgrade-Insecure-Requests",
     "Content-Type",
     "Origin",
+    "X-Request-Id",
     "X-Trace-Verbosity",
     "X-Want-Trace",
     "traceparent"

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -17,6 +17,17 @@
 
 namespace NMVP::NOIDC {
 
+namespace {
+
+NHttp::THttpOutgoingResponsePtr CreateResponseForAjaxRequest(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder& headers, const TString& redirectUrl, const TMvpLogContext* logContext) {
+    headers.Set("Content-Type", "application/json; charset=utf-8");
+    SetCORS(request, &headers);
+    SetRequestIdHeader(&headers, logContext);
+    TString body {"{\"error\":\"Authorization Required\",\"authUrl\":\"" + redirectUrl + "\"}"};
+    return request->CreateResponse("401", "Unauthorized", headers, body);
+}
+
+} // namespace
 TRestoreOidcContextResult::TRestoreOidcContextResult(const TStatus& status, const TContext& context)
     : Context(context)
     , Status(status)
@@ -44,7 +55,7 @@ void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuild
     headers->Set("Access-Control-Allow-Origin", origin);
     headers->Set("Access-Control-Allow-Credentials", "true");
     headers->Set("Access-Control-Allow-Headers", "Content-Type,Authorization,Origin,Accept,X-Trace-Verbosity,X-Want-Trace,traceparent");
-    headers->Set("Access-Control-Expose-Headers", "traceresponse,X-Worker-Name");
+    headers->Set("Access-Control-Expose-Headers", "traceresponse,X-Worker-Name,X-Request-Id");
     headers->Set("Access-Control-Allow-Methods", "OPTIONS,GET,POST,PUT,DELETE");
     headers->Set("Allow", "OPTIONS,GET,POST,PUT,DELETE");
 }
@@ -77,7 +88,7 @@ void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& va
     meta.Aux.emplace_back(name, value);
 }
 
-NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings) {
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, const TMvpLogContext* logContext) {
     TContext context(request);
     const TString redirectUrl = TStringBuilder() << settings.GetAuthEndpointURL()
                                                  << "?response_type=code"
@@ -89,17 +100,13 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
                                                                      << GetAuthCallbackUrl();
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(request, &responseHeaders);
-
-    if (context.IsNavigationRequest()) {
-        responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
-        responseHeaders.Set(LOCATION_HEADER, redirectUrl);
-        return request->CreateResponse("302", "Authorization required", responseHeaders);
-    }
-
+    SetRequestIdHeader(&responseHeaders, logContext);
     responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
-    responseHeaders.Set("Content-Type", "application/json; charset=utf-8");
-    TString body {"{\"error\":\"Authorization Required\",\"authUrl\":\"" + redirectUrl + "\"}"};
-    return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
+    if (context.IsAjaxRequest()) {
+        return CreateResponseForAjaxRequest(request, responseHeaders, redirectUrl, logContext);
+    }
+    responseHeaders.Set(LOCATION_HEADER, redirectUrl);
+    return request->CreateResponse("302", "Authorization required", responseHeaders);
 }
 
 TString CreateNameYdbOidcCookie(TStringBuf key, TStringBuf state) {
@@ -249,6 +256,9 @@ TString DecodeToken(const TStringBuf& cookie) {
 }
 
 TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName) {
+    if (!cookies.Has(cookieName)) {
+        return {};
+    }
     TStringBuf cookieValue = cookies.Get(cookieName);
     if (!cookieValue.Empty()) {
         BLOG_D("Using cookie (" << cookieName << ": " << NKikimr::MaskTicket(cookieValue) << ")");
@@ -330,10 +340,11 @@ NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams&
     return outRequest;
 }
 
-NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage) {
+NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, const TMvpLogContext* logContext) {
     NHttp::THeadersBuilder headers;
     headers.Set("Content-Type", "text/html");
     SetCORS(request, &headers);
+    SetRequestIdHeader(&headers, logContext);
 
     TStringBuilder html;
     html << "<html><head><title>403 Forbidden</title></head><body bgcolor=\"white\"><center><h1>";
@@ -343,10 +354,11 @@ NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIn
     return request->CreateResponse("403", "Forbidden", headers, html);
 }
 
-NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage) {
+NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, const TMvpLogContext* logContext) {
     NHttp::THeadersBuilder headers;
     headers.Set("Content-Type", "text/html");
     SetCORS(request, &headers);
+    SetRequestIdHeader(&headers, logContext);
 
     TStringBuilder html;
     html << "<html><head><title>400 Bad Request</title></head><body bgcolor=\"white\"><center><h1>";

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -17,17 +17,6 @@
 
 namespace NMVP::NOIDC {
 
-namespace {
-
-NHttp::THttpOutgoingResponsePtr CreateResponseForAjaxRequest(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder& headers, const TString& redirectUrl, const TMvpLogContext* logContext) {
-    headers.Set("Content-Type", "application/json; charset=utf-8");
-    SetCORS(request, &headers);
-    SetRequestIdHeader(&headers, logContext);
-    TString body {"{\"error\":\"Authorization Required\",\"authUrl\":\"" + redirectUrl + "\"}"};
-    return request->CreateResponse("401", "Unauthorized", headers, body);
-}
-
-} // namespace
 TRestoreOidcContextResult::TRestoreOidcContextResult(const TStatus& status, const TContext& context)
     : Context(context)
     , Status(status)
@@ -88,7 +77,7 @@ void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& va
     meta.Aux.emplace_back(name, value);
 }
 
-NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, const TMvpLogContext* logContext) {
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId) {
     TContext context(request);
     const TString redirectUrl = TStringBuilder() << settings.GetAuthEndpointURL()
                                                  << "?response_type=code"
@@ -100,13 +89,15 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
                                                                      << GetAuthCallbackUrl();
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(request, &responseHeaders);
-    SetRequestIdHeader(&responseHeaders, logContext);
+    SetRequestIdHeader(responseHeaders, requestId);
     responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
-    if (context.IsAjaxRequest()) {
-        return CreateResponseForAjaxRequest(request, responseHeaders, redirectUrl, logContext);
+    if (context.IsNavigationRequest()) {
+        responseHeaders.Set(LOCATION_HEADER, redirectUrl);
+        return request->CreateResponse("302", "Authorization required", responseHeaders);
     }
-    responseHeaders.Set(LOCATION_HEADER, redirectUrl);
-    return request->CreateResponse("302", "Authorization required", responseHeaders);
+    responseHeaders.Set("Content-Type", "application/json; charset=utf-8");
+    TString body {"{\"error\":\"Authorization Required\",\"authUrl\":\"" + redirectUrl + "\"}"};
+    return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
 }
 
 TString CreateNameYdbOidcCookie(TStringBuf key, TStringBuf state) {
@@ -340,11 +331,11 @@ NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams&
     return outRequest;
 }
 
-NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, const TMvpLogContext* logContext) {
+NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, TStringBuf requestId) {
     NHttp::THeadersBuilder headers;
     headers.Set("Content-Type", "text/html");
     SetCORS(request, &headers);
-    SetRequestIdHeader(&headers, logContext);
+    SetRequestIdHeader(headers, requestId);
 
     TStringBuilder html;
     html << "<html><head><title>403 Forbidden</title></head><body bgcolor=\"white\"><center><h1>";
@@ -354,11 +345,11 @@ NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIn
     return request->CreateResponse("403", "Forbidden", headers, html);
 }
 
-NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, const TMvpLogContext* logContext) {
+NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, TStringBuf requestId) {
     NHttp::THeadersBuilder headers;
     headers.Set("Content-Type", "text/html");
     SetCORS(request, &headers);
-    SetRequestIdHeader(&headers, logContext);
+    SetRequestIdHeader(headers, requestId);
 
     TStringBuilder html;
     html << "<html><head><title>400 Bad Request</title></head><body bgcolor=\"white\"><center><h1>";

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -57,7 +57,7 @@ struct TCheckStateResult {
 TString HmacSHA256(TStringBuf key, TStringBuf data);
 TString HmacSHA1(TStringBuf key, TStringBuf data);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
-NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings);
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, const TMvpLogContext* logContext = nullptr);
 TString CreateNameYdbOidcCookie(TStringBuf key, TStringBuf state);
 TString CreateNameSessionCookie(TStringBuf key);
 TString CreateNameImpersonatedCookie(TStringBuf key);
@@ -82,8 +82,8 @@ struct TProxiedRequestParams {
 };
 
 NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams& param);
-NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage);
-NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage);
+NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, const TMvpLogContext* logContext = nullptr);
+NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, const TMvpLogContext* logContext = nullptr);
 
 template <typename TSessionService>
 std::unique_ptr<NYdbGrpc::TServiceConnection<TSessionService>> CreateGRpcServiceConnection(const TString& endpoint) {

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -57,7 +57,7 @@ struct TCheckStateResult {
 TString HmacSHA256(TStringBuf key, TStringBuf data);
 TString HmacSHA1(TStringBuf key, TStringBuf data);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
-NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, const TMvpLogContext* logContext = nullptr);
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId);
 TString CreateNameYdbOidcCookie(TStringBuf key, TStringBuf state);
 TString CreateNameSessionCookie(TStringBuf key);
 TString CreateNameImpersonatedCookie(TStringBuf key);
@@ -82,8 +82,8 @@ struct TProxiedRequestParams {
 };
 
 NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams& param);
-NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, const TMvpLogContext* logContext = nullptr);
-NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, const TMvpLogContext* logContext = nullptr);
+NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost(const NHttp::THttpIncomingRequestPtr request, const TCrackedPage& protectedPage, TStringBuf requestId);
+NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const NHttp::THttpIncomingRequestPtr request, const TString& errorMessage, TStringBuf requestId);
 
 template <typename TSessionService>
 std::unique_ptr<NYdbGrpc::TServiceConnection<TSessionService>> CreateGRpcServiceConnection(const TString& endpoint) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds request-scoped correlation to the MVP OIDC proxy by generating/propagating an `X-Request-Id` and including it in OIDC HTTP responses. MVP logs can now prefix messages with that request id via a log context. 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

For streaming responses, `X-Request-Id` is not added to the response headers: that path forwards an incomplete upstream response without rebuilding its headers.
