### PR TITLE
Support expressions in secret values in KQP processing

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer.h
@@ -180,7 +180,7 @@ IActor* CreateKqpExecuter(IKqpGateway::TExecPhysicalRequest&& request, const TSt
     std::shared_ptr<NYql::NDq::IDqChannelService> channelService);
 
 IActor* CreateKqpSchemeExecuter(
-    TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TActorId& target,
+    TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, TQueryData::TPtr queryData, const TActorId& target,
     const TMaybe<TString>& requestType, const TString& database,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& clientAddress,
     bool temporary, bool createTmpDir, bool isCreateTableAs, TString tempDirName, TIntrusivePtr<TUserRequestContext> ctx,

--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -16,6 +16,9 @@
 #include <ydb/services/metadata/abstract/kqp_common.h>
 #include <yql/essentials/minikql/mkql_node.h>
 #include <yql/essentials/minikql/mkql_string_util.h>
+#include <yql/essentials/public/udf/udf_data_type.h>
+
+#include <functional>
 
 
 namespace NKikimr::NKqp {
@@ -23,6 +26,30 @@ namespace NKikimr::NKqp {
 using namespace NThreading;
 
 namespace {
+
+TMaybe<TString> ResolveSecretValueFromParam(
+    const TString& operationDesc,
+    TQueryData::TPtr queryData,
+    const TString& paramName,
+    std::function<void(Ydb::StatusIds::StatusCode, const NYql::TIssue&)> onErrorCallback
+) {
+    if (!queryData) {
+        onErrorCallback(Ydb::StatusIds::INTERNAL_ERROR,
+            NYql::TIssue(TStringBuilder() << "Parameter " << paramName << " is required for " << operationDesc
+                << " but query has no parameters"));
+        return Nothing();
+    }
+    TString value;
+    TString error;
+    if (!queryData->TryGetParameterAsString(paramName, value, error)) {
+        onErrorCallback(
+            Ydb::StatusIds::BAD_REQUEST,
+            NYql::TIssue(TStringBuilder() << error << " for " << operationDesc)
+        );
+        return Nothing();
+    }
+    return value;
+}
 
 bool CheckAlterAccess(const NACLib::TUserToken& userToken, const NSchemeCache::TSchemeCacheNavigate* navigate) {
     bool isDatabaseEntry = true; // first entry is always database
@@ -78,13 +105,14 @@ public:
     }
 
     TKqpSchemeExecuter(
-        TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TActorId& target, const TMaybe<TString>& requestType,
+        TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, TQueryData::TPtr queryData, const TActorId& target, const TMaybe<TString>& requestType,
         const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& clientAddress,
         bool temporary, bool createTmpDir, bool isCreateTableAs, TString tempDirName, TIntrusivePtr<TUserRequestContext> ctx,
         bool expectsResult, TTxAllocatorState::TPtr txAlloc,
         const TActorId& kqpTempTablesAgentActor)
         : PhyTx(phyTx)
         , QueryType(queryType)
+        , QueryData(queryData)
         , Target(target)
         , Database(database)
         , UserToken(userToken)
@@ -633,13 +661,31 @@ public:
             }
 
             case NKqpProto::TKqpSchemeOperation::kCreateSecret: {
-                const auto& modifyScheme = schemeOp.GetCreateSecret();
+                auto modifyScheme = schemeOp.GetCreateSecret();
+                if (modifyScheme.GetCreateSecret().HasValueParamName()) {
+                    const auto paramValue = ResolveSecretValueFromParam(
+                        "CREATE SECRET", QueryData, modifyScheme.GetCreateSecret().GetValueParamName(),
+                        [this](Ydb::StatusIds::StatusCode status, const NYql::TIssue& issue) { ReplyErrorAndDie(status, issue); });
+                    if (!paramValue) {
+                        return;
+                    }
+                    modifyScheme.MutableCreateSecret()->SetValue(*paramValue);
+                }
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kAlterSecret: {
-                const auto& modifyScheme = schemeOp.GetAlterSecret();
+                auto modifyScheme = schemeOp.GetAlterSecret();
+                if (modifyScheme.GetAlterSecret().HasValueParamName()) {
+                    const auto paramValue = ResolveSecretValueFromParam(
+                        "ALTER SECRET", QueryData, modifyScheme.GetAlterSecret().GetValueParamName(),
+                        [this](Ydb::StatusIds::StatusCode status, const NYql::TIssue& issue) { ReplyErrorAndDie(status, issue); });
+                    if (!paramValue) {
+                        return;
+                    }
+                    modifyScheme.MutableAlterSecret()->SetValue(*paramValue);
+                }
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
@@ -1262,6 +1308,7 @@ private:
 private:
     TKqpPhyTxHolder::TConstPtr PhyTx;
     const NKikimrKqp::EQueryType QueryType;
+    const TQueryData::TPtr QueryData;
     const TActorId Target;
     const TString Database;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
@@ -1285,7 +1332,7 @@ private:
 } // namespace
 
 IActor* CreateKqpSchemeExecuter(
-    TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TActorId& target,
+    TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, TQueryData::TPtr queryData, const TActorId& target,
     const TMaybe<TString>& requestType, const TString& database,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& clientAddress,
     bool temporary, bool createTmpDir, bool isCreateTableAs,
@@ -1293,7 +1340,7 @@ IActor* CreateKqpSchemeExecuter(
     bool expectsResult, TTxAllocatorState::TPtr txAlloc, const TActorId& kqpTempTablesAgentActor)
 {
     return new TKqpSchemeExecuter(
-        phyTx, queryType, target, requestType, database, userToken, clientAddress,
+        phyTx, queryType, queryData, target, requestType, database, userToken, clientAddress,
         temporary, createTmpDir, isCreateTableAs, tempDirName, std::move(ctx),
         expectsResult, std::move(txAlloc), kqpTempTablesAgentActor);
 }

--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -670,6 +670,8 @@ public:
                         return;
                     }
                     modifyScheme.MutableCreateSecret()->SetValue(*paramValue);
+                    // Need to clear ValueParamName so schemeshard will see only the value itself
+                    modifyScheme.MutableCreateSecret()->ClearValueParamName();
                 }
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
@@ -685,6 +687,8 @@ public:
                         return;
                     }
                     modifyScheme.MutableAlterSecret()->SetValue(*paramValue);
+                    // Need to clear ValueParamName so schemeshard will see only the value itself
+                    modifyScheme.MutableAlterSecret()->ClearValueParamName();
                 }
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;

--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -615,7 +615,7 @@ public:
     void Bootstrap() {
         auto ctx = MakeIntrusive<TUserRequestContext>();
         ctx->DatabaseId = DatabaseId;
-        IActor* actor = CreateKqpSchemeExecuter(PhyTx, QueryType, SelfId(), RequestType, Database, UserToken, ClientAddress, false /* temporary */, false /* createTmpDir */, false /* isCreateTableAs */, TString() /* sessionId */, ctx);
+        IActor* actor = CreateKqpSchemeExecuter(PhyTx, QueryType, nullptr, SelfId(), RequestType, Database, UserToken, ClientAddress, false /* temporary */, false /* createTmpDir */, false /* isCreateTableAs */, TString() /* tempDirName */, ctx);
         Register(actor);
         Become(&TThis::WaitState);
     }

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/grpc_services/table_settings.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/protos/metrics_config.pb.h>
+#include <ydb/core/kqp/query_data/kqp_query_data.h>
 #include <ydb/core/protos/replication.pb.h>
 #include <ydb/core/ydb_convert/table_description.h>
 #include <ydb/core/ydb_convert/column_families.h>
@@ -3299,6 +3300,30 @@ public:
                     result.SetSuccess();
                     return MakeFuture(result);
                 } else {
+                    // DropSecret is instantiated with NKikimrSchemeOp::TDrop
+                    if constexpr (std::is_same_v<TSecretSchemaOp, NKikimrSchemeOp::TSecretSchemaOp>) {
+                        if (op.HasValueParamName()) {
+                            const TString& paramName = op.GetValueParamName();
+                            Y_ENSURE(GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSecret ||
+                                GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterSecret);
+                            const TString operationDesc = (GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateSecret)
+                                ? "CREATE SECRET" : "ALTER SECRET";
+                            auto queryData = SessionCtx_->Query().QueryData;
+                            if (!queryData) {
+                                return MakeFuture(ResultFromError<TGenericResult>(TStringBuilder()
+                                    << "Parameter " << paramName << " is required for " << operationDesc
+                                    << " but query has no parameters"));
+                            }
+                            TString resolvedValue;
+                            TString resolveError;
+                            if (!queryData->TryGetParameterAsString(paramName, resolvedValue, resolveError)) {
+                                return MakeFuture(ResultFromError<TGenericResult>(
+                                    TStringBuilder() << resolveError << " for " << operationDesc));
+                            }
+                            op.SetValue(resolvedValue);
+                            op.ClearValueParamName();
+                        }
+                    }
                     return Gateway_->ModifyScheme(std::move(tx));
                 }
             } catch (yexception& e) {
@@ -3339,7 +3364,11 @@ public:
         }
 
         void FillSchemaOperation(const NYql::TSecretSettings& settings, TSecretSchemaOp& op) const override {
-            op.SetValue(settings.Value);
+            if (!settings.ValueParamName.empty()) {
+                op.SetValueParamName(settings.ValueParamName);
+            } else {
+                op.SetValue(settings.Value);
+            }
             op.SetInheritPermissions(settings.InheritPermissions);
         }
 
