### PR TITLE
[stable-26-1] Fix scan fetcher oom (#35077)

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -26,6 +26,7 @@ private:
 
     std::set<NActors::TActorId> Fetchers;
     NMiniKQL::TKqpScanComputeContext::TScanData* ScanData = nullptr;
+    bool ScanDataInFlight = false;
 
     struct TLockHash {
         size_t operator()(const NKikimrDataEvents::TLock& lock) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Fixed unbounded inflight in ScanFetcher. Previously, it could store an unlimited number of blocks, which led to OOM.


### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
