### PR TITLE
Add compaction operation support in SDK and CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,5 +1,6 @@
 * When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
+* Added support for the new compact operation in the `ydb operation` subcommands.
 
 ## 2.29.0 ##
 

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,6 +1,6 @@
 * When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
-* Added support for the new compact operation in the `ydb operation` subcommands.
+* Added support for the new compaction operation in the `ydb operation` subcommands.
 
 ## 2.29.0 ##
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13819,7 +13819,7 @@ END DO)",
         TestTruncateTable(tableName, useQueryClient, createSecondaryIndex);
     }
 
-    Y_UNIT_TEST_TWIN(AlterTableCompact, UseQueryService) {
+    Y_UNIT_TEST_TWIN(AlterTableCompactSql, UseQueryService) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableForcedCompactions(true);
         TKikimrRunner kikimr(featureFlags);
@@ -13860,7 +13860,64 @@ END DO)",
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
         }
 
-        // TODO: check operation status
+        NYdb::NOperation::TOperationClient opClient(kikimr.GetDriver());
+        auto compactOps = opClient.List<NYdb::NTable::TCompactionOperation>().GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(compactOps.GetStatus(), EStatus::SUCCESS, compactOps.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(compactOps.GetList().size(), 1);
+
+        auto compactOp = compactOps.GetList()[0];
+        UNIT_ASSERT_VALUES_EQUAL_C(compactOp.Status().GetStatus(), EStatus::SUCCESS, compactOp.Status().GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(AlterTableCompactPublicApi) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableForcedCompactions(true);
+        TKikimrRunner kikimr(featureFlags);
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().ExtractValueSync().GetSession();
+
+        TExplicitPartitions partitions;
+        partitions.AppendSplitPoints(TValueBuilder().BeginTuple().AddElement().OptionalUint64(250).EndTuple().Build());
+        partitions.AppendSplitPoints(TValueBuilder().BeginTuple().AddElement().OptionalUint64(500).EndTuple().Build());
+        partitions.AppendSplitPoints(TValueBuilder().BeginTuple().AddElement().OptionalUint64(750).EndTuple().Build());
+
+        auto builder = TTableBuilder()
+            .AddNullableColumn("Key", EPrimitiveType::Uint64)
+            .AddNullableColumn("Value", EPrimitiveType::String)
+            .SetPrimaryKeyColumn("Key")
+            .SetPartitionAtKeys(partitions);
+
+        auto result = session.CreateTable("/Root/TestTable", builder.Build()).ExtractValueSync();
+        if (!result.IsSuccess()) {
+            ythrow yexception() << "Unexpected status create table: " << result.GetStatus() << ": " << result.GetIssues().ToString();
+        }
+
+        NYdb::TValueBuilder rows;
+        rows.BeginList();
+        rows.AddListItem().BeginStruct().AddMember("Key").Uint64(100).AddMember("Value").String("value_1").EndStruct();
+        rows.AddListItem().BeginStruct().AddMember("Key").Uint64(400).AddMember("Value").String("value_2").EndStruct();
+        rows.AddListItem().BeginStruct().AddMember("Key").Uint64(700).AddMember("Value").String("value_3").EndStruct();
+        rows.AddListItem().BeginStruct().AddMember("Key").Uint64(1000).AddMember("Value").String("value_4").EndStruct();
+        rows.EndList();
+
+        result = db.BulkUpsert("/Root/TestTable", rows.Build()).GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+        auto settings = NYdb::NTable::TAlterTableSettings().Compact(TCompact());
+        auto opId = session.AlterTableLong("/Root/TestTable", settings).ExtractValueSync().Id();
+
+        bool ready = false;
+        TMaybe<NYdb::NTable::TCompactionOperation> op;
+        while (!ready) {
+            Sleep(TDuration::MilliSeconds(100));
+            NYdb::NOperation::TOperationClient opClient(kikimr.GetDriver());
+            op = opClient.Get<NYdb::NTable::TCompactionOperation>(opId).GetValueSync();
+            ready = op->Ready();
+        }
+        if (!op->Status().IsSuccess()) {
+            ythrow yexception() << "Unexpected status of compaction operation: " << op->Status().GetStatus() << ": " << op->Status().GetIssues().ToString();
+        }
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_operation.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_operation.cpp
@@ -107,6 +107,8 @@ int TCommandGetOperation::Run(TConfig& config) {
         return GetOperation<NBackup::TIncrementalBackupResponse>(client, OperationId, OutputFormat);
     case TOperationId::RESTORE:
         return GetOperation<NBackup::TBackupCollectionRestoreResponse>(client, OperationId, OutputFormat);
+    case TOperationId::COMPACTION:
+        return GetOperation<NTable::TCompactionOperation>(client, OperationId, OutputFormat);
     default:
         throw TMisuseException() << "Invalid operation ID (unexpected kind of operation)";
     }
@@ -144,6 +146,7 @@ void TCommandListOperations::InitializeKindToHandler(TConfig& config) {
         {"scriptexec", &ListOperations<NQuery::TScriptExecutionOperation>},
         {"incbackup", &ListOperations<NBackup::TIncrementalBackupResponse>},
         {"restore", &ListOperations<NBackup::TBackupCollectionRestoreResponse>},
+        {"compaction", &ListOperations<NTable::TCompactionOperation>},
     };
     if (config.UseExportToYt) {
         KindToHandler.emplace("export", THandlerWrapper(&ListOperations<NExport::TExportToYtResponse>, true)); // deprecated

--- a/ydb/public/lib/ydb_cli/common/print_operation.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_operation.cpp
@@ -250,6 +250,33 @@ namespace {
         row.FreeText(freeText);
     }
 
+    TPrettyTable MakeTable(const NYdb::NTable::TCompactionOperation&) {
+        return TPrettyTable({"id", "ready", "status", "state", "progress", "table", "cascade", "max inflight", "total", "done"});
+    }
+
+    void PrettyPrint(const NYdb::NTable::TCompactionOperation& operation, TPrettyTable& table) {
+        const auto& status = operation.Status();
+        const auto& metadata = operation.Metadata();
+
+        auto& row = table.AddRow();
+        row
+            .Column(0, operation.Id().ToString())
+            .Column(1, operation.Ready() ? "true" : "false")
+            .Column(2, status.GetStatus() == NYdb::EStatus::STATUS_UNDEFINED ? "" : ToString(status.GetStatus()))
+            .Column(3, metadata.State)
+            .Column(4, FloatToString(metadata.Progress, PREC_POINT_DIGITS, 2) + "%")
+            .Column(5, metadata.Path)
+            .Column(6, metadata.Cascade ? "true" : "false")
+            .Column(7, metadata.MaxInFlight)
+            .Column(8, metadata.Total)
+            .Column(9, metadata.Done);
+
+        TStringBuilder freeText;
+        AppendIssues(status, freeText);
+        AppendOperationInfo(operation, freeText);
+        row.FreeText(freeText);
+    }
+
     /// QueryService
     TPrettyTable MakeTable(const NYdb::NQuery::TScriptExecutionOperation&) {
         return TPrettyTable({"id", "ready", "status", "execution_id", "exec_status", "exec_mode"});
@@ -439,6 +466,14 @@ void PrintOperation(const NYdb::NTable::TBuildIndexOperation& operation, EDataFo
 }
 
 void PrintOperationsList(const NOperation::TOperationsList<NYdb::NTable::TBuildIndexOperation>& operations, EDataFormat format) {
+    PrintOperationsListImpl(operations, format);
+}
+
+void PrintOperation(const NYdb::NTable::TCompactionOperation& operation, EDataFormat format) {
+    PrintOperationImpl(operation, format);
+}
+
+void PrintOperationsList(const NOperation::TOperationsList<NYdb::NTable::TCompactionOperation>& operations, EDataFormat format) {
     PrintOperationsListImpl(operations, format);
 }
 

--- a/ydb/public/lib/ydb_cli/common/print_operation.h
+++ b/ydb/public/lib/ydb_cli/common/print_operation.h
@@ -42,5 +42,8 @@ void PrintOperationsList(const NOperation::TOperationsList<NYdb::NBackup::TIncre
 void PrintOperation(const NYdb::NBackup::TBackupCollectionRestoreResponse& operation, EDataFormat format);
 void PrintOperationsList(const NOperation::TOperationsList<NYdb::NBackup::TBackupCollectionRestoreResponse>& operations, EDataFormat format);
 
+void PrintOperation(const NYdb::NTable::TCompactionOperation& operation, EDataFormat format);
+void PrintOperationsList(const NOperation::TOperationsList<NYdb::NTable::TCompactionOperation>& operations, EDataFormat format);
+
 }
 }

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,6 +1,6 @@
 * Added support for METRICS_LEVEL for the CreateTable/AlterTable requests.
 
-* Added support for the new alter compact operation in TableClient and OperationClient
+* Added support for the new alter table compact action in TableClient and compaction operation in OperationClient in SDK
 
 ## v3.16.0
 

--- a/ydb/public/sdk/cpp/CHANGELOG.md
+++ b/ydb/public/sdk/cpp/CHANGELOG.md
@@ -1,5 +1,7 @@
 * Added support for METRICS_LEVEL for the CreateTable/AlterTable requests.
 
+* Added support for the new alter compact operation in TableClient and OperationClient
+
 ## v3.16.0
 
 * Added support for the new inverted index type: JSON, intended to speed up queries on Json or JsonDocument columns.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/fwd.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/fwd.h
@@ -64,6 +64,7 @@ struct TPartitioningPolicy;
 struct TReplicationPolicy;
 
 class TBuildIndexOperation;
+class TCompactionOperation;
 
 class TTtlDeleteAction;
 class TTtlEvictToExternalStorageAction;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -42,6 +42,7 @@ class TableIndex;
 class TableIndexDescription;
 class ValueSinceUnixEpochModeSettings;
 class EvictionToExternalStorageSettings;
+class CompactItem;
 
 } // namespace Table
 } // namespace Ydb
@@ -546,6 +547,20 @@ public:
     const TMetadata& Metadata() const;
 private:
     TMetadata Metadata_;
+};
+
+class TCompact {
+public:
+    TCompact(bool cascade, uint32_t maxShardsInFlight);
+    TCompact();
+
+    bool GetCascade() const;
+    uint32_t GetMaxShardsInFlight() const;
+
+    void SerializeTo(Ydb::Table::CompactItem& proto) const;
+private:
+    bool Cascade_;
+    uint32_t MaxShardsInFlight_;
 };
 
 class TCompactionOperation : public TOperation {
@@ -2057,6 +2072,8 @@ struct TAlterTableSettings : public TOperationRequestSettings<TAlterTableSetting
     FLUENT_SETTING_OPTIONAL(TPartitioningSettings, AlterPartitioningSettings);
 
     FLUENT_SETTING_OPTIONAL(bool, SetKeyBloomFilter);
+
+    FLUENT_SETTING_OPTIONAL(TCompact, Compact);
 
     FLUENT_SETTING_OPTIONAL(TReadReplicasSettings, SetReadReplicasSettings);
     TSelf& SetReadReplicasSettings(TReadReplicasSettings::EMode mode, uint64_t readReplicasCount) {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -554,9 +554,6 @@ public:
     TCompact(bool cascade, uint32_t maxShardsInFlight);
     TCompact();
 
-    bool GetCascade() const;
-    uint32_t GetMaxShardsInFlight() const;
-
     void SerializeTo(Ydb::Table::CompactItem& proto) const;
 private:
     bool Cascade_;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -548,6 +548,26 @@ private:
     TMetadata Metadata_;
 };
 
+class TCompactionOperation : public TOperation {
+public:
+    using TOperation::TOperation;
+    TCompactionOperation(TStatus&& status, Ydb::Operations::Operation&& operation);
+
+    struct TMetadata {
+        ECompactState State;
+        float Progress;
+        std::string Path;
+        bool Cascade;
+        uint32_t MaxInFlight;
+        uint32_t Total;
+        uint32_t Done;
+    };
+
+    const TMetadata& Metadata() const;
+private:
+    TMetadata Metadata_;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Represents changefeed description

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
@@ -44,7 +44,7 @@ enum class EIndexType {
 
 enum class ECompactState {
     Unspecified = 0,
-    InProgess = 1,
+    InProgress = 1,
     Done = 2,
     Cancelled = 3,
 };

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
@@ -42,6 +42,13 @@ enum class EIndexType {
     Unknown = std::numeric_limits<int>::max()
 };
 
+enum class ECompactState {
+    Unspecified = 0,
+    InProgess = 1,
+    Done = 2,
+    Cancelled = 3,
+};
+
 enum class EChangefeedMode {
     KeysOnly /* "KEYS_ONLY" */,
     Updates /* "UPDATES" */,

--- a/ydb/public/sdk/cpp/src/client/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/src/client/operation/operation.cpp
@@ -85,4 +85,10 @@ NThreading::TFuture<TOperationsList<NQuery::TScriptExecutionOperation>> TOperati
     return List<NQuery::TScriptExecutionOperation>("scriptexec", pageSize, pageToken);
 }
 
+template NThreading::TFuture<NTable::TCompactionOperation> TOperationClient::Get(const TOperation::TOperationId& id);
+template <>
+NThreading::TFuture<TOperationsList<NTable::TCompactionOperation>> TOperationClient::List(std::uint64_t pageSize, const std::string& pageToken) {
+    return List<NTable::TCompactionOperation>("compaction", pageSize, pageToken);
+}
+
 } // namespace NYdb::NOperation

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -191,6 +191,24 @@ const TBuildIndexOperation::TMetadata& TBuildIndexOperation::Metadata() const {
     return Metadata_;
 }
 
+TCompactionOperation::TCompactionOperation(TStatus &&status, Ydb::Operations::Operation &&operation)
+    : TOperation(std::move(status), std::move(operation))
+{
+    Ydb::Table::CompactMetadata metadata;
+    GetProto().metadata().UnpackTo(&metadata);
+    Metadata_.State = static_cast<ECompactState>(metadata.state());
+    Metadata_.Progress = metadata.progress();
+    Metadata_.Path = metadata.path();
+    Metadata_.Cascade = metadata.cascade();
+    Metadata_.MaxInFlight = metadata.max_shards_in_flight();
+    Metadata_.Total = metadata.shards_total();
+    Metadata_.Done = metadata.shards_done();
+}
+
+const TCompactionOperation::TMetadata& TCompactionOperation::Metadata() const {
+    return Metadata_;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TPartitioningSettings::TImpl {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -191,6 +191,28 @@ const TBuildIndexOperation::TMetadata& TBuildIndexOperation::Metadata() const {
     return Metadata_;
 }
 
+TCompact::TCompact(bool cascade, uint32_t maxShardsInFlight)
+    : Cascade_(cascade)
+    , MaxShardsInFlight_(maxShardsInFlight)
+{}
+
+TCompact::TCompact()
+    : TCompact(false, 1)
+{}
+
+bool TCompact::GetCascade() const {
+    return Cascade_;
+}
+
+uint32_t TCompact::GetMaxShardsInFlight() const {
+    return MaxShardsInFlight_;
+}
+
+void TCompact::SerializeTo(Ydb::Table::CompactItem& proto) const {
+    proto.set_cascade(Cascade_);
+    proto.set_max_shards_in_flight(MaxShardsInFlight_);
+}
+
 TCompactionOperation::TCompactionOperation(TStatus &&status, Ydb::Operations::Operation &&operation)
     : TOperation(std::move(status), std::move(operation))
 {
@@ -1877,6 +1899,10 @@ static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
             request.mutable_drop_metrics_settings();
             break;
         }
+    }
+
+    if (settings.Compact_) {
+        settings.Compact_->SerializeTo(*request.mutable_compact());
     }
 
     return request;

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -200,14 +200,6 @@ TCompact::TCompact()
     : TCompact(false, 1)
 {}
 
-bool TCompact::GetCascade() const {
-    return Cascade_;
-}
-
-uint32_t TCompact::GetMaxShardsInFlight() const {
-    return MaxShardsInFlight_;
-}
-
 void TCompact::SerializeTo(Ydb::Table::CompactItem& proto) const {
     proto.set_cascade(Cascade_);
     proto.set_max_shards_in_flight(MaxShardsInFlight_);

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -2823,7 +2823,217 @@ R"___(<main>: Error: Transaction not found: , code: 2015
         UNIT_ASSERT_VALUES_EQUAL(str, "[[[111u];[1u];[\"One\"]]]");
     }
 
+    Y_UNIT_TEST(AlterTableCompact) {
+        TKikimrWithGrpcAndRootSchema server;
+        server.Server_->GetRuntime()->GetAppData().FeatureFlags.SetEnableForcedCompactions(true);
 
+        NYdb::TDriver driver(
+            TDriverConfig()
+                .SetEndpoint(
+                    TStringBuilder() << "localhost:" << server.GetPort())
+                .SetDatabase("/Root")
+        );
+
+        {
+            NYdb::NOperation::TOperationClient operationClient(driver);
+            auto result = operationClient.List<NYdb::NTable::TCompactionOperation>().GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetList().size(), 0); // No operations in progress
+        }
+
+        NYdb::NTable::TTableClient client(driver);
+        auto getSessionResult = client.CreateSession().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(getSessionResult.GetStatus(), EStatus::SUCCESS, getSessionResult.GetIssues().ToString());
+        auto session = getSessionResult.GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"___(
+                CREATE TABLE `/Root/Test` (
+                    Key Uint64,
+                    Value String,
+                    PRIMARY KEY (Key)
+                ) WITH (
+                    PARTITION_AT_KEYS = (250, 500, 750)
+                );
+            )___").ExtractValueSync();
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+
+            result = session.ExecuteDataQuery(R"___(
+                UPSERT INTO `/Root/Test` (Key, Value)
+                    VALUES
+                        (100, "value_1"),
+                        (400, "value_2"),
+                        (700, "value_3"),
+                        (1000, "value_4");
+            )___", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        {
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 0));
+
+            auto result = session.AlterTable("/Root/Test", settings).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        }
+
+        {
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 2));
+
+            auto result = session.AlterTable("", settings).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        }
+
+        {
+
+            NYdb::NTable::TClientSettings clientSettings;
+            clientSettings.AuthToken("badguy@builtin");
+            NYdb::NTable::TTableClient clientbad(driver, clientSettings);
+            auto getSessionResult = clientbad.CreateSession().ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(getSessionResult.GetStatus(), EStatus::SUCCESS, getSessionResult.GetIssues().ToString());
+            auto session = getSessionResult.GetSession();
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 2));
+
+            auto result = session.AlterTable("/Root/Test", settings).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::UNAUTHORIZED);
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
+                "Access denied for# badguy@builtin, path# /Root/Test, access# DescribeSchema|AlterSchema");
+        }
+
+        {
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 1));
+
+            auto result = session.AlterTable("/Root/Test", settings).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 3));
+
+            auto result = session.AlterTable("/Root/WrongPath", settings).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+        }
+
+        {
+            NYdb::NOperation::TOperationClient operationClient(driver);
+            auto result = operationClient.List<NYdb::NTable::TCompactionOperation>().GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetList().size(), 1);
+            auto op = result.GetList()[0];
+            UNIT_ASSERT_VALUES_EQUAL(op.Ready(), true);
+            UNIT_ASSERT_VALUES_EQUAL(op.Status().GetStatus(), EStatus::SUCCESS);
+            auto meta = op.Metadata();
+            UNIT_ASSERT_VALUES_EQUAL(meta.State, NYdb::NTable::ECompactState::Done);
+            UNIT_ASSERT_DOUBLES_EQUAL(meta.Progress, 100, 0.001);
+
+            UNIT_ASSERT_VALUES_EQUAL(meta.Path, "/Root/Test");
+            UNIT_ASSERT_VALUES_EQUAL(meta.Cascade, false);
+            UNIT_ASSERT_VALUES_EQUAL(meta.MaxInFlight, 1);
+            UNIT_ASSERT_VALUES_EQUAL(meta.Total, 4);
+            UNIT_ASSERT_VALUES_EQUAL(meta.Done, 4);
+
+
+            auto result2 = operationClient.Get<NYdb::NTable::TCompactionOperation>(result.GetList()[0].Id()).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result2.Status().GetStatus(), EStatus::SUCCESS, result2.Status().GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().State, NYdb::NTable::ECompactState::Done);
+            UNIT_ASSERT_DOUBLES_EQUAL(result2.Metadata().Progress, 100, 0.001);
+
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().Path, "/Root/Test");
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().Cascade, false);
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().MaxInFlight, 1);
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().Total, 4);
+            UNIT_ASSERT_VALUES_EQUAL(result2.Metadata().Done, 4);
+
+            {
+                // Cancel already finished operation do nothing
+                auto resultOp = operationClient.Cancel(result.GetList()[0].Id()).GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(resultOp.GetStatus(), EStatus::PRECONDITION_FAILED, resultOp.GetIssues().ToString());
+            }
+
+            {
+                auto resultOp = operationClient.Forget(result.GetList()[0].Id()).GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(resultOp.GetStatus(), EStatus::SUCCESS, resultOp.GetIssues().ToString());
+            }
+
+            {
+                auto resultOp = operationClient.Get<NYdb::NTable::TCompactionOperation>(result.GetList()[0].Id()).GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(resultOp.Status().GetStatus(), EStatus::NOT_FOUND, resultOp.Status().GetIssues().ToString());
+            }
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableCompactAsyncOp) {
+        TKikimrWithGrpcAndRootSchema server;
+        server.Server_->GetRuntime()->GetAppData().FeatureFlags.SetEnableForcedCompactions(true);
+
+        NYdb::TDriver driver(
+            TDriverConfig()
+                .SetEndpoint(
+                    TStringBuilder() << "localhost:" << server.GetPort())
+                .SetDatabase("/Root")
+        );
+
+        {
+            NYdb::NOperation::TOperationClient operationClient(driver);
+            auto result = operationClient.List<NYdb::NTable::TCompactionOperation>().GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetList().size(), 0); // No operations in progress
+        }
+
+        NYdb::NTable::TTableClient client(driver);
+        auto getSessionResult = client.CreateSession().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(getSessionResult.GetStatus(), EStatus::SUCCESS, getSessionResult.GetIssues().ToString());
+        auto session = getSessionResult.GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"___(
+                CREATE TABLE `/Root/Test` (
+                    Key Uint64,
+                    Value String,
+                    PRIMARY KEY (Key)
+                ) WITH (
+                    PARTITION_AT_KEYS = (250, 500, 750)
+                );
+            )___").ExtractValueSync();
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+
+            result = session.ExecuteDataQuery(R"___(
+                UPSERT INTO `/Root/Test` (Key, Value)
+                    VALUES
+                        (100, "value_1"),
+                        (400, "value_2"),
+                        (700, "value_3"),
+                        (1000, "value_4");
+            )___", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        {
+            auto settings = NYdb::NTable::TAlterTableSettings()
+                .Compact(TCompact(false, 3));
+
+            auto result = session.AlterTableLong("/Root/Test", settings).ExtractValueSync();
+
+            // Compact is async operation
+            UNIT_ASSERT_C(!result.Ready(), result.Status().GetIssues().ToString());
+
+            NYdb::NOperation::TOperationClient operationClient(driver);
+
+            for (;;) {
+                auto getResult = operationClient.Get<NYdb::NTable::TCompactionOperation>(result.Id()).GetValueSync();
+                if (getResult.Ready()) {
+                    UNIT_ASSERT_VALUES_EQUAL_C(getResult.Status().GetStatus(), EStatus::SUCCESS, getResult.Status().GetIssues().ToString());
+                    break;
+                } else {
+                    Sleep(TDuration::MilliSeconds(100));
+                }
+            }
+        }
+    }
 
     Y_UNIT_TEST(QueryStats) {
         NKikimrConfig::TAppConfig appConfig;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Added support for the new compaction operation in the `ydb operation` subcommands in CLI
- Added support for the new alter table compact action in TableClient and compaction operation in OperationClient in SDK

Internal design doc: https://nda.ya.ru/t/3sKflLJJ7U6Jyv
