### PR TITLE
NBS-7072: support multiple blocks io; increase threads count to 32 in executor pool

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -338,19 +338,27 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
         return result;
     }
 
-    TReadRangeHint readHint = makeDefaultHint(range);
+    ui64 maxLsn = 0;
     Inflight.EnumerateOverlapping(
         range,
         [&](TInflightMap::TFindItem& item)
         {
             const ui64 lsn = item.Key;
-            if (readHint.Lsn < lsn) {
-                readHint = makeHint(item.Value.ReadMask(), lsn, item.Range);
-            }
+            maxLsn = std::max(maxLsn, lsn);
 
             return TInflightMap::EEnumerateContinuation::Continue;
         });
 
+    const auto item = Inflight.GetValue(maxLsn);
+
+    // Read from DDisk if the range is not covered by the inflight range.
+    if (!item->Range.Contains(range)) {
+        result.RangeHints.push_back(makeDefaultHint(range));
+        return result;
+    }
+
+    TReadRangeHint readHint =
+        makeHint(item->Value.ReadMask(), item->Key, item->Range);
     if (readHint.LocationMask.Empty()) {
         // Reading from range with blocked lsn is forbidden.
         // Caller should wait until PBuffers quorum will be made.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -269,6 +269,47 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "123[10..19];",
             flushHint[ELocation::PBuffer2].DebugPrint());
     }
+
+    Y_UNIT_TEST(ShouldReadFromDDiskIfRangeIsNotCoveredByInflightRange)
+    {
+        TBlocksDirtyMap dirtyMap;
+
+        dirtyMap.WriteFinished(
+            123,
+            TBlockRange64::WithLength(0, 100),
+            TLocationMask::MakePrimaryPBuffers(),
+            TLocationMask::MakePrimaryPBuffers());
+
+        auto flushHint = dirtyMap.MakeFlushHint(1);
+        UNIT_ASSERT_EQUAL(false, flushHint.empty());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "123[0..99];",
+            flushHint[ELocation::PBuffer0].DebugPrint());
+
+        dirtyMap.FlushFinished(ELocation::PBuffer0, {123}, {});
+        dirtyMap.FlushFinished(ELocation::PBuffer1, {123}, {});
+        dirtyMap.FlushFinished(ELocation::PBuffer2, {123}, {});
+
+        auto eraseHint = dirtyMap.MakeEraseHint(1);
+        UNIT_ASSERT_EQUAL(false, eraseHint.empty());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "123[0..99];",
+            eraseHint[ELocation::PBuffer0].DebugPrint());
+
+        dirtyMap.EraseFinished(ELocation::PBuffer0, {123}, {});
+
+        dirtyMap.WriteFinished(
+            124,
+            TBlockRange64::WithLength(10, 10),
+            TLocationMask::MakePrimaryPBuffers(),
+            TLocationMask::MakePrimaryPBuffers());
+
+        auto readHint =
+            dirtyMap.MakeReadHint(TBlockRange64::WithLength(0, 100));
+        UNIT_ASSERT_VALUES_EQUAL(
+            "0{[D+++..P.....][0..99][0..99]};",
+            readHint.DebugPrint());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/load_actor_adapter.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/load_actor_adapter.cpp
@@ -47,7 +47,8 @@ void TLoadActorAdapter::HandleWriteBlocksRequest(
 
     totalSize = AlignUp(totalSize, DefaultBlockSize);
 
-    Y_ABORT_UNLESS(totalSize == 4096);
+    Y_ABORT_UNLESS(totalSize > 0);
+    Y_ABORT_UNLESS(totalSize % DefaultBlockSize == 0);
 
     auto data = std::make_shared<TString>(TString::Uninitialized(totalSize));
     char* ptr = data->Detach();
@@ -94,16 +95,16 @@ void TLoadActorAdapter::HandleReadBlocksRequest(
 {
     const auto* msg = ev->Get();
 
-    Y_ABORT_UNLESS(msg->Record.GetBlocksCount() == 1);
+    const ui32 blocksCount = msg->Record.GetBlocksCount();
+    Y_ABORT_UNLESS(blocksCount > 0);
 
-    auto data = std::make_shared<TString>(TString::Uninitialized(4096));
-    TSgList sglist = {TBlockDataRef(data->data(), data->size())};
+    auto buffer = std::make_shared<TString>(
+        TString::Uninitialized(blocksCount * DefaultBlockSize));
+    TSgList sglist = {TBlockDataRef(buffer->data(), buffer->size())};
 
     auto request = std::make_shared<TReadBlocksLocalRequest>(
         TRequestHeaders{},
-        TBlockRange64::WithLength(
-            msg->Record.GetStartIndex(),
-            msg->Record.GetBlocksCount()));
+        TBlockRange64::WithLength(msg->Record.GetStartIndex(), blocksCount));
     request->Sglist = TGuardedSgList(std::move(sglist));
 
     auto future = FastPathService->ReadBlocksLocal(
@@ -116,17 +117,17 @@ void TLoadActorAdapter::HandleReadBlocksRequest(
          selfId = ctx.SelfID,
          cookie = ev->Cookie,
          request,
-         data](const NThreading::TFuture<TReadBlocksLocalResponse>& f)
+         buffer](const NThreading::TFuture<TReadBlocksLocalResponse>& f)
         {
             auto response = std::make_unique<TEvService::TEvReadBlocksResponse>(
                 f.GetValue().Error);
 
             if (auto guard = request->Sglist.Acquire()) {
                 const auto& sglist = guard.Get();
-                for (const auto& block: sglist) {
+                for (const auto& data: sglist) {
                     response->Record.MutableBlocks()->AddBuffers(
-                        block.Data(),
-                        block.Size());
+                        data.Data(),
+                        data.Size());
                 }
             } else {
                 Y_ABORT_UNLESS(false);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -41,7 +41,7 @@ class TPartitionActor
     };
 
 private:
-    TExecutorPool ExecutorPool{4};
+    TExecutorPool ExecutorPool{32};
     NYdb::NBS::NProto::TStorageServiceConfig StorageConfig;
     NKikimrBlockStore::TVolumeConfig VolumeConfig;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -466,6 +466,73 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
                 expectedData);
         }
     }
