### PR TITLE
Support basic reads with JSON_EXISTS predicate from JSON index

### DIFF
--- a/ydb/core/base/fulltext.cpp
+++ b/ydb/core/base/fulltext.cpp
@@ -397,12 +397,22 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
         TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
         break;
     case NBinaryJson::EContainerType::Array:
+        if (root.GetSize() == 0) {
+            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
+            return;
+        }
+
         for (ui32 pos = 0; pos < root.GetSize(); pos++) {
             TokenizeBinaryJson(root.GetElement(pos), prefix, tokens);
         }
         break;
     case NBinaryJson::EContainerType::Object:
         auto it = root.GetObjectIterator();
+        if (!it.HasNext()) {
+            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
+            return;
+        }
+
         while (it.HasNext()) {
             auto kv = it.Next();
             Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);

--- a/ydb/core/base/fulltext.cpp
+++ b/ydb/core/base/fulltext.cpp
@@ -2,10 +2,6 @@
 
 #include <contrib/libs/snowball/include/libstemmer.h>
 
-#include <yql/essentials/public/udf/udf_types.h>
-#include <yql/essentials/types/binary_json/read.h>
-#include <yql/essentials/types/binary_json/write.h>
-
 #include <util/charset/utf8.h>
 #include <util/generic/xrange.h>
 
@@ -340,109 +336,6 @@ TVector<TString> Analyze(const TStringBuf text, const Ydb::Table::FulltextIndexS
     }
 
     return tokens;
-}
-
-void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens);
-
-void TokenizeBinaryJson(NBinaryJson::TEntryCursor element, const TString& prefix, TVector<TString>& tokens) {
-    if (element.GetType() == NBinaryJson::EEntryType::Container) {
-        TokenizeBinaryJson(element.GetContainer(), prefix, tokens);
-        return;
-    }
-    TString token = prefix;
-    token.push_back(0);
-    // Value always comes last in the token and we may want range queries on value,
-    // so we just store element type and data.
-    token.push_back((char)element.GetType());
-    switch (element.GetType()) {
-    case NBinaryJson::EEntryType::String:
-        token += element.GetString();
-        break;
-    case NBinaryJson::EEntryType::Number: {
-        double number = element.GetNumber();
-        token += TStringBuf((char*)&number, sizeof(double));
-        break;
-    }
-    case NBinaryJson::EEntryType::BoolFalse:
-    case NBinaryJson::EEntryType::BoolTrue:
-    case NBinaryJson::EEntryType::Null:
-        break;
-    case NBinaryJson::EEntryType::Container:
-        Y_ENSURE(false, "Unreachable");
-        break;
-    }
-    tokens.push_back(token);
-}
-
-TString TokenizeJsonNextPrefix(const TString& prefix, TStringBuf key) {
-    size_t size = key.size();
-    TString newPrefix = prefix;
-    // We don't need range queries on paths and keys may contain binary data,
-    // for example a zero byte, so we store keys with varint length
-    do {
-        if (size < 0x80) {
-            newPrefix.push_back((ui8)size);
-        } else {
-            newPrefix.push_back(0x80 | (ui8)(size & 0x7F));
-        }
-        size >>= 7;
-    } while (size > 0);
-    newPrefix += key;
-    return newPrefix;
-}
-
-void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens) {
-    switch (root.GetType()) {
-    case NBinaryJson::EContainerType::TopLevelScalar:
-        TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
-        break;
-    case NBinaryJson::EContainerType::Array:
-        if (root.GetSize() == 0) {
-            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
-            return;
-        }
-
-        for (ui32 pos = 0; pos < root.GetSize(); pos++) {
-            TokenizeBinaryJson(root.GetElement(pos), prefix, tokens);
-        }
-        break;
-    case NBinaryJson::EContainerType::Object:
-        auto it = root.GetObjectIterator();
-        if (!it.HasNext()) {
-            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
-            return;
-        }
-
-        while (it.HasNext()) {
-            auto kv = it.Next();
-            Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);
-            TString nextPrefix = TokenizeJsonNextPrefix(prefix, kv.first.GetString());
-            tokens.push_back(nextPrefix);
-            TokenizeBinaryJson(kv.second, nextPrefix, tokens);
-        }
-        break;
-    }
-}
-
-TVector<TString> TokenizeBinaryJson(const TStringBuf binaryJson) {
-    TVector<TString> tokens;
-    if (!binaryJson.size()) {
-        return tokens;
-    }
-    auto reader = NKikimr::NBinaryJson::TBinaryJsonReader::Make(binaryJson);
-    TokenizeBinaryJson(reader->GetRootCursor(), "", tokens);
-    return tokens;
-}
-
-TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error) {
-    auto json = NKikimr::NBinaryJson::SerializeToBinaryJson(jsonStr);
-    if (std::holds_alternative<TString>(json)) {
-        error = std::get<TString>(json);
-        return TVector<TString>();
-    }
-    error = "";
-    auto buffer = std::get<NKikimr::NBinaryJson::TBinaryJson>(json);
-    return TokenizeBinaryJson(TStringBuf(buffer.data(), buffer.size()));
 }
 
 TVector<TString> BuildSearchTerms(const TString& query, const Ydb::Table::FulltextIndexSettings::Analyzers& settings) {

--- a/ydb/core/base/fulltext.cpp
+++ b/ydb/core/base/fulltext.cpp
@@ -416,7 +416,9 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
         while (it.HasNext()) {
             auto kv = it.Next();
             Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);
-            TokenizeBinaryJson(kv.second, TokenizeJsonNextPrefix(prefix, kv.first.GetString()), tokens);
+            TString nextPrefix = TokenizeJsonNextPrefix(prefix, kv.first.GetString());
+            tokens.push_back(nextPrefix);
+            TokenizeBinaryJson(kv.second, nextPrefix, tokens);
         }
         break;
     }

--- a/ydb/core/base/fulltext.h
+++ b/ydb/core/base/fulltext.h
@@ -12,9 +12,6 @@ Ydb::Table::FulltextIndexSettings::Analyzers GetAnalyzersForQuery(Ydb::Table::Fu
 TVector<TString> Analyze(const TStringBuf text, const Ydb::Table::FulltextIndexSettings::Analyzers& settings, const std::unordered_set<wchar32>& ignoredDelimiters = {});
 TVector<TString> BuildSearchTerms(const TString& query, const Ydb::Table::FulltextIndexSettings::Analyzers& settings);
 
-TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error);
-TVector<TString> TokenizeBinaryJson(const TStringBuf text);
-
 bool ValidateColumnsMatches(const NProtoBuf::RepeatedPtrField<TString>& columns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
 bool ValidateColumnsMatches(const TVector<TString>& columns, const Ydb::Table::FulltextIndexSettings& settings, TString& error);
 

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -9,6 +9,10 @@ namespace NKikimr {
 
 namespace NJsonIndex {
 
+using NYql::TIssue;
+using NYql::TIssues;
+using namespace NYql::NJsonPath;
+
 namespace {
 
 NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
@@ -29,6 +33,21 @@ NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
             Y_ENSURE(false, "Unexpected item type");
     }
     return NBinaryJson::EEntryType::Null;
+}
+
+// Keys may contain binary data (e.g. a zero byte), so we prefix each key with its
+// varint-encoded length (LEB128). This allows unambiguous prefix-scan queries.
+void AppendKey(TString& prefix, TStringBuf key) {
+    size_t size = key.size();
+    do {
+        if (size < 0x80) {
+            prefix.push_back((ui8)size);
+        } else {
+            prefix.push_back(0x80 | (ui8)(size & 0x7F));
+        }
+        size >>= 7;
+    } while (size > 0);
+    prefix += key;
 }
 
 }  // namespace
@@ -224,20 +243,9 @@ TResult TQueryCollector::MemberAccess(const TJsonPathItem& item) {
         return input;
     }
 
+    // TODO: Handle multiple queries
     auto& query = input.GetQueries()[0];
-    auto member = TString(item.GetString());
-    auto size = member.size();
-
-    do {
-        if (size < 0x80) {
-            query.push_back((ui8)size);
-        } else {
-            query.push_back(0x80 | (ui8)(size & 0x7F));
-        }
-        size >>= 7;
-    } while (size > 0);
-
-    query += std::move(member);
+    AppendKey(query, item.GetString());
     return input;
 }
 
@@ -373,6 +381,7 @@ TResult TQueryCollector::FilterPredicate(const TJsonPathItem& item) {
     return TResult(TIssue("Not implemented"));
 }
 
+// TODO: Add support for filters and JSON_VALUE
 // Do not emit specific posting keys for the predicates: JsonExists/SqlExists treats any non-empty jsonpath
 // result as true, including a single boolean false from the predicate, so index + residual
 // JSON_EXISTS would return wrong rows. We just emit an empty query to indicate that the predicate
@@ -398,8 +407,8 @@ TResult TQueryCollector::Variable(const TJsonPathItem&) {
 }
 
 TVector<TString> BuildSearchTerms(const TString& jsonPathStr) {
-    NYql::TIssues issues;
-    const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPathStr, issues, 1);
+    TIssues issues;
+    const TJsonPathPtr path = ParseJsonPath(jsonPathStr, issues, 1);
     if (!issues.Empty()) {
         return {};
     }
@@ -445,19 +454,8 @@ void TokenizeBinaryJson(NBinaryJson::TEntryCursor element, const TString& prefix
 }
 
 TString TokenizeJsonNextPrefix(const TString& prefix, TStringBuf key) {
-    size_t size = key.size();
     TString newPrefix = prefix;
-    // We don't need range queries on paths and keys may contain binary data,
-    // for example a zero byte, so we store keys with varint length
-    do {
-        if (size < 0x80) {
-            newPrefix.push_back((ui8)size);
-        } else {
-            newPrefix.push_back(0x80 | (ui8)(size & 0x7F));
-        }
-        size >>= 7;
-    } while (size > 0);
-    newPrefix += key;
+    AppendKey(newPrefix, key);
     return newPrefix;
 }
 
@@ -467,22 +465,12 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
         TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
         break;
     case NBinaryJson::EContainerType::Array:
-        if (root.GetSize() == 0) {
-            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
-            return;
-        }
-
         for (ui32 pos = 0; pos < root.GetSize(); pos++) {
             TokenizeBinaryJson(root.GetElement(pos), prefix, tokens);
         }
         break;
     case NBinaryJson::EContainerType::Object:
         auto it = root.GetObjectIterator();
