### PR TITLE
Implemented users' password hashes migration on SchemeShard initialization

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -727,4 +727,6 @@ enum ETxTypes {
     TXTYPE_GET_FORCED_COMPACTION = 113      [(TxTypeOpts) = {Name: "TxGetForcedCompaction"}];
     TXTYPE_LIST_FORCED_COMPACTION = 114     [(TxTypeOpts) = {Name: "TxListForcedCompaction"}];
     TXTYPE_PROGRESS_FORCED_COMPACTION = 115 [(TxTypeOpts) = {Name: "TxProgressForcedCompaction"}];
+
+    TXTYPE_USER_HASHES_MIGRATION = 116 [(TxTypeOpts) = {Name: "TTxUserHashesMigration"}];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -830,7 +830,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         return true;
     }
-    
+
     bool LoadSharedShards(NIceDb::TNiceDb& db) const {
         auto rowSet = db.Table<Schema::SharedShards>().Range().Select();
         if (!rowSet.IsReady()) {
@@ -1393,6 +1393,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             ui64 secondsSinceEpoch = 0;
             RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_ServerlessStorageLastBillTime, secondsSinceEpoch));
             Self->ServerlessStorageLastBillTime = TInstant::Seconds(secondsSinceEpoch);
+        }
+
+        {
+            ui64 isOldArgonHashFormatMigrationCompletedVal = 0;
+            RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_IsOldArgonHashFormatMigrationCompleted,
+                isOldArgonHashFormatMigrationCompletedVal));
+            Self->IsOldArgonHashFormatMigrationCompleted = isOldArgonHashFormatMigrationCompletedVal;
         }
 
 #undef RETURN_IF_NO_PRECHARGED
@@ -2297,12 +2304,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             if (!LoadSharedShards(db)) {
                 return false;
             }
-            
+
             LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     "TTxInit for Shared Shards"
                         << ", read records: " << Self->SharedShards.size()
                         << ", at schemeshard: " << Self->TabletID());
-            
+
             for (const auto& [shardIdx, paths]: Self->SharedShards) {
                 Y_ABORT_UNLESS(Self->ShardInfos.contains(shardIdx));
                 for (const auto& path: paths) {
@@ -2310,7 +2317,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             "TTxInit for Shared Shards"
                             << ", read: " << shardIdx
                             << ", PathId: " << path
-                            << ", at schemeshard: " << Self->TabletID()); 
+                            << ", at schemeshard: " << Self->TabletID());
                 }
             }
         }

--- a/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
@@ -1,7 +1,12 @@
 #include "schemeshard_impl.h"
 
 #include <ydb/library/login/hashes_checker/hashes_checker.h>
+#include <ydb/library/login/password_checker/password_checker.h>
 #include <ydb/library/login/protos/login.pb.h>
