### PR TITLE
NBYDB-1974: Add detailed blob compaction metrics

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
@@ -938,6 +938,8 @@ public:                                                                         
                 COUNTER_INIT(BlobsPromoteSsts, true);
                 COUNTER_INIT(BlobsExplicit, true);
                 COUNTER_INIT(BlobsBalance, true);
+                COUNTER_INIT(BlobsBalanceLevel, true);
+                COUNTER_INIT(BlobsBalanceFull, true);
                 COUNTER_INIT(BlobsFreeSpace, true);
                 COUNTER_INIT(BlobsSqueeze, true);
 
@@ -954,6 +956,8 @@ public:                                                                         
             COUNTER_DEF(BlobsPromoteSsts);
             COUNTER_DEF(BlobsExplicit);
             COUNTER_DEF(BlobsBalance);
+            COUNTER_DEF(BlobsBalanceLevel);
+            COUNTER_DEF(BlobsBalanceFull);
             COUNTER_DEF(BlobsFreeSpace);
             COUNTER_DEF(BlobsSqueeze);
 

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
@@ -57,6 +57,11 @@ namespace NKikimr {
             action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
                 ++HullCtx->CompactionStrategyGroup.BlobsBalance();
+                if (Task->IsFullCompaction) {
+                    ++HullCtx->CompactionStrategyGroup.BlobsBalanceFull();
+                } else {
+                    ++HullCtx->CompactionStrategyGroup.BlobsBalanceLevel();
+                }
                 return action;
             }
 


### PR DESCRIPTION
### Changelog entry

Add separate metrics for blobs level compaction (`BlobsBalanceLevel`) and full compaction (`BlobsBalanceFull`). Previously, both were treated as `BlobsBalance`.

### Changelog category
* Improvement

