### PR TITLE
Added METRICS_LEVEL to the public API CreateTable/AlterTable

### DIFF
--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -886,39 +886,39 @@ message ReadReplicasSettings {
 }
 
 /**
- * The level at which metrics are aggregated and reported.
- */
-enum MetricsLevel {
-    /**
-     * The metrics level is not specified.
-     */
-    METRICS_LEVEL_UNSPECIFIED = 0;
-
-    /**
-     * All metrics are disabled.
-     */
-    METRICS_LEVEL_DISABLED = 1;
-
-    /**
-     * Metrics are aggregated and reported for the entire database.
-     */
-    METRICS_LEVEL_DATABASE = 2;
-
-    /**
-     * Metrics are aggregated and reported for individual tables.
-     */
-    METRICS_LEVEL_TABLE = 3;
-
-    /**
-     * Metrics are aggregated and reported for individual partitions.
-     */
-    METRICS_LEVEL_PARTITION = 4;
-}
-
-/**
  * The parameters for the detailed metrics for the given table.
  */
 message MetricsSettings {
+    /**
+     * The level at which metrics are aggregated and reported.
+     */
+    enum MetricsLevel {
+        /**
+         * The metrics level is not specified.
+         */
+        METRICS_LEVEL_UNSPECIFIED = 0;
+
+        /**
+         * All metrics are disabled.
+         */
+        METRICS_LEVEL_DISABLED = 1;
+
+        /**
+         * Metrics are aggregated and reported for the entire database.
+         */
+        METRICS_LEVEL_DATABASE = 2;
+
+        /**
+         * Metrics are aggregated and reported for individual tables.
+         */
+        METRICS_LEVEL_TABLE = 3;
+
+        /**
+         * Metrics are aggregated and reported for individual partitions.
+         */
+        METRICS_LEVEL_PARTITION = 4;
+    }
+
     /**
      * The level at which metrics are aggregated and reported.
      *

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -59,6 +59,11 @@ message GlobalIndexSettings {
     // Partitioning settings for the table that implements the index.
     PartitioningSettings partitioning_settings = 3;
     ReadReplicasSettings read_replicas_settings = 4;
+
+    /**
+     * The metrics configuration for the given index.
+     */
+    optional MetricsSettings metrics_settings = 5;
 }
 
 message VectorIndexSettings {
@@ -880,6 +885,48 @@ message ReadReplicasSettings {
     reserved 3; // cluster_replicas_settings (part of oneof settings)
 }
 
+/**
+ * The level at which metrics are aggregated and reported.
+ */
+enum MetricsLevel {
+    /**
+     * The metrics level is not specified.
+     */
+    METRICS_LEVEL_UNSPECIFIED = 0;
+
+    /**
+     * All metrics are disabled.
+     */
+    METRICS_LEVEL_DISABLED = 1;
+
+    /**
+     * Metrics are aggregated and reported for the entire database.
+     */
+    METRICS_LEVEL_DATABASE = 2;
+
+    /**
+     * Metrics are aggregated and reported for individual tables.
+     */
+    METRICS_LEVEL_TABLE = 3;
+
+    /**
+     * Metrics are aggregated and reported for individual partitions.
+     */
+    METRICS_LEVEL_PARTITION = 4;
+}
+
+/**
+ * The parameters for the detailed metrics for the given table.
+ */
+message MetricsSettings {
+    /**
+     * The level at which metrics are aggregated and reported.
+     *
+     * @note If this value is not set, METRICS_LEVEL_DATABASE is assumed.
+     */
+    MetricsLevel metrics_level = 1;
+}
+
 enum StoreType {
     STORE_TYPE_UNSPECIFIED = 0;
     STORE_TYPE_ROW = 1;
@@ -929,6 +976,11 @@ message CreateTableRequest {
     bool temporary = 19;
     // Is table column or row oriented
     StoreType store_type = 20;
+
+    /**
+     * The metrics configuration for the given table.
+     */
+    optional MetricsSettings metrics_settings = 21;
 }
 
 message CreateTableResponse {
@@ -1033,6 +1085,14 @@ message AlterTableRequest {
     reserved 22, 23;
     // Start compaction for table
     CompactItem compact = 24;
+
+    /**
+     * Set, update or remove the metrics configuration for the given table.
+     */
+    oneof metrics_settings_action {
+        MetricsSettings set_metrics_settings = 25;
+        google.protobuf.Empty drop_metrics_settings = 26;
+    }
 }
 
 message AlterTableResponse {
@@ -1159,6 +1219,11 @@ message DescribeTableResult {
     bool temporary = 17;
     // Is table column or row oriented
     StoreType store_type = 18;
+
+    /**
+     * The metrics configuration for the given table.
+     */
+    optional MetricsSettings metrics_settings = 19;
 }
 
 message Query {

--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -418,9 +418,11 @@ void PrintTtlSettings(const NTable::TTableDescription& tableDescription, IOutput
     }
     default:
         NColorizer::TColors colors = NConsoleClient::AutoColors(out);
-        out << "(unknown):" << Endl
-            << colors.RedColor() << "Unknown ttl settings mode. Please update your version of YDB cli"
-            << colors.OldColor() << Endl;
+
+        out << colors.RedColor()
+            << "Unknown TTL settings mode: " << static_cast<int>(settings->GetMode())
+            << colors.OldColor()
+            << Endl;
     }
 
     if (settings->GetRunInterval()) {
@@ -467,8 +469,11 @@ void PrintReadReplicasSettings(const NTable::TTableDescription& tableDescription
         break;
     default:
         NColorizer::TColors colors = NConsoleClient::AutoColors(out);
-        out << colors.RedColor() << "Unknown read replicas settings mode. Please update your version of YDB cli"
-            << colors.OldColor() << Endl;
+
+        out << colors.RedColor()
+            << "Unknown read replicas settings mode: " << static_cast<int>(settings->GetMode())
+            << colors.OldColor()
+            << Endl;
     }
 }
 
@@ -511,7 +516,7 @@ void PrintMetricsSettings(const NTable::TTableDescription& tableDescription, IOu
         NColorizer::TColors colors = NConsoleClient::AutoColors(out);
 
         out << colors.RedColor()
-            << "Unknown metrics level. Please update your version of YDB cli"
+            << "Unknown metrics level: " << static_cast<int>(settings->GetMetricsLevel())
             << colors.OldColor()
             << Endl;
 

--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -472,6 +472,53 @@ void PrintReadReplicasSettings(const NTable::TTableDescription& tableDescription
     }
 }
 
+/**
+ * Print the configuration for the table metrics.
+ *
+ * @param[in] tableDescription The description of the table
+ * @param[in] out The output stream to print to
+ */
+void PrintMetricsSettings(const NTable::TTableDescription& tableDescription, IOutputStream& out) {
+    const auto& settings = tableDescription.GetMetricsSettings();
+    if (!settings) {
+        return;
+    }
+
+    out << Endl << "Metrics settings: " << Endl;
+
+    switch (settings->GetMetricsLevel()) {
+    case NTable::TMetricsSettings::EMetricsLevel::Unspecified:
+        out << "Metrics level: UNSPECIFIED" << Endl;
+        break;
+
+    case NTable::TMetricsSettings::EMetricsLevel::Disabled:
+        out << "Metrics level: DISABLED" << Endl;
+        break;
+
+    case NTable::TMetricsSettings::EMetricsLevel::Database:
+        out << "Metrics level: DATABASE" << Endl;
+        break;
+
+    case NTable::TMetricsSettings::EMetricsLevel::Table:
+        out << "Metrics level: TABLE" << Endl;
+        break;
+
+    case NTable::TMetricsSettings::EMetricsLevel::Partition:
+        out << "Metrics level: PARTITION" << Endl;
+        break;
+
+    default:
+        NColorizer::TColors colors = NConsoleClient::AutoColors(out);
+
+        out << colors.RedColor()
+            << "Unknown metrics level. Please update your version of YDB cli"
+            << colors.OldColor()
+            << Endl;
+
+        break;
+    }
+}
+
 void PrintStatistics(const NTable::TTableDescription& tableDescription, IOutputStream& out) {
     out << Endl << "Table stats:" << Endl;
     out << "Partitions count: " << tableDescription.GetPartitionsCount() << Endl;
@@ -773,6 +820,7 @@ int TDescribeLogic::PrintTableResponsePretty(const NTable::TTableDescription& ta
             << (tableDescription.GetKeyBloomFilter().value() ? "true" : "false") << Endl;
     }
     PrintReadReplicasSettings(tableDescription, Out);
+    PrintMetricsSettings(tableDescription, Out);
     PrintPermissionsIfNeeded(tableDescription, options);
     if (options.ShowStats) {
         PrintStatistics(tableDescription, Out);

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -8,3 +8,5 @@ Each message can be associated with a partitioning key, which is used to determi
 * Removed the `layout` field from `FulltextIndexSettings` and replaced it with separate index types in `TableIndexDescription`.
   `layout` was a preliminary version of API, actual YDB release 26-1 uses separate index types, so please note that creating
   full text indexes via gRPC won't work with previous versions of SDK.
+
+* Added support for METRICS_LEVEL for the CreateTable/AlterTable requests.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -34,6 +34,7 @@ class KMeansTreeSettings;
 class FulltextIndexSettings;
 class PartitioningSettings;
 class ReadReplicasSettings;
+class MetricsSettings;
 class DateTypeColumnModeSettings;
 class TtlSettings;
 class TtlTier;
@@ -229,6 +230,70 @@ private:
     uint64_t ReadReplicasCount_;
 };
 
+/**
+ * The parameters for the detailed metrics for the given table.
+ */
+class TMetricsSettings {
+public:
+    /**
+     * The level at which metrics are aggregated and reported.
+     */
+    enum class EMetricsLevel {
+        /**
+         * The metrics level is not specified.
+         */
+        Unspecified = 0,
+
+        /**
+         * All metrics are disabled.
+         */
+        Disabled = 1,
+
+        /**
+         * Metrics are aggregated and reported for the entire database.
+         */
+        Database = 2,
+
+        /**
+         * Metrics are aggregated and reported for individual tables.
+         */
+        Table = 3,
+
+        /**
+         * Metrics are aggregated and reported for individual partitions.
+         */
+        Partition = 4,
+    };
+
+    TMetricsSettings(EMetricsLevel metricsLevel);
+
+    /**
+     * Return the configured metrics level.
+     *
+     * @return The metrics level
+     */
+    EMetricsLevel GetMetricsLevel() const;
+
+    /**
+     * Read the metrics configuration from the corresponding protobuf message.
+     *
+     * @param[in] proto The message to read from
+     *
+     * @return The corresponding metrics configuration
+     */
+    static std::optional<TMetricsSettings> FromProto(const Ydb::Table::MetricsSettings& proto);
+
+    /**
+     * Read the metrics configuration to the corresponding protobuf message.
+     *
+     * @param[in,out] proto The message to write to
+     */
+    void SerializeTo(Ydb::Table::MetricsSettings& proto) const;
+
+private:
+    EMetricsLevel MetricsLevel;
+};
+
 struct TGlobalIndexSettings {
     static constexpr const int VectorKMeansTreeLevelTablePosition = 0;
     static constexpr const int VectorKMeansTreePostingTablePosition = 1;
@@ -243,6 +308,7 @@ struct TGlobalIndexSettings {
     TPartitioningSettings PartitioningSettings;
     TUniformOrExplicitPartitions Partitions;
     std::optional<TReadReplicasSettings> ReadReplicasSettings;
+    std::optional<TMetricsSettings> MetricsSettings;
 
     static TGlobalIndexSettings FromProto(const Ydb::Table::GlobalIndexSettings& proto);
 
@@ -680,6 +746,100 @@ private:
     > Action_;
 };
 
+/**
+ * The holder for the detailed metrics configuration for the ALTER TABLE request.
+ */
+class TAlterMetricsSettings {
+private:
+    /**
+     * The constructor, which configures the ALTER TABLE request to remove
+     * the current metrics configuration.
+     */
+    TAlterMetricsSettings()
+        : Action(true)
+    {}
+
+    /**
+     * The constructor, which configures the ALTER TABLE request to use
+     * the given metrics configuration.
+     *
+     * @tparam Args The types of arguments for the TMetricsSettings constructor
+     *
+     * @param[in] args The arguments for the TMetricsSettings constructor
+     */
+    template <typename... Args>
+    explicit TAlterMetricsSettings(Args&&... args)
+        : Action(TMetricsSettings(std::forward<Args>(args)...))
+    {}
+
+public:
+    /**
+     * The type of the action for the metrics configuration in the ALTER TABLE request.
+     */
+    enum class EAction {
+        /**
+         * Remove the current metrics configuration.
+         */
+        Drop = 0,
+
+        /**
+         * Set the metrics configuration to the given values.
+         */
+        Set = 1,
+    };
+
+    /**
+     * Configure the ALTER TABLE request to remove the current metrics configuration.
+     *
+     * @return The metrics configuration holder for the EAction::Drop action
+     */
+    static TAlterMetricsSettings Drop() {
+        return TAlterMetricsSettings();
+    }
+
+    /**
+     * Configure the ALTER TABLE request to remove the current metrics configuration.
+     *
+     * @tparam Args The types of arguments for the TMetricsSettings constructor
+     *
+     * @param[in] args The arguments for the TMetricsSettings constructor
+     *
+     * @return The metrics configuration holder for the EAction::Drop action
+     */
+    template <typename... Args>
+    static TAlterMetricsSettings Set(Args&&... args) {
+        return TAlterMetricsSettings(std::forward<Args>(args)...);
+    }
+
+    /**
+     * Return the action for the metrics configuration (drop or set).
+     *
+     * @return The action for the metrics configuration
+     */
+    EAction GetAction() const {
+        return static_cast<EAction>(Action.index());
+    }
+
+    /**
+     * Return the current metrics configuration.
+     *
+     * @return The current metrics configuration
+     */
+    const TMetricsSettings& GetMetricsSettings() const {
+        return std::get<TMetricsSettings>(Action);
+    }
+
+private:
+    /**
+     * The holder for the current metrics configuration.
+     *
+     * @note If the first variant is set, the metrics configuration will be removed.
+     *       If the second variant is set, the metrics configuration will be set
+     *       to the given values.
+     */
+    std::variant<bool, TMetricsSettings> Action;
+};
+
 //! Represents table storage settings
 class TStorageSettings {
 public:
@@ -786,6 +946,13 @@ public:
     // Returns read replicas settings of the table
     std::optional<TReadReplicasSettings> GetReadReplicasSettings() const;
 
+    /**
+     * Return the metrics configuration for the given table.
+     *
+     * @return The metrics configuration
+     */
+    std::optional<TMetricsSettings> GetMetricsSettings() const;
+
     // Fills CreateTableRequest proto from this description
     void SerializeTo(Ydb::Table::CreateTableRequest& request) const;
 
@@ -837,6 +1004,14 @@ private:
     void SetPartitioningSettings(const TPartitioningSettings& settings);
     void SetKeyBloomFilter(bool enabled);
     void SetReadReplicasSettings(TReadReplicasSettings::EMode mode, uint64_t readReplicasCount);
+
+    /**
+     * Set the metrics configuration for the given table.
+     *
+     * @param[in] metricsLevel The metrics level
+     */
+    void SetMetricsSettings(TMetricsSettings::EMetricsLevel metricsLevel);
+
     void SetStoreType(EStoreType type);
     const Ydb::Table::DescribeTableResult& GetProto() const;
 
@@ -1094,6 +1269,15 @@ public:
     TTableBuilder& SetKeyBloomFilter(bool enabled);
 
     TTableBuilder& SetReadReplicasSettings(TReadReplicasSettings::EMode mode, uint64_t readReplicasCount);
+
+    /**
+     * Set the metrics configuration for the given table.
+     *
+     * @param[in] metricsLevel The metrics level
+     *
+     * @return The instance of the builder itself
+     */
+    TTableBuilder& SetMetricsSettings(TMetricsSettings::EMetricsLevel metricsLevel);
 
     TTableStorageSettingsBuilder BeginStorageSettings() {
         return TTableStorageSettingsBuilder(*this);
@@ -1634,6 +1818,66 @@ private:
     std::shared_ptr<TImpl> Impl_;
 };
 
+/**
+ * The builder for the metrics configuration for the ALTER TABLE request.
+ */
+class TAlterMetricsSettingsBuilder {
+public:
+    /**
+     * Start the process of building the metrics configuration for the ALTER TABLE request.
+     *
+     * @param[in] parent The instance of the ALTER TABLE request builder
+     */
+    TAlterMetricsSettingsBuilder(TAlterTableSettings& parent);
+
+    /**
+     * Configure the ALTER TABLE request to remove the metrics configuration.
+     *
+     * @return The instance of this builder
+     */
+    TAlterMetricsSettingsBuilder& Drop();
+
+    /**
+     * Configure the ALTER TABLE request to use the given metrics configuration.
+     *
+     * @param[in] settings The metrics configuration to use
+     *
+     * @return The instance of this builder
+     */
+    TAlterMetricsSettingsBuilder& Set(TMetricsSettings&& settings);
+
+    /**
+     * Configure the ALTER TABLE request to use the given metrics configuration.
+     *
+     * @param[in] settings The metrics configuration to use
+     *
+     * @return The instance of this builder
+     */
+    TAlterMetricsSettingsBuilder& Set(const TMetricsSettings& settings);
+
+    /**
+     * Configure the ALTER TABLE request to use the given metrics level.
+     *
+     * @param[in] metricsLevel The metrics level
+     *
+     * @return The instance of this builder
+     */
+    TAlterMetricsSettingsBuilder& Set(TMetricsSettings::EMetricsLevel metricsLevel);
+
+    /**
+     * Complete the building process and finalize the metrics configuration.
+     *
+     * @return The instance of the ALTER TABLE request builder
+     */
+    TAlterTableSettings& EndAlterMetricsSettings();
+
+private:
+    TAlterTableSettings& Parent;
+
+    class TImpl;
+    std::shared_ptr<TImpl> Impl;
+};
+
 class TAlterAttributesBuilder {
 public:
     TAlterAttributesBuilder(TAlterTableSettings& parent)
@@ -1760,6 +2004,31 @@ struct TAlterTableSettings : public TOperationRequestSettings<TAlterTableSetting
     TAlterTtlSettingsBuilder BeginAlterTtlSettings() {
         return TAlterTtlSettingsBuilder(*this);
     }
+
+    /**
+     * Start the process of updating the metrics configuration for the ALTER TABLE request.
+     *
+     * @return The instance of the metrics configuration builder
+     */
+    TAlterMetricsSettingsBuilder BeginAlterMetricsSettings() {
+        return TAlterMetricsSettingsBuilder(*this);
+    }
+
+    /**
+     * Return the current metrics configuration for the ALTER TABLE request.
+     *
+     * @return The current metrics configuration
+     */
+    const std::optional<TAlterMetricsSettings>& GetAlterMetricsSettings() const;
+
+    /**
+     * Update the metrics configuration for the ALTER TABLE request.
+     *
+     * @param[in] settings The metrics configuration to use
+     *
+     * @return The instance of this builder
+     */
+    TSelf& SetAlterMetricsSettings(const std::optional<TAlterMetricsSettings>& settings);
 
     TAlterAttributesBuilder BeginAlterAttributes() {
         return TAlterAttributesBuilder(*this);

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -265,7 +265,7 @@ public:
         Partition = 4,
     };
 
-    TMetricsSettings(EMetricsLevel metricsLevel);
+    explicit TMetricsSettings(EMetricsLevel metricsLevel);
 
     /**
      * Return the configured metrics level.
@@ -291,7 +291,7 @@ public:
     void SerializeTo(Ydb::Table::MetricsSettings& proto) const;
 
 private:
-    EMetricsLevel MetricsLevel;
+    EMetricsLevel MetricsLevel_;
 };
 
 struct TGlobalIndexSettings {
@@ -712,9 +712,7 @@ private:
 class TAlterTtlSettings {
     using EUnit = TValueSinceUnixEpochModeSettings::EUnit;
 
-    TAlterTtlSettings()
-        : Action_(true)
-    {}
+    TAlterTtlSettings() = default;
 
     template <typename... Args>
     explicit TAlterTtlSettings(Args&&... args)
@@ -741,7 +739,7 @@ public:
 
 private:
     std::variant<
-        bool, // EAction::Drop
+        std::monostate, // EAction::Drop
         TTtlSettings // EAction::Set
     > Action_;
 };
@@ -755,9 +753,7 @@ private:
      * The constructor, which configures the ALTER TABLE request to remove
      * the current metrics configuration.
      */
-    TAlterMetricsSettings()
-        : Action(true)
-    {}
+    TAlterMetricsSettings() = default;
 
     /**
      * The constructor, which configures the ALTER TABLE request to use
@@ -769,7 +765,7 @@ private:
      */
     template <typename... Args>
     explicit TAlterMetricsSettings(Args&&... args)
-        : Action(TMetricsSettings(std::forward<Args>(args)...))
+        : Action_(TMetricsSettings(std::forward<Args>(args)...))
     {}
 
 public:
@@ -798,13 +794,13 @@ public:
     }
 
     /**
-     * Configure the ALTER TABLE request to remove the current metrics configuration.
+     * Configure the ALTER TABLE request to update the current metrics configuration.
      *
      * @tparam Args The types of arguments for the TMetricsSettings constructor
      *
      * @param[in] args The arguments for the TMetricsSettings constructor
      *
-     * @return The metrics configuration holder for the EAction::Drop action
+     * @return The metrics configuration holder for the EAction::Set action
      */
     template <typename... Args>
     static TAlterMetricsSettings Set(Args&&... args) {
@@ -817,7 +813,7 @@ public:
      * @return The action for the metrics configuration
      */
     EAction GetAction() const {
-        return static_cast<EAction>(Action.index());
+        return static_cast<EAction>(Action_.index());
     }
 
     /**
@@ -826,7 +822,7 @@ public:
      * @return The current metrics configuration
      */
     const TMetricsSettings& GetMetricsSettings() const {
-        return std::get<TMetricsSettings>(Action);
+        return std::get<TMetricsSettings>(Action_);
     }
 
 private:
@@ -837,7 +833,7 @@ private:
      *       If the second variant is set, the metrics configuration will be set
      *       to the given values.
      */
-    std::variant<bool, TMetricsSettings> Action;
+    std::variant<std::monostate, TMetricsSettings> Action_;
 };
 
 //! Represents table storage settings
@@ -1872,10 +1868,10 @@ public:
     TAlterTableSettings& EndAlterMetricsSettings();
 
 private:
-    TAlterTableSettings& Parent;
+    TAlterTableSettings& Parent_;
 
     class TImpl;
-    std::shared_ptr<TImpl> Impl;
+    std::shared_ptr<TImpl> Impl_;
 };
 
 class TAlterAttributesBuilder {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -2503,7 +2503,7 @@ void TReadReplicasSettings::SerializeTo(Ydb::Table::ReadReplicasSettings& proto)
     }
 }
 
-std::optional<TMetricsSettings> TMetricsSettings::TMetricsSettings::FromProto(
+std::optional<TMetricsSettings> TMetricsSettings::FromProto(
     const Ydb::Table::MetricsSettings& proto
 ) {
     switch (proto.metrics_level()) {
@@ -3756,14 +3756,11 @@ TAlterTableSettings& TAlterTtlSettingsBuilder::EndAlterTtlSettings() {
  */
 class TAlterMetricsSettingsBuilder::TImpl {
 public:
-    TImpl() {
-    }
-
     /**
      * Configure the ALTER TABLE request to remove the metrics configuration.
      */
     void Drop() {
-        AlterMetricsSettings = TAlterMetricsSettings::Drop();
+        AlterMetricsSettings_ = TAlterMetricsSettings::Drop();
     }
 
     /**
@@ -3772,7 +3769,7 @@ public:
      * @param[in] settings The metrics configuration to use
      */
     void Set(TMetricsSettings&& settings) {
-        AlterMetricsSettings = TAlterMetricsSettings::Set(std::move(settings));
+        AlterMetricsSettings_ = TAlterMetricsSettings::Set(std::move(settings));
     }
 
     /**
@@ -3781,7 +3778,7 @@ public:
      * @param[in] settings The metrics configuration to use
      */
     void Set(const TMetricsSettings& settings) {
-        AlterMetricsSettings = TAlterMetricsSettings::Set(settings);
+        AlterMetricsSettings_ = TAlterMetricsSettings::Set(settings);
     }
 
     /**
@@ -3790,30 +3787,30 @@ public:
      * @return The current metrics configuration
      */
     const std::optional<TAlterMetricsSettings>& GetAlterMetricsSettings() const {
-        return AlterMetricsSettings;
+        return AlterMetricsSettings_;
     }
 
 private:
-    std::optional<TAlterMetricsSettings> AlterMetricsSettings;
+    std::optional<TAlterMetricsSettings> AlterMetricsSettings_;
 };
 
 TAlterMetricsSettingsBuilder::TAlterMetricsSettingsBuilder(TAlterTableSettings& parent)
-    : Parent(parent)
-    , Impl(std::make_shared<TImpl>())
+    : Parent_(parent)
+    , Impl_(std::make_shared<TImpl>())
 { }
 
 TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Drop() {
-    Impl->Drop();
+    Impl_->Drop();
     return *this;
 }
 
 TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(TMetricsSettings&& settings) {
-    Impl->Set(std::move(settings));
+    Impl_->Set(std::move(settings));
     return *this;
 }
 
 TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(const TMetricsSettings& settings) {
-    Impl->Set(settings);
+    Impl_->Set(settings);
     return *this;
 }
 
@@ -3822,7 +3819,7 @@ TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(TMetricsSettings
 }
 
 TAlterTableSettings& TAlterMetricsSettingsBuilder::EndAlterMetricsSettings() {
-    return Parent.SetAlterMetricsSettings(Impl->GetAlterMetricsSettings());
+    return Parent_.SetAlterMetricsSettings(Impl_->GetAlterMetricsSettings());
 }
 
 class TAlterTableSettings::TImpl {
@@ -3843,7 +3840,7 @@ public:
      * @param[in] settings The metrics configuration to use
      */
     void SetAlterMetricsSettings(const std::optional<TAlterMetricsSettings>& settings) {
-        AlterMetricsSettings = settings;
+        AlterMetricsSettings_ = settings;
     }
 
     /**
@@ -3852,12 +3849,12 @@ public:
      * @return The current metrics configuration
      */
     const std::optional<TAlterMetricsSettings>& GetAlterMetricsSettings() const {
-        return AlterMetricsSettings;
+        return AlterMetricsSettings_;
     }
 
 private:
     std::optional<TAlterTtlSettings> AlterTtlSettings_;
-    std::optional<TAlterMetricsSettings> AlterMetricsSettings;
+    std::optional<TAlterMetricsSettings> AlterMetricsSettings_;
 };
 
 TAlterTableSettings::TAlterTableSettings()
@@ -3900,11 +3897,11 @@ uint64_t TReadReplicasSettings::GetReadReplicasCount() const {
 }
 
 TMetricsSettings::TMetricsSettings(EMetricsLevel metricsLevel)
-    : MetricsLevel(metricsLevel) {
+    : MetricsLevel_(metricsLevel) {
 }
 
 TMetricsSettings::EMetricsLevel TMetricsSettings::GetMetricsLevel() const {
-    return MetricsLevel;
+    return MetricsLevel_;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -2507,19 +2507,19 @@ std::optional<TMetricsSettings> TMetricsSettings::TMetricsSettings::FromProto(
     const Ydb::Table::MetricsSettings& proto
 ) {
     switch (proto.metrics_level()) {
-    case Ydb::Table::METRICS_LEVEL_UNSPECIFIED:
+    case Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED:
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Unspecified);
 
-    case Ydb::Table::METRICS_LEVEL_DISABLED:
+    case Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED:
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Disabled);
 
-    case Ydb::Table::METRICS_LEVEL_DATABASE:
+    case Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE:
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Database);
 
-    case Ydb::Table::METRICS_LEVEL_TABLE:
+    case Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE:
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Table);
 
-    case Ydb::Table::METRICS_LEVEL_PARTITION:
+    case Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION:
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Partition);
 
     default:
@@ -2536,23 +2536,23 @@ std::optional<TMetricsSettings> TMetricsSettings::TMetricsSettings::FromProto(
 void TMetricsSettings::SerializeTo(Ydb::Table::MetricsSettings& proto) const {
     switch (GetMetricsLevel()) {
     case EMetricsLevel::Unspecified:
-        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_UNSPECIFIED);
+        proto.set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED);
         break;
 
     case EMetricsLevel::Disabled:
-        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_DISABLED);
+        proto.set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED);
         break;
 
     case EMetricsLevel::Database:
-        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_DATABASE);
+        proto.set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE);
         break;
 
     case EMetricsLevel::Table:
-        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_TABLE);
+        proto.set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE);
         break;
 
     case EMetricsLevel::Partition:
-        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_PARTITION);
+        proto.set_metrics_level(Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION);
         break;
     }
 }

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -379,6 +379,10 @@ class TTableDescription::TImpl {
 
         // read replicas settings
         ReadReplicasSettings_ = TReadReplicasSettings::FromProto(proto.read_replicas_settings());
+
+        if (proto.has_metrics_settings()) {
+            MetricsSettings_ = TMetricsSettings::FromProto(proto.metrics_settings());
+        }
     }
 
 public:
