### PR TITLE
DataShard: implement MultiTxId conflict tracking and cleanup

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -438,6 +438,7 @@ void TDataShard::SwitchToWork(const TActorContext &ctx) {
 
     if (State != TShardState::Offline) {
         VolatileTxManager.Start(ctx);
+        MultiTxIdManager.Start();
     }
 
     SignalTabletActive(ctx);
@@ -4782,6 +4783,8 @@ void TDataShard::BreakWriteConflict(ui64 txId, absl::flat_hash_set<ui64>& volati
         if (info->State != EVolatileTxState::Aborting) {
             volatileDependencies.insert(txId);
         }
+    } else if (auto* entry = GetMultiTxIdManager().FindMultiTxId(txId)) {
+        GetMultiTxIdManager().BreakMultiTxId(entry);
     } else {
         SysLocksTable().BreakLock(txId);
     }

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -697,7 +697,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     multiLock = MultiTxIdManager.FindMultiTxId(row.LockTxId);
                     if (multiLock) {
                         // Find the first conflicting lock we would need to wait
-                        TMultiTxIdEnumerator enumerator(MultiTxIdManager, multiLock, lockMode);
+                        auto enumerator = MultiTxIdManager.EnumerateLocks(multiLock, lockMode);
                         while (auto result = enumerator.Next()) {
                             if (result.LockId != lockId) {
                                 // Note: we are not supposed to have removed or broken locks in the owners list
@@ -815,12 +815,9 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     continue;
                 }
 
-                if (multiLock) {
-                    // We are going to overwrite this row lock below
-                    MultiTxIdManager.DecrementLockedRowsCount(db, row.LockTxId);
-                }
-
                 if (currentOwner) {
+                    // For multiLock currentOwner points to the first conflict (which we are not supposed to have)
+                    Y_ENSURE(!multiLock);
                     Y_ENSURE(currentOwner->GetLockId() != lockId);
                     Y_ENSURE(IsCompatibleRowLockMode(currentLockMode, lockMode));
 
@@ -840,6 +837,11 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     setLockMode(NTable::ELockMode::Multi, newMultiTxId);
                     finishLocked();
                     continue;
+                }
+
+                if (multiLock) {
+                    // We are going to overwrite this row lock below
+                    MultiTxIdManager.DecrementLockedRowsCount(db, row.LockTxId);
                 }
 
                 setLockMode(lockMode, lockId);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -259,6 +259,7 @@ class TDataShard
     class TTxLockRows;
     class TLockRowsTxObserver;
     class TLockRowsNotifyWaitGuard;
+    class TTxMultiTxIdCleanup;
 
     void HandleMonIndexPage(NMon::TEvRemoteHttpInfo::TPtr& ev);
     void HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev);

--- a/ydb/core/tx/datashard/datashard_locks_db.cpp
+++ b/ydb/core/tx/datashard/datashard_locks_db.cpp
@@ -2,6 +2,14 @@
 
 namespace NKikimr::NDataShard {
 
+void TDataShardLocksDb::PersistLockCounter(ui64 lockId, ui64 counter) {
+    TBase::PersistLockCounter(lockId, counter);
+    if (counter == Max<ui64>()) {
+        NIceDb::TNiceDb db(DB);
+        Self.GetMultiTxIdManager().OnLockBroken(db, lockId);
+    }
+}
+
 void TDataShardLocksDb::PersistRemoveLock(ui64 lockId) {
     // We remove lock changes unless it's managed by volatile tx manager
     bool isVolatile = Self.GetVolatileTxManager().FindByCommitTxId(lockId);
@@ -20,6 +28,8 @@ void TDataShardLocksDb::PersistRemoveLock(ui64 lockId) {
     NIceDb::TNiceDb db(DB);
     db.Table<typename Schema::Locks>().Key(lockId).Delete();
     HasChanges_ = true;
+
+    Self.GetMultiTxIdManager().OnLockRemoved(db, lockId);
 
     if (!isVolatile) {
         Self.ScheduleRemoveLockChanges(lockId);

--- a/ydb/core/tx/datashard/datashard_locks_db.h
+++ b/ydb/core/tx/datashard/datashard_locks_db.h
@@ -12,6 +12,7 @@ private:
 public:
     using TBase::TBase;
 
+    void PersistLockCounter(ui64 lockId, ui64 counter) override;
     void PersistRemoveLock(ui64 lockId) override;
     bool MayAddLock(ui64 lockId) override;
 };

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -869,6 +869,8 @@ void TDataShardUserDb::AddWriteConflict(ui64 txId) {
         if (info->State != EVolatileTxState::Aborting) {
             Self.SysLocksTable().AddVolatileDependency(info->TxId);
         }
+    } else if (auto* entry = Self.GetMultiTxIdManager().FindMultiTxId(txId)) {
+        Self.GetMultiTxIdManager().AddWriteConflict(entry);
     } else {
         Self.SysLocksTable().AddWriteConflict(txId);
         if (LockMode == ELockMode::OptimisticSnapshotIsolation) {
@@ -929,6 +931,8 @@ bool TDataShardUserDb::BreakWriteConflict(ui64 txId) {
             EnsureVolatileTxId();
             VolatileDependencies.insert(info->TxId);
         }
+    } else if (auto* entry = Self.GetMultiTxIdManager().FindMultiTxId(txId)) {
+        Self.GetMultiTxIdManager().BreakMultiTxId(entry);
     } else {
         // Break uncommitted locks from other transactions
         Self.SysLocksTable().BreakLock(txId);

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -96,6 +96,13 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             Runtime.SendToPipe(PipeActor, sender, payload, nodeIndex, cookie);
         }
 
+        auto GetOpenTxs(const TTableId& tableId) {
+            TActorId sender = Runtime.AllocateEdgeActor(GetNodeIndex());
+            Runtime.SendToPipe(PipeActor, sender, new TEvDataShard::TEvGetOpenTxs(tableId.PathId));
+            auto ev = Runtime.GrabEdgeEventRethrow<TEvDataShard::TEvGetOpenTxsResult>(sender);
+            return std::move(ev->Get()->OpenTxs);
+        }
+
     private:
         TTestActorRuntime& Runtime;
         const ui64 TabletId;
@@ -1232,6 +1239,270 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         UNIT_ASSERT_VALUES_EQUAL(
             waitGraph.ToString(),
             "");
+    }
+
+    Y_UNIT_TEST(MultipleSharedLocksCleanupBottomUp) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock key 1 by lock 1 in shared mode
+        auto req1 = lockRows.SendRequest(lock1, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 1u);
+
+        // Lock key 1 by lock 2 in shared mode
+        auto req2 = lockRows.SendRequest(lock2, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req2);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 2u);
+
+        // Lock key 1 by lock 3 in shared mode
+        auto req3 = lockRows.SendRequest(lock3, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req3);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 3u);
+
+        // Removing lock 1 should rollback its changes, making MultiTxId for locks [1..2] redundant which is also removed
+        lock1.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 1u);
+
+        // Removing lock 2 should cause MultiTxId for locks [2..3] to become an alias for lock 3
+        lock2.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 1u);
+
+        // Removing lock 3 should cause the last MultiTxId cleanup, leaving none
+        lock3.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 0u);
+    }
+
+    Y_UNIT_TEST(MultipleSharedLocksCleanupTopDown) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockHandle lock4(456, runtime.GetActorSystem(0));
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock key 1 by lock 1 in shared mode
+        auto req1 = lockRows.SendRequest(lock1, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 1u);
+
+        // Lock key 1 by lock 2 in shared mode
+        auto req2 = lockRows.SendRequest(lock2, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req2);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 2u);
+
+        // Lock key 1 by lock 3 in shared mode
+        auto req3 = lockRows.SendRequest(lock3, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req3);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 3u);
+
+        // Lock key 1 by lock 4 in shared mode
+        auto req4 = lockRows.SendRequest(lock4, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Build());
+        lockRows.ExpectResult(req4);
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 4u);
+
+        // Removing lock 4 shouldn't change anything, because MultiTxId for locks [1..4] has non-zero locked rows
+        lock4.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 4u);
+
+        // Removing lock 3 should cleanup MultiTxId for locks [1..3] and relink MultiTxId [1..4] to [1..2]
+        lock3.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 3u);
+
+        // Removing lock 2 makes MultiTxId [1..2] to be a redundant alias for lock 1, which is removed
+        lock2.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 2u);
+
+        // Finally removing lock 1 will cause a lock 1 rollback and removal of corresponding MultiTxId
+        lock1.Reset();
+        lockRows.ExpectNoResult();
+
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 0u);
+    }
+
+    Y_UNIT_TEST(MultipleSharedLocksLayers) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockHandle lock3(345, runtime.GetActorSystem(0));
+        TLockHandle lock4(456, runtime.GetActorSystem(0));
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Lock keys 1..4 by lock 1 in shared mode
+        auto req1 = lockRows.SendRequest(lock1, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(1).Add(2).Add(3).Add(4).Build());
+        lockRows.ExpectResult(req1);
+
+        // Uncommitted:
+        // * lock 1
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 1u);
+
+        // Lock keys 2..5 by lock 2 in shared mode
+        auto req2 = lockRows.SendRequest(lock2, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(2).Add(3).Add(4).Add(5).Build());
+        lockRows.ExpectResult(req2);
+
+        // Uncommitted:
+        // * lock 1
+        // * lock 2
+        // * multi[1, 2]
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 3u);
+
+        // Lock keys 3..6 by lock 3 in shared mode
+        auto req3 = lockRows.SendRequest(lock3, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(3).Add(4).Add(5).Add(6).Build());
+        lockRows.ExpectResult(req3);
+
+        // Uncommitted:
+        // * lock 1
+        // * lock 2
+        // * lock 3
+        // * multi[1, 2]
+        // * multi[multi[1, 2], 3]
+        // * multi[2, 3]
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 6u);
+
+        // Lock keys 4..7 by lock 4 in shared mode
+        auto req4 = lockRows.SendRequest(lock4, NKikimrDataEvents::PESSIMISTIC_SHARED, tableId, TKeysBuilder().Add(4).Add(5).Add(6).Add(7).Build());
+        lockRows.ExpectResult(req4);
+
+        // Uncommitted:
+        // * lock 1
+        // * lock 2
+        // * lock 3
+        // * lock 4
+        // * multi[1, 2]
+        // * multi[multi[1, 2], 3]
+        // * multi[multi[multi[1, 2], 3], 4]
+        // * multi[2, 3] (LockedRowsCount == 0)
+        // * multi[multi[2, 3], 4]
+        // * multi[3, 4]
+        // Rows and corresponding locks:
+        // * key1: lock 1
+        // * key2: multi[1..2]
+        // * key3: multi[1..3]
+        // * key4: multi[1..4]
+        // * key5: multi[2..4]
+        // * key6: multi[3..4]
+        // * key7: lock 4
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 10u);
+
+        // Removing lock 1 will not remove any MultiTxIds, because all of them are used by at least 1 row
+        lock1.Reset();
+        lockRows.ExpectNoResult();
+
+        // Uncommitted:
+        // * lock 2
+        // * lock 3
+        // * lock 4
+        // * multi[2]
+        // * multi[multi[2], 3]
+        // * multi[multi[multi[2], 3], 4]
+        // * multi[2, 3] (LockedRowsCount == 0)
+        // * multi[multi[2, 3], 4]
+        // * multi[3, 4]
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 9u);
+
+        // Removing lock 2 will also remove MultiTxId which used to combine lock 1 and 2 and collapse multi[2, 3]
+        lock2.Reset();
+        lockRows.ExpectNoResult();
+
+        // Uncommitted:
+        // * lock 3
+        // * lock 4
+        // * multi[3]
+        // * multi[multi[3], 4]
+        // * multi[3, 4]
+        // * multi[3, 4]
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 6u);
+
+        // Removing lock 3 will also remove MultiTxIds which only had lock 3 left
+        lock3.Reset();
+        lockRows.ExpectNoResult();
+
+        // Uncommitted:
+        // * lock 4
+        // * multi[4]
+        // * multi[4]
+        // * multi[4]
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 4u);
+
+        // Removing lock 4 will cleanup all remaining locks
+        lock4.Reset();
+        lockRows.ExpectNoResult();
+
+        // Uncommitted: none left
+        UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 0u);
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/datashard/multi_txids.cpp
+++ b/ydb/core/tx/datashard/multi_txids.cpp
@@ -3,6 +3,14 @@
 
 namespace NKikimr::NDataShard {
 
+static constexpr size_t MaxInlineCleanupReferences = 8;
+
+TMultiTxIdEnumerator::TMultiTxIdEnumerator(TMultiTxIdManager& self)
+    : Self(self)
+{
+    Filter = NTable::ELockMode::None;
+}
+
 TMultiTxIdEnumerator::TMultiTxIdEnumerator(TMultiTxIdManager& self, const TMultiTxId* entry, NTable::ELockMode filter)
     : Self(self)
 {
@@ -144,12 +152,7 @@ bool TMultiTxIdManager::LoadMultiTxIdGraph(NIceDb::TNiceDb& db) {
             auto& parent = it->second;
             TMultiTxId::TEdge* edge = new TMultiTxId::TEdge(edgeId, multiTxId, nestedTxId, nestedLockMode);
             parent.Edges.PushBack(edge);
-            if (auto itNested = MultiTxIds.find(nestedTxId); itNested != MultiTxIds.end()) {
-                // Track reference links between MultiTxIds
-                auto& nested = itNested->second;
-                nested.References.PushBack(edge);
-                nested.ReferencesCount++;
-            }
+            InitializeReference(*edge);
         } else {
             Y_DEBUG_ABORT_S(
                 "Cannot find parent for EdgeId# " << edgeId
@@ -168,20 +171,63 @@ bool TMultiTxIdManager::LoadMultiTxIdGraph(NIceDb::TNiceDb& db) {
     return true;
 }
 
+void TMultiTxIdManager::InitializeReference(TMultiTxId::TEdge& edge) {
+    if (TMultiTxId* nested = FindMultiTxId(edge.NestedTxId)) {
+        nested->References.PushBack(&edge);
+        nested->ReferencesCount++;
+    } else {
+        auto& shadow = GetLockShadow(edge.NestedTxId);
+        shadow.References.PushBack(&edge);
+        shadow.ReferencesCount++;
+    }
+}
+
+TMultiTxIdLockShadow& TMultiTxIdManager::GetLockShadow(ui64 lockId) {
+    auto it = LockShadows.find(lockId);
+    if (it == LockShadows.end()) {
+        auto res = LockShadows.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(lockId),
+            std::forward_as_tuple(lockId));
+        Y_ENSURE(res.second);
+        it = res.first;
+    }
+    return it->second;
+}
+
 void TMultiTxIdManager::Start() {
-    // TODO
+    // Check existing lock references and start cleaning up broken and missing
+    bool enqueueCleanup = false;
+    for (auto& [lockId, shadow] : LockShadows) {
+        auto lock = Self.SysLocksTable().GetRawLock(lockId);
+        if (!lock || lock->IsBroken()) {
+            shadow.Broken = true;
+            LockShadowCleanupQueue.PushBack(&shadow);
+            enqueueCleanup = true;
+        }
+    }
+    for (auto& [multiTxId, entry] : MultiTxIds) {
+        if (NeedCleanup(&entry)) {
+            MultiTxIdCleanupQueue.PushBack(&entry);
+            enqueueCleanup = true;
+        }
+    }
+    if (enqueueCleanup) {
+        EnqueueCleanupTx();
+    }
 }
 
 void TMultiTxIdManager::DecrementLockedRowsCount(NIceDb::TNiceDb& db, ui64 multiTxId) {
     using Schema = TDataShard::Schema;
 
     auto it = MultiTxIds.find(multiTxId);
-    Y_ENSURE(it != MultiTxIds.end());
-    TMultiTxId& entry = it->second;
-    Y_ENSURE(entry.LockedRowsCount > 0);
-    entry.LockedRowsCount--;
-    db.Table<Schema::MultiTxIds>().Key(entry.MultiTxId).Update(
-        NIceDb::TUpdate<Schema::MultiTxIds::LockedRowsCount>(entry.LockedRowsCount));
+    Y_ENSURE(it != MultiTxIds.end(), "Cannot decrement locked row count for a missing MultiTxId# " << multiTxId);
+    TMultiTxId* entry = &it->second;
+    Y_ENSURE(entry->LockedRowsCount > 0);
+    entry->LockedRowsCount--;
+    db.Table<Schema::MultiTxIds>().Key(entry->MultiTxId).Update(
+        NIceDb::TUpdate<Schema::MultiTxIds::LockedRowsCount>(entry->LockedRowsCount));
+    MaybeEnqueueCleanup(entry);
 }
 
 ui64 TMultiTxIdManager::CombineRowLocks(
@@ -238,6 +284,9 @@ ui64 TMultiTxIdManager::CombineRowLocks(
     entry.Edges.PushBack(new TMultiTxId::TEdge(NextEdgeId++, entry.MultiTxId, currentTxId, currentLockMode));
     entry.Edges.PushBack(new TMultiTxId::TEdge(NextEdgeId++, entry.MultiTxId, lockTxId, lockMode));
     entry.LockedRowsCount++;
+    for (auto& edge : entry.Edges) {
+        InitializeReference(edge);
+    }
 
     db.Table<Schema::MultiTxIds>().Key(entry.MultiTxId).Update(
         NIceDb::TUpdate<Schema::MultiTxIds::LockedRowsCount>(entry.LockedRowsCount),
@@ -252,6 +301,266 @@ ui64 TMultiTxIdManager::CombineRowLocks(
     globalTxId = 0;
 
     return entry.MultiTxId;
+}
+
+void TMultiTxIdManager::BreakMultiTxId(const TMultiTxId* entry) {
+    // TODO: make it possible to break MultiTxId directly
+    auto enumerator = EnumerateLocks(entry);
+    while (auto result = enumerator.Next()) {
+        Self.SysLocksTable().BreakLock(result.LockId);
+    }
+}
+
+void TMultiTxIdManager::AddWriteConflict(const TMultiTxId* entry) {
+    // TODO: make it possible to add MultiTxId to conflict list directly
+    auto enumerator = EnumerateLocks(entry);
+    while (auto result = enumerator.Next()) {
+        Self.SysLocksTable().AddWriteConflict(result.LockId);
+    }
+}
+
+void TMultiTxIdManager::OnLockBroken(NIceDb::TNiceDb& db, ui64 lockId) {
+    if (auto* shadow = LockShadows.FindPtr(lockId)) {
+        BreakShadow(db, shadow);
+    }
+}
+
+void TMultiTxIdManager::OnLockRemoved(NIceDb::TNiceDb& db, ui64 lockId) {
+    if (auto* shadow = LockShadows.FindPtr(lockId)) {
+        BreakShadow(db, shadow);
+    }
+}
+
+void TMultiTxIdManager::BreakShadow(NIceDb::TNiceDb& db, TMultiTxIdLockShadow* shadow) {
+    if (shadow->Broken) {
+        // Already known to be broken
+        return;
+    }
+    shadow->Broken = true;
+    RunLockShadowCleanup(db, shadow);
+}
+
+class TDataShard::TTxMultiTxIdCleanup
+    : public NTabletFlatExecutor::ITransaction
+{
+public:
+    explicit TTxMultiTxIdCleanup(TDataShard& self)
+        : Self(self)
+    {}
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        NIceDb::TNiceDb db(txc.DB);
+        Self.GetMultiTxIdManager().RunCleanup(db);
+        return true;
+    }
+
+    void Complete(const TActorContext&) override {
+        // nothing
+    }
+
+private:
+    TDataShard& Self;
+};
+
+void TMultiTxIdManager::EnqueueCleanupTx() {
+    if (!CleanupTxInFlight) {
+        Self.Enqueue(new TDataShard::TTxMultiTxIdCleanup(Self));
+        CleanupTxInFlight = true;
+    }
+}
+
+void TMultiTxIdManager::RunCleanup(NIceDb::TNiceDb& db) {
+    Y_ENSURE(CleanupTxInFlight);
+    CleanupTxInFlight = false;
+
+    if (!LockShadowCleanupQueue.Empty()) {
+        RunLockShadowCleanup(db, LockShadowCleanupQueue.PopFront());
+    } else if (!MultiTxIdCleanupQueue.Empty()) {
+        RunMultiTxIdCleanup(db, MultiTxIdCleanupQueue.PopFront());
+    }
+
+    if (!LockShadowCleanupQueue.Empty() || !MultiTxIdCleanupQueue.Empty()) {
+        EnqueueCleanupTx();
+    }
+}
+
+bool TMultiTxIdManager::NeedCleanup(const TMultiTxId* entry) const {
+    size_t edgesCount = 0;
+    for (auto& edge : entry->Edges) {
+        Y_UNUSED(edge);
+        edgesCount++;
+    }
+
+    if (edgesCount == 0) {
+        // We want to cleanup empty MultiTxIds
+        return true;
+    }
+
+    if (entry->LockedRowsCount == 0 && entry->ReferencesCount <= 1) {
+        // We want to cleanup unnecessary MultiTxIds
+        return edgesCount == 1 || entry->ReferencesCount == 0;
+    }
+
+    return false;
+}
+
+void TMultiTxIdManager::MaybeEnqueueCleanup(TMultiTxId* entry) {
+    if (!entry->ToCleanupQueueItem()->Empty()) {
+        // Item might be in the queue already
+        return;
+    }
+
+    if (NeedCleanup(entry)) {
+        MultiTxIdCleanupQueue.PushBack(entry);
+        EnqueueCleanupTx();
+    }
+}
+
+void TMultiTxIdManager::RunLockShadowCleanup(NIceDb::TNiceDb& db, TMultiTxIdLockShadow* shadow) {
+    size_t processed = 0;
+    while (processed < MaxInlineCleanupReferences && !shadow->References.Empty()) {
+        auto* ref = shadow->References.PopFront();
+        shadow->ReferencesCount--;
+        auto* parent = MultiTxIds.FindPtr(ref->MultiTxId);
+        Y_ENSURE(parent, "Unexpected failure to find parent MultiTxId# " << ref->MultiTxId << " for EdgeId# " << ref->EdgeId);
+        Y_ENSURE(!parent->Edges.Empty(), "Found unexpected parent MultiTxId# " << ref->MultiTxId << " for EdgeId# " << ref->EdgeId << " with no edges");
+        DeleteEdge(db, ref);
+        MaybeEnqueueCleanup(parent);
+        ++processed;
+    }
+
+    if (shadow->References.Empty()) {
+        ui64 lockId = shadow->LockId;
+        LockShadows.erase(lockId);
+        return;
+    }
+
+    LockShadowCleanupQueue.PushBack(shadow);
+    EnqueueCleanupTx();
+}
+
+void TMultiTxIdManager::RunMultiTxIdCleanup(NIceDb::TNiceDb& db, TMultiTxId* entry) {
+    using Schema = TDataShard::Schema;
+
+    // MultiTxId without any edges is removed from all references
+    // This happens even when there are rows locked to this MultiTxId, which is
+    // redundant this it represents an empty set of transactions.
+    if (entry->Edges.Empty()) {
+        size_t processed = 0;
+        while (processed < MaxInlineCleanupReferences && !entry->References.Empty()) {
+            auto* ref = entry->References.PopFront();
+            auto* parent = MultiTxIds.FindPtr(ref->MultiTxId);
+            Y_ENSURE(parent, "Unexpected failure to find parent MultiTxId# " << ref->MultiTxId << " for EdgeId# " << ref->EdgeId);
+            Y_ENSURE(!parent->Edges.Empty(), "Found unexpected parent MultiTxId# " << ref->MultiTxId << " for EdgeId# " << ref->EdgeId << " with no edges");
+            entry->ReferencesCount--;
+            DeleteEdge(db, ref);
+            // Deleting an edge from parent might trigger its cleanup
+            MaybeEnqueueCleanup(parent);
+            ++processed;
+        }
+
+        if (entry->References.Empty()) {
+            DeleteMultiTxId(db, entry);
+            return;
+        }
+
+        MultiTxIdCleanupQueue.PushBack(entry);
+        EnqueueCleanupTx();
+        return;
+    }
+
+    if (entry->LockedRowsCount > 0) {
+        // MultiTxId might be reused before the cleanup queue is processed
+        return;
+    }
+
+    if (entry->ReferencesCount > 1) {
+        // Avoid removing entries used by multiple upstream MultiTxIds
+        return;
+    }
+
+    // Remove MultiTxId that has no references
+    if (entry->ReferencesCount == 0) {
+        while (!entry->Edges.Empty()) {
+            auto* edge = entry->Edges.Front();
+            ui64 nestedTxId = edge->NestedTxId;
+            if (auto* child = MultiTxIds.FindPtr(nestedTxId)) {
+                Y_ENSURE(child->ReferencesCount > 0);
+                child->References.Remove(edge);
+                child->ReferencesCount--;
+                DeleteEdge(db, edge);
+                // Deleting a reference to child might trigger its cleanup
+                MaybeEnqueueCleanup(child);
+            } else if (auto* shadow = LockShadows.FindPtr(nestedTxId)) {
+                Y_ENSURE(shadow->ReferencesCount > 0);
+                shadow->References.Remove(edge);
+                shadow->ReferencesCount--;
+                DeleteEdge(db, edge);
+                // Deleting a reference to shadow might make it redundant
+                if (shadow->References.Empty()) {
+                    LockShadows.erase(nestedTxId);
+                }
+            } else {
+                Y_ENSURE(false, "Unexpected failure to find NestedTxId# " << nestedTxId
+                    << " from EdgeId# " << edge->EdgeId << " in MultiTxId# " << entry->MultiTxId);
+            }
+        }
+
+        DeleteMultiTxId(db, entry);
+        return;
+    }
+
+    // Otherwise we have edges which need to be moved up to a single parent
+    Y_ENSURE(!entry->References.Empty());
+    auto* ref = entry->References.Front();
+    auto* parent = MultiTxIds.FindPtr(ref->MultiTxId);
+    Y_ENSURE(parent, "Unexpected failure to find MultiTxId# " << ref->MultiTxId << " from EdgeId# " << ref->EdgeId);
+    while (!entry->Edges.Empty()) {
+        // For each edge in the current entry we relink it before the edge which
+        // is referring to the current entry. This way downstream edges will
+        // replace the reference without changing relative order.
+        auto* edge = entry->Edges.PopFront();
+        edge->MultiTxId = parent->MultiTxId;
+        edge->ToEdgesItem()->LinkBefore(ref);
+        db.Table<Schema::MultiTxIdGraph>().Key(edge->EdgeId).Update(
+            NIceDb::TUpdate<Schema::MultiTxIdGraph::MultiTxId>(edge->MultiTxId));
+    }
+
+    // Delete the reference to this entry from parent
+    entry->ReferencesCount--;
+    DeleteEdge(db, ref);
+
+    // Now we must have no edges and no references
+    Y_ENSURE(entry->Edges.Empty());
+    Y_ENSURE(entry->ReferencesCount == 0);
+    DeleteMultiTxId(db, entry);
+}
+
+void TMultiTxIdManager::DeleteEdge(NIceDb::TNiceDb& db, TMultiTxId::TEdge* edge) {
+    using Schema = TDataShard::Schema;
+
+    db.Table<Schema::MultiTxIdGraph>().Key(edge->EdgeId).Delete();
+    delete edge;
+}
+
+void TMultiTxIdManager::DeleteMultiTxId(NIceDb::TNiceDb& db, TMultiTxId* entry) {
+    using Schema = TDataShard::Schema;
+
+    ui64 multiTxId = entry->MultiTxId;
+    auto it = MultiTxIds.find(multiTxId);
+    Y_ENSURE(it != MultiTxIds.end() && entry == &it->second, "Unexpected MultiTxId# " << multiTxId << " not matching the hashmap entry");
+    Y_ENSURE(entry->Edges.Empty(), "Cannot delete MultiTxId# " << multiTxId << " which has graph edges");
+    Y_ENSURE(entry->References.Empty(), "Cannot delete MultiTxId# " << multiTxId << " which has references");
+    db.Table<Schema::MultiTxIds>().Key(multiTxId).Delete();
+    MultiTxIds.erase(it);
+
+    // Avoid leaving references to deleted MultiTxId in LocalDB
+    for (auto& pr : Self.GetUserTables()) {
+        auto tid = pr.second->LocalTid;
+        if (db.GetDatabase().HasOpenTx(tid, multiTxId)) {
+            db.GetDatabase().RemoveTx(tid, multiTxId);
+        }
+    }
 }
 
 } // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/multi_txids.h
+++ b/ydb/core/tx/datashard/multi_txids.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ydb/core/tablet_flat/flat_row_eggs.h>
+#include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <util/generic/intrlist.h>
 #include <util/generic/hash.h>
 #include <util/generic/vector.h>
@@ -27,9 +28,26 @@ namespace NKikimr::NDataShard {
 
     class TMultiTxIdManager;
 
+    struct TMultiTxIdCleanupQueueTag {};
     struct TMultiTxIdReferenceTag {};
 
-    struct TMultiTxId {
+    /**
+     * This class is used to represent MultiTxId in the graph, with multiple
+     * locks from different transactions or lock modes. Its multi identifier is
+     * used in place of a contained set of transactions. MultiTxId forms a tree,
+     * which is a union of other MultiTxIds or transaction locks. In the common
+     * case there are at most two edges. Since there cannot be more than two
+     * non-conflicting lock modes, it will either have two edges with the same
+     * lock mode (one of which may be a previously seen MultiTxId), or two
+     * edges with different lock modes.
+     *
+     * In complex cases where the same transaction acquires different lock modes
+     * at different savepoints, it may have more than two edges, one per
+     * corresponding lock mode.
+     */
+    struct TMultiTxId
+        : public TIntrusiveListItem<TMultiTxId, TMultiTxIdCleanupQueueTag>
+    {
         struct TEdge
             : public TIntrusiveListItem<TEdge>
             , public TIntrusiveListItem<TEdge, TMultiTxIdReferenceTag>
@@ -54,6 +72,14 @@ namespace NKikimr::NDataShard {
             const TEdge* NextEdge() const {
                 const TIntrusiveListItem<TEdge>* self = this;
                 return self->Next()->Node();
+            }
+
+            TIntrusiveListItem<TEdge>* ToEdgesItem() {
+                return this;
+            }
+
+            TIntrusiveListItem<TEdge, TMultiTxIdReferenceTag>* ToReferencesItem() {
+                return this;
             }
         };
 
@@ -95,6 +121,31 @@ namespace NKikimr::NDataShard {
             }
             return lockMode;
         }
+
+        TIntrusiveListItem<TMultiTxId, TMultiTxIdCleanupQueueTag>* ToCleanupQueueItem() {
+            return this;
+        }
+    };
+
+    /**
+     * This class is used to represent leaf nodes (transactions) referenced
+     * by MultiTxIds. This decouples MultiTxIds from the lock table, and allows
+     * tracking and cleaning up unnecessary transactions and MultiTxId nodes
+     * when transactions are committed or rolled back. Additionally we use these
+     * shadow nodes to cache pathways for reusing MultiTxIds with the same
+     * construction path.
+     */
+    struct TMultiTxIdLockShadow
+        : public TIntrusiveListItem<TMultiTxIdLockShadow, TMultiTxIdCleanupQueueTag>
+    {
+        const ui64 LockId;
+        TIntrusiveList<TMultiTxId::TEdge, TMultiTxIdReferenceTag> References;
+        size_t ReferencesCount = 0;
+        bool Broken = false;
+
+        explicit TMultiTxIdLockShadow(ui64 lockId)
+            : LockId(lockId)
+        {}
     };
 
     /**
@@ -105,6 +156,7 @@ namespace NKikimr::NDataShard {
      */
     class TMultiTxIdEnumerator {
     public:
+        TMultiTxIdEnumerator(TMultiTxIdManager& self);
         TMultiTxIdEnumerator(TMultiTxIdManager& self, const TMultiTxId* entry, NTable::ELockMode filter = NTable::ELockMode::None);
 
         struct TResult {
@@ -135,7 +187,7 @@ namespace NKikimr::NDataShard {
             const TMultiTxId::TEdge* Edge;
         };
         TMultiTxIdManager& Self;
-        TVector<TNextEdge> Stack;
+        TStackVec<TNextEdge> Stack;
         NTable::ELockMode Filter;
     };
 
@@ -148,21 +200,49 @@ namespace NKikimr::NDataShard {
         bool Load(NIceDb::TNiceDb& db);
         void Start();
 
-        const TMultiTxId* FindMultiTxId(ui64 multiTxId) const {
-            return MultiTxIds.FindPtr(multiTxId);
-        }
+        TMultiTxId* FindMultiTxId(ui64 multiTxId) { return MultiTxIds.FindPtr(multiTxId); }
+        const TMultiTxId* FindMultiTxId(ui64 multiTxId) const { return MultiTxIds.FindPtr(multiTxId); }
 
         void DecrementLockedRowsCount(NIceDb::TNiceDb& db, ui64 multiTxId);
         ui64 CombineRowLocks(NIceDb::TNiceDb& db, ui64 currentTxId, NTable::ELockMode currentLockMode, ui64 lockTxId, NTable::ELockMode lockMode, ui64& globalTxId);
+
+        TMultiTxIdEnumerator EnumerateLocks(const TMultiTxId* entry, NTable::ELockMode filter = NTable::ELockMode::None) {
+            return TMultiTxIdEnumerator(*this, entry, filter);
+        }
+
+        void BreakMultiTxId(const TMultiTxId* entry);
+        void AddWriteConflict(const TMultiTxId* entry);
+
+        void OnLockBroken(NIceDb::TNiceDb& db, ui64 lockId);
+        void OnLockRemoved(NIceDb::TNiceDb& db, ui64 lockId);
+        void RunCleanup(NIceDb::TNiceDb& db);
 
     private:
         bool LoadMultiTxIds(NIceDb::TNiceDb& db);
         bool LoadMultiTxIdGraph(NIceDb::TNiceDb& db);
 
     private:
+        void InitializeReference(TMultiTxId::TEdge& edge);
+        TMultiTxIdLockShadow& GetLockShadow(ui64 lockId);
+        void BreakShadow(NIceDb::TNiceDb& db, TMultiTxIdLockShadow* shadow);
+        void EnqueueCleanupTx();
+        bool NeedCleanup(const TMultiTxId* entry) const;
+        void MaybeEnqueueCleanup(TMultiTxId* entry);
+        void RunLockShadowCleanup(NIceDb::TNiceDb& db, TMultiTxIdLockShadow* shadow);
+        void RunMultiTxIdCleanup(NIceDb::TNiceDb& db, TMultiTxId* entry);
+
+    private:
+        void DeleteEdge(NIceDb::TNiceDb& db, TMultiTxId::TEdge* edge);
+        void DeleteMultiTxId(NIceDb::TNiceDb& db, TMultiTxId* entry);
+
+    private:
         TDataShard& Self;
-        THashMap<ui64, TMultiTxId> MultiTxIds;
         ui64 NextEdgeId = 1;
+        THashMap<ui64, TMultiTxId> MultiTxIds;
+        THashMap<ui64, TMultiTxIdLockShadow> LockShadows;
+        TIntrusiveList<TMultiTxId, TMultiTxIdCleanupQueueTag> MultiTxIdCleanupQueue;
+        TIntrusiveList<TMultiTxIdLockShadow, TMultiTxIdCleanupQueueTag> LockShadowCleanupQueue;
+        bool CleanupTxInFlight = false;
     };
 
     /**


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR implements basic conflict tracking between serializable transactions and pessimistic MultiTxId locks, as well as cleanup logic for MultiTxIds which become unnecessary.

Related to #35483.