### PR TITLE
[CBO] Fix join order hints

### DIFF
--- a/ydb/core/kqp/ut/join/data/queries/join_order_hints_complex_edge_boundary.sql
+++ b/ydb/core/kqp/ut/join/data/queries/join_order_hints_complex_edge_boundary.sql
@@ -1,0 +1,16 @@
+PRAGMA TablePathPrefix='/Root/test/ds';
+
+-- Two hints whose node sets partially overlap with the complex edge {item,warehouse}->store.
+-- Hint 1 (item,ship_mode): Overlaps with Left={item,warehouse} on 'item' but not a subset.
+-- Hint 2 (warehouse,date_dim): Overlaps with Left={item,warehouse} on 'warehouse' but not a subset.
+-- The outer widening loop must use IsSubset (not Overlaps) to avoid spuriously widening
+-- the complex edge: old Overlaps code would accumulate {item,warehouse,ship_mode,date_dim}->store,
+-- and the second hint would then add 'warehouse' to the Right side (creating an edge with
+-- warehouse on both Left and Right — a corrupted edge).
+PRAGMA ydb.OptimizerHints='JoinOrder(item ship_mode) JoinOrder(warehouse date_dim)';
+
+select * from item
+left join warehouse on warehouse.w_warehouse_id = item.i_item_id
+left join store on store.s_store_id = item.i_item_id and store.s_store_id = warehouse.w_warehouse_id
+left join date_dim on date_dim.d_date_id = warehouse.w_warehouse_id
+left join ship_mode on ship_mode.sm_ship_mode_id = item.i_item_id;

--- a/ydb/core/kqp/ut/join/data/queries/join_order_hints_nested_edges_bug.sql
+++ b/ydb/core/kqp/ut/join/data/queries/join_order_hints_nested_edges_bug.sql
@@ -1,0 +1,6 @@
+PRAGMA TablePathPrefix='/Root/test/ds';
+PRAGMA ydb.OptimizerHints='JoinOrder((item warehouse) store)';
+
+select * from item
+inner join warehouse on warehouse.w_warehouse_id = item.i_item_id
+inner join store on store.s_store_id = item.i_item_id and store.s_store_id = warehouse.w_warehouse_id;

