### PR TITLE
fix u-a-f on GetTableDescription

### DIFF
--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -703,9 +703,10 @@ Y_UNIT_TEST(OneShardNonLocalExec) {
 
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_EQUAL(res.GetStatus(), EStatus::SUCCESS);
-            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionsCount(), 8);
-            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionStats().size(), 8);
-            for (const auto& s : res.GetTableDescription().GetPartitionStats()) {
+            const auto& desc = res.GetTableDescription();
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetPartitionsCount(), 8);
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetPartitionStats().size(), 8);
+            for (const auto& s : desc.GetPartitionStats()) {
                 nodeIds.emplace(s.LeaderNodeId);
             }
             Cerr << "waitTablets: attempt " << i << ", tablet leader nodes: {";

--- a/ydb/core/kqp/ut/scan/kqp_scan_ut.cpp
+++ b/ydb/core/kqp/ut/scan/kqp_scan_ut.cpp
@@ -1817,7 +1817,8 @@ Y_UNIT_TEST_SUITE(KqpScan) {
             for (int i = 0; i < 10; i++) {
                 auto res = session.DescribeTable("Root/EmptyTable", describeSettings).ExtractValueSync();
                 UNIT_ASSERT_EQUAL(res.GetStatus(), EStatus::SUCCESS);
-                const auto& stats = res.GetTableDescription().GetPartitionStats();
+                const auto& desc = res.GetTableDescription();
+                const auto& stats = desc.GetPartitionStats();
                 if (stats.size() == 1 && stats[0].LeaderNodeId == firstNodeId + 1) {
                     done = true;
                     break;

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1012,7 +1012,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             TDescribeTableResult describe = session.DescribeTable(tableName).GetValueSync();
             UNIT_ASSERT_EQUAL(describe.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describe.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describe.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), false);
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
@@ -1195,7 +1196,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             TDescribeTableResult describe = session.DescribeTable(tableName).GetValueSync();
             UNIT_ASSERT_EQUAL(describe.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describe.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describe.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
@@ -1208,7 +1210,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             TDescribeTableResult describe = session.DescribeTable(tableName).GetValueSync();
             UNIT_ASSERT_EQUAL(describe.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describe.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describe.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), false);
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
@@ -1937,7 +1940,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             return parser.GetOptionalUint64().value();
         };
 
-        const std::vector<TKeyRange>& keyRanges = describeResult.GetTableDescription().GetKeyRanges();
+        const auto& desc = describeResult.GetTableDescription();
+        const std::vector<TKeyRange>& keyRanges = desc.GetKeyRanges();
 
         size_t n = 0;
         const std::vector<ui64> expectedRanges = { 10ul, 100ul, 1000ul, 10000ul };
@@ -2003,7 +2007,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             return parser.GetOptionalInt64().value();
         };
 
-        const std::vector<TKeyRange>& keyRanges = describeResult.GetTableDescription().GetKeyRanges();
+        const auto& desc = describeResult.GetTableDescription();
+        const std::vector<TKeyRange>& keyRanges = desc.GetKeyRanges();
 
         size_t n = 0;
         const std::vector<i64> expectedRanges = { 0l, 10l, 10000l };
@@ -2061,7 +2066,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             return std::pair<ui64, std::optional<std::string>>(pk1, pk2);
         };
 