-        if (!it.HasNext()) {
-            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
-            return;
-        }
-
         while (it.HasNext()) {
             auto kv = it.Next();
             Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -1,8 +1,34 @@
 #include "json_index.h"
 
+#include <yql/essentials/types/binary_json/format.h>
+
 namespace NKikimr {
 
 namespace NJsonIndex {
+
+namespace {
+
+NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
+    switch (item.Type) {
+        case EJsonPathItemType::StringLiteral:
+            return NBinaryJson::EEntryType::String;
+        case EJsonPathItemType::NumberLiteral:
+            return NBinaryJson::EEntryType::Number;
+        case EJsonPathItemType::BooleanLiteral:
+            if (item.GetBoolean()) {
+                return NBinaryJson::EEntryType::BoolTrue;
+            } else {
+                return NBinaryJson::EEntryType::BoolFalse;
+            }
+        case EJsonPathItemType::NullLiteral:
+            return NBinaryJson::EEntryType::Null;
+        default:
+            Y_ENSURE(false, "Unexpected item type");
+    }
+    return NBinaryJson::EEntryType::Null;
+}
+
+}  // namespace
 
 TResult::TResult(const TQuery& query)
     : Result(query)
@@ -45,6 +71,14 @@ bool TResult::IsError() const {
     return std::holds_alternative<TResult::TError>(Result);
 }
 
+bool TResult::IsDone() const {
+    return Done;
+}
+
+void TResult::MarkDone() {
+    Done = true;
+}
+
 TQueryCollector::TQueryCollector(const TJsonPathPtr path)
     : Reader(path)
 {
@@ -59,7 +93,7 @@ TResult TQueryCollector::Collect(const TJsonPathItem& item) {
         case EJsonPathItemType::MemberAccess:
             return MemberAccess(item);
         case EJsonPathItemType::WildcardMemberAccess:
-            return WildcardMemberAccess(item);
+            return Finalize(item);
         case EJsonPathItemType::ContextObject:
             return ContextObject();
         case EJsonPathItemType::Variable:
@@ -115,19 +149,13 @@ TResult TQueryCollector::Collect(const TJsonPathItem& item) {
         case EJsonPathItemType::BinaryNotEqual:
             return BinaryNotEqual(item);
         case EJsonPathItemType::AbsMethod:
-            return AbsMethod(item);
         case EJsonPathItemType::FloorMethod:
-            return FloorMethod(item);
         case EJsonPathItemType::CeilingMethod:
-            return CeilingMethod(item);
         case EJsonPathItemType::DoubleMethod:
-            return DoubleMethod(item);
         case EJsonPathItemType::TypeMethod:
-            return TypeMethod(item);
         case EJsonPathItemType::SizeMethod:
-            return SizeMethod(item);
         case EJsonPathItemType::KeyValueMethod:
-            return KeyValueMethod(item);
+            return Finalize(item);
         case EJsonPathItemType::StartsWithPredicate:
             return StartsWithPredicate(item);
         case EJsonPathItemType::IsUnknownPredicate:
@@ -139,21 +167,50 @@ TResult TQueryCollector::Collect(const TJsonPathItem& item) {
     }
 }
 
+TResult TQueryCollector::EvaluateLiteral(const TJsonPathItem& item) {
+    std::string value;
+    value.push_back(0);
+    value.push_back((char)GetEntryType(item));
+
+    switch (item.Type) {
+        case EJsonPathItemType::StringLiteral: {
+            value += item.GetString();
+            break;
+        }
+
+        case EJsonPathItemType::NumberLiteral: {
+            double number = item.GetNumber();
+            value += TStringBuf((char*)&number, sizeof(double));
+            break;
+        }
+
+        case EJsonPathItemType::BooleanLiteral:
+        case EJsonPathItemType::NullLiteral:
+            break;
+        default:
+            return TResult(TIssue("Expected a literal expression"));
+    }
+
+    return TResult(value);
+}
+
+TResult TQueryCollector::Finalize(const TJsonPathItem& item) {
+    auto input = Collect(Reader.ReadInput(item));
+    input.MarkDone();
+    return input;
+}
+
 TResult TQueryCollector::ContextObject() {
     return TResult(std::string{});
 }
 
 TResult TQueryCollector::MemberAccess(const TJsonPathItem& item) {
     auto input = Collect(Reader.ReadInput(item));
-    if (input.IsError()) {
+    if (input.IsError() || input.IsDone() || !input.GetQuery().has_value()) {
         return input;
     }
 
     auto& query = input.GetQuery();
-    if (!query.has_value()) {
-        return input;
-    }
-
     auto member = std::string(item.GetString());
     auto size = member.size();
 
@@ -168,12 +225,6 @@ TResult TQueryCollector::MemberAccess(const TJsonPathItem& item) {
 
     *query += std::move(member);
     return input;
-}
-
-TResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
 }
 
 TResult TQueryCollector::ArrayAccess(const TJsonPathItem& item) {
@@ -285,26 +336,19 @@ TResult TQueryCollector::BinaryNotEqual(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::NullLiteral() {
-    // TODO: Implement
-    return TResult(TIssue("Not implemented"));
+    return TResult(std::nullopt);
 }
 
-TResult TQueryCollector::BooleanLiteral(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+TResult TQueryCollector::BooleanLiteral(const TJsonPathItem&) {
+    return TResult(std::nullopt);
 }
 
-TResult TQueryCollector::NumberLiteral(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+TResult TQueryCollector::NumberLiteral(const TJsonPathItem&) {
+    return TResult(std::nullopt);
 }
 
-TResult TQueryCollector::StringLiteral(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+TResult TQueryCollector::StringLiteral(const TJsonPathItem&) {
+    return TResult(std::nullopt);
 }
 
 TResult TQueryCollector::FilterObject(const TJsonPathItem& item) {
@@ -319,52 +363,27 @@ TResult TQueryCollector::FilterPredicate(const TJsonPathItem& item) {
     return TResult(TIssue("Not implemented"));
 }
 
-TResult TQueryCollector::AbsMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::FloorMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::CeilingMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::DoubleMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::TypeMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::SizeMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
-TResult TQueryCollector::KeyValueMethod(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
-}
-
 TResult TQueryCollector::StartsWithPredicate(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    auto input = Collect(Reader.ReadInput(item));
+    if (input.IsError() || input.IsDone() || !input.GetQuery().has_value()) {
+        return input;
+    }
+
+    const auto& prefixItem = Reader.ReadPrefix(item);
+    if (prefixItem.Type != EJsonPathItemType::StringLiteral) {
+        return TResult(TIssue("Expected a string literal"));
+    }
+
+    auto prefix = EvaluateLiteral(prefixItem);
+    if (prefix.IsError()) {
+        return prefix;
+    }
+
+    auto& query = input.GetQuery();
+    *query += std::move(prefix.GetQuery().value());
+
+    input.MarkDone();
+    return input;
 }
 
 TResult TQueryCollector::IsUnknownPredicate(const TJsonPathItem& item) {
@@ -380,15 +399,13 @@ TResult TQueryCollector::ExistsPredicate(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::LikeRegexPredicate(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    auto input = Collect(Reader.ReadInput(item));
+    input.MarkDone();
+    return input;
 }
 
-TResult TQueryCollector::Variable(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+TResult TQueryCollector::Variable(const TJsonPathItem&) {
+    return TResult(TIssue("Variables are not supported at the moment"));
 }
 
 }  // namespace NJsonIndex

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -203,6 +203,17 @@ TResult TQueryCollector::Finalize(const TJsonPathItem& item) {
     return input;
 }
 
+TResult TQueryCollector::FinalizeEmpty(const TJsonPathItem& item) {
+    auto input = Collect(Reader.ReadInput(item));
+    if (input.IsError() || input.GetQueries().empty()) {
+        return input;
+    }
+
+    auto result = TResult("");
+    result.MarkDone();
+    return result;
+}
+
 TResult TQueryCollector::ContextObject() {
     return TResult(TResult::TQueries{TString{}});
 }
@@ -366,24 +377,24 @@ TResult TQueryCollector::FilterPredicate(const TJsonPathItem& item) {
     return TResult(TIssue("Not implemented"));
 }
 
+// Do not emit specific posting keys for the predicates: JsonExists/SqlExists treats any non-empty jsonpath
+// result as true, including a single boolean false from the predicate, so index + residual
+// JSON_EXISTS would return wrong rows. We just emit an empty query to indicate that the predicate
+// is present to read all json documents.
 TResult TQueryCollector::StartsWithPredicate(const TJsonPathItem& item) {
-    return Finalize(item);
+    return FinalizeEmpty(item);
 }
 
 TResult TQueryCollector::IsUnknownPredicate(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    return FinalizeEmpty(item);
 }
 
 TResult TQueryCollector::ExistsPredicate(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    return FinalizeEmpty(item);
 }
 
 TResult TQueryCollector::LikeRegexPredicate(const TJsonPathItem& item) {
-    return Finalize(item);
+    return FinalizeEmpty(item);
 }
 
 TResult TQueryCollector::Variable(const TJsonPathItem&) {

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -1,5 +1,8 @@
 #include "json_index.h"
 
+#include <yql/essentials/public/udf/udf_types.h>
+#include <yql/essentials/types/binary_json/read.h>
+#include <yql/essentials/types/binary_json/write.h>
 #include <yql/essentials/types/binary_json/format.h>
 
 namespace NKikimr {
@@ -30,23 +33,23 @@ NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
 
 }  // namespace
 
-TResult::TResult(const TQuery& query)
-    : Result(query)
+TResult::TResult(const TQueries& queries)
+    : Result(queries)
 {
 }
 
-TResult::TResult(TQuery&& query)
-    : Result(std::move(query))
+TResult::TResult(TQueries&& queries)
+    : Result(std::move(queries))
 {
 }
 
-TResult::TResult(std::string&& query)
-    : Result(std::move(query))
+TResult::TResult(TString&& query)
+    : Result(TQueries{std::move(query)})
 {
 }
 
-TResult::TResult(const std::string& query)
-    : Result(query)
+TResult::TResult(const TString& query)
+    : Result(TQueries{query})
 {
 }
 
@@ -55,12 +58,12 @@ TResult::TResult(TResult::TError&& issue)
 {
 }
 
-const TResult::TQuery& TResult::GetQuery() const {
-    return std::get<TQuery>(Result);
+const TResult::TQueries& TResult::GetQueries() const {
+    return std::get<TQueries>(Result);
 }
 
-TResult::TQuery& TResult::GetQuery() {
-    return std::get<TQuery>(Result);
+TResult::TQueries& TResult::GetQueries() {
+    return std::get<TQueries>(Result);
 }
 
 const TResult::TError& TResult::GetError() const {
@@ -168,7 +171,7 @@ TResult TQueryCollector::Collect(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::EvaluateLiteral(const TJsonPathItem& item) {
-    std::string value;
+    TString value;
     value.push_back(0);
     value.push_back((char)GetEntryType(item));
 
@@ -201,29 +204,29 @@ TResult TQueryCollector::Finalize(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::ContextObject() {
-    return TResult(std::string{});
+    return TResult(TResult::TQueries{TString{}});
 }
 
 TResult TQueryCollector::MemberAccess(const TJsonPathItem& item) {
     auto input = Collect(Reader.ReadInput(item));
-    if (input.IsError() || input.IsDone() || !input.GetQuery().has_value()) {
+    if (input.IsError() || input.IsDone() || input.GetQueries().empty()) {
         return input;
     }
 
-    auto& query = input.GetQuery();
-    auto member = std::string(item.GetString());
+    auto& query = input.GetQueries()[0];
+    auto member = TString(item.GetString());
     auto size = member.size();
 
     do {
         if (size < 0x80) {
-            query->push_back((ui8)size);
+            query.push_back((ui8)size);
         } else {
-            query->push_back(0x80 | (ui8)(size & 0x7F));
+            query.push_back(0x80 | (ui8)(size & 0x7F));
         }
         size >>= 7;
     } while (size > 0);
 
-    *query += std::move(member);
+    query += std::move(member);
     return input;
 }
 
@@ -336,19 +339,19 @@ TResult TQueryCollector::BinaryNotEqual(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::NullLiteral() {
-    return TResult(std::nullopt);
+    return TResult(TResult::TQueries{});
 }
 
 TResult TQueryCollector::BooleanLiteral(const TJsonPathItem&) {
-    return TResult(std::nullopt);
+    return TResult(TResult::TQueries{});
 }
 
 TResult TQueryCollector::NumberLiteral(const TJsonPathItem&) {
-    return TResult(std::nullopt);
+    return TResult(TResult::TQueries{});
 }
 
 TResult TQueryCollector::StringLiteral(const TJsonPathItem&) {
-    return TResult(std::nullopt);
+    return TResult(TResult::TQueries{});
 }
 
 TResult TQueryCollector::FilterObject(const TJsonPathItem& item) {
@@ -364,26 +367,7 @@ TResult TQueryCollector::FilterPredicate(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::StartsWithPredicate(const TJsonPathItem& item) {
-    auto input = Collect(Reader.ReadInput(item));
-    if (input.IsError() || input.IsDone() || !input.GetQuery().has_value()) {
-        return input;
-    }
-
-    const auto& prefixItem = Reader.ReadPrefix(item);
-    if (prefixItem.Type != EJsonPathItemType::StringLiteral) {
-        return TResult(TIssue("Expected a string literal"));
-    }
-
-    auto prefix = EvaluateLiteral(prefixItem);
-    if (prefix.IsError()) {
-        return prefix;
-    }
-
-    auto& query = input.GetQuery();
-    *query += std::move(prefix.GetQuery().value());
-
-    input.MarkDone();
-    return input;
+    return Finalize(item);
 }
 
 TResult TQueryCollector::IsUnknownPredicate(const TJsonPathItem& item) {
@@ -399,13 +383,130 @@ TResult TQueryCollector::ExistsPredicate(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::LikeRegexPredicate(const TJsonPathItem& item) {
-    auto input = Collect(Reader.ReadInput(item));
-    input.MarkDone();
-    return input;
+    return Finalize(item);
 }
 
 TResult TQueryCollector::Variable(const TJsonPathItem&) {
     return TResult(TIssue("Variables are not supported at the moment"));
+}
+
+TVector<TString> BuildSearchTerms(const TString& jsonPathStr) {
+    NYql::TIssues issues;
+    const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPathStr, issues, 1);
+    if (!issues.Empty()) {
+        return {};
+    }
+
+    auto result = TQueryCollector(path).Collect();
+    if (result.IsError()) {
+        return {};
+    }
+
+    return result.GetQueries();
+}
+
+void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens);
+
+void TokenizeBinaryJson(NBinaryJson::TEntryCursor element, const TString& prefix, TVector<TString>& tokens) {
+    if (element.GetType() == NBinaryJson::EEntryType::Container) {
+        TokenizeBinaryJson(element.GetContainer(), prefix, tokens);
+        return;
+    }
+    TString token = prefix;
+    token.push_back(0);
+    // Value always comes last in the token and we may want range queries on value,
+    // so we just store element type and data.
+    token.push_back((char)element.GetType());
+    switch (element.GetType()) {
+    case NBinaryJson::EEntryType::String:
+        token += element.GetString();
+        break;
+    case NBinaryJson::EEntryType::Number: {
+        double number = element.GetNumber();
+        token += TStringBuf((char*)&number, sizeof(double));
+        break;
+    }
+    case NBinaryJson::EEntryType::BoolFalse:
+    case NBinaryJson::EEntryType::BoolTrue:
+    case NBinaryJson::EEntryType::Null:
+        break;
+    case NBinaryJson::EEntryType::Container:
+        Y_ENSURE(false, "Unreachable");
+        break;
+    }
+    tokens.push_back(token);
+}
+
+TString TokenizeJsonNextPrefix(const TString& prefix, TStringBuf key) {
+    size_t size = key.size();
+    TString newPrefix = prefix;
+    // We don't need range queries on paths and keys may contain binary data,
+    // for example a zero byte, so we store keys with varint length
+    do {
+        if (size < 0x80) {
+            newPrefix.push_back((ui8)size);
+        } else {
+            newPrefix.push_back(0x80 | (ui8)(size & 0x7F));
+        }
+        size >>= 7;
+    } while (size > 0);
+    newPrefix += key;
+    return newPrefix;
+}
+
+void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString& prefix, TVector<TString>& tokens) {
+    switch (root.GetType()) {
+    case NBinaryJson::EContainerType::TopLevelScalar:
+        TokenizeBinaryJson(root.GetElement(0), prefix, tokens);
+        break;
+    case NBinaryJson::EContainerType::Array:
+        if (root.GetSize() == 0) {
+            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
+            return;
+        }
+
+        for (ui32 pos = 0; pos < root.GetSize(); pos++) {
+            TokenizeBinaryJson(root.GetElement(pos), prefix, tokens);
+        }
+        break;
+    case NBinaryJson::EContainerType::Object:
+        auto it = root.GetObjectIterator();
+        if (!it.HasNext()) {
+            tokens.push_back(prefix + (char)NBinaryJson::EEntryType::Container);
+            return;
+        }
+
+        while (it.HasNext()) {
+            auto kv = it.Next();
+            Y_ENSURE(kv.first.GetType() == NBinaryJson::EEntryType::String);
+            TString nextPrefix = TokenizeJsonNextPrefix(prefix, kv.first.GetString());
+            tokens.push_back(nextPrefix);
+            TokenizeBinaryJson(kv.second, nextPrefix, tokens);
+        }
+        break;
+    }
+}
+
+TVector<TString> TokenizeBinaryJson(const TStringBuf binaryJson) {
+    TVector<TString> tokens;
+    if (!binaryJson.size()) {
+        return tokens;
+    }
+    tokens.emplace_back();
+    auto reader = NKikimr::NBinaryJson::TBinaryJsonReader::Make(binaryJson);
+    TokenizeBinaryJson(reader->GetRootCursor(), "", tokens);
+    return tokens;
+}
+
+TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error) {
+    auto json = NKikimr::NBinaryJson::SerializeToBinaryJson(jsonStr);
+    if (std::holds_alternative<TString>(json)) {
+        error = std::get<TString>(json);
+        return TVector<TString>();
+    }
+    error = "";
+    auto buffer = std::get<NKikimr::NBinaryJson::TBinaryJson>(json);
+    return TokenizeBinaryJson(TStringBuf(buffer.data(), buffer.size()));
 }
 
 }  // namespace NJsonIndex

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -254,15 +254,11 @@ TResult TQueryCollector::LastArrayIndex(const TJsonPathItem& item) {
 }
 
 TResult TQueryCollector::UnaryMinus(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    return Finalize(item);
 }
 
 TResult TQueryCollector::UnaryPlus(const TJsonPathItem& item) {
-    // TODO: Implement
-    Y_UNUSED(item);
-    return TResult(TIssue("Not implemented"));
+    return Finalize(item);
 }
 
 TResult TQueryCollector::BinaryAdd(const TJsonPathItem& item) {

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -1,0 +1,396 @@
+#include "json_index.h"
+
+namespace NKikimr {
+
+namespace NJsonIndex {
+
+TResult::TResult(const TQuery& query)
+    : Result(query)
+{
+}
+
+TResult::TResult(TQuery&& query)
+    : Result(std::move(query))
+{
+}
+
+TResult::TResult(std::string&& query)
+    : Result(std::move(query))
+{
+}
+
+TResult::TResult(const std::string& query)
+    : Result(query)
+{
+}
+
+TResult::TResult(TResult::TError&& issue)
+    : Result(std::move(issue))
+{
+}
+
+const TResult::TQuery& TResult::GetQuery() const {
+    return std::get<TQuery>(Result);
+}
+
+TResult::TQuery& TResult::GetQuery() {
+    return std::get<TQuery>(Result);
+}
+
+const TResult::TError& TResult::GetError() const {
+    return std::get<TResult::TError>(Result);
+}
+
+bool TResult::IsError() const {
+    return std::holds_alternative<TResult::TError>(Result);
+}
+
+TQueryCollector::TQueryCollector(const TJsonPathPtr path)
+    : Reader(path)
+{
+}
+
+TResult TQueryCollector::Collect() {
+    return Collect(Reader.ReadFirst());
+}
+
+TResult TQueryCollector::Collect(const TJsonPathItem& item) {
+    switch (item.Type) {
+        case EJsonPathItemType::MemberAccess:
+            return MemberAccess(item);
+        case EJsonPathItemType::WildcardMemberAccess:
+            return WildcardMemberAccess(item);
+        case EJsonPathItemType::ContextObject:
+            return ContextObject();
+        case EJsonPathItemType::Variable:
+            return Variable(item);
+        case EJsonPathItemType::NumberLiteral:
+            return NumberLiteral(item);
+        case EJsonPathItemType::ArrayAccess:
+            return ArrayAccess(item);
+        case EJsonPathItemType::WildcardArrayAccess:
+            return WildcardArrayAccess(item);
+        case EJsonPathItemType::LastArrayIndex:
+            return LastArrayIndex(item);
+        case EJsonPathItemType::UnaryMinus:
+            return UnaryMinus(item);
+        case EJsonPathItemType::UnaryPlus:
+            return UnaryPlus(item);
+        case EJsonPathItemType::BinaryAdd:
+            return BinaryAdd(item);
+        case EJsonPathItemType::BinarySubstract:
+            return BinarySubstract(item);
+        case EJsonPathItemType::BinaryMultiply:
+            return BinaryMultiply(item);
+        case EJsonPathItemType::BinaryDivide:
+            return BinaryDivide(item);
+        case EJsonPathItemType::BinaryModulo:
+            return BinaryModulo(item);
+        case EJsonPathItemType::BinaryAnd:
+            return BinaryAnd(item);
+        case EJsonPathItemType::BinaryOr:
+            return BinaryOr(item);
+        case EJsonPathItemType::UnaryNot:
+            return UnaryNot(item);
+        case EJsonPathItemType::BooleanLiteral:
+            return BooleanLiteral(item);
+        case EJsonPathItemType::NullLiteral:
+            return NullLiteral();
+        case EJsonPathItemType::StringLiteral:
+            return StringLiteral(item);
+        case EJsonPathItemType::FilterObject:
+            return FilterObject(item);
+        case EJsonPathItemType::FilterPredicate:
+            return FilterPredicate(item);
+        case EJsonPathItemType::BinaryLess:
+            return BinaryLess(item);
+        case EJsonPathItemType::BinaryLessEqual:
+            return BinaryLessEqual(item);
+        case EJsonPathItemType::BinaryGreater:
+            return BinaryGreater(item);
+        case EJsonPathItemType::BinaryGreaterEqual:
+            return BinaryGreaterEqual(item);
+        case EJsonPathItemType::BinaryEqual:
+            return BinaryEqual(item);
+        case EJsonPathItemType::BinaryNotEqual:
+            return BinaryNotEqual(item);
+        case EJsonPathItemType::AbsMethod:
+            return AbsMethod(item);
+        case EJsonPathItemType::FloorMethod:
+            return FloorMethod(item);
+        case EJsonPathItemType::CeilingMethod:
+            return CeilingMethod(item);
+        case EJsonPathItemType::DoubleMethod:
+            return DoubleMethod(item);
+        case EJsonPathItemType::TypeMethod:
+            return TypeMethod(item);
+        case EJsonPathItemType::SizeMethod:
+            return SizeMethod(item);
+        case EJsonPathItemType::KeyValueMethod:
+            return KeyValueMethod(item);
+        case EJsonPathItemType::StartsWithPredicate:
+            return StartsWithPredicate(item);
+        case EJsonPathItemType::IsUnknownPredicate:
+            return IsUnknownPredicate(item);
+        case EJsonPathItemType::ExistsPredicate:
+            return ExistsPredicate(item);
+        case EJsonPathItemType::LikeRegexPredicate:
+            return LikeRegexPredicate(item);
+    }
+}
+
+TResult TQueryCollector::ContextObject() {
+    return TResult(std::string{});
+}
+
+TResult TQueryCollector::MemberAccess(const TJsonPathItem& item) {
+    auto input = Collect(Reader.ReadInput(item));
+    if (input.IsError()) {
+        return input;
+    }
+
+    auto& query = input.GetQuery();
+    if (!query.has_value()) {
+        return input;
+    }
+
+    auto member = std::string(item.GetString());
+    auto size = member.size();
+
+    do {
+        if (size < 0x80) {
+            query->push_back((ui8)size);
+        } else {
+            query->push_back(0x80 | (ui8)(size & 0x7F));
+        }
+        size >>= 7;
+    } while (size > 0);
+
+    *query += std::move(member);
+    return input;
+}
+
+TResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::ArrayAccess(const TJsonPathItem& item) {
+    return Collect(Reader.ReadInput(item));
+}
+
+TResult TQueryCollector::WildcardArrayAccess(const TJsonPathItem& item) {
+    return Collect(Reader.ReadInput(item));
+}
+
+TResult TQueryCollector::LastArrayIndex(const TJsonPathItem& item) {
+    return Collect(Reader.ReadInput(item));
+}
+
+TResult TQueryCollector::UnaryMinus(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::UnaryPlus(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryAdd(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinarySubstract(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryMultiply(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryDivide(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryModulo(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryAnd(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryOr(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::UnaryNot(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryLess(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryLessEqual(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryGreater(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryGreaterEqual(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryEqual(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BinaryNotEqual(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::NullLiteral() {
+    // TODO: Implement
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::BooleanLiteral(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::NumberLiteral(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::StringLiteral(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::FilterObject(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::FilterPredicate(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::AbsMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::FloorMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::CeilingMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::DoubleMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::TypeMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::SizeMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::KeyValueMethod(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::StartsWithPredicate(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::IsUnknownPredicate(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::ExistsPredicate(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::LikeRegexPredicate(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+TResult TQueryCollector::Variable(const TJsonPathItem& item) {
+    // TODO: Implement
+    Y_UNUSED(item);
+    return TResult(TIssue("Not implemented"));
+}
+
+}  // namespace NJsonIndex
+
+}  // namespace NKikimr

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -60,6 +60,8 @@ private:
 
     TResult Finalize(const TJsonPathItem& item);
 
+    TResult FinalizeEmpty(const TJsonPathItem& item);
+
     // The next methods are used to build the query step by step.
     TResult ContextObject();
 

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <yql/essentials/public/issue/yql_issue.h>
+#include <yql/essentials/minikql/jsonpath/parser/parser.h>
+
+#include <variant>
+
+namespace NKikimr {
+
+namespace NJsonIndex {
+
+using namespace NYql::NJsonPath;
+using namespace NYql;
+
+class TResult {
+public:
+    using TQuery = std::optional<std::string>;
+    using TError = TIssue;
+
+    TResult(const TQuery& query);
+
+    TResult(TQuery&& query);
+
+    TResult(const std::string& queryText);
+
+    TResult(std::string&& queryText);
+
+    TResult(TError&& issue);
+
+    const TQuery& GetQuery() const;
+
+    TQuery& GetQuery();
+
+    const TError& GetError() const;
+
+    bool IsError() const;
+
+private:
+    std::variant<TQuery, TError> Result;
+};
+
+class TQueryCollector {
+public:
+    TQueryCollector(const TJsonPathPtr path);
+
+    TResult Collect();
+
+private:
+    TResult Collect(const TJsonPathItem& item);
+
+    TResult ContextObject();
+
+    TResult MemberAccess(const TJsonPathItem& item);
+    TResult WildcardMemberAccess(const TJsonPathItem& item);
+
+    TResult ArrayAccess(const TJsonPathItem& item);
+    TResult WildcardArrayAccess(const TJsonPathItem& item);
+    TResult LastArrayIndex(const TJsonPathItem& item);
+
+    TResult NullLiteral();
+    TResult BooleanLiteral(const TJsonPathItem& item);
+    TResult NumberLiteral(const TJsonPathItem& item);
+    TResult StringLiteral(const TJsonPathItem& item);
+
+    TResult UnaryMinus(const TJsonPathItem& item);
+    TResult UnaryPlus(const TJsonPathItem& item);
+    TResult BinaryAdd(const TJsonPathItem& item);
+    TResult BinarySubstract(const TJsonPathItem& item);
+    TResult BinaryMultiply(const TJsonPathItem& item);
+    TResult BinaryDivide(const TJsonPathItem& item);
+    TResult BinaryModulo(const TJsonPathItem& item);
+
+    TResult UnaryNot(const TJsonPathItem& item);
+    TResult BinaryAnd(const TJsonPathItem& item);
+    TResult BinaryOr(const TJsonPathItem& item);
+    TResult BinaryLess(const TJsonPathItem& item);
+    TResult BinaryLessEqual(const TJsonPathItem& item);
+    TResult BinaryGreater(const TJsonPathItem& item);
+    TResult BinaryGreaterEqual(const TJsonPathItem& item);
+    TResult BinaryEqual(const TJsonPathItem& item);
+    TResult BinaryNotEqual(const TJsonPathItem& item);
+
+    TResult AbsMethod(const TJsonPathItem& item);
+    TResult FloorMethod(const TJsonPathItem& item);
+    TResult CeilingMethod(const TJsonPathItem& item);
+    TResult DoubleMethod(const TJsonPathItem& item);
+    TResult TypeMethod(const TJsonPathItem& item);
+    TResult SizeMethod(const TJsonPathItem& item);
+    TResult KeyValueMethod(const TJsonPathItem& item);
+
+    TResult StartsWithPredicate(const TJsonPathItem& item);
+    TResult IsUnknownPredicate(const TJsonPathItem& item);
+    TResult ExistsPredicate(const TJsonPathItem& item);
+    TResult LikeRegexPredicate(const TJsonPathItem& item);
+
+    TResult FilterObject(const TJsonPathItem& item);
+    TResult FilterPredicate(const TJsonPathItem& item);
+
+    TResult Variable(const TJsonPathItem& item);
+
+private:
+    TJsonPathReader Reader;
+};
+
+}  // namespace NJsonIndex
+
+}  // namespace NKikimr

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -35,8 +35,13 @@ public:
 
     bool IsError() const;
 
+    bool IsDone() const;
+
+    void MarkDone();
+
 private:
     std::variant<TQuery, TError> Result;
+    bool Done = false;
 };
 
 class TQueryCollector {
@@ -48,10 +53,17 @@ public:
 private:
     TResult Collect(const TJsonPathItem& item);
 
+    // Evaluates a literal node directly, without requiring a preceding ContextObject.
+    // Use this for sub-expressions that are unconditionally literal by design
+    // (e.g. the prefix argument of starts_with). Returns an error for non-literal nodes.
+    TResult EvaluateLiteral(const TJsonPathItem& item);
+
+    TResult Finalize(const TJsonPathItem& item);
+
+    // The next methods are used to build the query step by step.
     TResult ContextObject();
 
     TResult MemberAccess(const TJsonPathItem& item);
-    TResult WildcardMemberAccess(const TJsonPathItem& item);
 
     TResult ArrayAccess(const TJsonPathItem& item);
     TResult WildcardArrayAccess(const TJsonPathItem& item);
@@ -79,14 +91,6 @@ private:
     TResult BinaryGreaterEqual(const TJsonPathItem& item);
     TResult BinaryEqual(const TJsonPathItem& item);
     TResult BinaryNotEqual(const TJsonPathItem& item);
-
-    TResult AbsMethod(const TJsonPathItem& item);
-    TResult FloorMethod(const TJsonPathItem& item);
-    TResult CeilingMethod(const TJsonPathItem& item);
-    TResult DoubleMethod(const TJsonPathItem& item);
-    TResult TypeMethod(const TJsonPathItem& item);
-    TResult SizeMethod(const TJsonPathItem& item);
-    TResult KeyValueMethod(const TJsonPathItem& item);
 
     TResult StartsWithPredicate(const TJsonPathItem& item);
     TResult IsUnknownPredicate(const TJsonPathItem& item);

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -14,22 +14,22 @@ using namespace NYql;
 
 class TResult {
 public:
-    using TQuery = std::optional<std::string>;
+    using TQueries = TVector<TString>;
     using TError = TIssue;
 
-    TResult(const TQuery& query);
+    TResult(const TQueries& queries);
 
-    TResult(TQuery&& query);
+    TResult(TQueries&& queries);
 
-    TResult(const std::string& queryText);
+    TResult(const TString& query);
 
-    TResult(std::string&& queryText);
+    TResult(TString&& query);
 
     TResult(TError&& issue);
 
-    const TQuery& GetQuery() const;
+    const TQueries& GetQueries() const;
 
-    TQuery& GetQuery();
+    TQueries& GetQueries();
 
     const TError& GetError() const;
 
@@ -40,7 +40,7 @@ public:
     void MarkDone();
 
 private:
-    std::variant<TQuery, TError> Result;
+    std::variant<TQueries, TError> Result;
     bool Done = false;
 };
 
@@ -105,6 +105,11 @@ private:
 private:
     TJsonPathReader Reader;
 };
+
+TVector<TString> BuildSearchTerms(const TString& jsonPathStr);
+
+TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error);
+TVector<TString> TokenizeBinaryJson(const TStringBuf text);
 
 }  // namespace NJsonIndex
 

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -9,13 +9,10 @@ namespace NKikimr {
 
 namespace NJsonIndex {
 
-using namespace NYql::NJsonPath;
-using namespace NYql;
-
 class TResult {
 public:
     using TQueries = TVector<TString>;
-    using TError = TIssue;
+    using TError = NYql::TIssue;
 
     TResult(const TQueries& queries);
 
@@ -46,66 +43,66 @@ private:
 
 class TQueryCollector {
 public:
-    TQueryCollector(const TJsonPathPtr path);
+    TQueryCollector(const NYql::NJsonPath::TJsonPathPtr path);
 
     TResult Collect();
 
 private:
-    TResult Collect(const TJsonPathItem& item);
+    TResult Collect(const NYql::NJsonPath::TJsonPathItem& item);
 
     // Evaluates a literal node directly, without requiring a preceding ContextObject.
     // Use this for sub-expressions that are unconditionally literal by design
     // (e.g. the prefix argument of starts_with). Returns an error for non-literal nodes.
-    TResult EvaluateLiteral(const TJsonPathItem& item);
+    TResult EvaluateLiteral(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult Finalize(const TJsonPathItem& item);
+    TResult Finalize(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult FinalizeEmpty(const TJsonPathItem& item);
+    TResult FinalizeEmpty(const NYql::NJsonPath::TJsonPathItem& item);
 
     // The next methods are used to build the query step by step.
     TResult ContextObject();
 
-    TResult MemberAccess(const TJsonPathItem& item);
+    TResult MemberAccess(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult ArrayAccess(const TJsonPathItem& item);
-    TResult WildcardArrayAccess(const TJsonPathItem& item);
-    TResult LastArrayIndex(const TJsonPathItem& item);
+    TResult ArrayAccess(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult WildcardArrayAccess(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult LastArrayIndex(const NYql::NJsonPath::TJsonPathItem& item);
 
     TResult NullLiteral();
-    TResult BooleanLiteral(const TJsonPathItem& item);
-    TResult NumberLiteral(const TJsonPathItem& item);
-    TResult StringLiteral(const TJsonPathItem& item);
+    TResult BooleanLiteral(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult NumberLiteral(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult StringLiteral(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult UnaryMinus(const TJsonPathItem& item);
-    TResult UnaryPlus(const TJsonPathItem& item);
-    TResult BinaryAdd(const TJsonPathItem& item);
-    TResult BinarySubstract(const TJsonPathItem& item);
-    TResult BinaryMultiply(const TJsonPathItem& item);
-    TResult BinaryDivide(const TJsonPathItem& item);
-    TResult BinaryModulo(const TJsonPathItem& item);
+    TResult UnaryMinus(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult UnaryPlus(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryAdd(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinarySubstract(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryMultiply(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryDivide(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryModulo(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult UnaryNot(const TJsonPathItem& item);
-    TResult BinaryAnd(const TJsonPathItem& item);
-    TResult BinaryOr(const TJsonPathItem& item);
-    TResult BinaryLess(const TJsonPathItem& item);
-    TResult BinaryLessEqual(const TJsonPathItem& item);
-    TResult BinaryGreater(const TJsonPathItem& item);
-    TResult BinaryGreaterEqual(const TJsonPathItem& item);
-    TResult BinaryEqual(const TJsonPathItem& item);
-    TResult BinaryNotEqual(const TJsonPathItem& item);
+    TResult UnaryNot(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryAnd(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryOr(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryLess(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryLessEqual(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryGreater(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryGreaterEqual(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryEqual(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult BinaryNotEqual(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult StartsWithPredicate(const TJsonPathItem& item);
-    TResult IsUnknownPredicate(const TJsonPathItem& item);
-    TResult ExistsPredicate(const TJsonPathItem& item);
-    TResult LikeRegexPredicate(const TJsonPathItem& item);
+    TResult StartsWithPredicate(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult IsUnknownPredicate(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult ExistsPredicate(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult LikeRegexPredicate(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult FilterObject(const TJsonPathItem& item);
-    TResult FilterPredicate(const TJsonPathItem& item);
+    TResult FilterObject(const NYql::NJsonPath::TJsonPathItem& item);
+    TResult FilterPredicate(const NYql::NJsonPath::TJsonPathItem& item);
 
-    TResult Variable(const TJsonPathItem& item);
+    TResult Variable(const NYql::NJsonPath::TJsonPathItem& item);
 
 private:
-    TJsonPathReader Reader;
+    NYql::NJsonPath::TJsonPathReader Reader;
 };
 
 TVector<TString> BuildSearchTerms(const TString& jsonPathStr);

--- a/ydb/core/base/ut/fulltext_ut.cpp
+++ b/ydb/core/base/ut/fulltext_ut.cpp
@@ -7,65 +7,6 @@ namespace NKikimr::NFulltext {
 
 Y_UNIT_TEST_SUITE(NFulltext) {
 
-    Y_UNIT_TEST(TokenizeJson) {
-        TString error;
-
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"invalid json", error), TVector<TString>{});
-        UNIT_ASSERT(!error.empty());
-
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), TVector<TString>{TString("\0\3literal string", 16)});
-        UNIT_ASSERT_VALUES_EQUAL(error, "");
-
-        TString obj = "{\"id\":42042,\"brand\":\"bricks\",\"part_count\":1401,\"price\":null,\"parts\":"
-            "[{\"id\":32526,\"count\":7,\"name\":\"3x5\"},{\"id\":32523,\"count\":17,\"name\":\"1x3\"}]}";
-        auto tokens = TokenizeJson(obj, error);
-        std::sort(tokens.begin(), tokens.end());
-        UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
-            TString("\2id", 3),
-            TString("\2id\0\4\0\0\0\0@\x87\xE4@", 13),
-            TString("\5brand", 6),
-            TString("\5brand\0\3bricks", 14),
-            TString("\5parts", 6),
-            TString("\5parts\2id", 9),
-            TString("\5parts\2id", 9),
-            TString("\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@", 19),
-            TString("\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@", 19),
-            TString("\5parts\4name", 11),
-            TString("\5parts\4name", 11),
-            TString("\5parts\4name\0\0031x3", 16),
-            TString("\5parts\4name\0\0033x5", 16),
-            TString("\5parts\5count", 12),
-            TString("\5parts\5count", 12),
-            TString("\5parts\5count\0\4\0\0\0\0\0\0\x1C@", 22),
-            TString("\5parts\5count\0\4\0\0\0\0\0\0001@", 22),
-            TString("\5price", 6),
-            TString("\5price\0\2", 8),
-            TString("\npart_count", 11),
-            TString("\npart_count\0\4\0\0\0\0\0\xE4\x95@", 21)
-        }));
-        UNIT_ASSERT_VALUES_EQUAL(error, "");
-
-        TString emptyKeyObj = "{\"\":{\"a\":\"b\"}}";
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(emptyKeyObj, error), (TVector<TString>{
-            TString("\0", 1),
-            TString("\0\1a", 3),
-            TString("\0\1a\0\3b", 6)
-        }));
-        UNIT_ASSERT_VALUES_EQUAL(error, "");
-
-        TString longKey;
-        longKey.resize(1000);
-        for (size_t i = 0; i < longKey.size(); i++)
-            longKey[i] = 'a';
-        TString longKeyObj = "{\"" + longKey + "\":{\"short\":\"b\"}}";
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(longKeyObj, error), (TVector<TString>{
-            TString("\xE8\7") + longKey,
-            TString("\xE8\7") + longKey + TString("\5short", 6),
-            TString("\xE8\7") + longKey + TString("\5short\0\3b", 9)
-        }));
-        UNIT_ASSERT_VALUES_EQUAL(error, "");
-    }
-
     Y_UNIT_TEST(ValidateColumnsMatches) {
         TString error;
         

--- a/ydb/core/base/ut/fulltext_ut.cpp
+++ b/ydb/core/base/ut/fulltext_ut.cpp
@@ -21,33 +21,48 @@ Y_UNIT_TEST_SUITE(NFulltext) {
         auto tokens = TokenizeJson(obj, error);
         std::sort(tokens.begin(), tokens.end());
         UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
+            TString("\2id", 3),
             TString("\2id\0\4\0\0\0\0@\x87\xE4@", 13),
+            TString("\5brand", 6),
             TString("\5brand\0\3bricks", 14),
+            TString("\5parts", 6),
+            TString("\5parts\2id", 9),
+            TString("\5parts\2id", 9),
             TString("\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@", 19),
             TString("\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@", 19),
+            TString("\5parts\4name", 11),
+            TString("\5parts\4name", 11),
             TString("\5parts\4name\0\0031x3", 16),
             TString("\5parts\4name\0\0033x5", 16),
+            TString("\5parts\5count", 12),
+            TString("\5parts\5count", 12),
             TString("\5parts\5count\0\4\0\0\0\0\0\0\x1C@", 22),
             TString("\5parts\5count\0\4\0\0\0\0\0\0001@", 22),
+            TString("\5price", 6),
             TString("\5price\0\2", 8),
+            TString("\npart_count", 11),
             TString("\npart_count\0\4\0\0\0\0\0\xE4\x95@", 21)
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         TString emptyKeyObj = "{\"\":{\"a\":\"b\"}}";
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(emptyKeyObj, error), (TVector<TString>{
+            TString("\0", 1),
+            TString("\0\1a", 3),
             TString("\0\1a\0\3b", 6)
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         TString longKey;
-        longKey.resize(100000);
+        longKey.resize(1000);
         for (size_t i = 0; i < longKey.size(); i++)
             longKey[i] = 'a';
-        TString longKeyObj = "{\""+longKey+"\":{\"short\":\"b\"}}";
-        UNIT_ASSERT(TokenizeJson(longKeyObj, error) == TVector<TString>{
-            "\xA0\x8D\6"+longKey+TString("\5short\0\3b", 9)
-        });
+        TString longKeyObj = "{\"" + longKey + "\":{\"short\":\"b\"}}";
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(longKeyObj, error), (TVector<TString>{
+            TString("\xE8\7") + longKey,
+            TString("\xE8\7") + longKey + TString("\5short", 6),
+            TString("\xE8\7") + longKey + TString("\5short\0\3b", 9)
+        }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
     }
 

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -79,6 +79,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateQueries("$.key[0].*", {"\3key"});
     }
 
+    // Methods stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_Methods) {
         ValidateQueries("$.abs()", {""});
         ValidateQueries("$.*.floor()", {""});

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -121,7 +121,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"invalid json", error), TVector<TString>{});
         UNIT_ASSERT(!error.empty());
 
-        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), TVector<TString>{TString("\0\3literal string", 16)});
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), (TVector<TString>{TString(), TString("\0\3literal string", 16)}));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         TString obj = "{\"id\":42042,\"brand\":\"bricks\",\"part_count\":1401,\"price\":null,\"parts\":"
@@ -129,6 +129,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         auto tokens = TokenizeJson(obj, error);
         std::sort(tokens.begin(), tokens.end());
         UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
+            TString(),
             TString("\2id", 3),
             TString("\2id\0\4\0\0\0\0@\x87\xE4@", 13),
             TString("\5brand", 6),
@@ -155,6 +156,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         TString emptyKeyObj = "{\"\":{\"a\":\"b\"}}";
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(emptyKeyObj, error), (TVector<TString>{
+            TString(),
             TString("\0", 1),
             TString("\0\1a", 3),
             TString("\0\1a\0\3b", 6)
@@ -167,6 +169,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
             longKey[i] = 'a';
         TString longKeyObj = "{\"" + longKey + "\":{\"short\":\"b\"}}";
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(longKeyObj, error), (TVector<TString>{
+            TString(),
             TString("\xE8\7") + longKey,
             TString("\xE8\7") + longKey + TString("\5short", 6),
             TString("\xE8\7") + longKey + TString("\5short\0\3b", 9)

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -20,116 +20,170 @@ TQueries ParseAndCollect(const TString& jsonPath) {
     return result.GetQueries();
 }
 
-void ExpectError(const TString& jsonPath, const TString& errorMessage) {
+template <bool ParserError = false>
+void ValidateError(const TString& jsonPath, const TString& errorMessage) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
-    UNIT_ASSERT_C(issues.Empty(), "Parse errors found for path: " + jsonPath + ": " + issues.ToOneLineString());
 
-    TQueryCollector collector(path);
-    auto result = collector.Collect();
-    UNIT_ASSERT_C(result.IsError(), "Expected error for path: " + jsonPath + ": " + errorMessage);
+    if constexpr (ParserError) {
+        UNIT_ASSERT_STRING_CONTAINS_C(issues.ToOneLineString(), errorMessage, "Expected error message not found: " + errorMessage);
+    } else {
+        UNIT_ASSERT_C(issues.Empty(), "Parse errors found for path: " + jsonPath + ": " + issues.ToOneLineString());
 
-    UNIT_ASSERT_STRING_CONTAINS_C(result.GetError().GetMessage(), errorMessage, "Expected error message not found: " + errorMessage);
+        TQueryCollector collector(path);
+        auto result = collector.Collect();
+        UNIT_ASSERT_C(result.IsError(), "Expected error for path: " + jsonPath + ": " + errorMessage);
+
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetError().GetMessage(), errorMessage, "Expected error message not found: " + errorMessage);
+    }
+}
+
+void ValidateQueries(const TString& jsonPath, const TQueries& expectedQueries) {
+    UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect(jsonPath), expectedQueries);
 }
 
 }  // namespace
 
 Y_UNIT_TEST_SUITE(NJsonIndex) {
-    Y_UNIT_TEST(CorrectJsonPath) {
-        using T = TQueries;
 
-        // Context object
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), T{""});
+    // Every path must have a ContextObject ($)
+    Y_UNIT_TEST(CollectPath_EmptyPath) {
+        ValidateError<true>("", "Too many errors");
+    }
 
-        // Member access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), T{"\1a"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), T{"\1a\1b\1c"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), T{"\3aba\4caba"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), T{TString("\0\3abc", 5)});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), T{"\1a"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), T{"\1a"});
+    Y_UNIT_TEST(CollectPath_ContextObject) {
+        ValidateQueries("$", {""});
+    }
 
-        // Array access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), T{"\4key1\4key2"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), T{"\3arr"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), T{"\3key"});
+    Y_UNIT_TEST(CollectPath_MemberAccess) {
+        ValidateQueries("$.a", {"\1a"});
+        ValidateQueries("$.a.b.c", {"\1a\1b\1c"});
+        ValidateQueries("$.aba.\"caba\"", {"\3aba\4caba"});
+        ValidateQueries("$.\"\".abc", {TString("\0\3abc", 5)});
+        ValidateQueries("$.*", {""});
+        ValidateQueries("$.a.*", {"\1a"});
+        ValidateQueries("$.a.*.c", {"\1a"});
+    }
 
-        // Methods
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), T{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), T{"\3key\5value"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), T{"\3key"});
+    Y_UNIT_TEST(CollectPath_ArrayAccess) {
+        ValidateQueries("$[0]", {""});
+        ValidateQueries("$[1, 2, 3]", {""});
+        ValidateQueries("$[1 to 3]", {""});
+        ValidateQueries("$[last]", {""});
+        ValidateQueries("$[0, 2 to last]", {""});
+        ValidateQueries("$[0 to 1].key", {"\3key"});
+        ValidateQueries("$.key[0]", {"\3key"});
+        ValidateQueries("$.key1[last].key2", {"\4key1\4key2"});
+        ValidateQueries("$.arr[2 to last]", {"\3arr"});
+        ValidateQueries("$.*[2 to last].key", {""});
+        ValidateQueries("$.key[0].*", {"\3key"});
+    }
 
-        // Starts with predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""), T{""});
+    Y_UNIT_TEST(CollectPath_Methods) {
+        ValidateQueries("$.abs()", {""});
+        ValidateQueries("$.*.floor()", {""});
+        ValidateQueries("$[1, 2, 3].ceiling()", {""});
+        ValidateQueries("$.key.abs()", {"\3key"});
+        ValidateQueries("$.key.floor()", {"\3key"});
+        ValidateQueries("$.key.ceiling()", {"\3key"});
+        ValidateQueries("$.key.double()", {"\3key"});
+        ValidateQueries("$.key.type()", {"\3key"});
+        ValidateQueries("$.key.size()", {"\3key"});
+        ValidateQueries("$.key.keyvalue()", {"\3key"});
+        ValidateQueries("$.*.keyvalue()", {""});
+        ValidateQueries("$.key[1, 2, 3].value.size().floor()", {"\3key\5value"});
+        ValidateQueries("$.key.keyvalue().name", {"\3key"});
+    }
 
-        // Like regex predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"a.c\""), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \".*\""), T{""});
+    // Predicates return an empty query because they always return a boolean/null value
+    // For JSON_EXISTS, the result is always true even if the path does not exist
+    Y_UNIT_TEST(CollectPath_StartsWithPredicate) {
+        ValidateQueries("$ starts with \"lol\"", {""});
+        ValidateQueries("$[1 to last] starts with \"lol\"", {""});
+        ValidateQueries("$[*] starts with \"lol\"", {""});
+        ValidateQueries("$.key starts with \"abc\"", {""});
+        ValidateQueries("$.a.b.c[1, 2, 3] starts with \"abc\"", {""});
+        ValidateQueries("$.key.type().name starts with \"abc\"", {""});
+        ValidateQueries("$.* starts with \"abc\"", {""});
+        ValidateQueries("$.a.*.c[1, 2, 3] starts with \"abc\"", {""});
+    }
 
-        // Exists predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($)"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key)"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key[1, 2, 3])"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($[*].size())"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key.keyvalue().name)"), T{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key.keyvalue().name starts with \"abc\")"), T{""});
+    // Predicates return an empty query because they always return a boolean/null value
+    // For JSON_EXISTS, the result is always true even if the path does not exist
+    Y_UNIT_TEST(CollectPath_LikeRegexPredicate) {
+        ValidateQueries("$ like_regex \"abc\"", {""});
+        ValidateQueries("$[1 to 2] like_regex \"abc\"", {""});
+        ValidateQueries("$[*] like_regex \"abc\"", {""});
+        ValidateQueries("$.key like_regex \"abc\"", {""});
+        ValidateQueries("$.* like_regex \"abc\"", {""});
+        ValidateQueries("$.key[1, 2, 3] like_regex \"abc\"", {""});
+        ValidateQueries("$.key.keyvalue() like_regex \"abc\"", {""});
+        ValidateQueries("$.key like_regex \"a.c\"", {""});
+        ValidateQueries("$.key like_regex \".*\"", {""});
+    }
 
-        // Is unknown predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("($ starts with \"abc\") is unknown"), T{""});
+    // Predicates return an empty query because they always return a boolean/null value
+    // For JSON_EXISTS, the result is always true even if the path does not exist
+    Y_UNIT_TEST(CollectPath_ExistsPredicate) {
+        ValidateQueries("exists($)", {""});
+        ValidateQueries("exists($.key)", {""});
+        ValidateQueries("exists($.key[1, 2, 3])", {""});
+        ValidateQueries("exists($[*].size())", {""});
+        ValidateQueries("exists($.key.keyvalue().name)", {""});
+        ValidateQueries("exists($.key.keyvalue().name starts with \"abc\")", {""});
+    }
+
+    // Predicates return an empty query because they always return a boolean/null value
+    // For JSON_EXISTS, the result is always true even if the path does not exist
+    Y_UNIT_TEST(CollectPath_IsUnknownPredicate) {
+        ValidateQueries("($ starts with \"abc\") is unknown", {""});
+    }
+
+    // Unary +/- stop further path extraction (same as methods): operand path only
+    Y_UNIT_TEST(CollectPath_UnaryPlusMinus) {
+        ValidateQueries("-$.key", {"\3key"});
+        ValidateQueries("+$.key", {"\3key"});
+
+        ValidateQueries("-$", {""});
+        ValidateQueries("+$", {""});
+
+        ValidateQueries("-$.a.b.c", {"\1a\1b\1c"});
+        ValidateQueries("+$.a.b.c", {"\1a\1b\1c"});
+
+        ValidateQueries("-$.*", {""});
+        ValidateQueries("+$.*", {""});
+        ValidateQueries("-$.a.*", {"\1a"});
+        ValidateQueries("+$.a.*", {"\1a"});
+
+        ValidateQueries("-$.key[0]", {"\3key"});
+        ValidateQueries("+$.key[last]", {"\3key"});
+
+        ValidateQueries("-$.key.abs()", {"\3key"});
+        ValidateQueries("+$.key.type()", {"\3key"});
+
+        ValidateQueries("-(-$.key)", {"\3key"});
+        ValidateQueries("-(+$.key)", {"\3key"});
+        ValidateQueries("+(-$.key)", {"\3key"});
+        ValidateQueries("+(+$.key)", {"\3key"});
     }
 
     // Literals are not supported without a preceding ContextObject
-    Y_UNIT_TEST(Literals) {
-        using T = TQueries;
-
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), T{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), T{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), T{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), T{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), T{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), T{});
+    Y_UNIT_TEST(CollectPath_Literals) {
+        ValidateQueries("1", {});
+        ValidateQueries("1.2345", {});
+        ValidateQueries("true", {});
+        ValidateQueries("false", {});
+        ValidateQueries("null", {});
+        ValidateQueries("\"string\"", {});
     }
 
     // Variables are not supported now
-    Y_UNIT_TEST(Variables) {
+    Y_UNIT_TEST(CollectPath_Variables) {
         const TString errorMessage = "Variables are not supported at the moment";
 
-        ExpectError("$var", errorMessage);
-        ExpectError("$var.key", errorMessage);
-        ExpectError("$var[1, 2, 3]", errorMessage);
+        ValidateError("$var", errorMessage);
+        ValidateError("$var.key", errorMessage);
+        ValidateError("$var[1, 2, 3]", errorMessage);
     }
 
     Y_UNIT_TEST(TokenizeJson) {

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -1,0 +1,38 @@
+#include "json_index.h"
+
+#include <yql/essentials/minikql/jsonpath/parser/parser.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NJsonIndex {
+
+namespace {
+
+std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
+    NYql::TIssues issues;
+    const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
+    UNIT_ASSERT_C(issues.Empty(), "Parse errors found");
+
+    TQueryCollector collector(path);
+    auto result = collector.Collect();
+    UNIT_ASSERT_C(!result.IsError(), "Collect errors found: " + result.GetError().GetMessage());
+    return result.GetQuery();
+}
+
+}  // namespace
+
+Y_UNIT_TEST_SUITE(NJsonIndex) {
+    Y_UNIT_TEST(CorrectJsonPath) {
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), "\1a");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), "\1a\1b\1c");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), "\3aba\4caba");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), std::string("\0\3abc", 5));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.k1[last].k2"), "\2k1\2k2");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), "\3arr");
+    }
+}
+
+}  // namespace NKikimr::NJsonIndex

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -18,6 +18,18 @@ std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
     return result.GetQuery();
 }
 
+void ExpectError(const TString& jsonPath, const std::string& errorMessage) {
+    NYql::TIssues issues;
+    const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
+    UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
+
+    TQueryCollector collector(path);
+    auto result = collector.Collect();
+    UNIT_ASSERT_C(result.IsError(), "Expected error: " + errorMessage);
+
+    UNIT_ASSERT_STRING_CONTAINS_C(result.GetError().GetMessage(), errorMessage, "Expected error message not found: " + errorMessage);
+}
+
 }  // namespace
 
 Y_UNIT_TEST_SUITE(NJsonIndex) {
@@ -90,6 +102,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), std::nullopt);
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), std::nullopt);
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), std::nullopt);
+    }
+
+    // Variables are not supported now
+    Y_UNIT_TEST(Variables) {
+        const std::string errorMessage = "Variables are not supported at the moment";
+
+        ExpectError("$var", errorMessage);
+        ExpectError("$var.key", errorMessage);
+        ExpectError("$var[1, 2, 3]", errorMessage);
     }
 }
 

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -6,6 +6,7 @@
 namespace NKikimr::NJsonIndex {
 
 using TQueries = TVector<TString>;
+using namespace NYql::NJsonPath;
 
 namespace {
 

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -5,9 +5,11 @@
 
 namespace NKikimr::NJsonIndex {
 
+using TQueries = TVector<TString>;
+
 namespace {
 
-std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
+TQueries ParseAndCollect(const TString& jsonPath) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
     UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
@@ -15,10 +17,10 @@ std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
     TQueryCollector collector(path);
     auto result = collector.Collect();
     UNIT_ASSERT_C(!result.IsError(), "Collect errors found: " + result.GetError().GetMessage());
-    return result.GetQuery();
+    return result.GetQueries();
 }
 
-void ExpectError(const TString& jsonPath, const std::string& errorMessage) {
+void ExpectError(const TString& jsonPath, const TString& errorMessage) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
     UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
@@ -35,82 +37,141 @@ void ExpectError(const TString& jsonPath, const std::string& errorMessage) {
 Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(CorrectJsonPath) {
         // Context object
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), TQueries{""});
 
         // Member access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), "\1a");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), "\1a\1b\1c");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), "\3aba\4caba");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), std::string("\0\3abc", 5));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), "\1a");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), "\1a");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), TQueries{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), TQueries{"\1a\1b\1c"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), TQueries{"\3aba\4caba"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), TQueries{TString("\0\3abc", 5)});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), TQueries{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), TQueries{"\1a"});
 
         // Array access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), "\4key1\4key2");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), "\3arr");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), TQueries{"\4key1\4key2"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), TQueries{"\3arr"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), TQueries{"\3key"});
 
         // Methods
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), "\3key\5value");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), TQueries{"\3key\5value"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), TQueries{"\3key"});
 
         // Starts with predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), std::string("\0\3lol", 5));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), std::string("\0\3lol", 5));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), std::string("\0\3lol", 5));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), std::string("\3key\0\3abc", 9));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), std::string("\1a\1b\1c\0\3abc", 11));
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""),"\1a");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), TQueries{"\1a\1b\1c"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""), TQueries{"\1a"});
 
         // Like regex predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), "");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), TQueries{"\3key"});
     }
 
     // Literals are not supported without a preceding ContextObject
     Y_UNIT_TEST(Literals) {
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), std::nullopt);
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), std::nullopt);
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), std::nullopt);
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), std::nullopt);
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), std::nullopt);
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), TQueries{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), TQueries{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), TQueries{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), TQueries{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), TQueries{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), TQueries{});
     }
 
     // Variables are not supported now
     Y_UNIT_TEST(Variables) {
-        const std::string errorMessage = "Variables are not supported at the moment";
+        const TString errorMessage = "Variables are not supported at the moment";
 
         ExpectError("$var", errorMessage);
         ExpectError("$var.key", errorMessage);
         ExpectError("$var[1, 2, 3]", errorMessage);
+    }
+
+    Y_UNIT_TEST(TokenizeJson) {
+        TString error;
+
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"invalid json", error), TVector<TString>{});
+        UNIT_ASSERT(!error.empty());
+
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson("\"literal string\"", error), TVector<TString>{TString("\0\3literal string", 16)});
+        UNIT_ASSERT_VALUES_EQUAL(error, "");
+
+        TString obj = "{\"id\":42042,\"brand\":\"bricks\",\"part_count\":1401,\"price\":null,\"parts\":"
+            "[{\"id\":32526,\"count\":7,\"name\":\"3x5\"},{\"id\":32523,\"count\":17,\"name\":\"1x3\"}]}";
+        auto tokens = TokenizeJson(obj, error);
+        std::sort(tokens.begin(), tokens.end());
+        UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
+            TString("\2id", 3),
+            TString("\2id\0\4\0\0\0\0@\x87\xE4@", 13),
+            TString("\5brand", 6),
+            TString("\5brand\0\3bricks", 14),
+            TString("\5parts", 6),
+            TString("\5parts\2id", 9),
+            TString("\5parts\2id", 9),
+            TString("\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@", 19),
+            TString("\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@", 19),
+            TString("\5parts\4name", 11),
+            TString("\5parts\4name", 11),
+            TString("\5parts\4name\0\0031x3", 16),
+            TString("\5parts\4name\0\0033x5", 16),
+            TString("\5parts\5count", 12),
+            TString("\5parts\5count", 12),
+            TString("\5parts\5count\0\4\0\0\0\0\0\0\x1C@", 22),
+            TString("\5parts\5count\0\4\0\0\0\0\0\0001@", 22),
+            TString("\5price", 6),
+            TString("\5price\0\2", 8),
+            TString("\npart_count", 11),
+            TString("\npart_count\0\4\0\0\0\0\0\xE4\x95@", 21)
+        }));
+        UNIT_ASSERT_VALUES_EQUAL(error, "");
+
+        TString emptyKeyObj = "{\"\":{\"a\":\"b\"}}";
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(emptyKeyObj, error), (TVector<TString>{
+            TString("\0", 1),
+            TString("\0\1a", 3),
+            TString("\0\1a\0\3b", 6)
+        }));
+        UNIT_ASSERT_VALUES_EQUAL(error, "");
+
+        TString longKey;
+        longKey.resize(1000);
+        for (size_t i = 0; i < longKey.size(); i++)
+            longKey[i] = 'a';
+        TString longKeyObj = "{\"" + longKey + "\":{\"short\":\"b\"}}";
+        UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(longKeyObj, error), (TVector<TString>{
+            TString("\xE8\7") + longKey,
+            TString("\xE8\7") + longKey + TString("\5short", 6),
+            TString("\xE8\7") + longKey + TString("\5short\0\3b", 9)
+        }));
+        UNIT_ASSERT_VALUES_EQUAL(error, "");
     }
 }
 

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -12,22 +12,22 @@ namespace {
 TQueries ParseAndCollect(const TString& jsonPath) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
-    UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
+    UNIT_ASSERT_C(issues.Empty(), "Parse errors found for path: " + jsonPath + ": " + issues.ToOneLineString());
 
     TQueryCollector collector(path);
     auto result = collector.Collect();
-    UNIT_ASSERT_C(!result.IsError(), "Collect errors found: " + result.GetError().GetMessage());
+    UNIT_ASSERT_C(!result.IsError(), "Collect errors found for path: " + jsonPath + ": " + result.GetError().GetMessage());
     return result.GetQueries();
 }
 
 void ExpectError(const TString& jsonPath, const TString& errorMessage) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
-    UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
+    UNIT_ASSERT_C(issues.Empty(), "Parse errors found for path: " + jsonPath + ": " + issues.ToOneLineString());
 
     TQueryCollector collector(path);
     auto result = collector.Collect();
-    UNIT_ASSERT_C(result.IsError(), "Expected error: " + errorMessage);
+    UNIT_ASSERT_C(result.IsError(), "Expected error for path: " + jsonPath + ": " + errorMessage);
 
     UNIT_ASSERT_STRING_CONTAINS_C(result.GetError().GetMessage(), errorMessage, "Expected error message not found: " + errorMessage);
 }
@@ -36,74 +36,91 @@ void ExpectError(const TString& jsonPath, const TString& errorMessage) {
 
 Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(CorrectJsonPath) {
+        using T = TQueries;
+
         // Context object
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), TQueries{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), T{""});
 
         // Member access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), TQueries{"\1a"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), TQueries{"\1a\1b\1c"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), TQueries{"\3aba\4caba"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), TQueries{TString("\0\3abc", 5)});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), TQueries{"\1a"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), TQueries{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), T{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), T{"\1a\1b\1c"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), T{"\3aba\4caba"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), T{TString("\0\3abc", 5)});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), T{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), T{"\1a"});
 
         // Array access
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), TQueries{"\4key1\4key2"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), TQueries{"\3arr"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), T{"\4key1\4key2"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), T{"\3arr"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), T{"\3key"});
 
         // Methods
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), TQueries{"\3key\5value"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), T{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), T{"\3key\5value"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), T{"\3key"});
 
         // Starts with predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), TQueries{"\1a\1b\1c"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""), TQueries{"\1a"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""), T{""});
 
         // Like regex predicate
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), TQueries{""});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), TQueries{"\3key"});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), TQueries{"\3key"});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"a.c\""), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \".*\""), T{""});
+
+        // Exists predicate
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($)"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key)"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key[1, 2, 3])"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($[*].size())"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key.keyvalue().name)"), T{""});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("exists($.key.keyvalue().name starts with \"abc\")"), T{""});
+
+        // Is unknown predicate
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("($ starts with \"abc\") is unknown"), T{""});
     }
 
     // Literals are not supported without a preceding ContextObject
     Y_UNIT_TEST(Literals) {
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), TQueries{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), TQueries{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), TQueries{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), TQueries{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), TQueries{});
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), TQueries{});
+        using T = TQueries;
+
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), T{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), T{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), T{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), T{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), T{});
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), T{});
     }
 
     // Variables are not supported now

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -10,7 +10,7 @@ namespace {
 std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
     NYql::TIssues issues;
     const TJsonPathPtr path = NYql::NJsonPath::ParseJsonPath(jsonPath, issues, 1);
-    UNIT_ASSERT_C(issues.Empty(), "Parse errors found");
+    UNIT_ASSERT_C(issues.Empty(), "Parse errors found: " + issues.ToOneLineString());
 
     TQueryCollector collector(path);
     auto result = collector.Collect();
@@ -22,16 +22,74 @@ std::optional<std::string> ParseAndCollect(const TString& jsonPath) {
 
 Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(CorrectJsonPath) {
+        // Context object
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$"), "");
+
+        // Member access
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a"), "\1a");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c"), "\1a\1b\1c");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.aba.\"caba\""), "\3aba\4caba");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.\"\".abc"), std::string("\0\3abc", 5));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*"), "\1a");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c"), "\1a");
+
+        // Array access
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0]"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3]"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 3]"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[last]"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0, 2 to last]"), "");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[0 to 1].key"), "\3key");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0]"), "\3key");
-        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.k1[last].k2"), "\2k1\2k2");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key1[last].key2"), "\4key1\4key2");
         UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.arr[2 to last]"), "\3arr");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*[2 to last].key"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[0].*"), "\3key");
