### PR TITLE
[EXT-2072] meta stub capabilities

### DIFF
--- a/ydb/mvp/meta/meta.cpp
+++ b/ydb/mvp/meta/meta.cpp
@@ -216,7 +216,7 @@ void TMVP::InitMeta() {
                      );
 
     ActorSystem.Send(httpIncomingProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
-                         "/meta/capabilities",
+                         "/capabilities",
                          ActorSystem.Register(new NMVP::THandlerActorMetaCapabilities())
                          )
                      );

--- a/ydb/mvp/meta/meta.cpp
+++ b/ydb/mvp/meta/meta.cpp
@@ -5,6 +5,7 @@
 #include "meta_cp_databases.h"
 #include "meta_cp_databases_verbose.h"
 #include "meta_cloud.h"
+#include "meta_capabilities.h"
 #include "meta_support_links.h"
 #include "meta_cache.h"
 
@@ -211,6 +212,12 @@ void TMVP::InitMeta() {
     ActorSystem.Send(httpIncomingProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
                          "/meta/cloud",
                          ActorSystem.Register(new NMVP::THandlerActorMetaCloud(HttpProxyId, MetaLocation))
+                         )
+                     );
+
+    ActorSystem.Send(httpIncomingProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                         "/meta/capabilities",
+                         ActorSystem.Register(new NMVP::THandlerActorMetaCapabilities())
                          )
                      );
 

--- a/ydb/mvp/meta/meta_capabilities.h
+++ b/ydb/mvp/meta/meta_capabilities.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/http/http_proxy.h>
+
+namespace NMVP {
+
+class THandlerActorMetaCapabilities : public NActors::TActor<THandlerActorMetaCapabilities> {
+public:
+    using TBase = NActors::TActor<THandlerActorMetaCapabilities>;
+
+    THandlerActorMetaCapabilities()
+        : TBase(&THandlerActorMetaCapabilities::StateWork)
+    {}
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx) {
+        // Stub endpoint for UI compatibility so clients do not receive 404 while capabilities are not implemented yet.
+        static constexpr TStringBuf ResponseBody = "{\n  \"Capabilities\": {}\n}\n";
+        auto response = event->Get()->Request->CreateResponseOK(ResponseBody, "application/json; charset=utf-8");
+        ctx.Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+        }
+    }
+};
+
+} // namespace NMVP

--- a/ydb/mvp/meta/meta_capabilities.h
+++ b/ydb/mvp/meta/meta_capabilities.h
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/http/http_proxy.h>
 
 namespace NMVP {

--- a/ydb/mvp/meta/meta_capabilities.h
+++ b/ydb/mvp/meta/meta_capabilities.h
@@ -14,7 +14,7 @@ public:
         : TBase(&THandlerActorMetaCapabilities::StateWork)
     {}
 
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx) {
+    void Handle(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& event, const NActors::TActorContext& ctx) {
         // Stub endpoint for UI compatibility so clients do not receive 404 while capabilities are not implemented yet.
         static constexpr TStringBuf ResponseBody = "{\n  \"Capabilities\": {}\n}\n";
         auto response = event->Get()->Request->CreateResponseOK(ResponseBody, "application/json; charset=utf-8");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

added stub capabilities handler

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The /capabilities endpoint is used in the UI and currently returns a 404 when the classic meta is used.

This change adds a stub endpoint to the classic meta that always returns 200 for this request.
