### PR TITLE
fix backport cli-release-notes-2-28-0 to stable-25-3

### DIFF
--- a/ydb/docs/en/core/changelog-cli.md
+++ b/ydb/docs/en/core/changelog-cli.md
@@ -59,11 +59,11 @@ Released on October 30, 2025. To update to version **2.27.0**, select the [Downl
 ### Features
 
 * Added the `--exclude` option to the `{{ ydb-cli }} import s3` [command](./reference/ydb-cli/export-import/import-s3.md), allowing schema objects to be excluded from the import if their names match a pattern.
-* Added the `{{ ydb-cli }} admin cluster state fetch` command to collect information about cluster nodes' state and metrics.
 * Added [transfer](./concepts/transfer.md) objects support to the `{{ ydb-cli }} tools dump` [command](./reference/ydb-cli/export-import/tools-dump.md) and `{{ ydb-cli }} tools restore` [command](./reference/ydb-cli/export-import/tools-restore.md).
 * Added a new `--retention-period` option to the `{{ ydb-cli }} topic` subcommands. Usage of the legacy `--retention-period-hours` option is discouraged.
 * The `{{ ydb-cli }} topic consumer add` [command](./reference/ydb-cli/topic-consumer-add.md) now has a new `--availability-period` option, which overrides the consumer's retention guarantee.
 * The `{{ ydb-cli }} workload vector` [commands](./reference/ydb-cli/commands/workload/index.md) now support `build-index` and `drop-index` subcommands.
+* **_(Requires server v26.1+)_** Added the `{{ ydb-cli }} admin cluster state fetch` command to collect information about cluster nodes' state and metrics.
 
 ### Bug fixes
 

--- a/ydb/docs/ru/core/changelog-cli.md
+++ b/ydb/docs/ru/core/changelog-cli.md
@@ -58,11 +58,11 @@
 ### Функциональность
 
 * Добавлена опция `--exclude` в [команду](./reference/ydb-cli/export-import/import-s3.md) `{{ ydb-cli }} import s3`, позволяющая исключать схемные объекты из импорта по шаблону имени.
-* Добавлена команда `{{ ydb-cli }} admin cluster state fetch` для сбора информации о состоянии узлов кластера и метриках.
 * Добавлена поддержка объектов типа [трансфер](./concepts/transfer.md) при выполнении [команды](./reference/ydb-cli/export-import/tools-dump.md) `{{ ydb-cli }} tools dump` и [команды](./reference/ydb-cli/export-import/tools-restore.md) `{{ ydb-cli }} tools restore`.
 * Добавлена новая опция `--retention-period` в подкоманды `{{ ydb-cli }} topic`. Использование устаревшей опции `--retention-period-hours` не рекомендуется.
 * В [команде](./reference/ydb-cli/topic-consumer-add.md) `{{ ydb-cli }} topic consumer add` появилась новая опция `--availability-period`, которая переопределяет гарантию удержания для читателя.
 * В [командах](./reference/ydb-cli/commands/workload/index.md) `{{ ydb-cli }} workload vector` добавлены подкоманды `build-index` и `drop-index`.
+* **_(Требуется сервер v26.1+)_** Добавлена команда `{{ ydb-cli }} admin cluster state fetch` для сбора информации о состоянии узлов кластера и метриках.
 
 ### Исправления ошибок
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fix problems with 2.27.0. For now it looks like in the PR https://github.com/ydb-platform/ydb/pull/31185

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)