+
+        // Methods
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.abs()"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.floor()"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1, 2, 3].ceiling()"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.abs()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.floor()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.ceiling()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.double()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.size()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue()"), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.*.keyvalue()"), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3].value.size().floor()"), "\3key\5value");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue().name"), "\3key");
+
+        // Starts with predicate
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ starts with \"lol\""), std::string("\0\3lol", 5));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to last] starts with \"lol\""), std::string("\0\3lol", 5));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] starts with \"lol\""), std::string("\0\3lol", 5));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key starts with \"abc\""), std::string("\3key\0\3abc", 9));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.b.c[1, 2, 3] starts with \"abc\""), std::string("\1a\1b\1c\0\3abc", 11));
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.type().name starts with \"abc\""), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* starts with \"abc\""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.a.*.c[1, 2, 3] starts with \"abc\""),"\1a");
+
+        // Like regex predicate
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$ like_regex \"abc\""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[1 to 2] like_regex \"abc\""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$[*] like_regex \"abc\""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key like_regex \"abc\""), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.* like_regex \"abc\""), "");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key[1, 2, 3] like_regex \"abc\""), "\3key");
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("$.key.keyvalue() like_regex \"abc\""), "\3key");
+    }
+
+    // Literals are not supported without a preceding ContextObject
+    Y_UNIT_TEST(Literals) {
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1"), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("1.2345"), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("true"), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("false"), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("null"), std::nullopt);
+        UNIT_ASSERT_VALUES_EQUAL(ParseAndCollect("\"string\""), std::nullopt);
     }
 }
 

