### PR TITLE
Fix team dash no data

### DIFF
--- a/.github/config/owner_area_mapping.json
+++ b/.github/config/owner_area_mapping.json
@@ -19,5 +19,6 @@
   "engineering": "area/engineering",
   "postgres-compatibility": "area/pg",
   "security": "area/security",
-  "changelog-reviewers": "area/changelog"
+  "changelog-reviewers": "area/changelog",
+  "nbs": "area/nbs"
 }

--- a/.github/config/owner_area_mapping.json
+++ b/.github/config/owner_area_mapping.json
@@ -19,6 +19,5 @@
   "engineering": "area/engineering",
   "postgres-compatibility": "area/pg",
   "security": "area/security",
-  "changelog-reviewers": "area/changelog",
-  "nbs": "area/nbs"
+  "changelog-reviewers": "area/changelog"
 }

--- a/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_with_owner_from_mapping.sql
+++ b/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_with_owner_from_mapping.sql
@@ -41,7 +41,12 @@ SELECT
     t.env AS env,
     t.priority AS priority,
     t.branch AS branch,
-    t.area AS area,
+    t.area AS area_full,
+    Cast(CASE
+        WHEN ListLength(String::SplitToList(Cast(t.area AS String), '/')) >= 2
+        THEN String::SplitToList(Cast(t.area AS String), '/')[0] || '/' || String::SplitToList(Cast(t.area AS String), '/')[1]
+        ELSE Cast(t.area AS String)
+    END AS Utf8) AS area,
     CASE
         WHEN t.area = 'area/-' THEN 'unknown'
         WHEN o.owner_team IS NOT NULL THEN o.owner_team

--- a/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
@@ -1,7 +1,9 @@
 -- Daily bug counts per (date_window, owner_team, area). One row per day per team per area.
--- Bug = issue with max_branch != '-' (assigned to a release branch). Uses test_results/analytics/github_issues_timeline.
--- Owner_team from area_to_owner_mapping at read time (same logic as ля: prefix match by area).
--- SLA counts: low >= 30d, med/high/noprio >= 7d (out of SLA).
+-- Bug = issue with max_branch != '-' (assigned to a release branch).
+-- Area normalized to first two path segments (area/cs/analytics → area/cs).
+-- Owner_team via prefix match from area_to_owner_mapping (longest wins).
+-- Grid includes all areas from timeline + mapping + 'area/-', so areas without bugs show total=0.
+-- SLA: low >= 30d, med/high/noprio >= 7d.
 --
 $sla_low_days = 30;
 $sla_med_days = 7;
@@ -9,53 +11,80 @@ $sla_high_days = 7;
 $sla_noprio_days = 7;
 $window_days = 365;
 
--- Owner by area (prefix match), same as timeline view
-$owner_mapping = (
-    SELECT area AS area, owner_team AS owner_team
-    FROM (
-        SELECT
-            a.area AS area,
-            om.owner_team AS owner_team,
-            ROW_NUMBER() OVER (PARTITION BY a.area ORDER BY LENGTH(om.area) DESC) AS rn
-        FROM (SELECT DISTINCT area AS area FROM `test_results/analytics/github_issues_timeline`) AS a
-        CROSS JOIN `test_results/analytics/area_to_owner_mapping` AS om
-        WHERE a.area = om.area OR StartsWith(a.area, om.area || '/')
-    )
-    WHERE rn = 1
-);
+-- 1) Bugs from timeline with area normalized to 2 segments
+$normalize = ($raw_area) -> {
+    RETURN Cast(CASE
+        WHEN ListLength(String::SplitToList(Cast($raw_area AS String), '/')) >= 2
+        THEN String::SplitToList(Cast($raw_area AS String), '/')[0] || '/' || String::SplitToList(Cast($raw_area AS String), '/')[1]
+        ELSE Cast($raw_area AS String)
+    END AS Utf8);
+};
 