@@ -546,6 +550,15 @@ public:
         ReadReplicasSettings_ = TReadReplicasSettings(mode, readReplicasCount);
     }
 
+    /**
+     * Set the metrics configuration for the given table.
+     *
+     * @param[in] metricsLevel The metrics level
+     */
+    void SetMetricsSettings(TMetricsSettings::EMetricsLevel metricsLevel) {
+        MetricsSettings_ = TMetricsSettings(metricsLevel);
+    }
+
     void SetStoreType(EStoreType type) {
         StoreType_ = type;
     }
@@ -642,6 +655,15 @@ public:
         return ReadReplicasSettings_;
     }
 
+    /**
+     * Return the metrics configuration for the given table.
+     *
+     * @return The metrics configuration
+     */
+    const std::optional<TMetricsSettings>& GetMetricsSettings() const {
+        return MetricsSettings_;
+    }
+
 private:
     Ydb::Table::DescribeTableResult Proto_;
     TStorageSettings StorageSettings_;
@@ -664,6 +686,7 @@ private:
     TPartitioningSettings PartitioningSettings_;
     std::optional<bool> KeyBloomFilter_;
     std::optional<TReadReplicasSettings> ReadReplicasSettings_;
+    std::optional<TMetricsSettings> MetricsSettings_;
     bool HasStorageSettings_ = false;
     bool HasPartitioningSettings_ = false;
     EStoreType StoreType_ = EStoreType::Row;