--- a/ydb/core/base/ut/ya.make
+++ b/ydb/core/base/ut/ya.make
@@ -24,6 +24,7 @@ SRCS(
     statestorage_guardian_impl_ut.cpp
     statestorage_ut.cpp
     table_index_ut.cpp
+    json_index_ut.cpp
 )
 
 END()

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -88,6 +88,8 @@ SRCS(
     tx_processing.cpp
     user_registry.h
     wilson_tracing_control.cpp
+    json_index.cpp
+    json_index.h
 )
 
 PEERDIR(

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -1,6 +1,7 @@
 #include "kqp_query_plan.h"
 
 #include <ydb/core/base/fulltext.h>
+#include <ydb/core/base/json_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 #include <ydb/library/formats/arrow/protos/ssa.pb.h>
@@ -773,14 +774,21 @@ private:
                 auto [implTable, indexDesc] = tableData.Metadata->GetIndex(index);
                 YQL_ENSURE(indexDesc);
                 YQL_ENSURE(indexDesc->Type == TIndexDescription::EType::GlobalFulltextPlain
-                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance);
+                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance
+                    || indexDesc->Type == TIndexDescription::EType::GlobalJson);
 
-                auto& desc = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexDesc->SpecializedIndexDescription);
-                for(const auto& column: readColumns) {
-                    for(const auto& analyzer: desc.settings().columns()) {
-                        if (analyzer.column() == column) {
-                            for(const auto& term: NFulltext::BuildSearchTerms(literal, analyzer.analyzers())) {
-                                searchTerms.push_back(term);
+                if (indexDesc->Type == TIndexDescription::EType::GlobalJson) {
+                    for (auto term: NJsonIndex::BuildSearchTerms(literal)) {
+                        searchTerms.emplace_back(std::move(term));
+                    }
+                } else {
+                    auto& desc = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexDesc->SpecializedIndexDescription);
+                    for(const auto& column: readColumns) {
+                        for(const auto& analyzer: desc.settings().columns()) {
+                            if (analyzer.column() == column) {
+                                for(const auto& term: NFulltext::BuildSearchTerms(literal, analyzer.analyzers())) {
+                                    searchTerms.push_back(term);
+                                }
                             }
                         }
                     }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -53,8 +53,6 @@ public:
         AddHandler(0, &TKqlUpsertRowsBase::Match, HNDL(ExcessUpsertInputColumns));
         AddHandler(0, &TCoTake::Match, HNDL(DropTakeOverLookupTable));
         AddHandler(0, &TCoTopBase::Match, HNDL(PushLimitOverFullText));
-        AddHandler(0, &TCoTop::Match, HNDL(RewriteFlatMapOverFullTextMatch));
-        AddHandler(0, &TCoTopSort::Match, HNDL(RewriteFlatMapOverFullTextMatch));
 
         AddHandler(0, &TKqlReadTableBase::Match, HNDL(ApplyExtractMembersToReadTable<false>));
         AddHandler(0, &TKqlReadTableRangesBase::Match, HNDL(ApplyExtractMembersToReadTable<false>));
@@ -74,6 +72,7 @@ public:
         AddHandler(0, &TCoMatchRecognize::Match, HNDL(MatchRecognize));
 
         AddHandler(1, &TCoFlatMapBase::Match, HNDL(RewriteFlatMapOverFullTextMatch));
+        AddHandler(1, &TCoFlatMapBase::Match, HNDL(RewriteFlatMapOverJsonRead));
         AddHandler(1, &TCoTop::Match, HNDL(RewriteTopSortOverIndexRead));
         AddHandler(1, &TCoTopSort::Match, HNDL(RewriteTopSortOverIndexRead));
         AddHandler(1, &TCoTake::Match, HNDL(RewriteTakeOverIndexRead));
@@ -268,6 +267,16 @@ protected:
         }
 
         DumpAppliedRule("RewriteFlatMapOverFullTextMatch", node.Ptr(), output.Cast().Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> RewriteFlatMapOverJsonRead(TExprBase node, TExprContext& ctx) {
+        auto output = KqpRewriteFlatMapOverJsonRead(node, ctx, KqpCtx);
+        if (!output.IsValid()) {
+            return {};
+        }
+
+        DumpAppliedRule("RewriteFlatMapOverJsonRead", node.Ptr(), output.Cast().Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -325,8 +325,23 @@ struct TReadMatch {
         YQL_ENSURE(tableDesc.Metadata);
         auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
         if (indexDesc->Type != TIndexDescription::EType::GlobalFulltextPlain
-            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance
-            && indexDesc->Type != TIndexDescription::EType::GlobalJson) {
+            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance) {
+            return {};
+        }
+
+        return read;
+    }
+
+    static TReadMatch MatchJsonRead(const TExprBase& node, const TKqpOptimizeContext& kqpCtx) {
+        auto read = TReadMatch::Match(node, kqpCtx);
+        if (!read || read.Index().Value().empty()) {
+            return {};
+        }
+
+        const auto& tableDesc = GetTableData(*kqpCtx.Tables, kqpCtx.Cluster, read.Table().Path());
+        YQL_ENSURE(tableDesc.Metadata);
+        auto [_, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
+        if (indexDesc->Type != TIndexDescription::EType::GlobalJson) {
             return {};
         }
 
@@ -1857,6 +1872,66 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverFullTextMatch(const NYql::NNodes::TEx
         .Lambda(NewLambdaFrom(ctx, flatMap.Lambda().Pos(), result.Replaces, flatMap.Lambda().Args().Ref(), newLambdaBody.Body()))
         .Done();
     return res;
+}
+
+TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
+    if (!node.Maybe<TCoFlatMap>()) {
+        return node;
+    }
+
+    auto flatMap = node.Maybe<TCoFlatMap>().Cast();
+
+    auto read = TReadMatch::MatchJsonRead(flatMap.Input(), kqpCtx);
+    if (!read) {
+        return node;
+    }
+
+    const auto& tableDesc = GetTableData(*kqpCtx.Tables, kqpCtx.Cluster, read.Table().Path());
+    YQL_ENSURE(tableDesc.Metadata);
+    auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
+    if (indexDesc->Type != TIndexDescription::EType::GlobalJson) {
+        return {};
+    }
+
+    auto body = flatMap.Lambda().Body();
+    if (!body.Maybe<TCoOptionalIf>()) {
+        return {};
+    }
+
+    auto optionalIf = body.Maybe<TCoOptionalIf>().Cast();
+    if (!optionalIf.Predicate().Maybe<TCoCoalesce>()) {
+        return {};
+    }
+
+    auto coalesce = optionalIf.Predicate().Maybe<TCoCoalesce>().Cast();
+    if (!coalesce.Predicate().Maybe<TCoJsonExists>()) {
+        return {};
+    }
+
+    auto jsonExists = coalesce.Predicate().Maybe<TCoJsonExists>().Cast();
+    Cerr << NCommon::ExprToPrettyString(ctx, jsonExists.Ref()) << Endl;
+
+    if (!jsonExists.Json().Maybe<TCoMember>()) {
+        return {};
+    }
+
+    if (!jsonExists.JsonPath().Maybe<TCoUtf8>()) {
+        return {};
+    }
+
+    auto jsonPath = jsonExists.JsonPath().Maybe<TCoUtf8>().Cast().Literal().StringValue();
+    Cerr << "jsonPath: " << jsonPath << Endl;
+
+    const auto& variables = jsonExists.Variables().Ref();
+    if (!variables.GetTypeAnn() || variables.GetTypeAnn()->GetKind() != ETypeAnnotationKind::EmptyDict) {
+        return {};
+    }
+
+    TIssue issue{ctx.GetPosition(read.Pos()), "Json index is not supported for now"};
+    SetIssueCode(EYqlIssueCode::TIssuesIds_EIssueCode_KIKIMR_BAD_REQUEST, issue);
+    ctx.AddError(issue);
+
+    return {};
 }
 
 // The index and main table have same number of rows, so we can push a copy of TCoTopSort or TCoTake

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -1909,7 +1909,6 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBas
     }
 
     auto jsonExists = coalesce.Predicate().Maybe<TCoJsonExists>().Cast();
-    Cerr << NCommon::ExprToPrettyString(ctx, jsonExists.Ref()) << Endl;
 
     if (!jsonExists.Json().Maybe<TCoMember>()) {
         return {};
@@ -1919,19 +1918,40 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBas
         return {};
     }
 
-    auto jsonPath = jsonExists.JsonPath().Maybe<TCoUtf8>().Cast().Literal().StringValue();
-    Cerr << "jsonPath: " << jsonPath << Endl;
+    auto jsonColumnName = jsonExists.Json().Maybe<TCoMember>().Cast().Name().StringValue();
+    auto jsonPathStr = jsonExists.JsonPath().Maybe<TCoUtf8>().Cast().Literal().StringValue();
 
     const auto& variables = jsonExists.Variables().Ref();
     if (!variables.GetTypeAnn() || variables.GetTypeAnn()->GetKind() != ETypeAnnotationKind::EmptyDict) {
         return {};
     }
 
-    TIssue issue{ctx.GetPosition(read.Pos()), "Json index is not supported for now"};
-    SetIssueCode(EYqlIssueCode::TIssuesIds_EIssueCode_KIKIMR_BAD_REQUEST, issue);
-    ctx.AddError(issue);
+    auto settings = TKqpReadTableFullTextIndexSettings{};
+    settings.SetDefaultOperator(Build<TCoString>(ctx, node.Pos()).Literal().Build("and").Done().Ptr());
+    settings.SetMinimumShouldMatch(Build<TCoString>(ctx, node.Pos()).Literal().Build("").Done().Ptr());
 
-    return {};
+    auto queryExpr = Build<TCoString>(ctx, node.Pos())
+        .Literal()
+        .Build(jsonPathStr)
+        .Done();
+
+    auto searchColumns = Build<TCoAtomList>(ctx, node.Pos())
+        .Add(Build<TCoAtom>(ctx, node.Pos()).Value(jsonColumnName).Done())
+        .Done();
+
+    auto newInput = Build<TKqlReadTableFullTextIndex>(ctx, node.Pos())
+        .Table(read.Table())
+        .Index(read.Index())
+        .Columns(read.Columns())
+        .Query<TExprList>().Add(queryExpr).Build()
+        .QueryColumns(searchColumns.Ptr())
+        .Settings(settings.BuildNode(ctx, node.Pos()))
+        .Done();
+
+    return Build<TCoFlatMap>(ctx, read.Pos())
+        .Input(newInput)
+        .Lambda(flatMap.Lambda())
+        .Done();
 }
 
 // The index and main table have same number of rows, so we can push a copy of TCoTopSort or TCoTake

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
@@ -52,6 +52,9 @@ NYql::NNodes::TMaybeNode<NYql::NNodes::TExprBase> KqpPushLimitOverFullText(const
 NYql::NNodes::TMaybeNode<NYql::NNodes::TExprBase> KqpRewriteFlatMapOverFullTextMatch(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx,
     const TKqpOptimizeContext& kqpCtx);
 
+NYql::NNodes::TMaybeNode<NYql::NNodes::TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx);
+
 NYql::NNodes::TExprBase KqpRewriteTopSortOverFlatMap(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx);
 
 NYql::NNodes::TExprBase KqpRewriteTakeOverIndexRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext&,

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1387,14 +1387,19 @@ private:
 
             auto [indexMeta, index] = tableMeta->GetIndex(indexName);
 
-            auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
-            YQL_ENSURE(desc, "unexpected index description type");
-            fullTextProto.MutableIndexDescription()->MutableSettings()->CopyFrom(desc->GetSettings());
             YQL_ENSURE(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                || index->Type == TIndexDescription::EType::GlobalFulltextPlain);
-            fullTextProto.SetIndexType(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                ? NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance
-                : NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain);
+                || index->Type == TIndexDescription::EType::GlobalFulltextPlain
+                || index->Type == TIndexDescription::EType::GlobalJson);
+            if (index->Type == TIndexDescription::EType::GlobalJson) {
+                fullTextProto.SetIndexType(NKqpProto::EKqpFullTextIndexType::EKqpFullTextJson);
+            } else {
+                auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
+                YQL_ENSURE(desc, "unexpected index description type");
+                fullTextProto.MutableIndexDescription()->MutableSettings()->CopyFrom(desc->GetSettings());
+                fullTextProto.SetIndexType(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
+                    ? NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance
+                    : NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain);
+            }
 
             auto fillCol = [&](const NYql::TKikimrColumnMetadata* columnMeta, NKikimrKqp::TKqpColumnMetadataProto* columnProto) {
                 columnProto->SetName(columnMeta->Name);

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -58,6 +58,7 @@
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/engine/minikql/minikql_engine_host.h>
 #include <ydb/core/base/fulltext.h>
+#include <ydb/core/base/json_index.h>
 #include <ydb/core/base/table_index.h>
 
 #include <ydb/core/kqp/gateway/kqp_gateway.h>
@@ -2207,9 +2208,17 @@ private:
         const auto& expr = Settings->GetQuerySettings().GetQuery();
         YQL_ENSURE(Settings->GetQuerySettings().GetColumns().size() == 1);
 
-        for(const auto& column : Settings->GetQuerySettings().GetColumns()) {
+        for (const auto& column : Settings->GetQuerySettings().GetColumns()) {
+            if (Settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextJson) {
+                size_t wordIndex = 0;
+                for (const TString& query: NJsonIndex::BuildSearchTerms(expr)) {
+                    YQL_ENSURE(IndexTableReader);
+                    Words.emplace_back(MakeIntrusive<TWordReadState>(wordIndex++, query, IndexTableReader));
+                }
+                continue;
+            }
 
-            for(const auto& analyzer : Settings->GetIndexDescription().GetSettings().columns()) {
+            for (const auto& analyzer : Settings->GetIndexDescription().GetSettings().columns()) {
                 if (analyzer.analyzers().use_filter_ngram() || analyzer.analyzers().use_filter_edge_ngram()) {
                     IsNgram = true;
                 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -243,6 +243,34 @@ void ValidateError(TQueryClient& db, const std::string& table, const std::string
     UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), errorMessage);
 }
 
+void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
+    const std::function<void(TQueryClient&, const std::function<std::string(const std::string&)>&)>& body)
+{
+    auto kikimr = Kikimr();
+    auto db = kikimr.GetQueryClient();
+
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+    const std::string jsonType = isJsonDocument ? "JsonDocument" : "Json";
+    const auto jsonExists = [&](const std::string& predicate) {
+        return std::format("JSON_EXISTS(Text, '{}')", (isStrict ? "strict " : "lax ") + predicate);
+    };
+
+    CreateTestTable(db, jsonType, /* withIndex */ false);
+    FillTestTable(db, "TestTable", jsonType);
+
+    {
+        auto query = R"(
+            ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (Text)
+        )";
+        auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    body(db, jsonExists);
+}
+
 }  // namespace
 
 Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
@@ -432,36 +460,14 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         }
     }
 
-    Y_UNIT_TEST_QUAD(SelectJsonExists, IsJsonDocument, IsStrict) {
-        auto kikimr = Kikimr();
-        auto db = kikimr.GetQueryClient();
-
-        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-
-        const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
-        const auto jsonExists = [&](const std::string& predicate) {
-            return std::format("JSON_EXISTS(Text, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
-        };
-
-        CreateTestTable(db, jsonType, /* withIndex */ false);
-        FillTestTable(db, "TestTable", jsonType);
-
-        {
-            auto query = R"(
-                ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (Text)
-            )";
-            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
-
-        // Any json value existence
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_ContextObject, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$"));
-        }
+        });
+    }
 
-        // Keys existence (with empty keys)
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_MemberAccess, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3"));
@@ -470,12 +476,6 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k6"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k7"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k8"));
-
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k3"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k4"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k5"));
 
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2"));
@@ -502,10 +502,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1.*"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.*"));
-        }
+        });
+    }
 