@@ -3370,7 +3399,11 @@ public:
         }
 
         void FillSchemaOperation(const NYql::TSecretSettings& settings, TSecretSchemaOp& op) const override {
-            op.SetValue(settings.Value);
+            if (!settings.ValueParamName.empty()) {
+                op.SetValueParamName(settings.ValueParamName);
+            } else {
+                op.SetValue(settings.Value);
+            }
         }
 
     private:

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -691,104 +691,110 @@ const TTypedUnboxedValue* ValidateParameter(const TString& name, const TTypeAnno
     return parameter;
 }
 
-// EvaluateExpr nodes containing Parameter references cannot be evaluated at compile time
+// EvaluateExpr nodes containing parameter references cannot be evaluated at compile time
 // because parameter values are not available in the evaluation context for DDL queries.
-// This transformer unwraps such nodes before expression evaluation so the existing
-// parameter-at-execution-time flow handles them. Pure expressions (no parameters) keep
-// their EvaluateExpr wrapper and are evaluated normally.
-class TUnwrapEvaluateExprForParametersTransformer {
+// However, secret values can be set in SQL statements with parameters.
+// This transformer unwraps the first EvaluateExpr node, if it's presented, before expression evaluation
+// so the existing parameter-at-execution-time flow could handle them.
+class TSecretValueExprTransformer {
 public:
-    IGraphTransformer::TStatus operator()(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExprContext& ctx) {
-        TOptimizeExprSettings optSettings(nullptr);
-        optSettings.VisitChanges = true;
-
-        return OptimizeExpr(input, output,
-            [](const TExprNode::TPtr& node, TExprContext&) -> TExprNode::TPtr {
-                if (node->IsCallable("EvaluateExpr") && node->ChildrenSize() == 1 &&
-                    ContainsParameter(node->Head())
-                ) {
-                    return node->HeadPtr();
-                }
-                return node;
-            }, ctx, optSettings);
-    }
-
-    static TAutoPtr<IGraphTransformer> Sync() {
-        return CreateFunctorTransformer(TUnwrapEvaluateExprForParametersTransformer());
-    }
-
-private:
-    static bool ContainsParameter(const TExprNode& node) {
-        if (node.IsCallable("Parameter")) {
-            return true;
-        }
-        for (ui32 i = 0; i < node.ChildrenSize(); ++i) {
-            if (ContainsParameter(*node.Child(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-};
-
-// Collects parameters from CREATE/ALTER SECRET. We need this because parameters are not supported in DDL operations.
-// Secrets are the only schema objects that support parameters.
-class TCollectParametersForSecretsTransformer {
-public:
-    TCollectParametersForSecretsTransformer(TIntrusivePtr<TKikimrQueryContext> queryCtx)
+    TSecretValueExprTransformer(TIntrusivePtr<TKikimrQueryContext> queryCtx)
         : QueryCtx(queryCtx) {}
 
     IGraphTransformer::TStatus operator()(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExprContext& ctx) {
-        if (!QueryCtx->PrepareOnly || !QueryCtx->PreparingQuery) {
-            output = input;
-            return IGraphTransformer::TStatus::Ok;
-        }
-
         TOptimizeExprSettings optSettings(nullptr);
         optSettings.VisitChanges = false;
 
         auto& queryCtx = QueryCtx;
-        auto status = OptimizeExpr(input, output,
-            [&queryCtx](const TExprNode::TPtr& input, TExprContext&) -> TExprNode::TPtr {
-                auto ret = input;
-                TExprBase node(input);
-
-                auto addSecretValueParam = [&](auto secretNode) {
-                    TString paramName(secretNode.ValueParamName().Value());
-                    if (paramName.empty()) {
-                        return;
-                    }
-                    for (const auto& param : queryCtx->PreparingQuery->GetParameters()) {
-                        if (param.GetName() == paramName) {
-                            return;
-                        }
-                    }
-                    auto& paramDesc = *queryCtx->PreparingQuery->AddParameters();
-                    paramDesc.SetName(paramName);
-                    auto guard = queryCtx->QueryData->TypeEnv().BindAllocator();
-                    auto* utf8Type = NKikimr::NMiniKQL::TDataType::Create(
-                        NYql::NUdf::TDataType<NYql::NUdf::TUtf8>::Id,
-                        queryCtx->QueryData->TypeEnv());
-                    NKikimr::NMiniKQL::ExportTypeToProto(utf8Type, *paramDesc.MutableType());
-                };
-
-                if (auto createSecret = node.Maybe<TKiCreateSecret>()) {
-                    addSecretValueParam(createSecret.Cast());
-                } else if (auto alterSecret = node.Maybe<TKiAlterSecret>()) {
-                    addSecretValueParam(alterSecret.Cast());
+        return OptimizeExpr(input, output,
+            [&queryCtx](const TExprNode::TPtr& node, TExprContext& ctx) -> TExprNode::TPtr {
+                if (!IsSecretStatement(*node)) {
+                    return node;
                 }
 
-                return ret;
-            }, ctx, optSettings);
+                const auto& settings = *node->Child(WriteSettingsChildIndex);
+                const auto [evaluateExprNode, evaluateExprNodeIdx] = FindFirstEvaluateExprInValueExpr(settings);
+                if (!evaluateExprNode) {
+                    return node;
+                }
 
-        return status;
+                if (!evaluateExprNode->Head().IsCallable("Parameter")) {
+                    ctx.AddError(YqlIssue(ctx.GetPosition(evaluateExprNode->Pos()),
+                        TIssuesIds::KIKIMR_BAD_REQUEST,
+                        "Only string or single string parameter is supported as secret value"));
+                    return {};
+                }
+
+                const TString paramName(evaluateExprNode->Head().Child(0)->Content());
+                RegisterParameterIfNeeded(queryCtx, paramName);
+
+                return UnwrapEvaluateExpr(*node, settings, *evaluateExprNode, evaluateExprNodeIdx, ctx);
+            }, ctx, optSettings);
     }
 
     static TAutoPtr<IGraphTransformer> Sync(TIntrusivePtr<TKikimrQueryContext> queryCtx) {
-        return CreateFunctorTransformer(TCollectParametersForSecretsTransformer(queryCtx));
+        return CreateFunctorTransformer(TSecretValueExprTransformer(queryCtx));
     }
 
 private:
+    static bool IsSecretStatement(const TExprNode& node) {
+        if (!node.IsCallable("Write!") || node.ChildrenSize() <= WriteSettingsChildIndex) {
+            return false;
+        }
+        const auto& key = *node.Child(2);
+        return key.ChildrenSize() > 0 &&
+               key.Child(0)->ChildrenSize() > 0 &&
+               key.Child(0)->Child(0)->Content() == "secret";
+    }
+
+    static std::pair<const TExprNode*, ui32> FindFirstEvaluateExprInValueExpr(const TExprNode& settings) {
+        for (ui32 i = 0; i < settings.ChildrenSize(); ++i) {
+            const auto& node = *settings.Child(i);
+            if (node.ChildrenSize() < 2 || node.Child(0)->Content() != "value_expr") {
+                continue;
+            }
+            const auto* expr = node.Child(1);
+            if (expr->IsCallable("EvaluateExpr") && expr->ChildrenSize() == 1) {
+                return {expr, i};
+            }
+
+            break; // We need only the first EvaluateExpr
+        }
+        return {nullptr, 0};
+    }
+
+    static void RegisterParameterIfNeeded(
+        TIntrusivePtr<TKikimrQueryContext>& queryCtx,
+        const TString& paramName)
+    {
+        if (!queryCtx->PrepareOnly || !queryCtx->PreparingQuery) {
+            return;
+        }
+        for (const auto& param : queryCtx->PreparingQuery->GetParameters()) {
+            if (param.GetName() == paramName) {
+                return;
+            }
+        }
+        auto& paramDesc = *queryCtx->PreparingQuery->AddParameters();
+        paramDesc.SetName(paramName);
+        auto guard = queryCtx->QueryData->TypeEnv().BindAllocator();
+        auto* utf8Type = NKikimr::NMiniKQL::TDataType::Create(
+            NYql::NUdf::TDataType<NYql::NUdf::TUtf8>::Id,
+            queryCtx->QueryData->TypeEnv());
+        NKikimr::NMiniKQL::ExportTypeToProto(utf8Type, *paramDesc.MutableType());
+    }
+
+    static TExprNode::TPtr UnwrapEvaluateExpr(
+        const TExprNode& writeNode, const TExprNode& settings, const TExprNode& evaluateExprNode,
+        const ui32 evaluateExprNodeIdx, TExprContext& ctx)
+    {
+        auto newTuple = ctx.ChangeChild(*settings.Child(evaluateExprNodeIdx), 1, evaluateExprNode.HeadPtr());
+        auto newSettings = ctx.ChangeChild(settings, evaluateExprNodeIdx, std::move(newTuple));
+        return ctx.ChangeChild(writeNode, WriteSettingsChildIndex, std::move(newSettings));
+    }
+
+private:
+    static constexpr ui32 WriteSettingsChildIndex = 4;
     TIntrusivePtr<TKikimrQueryContext> QueryCtx;
 };
 
@@ -1866,11 +1872,10 @@ private:
         auto transformer = TTransformationPipeline(TypesCtx)
             .AddServiceTransformers()
             .AddPreTypeAnnotation()
-            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
+            .Add(TSecretValueExprTransformer::Sync(SessionCtx->QueryPtr()), "SecretValueExpr")
             .AddIOAnnotation()
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
-            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .Build(false);
 
         return MakeIntrusive<TAsyncValidateYqlResult>(compileResult.QueryExpr.Get(), SessionCtx, ctx, transformer, sqlVersion, compileResult.KeepInCache, compileResult.CommandTagName, DataProvidersFinalizer);
@@ -2161,13 +2166,12 @@ private:
             .Add(TLogExprTransformer::Sync("YqlTransformer", NYql::NLog::EComponent::ProviderKqp,
                 NYql::NLog::ELevel::TRACE), "LogYqlTransform")
             .AddPreTypeAnnotation()
-            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
+            .Add(TSecretValueExprTransformer::Sync(SessionCtx->QueryPtr()), "SecretValueExpr")
             .AddExpressionEvaluation(*FuncRegistry)
             .Add(new TFailExpressionEvaluation(queryType), "FailExpressionEvaluation")
             .AddIOAnnotation(false)
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
-            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .AddPostTypeAnnotation()
             .AddOptimization(true, false)
             .Add(GetDqIntegrationPeepholeTransformer(true, TypesCtx), "DqIntegrationPeephole")
@@ -2224,13 +2228,12 @@ private:
             .Add(TLogExprTransformer::Sync("YqlTransformerNewRBO", NYql::NLog::EComponent::ProviderKqp,
                 NYql::NLog::ELevel::TRACE), "LogYqlTransformNewRBO")
             .AddPreTypeAnnotation()
-            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
+            .Add(TSecretValueExprTransformer::Sync(SessionCtx->QueryPtr()), "SecretValueExpr")
             .AddExpressionEvaluation(*FuncRegistry)
             .Add(new TFailExpressionEvaluation(queryType), "FailExpressionEvaluation")
             .AddIOAnnotation(false)
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
-            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .AddPostTypeAnnotation()
             //.AddOptimization(true, false, TIssuesIds::CORE_OPTIMIZATION)
             .Add(RBOOptimizationTransformer.Release(), "RBOOptimizationTransformer")

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -691,6 +691,113 @@ const TTypedUnboxedValue* ValidateParameter(const TString& name, const TTypeAnno
     return parameter;
 }
 
+// EvaluateExpr nodes containing Parameter references cannot be evaluated at compile time
+// because parameter values are not available in the evaluation context for DDL queries.
+// This transformer unwraps such nodes before expression evaluation so the existing
+// parameter-at-execution-time flow handles them. Pure expressions (no parameters) keep
+// their EvaluateExpr wrapper and are evaluated normally.
+class TUnwrapEvaluateExprForParametersTransformer {
+public:
+    IGraphTransformer::TStatus operator()(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExprContext& ctx) {
+        TOptimizeExprSettings optSettings(nullptr);
+        optSettings.VisitChanges = true;
+
+        return OptimizeExpr(input, output,
+            [](const TExprNode::TPtr& node, TExprContext&) -> TExprNode::TPtr {
+                if (node->IsCallable("EvaluateExpr") && node->ChildrenSize() == 1 &&
+                    ContainsParameter(node->Head())
+                ) {
+                    return node->HeadPtr();
+                }
+                return node;
+            }, ctx, optSettings);
+    }
+
+    static TAutoPtr<IGraphTransformer> Sync() {
+        return CreateFunctorTransformer(TUnwrapEvaluateExprForParametersTransformer());
+    }
+
+private:
+    static bool ContainsParameter(const TExprNode& node) {
+        if (node.IsCallable("Parameter")) {
+            return true;
+        }
+        for (ui32 i = 0; i < node.ChildrenSize(); ++i) {
+            if (ContainsParameter(*node.Child(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+// Collects parameters from CREATE/ALTER SECRET. We need this because parameters are not supported in DDL operations.
+// Secrets are the only schema objects that support parameters.
+class TCollectParametersForSecretsTransformer {
+public:
+    TCollectParametersForSecretsTransformer(TIntrusivePtr<TKikimrQueryContext> queryCtx)
+        : QueryCtx(queryCtx) {}
+
+    IGraphTransformer::TStatus operator()(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExprContext& ctx) {
+        if (!QueryCtx->PrepareOnly || !QueryCtx->PreparingQuery) {
+            output = input;
+            return IGraphTransformer::TStatus::Ok;
+        }
+
+        TOptimizeExprSettings optSettings(nullptr);
+        optSettings.VisitChanges = false;
+
+        auto& queryCtx = QueryCtx;
+        auto status = OptimizeExpr(input, output,
+            [&queryCtx](const TExprNode::TPtr& input, TExprContext&) -> TExprNode::TPtr {
+                auto ret = input;
+                TExprBase node(input);
+
+                auto addSecretValueParam = [&](auto secretNode) {
+                    if (secretNode.ValueFromParam().Value() != "1") {
+                        return;
+                    }
+                    if (!secretNode.Value().template Maybe<TCoAtom>()) {
+                        return;
+                    }
+                    TString paramName(secretNode.Value().template Cast<TCoAtom>().Value());
+                    if (!paramName.StartsWith("$")) {
+                        paramName = "$" + paramName;
+                    }
+                    for (const auto& param : queryCtx->PreparingQuery->GetParameters()) {
+                        if (param.GetName() == paramName) {
+                            return;
+                        }
+                    }
+                    auto& paramDesc = *queryCtx->PreparingQuery->AddParameters();
+                    paramDesc.SetName(paramName);
+                    auto guard = queryCtx->QueryData->TypeEnv().BindAllocator();
+                    auto* utf8Type = NKikimr::NMiniKQL::TDataType::Create(
+                        NYql::NUdf::TDataType<NYql::NUdf::TUtf8>::Id,
+                        queryCtx->QueryData->TypeEnv());
+                    NKikimr::NMiniKQL::ExportTypeToProto(utf8Type, *paramDesc.MutableType());
+                };
+
+                if (auto createSecret = node.Maybe<TKiCreateSecret>()) {
+                    addSecretValueParam(createSecret.Cast());
+                } else if (auto alterSecret = node.Maybe<TKiAlterSecret>()) {
+                    addSecretValueParam(alterSecret.Cast());
+                }
+
+                return ret;
+            }, ctx, optSettings);
+
+        return status;
+    }
+
+    static TAutoPtr<IGraphTransformer> Sync(TIntrusivePtr<TKikimrQueryContext> queryCtx) {
+        return CreateFunctorTransformer(TCollectParametersForSecretsTransformer(queryCtx));
+    }
+
+private:
+    TIntrusivePtr<TKikimrQueryContext> QueryCtx;
+};
+
 class TCollectParametersTransformer {
 public:
     TCollectParametersTransformer(TIntrusivePtr<TKikimrQueryContext> queryCtx)
@@ -1765,9 +1872,11 @@ private:
         auto transformer = TTransformationPipeline(TypesCtx)
             .AddServiceTransformers()
             .AddPreTypeAnnotation()
+            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
             .AddIOAnnotation()
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
+            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .Build(false);
 
         return MakeIntrusive<TAsyncValidateYqlResult>(compileResult.QueryExpr.Get(), SessionCtx, ctx, transformer, sqlVersion, compileResult.KeepInCache, compileResult.CommandTagName, DataProvidersFinalizer);
@@ -2058,11 +2167,13 @@ private:
             .Add(TLogExprTransformer::Sync("YqlTransformer", NYql::NLog::EComponent::ProviderKqp,
                 NYql::NLog::ELevel::TRACE), "LogYqlTransform")
             .AddPreTypeAnnotation()
+            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
             .AddExpressionEvaluation(*FuncRegistry)
             .Add(new TFailExpressionEvaluation(queryType), "FailExpressionEvaluation")
             .AddIOAnnotation(false)
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
+            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .AddPostTypeAnnotation()
             .AddOptimization(true, false)
             .Add(GetDqIntegrationPeepholeTransformer(true, TypesCtx), "DqIntegrationPeephole")
@@ -2119,11 +2230,13 @@ private:
             .Add(TLogExprTransformer::Sync("YqlTransformerNewRBO", NYql::NLog::EComponent::ProviderKqp,
                 NYql::NLog::ELevel::TRACE), "LogYqlTransformNewRBO")
             .AddPreTypeAnnotation()
+            .Add(TUnwrapEvaluateExprForParametersTransformer::Sync(), "UnwrapEvaluateExprForParameters")
             .AddExpressionEvaluation(*FuncRegistry)
             .Add(new TFailExpressionEvaluation(queryType), "FailExpressionEvaluation")
             .AddIOAnnotation(false)
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
+            .Add(TCollectParametersForSecretsTransformer::Sync(SessionCtx->QueryPtr()), "CollectParametersForSecrets")
             .AddPostTypeAnnotation()
             //.AddOptimization(true, false, TIssuesIds::CORE_OPTIMIZATION)
             .Add(RBOOptimizationTransformer.Release(), "RBOOptimizationTransformer")

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -754,15 +754,9 @@ public:
                 TExprBase node(input);
 
                 auto addSecretValueParam = [&](auto secretNode) {
-                    if (secretNode.ValueFromParam().Value() != "1") {
+                    TString paramName(secretNode.ValueParamName().Value());
+                    if (paramName.empty()) {
                         return;
-                    }
-                    if (!secretNode.Value().template Maybe<TCoAtom>()) {
-                        return;
-                    }
-                    TString paramName(secretNode.Value().template Cast<TCoAtom>().Value());
-                    if (!paramName.StartsWith("$")) {
-                        paramName = "$" + paramName;
                     }
                     for (const auto& param : queryCtx->PreparingQuery->GetParameters()) {
                         if (param.GetName() == paramName) {

--- a/ydb/core/kqp/host/ya.make
+++ b/ydb/core/kqp/host/ya.make
@@ -13,6 +13,7 @@ SRCS(
 PEERDIR(
     ydb/core/base
     ydb/core/kqp/common
+    ydb/core/kqp/query_data
     ydb/core/kqp/federated_query
     ydb/core/kqp/gateway/utils
     ydb/core/kqp/opt

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -1834,8 +1834,13 @@ public:
                 TWriteSecretSettings settings = ParseSecretSettings(TExprList(node->Child(4)), ctx);
                 YQL_ENSURE(settings.Mode);
                 auto mode = settings.Mode.Cast();
+                if (settings.HasError) {
+                    return nullptr; // Error has been already reported in parsing
+                }
                 if (mode == "create") {
                     if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
+                        ctx.AddError(YqlIssue(ctx.GetPosition(node->Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                            "Secret value is required: provide a literal or a single string parameter"));
                         return nullptr;
                     }
                     const bool valueFromParam = settings.ValueParamName.IsValid();
@@ -1850,6 +1855,8 @@ public:
                         .Ptr();
                 } else if (mode == "alter") {
                     if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
+                        ctx.AddError(YqlIssue(ctx.GetPosition(node->Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                            "Secret value is required: provide a literal or a single string parameter"));
                         return nullptr;
                     }
                     const bool valueFromParam = settings.ValueParamName.IsValid();
@@ -1975,11 +1982,11 @@ TWriteBackupCollectionSettings ParseWriteBackupCollectionSettings(TExprList node
 }
 
 TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& ctx) {
-    Y_UNUSED(ctx);
     TMaybeNode<TCoAtom> mode;
     TMaybeNode<TCoAtom> value;
     TMaybeNode<TCoAtom> valueParamName;
     TMaybeNode<TCoAtom> inheritPermissions;
+    bool hasError = false;
 
     for (auto child : node) {
         if (auto maybeTuple = child.Maybe<TCoNameValueTuple>()) {
@@ -1991,6 +1998,10 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
             } else if (name == "value") {
                 if (tuple.Value().Maybe<TCoAtom>()) {
                     value = tuple.Value().Cast<TCoAtom>();
+                } else {
+                    ctx.AddError(YqlIssue(ctx.GetPosition(tuple.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                        "Only literal string is supported for 'value' option in secret"));
+                    hasError = true;
                 }
             } else if (name == "value_expr") {
                 auto expr = tuple.Value();
@@ -2001,6 +2012,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
                 } else {
                     ctx.AddError(YqlIssue(ctx.GetPosition(tuple.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                         "Only string or single string parameter is supported as secret value"));
+                    hasError = true;
                 }
             } else if (name == "inherit_permissions") {
                 YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
@@ -2009,7 +2021,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
         }
     }
 
-    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(valueParamName), std::move(inheritPermissions));
+    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(valueParamName), std::move(inheritPermissions), hasError);
 }
 
 IGraphTransformer::TStatus TKiSinkVisitorTransformer::DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output,

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -4,6 +4,7 @@
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
 
 #include <yql/essentials/core/yql_expr_optimize.h>
+#include <yql/essentials/core/issue/yql_issue.h>
 
 #include <yql/essentials/utils/log/log.h>
 
@@ -1834,20 +1835,30 @@ public:
                 YQL_ENSURE(settings.Mode);
                 auto mode = settings.Mode.Cast();
                 if (mode == "create") {
+                    if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
+                        return nullptr;
+                    }
+                    const bool valueFromParam = settings.ValueParamName.IsValid();
                     return Build<TKiCreateSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
-                        .Value(settings.Value.Cast())
+                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : settings.ValueParamName.Cast())
+                        .ValueFromParam(Build<TCoAtom>(ctx, node->Pos()).Value(valueFromParam ? "1" : "0").Done())
                         .InheritPermissions(settings.InheritPermissions.IsValid() ? settings.InheritPermissions.Cast() : Build<TCoAtom>(ctx, node->Pos()).Value("0").Done())
                         .Done()
                         .Ptr();
                 } else if (mode == "alter") {
+                    if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
+                        return nullptr;
+                    }
+                    const bool valueFromParam = settings.ValueParamName.IsValid();
                     return Build<TKiAlterSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
-                        .Value(settings.Value.Cast())
+                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : settings.ValueParamName.Cast())
+                        .ValueFromParam(Build<TCoAtom>(ctx, node->Pos()).Value(valueFromParam ? "1" : "0").Done())
                         .Done()
                         .Ptr();
                 } else if (mode == "drop") {
@@ -1967,6 +1978,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
     Y_UNUSED(ctx);
     TMaybeNode<TCoAtom> mode;
     TMaybeNode<TCoAtom> value;
+    TMaybeNode<TCoAtom> valueParamName;
     TMaybeNode<TCoAtom> inheritPermissions;
 
     for (auto child : node) {
@@ -1977,9 +1989,19 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
                 YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
                 mode = tuple.Value().Cast<TCoAtom>();
             } else if (name == "value") {
-                // TODO(yurikiselev): support parsing from declare
-                YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
-                value = tuple.Value().Cast<TCoAtom>();
+                if (tuple.Value().Maybe<TCoAtom>()) {
+                    value = tuple.Value().Cast<TCoAtom>();
+                }
+            } else if (name == "value_expr") {
+                auto expr = tuple.Value();
+                if (expr.Maybe<TCoParameter>()) {
+                    valueParamName = Build<TCoAtom>(ctx, tuple.Pos()).Value(expr.Cast<TCoParameter>().Name().StringValue()).Done();
+                } else if (expr.Maybe<TCoDataCtor>()) {
+                    value = expr.Cast<TCoDataCtor>().Literal().Cast<TCoAtom>();
+                } else {
+                    ctx.AddError(YqlIssue(ctx.GetPosition(tuple.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                        "Only string or single string parameter is supported as secret value"));
+                }
             } else if (name == "inherit_permissions") {
                 YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
                 inheritPermissions = tuple.Value().Cast<TCoAtom>();
@@ -1987,7 +2009,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
         }
     }
 
-    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(inheritPermissions));
+    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(valueParamName), std::move(inheritPermissions));
 }
 
 IGraphTransformer::TStatus TKiSinkVisitorTransformer::DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output,

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -1832,40 +1832,29 @@ public:
             }
             case TKikimrKey::Type::Secret: {
                 TWriteSecretSettings settings = ParseSecretSettings(TExprList(node->Child(4)), ctx);
-                YQL_ENSURE(settings.Mode);
-                auto mode = settings.Mode.Cast();
                 if (settings.HasError) {
                     return nullptr; // Error has been already reported in parsing
                 }
+                auto mode = settings.Mode.Cast();
                 if (mode == "create") {
-                    if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
-                        ctx.AddError(YqlIssue(ctx.GetPosition(node->Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
-                            "Secret value is required: provide a literal or a single string parameter"));
-                        return nullptr;
-                    }
-                    const bool valueFromParam = settings.ValueParamName.IsValid();
+                    const auto emptyAtom = Build<TCoAtom>(ctx, node->Pos()).Value("").Done();
                     return Build<TKiCreateSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
-                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : settings.ValueParamName.Cast())
-                        .ValueFromParam(Build<TCoAtom>(ctx, node->Pos()).Value(valueFromParam ? "1" : "0").Done())
+                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : emptyAtom)
                         .InheritPermissions(settings.InheritPermissions.IsValid() ? settings.InheritPermissions.Cast() : Build<TCoAtom>(ctx, node->Pos()).Value("0").Done())
+                        .ValueParamName(settings.ValueParamName.IsValid() ? settings.ValueParamName.Cast() : emptyAtom)
                         .Done()
                         .Ptr();
                 } else if (mode == "alter") {
-                    if (!settings.Value.IsValid() && !settings.ValueParamName.IsValid()) {
-                        ctx.AddError(YqlIssue(ctx.GetPosition(node->Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
-                            "Secret value is required: provide a literal or a single string parameter"));
-                        return nullptr;
-                    }
-                    const bool valueFromParam = settings.ValueParamName.IsValid();
+                    const auto emptyAtom = Build<TCoAtom>(ctx, node->Pos()).Value("").Done();
                     return Build<TKiAlterSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
-                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : settings.ValueParamName.Cast())
-                        .ValueFromParam(Build<TCoAtom>(ctx, node->Pos()).Value(valueFromParam ? "1" : "0").Done())
+                        .Value(settings.Value.IsValid() ? settings.Value.Cast() : emptyAtom)
+                        .ValueParamName(settings.ValueParamName.IsValid() ? settings.ValueParamName.Cast() : emptyAtom)
                         .Done()
                         .Ptr();
                 } else if (mode == "drop") {
@@ -1986,7 +1975,6 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
     TMaybeNode<TCoAtom> value;
     TMaybeNode<TCoAtom> valueParamName;
     TMaybeNode<TCoAtom> inheritPermissions;
-    bool hasError = false;
 
     for (auto child : node) {
         if (auto maybeTuple = child.Maybe<TCoNameValueTuple>()) {
@@ -2001,7 +1989,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
                 } else {
                     ctx.AddError(YqlIssue(ctx.GetPosition(tuple.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                         "Only literal string is supported for 'value' option in secret"));
-                    hasError = true;
+                    return TWriteSecretSettings::CreateWithError();
                 }
             } else if (name == "value_expr") {
                 auto expr = tuple.Value();
@@ -2012,7 +2000,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
                 } else {
                     ctx.AddError(YqlIssue(ctx.GetPosition(tuple.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                         "Only string or single string parameter is supported as secret value"));
-                    hasError = true;
+                    return TWriteSecretSettings::CreateWithError();
                 }
             } else if (name == "inherit_permissions") {
                 YQL_ENSURE(tuple.Value().Maybe<TCoAtom>());
@@ -2021,7 +2009,22 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
         }
     }
 
-    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(valueParamName), std::move(inheritPermissions), hasError);
+    YQL_ENSURE(mode);
+    auto modeStr = mode.Cast().Value();
+    if (modeStr == "create" || modeStr == "alter") {
+        if (!value && !valueParamName) {
+            ctx.AddError(YqlIssue(ctx.GetPosition(node.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                "Secret value is required: provide a literal or a single string parameter"));
+            return TWriteSecretSettings::CreateWithError();
+        }
+        if (value && valueParamName) {
+            ctx.AddError(YqlIssue(ctx.GetPosition(node.Pos()), TIssuesIds::UNEXPECTED,
+                "Both literal value and parameter name are set for secret"));
+            return TWriteSecretSettings::CreateWithError();
+        }
+    }
+
+    return TWriteSecretSettings(std::move(mode), std::move(value), std::move(valueParamName), std::move(inheritPermissions));
 }
 
 IGraphTransformer::TStatus TKiSinkVisitorTransformer::DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output,

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -445,7 +445,13 @@ namespace {
     TSecretSettings ParseSecretSettings(TKiCreateSecret createSecret) {
         TSecretSettings settings;
         settings.Name = TString(createSecret.Secret());
-        settings.Value = TString(createSecret.Value());
+        if (auto value = createSecret.Value().Maybe<TCoAtom>()) {
+            if (createSecret.ValueFromParam().Value() == "1") {
+                settings.ValueParamName = TString(value.Cast().Value());
+            } else {
+                settings.Value = TString(value.Cast().Value());
+            }
+        }
         settings.InheritPermissions = FromString<bool>(TString(createSecret.InheritPermissions()));
         return settings;
     }
@@ -453,7 +459,13 @@ namespace {
     TSecretSettings ParseSecretSettings(TKiAlterSecret alterSecret) {
         TSecretSettings settings;
         settings.Name = TString(alterSecret.Secret());
-        settings.Value = TString(alterSecret.Value());
+        if (auto value = alterSecret.Value().Maybe<TCoAtom>()) {
+            if (alterSecret.ValueFromParam().Value() == "1") {
+                settings.ValueParamName = TString(value.Cast().Value());
+            } else {
+                settings.Value = TString(value.Cast().Value());
+            }
+        }
         return settings;
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -445,12 +445,11 @@ namespace {
     TSecretSettings ParseSecretSettings(TKiCreateSecret createSecret) {
         TSecretSettings settings;
         settings.Name = TString(createSecret.Secret());
-        if (auto value = createSecret.Value().Maybe<TCoAtom>()) {
-            if (createSecret.ValueFromParam().Value() == "1") {
-                settings.ValueParamName = TString(value.Cast().Value());
-            } else {
-                settings.Value = TString(value.Cast().Value());
-            }
+        if (auto value = TString(createSecret.Value())) {
+            settings.Value = std::move(value);
+        }
+        if (auto paramName = TString(createSecret.ValueParamName())) {
+            settings.ValueParamName = std::move(paramName);
         }
         settings.InheritPermissions = FromString<bool>(TString(createSecret.InheritPermissions()));
         return settings;
@@ -459,12 +458,11 @@ namespace {
     TSecretSettings ParseSecretSettings(TKiAlterSecret alterSecret) {
         TSecretSettings settings;
         settings.Name = TString(alterSecret.Secret());
-        if (auto value = alterSecret.Value().Maybe<TCoAtom>()) {
-            if (alterSecret.ValueFromParam().Value() == "1") {
-                settings.ValueParamName = TString(value.Cast().Value());
-            } else {
-                settings.Value = TString(value.Cast().Value());
-            }
+        if (auto value = TString(alterSecret.Value())) {
+            settings.Value = std::move(value);
+        }
+        if (auto paramName = TString(alterSecret.ValueParamName())) {
+            settings.ValueParamName = std::move(paramName);
         }
         return settings;
     }

--- a/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
+++ b/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
@@ -672,7 +672,7 @@
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
                 {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
                 {"Index": 4, "Name": "InheritPermissions", "Type": "TCoAtom"},
-                {"Index": 5, "Name": "ValueFromParam", "Type": "TCoAtom"}
+                {"Index": 5, "Name": "ValueParamName", "Type": "TCoAtom"}
             ]
         },
         {
@@ -684,7 +684,7 @@
                 {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
                 {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
-                {"Index": 4, "Name": "ValueFromParam", "Type": "TCoAtom"}
+                {"Index": 4, "Name": "ValueParamName", "Type": "TCoAtom"}
             ]
         },
         {

--- a/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
+++ b/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
@@ -671,7 +671,8 @@
                 {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
                 {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
-                {"Index": 4, "Name": "InheritPermissions", "Type": "TCoAtom"}
+                {"Index": 4, "Name": "InheritPermissions", "Type": "TCoAtom"},
+                {"Index": 5, "Name": "ValueFromParam", "Type": "TCoAtom"}
             ]
         },
         {
@@ -682,7 +683,8 @@
                 {"Index": 0, "Name": "World", "Type": "TExprBase"},
                 {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
-                {"Index": 3, "Name": "Value", "Type": "TCoAtom"}
+                {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
+                {"Index": 4, "Name": "ValueFromParam", "Type": "TCoAtom"}
             ]
         },
         {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1212,6 +1212,7 @@ struct TBackupSettings {
 struct TSecretSettings {
     TString Name;
     TString Value;
+    TString ValueParamName; // when set, the value is taken from parameter at execution
     bool InheritPermissions = false;
 };
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
@@ -277,17 +277,20 @@ struct TWriteSecretSettings {
     NNodes::TMaybeNode<NNodes::TCoAtom> Value;
     NNodes::TMaybeNode<NNodes::TCoAtom> ValueParamName;
     NNodes::TMaybeNode<NNodes::TCoAtom> InheritPermissions;
+    bool HasError = false;
 
     TWriteSecretSettings(
         NNodes::TMaybeNode<NNodes::TCoAtom>&& mode,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& value,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& valueParamName,
-        NNodes::TMaybeNode<NNodes::TCoAtom>&& inheritPermissions
+        NNodes::TMaybeNode<NNodes::TCoAtom>&& inheritPermissions,
+        bool hasError = false
     )
         : Mode(std::move(mode))
         , Value(std::move(value))
         , ValueParamName(std::move(valueParamName))
         , InheritPermissions(std::move(inheritPermissions))
+        , HasError(hasError)
     {
     }
 };

--- a/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
@@ -275,15 +275,18 @@ struct TWriteBackupCollectionSettings {
 struct TWriteSecretSettings {
     NNodes::TMaybeNode<NNodes::TCoAtom> Mode;
     NNodes::TMaybeNode<NNodes::TCoAtom> Value;
+    NNodes::TMaybeNode<NNodes::TCoAtom> ValueParamName;
     NNodes::TMaybeNode<NNodes::TCoAtom> InheritPermissions;
 
     TWriteSecretSettings(
         NNodes::TMaybeNode<NNodes::TCoAtom>&& mode,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& value,
+        NNodes::TMaybeNode<NNodes::TCoAtom>&& valueParamName,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& inheritPermissions
     )
         : Mode(std::move(mode))
         , Value(std::move(value))
+        , ValueParamName(std::move(valueParamName))
         , InheritPermissions(std::move(inheritPermissions))
     {
     }

--- a/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
@@ -273,26 +273,35 @@ struct TWriteBackupCollectionSettings {
 };
 
 struct TWriteSecretSettings {
+public:
     NNodes::TMaybeNode<NNodes::TCoAtom> Mode;
     NNodes::TMaybeNode<NNodes::TCoAtom> Value;
     NNodes::TMaybeNode<NNodes::TCoAtom> ValueParamName;
     NNodes::TMaybeNode<NNodes::TCoAtom> InheritPermissions;
     bool HasError = false;
 
+public:
     TWriteSecretSettings(
         NNodes::TMaybeNode<NNodes::TCoAtom>&& mode,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& value,
         NNodes::TMaybeNode<NNodes::TCoAtom>&& valueParamName,
-        NNodes::TMaybeNode<NNodes::TCoAtom>&& inheritPermissions,
-        bool hasError = false
+        NNodes::TMaybeNode<NNodes::TCoAtom>&& inheritPermissions
     )
         : Mode(std::move(mode))
         , Value(std::move(value))
         , ValueParamName(std::move(valueParamName))
         , InheritPermissions(std::move(inheritPermissions))
-        , HasError(hasError)
     {
     }
+
+    static TWriteSecretSettings CreateWithError() {
+        TWriteSecretSettings result;
+        result.HasError = true;
+        return result;
+    }
+
+private:
+    TWriteSecretSettings() = default;
 };
 
 TAutoPtr<IGraphTransformer> CreateKiSourceTypeAnnotationTransformer(TIntrusivePtr<TKikimrSessionContext> sessionCtx,

--- a/ydb/core/kqp/query_data/kqp_query_data.cpp
+++ b/ydb/core/kqp/query_data/kqp_query_data.cpp
@@ -354,8 +354,14 @@ bool TQueryData::TryGetParameterAsString(const TString& name, TString& outValue,
     }
     TType* type = it->second.first;
     // remove all optionals
+    NUdf::TUnboxedValue unboxedValue = it->second.second;
     while (type->IsOptional()) {
         type = static_cast<const TOptionalType*>(type)->GetItemType();
+        if (!unboxedValue.HasValue()) {
+            outError = TStringBuilder() << "Parameter " << name << " must not be NULL";
+            return false;
+        }
+        unboxedValue = unboxedValue.GetOptionalValue();
     }
 
     if (!type->IsData()) {
@@ -367,7 +373,7 @@ bool TQueryData::TryGetParameterAsString(const TString& name, TString& outValue,
         outError = TStringBuilder() << "Parameter " << name << " must be String or Utf8";
         return false;
     }
-    outValue = TString(it->second.second.AsStringRef());
+    outValue = TString(unboxedValue.AsStringRef());
     return true;
 }
 

--- a/ydb/core/kqp/query_data/kqp_query_data.cpp
+++ b/ydb/core/kqp/query_data/kqp_query_data.cpp
@@ -11,6 +11,7 @@
 #include <ydb/library/mkql_proto/mkql_proto.h>
 #include <ydb/library/yql/dq/runtime/dq_transport.h>
 #include <yql/essentials/core/yql_type_annotation.h>
+#include <yql/essentials/minikql/mkql_node.h>
 #include <yql/essentials/minikql/mkql_string_util.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
 #include <yql/essentials/utils/yql_panic.h>
@@ -345,6 +346,30 @@ TQueryData::TTypedUnboxedValue* TQueryData::GetParameterUnboxedValuePtr(const TS
     return &it->second;
 }
 
+bool TQueryData::TryGetParameterAsString(const TString& name, TString& outValue, TString& outError) const {
+    auto it = UnboxedData.find(name);
+    if (it == UnboxedData.end()) {
+        outError = TStringBuilder() << "Parameter " << name << " is required";
+        return false;
+    }
+    TType* type = it->second.first;
+    // remove all optionals
+    while (type->IsOptional()) {
+        type = static_cast<const TOptionalType*>(type)->GetItemType();
+    }
+
+    if (!type->IsData()) {
+        outError = TStringBuilder() << "Parameter " << name << " must be String or Utf8";
+        return false;
+    }
+    const auto schemeType = static_cast<const TDataType*>(type)->GetSchemeType();
+    if (schemeType != NUdf::TDataType<NUdf::TUtf8>::Id && schemeType != NUdf::TDataType<char*>::Id) {
+        outError = TStringBuilder() << "Parameter " << name << " must be String or Utf8";
+        return false;
+    }
+    outValue = TString(it->second.second.AsStringRef());
+    return true;
+}
 
 const Ydb::TypedValue* TQueryData::GetParameterTypedValue(const TString& name) {
     if (UnboxedData.find(name) == UnboxedData.end())

--- a/ydb/core/kqp/query_data/kqp_query_data.h
+++ b/ydb/core/kqp/query_data/kqp_query_data.h
@@ -265,6 +265,9 @@ public:
     TTypedUnboxedValue* GetParameterUnboxedValuePtr(const TString& name);
     const Ydb::TypedValue* GetParameterTypedValue(const TString& name);
 
+    // Returns true and sets outValue if parameter exists and has type String/Utf8; otherwise sets outError and returns false.
+    bool TryGetParameterAsString(const TString& name, TString& outValue, TString& outError) const;
+
     NYql::NDqProto::TData SerializeParamValue(const TString& name);
     void Clear();
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1898,7 +1898,7 @@ public:
         }
 
         auto executerActor = CreateKqpSchemeExecuter(
-            tx, QueryState->GetType(), SelfId(), requestType, Settings.Database, userToken, clientAddress,
+            tx, QueryState->GetType(), QueryState->QueryData, SelfId(), requestType, Settings.Database, userToken, clientAddress,
             temporary, /* createTmpDir */ temporary && !TempTablesState.NeedCleaning,
             QueryState->IsCreateTableAs(), TempTablesState.TempDirName, QueryState->UserRequestContext,
             expectsResult, expectsResult ? QueryState->QueryData->GetAllocState() : nullptr,

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13721,6 +13721,22 @@ END DO)",
                 UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             }
         }
+        { // Without DECLARE — parameter type inferred from the passed value
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").Utf8(TString("no-declare-") + operationType).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            %s SECRET `sec-no-declare` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
     }
 
     Y_UNIT_TEST(SetSecretValueWithParamFail) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13687,6 +13687,40 @@ END DO)",
                 UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             }
         }
+        { // non-null optional<Utf8> parameter type
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").OptionalUtf8(TString("opt-value-") + operationType).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Optional<Utf8>;
+                            %s SECRET `sec-optional` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
+        { // non-null optional<String> parameter type
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").OptionalString(TString("opt-value-") + operationType).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Optional<String>;
+                            %s SECRET `sec-optional-str` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
     }
 
     Y_UNIT_TEST(SetSecretValueWithParamFail) {
@@ -13778,6 +13812,26 @@ END DO)",
                 ).ExtractValueSync();
                 UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
                 UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Only string or single string parameter is supported as secret value", result.GetIssues().ToString());
+            }
+        }
+
+        { // NULL Optional<Utf8> parameter
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                auto params = TParamsBuilder()
+                    .AddParam("$secValue").EmptyOptional(EPrimitiveType::Utf8).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Optional<Utf8>;
+                            %s SECRET `%s` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType,
+                        TString(operationType) == "CREATE" ? "new-sec" : "old-sec"),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Parameter $secValue must not be NULL", result.GetIssues().ToString());
             }
         }
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -13632,6 +13632,156 @@ END DO)",
         }
     }
 
+    Y_UNIT_TEST(SetSecretValueWithParamOk) {
+        TKikimrRunner kikimr;
+        auto queryClient = kikimr.GetQueryClient();
+
+        { // Utf8 parameter type
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").Utf8(TString("value") + operationType).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Utf8;
+                            %s SECRET `sec-utf8` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
+        { // String parameter type
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").String(TString("value") + operationType).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS String;
+                            %s SECRET `sec-string` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
+        { // empty value in parameter
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto params = TParamsBuilder()
+                    .AddParam("$secValue").Utf8("").Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Utf8;
+                            %s SECRET `sec-empty` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+        }
+    }
+
+    Y_UNIT_TEST(SetSecretValueWithParamFail) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        { // Create secret so we can try to alter it later
+            static const auto query = R"sql(
+                CREATE SECRET `old-sec` WITH (value = "val");
+            )sql";
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        { // No parameter passed
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Utf8;
+                            %s SECRET `%s` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType,
+                        TString(operationType) == "CREATE" ? "new-sec" : "old-sec"),
+                    NYdb::NQuery::TTxControl::NoTx()
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Parameter $secValue is required for " + TString(operationType) + " SECRET", result.GetIssues().ToString());
+            }
+        }
+
+        { // Wrong parameter type – integer is passed instead of string
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                auto params = TParamsBuilder()
+                    .AddParam("$secValue").Uint64(42).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS String;
+                            %s SECRET `%s` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType,
+                        TString(operationType) == "CREATE" ? "new-sec" : "old-sec"),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Parameter $secValue must be String or Utf8", result.GetIssues().ToString());
+            }
+        }
+
+        { // Wrong parameter type – integer is declared instead of string
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                auto params = TParamsBuilder()
+                    .AddParam("$secValue").Uint64(42).Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue AS Uint64;
+                            %s SECRET `%s` WITH (VALUE = $secValue);
+                        )sql",
+                        operationType,
+                        TString(operationType) == "CREATE" ? "new-sec" : "old-sec"),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Parameter $secValue must be String or Utf8", result.GetIssues().ToString());
+            }
+        }
+
+        { // Too complex expression
+            for (const auto* operationType : { "CREATE", "ALTER" }) {
+                auto params = TParamsBuilder()
+                    .AddParam("$secValue1").Utf8("").Build()
+                    .AddParam("$secValue2").Utf8("").Build()
+                    .Build();
+                const auto result = queryClient.ExecuteQuery(
+                    Sprintf(R"sql(
+                            DECLARE $secValue1 AS String;
+                            DECLARE $secValue2 AS String;
+                            %s SECRET `%s` WITH (VALUE = $secValue1 || $secValue2);
+                        )sql",
+                        operationType,
+                        TString(operationType) == "CREATE" ? "new-sec" : "old-sec"),
+                    NYdb::NQuery::TTxControl::NoTx(),
+                    params
+                ).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+                UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Only string or single string parameter is supported as secret value", result.GetIssues().ToString());
+            }
+        }
+    }
+
     Y_UNIT_TEST_TWIN(AlterSecret, UseQueryService) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableSchemaSecrets(true);

--- a/ydb/core/kqp/ut/scheme/kqp_secrets_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_secrets_ut.cpp
@@ -1,0 +1,150 @@
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
+
+#include <contrib/libs/fmt/include/fmt/format.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+using namespace NYdb;
+using namespace NActors;
+using namespace Tests;
+
+class TTenantsSetup {
+public:
+    explicit TTenantsSetup() {
+        InitializeServer();
+    }
+
+    TString GetDedicatedTenantPath() const {
+        return TStringBuilder() << CanonizePath(DomainName) << "/test-dedicated";
+    }
+
+    TString GetSharedTenantPath() const {
+        return TStringBuilder() << CanonizePath(DomainName) << "/test-shared";
+    }
+
+    TString GetServerlessTenantPath() const {
+        return TStringBuilder() << CanonizePath(DomainName) << "/test-serverless";
+    }
+
+    TTestActorRuntime* GetRuntime() const {
+        return Server->GetRuntime();
+    }
+
+    TString GetEndpoint() const {
+        return Endpoint;
+    }
+
+private:
+    TServerSettings GetServerSettings(ui32 grpcPort) {
+        const ui32 msgBusPort = PortManager.GetPort();
+
+        return TServerSettings(msgBusPort)
+            .SetGrpcPort(grpcPort)
+            .SetNodeCount(1)
+            .SetDomainName(DomainName)
+            .SetUseRealThreads(true)
+            .SetDynamicNodeCount(2)
+            .AddStoragePoolType(GetDedicatedTenantPath())
+            .AddStoragePoolType(GetSharedTenantPath());
+    }
+
+    void SetupResourcesTenant(Ydb::Cms::CreateDatabaseRequest& request, Ydb::Cms::StorageUnits* storage, const TString& name) {
+        request.set_path(name);
+        storage->set_unit_kind(name);
+        storage->set_count(1);
+    }
+
+    void CreateTenants() {
+        {  // Dedicated
+            Ydb::Cms::CreateDatabaseRequest request;
+            SetupResourcesTenant(request, request.mutable_resources()->add_storage_units(), GetDedicatedTenantPath());
+            Tenants->CreateTenant(std::move(request));
+        }
+
+        {  // Shared
+            Ydb::Cms::CreateDatabaseRequest request;
+            SetupResourcesTenant(request, request.mutable_shared_resources()->add_storage_units(), GetSharedTenantPath());
+            Tenants->CreateTenant(std::move(request));
+        }
+
+        {  // Serverless
+            Ydb::Cms::CreateDatabaseRequest request;
+            request.set_path(GetServerlessTenantPath());
+            request.mutable_serverless_resources()->set_shared_database_path(GetSharedTenantPath());
+            Tenants->CreateTenant(std::move(request));
+        }
+
+        SetupDiscovery(GetDedicatedTenantPath());
+        SetupDiscovery(GetSharedTenantPath());
+    }
+
+    void SetupDiscovery(const TString& tenantPath) {
+        for (auto nodeIdx : Tenants->List(tenantPath)) {
+            Server->EnableGRpc(PortManager.GetPort(), nodeIdx, tenantPath);
+        }
+    }
+
+    void InitializeServer() {
+        const auto grpcPort = PortManager.GetPort();
+        const auto serverSettings = GetServerSettings(grpcPort);
+
+        Server = MakeIntrusive<TServer>(serverSettings);
+        Server->EnableGRpc(grpcPort);
+
+        TClient client(serverSettings);
+        client.InitRootScheme();
+
+        Endpoint = TStringBuilder() << "localhost:" << grpcPort;
+
+        Tenants = std::make_unique<TTenants>(Server);
+        CreateTenants();
+    }
+
+private:
+    const TString DomainName{"Root"};
+    TString Endpoint;
+    TPortManager PortManager;
+    TServer::TPtr Server;
+    std::unique_ptr<TTenants> Tenants;
+};
+
+Y_UNIT_TEST_SUITE(KqpSecrets) {
+    Y_UNIT_TEST(CreateSecretWithParamInNestedDbs) {
+        auto ydb = TTenantsSetup();
+        for (const auto& tenantPath : {ydb.GetDedicatedTenantPath(), ydb.GetSharedTenantPath(), ydb.GetServerlessTenantPath()}) {
+            // Setup
+            auto driver = std::make_unique<TDriver>(TDriverConfig()
+                .SetEndpoint(ydb.GetEndpoint())
+                .SetDatabase(tenantPath));
+            auto queryClient = NYdb::NQuery::TQueryClient(*driver);
+            const TString secretName = TString(ExtractBase(tenantPath)) + "-secret";
+            const auto params = NYdb::TParamsBuilder()
+                .AddParam("$value").Utf8("param-secret-value").Build()
+                .Build();
+            const auto query = queryClient.ExecuteQuery(
+                fmt::format(
+                    R"sql(
+                        DECLARE $value AS Utf8;
+                        CREATE SECRET `{}` WITH (value = $value);
+                    )sql",
+                    secretName
+                ),
+                NYdb::NQuery::TTxControl::NoTx(),
+                params
+            ).GetValueSync();
+
+            // Checks
+            UNIT_ASSERT_VALUES_EQUAL_C(query.GetStatus(), NYdb::EStatus::SUCCESS, query.GetIssues().ToOneLineString());
+
+            auto schemeClient = NYdb::NScheme::TSchemeClient(*driver);
+            const auto describeResult = schemeClient.DescribePath(CanonizePath(tenantPath + "/" + secretName)).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describeResult.GetStatus(), NYdb::EStatus::SUCCESS, describeResult.GetIssues().ToOneLineString());
+        }
+    }
+}
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/ut/scheme/ya.make
+++ b/ydb/core/kqp/ut/scheme/ya.make
@@ -15,6 +15,7 @@ SRCS(
     kqp_acl_ut.cpp
     kqp_constraints_ut.cpp
     kqp_scheme_ut.cpp
+    kqp_secrets_ut.cpp
     kqp_scheme_fulltext_ut.cpp
     kqp_scheme_type_info_ut.cpp
     kqp_user_management_ut.cpp

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2434,7 +2434,10 @@ message TSecretSchemaOp {
     optional string Name = 1;
     optional string Value = 2; // original, unencrypted value
     optional bool InheritPermissions = 3;
-    optional string ValueParamName = 4; // name of parameter for value (resolved at execution)
+    // The following field is needed at KQP for sending between the prepare и execute phases.
+    // However, this field is supposed to be resolved at KQP to the actual value and be cleared.
+    // Schemeshard always uses secret's value from the Value field and asserts that the ValueParamName field is empty.
+    optional string ValueParamName = 4;
 }
 
 message TStreamingQueryProperties {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2434,6 +2434,7 @@ message TSecretSchemaOp {
     optional string Name = 1;
     optional string Value = 2; // original, unencrypted value
     optional bool InheritPermissions = 3;
+    optional string ValueParamName = 4; // name of parameter for value (resolved at execution)
 }
 
 message TStreamingQueryProperties {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -172,8 +172,11 @@ public:
         context.DbChanges.PersistAlterSecret(secretPath.Base()->PathId);
         context.DbChanges.PersistTxState(OperationId);
 
-        Y_ENSURE(!alterSecretProto.HasValueParamName(),
-            "ValueParamName must be resolved by scheme executer before reaching schemeshard");
+        if (alterSecretProto.HasValueParamName()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter,
+                "Secret value must be set via Value, however ValueParamName was passed");
+            return result;
+        }
 
         auto alterData = secretInfo->CreateNextVersion();
         alterData->Description.SetValue(alterSecretProto.GetValue());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -172,6 +172,9 @@ public:
         context.DbChanges.PersistAlterSecret(secretPath.Base()->PathId);
         context.DbChanges.PersistTxState(OperationId);
 
+        Y_ENSURE(!alterSecretProto.HasValueParamName(),
+            "ValueParamName must be resolved by scheme executer before reaching schemeshard");
+
         auto alterData = secretInfo->CreateNextVersion();
         alterData->Description.SetValue(alterSecretProto.GetValue());
         alterData->Description.SetVersion(secretInfo->AlterVersion);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -257,8 +257,11 @@ public:
             }
         }
 
-        Y_ENSURE(!createSecretProto.HasValueParamName(),
-            "ValueParamName must be resolved by scheme executer before reaching schemeshard");
+        if (createSecretProto.HasValueParamName()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter,
+                "Secret value must be set via Value, however ValueParamName was passed");
+            return result;
+        }
 
         NKikimrSchemeOp::TSecretDescription secretDescription;
         secretDescription.SetName(createSecretProto.GetName());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -257,6 +257,9 @@ public:
             }
         }
 
+        Y_ENSURE(!createSecretProto.HasValueParamName(),
+            "ValueParamName must be resolved by scheme executer before reaching schemeshard");
+
         NKikimrSchemeOp::TSecretDescription secretDescription;
         secretDescription.SetName(createSecretProto.GetName());
         secretDescription.SetValue(createSecretProto.GetValue());

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -771,6 +771,50 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         TestDescribeResult(describeResult, {NLs::Finished, NLs::IsDirectory});
     }
 
+    Y_UNIT_TEST(RejectValueParamName) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        // Create with ValueParamName should be rejected
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                ValueParamName: "$val"
+            )",
+            {{EStatus::StatusInvalidParameter, "ValueParamName was passed"}}
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+
+        // Create normally so we can test alter
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "original"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // Alter with ValueParamName should be rejected
+        TestAlterSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                ValueParamName: "$val"
+            )",
+            {{EStatus::StatusInvalidParameter, "ValueParamName was passed"}}
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // Value should remain unchanged
+        const auto describeResult = DescribePathWithSecretValue(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "original", 0);
+    }
+
     Y_UNIT_TEST(AsyncAlterSameSecret) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -594,7 +594,7 @@ def test_set_secret_value_with_param(db_fixture, ydb_cluster, secret_setup):
         run_with_assert(config, f"CREATE SECRET `{name}` WITH (value = '');")
 
     def alter_secret_with_param(config, name, value):