-$bugs = (
+$bugs_raw = (
     SELECT
         t.date AS date,
-        t.area AS area,
+        $normalize(t.area) AS area,
         t.project_item_id AS project_item_id,
         t.created_date AS created_date,
-        t.priority AS priority,
-        CASE
-            WHEN t.area = 'area/-' THEN 'unknown'
-            WHEN o.owner_team IS NOT NULL THEN o.owner_team
-            ELSE 'team_unmatched:' || t.area
-        END AS owner_team
+        t.priority AS priority
     FROM `test_results/analytics/github_issues_timeline` AS t
-    LEFT JOIN $owner_mapping AS o ON t.area = o.area
     WHERE t.date >= CurrentUtcDate() - $window_days * Interval("P1D")
       AND t.is_open_at_end_of_day = 1
       AND t.max_branch IS NOT NULL AND t.max_branch != '-'
 );
 
-$with_days = (
-    SELECT
-        b.*,
-        DateTime::ToDays(Cast(b.date AS Date) - Cast(b.created_date AS Date)) AS days_open
-    FROM $bugs AS b
+-- 2) Full area list: bugs + mapping + fallback, all normalized
+$area_list = (
+    SELECT DISTINCT area AS area FROM $bugs_raw
+    UNION
+    SELECT DISTINCT $normalize(area) AS area FROM `test_results/analytics/area_to_owner_mapping`
+    UNION
+    SELECT Cast('area/-' AS Utf8) AS area
 );
 
--- Aggregated counts per (date, owner_team, area). Will be left-joined to grid so missing combinations become 0.
+-- 3) Owner resolution on normalized areas
+$owner = (
+    SELECT
+        al.area AS area,
+        Cast(CASE
+            WHEN al.area = 'area/-' THEN 'unknown'
+            WHEN o.owner_team IS NOT NULL THEN o.owner_team
+            ELSE 'team_unmatched:' || al.area
+        END AS Utf8) AS owner_team
+    FROM $area_list AS al
+    LEFT JOIN (
+        SELECT area AS area, owner_team AS owner_team
+        FROM (
+            SELECT
+                a.area AS area,
+                om.owner_team AS owner_team,
+                ROW_NUMBER() OVER (PARTITION BY a.area ORDER BY LENGTH(om.area) DESC) AS rn
+            FROM $area_list AS a
+            CROSS JOIN `test_results/analytics/area_to_owner_mapping` AS om
+            WHERE a.area = om.area OR StartsWith(a.area, om.area || '/')
+        )
+        WHERE rn = 1
+    ) AS o ON al.area = o.area
+);
+
+-- 4) Enrich bugs with owner, compute days_open, aggregate
+$bugs = (
+    SELECT
+        b.date AS date,
+        b.area AS area,
+        b.project_item_id AS project_item_id,
+        b.priority AS priority,
+        o.owner_team AS owner_team,
+        DateTime::ToDays(Cast(b.date AS Date) - Cast(b.created_date AS Date)) AS days_open
+    FROM $bugs_raw AS b
+    LEFT JOIN $owner AS o ON b.area = o.area
+);
+
 $agg = (
     SELECT
         date AS date_window,
-        Cast(owner_team AS Utf8) AS owner_team,
-        Cast(area AS Utf8) AS area,
+        owner_team AS owner_team,
+        area AS area,
         COUNT(*) AS total,
         COUNT(CASE WHEN priority LIKE '%low%' THEN 1 ELSE NULL END) AS total_low,
         COUNT(CASE WHEN priority NOT LIKE '%low%' OR priority IS NULL THEN 1 ELSE NULL END) AS total_not_low,
@@ -66,17 +95,14 @@ $agg = (
         COUNT(CASE WHEN (priority LIKE '%med%') AND days_open >= $sla_med_days THEN 1 ELSE NULL END) AS med_out_of_sla,
         COUNT(CASE WHEN (priority LIKE '%high%') AND days_open >= $sla_high_days THEN 1 ELSE NULL END) AS high_out_of_sla,
         COUNT(CASE WHEN (priority IS NULL OR (priority NOT LIKE '%low%' AND priority NOT LIKE '%med%' AND priority NOT LIKE '%high%')) AND days_open >= $sla_noprio_days THEN 1 ELSE NULL END) AS noprio_out_of_sla
-    FROM $with_days
+    FROM $bugs
     GROUP BY date, owner_team, area
 );
 
--- Full grid: every (date, owner_team, area) that appears in the period. Missing combinations get 0. Always include today.
-$dates = (SELECT DISTINCT date AS date FROM $with_days UNION SELECT CurrentUtcDate() AS date);
-$owner_area = (SELECT DISTINCT Cast(owner_team AS Utf8) AS owner_team, Cast(area AS Utf8) AS area FROM $with_days);
-$grid = (SELECT d.date AS date_window, o.owner_team AS owner_team, o.area AS area FROM $dates AS d CROSS JOIN $owner_area AS o);
+-- Grid: all dates × all (area, owner) combinations
+$dates = (SELECT DISTINCT date AS date FROM $bugs UNION SELECT CurrentUtcDate() AS date);
+$grid = (SELECT d.date AS date_window, o.owner_team AS owner_team, o.area AS area FROM $dates AS d CROSS JOIN $owner AS o);
 
--- One row per (date_window, owner_team, area): daily snapshot. Missing (day, owner, area) → 0.
--- total_* = count by priority (all bugs); *_out_of_sla = count exceeding SLA (low 30d, med/high/noprio 7d).
 SELECT
     g.date_window AS date_window,
     g.owner_team AS owner_team,

--- a/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
@@ -2,7 +2,7 @@
 -- Bug = issue with max_branch != '-' (assigned to a release branch).
 -- Area normalized to first two path segments (area/cs/analytics → area/cs).
 -- Owner_team via prefix match from area_to_owner_mapping (longest wins).
--- Grid includes all areas from timeline + mapping + 'area/-', so areas without bugs show total=0.
+-- Grid: date spine from timeline in the window (+ today) × (area, owner); zeros via LEFT JOIN.
 -- SLA: low >= 30d, med/high/noprio >= 7d.
 --
 $sla_low_days = 30;
@@ -11,13 +11,18 @@ $sla_high_days = 7;
 $sla_noprio_days = 7;
 $window_days = 365;
 
--- 1) Bugs from timeline with area normalized to 2 segments
 $normalize = ($raw_area) -> {
     $parts = String::SplitToList(Cast($raw_area AS String), '/');
     RETURN Cast(
         IF(ListLength($parts) >= 2, $parts[0] || '/' || $parts[1], Cast($raw_area AS String))
     AS Utf8);
 };
