### PR TITLE
Fix the C++ SDK tests for the table service

### DIFF
--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -1,7 +1,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
-#include <library/cpp/testing/unittest/tests_data.h>
+#include <library/cpp/testing/common/network.h>
 
 #include <util/string/builder.h>
 
@@ -129,8 +129,9 @@ namespace {
         std::unique_ptr<NTable::TSession>& tableSession
     ) {
         // Start the local GRPC service for the given table API service
-        TPortManager pm;
-        ui16 tablePort = pm.GetPort();
+        NTesting::InitPortManagerFromEnv();
+        const auto tablePortHolder = NTesting::GetFreePort();
+        const ui16 tablePort = static_cast<ui16>(tablePortHolder);
 
         grpcServer = StartGrpcServer(
             TStringBuilder() << "127.0.0.1:" << tablePort,

--- a/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/ya.make
@@ -10,7 +10,8 @@ ENDIF()
 FORK_SUBTESTS()
 
 PEERDIR(
-    library/cpp/testing/unittest
+    library/cpp/testing/common
+    library/cpp/testing/gtest
     ydb/public/api/grpc
     ydb/public/sdk/cpp/src/client/table
 )


### PR DESCRIPTION
### Changelog entry

Fix the C++ SDK build

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

* Remove the dependency on the library/cpp/testing/unittest library
* Use TPortManager from the library/cpp/testing/common library