@@ -868,6 +891,10 @@ void TTableDescription::SetReadReplicasSettings(TReadReplicasSettings::EMode mod
     Impl_->SetReadReplicasSettings(mode, readReplicasCount);
 }
 
+void TTableDescription::SetMetricsSettings(TMetricsSettings::EMetricsLevel metricsLevel) {
+    Impl_->SetMetricsSettings(metricsLevel);
+}
+
 void TTableDescription::SetStoreType(EStoreType type) {
     Impl_->SetStoreType(type);
 }
@@ -918,6 +945,10 @@ std::optional<bool> TTableDescription::GetKeyBloomFilter() const {
 
 std::optional<TReadReplicasSettings> TTableDescription::GetReadReplicasSettings() const {
     return Impl_->GetReadReplicasSettings();
+}
+
+std::optional<TMetricsSettings> TTableDescription::GetMetricsSettings() const {
+    return Impl_->GetMetricsSettings();
 }
 
 const Ydb::Table::DescribeTableResult& TTableDescription::GetProto() const {
@@ -1001,6 +1032,10 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
 
     if (const auto& settings = Impl_->GetReadReplicasSettings()) {
         settings->SerializeTo(*request.mutable_read_replicas_settings());
+    }
+
+    if (const auto& settings = Impl_->GetMetricsSettings()) {
+        settings->SerializeTo(*request.mutable_metrics_settings());
     }
 }
 
@@ -1391,6 +1426,11 @@ TTableBuilder& TTableBuilder::SetKeyBloomFilter(bool enabled) {
 
 TTableBuilder& TTableBuilder::SetReadReplicasSettings(TReadReplicasSettings::EMode mode, uint64_t readReplicasCount) {
     TableDescription_.SetReadReplicasSettings(mode, readReplicasCount);
+    return *this;
+}
+
+TTableBuilder& TTableBuilder::SetMetricsSettings(TMetricsSettings::EMetricsLevel metricsLevel) {
+    TableDescription_.SetMetricsSettings(metricsLevel);
     return *this;
 }
 
@@ -1808,6 +1848,17 @@ static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
     if (settings.SetReadReplicasSettings_.has_value()) {
         const auto& replSettings = settings.SetReadReplicasSettings_.value();
         replSettings.SerializeTo(*request.mutable_set_read_replicas_settings());
+    }
+
+    if (const auto& metricsSettings = settings.GetAlterMetricsSettings()) {
+        switch (metricsSettings->GetAction()) {
+        case TAlterMetricsSettings::EAction::Set:
+            metricsSettings->GetMetricsSettings().SerializeTo(*request.mutable_set_metrics_settings());
+            break;
+        case TAlterMetricsSettings::EAction::Drop:
+            request.mutable_drop_metrics_settings();
+            break;
+        }
     }
 
     return request;
@@ -2452,6 +2503,61 @@ void TReadReplicasSettings::SerializeTo(Ydb::Table::ReadReplicasSettings& proto)
     }
 }
 
