### PR TITLE
Remove (step, txid) from handle TEvValidateRowConditionRequest

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1524,11 +1524,9 @@ message TEvValidateRowConditionRequest {
     optional uint64 TabletId = 2;
     optional uint64 OwnerId = 3;
     optional uint64 PathId = 4;
-    optional uint64 SnapshotTxId = 5;
-    optional uint64 SnapshotStep = 6;
-    optional uint64 SeqNoGeneration = 7;
-    optional uint64 SeqNoRound = 8;
-    repeated string NotNullColumns = 9;
+    optional uint64 SeqNoGeneration = 5;
+    optional uint64 SeqNoRound = 6;
+    repeated string NotNullColumns = 7;
 }
 
 message TEvValidateRowConditionResponse {

--- a/ydb/core/tx/datashard/ut_validate_row_condition/datashard_ut_validate_row_condition_scan.cpp
+++ b/ydb/core/tx/datashard/ut_validate_row_condition/datashard_ut_validate_row_condition_scan.cpp
@@ -30,7 +30,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
 
         ExecSQL(server, sender, "UPSERT INTO `/Root/test` (key, value) VALUES (1, 1), (2, 2);");
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/test" });
         auto tableId = ResolveTableId(server, sender, "/Root/test");
 
         auto request = MakeHolder<TEvDataShard::TEvValidateRowConditionRequest>();
@@ -39,8 +38,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
         request->Record.SetOwnerId(tableId.PathId.OwnerId);
         request->Record.SetPathId(tableId.PathId.LocalPathId);
         request->Record.AddNotNullColumns("value");
-        request->Record.SetSnapshotStep(snapshot.Step);
-        request->Record.SetSnapshotTxId(snapshot.TxId);
 
         runtime.SendToPipe(shards[0], sender, request.Release(), 0, GetPipeConfigWithRetries());
 
@@ -72,7 +69,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
 
         ExecSQL(server, sender, "UPSERT INTO `/Root/test_nulls` (key, value) VALUES (1, 1), (2, NULL);");
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/test_nulls" });
         auto tableId = ResolveTableId(server, sender, "/Root/test_nulls");
 
         auto request = MakeHolder<TEvDataShard::TEvValidateRowConditionRequest>();
@@ -81,8 +77,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
         request->Record.SetOwnerId(tableId.PathId.OwnerId);
         request->Record.SetPathId(tableId.PathId.LocalPathId);
         request->Record.AddNotNullColumns("value");
-        request->Record.SetSnapshotStep(snapshot.Step);
-        request->Record.SetSnapshotTxId(snapshot.TxId);
 
         runtime.SendToPipe(shards[0], sender, request.Release(), 0, GetPipeConfigWithRetries());
 
@@ -119,7 +113,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
 
         ExecSQL(server, sender, "UPSERT INTO `/Root/test_cols` (key, col2, col3) VALUES (1, NULL, 10);");
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/test_cols" });
         auto tableId = ResolveTableId(server, sender, "/Root/test_cols");
 
         auto request = MakeHolder<TEvDataShard::TEvValidateRowConditionRequest>();
@@ -128,8 +121,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
         request->Record.SetOwnerId(tableId.PathId.OwnerId);
         request->Record.SetPathId(tableId.PathId.LocalPathId);
         request->Record.AddNotNullColumns("col3");
-        request->Record.SetSnapshotStep(snapshot.Step);
-        request->Record.SetSnapshotTxId(snapshot.TxId);
 
         runtime.SendToPipe(shards[0], sender, request.Release(), 0, GetPipeConfigWithRetries());
 
@@ -166,7 +157,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
 
         ExecSQL(server, sender, "UPSERT INTO `/Root/test_cols_null` (key, col2, col3) VALUES (1, NULL, 10);");
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/test_cols_null" });
         auto tableId = ResolveTableId(server, sender, "/Root/test_cols_null");
 
         auto request = MakeHolder<TEvDataShard::TEvValidateRowConditionRequest>();
@@ -175,8 +165,6 @@ Y_UNIT_TEST_SUITE(DataShardCheckConstraintScan) {
         request->Record.SetOwnerId(tableId.PathId.OwnerId);
         request->Record.SetPathId(tableId.PathId.LocalPathId);
         request->Record.AddNotNullColumns("col2");
-        request->Record.SetSnapshotStep(snapshot.Step);
-        request->Record.SetSnapshotTxId(snapshot.TxId);
 
         runtime.SendToPipe(shards[0], sender, request.Release(), 0, GetPipeConfigWithRetries());
 

--- a/ydb/core/tx/datashard/validate_row_condition.cpp
+++ b/ydb/core/tx/datashard/validate_row_condition.cpp
@@ -137,7 +137,10 @@ void TDataShard::Handle(TEvDataShard::TEvValidateRowConditionRequest::TPtr& ev, 
 void TDataShard::HandleSafe(TEvDataShard::TEvValidateRowConditionRequest::TPtr& ev, const TActorContext& ctx) {
     const auto& record = ev->Get()->Record;
 
-    TRowVersion rowVersion(record.GetSnapshotStep(), record.GetSnapshotTxId());
+    const ui64 id = record.GetId();
+    auto rowVersion = GetMvccTxVersion(EMvccTxMode::ReadOnly);
+    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
+
     if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
         VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
         return;
@@ -145,7 +148,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateRowConditionRequest::TPtr& 
 
     auto sendResponse = [&](NKikimrIndexBuilder::EBuildStatus status, const TString& error = "") {
         auto response = MakeHolder<TEvDataShard::TEvValidateRowConditionResponse>();
-        response->Record.SetId(record.GetId());
+        response->Record.SetId(id);
         response->Record.SetTabletId(TabletID());
         response->Record.SetStatus(status);
         if (!error.empty()) {
@@ -167,32 +170,15 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateRowConditionRequest::TPtr& 
         return;
     }
 
-    if (!record.HasSnapshotStep() || !record.HasSnapshotTxId()) {
-        sendResponse(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST, "Request doesn't have Snapshot Step or TxId");
-        return;
-    }
-
-    const TSnapshotKey snapshotKey(tableId.PathId, rowVersion.Step, rowVersion.TxId);
-    const TSnapshot* snapshot = SnapshotManager.FindAvailable(snapshotKey);
-    if (!snapshot) {
-        sendResponse(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST, TStringBuilder()
-                   << "No snapshot has been found"
-                   << ", path id is " << tableId.PathId.OwnerId << ":" << tableId.PathId.LocalPathId
-                   << ", snapshot step is " << snapshotKey.Step
-                   << ", snapshot tx is " << snapshotKey.TxId);
-        return;
-    }
-
     if (!IsStateActive()) {
         sendResponse(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST, TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
         return;
     }
 
     const auto& userTable = *GetUserTables().at(tableId.PathId.LocalPathId);
-    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
 
     auto scan = new TValidateRowConditionScan(record, ev->Sender, TabletID(), userTable);
-    StartScan(this, scan, record.GetId(), seqNo, rowVersion, userTable.LocalTid);
+    StartScan(this, scan, id, seqNo, rowVersion, userTable.LocalTid);
 }
 
 } // namespace NKikimr::NDataShard


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```TEvValidateRowConditionRequest``` previously required the caller to supply an explicit snapshot (step, txId), which the datashard then looked up in SnapshotManager. This was unnecessary.

The purpose of a snapshot in distributed scans is to coordinate all shards to read the same version of the data. However, ValidateRowCondition is always executed after a NOT NULL write lock has been placed on the column — meaning no new NULL values can be written during the scan. Therefore, it does not matter which version each shard reads, as long as it is at least as recent as the moment the write lock was applied. Reading the current head version ```(GetMvccTxVersion(EMvccTxMode::ReadOnly))``` satisfies this requirement trivially.

This change removes ```SnapshotStep``` and ```SnapshotTxId``` from the proto message, updates the datashard handler to use ```GetMvccTxVersion(EMvccTxMode::ReadOnly)``` (following the same pattern as ```TEvValidateUniqueIndexRequest```), and updates the unit tests accordingly.