-        query = f"DECLARE $value AS Utf8; ALTER SECRET `{name}` WITH (value = $value);"
+        query = f"ALTER SECRET `{name}` WITH (value = $value);"
         run_query_with_param(config, query, value)
 
     def prepare_secret(config, name, value, setup_kind):

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -4,6 +4,8 @@ import logging
 import os
 import time
 
+import pytest
+
 from .conftest import (
     run_with_assert,
     create_user,
@@ -13,6 +15,7 @@ from .conftest import (
     DATABASE,
     USE_SECRET_GRANTS,
 )
+from ydb.tests.oss.ydb_sdk_import import ydb
 
 logger = logging.getLogger(__name__)
 
@@ -556,3 +559,84 @@ def test_migration_to_new_secrets_in_transfer(db_fixture, ydb_cluster):
     assert_transfer_has_skipped_the_last_change(user1_config, table_name, messages_cnt - 1)
     _fix_auth_with_new_secret(user1_config, "TRANSFER", transfer_name, secret_name)
     assert_transfer_has_processed_all_changes(user1_config, table_name, messages_cnt)
+
+
+@pytest.mark.parametrize("secret_setup", ["create_with_param", "create_empty_then_alter_with_param"])
+def test_set_secret_value_with_param(db_fixture, ydb_cluster, secret_setup):
+    """Create secret via parameter (CREATE or CREATE+ALTER with $value), then use it in async replication."""
+    user_password = '1234'
+    run_with_assert(db_fixture, f"CREATE USER user1 PASSWORD '{user_password}';")
+    user1_config = ydb.DriverConfig(
+        endpoint="%s:%s" % (ydb_cluster.nodes[1].host, ydb_cluster.nodes[1].port),
+        database=DATABASE,
+        credentials=ydb.StaticCredentials.from_user_password("user1", user_password),
+    )
+    provide_grants(db_fixture, "user1", DATABASE, ["ydb.granular.create_table", "ydb.granular.alter_schema"])
+
+    table_name = 'table'
+    replica_name = 'replica'
+    replication_name = 'replication'
+    connection_string = f"grpc://{ydb_cluster.nodes[1].host}:{ydb_cluster.nodes[1].port}/?database={DATABASE}"
+    secret_name = 'user_password_secret'
+    secret_value = user_password
+
+    def run_query_with_param(config, query, value):
+        parameters = {"$value": (value, ydb.PrimitiveType.Utf8.proto)}
+        with ydb.Driver(config) as driver:
+            with ydb.QuerySessionPool(driver, size=1) as pool:
+                pool.execute_with_retries(query, parameters=parameters)
+
+    def create_secret_with_param(config, name, value):
+        query = f"DECLARE $value AS Utf8; CREATE SECRET `{name}` WITH (value = $value);"
+        run_query_with_param(config, query, value)
+
+    def create_secret_empty(config, name):
+        run_with_assert(config, f"CREATE SECRET `{name}` WITH (value = '');")
+
+    def alter_secret_with_param(config, name, value):
+        query = f"DECLARE $value AS String; ALTER SECRET `{name}` WITH (value = $value);"
+        run_query_with_param(config, query, value)
+
+    def prepare_secret(config, name, value, setup_kind):
+        if setup_kind == 'create_with_param':
+            create_secret_with_param(config, name, value)
+        elif setup_kind == 'create_empty_then_alter_with_param':
+            create_secret_empty(config, name)
+            alter_secret_with_param(config, name, value)
+        else:
+            raise ValueError(f"Unknown secret_setup: {setup_kind}")
+
+    def create_table_for_replication(table_name):
+        run_with_assert(
+            user1_config,
+            f'CREATE TABLE `{table_name}` (Key Uint64, PRIMARY KEY (Key));',
+        )
+
+    def insert_one_row_into_table(table_name, rows_cnt):
+        run_with_assert(
+            user1_config,
+            f'INSERT INTO `{table_name}` (Key) VALUES ({rows_cnt});',
+        )
+        return rows_cnt + 1
+
+    def create_async_replication(replication_name, replica_name, table_name, connection_string, secret_name):
+        run_with_assert(
+            user1_config,
+            f"""
+                CREATE ASYNC REPLICATION `{replication_name}` FOR `{table_name}` AS `{replica_name}` WITH (
+                    CONNECTION_STRING="{connection_string}",
+                    USER = "user1",
+                    PASSWORD_SECRET_PATH = "{secret_name}"
+                );
+            """,
+        )
+
+    def assert_replication_has_processed_all_changes(user1_config, replica_name, rows_cnt):
+        _wait_for_rows_count(user1_config, replica_name, rows_cnt, wait_for_the_first_success=True)
+
+    create_table_for_replication(table_name)
+    rows_cnt = 0
+    rows_cnt = insert_one_row_into_table(table_name, rows_cnt)
+    prepare_secret(user1_config, secret_name, secret_value, secret_setup)
+    create_async_replication(replication_name, replica_name, table_name, connection_string, secret_name)
+    assert_replication_has_processed_all_changes(user1_config, replica_name, rows_cnt)

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -594,7 +594,7 @@ def test_set_secret_value_with_param(db_fixture, ydb_cluster, secret_setup):
         run_with_assert(config, f"CREATE SECRET `{name}` WITH (value = '');")
 
     def alter_secret_with_param(config, name, value):
-        query = f"DECLARE $value AS String; ALTER SECRET `{name}` WITH (value = $value);"
+        query = f"DECLARE $value AS Utf8; ALTER SECRET `{name}` WITH (value = $value);"
         run_query_with_param(config, query, value)
 
     def prepare_secret(config, name, value, setup_kind):


### PR DESCRIPTION
### Changelog entry

Added a possibility to set secret values in SQL commands `CREATE SECRET` and `ALTER SECRET` via parameters, i.e.
```sql
DECLARE $value AS String;
CREATE SECRET sec WITH (VALUE = $value);
ALTER SECRET sec WITH (VALUE = $value);
```

### Changelog category

* Improvement

### Description for reviewers
На стороне парсинга SQL-команд `CREATE/ALTER SECRET` в опции `value_expr` может приходить произвольное выражение (оно сейчас не обрабатывается). Это сделано для того, чтобы можно было задавать значение секрета через параметр. В этом ПРе:
- поддержана обработка новой опции `value_expr`: извлекается имя параметра или литерал (TCoDataCtor); сложные выражения отклоняются с ошибкой;
- `QueryData` пробрасывается до схемных операций, чтобы в них можно было работать с параметрами;
- сделаны трансформер TSecretValueExprTransformer: снимает обёртку EvaluateExpr с выражений создания/изменения секретов, содержащих Parameter, до фазы EvaluateExpression — без этого compile-time evaluation падает, т.к. значения параметров недоступны; добавляет описания параметров секретов в PreparingQuery.
- Добавлено поле `ValueParamName` в `flat_scheme_op.proto`: передаётcя имя параметра из compile-time в scheme executer.
- написаны юнит-тесты, в том числе на негативные сценарии использования параметров;
- написаны функциональные тесты, проверяющие, что значение из параметра действительно задаётся ожидаемым значением.