+
+    Y_UNIT_TEST(ShouldWriteAndReadMultipleBlocks)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+        runtime->SetLogPriority(
+            NKikimrServices::NBS_PARTITION,
+            NActors::NLog::PRI_DEBUG);
+
+        SetupStorage(env);
+
+        auto partition = CreatePartitionTablet(env);
+
+        const TActorId& edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+
+        auto loadActorAdapter =
+            GetLoadActorAdapterActorId(env, partition, edge);
+
+        TString expectedData = NUnitTest::RandomString(
+            DefaultBlockSize * 128,
+            RandomNumber<ui32>());
+
+        {
+            auto request =
+                std::make_unique<TEvService::TEvWriteBlocksRequest>();
+            request->Record.SetStartIndex(100);
+            request->Record.MutableBlocks()->AddBuffers(expectedData);
+
+            runtime->Send(
+                new IEventHandle(loadActorAdapter, edge, request.release()),
+                edge.NodeId());
+
+            auto res =
+                env.WaitForEdgeActorEvent<TEvService::TEvWriteBlocksResponse>(
+                    edge,
+                    false);
+            UNIT_ASSERT(res->Get()->Record.MutableError()->GetCode() == S_OK);
+        }
+
+        env.Sim(TDuration::Seconds(10));
+
+        {
+            auto request = std::make_unique<TEvService::TEvReadBlocksRequest>();
+            request->Record.SetStartIndex(100);
+            request->Record.SetBlocksCount(128);
+
+            runtime->Send(
+                new IEventHandle(loadActorAdapter, edge, request.release()),
+                edge.NodeId());
+
+            auto res =
+                env.WaitForEdgeActorEvent<TEvService::TEvReadBlocksResponse>(
+                    edge,
+                    false);
+            UNIT_ASSERT(res->Get()->Record.MutableError()->GetCode() == S_OK);
+            UNIT_ASSERT(res->Get()->Record.MutableBlocks()->BuffersSize() == 1);
+            UNIT_ASSERT_VALUES_EQUAL(
+                res->Get()->Record.MutableBlocks()->GetBuffers(0),
+                expectedData);
+        }
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect


### PR DESCRIPTION
- support multiple blocks io
- increase threads count to 32 in executor pool

___
fio write 4k
test: (groupid=0, jobs=1): err= 0: pid=1084: Wed Mar 25 10:58:29 2026
  write: IOPS=5961, BW=23.3MiB/s (24.4MB/s)(1397MiB/60006msec); 0 zone resets
___
fio write 512k
test: (groupid=0, jobs=1): err= 0: pid=1099: Wed Mar 25 10:59:41 2026
  write: IOPS=844, BW=422MiB/s (443MB/s)(24.7GiB/60027msec); 0 zone resets