+
+#include <util/generic/vector.h>
+#include <util/random/random.h>
+#include <algorithm>
 
 
 namespace NKikimr {
@@ -9,7 +14,63 @@ namespace NSchemeShard {
 
 using namespace NTabletFlatExecutor;
 
+namespace {
+
+TString GenerateRandomPassword(const NLogin::TPasswordComplexity& complexity) {
+    static constexpr char lowerLetters[] = "abcdefghijklmnopqrstuvwxyz";
+    static constexpr char upperLetters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    static constexpr char digits[] = "0123456789";
+    static constexpr size_t lowerCount = sizeof(lowerLetters) - 1;
+    static constexpr size_t upperCount = sizeof(upperLetters) - 1;
+    static constexpr size_t digitsCount = sizeof(digits) - 1;
+
+
+    TVector<char> specialChars(complexity.SpecialChars.begin(), complexity.SpecialChars.end());
+
+    TVector<char> password;
+
+    // Add required minimum counts for each character class
+    for (size_t i = 0; i < complexity.MinLowerCaseCount; ++i) {
+        password.push_back(lowerLetters[RandomNumber<size_t>(lowerCount)]);
+    }
+    for (size_t i = 0; i < complexity.MinUpperCaseCount; ++i) {
+        password.push_back(upperLetters[RandomNumber<size_t>(upperCount)]);
+    }
+    for (size_t i = 0; i < complexity.MinNumbersCount; ++i) {
+        password.push_back(digits[RandomNumber<size_t>(digitsCount)]);
+    }
+    for (size_t i = 0; i < complexity.MinSpecialCharsCount; ++i) {
+        password.push_back(specialChars[RandomNumber<size_t>(specialChars.size())]);
+    }
+
+    // Fill remaining positions with random chars from all allowed categories
+    if (password.size() < complexity.MinLength) {
+
+        TVector<char> pool;
+        pool.insert(pool.end(), lowerLetters, lowerLetters + lowerCount);
+        pool.insert(pool.end(), upperLetters, upperLetters + upperCount);
+        pool.insert(pool.end(), digits, digits + digitsCount);
+        pool.insert(pool.end(), specialChars.begin(), specialChars.end());
+
+        while (password.size() < complexity.MinLength) {
+            password.push_back(pool[RandomNumber<size_t>(pool.size())]);
+        }
+    }
+
+
+    // Shuffle to avoid predictable prefix pattern
+    for (size_t i = password.size() - 1; i > 0; --i) {
+        size_t j = RandomNumber<size_t>(i + 1);
+        std::swap(password[i], password[j]);
+    }
+
+    return TString(password.begin(), password.end());
+}
+
+} // anonymous namespace
+
 struct TSchemeShard::TTxUserHashesMigration : public TTransactionBase<TSchemeShard> {
+    bool IsLoginProviderModified = false;
 
     TTxUserHashesMigration(TSelf* self)
         : TTransactionBase<TSchemeShard>(self)
@@ -23,32 +84,41 @@ struct TSchemeShard::TTxUserHashesMigration : public TTransactionBase<TSchemeSha
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxUserHashesMigration Execute at schemeshard: " << Self->TabletID());
 
-        const auto& securityConfig = Self->GetDomainsConfig().GetSecurityConfig();
-        TString defaultPassword;
-        if (securityConfig.DefaultUsersSize()) {
-            defaultPassword = securityConfig.GetDefaultUsers(0).GetPassword();
-        }
-
         NIceDb::TNiceDb db(txc.DB);
         for (const auto& [sidName, sid] : Self->LoginProvider.Sids) {
             if (sid.Type == NLoginProto::ESidType::USER) {
-                if (!sid.PasswordHashes) {
+                if (!sid.PasswordHashes) { // change password for user with unsupported password hash format
                     auto response = Self->LoginProvider.ModifyUser({
                         .User = sid.Name,
-                        .Password = defaultPassword,
+                        .Password = GenerateRandomPassword(Self->LoginProvider.GetPasswordCheckParameters()),
                     });
 
                     if (response.Error) {
                         LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxUserHashesMigration Execute"
-                            << ", can't set default password in place inacceptable argon hash: "
+                            << ", can't set generated password in place unacceptable argon hash: "
                             << response.Error << ", at schemeshard: "<< Self->TabletID());
                         continue;
                     }
+
+                    IsLoginProviderModified = true;
                 }
 
+                // persist password hashes in the new column 'PasswordHashes' to get rid of old column 'SidHash' in the next release
                 db.Table<Schema::LoginSids>().Key(sidName).Update<Schema::LoginSids::SidHash, Schema::LoginSids::PasswordHashes>(
                                                                     sid.ArgonHash, sid.PasswordHashes);
             }
+        }
+
+        Self->IsOldArgonHashFormatMigrationCompleted = true;
+        db.Table<Schema::SysParams>().Key(Schema::SysParam_IsOldArgonHashFormatMigrationCompleted).Update(
+            NIceDb::TUpdate<Schema::SysParams::Value>("1"));
+
+        if (IsLoginProviderModified) {
+            TPathId subDomainPathId = Self->GetCurrentSubDomainPathId();
+            TSubDomainInfo::TPtr domainPtr = Self->ResolveDomainInfo(subDomainPathId);
+            domainPtr->UpdateSecurityState(Self->LoginProvider.GetSecurityState());
+            domainPtr->IncSecurityStateVersion();
+            Self->PersistSubDomainSecurityStateVersion(db, subDomainPathId, *domainPtr);
         }
 
         return true;
@@ -57,6 +127,10 @@ struct TSchemeShard::TTxUserHashesMigration : public TTransactionBase<TSchemeSha
     void Complete(const TActorContext &ctx) override {
         LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxUserHashesMigration Complete, at schemeshard: "<< Self->TabletID());
+
+        if (IsLoginProviderModified) {
+            Self->PublishToSchemeBoard(TTxId(), {Self->GetCurrentSubDomainPathId()}, ctx);
+        }
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
@@ -1,0 +1,68 @@
+#include "schemeshard_impl.h"
+
+#include <ydb/library/login/hashes_checker/hashes_checker.h>
+#include <ydb/library/login/protos/login.pb.h>
+
+
+namespace NKikimr {
+namespace NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+struct TSchemeShard::TTxUserHashesMigration : public TTransactionBase<TSchemeShard> {
+
+    TTxUserHashesMigration(TSelf* self)
+        : TTransactionBase<TSchemeShard>(self)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_USER_HASHES_MIGRATION;
+    }
+
+    bool Execute(TTransactionContext &txc, const TActorContext &ctx) override {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TTxUserHashesMigration Execute at schemeshard: " << Self->TabletID());
+
+        const auto& securityConfig = Self->GetDomainsConfig().GetSecurityConfig();
+        TString defaultPassword;
+        if (securityConfig.DefaultUsersSize()) {
+            defaultPassword = securityConfig.GetDefaultUsers(0).GetPassword();
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+        for (const auto& [sidName, sid] : Self->LoginProvider.Sids) {
+            if (sid.Type == NLoginProto::ESidType::USER) {
+                if (!sid.PasswordHashes) {
+                    auto response = Self->LoginProvider.ModifyUser({
+                        .User = sid.Name,
+                        .Password = defaultPassword,
+                    });
+
+                    if (response.Error) {
+                        LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxUserHashesMigration Execute"
+                            << ", can't set default password in place inacceptable argon hash: "
+                            << response.Error << ", at schemeshard: "<< Self->TabletID());
+                        continue;
+                    }
+                }
+
+                db.Table<Schema::LoginSids>().Key(sidName).Update<Schema::LoginSids::SidHash, Schema::LoginSids::PasswordHashes>(
+                                                                    sid.ArgonHash, sid.PasswordHashes);
+            }
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext &ctx) override {
+        LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TTxUserHashesMigration Complete, at schemeshard: "<< Self->TabletID());
+    }
+};
+
+ITransaction* TSchemeShard::CreateTxUserHashesMigration() {
+    return new TTxUserHashesMigration(this);
+}
+
+} // NSchemeShard
+} // NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -213,7 +213,9 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
         InitializeTabletMigrations();
     }
 
-    Execute(CreateTxUserHashesMigration(), ctx);
+    if (!IsOldArgonHashFormatMigrationCompleted) {
+        Execute(CreateTxUserHashesMigration(), ctx);
+    }
 
     ResumeExports(opts.ExportIds, ctx);
     ResumeImports(opts.ImportsIds, ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -213,6 +213,8 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
         InitializeTabletMigrations();
     }
 
+    Execute(CreateTxUserHashesMigration(), ctx);
+
     ResumeExports(opts.ExportIds, ctx);
     ResumeImports(opts.ImportsIds, ctx);
     ResumeCdcStreamScans(opts.CdcStreamScans, ctx);
@@ -8464,7 +8466,7 @@ void TSchemeShard::Handle(TEvSchemeShard::TEvWakeupToRunShred::TPtr &ev, const T
     if (!IsDomainSchemeShard) {
         LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Cannot handle EvWakeupToRunShred in tenant schemeshard: " << TabletID());
         return;
-    } 
+    }
     RootShredManager->WakeupToRunShred(ev, ctx);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1048,6 +1048,9 @@ public:
     struct TTxCleanDroppedPaths;
     NTabletFlatExecutor::ITransaction* CreateTxCleanDroppedPaths();
 
+    struct TTxUserHashesMigration;
+    NTabletFlatExecutor::ITransaction* CreateTxUserHashesMigration();
+
     void ScheduleCleanDroppedPaths();
     void Handle(TEvPrivate::TEvCleanDroppedPaths::TPtr& ev, const TActorContext& ctx);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -417,6 +417,8 @@ public:
     bool EnableExternalSourceSchemaInference = false;
     bool EnableMoveColumnTable = false;
 
+    bool IsOldArgonHashFormatMigrationCompleted = false;
+
     TShardDeleter ShardDeleter;
 
     // Counter-strike stuff

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2475,6 +2475,7 @@ struct Schema : NIceDb::Schema {
     static constexpr ui64 SysParam_TenantInitState = 9;
     static constexpr ui64 SysParam_ServerlessStorageLastBillTime = 10;
     static constexpr ui64 SysParam_MaxIncompatibleChange = 11;
+    static constexpr ui64 SysParam_IsOldArgonHashFormatMigrationCompleted = 12;
 
     // List of incompatible changes:
     // * Change 1: store migrated shards of local tables (e.g. after a rename) as a migrated record

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -238,6 +238,7 @@ SRCS(
     schemeshard__unmark_restore_tables.cpp
     schemeshard__upgrade_access_database.cpp
     schemeshard__upgrade_schema.cpp
+    schemeshard__user_hashes_migration.cpp
     schemeshard_audit_log.cpp
     schemeshard_audit_log_fragment.cpp
     schemeshard_backup.cpp

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -1149,6 +1149,7 @@ void TLoginProvider::UpdateSecurityState(const NLoginProto::TSecurityState& stat
             if (pbSid.GetPasswordHashes()) {
                 sid.PasswordHashes = pbSid.GetPasswordHashes();
             } else if (pbSid.GetArgonHash()) {
+                // ignore old hash format because we can't parse it
                 if (const auto argonHashInNewFormat = ArgonHashToNewFormat(pbSid.GetArgonHash())) {
                     sid.PasswordHashes = HashedPasswordFromNewArgonHashFormat(*argonHashInNewFormat);
                 }
@@ -1178,6 +1179,10 @@ TString TLoginProvider::SanitizeJwtToken(const TString& token) {
 
 void TLoginProvider::UpdatePasswordCheckParameters(const TPasswordComplexity& passwordComplexity) {
     PasswordChecker.Update(passwordComplexity);
+}
+
+const TPasswordComplexity& TLoginProvider::GetPasswordCheckParameters() const {
+    return PasswordChecker.GetPasswordComplexity();
 }
 
 void TLoginProvider::UpdateAccountLockout(const TAccountLockout::TInitializer& accountLockoutInitializer) {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -273,6 +273,7 @@ public:
     bool CheckGroupExists(const TString& group);
 
     void UpdatePasswordCheckParameters(const TPasswordComplexity& passwordComplexity);
+    const TPasswordComplexity& GetPasswordCheckParameters() const;
     void UpdateAccountLockout(const TAccountLockout::TInitializer& accountLockoutInitializer);
     void UpdateCacheSettings(const TCacheSettings& settings);
 

--- a/ydb/library/login/password_checker/password_checker.cpp
+++ b/ydb/library/login/password_checker/password_checker.cpp
@@ -140,4 +140,8 @@ void TPasswordChecker::Update(const TPasswordComplexity& passwordComplexity) {
     PasswordComplexity = passwordComplexity;
 }
 
+const TPasswordComplexity& TPasswordChecker::GetPasswordComplexity() const {
+    return PasswordComplexity;
+}
+
 } // NLogin

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -72,6 +72,7 @@ public:
     TPasswordChecker(const TPasswordComplexity& passwordComplexity);
     TResult Check(const std::string& username, const std::string& password) const;
     void Update(const TPasswordComplexity& passwordComplexity);
+    const TPasswordComplexity& GetPasswordComplexity() const;
 };
 
 } // NLogin


### PR DESCRIPTION
Implemented automatic migration of user password hashes during SchemeShard activation.
The migration:

- sets generated password for users with unsupported password hash format;
- updates `PasswordHashes` field in `LoginSids` local base table for all users.

The first allows those users to login again, and the second is needed to stop using old column `SidHash` in next release.

