### PR TITLE
Fix TLI VictimQuerySpanId linkage for deferred lock detection

### DIFF
--- a/ydb/core/kqp/common/kqp_tx_manager.cpp
+++ b/ydb/core/kqp/common/kqp_tx_manager.cpp
@@ -118,10 +118,18 @@ public:
             broken = lockPtr->Invalidated || lockPtr->LocksAcquireFailure;
 
             if (broken && isInvalidated) {
-                // For broken locks from shard: use effectiveVictimSpanId (from shard's determination).
-                // For comparison-based invalidation: use the original lock setter's SpanId.
-                ui64 victimSpanId = (isError && effectiveVictimSpanId != 0)
-                    ? effectiveVictimSpanId : lockPtr->VictimQuerySpanId;
+                // Prefer the lock's original VictimQuerySpanId (set when the lock was first created
+                // during the read that established it). This matches what the DataShard recorded.
+                // Only use effectiveVictimSpanId when the shard explicitly provided a deferred victim
+                // (deferredVictimQuerySpanId != 0), or as a fallback when the lock has no SpanId.
+                // Without this, commit-phase AddLock would use the write's querySpanId, breaking
+                // the linkage between SessionActor and DataShard TLI records.
+                ui64 victimSpanId = lockPtr->VictimQuerySpanId;
+                if (isError && deferredVictimQuerySpanId != 0) {
+                    victimSpanId = effectiveVictimSpanId;
+                } else if (victimSpanId == 0 && isError && effectiveVictimSpanId != 0) {
+                    victimSpanId = effectiveVictimSpanId;
+                }
                 SetVictimQuerySpanId(victimSpanId);
             }
         } else {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2308,20 +2308,6 @@ public:
             victimQueryText = QueryState->TxCtx->QueryTextCollector.GetQueryTextBySpanId(*brokenLockQuerySpanId);
         }
 
-        // In Snapshot Isolation the conflict is detected during the write, but the actual
-        // victim is the read that established the snapshot.  When the resolved VictimQueryText
-        // is the same as the current (commit) query, prefer the first collected query text
-        // which is the lock-establishing read.
-        if (!victimQueryText.empty() && QueryState->TxCtx) {
-            TString currentQueryText = QueryState->ExtractQueryText();
-            if (victimQueryText == currentQueryText) {
-                TString firstText = QueryState->TxCtx->QueryTextCollector.GetFirstQueryText();
-                if (!firstText.empty() && firstText != currentQueryText) {
-                    victimQueryText = firstText;
-                }
-            }
-        }
-
         // Fallback for query text: the lock-derived VictimQuerySpanId may differ from the
         // session-level QuerySpanId (e.g. with OLTP sink where the shard-side SpanId diverges
         // from the session's). Preserve the lock-derived SpanId for DataShard linkage but


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When a lock transitions to broken during commit-phase AddLock,
prefer the lock's original VictimQuerySpanId (set at read time)
over the write's querySpanId. Remove the Snapshot Isolation
VictimQueryText heuristic that is no longer needed.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