--- a/ydb/core/kqp/ut/join/data/queries/join_order_hints_reversed.sql
+++ b/ydb/core/kqp/ut/join/data/queries/join_order_hints_reversed.sql
@@ -1,0 +1,12 @@
+PRAGMA TablePathPrefix='/Root';
+
+-- Without the hint the optimizer prefers to stream R (R is much larger than S).
+-- The hint forces S to be the right (build) table.
+PRAGMA ydb.OptimizerHints=
+'
+    Rows(S # 1000)
+    Rows(R # 10000000000)
+    JoinOrder(S R)
+';
+
+select * from R inner join S on R.id = S.id;

--- a/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
@@ -1001,6 +1001,33 @@ Y_UNIT_TEST_SUITE(KqpJoinOrder) {
         UNIT_ASSERT_C(joinOrder.find(R"(["T","U"])") != TString::npos, joinOrder);
     }
 
+    Y_UNIT_TEST(JoinOrderHintsNestedEdgesBug) {
+        auto [plan, _] = ExecuteJoinOrderTestGenericQueryWithStats("queries/join_order_hints_nested_edges_bug.sql", "stats/tpcds1000s.json", false, true);
+        auto joinOrder = GetJoinOrder(plan).GetStringRobust();
+        UNIT_ASSERT_C(joinOrder.find(R"([["item","warehouse"],"store"])") != TString::npos, joinOrder);
+    }
+
+    Y_UNIT_TEST(JoinOrderHintsReversedOrder) {
+        // Verifies that a hint can force the join order to be the reverse of what the cost
+        // model would choose. R is much larger than S, so the optimizer naturally puts R
+        // first; JoinOrder((S R)) must override that to produce ["S","R"].
+        auto [plan, _] = ExecuteJoinOrderTestGenericQueryWithStats("queries/join_order_hints_reversed.sql", "stats/basic.json", false, true);
+        UNIT_ASSERT_VALUES_EQUAL(GetJoinOrder(plan).GetStringRobust(), R"(["S","R"])");
+    }
+
+    Y_UNIT_TEST(JoinOrderHintsComplexEdgeBoundary) {
+        // Two hints (item,ship_mode) and (warehouse,date_dim) both partially overlap
+        // with the complex edge {item,warehouse}->store created by the dual-condition
+        // LEFT JOIN on store.
+        auto [plan, _] = ExecuteJoinOrderTestGenericQueryWithStats(
+            "queries/join_order_hints_complex_edge_boundary.sql",
+            "stats/tpcds1000s.json", false, true);
+        auto joinOrder = GetJoinOrder(plan).GetStringRobust();
+        UNIT_ASSERT_C(joinOrder.find(R"(["item","ship_mode"])") != TString::npos, joinOrder);
+        UNIT_ASSERT_C(joinOrder.find(R"(["warehouse","date_dim"])") != TString::npos, joinOrder);
+    }
+
+
     void CanonizedJoinOrderTest(
         const TString& queryPath, const TString& statsPath, TString correctJoinOrderPath, bool useStreamLookupJoin, bool useColumnStore
     ) {

--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -55,6 +55,12 @@ public:
             return HasSingleBit(Left) && HasSingleBit(Right);
         }
 
+        bool Bridges(const TNodeSet& lhs, const TNodeSet& rhs) const {
+            return
+                IsSubset(Left,  lhs) && !Overlaps(Left,  rhs) &&
+                IsSubset(Right, rhs) && !Overlaps(Right, lhs);
+        }
+
         TNodeSet Left;
         TNodeSet Right;
         EJoinKind JoinKind;
@@ -223,12 +229,7 @@ public:
     /* Find any edge between lhs and rhs. (It can skip conditions and generate invalid plan in case of cycles) */
     const TEdge* FindEdgeBetween(const TNodeSet& lhs, const TNodeSet& rhs) const {
         for (const auto& edge: Edges_) {
-            if (
-                IsSubset(edge.Left, lhs) &&
-                !Overlaps(edge.Left, rhs) &&
-                IsSubset(edge.Right, rhs) &&
-                !Overlaps(edge.Right, lhs)
-            ) {
+            if (edge.Bridges(lhs, rhs)) {
                 return &edge;
             }
         }
@@ -248,12 +249,7 @@ public:
         TVector<TJoinColumn>& resRightJoinKeys
     ) {
         for (const auto& edge: Edges_) {
-            if (
-                IsSubset(edge.Left, lhs) &&
-                !Overlaps(edge.Left, rhs) &&
-                IsSubset(edge.Right, rhs) &&
-                !Overlaps(edge.Right, lhs)
-            ) {
+            if (edge.Bridges(lhs, rhs)) {
                 for (const auto& [lhsEdgeCond, rhsEdgeCond]: Zip(edge.LeftJoinKeys, edge.RightJoinKeys)) {
                     bool hasSameEquivClass = false;
                     for (const auto& lhsResJoinKey: resLeftJoinKeys) {

--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -357,28 +357,70 @@ private:
             TVector<TString> lhsLabels = ApplyHintsToSubgraph(join->Lhs);
             TVector<TString> rhsLabels = ApplyHintsToSubgraph(join->Rhs);
 
+            // Construct hint name for error name, e.g. ({A B C} {D E}), i.e.
+            // this particular "level" of this particular hint implies that
+            // subtree containing {A B C} and subtree containing {D E} should
+            // be joined together, which is not satisfiable.
+
+            // Possible reasons include:
+            // 1. The edge that represents this join is absent, creating
+            //    it requires inserting a cross join, which is usually not desirable
+            // 2. There exits an edge that is the reverse of what is hinted
+            //    and it's not commutative -> hint contradicts semantics
+            auto describeHintedPart = [&]() {
+                return Sprintf(
+                    "({{%s}} {{%s}})",
+                    JoinSeq(", ", lhsLabels).c_str(),
+                    JoinSeq(", ", rhsLabels).c_str()
+                );
+            };
+
             auto lhs = Graph_.GetNodesByRelNames(lhsLabels);
             auto rhs = Graph_.GetNodesByRelNames(rhsLabels);
 
-            auto* maybeEdge = Graph_.FindEdgeBetween(lhs, rhs);
-            if (maybeEdge == nullptr) {
-                const char* errStr = "There is no edge between {%s}, {%s}. The graf: %s";
-                Y_ENSURE(false, Sprintf(errStr, JoinSeq(", ", lhsLabels).c_str(), JoinSeq(", ", rhsLabels).c_str(), Graph_.String().c_str()));
+            TVector<size_t> bridgingEdgeIdxs;
+            const auto& edges = Graph_.GetEdges();
+            for (size_t i = 0; i < edges.size(); ++i) {
+                if (!edges[i].Bridges(lhs, rhs)) {
+                    continue;
+                }
+
+                // A non-commutative reversed edge bridges (lhs, rhs) but its canonical
+                // direction is (rhs, lhs) — the hint contradicts a mandatory edge.
+                if (!edges[i].IsCommutative && edges[i].IsReversed) {
+                    Y_ENSURE(false,
+                        Sprintf("Hinted join %s breaks semantics by contradicting"
+                                " non-commutative join of the opposite direction"
+                                " - hint will be ignored", describeHintedPart().c_str())
+                    );
+                    continue;
+                }
+
+                bridgingEdgeIdxs.push_back(i);
             }
 
-            size_t revEdgeIdx = maybeEdge->ReversedEdgeId;
-            auto& revEdge = Graph_.GetEdge(revEdgeIdx);
-            size_t edgeIdx = revEdge.ReversedEdgeId;
-            auto& edge = Graph_.GetEdge(edgeIdx);
+            if (bridgingEdgeIdxs.empty()) {
+                Y_ENSURE(false,
+                    Sprintf("Hinted join %s does not exist - hint will be ignored",
+                            describeHintedPart().c_str())
+                );
+            }
 
-            edge.IsReversed = false;
-            revEdge.IsReversed = true;
+            for (size_t edgeIdx : bridgingEdgeIdxs) {
+                auto& edge = Graph_.GetEdge(edgeIdx);
+                size_t revEdgeIdx = edge.ReversedEdgeId;
+                auto& revEdge = Graph_.GetEdge(revEdgeIdx);
 
-            edge.IsCommutative = false;
-            revEdge.IsCommutative = false;
+                edge.IsReversed = false;
+                revEdge.IsReversed = true;
 
-            Graph_.UpdateEdgeSides(edgeIdx, lhs, rhs);
-            Graph_.UpdateEdgeSides(revEdgeIdx, rhs, lhs);
+                // Hint selects a certain direction, therefore
+                // now edge is no longer commutative
+                edge.IsCommutative = revEdge.IsCommutative = false;
+
+                Graph_.UpdateEdgeSides(edgeIdx, lhs, rhs);
+                Graph_.UpdateEdgeSides(revEdgeIdx, rhs, lhs);
+            }
 
             TVector<TString> joinLabels = std::move(lhsLabels);
             joinLabels.insert(

--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -334,12 +334,12 @@ public:
 
             for (size_t i = 0; i < Graph_.GetEdges().size(); ++i) {
                 TNodeSet newLeft = Graph_.GetEdge(i).Left;
-                if (Overlaps(Graph_.GetEdge(i).Left, nodes) && !IsSubset(Graph_.GetEdge(i).Right, nodes)) {
+                if (IsSubset(Graph_.GetEdge(i).Left, nodes) && !Overlaps(Graph_.GetEdge(i).Right, nodes)) {
                     newLeft |= nodes;
                 }
 
                 TNodeSet newRight = Graph_.GetEdge(i).Right;
-                if (Overlaps(Graph_.GetEdge(i).Right, nodes) && !IsSubset(Graph_.GetEdge(i).Left, nodes)) {
+                if (IsSubset(Graph_.GetEdge(i).Right, nodes) && !Overlaps(Graph_.GetEdge(i).Left, nodes)) {
                     newRight |= nodes;
                 }
 

--- a/ydb/library/yql/dq/opt/dq_opt_make_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_make_join_hypergraph.h
@@ -253,37 +253,30 @@ TJoinHypergraph<TNodeSet> MakeJoinHypergraph(
     bool logGraph = true
 ) {
     TJoinHypergraph<TNodeSet> graph{};
+
+    auto logHypergraph = [&graph, logGraph](const char* name) {
+        if (logGraph && NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE)) {
+            YQL_CLOG(TRACE, CoreDq) << name << ": ";
+            YQL_CLOG(TRACE, CoreDq) << graph.String();
+        }
+    };
+
     std::unordered_map<std::shared_ptr<IBaseOptimizerNode>, TNodeSet> subtreeNodes{};
     TVector<typename TJoinHypergraph<TNodeSet>::TEdge> crossJoins;
     MakeJoinHypergraphRec(graph, joinTree, subtreeNodes, crossJoins);
+    logHypergraph("Hypergraph build");
 
-    if (logGraph && NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE)) {
-        YQL_CLOG(TRACE, CoreDq) << "Hypergraph build: ";
-        YQL_CLOG(TRACE, CoreDq) << graph.String();
-    }
+    TTransitiveClosureConstructor transitiveClosure(graph);
+    transitiveClosure.Construct();
+    logHypergraph("Hypergraph after transitive closure");
+
+    AddCrossJoins(graph, crossJoins);
+    logHypergraph("Hypergraph after cross joins");
 
     if (!hints.JoinOrderHints->Hints.empty()) {
         TJoinOrderHintsApplier joinHints(graph);
         joinHints.Apply(*hints.JoinOrderHints);
-        if (logGraph && NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE)) {
-            YQL_CLOG(TRACE, CoreDq) << "Hypergraph after hints: ";
-            YQL_CLOG(TRACE, CoreDq) << graph.String();
-        }
-    }
-
-    TTransitiveClosureConstructor transitveClosure(graph);
-    transitveClosure.Construct();
-
-    if (logGraph && NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE)) {
-        YQL_CLOG(TRACE, CoreDq) << "Hypergraph after transitive closure: ";
-        YQL_CLOG(TRACE, CoreDq) << graph.String();
-    }
-
-    AddCrossJoins(graph, crossJoins);
-
-    if (logGraph && NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE)) {
-        YQL_CLOG(TRACE, CoreDq) << "Hypergraph after adding cross joins: ";
-        YQL_CLOG(TRACE, CoreDq) << graph.String();
+        logHypergraph("Hypergraph after hints");
     }
 
     return graph;


### PR DESCRIPTION
CBO join order hints used to:
1. Sometimes apply only partially, leading to the order different from requested
2. Sometimes produce over-restrictive edges
3. Not report inapplicable hints in some cases
4. Struggle to enforce reverse order, i.e. [B A], when cost model suggests [A B]

This PR addresses all those issues. 