+std::optional<TMetricsSettings> TMetricsSettings::TMetricsSettings::FromProto(
+    const Ydb::Table::MetricsSettings& proto
+) {
+    switch (proto.metrics_level()) {
+    case Ydb::Table::METRICS_LEVEL_UNSPECIFIED:
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Unspecified);
+
+    case Ydb::Table::METRICS_LEVEL_DISABLED:
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Disabled);
+
+    case Ydb::Table::METRICS_LEVEL_DATABASE:
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Database);
+
+    case Ydb::Table::METRICS_LEVEL_TABLE:
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Table);
+
+    case Ydb::Table::METRICS_LEVEL_PARTITION:
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Partition);
+
+    default:
+        // Unknown metrics level, ignore the metrics settings completely
+        return {};
+    }
+}
+
+/**
+ * Read the metrics configuration to the corresponding protobuf message.
+ *
+ * @param[in,out] proto The message to write to
+ */
+void TMetricsSettings::SerializeTo(Ydb::Table::MetricsSettings& proto) const {
+    switch (GetMetricsLevel()) {
+    case EMetricsLevel::Unspecified:
+        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_UNSPECIFIED);
+        break;
+
+    case EMetricsLevel::Disabled:
+        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_DISABLED);
+        break;
+
+    case EMetricsLevel::Database:
+        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_DATABASE);
+        break;
+
+    case EMetricsLevel::Table:
+        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_TABLE);
+        break;
+
+    case EMetricsLevel::Partition:
+        proto.set_metrics_level(Ydb::Table::METRICS_LEVEL_PARTITION);
+        break;
+    }
+}
+
+
 TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalIndexSettings& proto) {
     auto partitionsFromProto = [](const Ydb::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
         switch (proto.partitions_case()) {
@@ -2464,10 +2570,17 @@ TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalInd
         }
     };
 
+    std::optional<TMetricsSettings> metricsSettings;
+
+    if (proto.has_metrics_settings()) {
+        metricsSettings = TMetricsSettings::FromProto(proto.metrics_settings());
+    }
+
     return {
         .PartitioningSettings = TPartitioningSettings(proto.partitioning_settings()),
         .Partitions = partitionsFromProto(proto),
-        .ReadReplicasSettings = TReadReplicasSettings::FromProto(proto.read_replicas_settings())
+        .ReadReplicasSettings = TReadReplicasSettings::FromProto(proto.read_replicas_settings()),
+        .MetricsSettings = metricsSettings,
     };
 }
 
@@ -2486,6 +2599,10 @@ void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings
 
     if (ReadReplicasSettings) {
         ReadReplicasSettings->SerializeTo(*settings.mutable_read_replicas_settings());
+    }
+
+    if (MetricsSettings) {
+        MetricsSettings->SerializeTo(*settings.mutable_metrics_settings());
     }
 }
 
@@ -3633,6 +3750,81 @@ TAlterTableSettings& TAlterTtlSettingsBuilder::EndAlterTtlSettings() {
     return Parent_.AlterTtlSettings(Impl_->GetAlterTtlSettings());
 }
 
+/**
+ * The implementation of the builder for the metrics configuration
+ * for the ALTER TABLE request.
+ */
+class TAlterMetricsSettingsBuilder::TImpl {
+public:
+    TImpl() {
+    }
+
+    /**
+     * Configure the ALTER TABLE request to remove the metrics configuration.
+     */
+    void Drop() {
+        AlterMetricsSettings = TAlterMetricsSettings::Drop();
+    }
+
+    /**
+     * Configure the ALTER TABLE request to use the given metrics configuration.
+     *
+     * @param[in] settings The metrics configuration to use
+     */
+    void Set(TMetricsSettings&& settings) {
+        AlterMetricsSettings = TAlterMetricsSettings::Set(std::move(settings));
+    }
+
+    /**
+     * Configure the ALTER TABLE request to use the given metrics configuration.
+     *
+     * @param[in] settings The metrics configuration to use
+     */
+    void Set(const TMetricsSettings& settings) {
+        AlterMetricsSettings = TAlterMetricsSettings::Set(settings);
+    }
+
+    /**
+     * Return the current metrics configuration.
+     *
+     * @return The current metrics configuration
+     */
+    const std::optional<TAlterMetricsSettings>& GetAlterMetricsSettings() const {
+        return AlterMetricsSettings;
+    }
+
+private:
+    std::optional<TAlterMetricsSettings> AlterMetricsSettings;
+};
+
+TAlterMetricsSettingsBuilder::TAlterMetricsSettingsBuilder(TAlterTableSettings& parent)
+    : Parent(parent)
+    , Impl(std::make_shared<TImpl>())
+{ }
+
+TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Drop() {
+    Impl->Drop();
+    return *this;
+}
+
+TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(TMetricsSettings&& settings) {
+    Impl->Set(std::move(settings));
+    return *this;
+}
+
+TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(const TMetricsSettings& settings) {
+    Impl->Set(settings);
+    return *this;
+}
+
+TAlterMetricsSettingsBuilder& TAlterMetricsSettingsBuilder::Set(TMetricsSettings::EMetricsLevel metricsLevel) {
+    return Set(TMetricsSettings(metricsLevel));
+}
+
+TAlterTableSettings& TAlterMetricsSettingsBuilder::EndAlterMetricsSettings() {
+    return Parent.SetAlterMetricsSettings(Impl->GetAlterMetricsSettings());
+}
+
 class TAlterTableSettings::TImpl {
 public:
     TImpl() { }
@@ -3645,8 +3837,27 @@ public:
         return AlterTtlSettings_;
     }
 
+    /**
+     * Update the metrics configuration for the ALTER TABLE request.
+     *
+     * @param[in] settings The metrics configuration to use
+     */
+    void SetAlterMetricsSettings(const std::optional<TAlterMetricsSettings>& settings) {
+        AlterMetricsSettings = settings;
+    }
+
+    /**
+     * Return the current metrics configuration for the ALTER TABLE request.
+     *
+     * @return The current metrics configuration
+     */
+    const std::optional<TAlterMetricsSettings>& GetAlterMetricsSettings() const {
+        return AlterMetricsSettings;
+    }
+
 private:
     std::optional<TAlterTtlSettings> AlterTtlSettings_;
+    std::optional<TAlterMetricsSettings> AlterMetricsSettings;
 };
 
 TAlterTableSettings::TAlterTableSettings()