+
+-- Single read of mapping table, normalized once and reused everywhere
+$mapping = (
+    SELECT $normalize(area) AS area, owner_team AS owner_team
+    FROM `test_results/analytics/area_to_owner_mapping`
+);
 
 $bugs_raw = (
     SELECT
@@ -32,16 +37,14 @@ $bugs_raw = (
       AND t.max_branch IS NOT NULL AND t.max_branch != '-'
 );
 
--- 2) Full area list: bugs + mapping + fallback, all normalized
 $area_list = (
     SELECT DISTINCT area AS area FROM $bugs_raw
     UNION
-    SELECT DISTINCT $normalize(area) AS area FROM `test_results/analytics/area_to_owner_mapping`
+    SELECT DISTINCT area AS area FROM $mapping
     UNION
     SELECT Cast('area/-' AS Utf8) AS area
 );
 
--- 3) Owner resolution on normalized areas
 $owner = (
     SELECT
         al.area AS area,
@@ -52,17 +55,13 @@ $owner = (
         END AS Utf8) AS owner_team
     FROM $area_list AS al
     LEFT JOIN (
-        SELECT area AS area, owner_team AS owner_team
-        FROM (
-            SELECT
-                a.area AS area,
-                om.owner_team AS owner_team,
-                ROW_NUMBER() OVER (PARTITION BY a.area ORDER BY LENGTH(om.area) DESC) AS rn
+        SELECT area AS area, owner_team AS owner_team FROM (
+            SELECT a.area AS area, om.owner_team AS owner_team,
+                   ROW_NUMBER() OVER (PARTITION BY a.area ORDER BY LENGTH(om.area) DESC) AS rn
             FROM $area_list AS a
-            CROSS JOIN `test_results/analytics/area_to_owner_mapping` AS om
+            CROSS JOIN $mapping AS om
             WHERE a.area = om.area OR StartsWith(a.area, om.area || '/')
-        )
-        WHERE rn = 1
+        ) WHERE rn = 1
     ) AS o ON al.area = o.area
 );
 
@@ -98,8 +97,14 @@ $agg = (
     GROUP BY date, owner_team, area
 );
 
--- Grid: all dates × all (area, owner) combinations
-$dates = (SELECT DISTINCT date AS date FROM $bugs UNION SELECT CurrentUtcDate() AS date);
+-- Grid: date spine = all days present in timeline for the window (not only days with bugs)
+$dates = (
+    SELECT DISTINCT t.date AS date
+    FROM `test_results/analytics/github_issues_timeline` AS t
+    WHERE t.date >= CurrentUtcDate() - $window_days * Interval("P1D")
+    UNION
+    SELECT CurrentUtcDate() AS date
+);
 $grid = (SELECT d.date AS date_window, o.owner_team AS owner_team, o.area AS area FROM $dates AS d CROSS JOIN $owner AS o);
 
 SELECT