-        const std::vector<TKeyRange>& keyRanges = describeResult.GetTableDescription().GetKeyRanges();
+        const auto& desc = describeResult.GetTableDescription();
+        const std::vector<TKeyRange>& keyRanges = desc.GetKeyRanges();
 
         size_t n = 0;
         const std::vector<std::pair<ui64, TString>> expectedRanges = {
@@ -2284,7 +2290,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         auto describeResult = session.DescribeTable(tableName, NYdb::NTable::TDescribeTableSettings()).GetValueSync();
         UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
-        const auto& columnFamilies = describeResult.GetTableDescription().GetColumnFamilies();
+        const auto& desc = describeResult.GetTableDescription();
+        const auto& columnFamilies = desc.GetColumnFamilies();
         UNIT_ASSERT_VALUES_EQUAL(columnFamilies.size(), 3);
         for (const auto& family : columnFamilies) {
             if (family.GetName() == "Family1") {
@@ -2505,7 +2512,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto describeResult = session.DescribeTable(tableName, NYdb::NTable::TDescribeTableSettings()).GetValueSync();
             UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
-            const auto& columnFamilies = describeResult.GetTableDescription().GetColumnFamilies();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& columnFamilies = desc.GetColumnFamilies();
             UNIT_ASSERT_VALUES_EQUAL(columnFamilies.size(), 2);
             for (const auto& family : columnFamilies) {
                 if (family.GetName() == "Family1") {
@@ -2541,7 +2549,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto describeResult = session.DescribeTable(tableName, NYdb::NTable::TDescribeTableSettings()).GetValueSync();
             UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
-            const auto& columnFamilies = describeResult.GetTableDescription().GetColumnFamilies();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& columnFamilies = desc.GetColumnFamilies();
             UNIT_ASSERT_VALUES_EQUAL(columnFamilies.size(), 3);
             for (const auto& family : columnFamilies) {
                 if (family.GetName() == "Family1") {

--- a/ydb/core/tx/replication/controller/resource_id_resolver.cpp
+++ b/ydb/core/tx/replication/controller/resource_id_resolver.cpp
@@ -23,7 +23,8 @@ class TResourceIdResolver: public TActorBootstrapped<TResourceIdResolver> {
             LOG_D("Describe succeeded"
                 << ": path# " << Database);
 
-            for (const auto& [k, v] : result.GetTableDescription().GetAttributes()) {
+            const auto& desc = result.GetTableDescription();
+            for (const auto& [k, v] : desc.GetAttributes()) {
                 if (k == "cloud_id") {
                     return Reply(TString{v});
                 }

--- a/ydb/core/tx/replication/controller/target_discoverer.cpp
+++ b/ydb/core/tx/replication/controller/target_discoverer.cpp
@@ -122,7 +122,8 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
                 << ", dstPath# " << target.Config->GetDstPath()
                 << ", kind# " << target.Kind);
 
-            for (const auto& index : result.GetTableDescription().GetIndexDescriptions()) {
+            const auto& desc = result.GetTableDescription();
+            for (const auto& index : desc.GetIndexDescriptions()) {
                 switch (index.GetIndexType()) {
                 case NYdb::NTable::EIndexType::GlobalSync:
                 case NYdb::NTable::EIndexType::GlobalUnique:

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
@@ -44,7 +44,8 @@ namespace {
             auto describeResult = session.DescribeTable(entry.Name).ExtractValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(describeResult);
 
-            const auto& attributes = describeResult.GetTableDescription().GetAttributes();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& attributes = desc.GetAttributes();
             auto it = attributes.find("__async_replica");
             return it != attributes.end() && it->second == "true";
         };

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -1988,7 +1988,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
         expected.push_back(R"___([[3865470565u];[200000001u];["F"]])___");
 
         int row = 0;
-        for (const auto& range : describeResult.GetTableDescription().GetKeyRanges()) {
+        const auto& desc = describeResult.GetTableDescription();
+        for (const auto& range : desc.GetKeyRanges()) {
             TReadTableSettings readTableSettings;
             if (auto from = range.From()) {
                 readTableSettings.From(from.value());
@@ -3459,13 +3460,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3489,13 +3491,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
         }
@@ -3515,13 +3518,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3551,13 +3555,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3581,13 +3586,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
         }
@@ -3611,13 +3617,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3643,13 +3650,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3771,13 +3779,14 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[1].GetName(), "alt");
@@ -3840,17 +3849,18 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS,
                 "Status: " << res.GetStatus() << " Issues: " << TPrintableIssues(res.GetIssues()));
-            auto columns = res.GetTableDescription().GetTableColumns();
+            const auto& desc = res.GetTableDescription();
+            auto columns = desc.GetTableColumns();
             UNIT_ASSERT_EQUAL(columns.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Name, "Key");
             UNIT_ASSERT_VALUES_EQUAL(columns[0].Family, "");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Name, "Value");
             UNIT_ASSERT_VALUES_EQUAL(columns[1].Family, "alt");
-            const auto& settings = res.GetTableDescription().GetStorageSettings();
+            const auto& settings = desc.GetStorageSettings();
             UNIT_ASSERT_VALUES_EQUAL(settings.GetExternal(), "hdd");
             UNIT_ASSERT_VALUES_EQUAL(settings.GetStoreExternalBlobs().value(), true);
             UNIT_ASSERT_VALUES_EQUAL(settings.GetExternalDataChannelsCount().value(), 7U);
-            const auto& families = res.GetTableDescription().GetColumnFamilies();
+            const auto& families = desc.GetColumnFamilies();
             UNIT_ASSERT_EQUAL(families.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetName(), "default");
             UNIT_ASSERT_VALUES_EQUAL(families[0].GetData(), "ssd");
@@ -4116,7 +4126,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
@@ -4194,7 +4205,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
@@ -4237,7 +4249,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
@@ -4261,7 +4274,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitionSizeMb(), 50);
@@ -4281,7 +4295,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), false);
         }
@@ -4298,7 +4313,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningByLoad().value(), true);
         }
@@ -4334,7 +4350,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), false);
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
@@ -4354,7 +4371,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningBySize().value(), true);
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
@@ -4375,7 +4393,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningByLoad().value(), false);
         }