-        // Array elements existence
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_ArrayAccess, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3]"));
@@ -527,12 +528,12 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
-        }
+        });
+    }
 
-        // Methods
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_Methods, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             auto validateMethod = [&](const std::string& method) {
-                Cerr << std::format("Validating method: {}", method) << Endl;
                 ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.{}", method)));
                 ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.{}", method)));
                 ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.*.{}", method)));
@@ -556,10 +557,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             validateMethod("size().double()");
             validateMethod("abs().ceiling()");
             validateMethod("abs().floor().type()");
-        }
+        });
+    }
 
-        // Starts with predicate
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_StartsWithPredicate, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ starts with \"1\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ starts with \"text\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 starts with \"1\""));
@@ -600,35 +602,40 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\" starts with \"1\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\" starts with \"1\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last].k1 starts with \"1\""));
-        }
+        });
+    }
 
-        // Like regex predicate
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_LikeRegexPredicate, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 like_regex \"1\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ like_regex \".*\""));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*].k1 like_regex \"1\""));
-        }
+        });
+    }
 
-        // Is unknown predicate
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_IsUnknownPredicate, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("($ starts with \"abc\") is unknown"));
-        }
+        });
+    }
 
-        // Exists predicate
-        {
+    Y_UNIT_TEST_QUAD(SelectJsonExists_ExistsPredicate, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($)"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($.key)"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($.key[1, 2, 3])"));
-        }
+        });
+    }
 