--- a/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_bugs_count_by_period.sql
@@ -13,11 +13,10 @@ $window_days = 365;
 
 -- 1) Bugs from timeline with area normalized to 2 segments
 $normalize = ($raw_area) -> {
-    RETURN Cast(CASE
-        WHEN ListLength(String::SplitToList(Cast($raw_area AS String), '/')) >= 2
-        THEN String::SplitToList(Cast($raw_area AS String), '/')[0] || '/' || String::SplitToList(Cast($raw_area AS String), '/')[1]
-        ELSE Cast($raw_area AS String)
-    END AS Utf8);
+    $parts = String::SplitToList(Cast($raw_area AS String), '/');
+    RETURN Cast(
+        IF(ListLength($parts) >= 2, $parts[0] || '/' || $parts[1], Cast($raw_area AS String))
+    AS Utf8);
 };
 
 $bugs_raw = (

--- a/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
@@ -1,9 +1,57 @@
 -- Pre-aggregation: muted tests by team and by day, per build_type.
 -- Filters: is_test_chunk = 0, is_muted = 1 (as required for BI).
--- One row per (date_window, owner_team, branch, build_type). area from area_to_owner_mapping (one area per owner_team). In BI: filter by build_type for per-config metrics, or sum for total.
+-- One row per (date_window, owner_team, branch, build_type).
+-- Grid includes all areas from timeline + mapping + 'area/-', so areas without muted tests show 0.
 $window_days = 365;
 $muted_sla_days = 30;
 
+$normalize = ($raw_area) -> {
+    RETURN Cast(CASE
+        WHEN ListLength(String::SplitToList(Cast($raw_area AS String), '/')) >= 2
+        THEN String::SplitToList(Cast($raw_area AS String), '/')[0] || '/' || String::SplitToList(Cast($raw_area AS String), '/')[1]
+        ELSE Cast($raw_area AS String)
+    END AS Utf8);
+};
+
+-- Single read of mapping table, reused everywhere
+$mapping = (
+    SELECT $normalize(area) AS area, owner_team AS owner_team
+    FROM `test_results/analytics/area_to_owner_mapping`
+);
+
+-- Full normalized area list: timeline + mapping + fallback
+$area_list = (
+    SELECT DISTINCT $normalize(area) AS area
+    FROM `test_results/analytics/github_issues_timeline`
+    WHERE area IS NOT NULL AND max_branch != '-'
+    UNION
+    SELECT DISTINCT area AS area FROM $mapping
+    UNION
+    SELECT Cast('area/-' AS Utf8) AS area
+);
+
+-- Owner by area (prefix match, longest wins) + fallback
+$owner = (
+    SELECT
+        al.area AS area,
+        Cast(CASE
+            WHEN al.area = 'area/-' THEN 'unknown'
+            WHEN o.owner_team IS NOT NULL THEN o.owner_team
+            ELSE 'team_unmatched:' || al.area
+        END AS Utf8) AS owner_team
+    FROM $area_list AS al
+    LEFT JOIN (
+        SELECT area AS area, owner_team AS owner_team FROM (
+            SELECT a.area AS area, om.owner_team AS owner_team,
+                   ROW_NUMBER() OVER (PARTITION BY a.area ORDER BY LENGTH(om.area) DESC) AS rn
+            FROM $area_list AS a
+            CROSS JOIN $mapping AS om
+            WHERE a.area = om.area OR StartsWith(a.area, om.area || '/')
+        ) WHERE rn = 1
+    ) AS o ON al.area = o.area
+);
+
+-- Tests with area resolved via owner_team → MIN(area) from mapping
 $tm = (
     SELECT
         t.*,
@@ -12,14 +60,14 @@ $tm = (
     WHERE t.date_window >= CurrentUtcDate() - $window_days * Interval("P1D")
       AND t.build_type = 'relwithdebinfo'
       AND t.is_test_chunk = 0
-      and t.state != 'Skipped'
+      AND t.state != 'Skipped'
 );
 
 $base = (
     SELECT
         tm.date_window AS date_window,
         tm.owner_team_key AS owner_team,
-        Coalesce(om.area, 'area/-') AS area,
+        $normalize(Coalesce(om.area, 'area/-')) AS area,
         tm.branch AS branch,
         tm.build_type AS build_type,
         tm.full_name AS full_name,
@@ -28,7 +76,7 @@ $base = (
     FROM $tm AS tm
     LEFT JOIN (
         SELECT owner_team AS owner_team, MIN(area) AS area
-        FROM `test_results/analytics/area_to_owner_mapping`
+        FROM $mapping
         GROUP BY owner_team
     ) AS om ON tm.owner_team_key = om.owner_team
 );
@@ -57,24 +105,26 @@ $agg = (
         base.build_type
 );
 
-$dates = (SELECT DISTINCT date_window AS date_window FROM $tm);
-$dims = (
-    SELECT DISTINCT
-        owner_team AS owner_team,
-        area AS area,
-        branch AS branch,
-        build_type AS build_type
-    FROM $base
+-- Grid: all (area, owner) from tests + timeline/mapping × all dates × all branches/builds
+$all_area_owner = (
+    SELECT DISTINCT owner_team AS owner_team, area AS area FROM $base
+    UNION
+    SELECT DISTINCT owner_team AS owner_team, area AS area FROM $owner
 );
+
+$dates = (SELECT DISTINCT date_window AS date_window FROM $tm);
+$branches_builds = (SELECT DISTINCT branch AS branch, build_type AS build_type FROM $base);
+
 $grid = (
     SELECT
         d.date_window AS date_window,
-        x.owner_team AS owner_team,
-        x.area AS area,
-        x.branch AS branch,
-        x.build_type AS build_type
+        ao.owner_team AS owner_team,
+        ao.area AS area,
+        bb.branch AS branch,
+        bb.build_type AS build_type
     FROM $dates AS d
-    CROSS JOIN $dims AS x
+    CROSS JOIN $all_area_owner AS ao
+    CROSS JOIN $branches_builds AS bb
 );
 
 SELECT

--- a/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
@@ -6,11 +6,10 @@ $window_days = 365;
 $muted_sla_days = 30;
 
 $normalize = ($raw_area) -> {
-    RETURN Cast(CASE
-        WHEN ListLength(String::SplitToList(Cast($raw_area AS String), '/')) >= 2
-        THEN String::SplitToList(Cast($raw_area AS String), '/')[0] || '/' || String::SplitToList(Cast($raw_area AS String), '/')[1]
-        ELSE Cast($raw_area AS String)
-    END AS Utf8);
+    $parts = String::SplitToList(Cast($raw_area AS String), '/');
+    RETURN Cast(
+        IF(ListLength($parts) >= 2, $parts[0] || '/' || $parts[1], Cast($raw_area AS String))
+    AS Utf8);
 };
 
 -- Single read of mapping table, reused everywhere

--- a/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_daily_by_team.sql
@@ -1,7 +1,8 @@
 -- Pre-aggregation: muted tests by team and by day, per build_type.
 -- Filters: is_test_chunk = 0, is_muted = 1 (as required for BI).
 -- One row per (date_window, owner_team, branch, build_type).
--- Grid includes all areas from timeline + mapping + 'area/-', so areas without muted tests show 0.
+-- Grid: date spine from github_issues_timeline in the window (+ today), same calendar as bugs mart.
+-- Areas from timeline + mapping + 'area/-'; muted=0 where no rows.
 $window_days = 365;
 $muted_sla_days = 30;
 
@@ -111,7 +112,13 @@ $all_area_owner = (
     SELECT DISTINCT owner_team AS owner_team, area AS area FROM $owner
 );
 
-$dates = (SELECT DISTINCT date_window AS date_window FROM $tm);
+$dates = (
+    SELECT DISTINCT t.date AS date_window
+    FROM `test_results/analytics/github_issues_timeline` AS t
+    WHERE t.date >= CurrentUtcDate() - $window_days * Interval("P1D")
+    UNION
+    SELECT CurrentUtcDate() AS date_window
+);
 $branches_builds = (SELECT DISTINCT branch AS branch, build_type AS build_type FROM $base);
 
 $grid = (


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Источники данных несимметричные — одни area есть в мьютах но не в github issues и наоборот. Поэтому строится объединённый список area из всех источников чтобы ни одна команда не выпала из отчёта.
Area нормализуются до двух сегментов (area/cs/analytics → area/cs) для консистентного матчинга. Owner определяется через longest-prefix match с fallback на team_unmatched и unknown.
Grid (все даты × все area/owner) + LEFT JOIN нужен чтобы показывать 0 там где данных нет — иначе дашборд не отличает "нет багов" от "нет данных".

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