@@ -4406,7 +4425,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningByLoad().value(), false);
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
@@ -4442,7 +4462,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningByLoad().value(), false);
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());
@@ -4480,7 +4501,8 @@ R"___(<main>: Error: Transaction not found: , code: 2015
             TDescribeTableResult describeResult = session.DescribeTable(tableName)
                 .GetValueSync();
             UNIT_ASSERT_EQUAL(describeResult.GetStatus(), EStatus::SUCCESS);
-            const auto& partSettings = describeResult.GetTableDescription().GetPartitioningSettings();
+            const auto& desc = describeResult.GetTableDescription();
+            const auto& partSettings = desc.GetPartitioningSettings();
             UNIT_ASSERT(partSettings.GetPartitioningByLoad().has_value());
             UNIT_ASSERT_VALUES_EQUAL(partSettings.GetPartitioningByLoad().value(), true);
             UNIT_ASSERT(partSettings.GetPartitioningBySize().has_value());

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -4548,7 +4548,8 @@ Y_UNIT_TEST_SUITE(TTableProfileTests) {
                 ).GetValueSync();
 
             UNIT_ASSERT(descResult.IsSuccess());
-            auto ranges = descResult.GetTableDescription().GetKeyRanges();
+            const auto& desc = descResult.GetTableDescription();
+            const auto& ranges = desc.GetKeyRanges();
             UNIT_ASSERT_VALUES_EQUAL(ranges.size(), 10);
 
             auto extractValue = [](const TValue& val) {

--- a/ydb/tests/functional/kqp/kqp_query_svc/main.cpp
+++ b/ydb/tests/functional/kqp/kqp_query_svc/main.cpp
@@ -123,9 +123,10 @@ Y_UNIT_TEST_SUITE(NodeIdDescribe)
             auto res = session.DescribeTable("/local/UniformDist", describeTableSettings).ExtractValueSync();
             UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
             UNIT_ASSERT_EQUAL_C(res.GetStatus(), EStatus::SUCCESS, res.GetIssues().ToString());
-            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionsCount(), 4096);
-            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionStats().size(), 4096);
-            for (const auto& x : res.GetTableDescription().GetPartitionStats()) {
+            const auto& desc = res.GetTableDescription();
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetPartitionsCount(), 4096);
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetPartitionStats().size(), 4096);
+            for (const auto& x : desc.GetPartitionStats()) {
                 nodes.insert(x.LeaderNodeId);
             }
         }


### PR DESCRIPTION
GetTableDescription() return result by-value (a bit wasteful, but ok)
        Some of TTableDescription::Get*() return result by-value (again, wasteful, but good)
        Some return result by-reference
                If result is used inside one statement, still good (ttl of TTableDescription is extended until end of statement
                If result is copied, still good
                And if it is assigned to reference, hell breaks loose

Fortunately, broken pattern is mostly present inside of tests, and only twice in production code (cli and rare replication case)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