-        // Without context object ($)
-        {
-            ValidateError(db, "TestTable", "json_idx", jsonExists("null"), "No search terms were extracted from the query");
-            ValidateError(db, "TestTable", "json_idx", jsonExists("1"), "No search terms were extracted from the query");
-            ValidateError(db, "TestTable", "json_idx", jsonExists("\"str\""), "No search terms were extracted from the query");
-            ValidateError(db, "TestTable", "json_idx", jsonExists("true"), "No search terms were extracted from the query");
-            ValidateError(db, "TestTable", "json_idx", jsonExists("false"), "No search terms were extracted from the query");
-        }
+    Y_UNIT_TEST_QUAD(SelectJsonExists_Literals, IsJsonDocument, IsStrict) {
+        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+            const auto errorMessage = "No search terms were extracted from the query";
+            ValidateError(db, "TestTable", "json_idx", jsonExists("null"), errorMessage);
+            ValidateError(db, "TestTable", "json_idx", jsonExists("1"), errorMessage);
+            ValidateError(db, "TestTable", "json_idx", jsonExists("\"str\""), errorMessage);
+            ValidateError(db, "TestTable", "json_idx", jsonExists("true"), errorMessage);
+            ValidateError(db, "TestTable", "json_idx", jsonExists("false"), errorMessage);
+        });
     }
 }
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2,56 +2,59 @@
 
 namespace NKikimr::NKqp {
 
-using namespace NYdb;
 using namespace NYdb::NQuery;
+using namespace NYdb;
 
-Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
+namespace {
 
-TKikimrRunner Kikimr() {
+TKikimrRunner Kikimr(bool enableJsonIndex = true) {
     NKikimrConfig::TFeatureFlags featureFlags;
-    featureFlags.SetEnableJsonIndex(true);
+    featureFlags.SetEnableJsonIndex(enableJsonIndex);
     auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
     return TKikimrRunner(settings);
 }
 
-void CreateTestTable(NQuery::TQueryClient& db, const char* type = "Json", bool withIndex = false) {
-    TString query = std::format(R"sql(
-        CREATE TABLE `/Root/TestTable` (
+void CreateTestTable(TQueryClient& db, const std::string& type = "Json", bool withIndex = false) {
+    const auto query = std::format(R"(
+        CREATE TABLE TestTable (
             Key Uint64,
             Text {0},
             Data Utf8,
             PRIMARY KEY (Key)
             {1}
         );
-    )sql", type, withIndex ? ", INDEX `json_idx` GLOBAL USING json ON (Text)" : "");
-    auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    )", type, withIndex ? ", INDEX `json_idx` GLOBAL USING json ON (Text)" : "");
+    auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 }
 
-TResultSet ReadIndex(NQuery::TQueryClient& db, const char* table = "indexImplTable") {
-    TString query = Sprintf(R"sql(
-        SELECT * FROM `/Root/TestTable/json_idx/%s`;
-    )sql", table);
-    auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+TResultSet ReadIndex(TQueryClient& db, const char* table = "indexImplTable") {
+    const auto query = std::format(R"(
+        SELECT * FROM `TestTable/json_idx/{}`;
+    )", table);
+    auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
     return result.GetResultSet(0);
 }
 
-void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
+void TestAddJsonIndex(const std::string& type, bool nullable, bool covered) {
     auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
     auto db = kikimr.GetQueryClient();
 
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
     auto columnType = type + (nullable ? "" : " not null");
-    CreateTestTable(db, columnType.c_str());
+    CreateTestTable(db, columnType);
+
     {
-        TString castStart, castEnd;
+        std::string castStart, castEnd;
         if (type == "JsonDocument") {
             castStart = !nullable ? "unwrap(cast(" : "cast(";
             castEnd = !nullable ? " as JsonDocument))" : " as JsonDocument)";
         }
-        TString query = Sprintf(R"sql(
+
+        std::string query = Sprintf(R"(
             UPSERT INTO `/Root/TestTable` (Key, Text, Data) VALUES
                 (10, %1$s"\"literal string\""%2$s, "d1"),
                 (11, %1$s"0.123"%2$s, "data 2"),
@@ -61,27 +64,33 @@ void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
                 (15, %1$s"[false,\"item 1\",45]"%2$s, "array data 6"),
                 (16, %1$s"{\"id\":42042,\"brand\":\"bricks\",\"part_count\":1401,\"price\":null,\"parts\":
                     [{\"id\":32526,\"count\":7,\"name\":\"3x5\"},{\"id\":32523,\"count\":17,\"name\":\"1x3\"}]}"%2$s, "object data 7")
-        )sql", castStart.c_str(), castEnd.c_str());
+        )", castStart.c_str(), castEnd.c_str());
         if (nullable) {
             query += ", (17, NULL, \"null data 8\")";
         }
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
     }
     {
-        TString query = R"sql(
+        std::string query = R"(
             ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
                 GLOBAL USING json ON (Text)
-        )sql";
-        if (covered) {
-            query += " COVER (Data)";
-        }
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        )" + std::string(covered ? " COVER (Data)" : "");
+
+        auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
     }
     auto index = ReadIndex(db);
     if (covered) {
         CompareYson(R"([
+            [["d1"];[10u];""];
+            [["data 2"];[11u];""];
+            [["very long unit test data 3"];[12u];""];
+            [["data 4"];[13u];""];
+            [["data 5"];[14u];""];
+            [["array data 6"];[15u];""];
+            [["object data 7"];[16u];""];
             [["data 4"];[13u];"\0\0"];
             [["array data 6"];[15u];"\0\0"];
             [["very long unit test data 3"];[12u];"\0\1"];
@@ -108,9 +117,16 @@ void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
             [["object data 7"];[16u];"\5price\0\2"];
             [["object data 7"];[16u];"\npart_count"];
             [["object data 7"];[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
-        ])", NYdb::FormatResultSetYson(index));
+        ])", FormatResultSetYson(index));
     } else {
         CompareYson(R"([
+            [[10u];""];
+            [[11u];""];
+            [[12u];""];
+            [[13u];""];
+            [[14u];""];
+            [[15u];""];
+            [[16u];""];
             [[13u];"\0\0"];
             [[15u];"\0\0"];
             [[12u];"\0\1"];
@@ -137,15 +153,15 @@ void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
             [[16u];"\5price\0\2"];
             [[16u];"\npart_count"];
             [[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
-        ])", NYdb::FormatResultSetYson(index));
+        ])", FormatResultSetYson(index));
     }
 }
 
-void ValidatePredicate(NQuery::TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
+void ValidatePredicate(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
     auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
-        return std::format(R"sql(
+        return std::format(R"(
             SELECT k, v FROM {} {} WHERE {} ORDER BY k;
-        )sql", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
+        )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
     };
 
     auto mainResult = db.ExecuteQuery(query(table, "", predicate), TTxControl::NoTx()).ExtractValueSync();
@@ -154,355 +170,360 @@ void ValidatePredicate(NQuery::TQueryClient& db, const std::string& table, const
     auto indexResult = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_VALUES_EQUAL_C(indexResult.GetStatus(), EStatus::SUCCESS, indexResult.GetIssues().ToString());
 
-    // Cerr << "MAIN: " << Endl << NYdb::FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
-    // Cerr << "INDEX: " << Endl << NYdb::FormatResultSetYson(indexResult.GetResultSet(0)) << Endl;
+    // Cerr << "MAIN: " << Endl << FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
+    // Cerr << "INDEX: " << Endl << FormatResultSetYson(indexResult.GetResultSet(0)) << Endl;
 
     Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
-    CompareYson(NYdb::FormatResultSetYson(mainResult.GetResultSet(0)), NYdb::FormatResultSetYson(indexResult.GetResultSet(0)));
+    CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
-Y_UNIT_TEST(AddJsonIndexJson) {
-    DoTestAddJsonIndex("Json", true, false);
-}
+}  // namespace
 
-Y_UNIT_TEST(AddJsonIndexJsonDocument) {
-    DoTestAddJsonIndex("JsonDocument", true, false);
-}
-
-Y_UNIT_TEST(AddJsonIndexJsonNotNull) {
-    DoTestAddJsonIndex("Json", false, false);
-}
-
-Y_UNIT_TEST(AddJsonIndexJsonDocumentNotNull) {
-    DoTestAddJsonIndex("JsonDocument", false, false);
-}
-
-Y_UNIT_TEST(AddJsonIndexCoveringJson) {
-    DoTestAddJsonIndex("Json", true, true);
-}
-
-Y_UNIT_TEST(AddJsonIndexCoveringJsonDocument) {
-    DoTestAddJsonIndex("JsonDocument", true, true);
-}
-
-Y_UNIT_TEST(AddJsonIndexCoveringJsonNotNull) {
-    DoTestAddJsonIndex("Json", false, true);
-}
-
-Y_UNIT_TEST(AddJsonIndexCoveringJsonDocumentNotNull) {
-    DoTestAddJsonIndex("JsonDocument", false, true);
-}
-
-Y_UNIT_TEST(OnCreate) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    CreateTestTable(db, "Json", true);
-
-    // TODO: Test it with update after implementing update
-}
-
-Y_UNIT_TEST(UnsupportedType) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    CreateTestTable(db, "Uint64");
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
-                GLOBAL USING json ON (Text)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST(NoMultipleColumns) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/TestTable` (
-                Key Uint64,
-                Field1 Json,
-                Field2 Json,
-                PRIMARY KEY (Key)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
+    Y_UNIT_TEST(AddJsonIndexJson) {
+        TestAddJsonIndex("Json", true, false);
     }
 
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
-                GLOBAL USING json ON (Field1, Field2)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST(NonUint64Pk) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/TestTable` (
-                Key Uint32,
-                Field1 Json,
-                PRIMARY KEY (Key)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    Y_UNIT_TEST(AddJsonIndexJsonDocument) {
+        TestAddJsonIndex("JsonDocument", true, false);
     }
 
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
-                GLOBAL USING json ON (Field1)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST(NoCompositePk) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-    auto db = kikimr.GetQueryClient();
-
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/TestTable` (
-                Key1 Uint64,
-                Key2 Uint64,
-                Field1 Json,
-                PRIMARY KEY (Key1, Key2)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    Y_UNIT_TEST(AddJsonIndexJsonNotNull) {
+        TestAddJsonIndex("Json", false, false);
     }
 
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
-                GLOBAL USING json ON (Field1)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST(DisabledFlagRejectAlter) {
-    NKikimrConfig::TFeatureFlags featureFlags;
-    featureFlags.SetEnableJsonIndex(false);
-    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
-    auto kikimr = TKikimrRunner(settings);
-    auto db = kikimr.GetQueryClient();
-
-    CreateTestTable(db, "Json");
-    {
-        TString query = R"sql(
-            ALTER TABLE `/Root/TestTable` ADD INDEX json_idx
-                GLOBAL USING json ON (Text)
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST(DisabledFlagRejectCreate) {
-    NKikimrConfig::TFeatureFlags featureFlags;
-    featureFlags.SetEnableJsonIndex(false);
-    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
-    auto kikimr = TKikimrRunner(settings);
-    auto db = kikimr.GetQueryClient();
-
-    {
-        TString query = R"sql(
-            CREATE TABLE `/Root/TestTable` (
-                Key Uint64,
-                Text Json,
-                Data Utf8,
-                PRIMARY KEY (Key),
-                INDEX `json_idx` GLOBAL USING json ON (Text)
-            );
-        )sql";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-    }
-}
-
-Y_UNIT_TEST_QUAD(SelectJsonExists, IsJsonDocument, IsStrict) {
-    auto kikimr = Kikimr();
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-
-    auto db = kikimr.GetQueryClient();
-
-    const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
-    const auto jsonExists = [&](const std::string& predicate) {
-        return std::format("JSON_EXISTS(v, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
-    };
-
-    {
-        auto query = std::format(R"(
-            CREATE TABLE TestTable (
-                k Uint64,
-                v {0},
-                PRIMARY KEY (k)
-            );
-        )", jsonType);
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    Y_UNIT_TEST(AddJsonIndexJsonDocumentNotNull) {
+        TestAddJsonIndex("JsonDocument", false, false);
     }
 
-    {
-        std::vector<std::string> values = {
-            R"(('null'))",
-            R"(('1'))",
-            R"(('true'))",
-            R"(('false'))",
-            R"(('"string"'))",
-            R"(('[]'))",
-            R"(('{}'))",
-            R"(('{"k1": null}'))",
-            R"(('{"k1": 1}'))",
-            R"(('{"k1": true}'))",
-            R"(('{"k1": false}'))",
-            R"(('{"k1": "string"}'))",
-            R"(('{"k1": []}'))",
-            R"(('{"k1": {}}'))",
-            R"(('{"k1": [1, 2, 3]}'))",
-            R"(('{"k1": "string", "k2": "string2"}'))",
-            R"(('[{"k1": "string", "k2": "string2"}, {"k1": "string", "k2": "string2"}]'))",
-            R"(('{"k1": {"k2": {"k3": {"k4": "string"}}}}'))",
-            R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "string", false], "k7": {"k1": "v"}}'))",
-            R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
-            R"(('{"": null}'))",
-            R"(('{"": 1}'))",
-            R"(('{"": true}'))",
-            R"(('{"": false}'))",
-            R"(('{"": "string"}'))",
-            R"(('{"": []}'))",
-            R"(('{"": {}}'))",
-            R"(('{"": [1, 2, 3]}'))",
-            R"(('{"": {"": {"": {"": ["", "string", null, 1, {"": ""}]}}}}'))",
-            R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
-            R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
-            R"(('[1, [2, [3, [4, []]]]]'))",
-            R"(('["string", {"k1": 1}, [2, 3], 4, null, false]'))",
-            R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
-            R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
-            "NULL"
-        };
+    Y_UNIT_TEST(AddJsonIndexCoveringJson) {
+        TestAddJsonIndex("Json", true, true);
+    }
 
-        std::string query = R"(
-            UPSERT INTO TestTable (k, v) VALUES
-        )";
+    Y_UNIT_TEST(AddJsonIndexCoveringJsonDocument) {
+        TestAddJsonIndex("JsonDocument", true, true);
+    }
 
-        for (size_t i = 0; i < values.size(); ++i) {
-            query += std::format("({}, {}),", i + 1, (values[i] == "NULL" ? "" : jsonType) + values[i]);
+    Y_UNIT_TEST(AddJsonIndexCoveringJsonNotNull) {
+        TestAddJsonIndex("Json", false, true);
+    }
+
+    Y_UNIT_TEST(AddJsonIndexCoveringJsonDocumentNotNull) {
+        TestAddJsonIndex("JsonDocument", false, true);
+    }
+
+    Y_UNIT_TEST(OnCreate) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        CreateTestTable(db, "Json", true);
+
+        // TODO: Test it with update after implementing update
+    }
+
+    Y_UNIT_TEST(UnsupportedType) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        CreateTestTable(db, "Uint64");
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Error: JSON column 'Text' must have type 'Json' or 'JsonDocument' but got Uint64");
+        }
+    }
+
+    Y_UNIT_TEST(NoMultipleColumns) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key Uint64,
+                    Field1 Json,
+                    Field2 Json,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
 
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Field1, Field2)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "JSON index supports only 1 key column, but 2 are requested");
+        }
     }
 
-    {
-        auto query = R"(
-            ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (v)
-        )";
-        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    Y_UNIT_TEST(NonUint64Pk) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key Uint32,
+                    Field1 Json,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Field1)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Error: JSON index requires primary key column 'Key' to be of type 'Uint64' but got Uint32");
+        }
     }
 
-    // Any json value existence
-    {
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$"));
+    Y_UNIT_TEST(NoCompositePk) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key1 Uint64,
+                    Key2 Uint64,
+                    Field1 Json,
+                    PRIMARY KEY (Key1, Key2)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Field1)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Error: JSON index requires exactly one primary key column of type 'Uint64', but table has 2 primary key columns");
+        }
     }
 
-    // Keys existence (with empty keys)
-    {
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 1)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 2)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 3)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 4)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 5)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 6)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 7)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 8)));
+    Y_UNIT_TEST(DisabledFlagRejectAlter) {
+        auto kikimr = Kikimr(/* enableJsonIndex */ false);
+        auto db = kikimr.GetQueryClient();
 
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 1)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 2)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 3)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 4)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 5)));
+        CreateTestTable(db, "Json");
 
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 1)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 2)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 3)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 4)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 5)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 1)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 2)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 3)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 4)));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 5)));
-
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\""));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\""));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\""));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\""));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\".\"\""));
-
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1.*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.*"));
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
     }
 
-    // Array elements existence
-    {
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3].k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3].k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last].k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].k1"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].*"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0, 3]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[1 to 3]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
-        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
+    Y_UNIT_TEST(DisabledFlagRejectCreate) {
+        auto kikimr = Kikimr(/* enableJsonIndex */ false);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key Uint64,
+                    Text Json,
+                    Data Utf8,
+                    PRIMARY KEY (Key),
+                    INDEX `json_idx` GLOBAL USING json ON (Text)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(SelectJsonExists, IsJsonDocument, IsStrict) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+        const auto jsonExists = [&](const std::string& predicate) {
+            return std::format("JSON_EXISTS(v, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
+        };
+
+        {
+            auto query = std::format(R"(
+                CREATE TABLE TestTable (
+                    k Uint64,
+                    v {0},
+                    PRIMARY KEY (k)
+                );
+            )", jsonType);
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::vector<std::string> values = {
+                R"(('null'))",
+                R"(('1'))",
+                R"(('true'))",
+                R"(('false'))",
+                R"(('"string"'))",
+                R"(('[]'))",
+                R"(('{}'))",
+                R"(('{"k1": null}'))",
+                R"(('{"k1": 1}'))",
+                R"(('{"k1": true}'))",
+                R"(('{"k1": false}'))",
+                R"(('{"k1": "string"}'))",
+                R"(('{"k1": []}'))",
+                R"(('{"k1": {}}'))",
+                R"(('{"k1": [1, 2, 3]}'))",
+                R"(('{"k1": "string", "k2": "string2"}'))",
+                R"(('[{"k1": "string", "k2": "string2"}, {"k1": "string", "k2": "string2"}]'))",
+                R"(('{"k1": {"k2": {"k3": {"k4": "string"}}}}'))",
+                R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "string", false], "k7": {"k1": "v"}}'))",
+                R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
+                R"(('{"": null}'))",
+                R"(('{"": 1}'))",
+                R"(('{"": true}'))",
+                R"(('{"": false}'))",
+                R"(('{"": "string"}'))",
+                R"(('{"": []}'))",
+                R"(('{"": {}}'))",
+                R"(('{"": [1, 2, 3]}'))",
+                R"(('{"": {"": {"": {"": ["", "string", null, 1, {"": ""}]}}}}'))",
+                R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
+                R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
+                R"(('[1, [2, [3, [4, []]]]]'))",
+                R"(('["string", {"k1": 1}, [2, 3], 4, null, false]'))",
+                R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
+                R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
+                "NULL"
+            };
+
+            std::string query = R"(
+                UPSERT INTO TestTable (k, v) VALUES
+            )";
+
+            for (size_t i = 0; i < values.size(); ++i) {
+                query += std::format("({}, {}),", i + 1, (values[i] == "NULL" ? "" : jsonType) + values[i]);
+            }
+
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (v)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        // Any json value existence
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$"));
+        }
+
+        // Keys existence (with empty keys)
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k4"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k5"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k6"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k7"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k8"));
+
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k3"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k4"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k5"));
+
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k3"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k4"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k5"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k2"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k3"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k4"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k5"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k4.k1"));
+
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\".\"\""));
+
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1.*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.*"));
+        }
+
+        // Array elements existence
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0][0][0]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3].k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3].k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last].k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].k1"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].*"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0, 3]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[1 to 3]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
+        }
     }
 }
 
-}
-
-} // namespace NKikimr::NKqp
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -177,6 +177,18 @@ void ValidatePredicate(TQueryClient& db, const std::string& table, const std::st
     CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
+void ValidateError(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate, const std::string& errorMessage) {
+    auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
+        return std::format(R"(
+            SELECT * FROM {} {} WHERE {} ORDER BY k;
+        )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
+    };
+
+    auto result = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+    UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), errorMessage);
+}
+
 }  // namespace
 
 Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
@@ -396,37 +408,39 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
                 R"(('1'))",
                 R"(('true'))",
                 R"(('false'))",
-                R"(('"string"'))",
+                R"(('"1"'))",
                 R"(('[]'))",
                 R"(('{}'))",
                 R"(('{"k1": null}'))",
                 R"(('{"k1": 1}'))",
                 R"(('{"k1": true}'))",
                 R"(('{"k1": false}'))",
-                R"(('{"k1": "string"}'))",
+                R"(('{"k1": "1"}'))",
                 R"(('{"k1": []}'))",
                 R"(('{"k1": {}}'))",
                 R"(('{"k1": [1, 2, 3]}'))",
-                R"(('{"k1": "string", "k2": "string2"}'))",
-                R"(('[{"k1": "string", "k2": "string2"}, {"k1": "string", "k2": "string2"}]'))",
-                R"(('{"k1": {"k2": {"k3": {"k4": "string"}}}}'))",
-                R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "string", false], "k7": {"k1": "v"}}'))",
+                R"(('{"k1": "1", "k2": "22"}'))",
+                R"(('[{"k1": "1", "k2": "22"}, {"k1": "1", "k2": "22"}]'))",
+                R"(('{"k1": {"k2": {"k3": {"k4": "1"}}}}'))",
+                R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "1", false], "k7": {"k1": "v"}}'))",
                 R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
                 R"(('{"": null}'))",
                 R"(('{"": 1}'))",
                 R"(('{"": true}'))",
                 R"(('{"": false}'))",
-                R"(('{"": "string"}'))",
+                R"(('{"": "1"}'))",
                 R"(('{"": []}'))",
                 R"(('{"": {}}'))",
                 R"(('{"": [1, 2, 3]}'))",
-                R"(('{"": {"": {"": {"": ["", "string", null, 1, {"": ""}]}}}}'))",
+                R"(('{"": {"": {"": {"": ["", "1", null, 1, {"": ""}]}}}}'))",
                 R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
                 R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
                 R"(('[1, [2, [3, [4, []]]]]'))",
-                R"(('["string", {"k1": 1}, [2, 3], 4, null, false]'))",
+                R"(('["1", {"k1": 1}, [2, 3], 4, null, false]'))",
                 R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
                 R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
+                "NULL",
+                "NULL",
                 "NULL"
             };
 
@@ -522,6 +536,44 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
+        }
+
+        // Methods
+        {
+            auto validateMethod = [&](const std::string& method) {
+                Cerr << std::format("Validating method: {}", method) << Endl;
+                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.{}", method)));
+                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.{}", method)));
+                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.*.{}", method)));
+                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$[0].{}", method)));
+                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$[*].{}", method)));
+            };
+
+            validateMethod("type()");
+            validateMethod("size()");
+            validateMethod("double()");
+            validateMethod("ceiling()");
+            validateMethod("floor()");
+            validateMethod("abs()");
+            validateMethod("keyvalue()");
+
+            validateMethod("keyvalue().size()");
+            validateMethod("keyvalue().name");
+            validateMethod("keyvalue().value");
+            validateMethod("keyvalue().value.size()");
+
+            validateMethod("size().double()");
+            validateMethod("abs().ceiling()");
+            validateMethod("abs().floor().type()");
+        }
+
+        // Without context object ($)
+        {
+            ValidateError(db, "TestTable", "json_idx", jsonExists("null"), "No search terms were extracted from the query");
+            ValidateError(db, "TestTable", "json_idx", jsonExists("1"), "No search terms were extracted from the query");
+            ValidateError(db, "TestTable", "json_idx", jsonExists("\"str\""), "No search terms were extracted from the query");
+            ValidateError(db, "TestTable", "json_idx", jsonExists("true"), "No search terms were extracted from the query");
+            ValidateError(db, "TestTable", "json_idx", jsonExists("false"), "No search terms were extracted from the query");
         }
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -3,6 +3,7 @@
 namespace NKikimr::NKqp {
 
 using namespace NYdb;
+using namespace NYdb::NQuery;
 
 Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
@@ -89,15 +90,23 @@ void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
             [["d1"];[10u];"\0\3literal string"];
             [["array data 6"];[15u];"\0\4\0\0\0\0\0\200F@"];
             [["data 2"];[11u];"\0\4\xB0rh\x91\xED|\xBF?"];
+            [["object data 7"];[16u];"\2id"];
             [["object data 7"];[16u];"\2id\0\4\0\0\0\0@\x87\xE4@"];
+            [["object data 7"];[16u];"\5brand"];
             [["object data 7"];[16u];"\5brand\0\3bricks"];
+            [["object data 7"];[16u];"\5parts"];
+            [["object data 7"];[16u];"\5parts\2id"];
             [["object data 7"];[16u];"\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@"];
             [["object data 7"];[16u];"\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@"];
+            [["object data 7"];[16u];"\5parts\4name"];
             [["object data 7"];[16u];"\5parts\4name\0\0031x3"];
             [["object data 7"];[16u];"\5parts\4name\0\0033x5"];
+            [["object data 7"];[16u];"\5parts\5count"];
             [["object data 7"];[16u];"\5parts\5count\0\4\0\0\0\0\0\0\x1C@"];
             [["object data 7"];[16u];"\5parts\5count\0\4\0\0\0\0\0\0001@"];
+            [["object data 7"];[16u];"\5price"];
             [["object data 7"];[16u];"\5price\0\2"];
+            [["object data 7"];[16u];"\npart_count"];
             [["object data 7"];[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
         ])", NYdb::FormatResultSetYson(index));
     } else {
@@ -110,18 +119,46 @@ void DoTestAddJsonIndex(const TString& type, bool nullable, bool covered) {
             [[10u];"\0\3literal string"];
             [[15u];"\0\4\0\0\0\0\0\200F@"];
             [[11u];"\0\4\xB0rh\x91\xED|\xBF?"];
+            [[16u];"\2id"];
             [[16u];"\2id\0\4\0\0\0\0@\x87\xE4@"];
+            [[16u];"\5brand"];
             [[16u];"\5brand\0\3bricks"];
+            [[16u];"\5parts"];
+            [[16u];"\5parts\2id"];
             [[16u];"\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@"];
             [[16u];"\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@"];
+            [[16u];"\5parts\4name"];
             [[16u];"\5parts\4name\0\0031x3"];
             [[16u];"\5parts\4name\0\0033x5"];
+            [[16u];"\5parts\5count"];
             [[16u];"\5parts\5count\0\4\0\0\0\0\0\0\x1C@"];
             [[16u];"\5parts\5count\0\4\0\0\0\0\0\0001@"];
+            [[16u];"\5price"];
             [[16u];"\5price\0\2"];
+            [[16u];"\npart_count"];
             [[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
         ])", NYdb::FormatResultSetYson(index));
     }
+}
+
+void ValidatePredicate(NQuery::TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
+    auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
+        return std::format(R"sql(
+            SELECT k, v FROM {} {} WHERE {} ORDER BY k;
+        )sql", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
+    };
+
+    auto mainResult = db.ExecuteQuery(query(table, "", predicate), TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(mainResult.GetStatus(), EStatus::SUCCESS, mainResult.GetIssues().ToString());
+
+    auto indexResult = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(indexResult.GetStatus(), EStatus::SUCCESS, indexResult.GetIssues().ToString());
+
+    // Cerr << "MAIN: " << Endl << NYdb::FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
+    // Cerr << "INDEX: " << Endl << NYdb::FormatResultSetYson(indexResult.GetResultSet(0)) << Endl;
+
+    Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
+    CompareYson(NYdb::FormatResultSetYson(mainResult.GetResultSet(0)), NYdb::FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
 Y_UNIT_TEST(AddJsonIndexJson) {
@@ -307,6 +344,162 @@ Y_UNIT_TEST(DisabledFlagRejectCreate) {
         )sql";
         auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+    }
+}
+
+Y_UNIT_TEST_QUAD(SelectJsonExists, IsJsonDocument, IsStrict) {
+    auto kikimr = Kikimr();
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+    auto db = kikimr.GetQueryClient();
+
+    const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+    const auto jsonExists = [&](const std::string& predicate) {
+        return std::format("JSON_EXISTS(v, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
+    };
+
+    {
+        auto query = std::format(R"(
+            CREATE TABLE TestTable (
+                k Uint64,
+                v {0},
+                PRIMARY KEY (k)
+            );
+        )", jsonType);
+        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    {
+        std::vector<std::string> values = {
+            R"(('null'))",
+            R"(('1'))",
+            R"(('true'))",
+            R"(('false'))",
+            R"(('"string"'))",
+            R"(('[]'))",
+            R"(('{}'))",
+            R"(('{"k1": null}'))",
+            R"(('{"k1": 1}'))",
+            R"(('{"k1": true}'))",
+            R"(('{"k1": false}'))",
+            R"(('{"k1": "string"}'))",
+            R"(('{"k1": []}'))",
+            R"(('{"k1": {}}'))",
+            R"(('{"k1": [1, 2, 3]}'))",
+            R"(('{"k1": "string", "k2": "string2"}'))",
+            R"(('[{"k1": "string", "k2": "string2"}, {"k1": "string", "k2": "string2"}]'))",
+            R"(('{"k1": {"k2": {"k3": {"k4": "string"}}}}'))",
+            R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "string", false], "k7": {"k1": "v"}}'))",
+            R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
+            R"(('{"": null}'))",
+            R"(('{"": 1}'))",
+            R"(('{"": true}'))",
+            R"(('{"": false}'))",
+            R"(('{"": "string"}'))",
+            R"(('{"": []}'))",
+            R"(('{"": {}}'))",
+            R"(('{"": [1, 2, 3]}'))",
+            R"(('{"": {"": {"": {"": ["", "string", null, 1, {"": ""}]}}}}'))",
+            R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
+            R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
+            R"(('[1, [2, [3, [4, []]]]]'))",
+            R"(('["string", {"k1": 1}, [2, 3], 4, null, false]'))",
+            R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
+            R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
+            "NULL"
+        };
+
+        std::string query = R"(
+            UPSERT INTO TestTable (k, v) VALUES
+        )";
+
+        for (size_t i = 0; i < values.size(); ++i) {
+            query += std::format("({}, {}),", i + 1, (values[i] == "NULL" ? "" : jsonType) + values[i]);
+        }
+
+        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    {
+        auto query = R"(
+            ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (v)
+        )";
+        auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    // Any json value existence
+    {
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$"));
+    }
+
+    // Keys existence (with empty keys)
+    {
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 1)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 2)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 3)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 4)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 5)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 6)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 7)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}", 8)));
+
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 1)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 2)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 3)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 4)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.k{}", 5)));
+
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 1)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 2)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 3)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 4)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 1, 5)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 1)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 2)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 3)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 4)));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k{}.k{}", 2, 5)));
+
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\""));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\""));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\""));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\""));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\".\"\""));
+
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1.*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.*"));
+    }
+
+    // Array elements existence
+    {
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3].k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3].k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last].k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].k1"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].*"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0, 3]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[1 to 3]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
+        ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
     }
 }
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -157,10 +157,64 @@ void TestAddJsonIndex(const std::string& type, bool nullable, bool covered) {
     }
 }
 
+void FillTestTable(TQueryClient& db, const std::string& tableName, const std::string& jsonType) {
+    const std::vector<std::string> values = {
+        R"(('null'))",
+        R"(('1'))",
+        R"(('true'))",
+        R"(('false'))",
+        R"(('"1"'))",
+        R"(('[]'))",
+        R"(('{}'))",
+        R"(('{"k1": null}'))",
+        R"(('{"k1": 1}'))",
+        R"(('{"k1": true}'))",
+        R"(('{"k1": false}'))",
+        R"(('{"k1": "1"}'))",
+        R"(('{"k1": []}'))",
+        R"(('{"k1": {}}'))",
+        R"(('{"k1": [1, 2, 3]}'))",
+        R"(('{"k1": "1", "k2": "22"}'))",
+        R"(('[{"k1": "1", "k2": "22"}, {"k1": "1", "k2": "22"}]'))",
+        R"(('{"k1": {"k2": {"k3": {"k4": "1"}}}}'))",
+        R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "1", false], "k7": {"k1": "v"}}'))",
+        R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
+        R"(('{"": null}'))",
+        R"(('{"": 1}'))",
+        R"(('{"": true}'))",
+        R"(('{"": false}'))",
+        R"(('{"": "1"}'))",
+        R"(('{"": []}'))",
+        R"(('{"": {}}'))",
+        R"(('{"": [1, 2, 3]}'))",
+        R"(('{"": {"": {"": {"": ["", "1", null, 1, {"": ""}]}}}}'))",
+        R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
+        R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
+        R"(('[1, [2, [3, [4, []]]]]'))",
+        R"(('["1", {"k1": 1}, [2, 3], 4, null, false]'))",
+        R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
+        R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
+        "NULL",
+        "NULL",
+        "NULL"
+    };
+
+    std::string query = std::format(R"(
+        UPSERT INTO {} (Key, Text) VALUES
+    )", tableName);
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        query += std::format("({}, {}),", i + 1, (values[i] == "NULL" ? "" : jsonType) + values[i]);
+    }
+
+    auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+}
+
 void ValidatePredicate(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
     auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
         return std::format(R"(
-            SELECT k, v FROM {} {} WHERE {} ORDER BY k;
+            SELECT Key, Text FROM {} {} WHERE {} ORDER BY Key;
         )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
     };
 
@@ -180,7 +234,7 @@ void ValidatePredicate(TQueryClient& db, const std::string& table, const std::st
 void ValidateError(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate, const std::string& errorMessage) {
     auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
         return std::format(R"(
-            SELECT * FROM {} {} WHERE {} ORDER BY k;
+            SELECT * FROM {} {} WHERE {} ORDER BY Key;
         )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
     };
 
@@ -387,78 +441,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
         const std::string jsonType = IsJsonDocument ? "JsonDocument" : "Json";
         const auto jsonExists = [&](const std::string& predicate) {
-            return std::format("JSON_EXISTS(v, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
+            return std::format("JSON_EXISTS(Text, '{}')", (IsStrict ? "strict " : "lax ") + predicate);
         };
 
-        {
-            auto query = std::format(R"(
-                CREATE TABLE TestTable (
-                    k Uint64,
-                    v {0},
-                    PRIMARY KEY (k)
-                );
-            )", jsonType);
-            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
-
-        {
-            std::vector<std::string> values = {
-                R"(('null'))",
-                R"(('1'))",
-                R"(('true'))",
-                R"(('false'))",
-                R"(('"1"'))",
-                R"(('[]'))",
-                R"(('{}'))",
-                R"(('{"k1": null}'))",
-                R"(('{"k1": 1}'))",
-                R"(('{"k1": true}'))",
-                R"(('{"k1": false}'))",
-                R"(('{"k1": "1"}'))",
-                R"(('{"k1": []}'))",
-                R"(('{"k1": {}}'))",
-                R"(('{"k1": [1, 2, 3]}'))",
-                R"(('{"k1": "1", "k2": "22"}'))",
-                R"(('[{"k1": "1", "k2": "22"}, {"k1": "1", "k2": "22"}]'))",
-                R"(('{"k1": {"k2": {"k3": {"k4": "1"}}}}'))",
-                R"(('{"k1": 0, "k2": -1.5, "k3": "text", "k4": true, "k5": null, "k6": [1, "1", false], "k7": {"k1": "v"}}'))",
-                R"(('{"k1": [{"k1": 10}, {"k1": 20}], "k2": {"k1": 2, "k2": true}}'))",
-                R"(('{"": null}'))",
-                R"(('{"": 1}'))",
-                R"(('{"": true}'))",
-                R"(('{"": false}'))",
-                R"(('{"": "1"}'))",
-                R"(('{"": []}'))",
-                R"(('{"": {}}'))",
-                R"(('{"": [1, 2, 3]}'))",
-                R"(('{"": {"": {"": {"": ["", "1", null, 1, {"": ""}]}}}}'))",
-                R"(('[{"": ""}, {"": ""}, {"": ""}, {"": ""}]'))",
-                R"(('{"k1": [[{"k2": 0}, {"k2": 1}], []]}'))",
-                R"(('[1, [2, [3, [4, []]]]]'))",
-                R"(('["1", {"k1": 1}, [2, 3], 4, null, false]'))",
-                R"(('[[{"k1": 1}], [{"k2": [{"k3": 2}]}]]'))",
-                R"(('{"k1": {"k2": {"k3": [{"k1": "a"}, {"k2": "b"}], "k4": [0, 1.5, -2, null]}}}'))",
-                "NULL",
-                "NULL",
-                "NULL"
-            };
-
-            std::string query = R"(
-                UPSERT INTO TestTable (k, v) VALUES
-            )";
-
-            for (size_t i = 0; i < values.size(); ++i) {
-                query += std::format("({}, {}),", i + 1, (values[i] == "NULL" ? "" : jsonType) + values[i]);
-            }
-
-            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }
+        CreateTestTable(db, jsonType, /* withIndex */ false);
+        FillTestTable(db, "TestTable", jsonType);
 
         {
             auto query = R"(
-                ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (v)
+                ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (Text)
             )";
             auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -567,6 +567,69 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             validateMethod("abs().floor().type()");
         }
 
+        // Starts with predicate
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ starts with \"text\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3 starts with \"te\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k8 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3.k4 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.* starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.* starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*.k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[1 to last] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].* starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*] starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*].k1 starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.type() starts with \"s\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.keyvalue().name starts with \"k\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.keyvalue().value starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*.type() starts with \"s\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].type() starts with \"s\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].type() starts with \"s\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.keyvalue().name starts with \"k\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\" starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\" starts with \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last].k1 starts with \"1\""));
+        }
+
+        // Like regex predicate
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 like_regex \"1\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ like_regex \".*\""));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*].k1 like_regex \"1\""));
+        }
+
+        // Is unknown predicate
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("($ starts with \"abc\") is unknown"));
+        }
+
+        // Exists predicate
+        {
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($)"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($.key)"));
+            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("exists($.key[1, 2, 3])"));
+        }
+
         // Without context object ($)
         {
             ValidateError(db, "TestTable", "json_idx", jsonExists("null"), "No search terms were extracted from the query");

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -398,6 +398,7 @@ message TKqpPhyConnection {
 enum EKqpFullTextIndexType {
     EKqpFullTextPlain = 0;
     EKqpFullTextRelevance = 1;
+    EKqpFullTextJson = 2;
 }
 
 message TKqpFullTextSource {

--- a/ydb/core/tx/datashard/build_index/fulltext.cpp
+++ b/ydb/core/tx/datashard/build_index/fulltext.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/base/fulltext.h>
+#include <ydb/core/base/json_index.h>
 #include <ydb/core/kqp/common/kqp_types.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 
@@ -204,10 +205,10 @@ public:
         TVector<TString> tokens;
         if (Request.GetIndexType() == NKikimrTxDataShard::EFulltextIndexType::Json) {
             if (IsBinaryJson) {
-                tokens = TokenizeBinaryJson(row.Get(0).AsBuf());
+                tokens = NJsonIndex::TokenizeBinaryJson(row.Get(0).AsBuf());
             } else {
                 TString error;
-                tokens = TokenizeJson(row.Get(0).AsBuf(), error);
+                tokens = NJsonIndex::TokenizeJson(row.Get(0).AsBuf(), error);
                 if (error != "") {
                     JsonErrors++;
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The first iteration of JSON index: only supports `SELECT ... WHERE JSON_EXISTS(...)`.

...

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

- `TokenizeJson` and `TokenizeBinaryJson` moved to a new file: `json_index.cpp` (with tests to `json_index_ut.cpp`).
- Supported reads: `SELECT * FROM table VIEW json` is rewriting as `TKqlReadTableFullTextIndex`.
- New `TQueryCollector` builds search terms (`NJsonIndex::BuildSearchTerms`) from jsonpath expressions (in progress).
- New `EKqpFullTextIndexType` index type: `EKqpFullTextJson`.
- New json tests for `SELECT ... WHERE JSON_EXISTS(...)`.

...