@@ -3662,6 +3873,17 @@ const std::optional<TAlterTtlSettings>& TAlterTableSettings::GetAlterTtlSettings
     return Impl_->GetAlterTtlSettings();
 }
 
+const std::optional<TAlterMetricsSettings>& TAlterTableSettings::GetAlterMetricsSettings() const {
+    return Impl_->GetAlterMetricsSettings();
+}
+
+TAlterTableSettings& TAlterTableSettings::SetAlterMetricsSettings(
+    const std::optional<TAlterMetricsSettings>& settings
+) {
+    Impl_->SetAlterMetricsSettings(settings);
+    return *this;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TReadReplicasSettings::TReadReplicasSettings(EMode mode, uint64_t readReplicasCount)
@@ -3675,6 +3897,14 @@ TReadReplicasSettings::EMode TReadReplicasSettings::GetMode() const {
 
 uint64_t TReadReplicasSettings::GetReadReplicasCount() const {
     return ReadReplicasCount_;
+}
+
+TMetricsSettings::TMetricsSettings(EMetricsLevel metricsLevel)
+    : MetricsLevel(metricsLevel) {
+}
+
+TMetricsSettings::EMetricsLevel TMetricsSettings::GetMetricsLevel() const {
+    return MetricsLevel;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -2523,8 +2523,7 @@ std::optional<TMetricsSettings> TMetricsSettings::FromProto(
         return TMetricsSettings(TMetricsSettings::EMetricsLevel::Partition);
 
     default:
-        // Unknown metrics level, ignore the metrics settings completely
-        return {};
+        return TMetricsSettings(TMetricsSettings::EMetricsLevel::Unspecified);
     }
 }
 

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -10,6 +10,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include <gtest/gtest.h>
+
 using namespace NYdb;
 
 namespace {
@@ -157,302 +159,299 @@ namespace {
 } // namespace <anonymous>
 
 /**
- * The unit tests for the Table client in the C++ SDK.
+ * Verify that the SDK creates the CREATE TABLE request correctly,
+ * when no metrics configuration is provided.
  */
-Y_UNIT_TEST_SUITE(Table) {
-    /**
-     * Verify that the SDK creates the CREATE TABLE request correctly,
-     * when no metrics configuration is provided.
-     */
-    Y_UNIT_TEST(CreateTableNoMetricsSettings) {
-        // Start the mocked table API service
-        TMockTableService tableService;
-        std::unique_ptr<grpc::Server> grpcServer;
-        std::unique_ptr<TDriver> driver;
-        std::unique_ptr<NTable::TTableClient> tableClient;
-        std::unique_ptr<NTable::TSession> tableSession;
+TEST(TableTest, CreateTableNoMetricsSettings) {
+    // Start the mocked table API service
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
 
-        StartServerWithTableService(
-            tableService,
-            grpcServer,
-            driver,
-            tableClient,
-            tableSession
-        );
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
 
-        // Call the CreateTable() API without any metrics configuration
+    // Call the CreateTable() API without any metrics configuration
+    auto requestFuture = tableSession->CreateTable(
+        "/Root/My/DB/test_table",
+        NTable::TTableBuilder()
+            .Build()
+    );
+
+    ASSERT_TRUE(requestFuture.Wait(TDuration::Seconds(10)));
+
+    auto result = requestFuture.ExtractValueSync();
+    ASSERT_TRUE(result.IsSuccess());
+
+    // Make sure the metrics configuration was not set in the CreateTable request
+    ASSERT_TRUE(tableService.LastCreateTableRequest.has_value());
+    ASSERT_TRUE(!tableService.LastCreateTableRequest->has_metrics_settings());
+}
+
+/**
+ * Verify that the SDK creates the CREATE TABLE request correctly,
+ * when the metrics configuration is provided.
+ */
+TEST(TableTest, CreateTableWithMetricsSettings) {
+    // Start the mocked table API service
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    // Call the CreateTable() API with the metrics configuration configured
+    // to every allowed metrics level
+    const auto verifyMetricsLevelFunc = [&](
+        const TString& metricsLevelName,
+        NTable::TMetricsSettings::EMetricsLevel metricsLevel,
+        Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
+    ) {
+        SCOPED_TRACE(testing::Message() << "Metrics level: " << metricsLevelName);
+
         auto requestFuture = tableSession->CreateTable(
             "/Root/My/DB/test_table",
             NTable::TTableBuilder()
+                .SetMetricsSettings(metricsLevel)
                 .Build()
         );
 
-        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+        ASSERT_TRUE(requestFuture.Wait(TDuration::Seconds(10)));
 
         auto result = requestFuture.ExtractValueSync();
-        UNIT_ASSERT(result.IsSuccess());
+        ASSERT_TRUE(result.IsSuccess());
 
-        // Make sure the metrics configuration was not set in the CreateTable request
-        UNIT_ASSERT(tableService.LastCreateTableRequest.has_value());
-        UNIT_ASSERT(!tableService.LastCreateTableRequest->has_metrics_settings());
-    }
+        // Make sure the metrics configuration is set in the CreateTable request
+        ASSERT_TRUE(tableService.LastCreateTableRequest.has_value());
+        ASSERT_TRUE(tableService.LastCreateTableRequest->has_metrics_settings());
 
-    /**
-     * Verify that the SDK creates the CREATE TABLE request correctly,
-     * when the metrics configuration is provided.
-     */
-    Y_UNIT_TEST(CreateTableWithMetricsSettings) {
-        // Start the mocked table API service
-        TMockTableService tableService;
-        std::unique_ptr<grpc::Server> grpcServer;
-        std::unique_ptr<TDriver> driver;
-        std::unique_ptr<NTable::TTableClient> tableClient;
-        std::unique_ptr<NTable::TSession> tableSession;
-
-        StartServerWithTableService(
-            tableService,
-            grpcServer,
-            driver,
-            tableClient,
-            tableSession
+        ASSERT_EQ(
+            tableService.LastCreateTableRequest->metrics_settings().metrics_level(),
+            protoMetricsLevel
         );
+    };
 
-        // Call the CreateTable() API with the metrics configuration configured
-        // to every allowed metrics level
-        const auto verifyMetricsLevelFunc = [&](
-            const TString& metricsLevelName,
-            NTable::TMetricsSettings::EMetricsLevel metricsLevel,
-            Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
-        ) {
-            auto requestFuture = tableSession->CreateTable(
-                "/Root/My/DB/test_table",
-                NTable::TTableBuilder()
-                    .SetMetricsSettings(metricsLevel)
-                    .Build()
-            );
+    verifyMetricsLevelFunc(
+        "UNSPECIFIED",
+        NTable::TMetricsSettings::EMetricsLevel::Unspecified,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
+    );
 
-            UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+    verifyMetricsLevelFunc(
+        "DISABLED",
+        NTable::TMetricsSettings::EMetricsLevel::Disabled,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
+    );
 
-            auto result = requestFuture.ExtractValueSync();
-            UNIT_ASSERT(result.IsSuccess());
+    verifyMetricsLevelFunc(
+        "DATABASE",
+        NTable::TMetricsSettings::EMetricsLevel::Database,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
+    );
 
-            // Make sure the metrics configuration is set in the CreateTable request
-            UNIT_ASSERT(tableService.LastCreateTableRequest.has_value());
-            UNIT_ASSERT(tableService.LastCreateTableRequest->has_metrics_settings());
+    verifyMetricsLevelFunc(
+        "TABLE",
+        NTable::TMetricsSettings::EMetricsLevel::Table,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
+    );
 
-            UNIT_ASSERT_EQUAL_C(
-                tableService.LastCreateTableRequest->metrics_settings().metrics_level(),
-                protoMetricsLevel,
-                "Incorrect metrics level for " << metricsLevelName
-            );
-        };
+    verifyMetricsLevelFunc(
+        "PARTITION",
+        NTable::TMetricsSettings::EMetricsLevel::Partition,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
+    );
+}
 
-        verifyMetricsLevelFunc(
-            "UNSPECIFIED",
-            NTable::TMetricsSettings::EMetricsLevel::Unspecified,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
-        );
+/**
+ * Verify that the SDK creates the ALTER TABLE request correctly,
+ * when no metrics configuration is provided.
+ */
+TEST(TableTest, AlterTableNoMetricsSettings) {
+    // Start the mocked table API service
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
 
-        verifyMetricsLevelFunc(
-            "DISABLED",
-            NTable::TMetricsSettings::EMetricsLevel::Disabled,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
-        );
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
 
-        verifyMetricsLevelFunc(
-            "DATABASE",
-            NTable::TMetricsSettings::EMetricsLevel::Database,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
-        );
+    // Call the AlterTable() API without any metrics configuration
+    auto requestFuture = tableSession->AlterTable(
+        "/Root/My/DB/test_table",
+        NTable::TAlterTableSettings()
+    );
 
-        verifyMetricsLevelFunc(
-            "TABLE",
-            NTable::TMetricsSettings::EMetricsLevel::Table,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
-        );
+    ASSERT_TRUE(requestFuture.Wait(TDuration::Seconds(10)));
 
-        verifyMetricsLevelFunc(
-            "PARTITION",
-            NTable::TMetricsSettings::EMetricsLevel::Partition,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
-        );
-    }
+    auto result = requestFuture.ExtractValueSync();
+    ASSERT_TRUE(result.IsSuccess());
 
-    /**
-     * Verify that the SDK creates the ALTER TABLE request correctly,
-     * when no metrics configuration is provided.
-     */
-    Y_UNIT_TEST(AlterTableNoMetricsSettings) {
-        // Start the mocked table API service
-        TMockTableService tableService;
-        std::unique_ptr<grpc::Server> grpcServer;
-        std::unique_ptr<TDriver> driver;
-        std::unique_ptr<NTable::TTableClient> tableClient;
-        std::unique_ptr<NTable::TSession> tableSession;
+    // Make sure the metrics configuration was not set in the AlterTable request
+    ASSERT_TRUE(tableService.LastAlterTableRequest.has_value());
 
-        StartServerWithTableService(
-            tableService,
-            grpcServer,
-            driver,
-            tableClient,
-            tableSession
-        );
+    ASSERT_EQ(
+        tableService.LastAlterTableRequest->metrics_settings_action_case(),
+        Ydb::Table::AlterTableRequest::METRICS_SETTINGS_ACTION_NOT_SET
+    );
 
-        // Call the AlterTable() API without any metrics configuration
-        auto requestFuture = tableSession->AlterTable(
-            "/Root/My/DB/test_table",
-            NTable::TAlterTableSettings()
-        );
+    ASSERT_TRUE(!tableService.LastAlterTableRequest->has_set_metrics_settings());
+    ASSERT_TRUE(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
+}
 
-        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+/**
+ * Verify that the SDK creates the ALTER TABLE request correctly,
+ * when the metrics configuration is explicitly dropped.
+ */
+TEST(TableTest, AlterTableDroppedMetricsSettings) {
+    // Start the mocked table API service
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
 
-        auto result = requestFuture.ExtractValueSync();
-        UNIT_ASSERT(result.IsSuccess());
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
 
-        // Make sure the metrics configuration was not set in the AlterTable request
-        UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+    // Call the AlterTable() API with the metrics configuration dropped
+    auto requestFuture = tableSession->AlterTable(
+        "/Root/My/DB/test_table",
+        NTable::TAlterTableSettings()
+            .BeginAlterMetricsSettings()
+            .Drop()
+            .EndAlterMetricsSettings()
+    );
 
-        UNIT_ASSERT_EQUAL(
-            tableService.LastAlterTableRequest->metrics_settings_action_case(),
-            Ydb::Table::AlterTableRequest::METRICS_SETTINGS_ACTION_NOT_SET
-        );
+    ASSERT_TRUE(requestFuture.Wait(TDuration::Seconds(10)));
 
-        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_set_metrics_settings());
-        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
-    }
+    auto result = requestFuture.ExtractValueSync();
+    ASSERT_TRUE(result.IsSuccess());
 
-    /**
-     * Verify that the SDK creates the ALTER TABLE request correctly,
-     * when the metrics configuration is explicitly dropped.
-     */
-    Y_UNIT_TEST(AlterTableDroppedMetricsSettings) {
-        // Start the mocked table API service
-        TMockTableService tableService;
-        std::unique_ptr<grpc::Server> grpcServer;
-        std::unique_ptr<TDriver> driver;
-        std::unique_ptr<NTable::TTableClient> tableClient;
-        std::unique_ptr<NTable::TSession> tableSession;
+    // Make sure the metrics configuration was not set in the AlterTable request
+    ASSERT_TRUE(tableService.LastAlterTableRequest.has_value());
 
-        StartServerWithTableService(
-            tableService,
-            grpcServer,
-            driver,
-            tableClient,
-            tableSession
-        );
+    ASSERT_EQ(
+        tableService.LastAlterTableRequest->metrics_settings_action_case(),
+        Ydb::Table::AlterTableRequest::kDropMetricsSettings
+    );
 
-        // Call the AlterTable() API with the metrics configuration dropped
+    ASSERT_TRUE(!tableService.LastAlterTableRequest->has_set_metrics_settings());
+    ASSERT_TRUE(tableService.LastAlterTableRequest->has_drop_metrics_settings());
+}
+
+/**
+ * Verify that the SDK creates the ALTER TABLE request correctly,
+ * when the metrics configuration is explicitly set.
+ */
+TEST(TableTest, AlterTableSetMetricsSettings) {
+    // Start the mocked table API service
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    // Call the AlterTable() API with the metrics configuration set explicitly
+    // to every allowed metrics level
+    const auto verifyMetricsLevelFunc = [&](
+        const TString& metricsLevelName,
+        NTable::TMetricsSettings::EMetricsLevel metricsLevel,
+        Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
+    ) {
+        SCOPED_TRACE(testing::Message() << "Metrics level: " << metricsLevelName);
+
         auto requestFuture = tableSession->AlterTable(
             "/Root/My/DB/test_table",
             NTable::TAlterTableSettings()
                 .BeginAlterMetricsSettings()
-                .Drop()
+                .Set(metricsLevel)
                 .EndAlterMetricsSettings()
         );
 
-        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+        ASSERT_TRUE(requestFuture.Wait(TDuration::Seconds(10)));
 
         auto result = requestFuture.ExtractValueSync();
-        UNIT_ASSERT(result.IsSuccess());
+        ASSERT_TRUE(result.IsSuccess());
 
-        // Make sure the metrics configuration was not set in the AlterTable request
-        UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+        // Make sure the metrics configuration was set in the AlterTable request
+        ASSERT_TRUE(tableService.LastAlterTableRequest.has_value());
 
-        UNIT_ASSERT_EQUAL(
+        ASSERT_EQ(
             tableService.LastAlterTableRequest->metrics_settings_action_case(),
-            Ydb::Table::AlterTableRequest::kDropMetricsSettings
+            Ydb::Table::AlterTableRequest::kSetMetricsSettings
         );
 
-        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_set_metrics_settings());
-        UNIT_ASSERT(tableService.LastAlterTableRequest->has_drop_metrics_settings());
-    }
-
-    /**
-     * Verify that the SDK creates the ALTER TABLE request correctly,
-     * when the metrics configuration is explicitly set.
-     */
-    Y_UNIT_TEST(AlterTableSetMetricsSettings) {
-        // Start the mocked table API service
-        TMockTableService tableService;
-        std::unique_ptr<grpc::Server> grpcServer;
-        std::unique_ptr<TDriver> driver;
-        std::unique_ptr<NTable::TTableClient> tableClient;
-        std::unique_ptr<NTable::TSession> tableSession;
-
-        StartServerWithTableService(
-            tableService,
-            grpcServer,
-            driver,
-            tableClient,
-            tableSession
+        ASSERT_EQ(
+            tableService.LastAlterTableRequest->set_metrics_settings().metrics_level(),
+            protoMetricsLevel
         );
 
-        // Call the AlterTable() API with the metrics configuration set explicitly
-        // to every allowed metrics level
-        const auto verifyMetricsLevelFunc = [&](
-            const TString& metricsLevelName,
-            NTable::TMetricsSettings::EMetricsLevel metricsLevel,
-            Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
-        ) {
-            auto requestFuture = tableSession->AlterTable(
-                "/Root/My/DB/test_table",
-                NTable::TAlterTableSettings()
-                    .BeginAlterMetricsSettings()
-                    .Set(metricsLevel)
-                    .EndAlterMetricsSettings()
-            );
+        ASSERT_TRUE(tableService.LastAlterTableRequest->has_set_metrics_settings());
+        ASSERT_TRUE(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
+    };
 
-            UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+    verifyMetricsLevelFunc(
+        "UNSPECIFIED",
+        NTable::TMetricsSettings::EMetricsLevel::Unspecified,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
+    );
 
-            auto result = requestFuture.ExtractValueSync();
-            UNIT_ASSERT(result.IsSuccess());
+    verifyMetricsLevelFunc(
+        "DISABLED",
+        NTable::TMetricsSettings::EMetricsLevel::Disabled,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
+    );
 
-            // Make sure the metrics configuration was set in the AlterTable request
-            UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+    verifyMetricsLevelFunc(
+        "DATABASE",
+        NTable::TMetricsSettings::EMetricsLevel::Database,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
+    );
 
-            UNIT_ASSERT_EQUAL(
-                tableService.LastAlterTableRequest->metrics_settings_action_case(),
-                Ydb::Table::AlterTableRequest::kSetMetricsSettings
-            );
+    verifyMetricsLevelFunc(
+        "TABLE",
+        NTable::TMetricsSettings::EMetricsLevel::Table,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
+    );
 
-            UNIT_ASSERT_EQUAL_C(
-                tableService.LastAlterTableRequest->set_metrics_settings().metrics_level(),
-                protoMetricsLevel,
-                "Incorrect metrics level for " << metricsLevelName
-            );
-
-            UNIT_ASSERT(tableService.LastAlterTableRequest->has_set_metrics_settings());
-            UNIT_ASSERT(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
-        };
-
-        verifyMetricsLevelFunc(
-            "UNSPECIFIED",
-            NTable::TMetricsSettings::EMetricsLevel::Unspecified,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
-        );
-
-        verifyMetricsLevelFunc(
-            "DISABLED",
-            NTable::TMetricsSettings::EMetricsLevel::Disabled,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
-        );
-
-        verifyMetricsLevelFunc(
-            "DATABASE",
-            NTable::TMetricsSettings::EMetricsLevel::Database,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
-        );
-
-        verifyMetricsLevelFunc(
-            "TABLE",
-            NTable::TMetricsSettings::EMetricsLevel::Table,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
-        );
-
-        verifyMetricsLevelFunc(
-            "PARTITION",
-            NTable::TMetricsSettings::EMetricsLevel::Partition,
-            Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
-        );
-    }
+    verifyMetricsLevelFunc(
+        "PARTITION",
+        NTable::TMetricsSettings::EMetricsLevel::Partition,
+        Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
+    );
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -222,7 +222,7 @@ Y_UNIT_TEST_SUITE(Table) {
         const auto verifyMetricsLevelFunc = [&](
             const TString& metricsLevelName,
             NTable::TMetricsSettings::EMetricsLevel metricsLevel,
-            Ydb::Table::MetricsLevel protoMetricsLevel
+            Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
         ) {
             auto requestFuture = tableSession->CreateTable(
                 "/Root/My/DB/test_table",
@@ -250,31 +250,31 @@ Y_UNIT_TEST_SUITE(Table) {
         verifyMetricsLevelFunc(
             "UNSPECIFIED",
             NTable::TMetricsSettings::EMetricsLevel::Unspecified,
-            Ydb::Table::METRICS_LEVEL_UNSPECIFIED
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
         );
 
         verifyMetricsLevelFunc(
             "DISABLED",
             NTable::TMetricsSettings::EMetricsLevel::Disabled,
-            Ydb::Table::METRICS_LEVEL_DISABLED
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
         );
 
         verifyMetricsLevelFunc(
             "DATABASE",
             NTable::TMetricsSettings::EMetricsLevel::Database,
-            Ydb::Table::METRICS_LEVEL_DATABASE
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
         );
 
         verifyMetricsLevelFunc(
             "TABLE",
             NTable::TMetricsSettings::EMetricsLevel::Table,
-            Ydb::Table::METRICS_LEVEL_TABLE
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
         );
 
         verifyMetricsLevelFunc(
             "PARTITION",
             NTable::TMetricsSettings::EMetricsLevel::Partition,
-            Ydb::Table::METRICS_LEVEL_PARTITION
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
         );
     }
 
@@ -392,7 +392,7 @@ Y_UNIT_TEST_SUITE(Table) {
         const auto verifyMetricsLevelFunc = [&](
             const TString& metricsLevelName,
             NTable::TMetricsSettings::EMetricsLevel metricsLevel,
-            Ydb::Table::MetricsLevel protoMetricsLevel
+            Ydb::Table::MetricsSettings::MetricsLevel protoMetricsLevel
         ) {
             auto requestFuture = tableSession->AlterTable(
                 "/Root/My/DB/test_table",
@@ -428,31 +428,31 @@ Y_UNIT_TEST_SUITE(Table) {
         verifyMetricsLevelFunc(
             "UNSPECIFIED",
             NTable::TMetricsSettings::EMetricsLevel::Unspecified,
-            Ydb::Table::METRICS_LEVEL_UNSPECIFIED
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_UNSPECIFIED
         );
 
         verifyMetricsLevelFunc(
             "DISABLED",
             NTable::TMetricsSettings::EMetricsLevel::Disabled,
-            Ydb::Table::METRICS_LEVEL_DISABLED
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_DISABLED
         );
 
         verifyMetricsLevelFunc(
             "DATABASE",
             NTable::TMetricsSettings::EMetricsLevel::Database,
-            Ydb::Table::METRICS_LEVEL_DATABASE
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_DATABASE
         );
 
         verifyMetricsLevelFunc(
             "TABLE",
             NTable::TMetricsSettings::EMetricsLevel::Table,
-            Ydb::Table::METRICS_LEVEL_TABLE
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_TABLE
         );
 
         verifyMetricsLevelFunc(
             "PARTITION",
             NTable::TMetricsSettings::EMetricsLevel::Partition,
-            Ydb::Table::METRICS_LEVEL_PARTITION
+            Ydb::Table::MetricsSettings::METRICS_LEVEL_PARTITION
         );
     }
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -1,8 +1,9 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
-#include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/testing/unittest/tests_data.h>
+
+#include <util/string/builder.h>
 
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
 
@@ -148,10 +149,10 @@ namespace {
         tableClient = std::make_unique<NTable::TTableClient>(*driver);
 
         auto sessionFuture = tableClient->CreateSession();
-        UNIT_ASSERT(sessionFuture.Wait(TDuration::Seconds(10)));
+        ASSERT_TRUE(sessionFuture.Wait(TDuration::Seconds(10)));
 
         auto sessionResult = sessionFuture.ExtractValueSync();
-        UNIT_ASSERT(sessionResult.IsSuccess());
+        ASSERT_TRUE(sessionResult.IsSuccess());
 
         tableSession = std::make_unique<NTable::TSession>(sessionResult.GetSession());
     }

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -1,0 +1,458 @@
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+#include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
+
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+
+using namespace NYdb;
+
+namespace {
+    /**
+     * The mock for the table service in the YDB public API.
+     */
+    class TMockTableService : public Ydb::Table::V1::TableService::Service {
+    public:
+        virtual grpc::Status CreateSession(
+            grpc::ServerContext* /* context */,
+            const Ydb::Table::CreateSessionRequest* request,
+            Ydb::Table::CreateSessionResponse* response
+        ) override {
+            std::cerr << "CreateSession():" << std::endl
+                << request->DebugString()
+                << std::endl;
+
+            // Complete the request successfully with a fake session ID
+            //
+            // NOTE: This method needs to be mocked to allow the test code to create
+            //       a new API session. The test code must call CreateSession()
+            //       before calling any other methods, like CreateTable() or AlterTable().
+            //       And CreateSession() must see a successful response from the server
+            //       in order to create a valid session.
+            Ydb::Table::CreateSessionResult result;
+            result.set_session_id("fake-session-id");
+
+            auto op = response->mutable_operation();
+            op->set_ready(true);
+            op->set_status(Ydb::StatusIds::SUCCESS);
+            op->mutable_result()->PackFrom(result);
+
+            return grpc::Status::OK;
+        }
+
+        virtual grpc::Status CreateTable(
+            grpc::ServerContext* /* context */,
+            const Ydb::Table::CreateTableRequest* request,
+            Ydb::Table::CreateTableResponse* response
+        ) override {
+            std::cerr << "CreateTable():" << std::endl
+                << request->DebugString()
+                << std::endl;
+
+            //
+
+            auto op = response->mutable_operation();
+
+            op->set_ready(true);
+            op->set_status(Ydb::StatusIds::SUCCESS);
+
+            // Save the CreateTable request to allow the test to verify it
+            LastCreateTableRequest = Ydb::Table::CreateTableRequest(*request);
+            return grpc::Status::OK;
+        }
+
+        virtual grpc::Status AlterTable(
+            grpc::ServerContext* /* context */,
+            const Ydb::Table::AlterTableRequest* request,
+            Ydb::Table::AlterTableResponse* response
+        ) override {
+            std::cerr << "AlterTable():" << std::endl
+                << request->DebugString()
+                << std::endl;
+
+            //
+
+            auto op = response->mutable_operation();
+
+            op->set_ready(true);
+            op->set_status(Ydb::StatusIds::SUCCESS);
+
+            // Save the AlterTable request to allow the test to verify it
+            LastAlterTableRequest = Ydb::Table::AlterTableRequest(*request);
+            return grpc::Status::OK;
+        }
+
+        std::optional<Ydb::Table::CreateTableRequest> LastCreateTableRequest;
+        std::optional<Ydb::Table::AlterTableRequest> LastAlterTableRequest;
+    };
+
+    /**
+     * Start the local GRPC server for the given API service.
+     *
+     * @tparam TService The type of the API service
+     *
+     * @param[in] address The address/port to listen to
+     * @param[in] service The API service to start
+     *
+     * @return The corresponding GRPC server
+     */
+    template<class TService>
+    std::unique_ptr<grpc::Server> StartGrpcServer(const std::string& address, TService& service) {
+        return grpc::ServerBuilder()
+            .AddListeningPort(TString{address}, grpc::InsecureServerCredentials())
+            .RegisterService(&service)
+            .BuildAndStart();
+    }
+
+    /**
+     * Configure and start a local GRPC server with the mocked table API service.
+     *
+     * @param[in] tableService The table service to start
+     * @param[out] grpcServer Receives the corresponding GRPC server
+     * @param[out] driver Receives the connection pool to the server
+     * @param[out] tableClient Receives the API client for the table API service
+     * @param[out] tableSession Receives the client session for the table API service
+     */
+    void StartServerWithTableService(
+        TMockTableService& tableService,
+        std::unique_ptr<grpc::Server>& grpcServer,
+        std::unique_ptr<TDriver>& driver,
+        std::unique_ptr<NTable::TTableClient>& tableClient,
+        std::unique_ptr<NTable::TSession>& tableSession
+    ) {
+        // Start the local GRPC service for the given table API service
+        TPortManager pm;
+        ui16 tablePort = pm.GetPort();
+
+        grpcServer = StartGrpcServer(
+            TStringBuilder() << "127.0.0.1:" << tablePort,
+            tableService
+        );
+
+        // Start the connection pool and create the API client for the table API service
+        driver = std::make_unique<TDriver>(
+            TDriverConfig()
+                .SetEndpoint(TStringBuilder() << "localhost:" << tablePort)
+                .SetDiscoveryMode(EDiscoveryMode::Off)
+                .SetDatabase("/Root/My/DB")
+        );
+
+        // Create a new session
+        tableClient = std::make_unique<NTable::TTableClient>(*driver);
+
+        auto sessionFuture = tableClient->CreateSession();
+        UNIT_ASSERT(sessionFuture.Wait(TDuration::Seconds(10)));
+
+        auto sessionResult = sessionFuture.ExtractValueSync();
+        UNIT_ASSERT(sessionResult.IsSuccess());
+
+        tableSession = std::make_unique<NTable::TSession>(sessionResult.GetSession());
+    }
+
+} // namespace <anonymous>
+
+/**
+ * The unit tests for the Table client in the C++ SDK.
+ */
+Y_UNIT_TEST_SUITE(Table) {
+    /**
+     * Verify that the SDK creates the CREATE TABLE request correctly,
+     * when no metrics configuration is provided.
+     */
+    Y_UNIT_TEST(CreateTableNoMetricsSettings) {
+        // Start the mocked table API service
+        TMockTableService tableService;
+        std::unique_ptr<grpc::Server> grpcServer;
+        std::unique_ptr<TDriver> driver;
+        std::unique_ptr<NTable::TTableClient> tableClient;
+        std::unique_ptr<NTable::TSession> tableSession;
+
+        StartServerWithTableService(
+            tableService,
+            grpcServer,
+            driver,
+            tableClient,
+            tableSession
+        );
+
+        // Call the CreateTable() API without any metrics configuration
+        auto requestFuture = tableSession->CreateTable(
+            "/Root/My/DB/test_table",
+            NTable::TTableBuilder()
+                .Build()
+        );
+
+        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+
+        auto result = requestFuture.ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+
+        // Make sure the metrics configuration was not set in the CreateTable request
+        UNIT_ASSERT(tableService.LastCreateTableRequest.has_value());
+        UNIT_ASSERT(!tableService.LastCreateTableRequest->has_metrics_settings());
+    }
+
+    /**
+     * Verify that the SDK creates the CREATE TABLE request correctly,
+     * when the metrics configuration is provided.
+     */
+    Y_UNIT_TEST(CreateTableWithMetricsSettings) {
+        // Start the mocked table API service
+        TMockTableService tableService;
+        std::unique_ptr<grpc::Server> grpcServer;
+        std::unique_ptr<TDriver> driver;
+        std::unique_ptr<NTable::TTableClient> tableClient;
+        std::unique_ptr<NTable::TSession> tableSession;
+
+        StartServerWithTableService(
+            tableService,
+            grpcServer,
+            driver,
+            tableClient,
+            tableSession
+        );
+
+        // Call the CreateTable() API with the metrics configuration configured
+        // to every allowed metrics level
+        const auto verifyMetricsLevelFunc = [&](
+            const TString& metricsLevelName,
+            NTable::TMetricsSettings::EMetricsLevel metricsLevel,
+            Ydb::Table::MetricsLevel protoMetricsLevel
+        ) {
+            auto requestFuture = tableSession->CreateTable(
+                "/Root/My/DB/test_table",
+                NTable::TTableBuilder()
+                    .SetMetricsSettings(metricsLevel)
+                    .Build()
+            );
+
+            UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+
+            auto result = requestFuture.ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+
+            // Make sure the metrics configuration is set in the CreateTable request
+            UNIT_ASSERT(tableService.LastCreateTableRequest.has_value());
+            UNIT_ASSERT(tableService.LastCreateTableRequest->has_metrics_settings());
+
+            UNIT_ASSERT_EQUAL_C(
+                tableService.LastCreateTableRequest->metrics_settings().metrics_level(),
+                protoMetricsLevel,
+                "Incorrect metrics level for " << metricsLevelName
+            );
+        };
+
+        verifyMetricsLevelFunc(
+            "UNSPECIFIED",
+            NTable::TMetricsSettings::EMetricsLevel::Unspecified,
+            Ydb::Table::METRICS_LEVEL_UNSPECIFIED
+        );
+
+        verifyMetricsLevelFunc(
+            "DISABLED",
+            NTable::TMetricsSettings::EMetricsLevel::Disabled,
+            Ydb::Table::METRICS_LEVEL_DISABLED
+        );
+
+        verifyMetricsLevelFunc(
+            "DATABASE",
+            NTable::TMetricsSettings::EMetricsLevel::Database,
+            Ydb::Table::METRICS_LEVEL_DATABASE
+        );
+
+        verifyMetricsLevelFunc(
+            "TABLE",
+            NTable::TMetricsSettings::EMetricsLevel::Table,
+            Ydb::Table::METRICS_LEVEL_TABLE
+        );
+
+        verifyMetricsLevelFunc(
+            "PARTITION",
+            NTable::TMetricsSettings::EMetricsLevel::Partition,
+            Ydb::Table::METRICS_LEVEL_PARTITION
+        );
+    }
+
+    /**
+     * Verify that the SDK creates the ALTER TABLE request correctly,
+     * when no metrics configuration is provided.
+     */
+    Y_UNIT_TEST(AlterTableNoMetricsSettings) {
+        // Start the mocked table API service
+        TMockTableService tableService;
+        std::unique_ptr<grpc::Server> grpcServer;
+        std::unique_ptr<TDriver> driver;
+        std::unique_ptr<NTable::TTableClient> tableClient;
+        std::unique_ptr<NTable::TSession> tableSession;
+
+        StartServerWithTableService(
+            tableService,
+            grpcServer,
+            driver,
+            tableClient,
+            tableSession
+        );
+
+        // Call the AlterTable() API without any metrics configuration
+        auto requestFuture = tableSession->AlterTable(
+            "/Root/My/DB/test_table",
+            NTable::TAlterTableSettings()
+        );
+
+        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+
+        auto result = requestFuture.ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+
+        // Make sure the metrics configuration was not set in the AlterTable request
+        UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+
+        UNIT_ASSERT_EQUAL(
+            tableService.LastAlterTableRequest->metrics_settings_action_case(),
+            Ydb::Table::AlterTableRequest::METRICS_SETTINGS_ACTION_NOT_SET
+        );
+
+        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_set_metrics_settings());
+        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
+    }
+
+    /**
+     * Verify that the SDK creates the ALTER TABLE request correctly,
+     * when the metrics configuration is explicitly dropped.
+     */
+    Y_UNIT_TEST(AlterTableDroppedMetricsSettings) {
+        // Start the mocked table API service
+        TMockTableService tableService;
+        std::unique_ptr<grpc::Server> grpcServer;
+        std::unique_ptr<TDriver> driver;
+        std::unique_ptr<NTable::TTableClient> tableClient;
+        std::unique_ptr<NTable::TSession> tableSession;
+
+        StartServerWithTableService(
+            tableService,
+            grpcServer,
+            driver,
+            tableClient,
+            tableSession
+        );
+
+        // Call the AlterTable() API with the metrics configuration dropped
+        auto requestFuture = tableSession->AlterTable(
+            "/Root/My/DB/test_table",
+            NTable::TAlterTableSettings()
+                .BeginAlterMetricsSettings()
+                .Drop()
+                .EndAlterMetricsSettings()
+        );
+
+        UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+
+        auto result = requestFuture.ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+
+        // Make sure the metrics configuration was not set in the AlterTable request
+        UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+
+        UNIT_ASSERT_EQUAL(
+            tableService.LastAlterTableRequest->metrics_settings_action_case(),
+            Ydb::Table::AlterTableRequest::kDropMetricsSettings
+        );
+
+        UNIT_ASSERT(!tableService.LastAlterTableRequest->has_set_metrics_settings());
+        UNIT_ASSERT(tableService.LastAlterTableRequest->has_drop_metrics_settings());
+    }
+
+    /**
+     * Verify that the SDK creates the ALTER TABLE request correctly,
+     * when the metrics configuration is explicitly set.
+     */
+    Y_UNIT_TEST(AlterTableSetMetricsSettings) {
+        // Start the mocked table API service
+        TMockTableService tableService;
+        std::unique_ptr<grpc::Server> grpcServer;
+        std::unique_ptr<TDriver> driver;
+        std::unique_ptr<NTable::TTableClient> tableClient;
+        std::unique_ptr<NTable::TSession> tableSession;
+
+        StartServerWithTableService(
+            tableService,
+            grpcServer,
+            driver,
+            tableClient,
+            tableSession
+        );
+
+        // Call the AlterTable() API with the metrics configuration set explicitly
+        // to every allowed metrics level
+        const auto verifyMetricsLevelFunc = [&](
+            const TString& metricsLevelName,
+            NTable::TMetricsSettings::EMetricsLevel metricsLevel,
+            Ydb::Table::MetricsLevel protoMetricsLevel
+        ) {
+            auto requestFuture = tableSession->AlterTable(
+                "/Root/My/DB/test_table",
+                NTable::TAlterTableSettings()
+                    .BeginAlterMetricsSettings()
+                    .Set(metricsLevel)
+                    .EndAlterMetricsSettings()
+            );
+
+            UNIT_ASSERT(requestFuture.Wait(TDuration::Seconds(10)));
+
+            auto result = requestFuture.ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+
+            // Make sure the metrics configuration was set in the AlterTable request
+            UNIT_ASSERT(tableService.LastAlterTableRequest.has_value());
+
+            UNIT_ASSERT_EQUAL(
+                tableService.LastAlterTableRequest->metrics_settings_action_case(),
+                Ydb::Table::AlterTableRequest::kSetMetricsSettings
+            );
+
+            UNIT_ASSERT_EQUAL_C(
+                tableService.LastAlterTableRequest->set_metrics_settings().metrics_level(),
+                protoMetricsLevel,
+                "Incorrect metrics level for " << metricsLevelName
+            );
+
+            UNIT_ASSERT(tableService.LastAlterTableRequest->has_set_metrics_settings());
+            UNIT_ASSERT(!tableService.LastAlterTableRequest->has_drop_metrics_settings());
+        };
+
+        verifyMetricsLevelFunc(
+            "UNSPECIFIED",
+            NTable::TMetricsSettings::EMetricsLevel::Unspecified,
+            Ydb::Table::METRICS_LEVEL_UNSPECIFIED
+        );
+
+        verifyMetricsLevelFunc(
+            "DISABLED",
+            NTable::TMetricsSettings::EMetricsLevel::Disabled,
+            Ydb::Table::METRICS_LEVEL_DISABLED
+        );
+
+        verifyMetricsLevelFunc(
+            "DATABASE",
+            NTable::TMetricsSettings::EMetricsLevel::Database,
+            Ydb::Table::METRICS_LEVEL_DATABASE
+        );
+
+        verifyMetricsLevelFunc(
+            "TABLE",
+            NTable::TMetricsSettings::EMetricsLevel::Table,
+            Ydb::Table::METRICS_LEVEL_TABLE
+        );
+
+        verifyMetricsLevelFunc(
+            "PARTITION",
+            NTable::TMetricsSettings::EMetricsLevel::Partition,
+            Ydb::Table::METRICS_LEVEL_PARTITION
+        );
+    }
+}

--- a/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
@@ -1,0 +1,21 @@
+UNITTEST()
+
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+FORK_SUBTESTS()
+
+PEERDIR(
+    ydb/public/api/grpc
+    ydb/public/sdk/cpp/src/client/table
+)
+
+SRCS(
+    table_ut.cpp
+)
+
+END()

--- a/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
@@ -1,8 +1,8 @@
-UNITTEST()
+GTEST()
 
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
-    TAG(ya:fat)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 ELSE()
     SIZE(MEDIUM)
 ENDIF()
@@ -10,6 +10,7 @@ ENDIF()
 FORK_SUBTESTS()
 
 PEERDIR(
+    library/cpp/testing/unittest
     ydb/public/api/grpc
     ydb/public/sdk/cpp/src/client/table
 )

--- a/ydb/public/sdk/cpp/tests/unit/client/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/ya.make
@@ -8,5 +8,6 @@ RECURSE(
     oauth2_token_exchange
     params
     result
+    table
     value
 )


### PR DESCRIPTION
### Changelog entry

Added support for METRICS_LEVEL for the CreateTable/AlterTable requests in the public API and the C++ SDK

### Changelog category

* New feature

### Description for reviewers

* Added support for METRICS_LEVEL for the CreateTable/AlterTable requests in the public API
* Added support for METRICS_LEVEL for the CreateTable/AlterTable requests in the C++ SDK
* Added unit tests for the CreateTable/AlterTable requests in the C++ SDK
* Added METRICS_LEVEL to the CreateTableRequest public API structure
* Added METRICS_LEVEL to the AlterTableRequest public API structure
