### PR TITLE
Disabled by default --replace-sys-acl option in tools restore

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.h
@@ -59,7 +59,7 @@ private:
     bool RestoreData = true;
     bool RestoreIndexes = true;
     bool RestoreACL = true;
-    bool ReplaceSysACL = true;
+    bool ReplaceSysACL = false;
     bool SkipDocumentTables = false;
     bool SavePartialResult = false;
     bool Replace = false;

--- a/ydb/public/lib/ydb_cli/dump/dump.h
+++ b/ydb/public/lib/ydb_cli/dump/dump.h
@@ -99,7 +99,7 @@ struct TRestoreSettings: public TOperationRequestSettings<TRestoreSettings> {
     FLUENT_SETTING_DEFAULT(bool, RestoreIndexes, true);
     FLUENT_SETTING_DEFAULT(bool, RestoreChangefeeds, true);
     FLUENT_SETTING_DEFAULT(bool, RestoreACL, true);
-    FLUENT_SETTING_DEFAULT(bool, ReplaceSysACL, true);
+    FLUENT_SETTING_DEFAULT(bool, ReplaceSysACL, false);
     FLUENT_SETTING_DEFAULT(bool, SkipDocumentTables, false);
     FLUENT_SETTING_DEFAULT(bool, SavePartialResult, false);
     FLUENT_SETTING_DEFAULT(bool, Replace, false);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -809,7 +809,9 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
 
     if (settings.WithContent_) {
         ExistingEntries.emplace(dbPath, ESchemeEntryType::SubDomain);
-        auto restoreResult = RestoreFolder(fsPath, dbPath, {});
+        TRestoreSettings restoreSettings;
+        restoreSettings.ReplaceSysACL(true);
+        auto restoreResult = RestoreFolder(fsPath, dbPath, restoreSettings);
         if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
             restoreResult = result;
         }

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -3091,7 +3091,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
                 systemDirectory,
                 schemeClient,
                 CreateBackupLambda(driver, pathToBackup),
-                CreateRestoreLambda(driver, pathToBackup)
+                CreateRestoreLambda(driver, pathToBackup, "/Root", NDump::TRestoreSettings().ReplaceSysACL(true))
             );
         }
 
@@ -3104,7 +3104,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
                 session,
                 schemeClient,
                 CreateBackupLambda(driver, pathToBackup),
-                CreateRestoreLambda(driver, pathToBackup)
+                CreateRestoreLambda(driver, pathToBackup, "/Root", NDump::TRestoreSettings().ReplaceSysACL(true))
             );
         }
     }
@@ -3249,7 +3249,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         constexpr const char* systemDirectory = "/Root/.sys";
         constexpr const char* sysView = "/Root/.sys/partition_stats";
 
-        const auto restorationSettings = NDump::TRestoreSettings().Replace(true);
+        const auto restorationSettings = NDump::TRestoreSettings().Replace(true).ReplaceSysACL(true);
 
         cleanup();
         TestTableContentIsPreserved(table, querySession,

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -1892,7 +1892,7 @@ class TestRestoreReplaceOption(BaseTestBackupInFiles):
 class TestReplaceSysACLOption(BaseTestBackupInFiles):
     @classmethod
     def setup_class(cls):
-        cls.cluster = KiKiMR(KikimrConfigGenerator(extra_feature_flags=["enable_real_system_view_paths"]))
+        cls.cluster = KiKiMR(KikimrConfigGenerator())
         cls.cluster.start()
         cls.root_dir = '/Root'
         driver_config = ydb.DriverConfig(
@@ -2034,7 +2034,7 @@ class TestReplaceSysACLOption(BaseTestBackupInFiles):
         self.driver.scheme_client.modify_permissions('/Root/.sys/partition_stats', new_permissions_settings)
 
         # Restore the domain
-        self.ydb_cli(['tools', 'restore', '--path', '/Root', '--input', backup_files_dir])
+        self.ydb_cli(['tools', 'restore', '--path', '/Root', '--input', backup_files_dir, '--replace-sys-acl', 'true'])
 
         # Check the restored directory
         assert_that(
@@ -2079,7 +2079,7 @@ class TestReplaceSysACLOption(BaseTestBackupInFiles):
         # Restore the domain in ordinary directory
         assert_that(
             self.try_ydb_cli(
-                ['tools', 'restore', '--path', '/Root/restored', '--input', backup_files_dir]
+                ['tools', 'restore', '--path', '/Root/restored', '--input', backup_files_dir, '--replace-sys-acl', 'true']
             )[0],
             is_(True),
         )


### PR DESCRIPTION
Regular users now can't use tools restore with `-p .` option, because they don't have permissions to change an owner of `.sys` folder with its content. This PR fixes that.
