### PR TITLE
"Skip conflict check" mode into KQP topic transactions

### DIFF
--- a/ydb/core/kqp/common/kqp_tx_manager.cpp
+++ b/ydb/core/kqp/common/kqp_tx_manager.cpp
@@ -214,7 +214,7 @@ public:
     void SetTopicOperations(NTopic::TTopicOperations&& topicOperations) override {
         AFL_ENSURE(TopicOperations.GetSize() == 0);
         TopicOperations = std::move(topicOperations);
-        TopicOperations.SetSkipConflictCheck(SkipConflictCheck);
+        TopicOperations.SetSkipConflictCheck(SkipTopicsConflictCheck);
     }
 
     const NTopic::TTopicOperations& GetTopicOperations() const override {
@@ -233,9 +233,9 @@ public:
         return GetTopicOperations().GetSize() != 0;
     }
 
-    void SetSkipConflictCheckForTopicsInTransaction(bool skipConflictCheck) override {
-        SkipConflictCheck = skipConflictCheck;
-        TopicOperations.SetSkipConflictCheck(SkipConflictCheck);
+    void SetSkipTopicsConflictCheck(bool skipConflictCheck) override {
+        SkipTopicsConflictCheck = skipConflictCheck;
+        TopicOperations.SetSkipConflictCheck(SkipTopicsConflictCheck);
     }
 
     TVector<NKikimrDataEvents::TLock> GetLocks() const override {
@@ -696,7 +696,7 @@ private:
     THashSet<ui64> ShardsToWait;
 
     NTopic::TTopicOperations TopicOperations;
-    bool SkipConflictCheck = false;
+    bool SkipTopicsConflictCheck = false;
 
     ui64 MinStep = 0;
     ui64 MaxStep = 0;

--- a/ydb/core/kqp/common/kqp_tx_manager.cpp
+++ b/ydb/core/kqp/common/kqp_tx_manager.cpp
@@ -214,6 +214,7 @@ public:
     void SetTopicOperations(NTopic::TTopicOperations&& topicOperations) override {
         AFL_ENSURE(TopicOperations.GetSize() == 0);
         TopicOperations = std::move(topicOperations);
+        TopicOperations.SetSkipConflictCheck(SkipConflictCheck);
     }
 
     const NTopic::TTopicOperations& GetTopicOperations() const override {
@@ -230,6 +231,10 @@ public:
 
     bool HasTopics() const override {
         return GetTopicOperations().GetSize() != 0;
+    }
+
+    void SetSkipConflictCheckForTopicsInTransaction(bool skipConflictCheck) override {
+        SkipConflictCheck = skipConflictCheck;
     }
 
     TVector<NKikimrDataEvents::TLock> GetLocks() const override {
@@ -690,6 +695,7 @@ private:
     THashSet<ui64> ShardsToWait;
 
     NTopic::TTopicOperations TopicOperations;
+    bool SkipConflictCheck = false;
 
     ui64 MinStep = 0;
     ui64 MaxStep = 0;

--- a/ydb/core/kqp/common/kqp_tx_manager.cpp
+++ b/ydb/core/kqp/common/kqp_tx_manager.cpp
@@ -235,6 +235,7 @@ public:
 
     void SetSkipConflictCheckForTopicsInTransaction(bool skipConflictCheck) override {
         SkipConflictCheck = skipConflictCheck;
+        TopicOperations.SetSkipConflictCheck(SkipConflictCheck);
     }
 
     TVector<NKikimrDataEvents::TLock> GetLocks() const override {

--- a/ydb/core/kqp/common/kqp_tx_manager.h
+++ b/ydb/core/kqp/common/kqp_tx_manager.h
@@ -72,6 +72,7 @@ public:
     virtual const NTopic::TTopicOperations& GetTopicOperations() const = 0;
     virtual void BuildTopicTxs(NTopic::TTopicOperationTransactions& txs) = 0;
     virtual bool HasTopics() const = 0;
+    virtual void SetSkipConflictCheckForTopicsInTransaction(bool skipConflictCheck) = 0;
 
     virtual void AddParticipantNode(const ui32 nodeId) = 0;
     virtual const THashSet<ui32>& GetParticipantNodes() const = 0;

--- a/ydb/core/kqp/common/kqp_tx_manager.h
+++ b/ydb/core/kqp/common/kqp_tx_manager.h
@@ -72,7 +72,7 @@ public:
     virtual const NTopic::TTopicOperations& GetTopicOperations() const = 0;
     virtual void BuildTopicTxs(NTopic::TTopicOperationTransactions& txs) = 0;
     virtual bool HasTopics() const = 0;
-    virtual void SetSkipConflictCheckForTopicsInTransaction(bool skipConflictCheck) = 0;
+    virtual void SetSkipTopicsConflictCheck(bool skipConflictCheck) = 0;
 
     virtual void AddParticipantNode(const ui32 nodeId) = 0;
     virtual const THashSet<ui32>& GetParticipantNodes() const = 0;

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -155,7 +155,7 @@ namespace {
                 transaction.AddReceivingShards(receivingShardId);
             }
 
-            AFL_ENSURE(transaction.GetSendingShards().size() == 1);
+            AFL_ENSURE(transaction.GetSendingShards().size() <= 1);
             AFL_ENSURE(transaction.GetReceivingShards().size() == 1);
         }
     }

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -472,6 +472,10 @@ void TKqpQueryState::FillTopicOperations() {
     }
 
     TopicOperations = NTopic::TTopicOperations();
+
+    bool trackProducerId = !operations.HasTrackProducerId() || operations.GetTrackProducerId();
+    TopicOperations.SetTrackProducerId(trackProducerId);
+
     for (auto& topic : operations.GetTopics()) {
         auto path = CanonizePath(NPersQueue::GetFullTopicPath(GetDatabase(), topic.path()));
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -625,9 +625,6 @@ public:
         if (QueryState->HasTopicOperations()) {
             const NKikimrKqp::TTopicOperationsRequest& operations = QueryState->GetTopicOperationsFromRequest();
 
-            bool trackProducerId = !operations.HasTrackProducerId() || operations.GetTrackProducerId();
-            QueryState->TxCtx->TopicOperations.SetTrackProducerId(trackProducerId);
-
             if (operations.HasTabletId()) {
                 for (const auto& topic : operations.GetTopics()) {
                     auto path = CanonizePath(NPersQueue::GetFullTopicPath(QueryState->GetDatabase(), topic.path()));

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1939,6 +1939,8 @@ public:
             (span_id_size, request.TraceId.GetSpanIdSize()),
             (trace_id, TraceId()));
 
+        txCtx->TxManager->SetSkipConflictCheckForTopicsInTransaction(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
+
         if (!txCtx->BufferActorId
             && (txCtx->HasTableWrite || request.TopicOperations.GetSize() != 0)) {
             txCtx->TxManager->SetTopicOperations(std::move(request.TopicOperations));

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -625,6 +625,9 @@ public:
         if (QueryState->HasTopicOperations()) {
             const NKikimrKqp::TTopicOperationsRequest& operations = QueryState->GetTopicOperationsFromRequest();
 
+            bool trackProducerId = !operations.HasTrackProducerId() || operations.GetTrackProducerId();
+            QueryState->TxCtx->TopicOperations.SetTrackProducerId(trackProducerId);
+
             if (operations.HasTabletId()) {
                 for (const auto& topic : operations.GetTopics()) {
                     auto path = CanonizePath(NPersQueue::GetFullTopicPath(QueryState->GetDatabase(), topic.path()));

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1939,7 +1939,7 @@ public:
             (span_id_size, request.TraceId.GetSpanIdSize()),
             (trace_id, TraceId()));
 
-        txCtx->TxManager->SetSkipConflictCheckForTopicsInTransaction(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
+        txCtx->TxManager->SetSkipTopicsConflictCheck(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
 
         if (!txCtx->BufferActorId
             && (txCtx->HasTableWrite || request.TopicOperations.GetSize() != 0)) {

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -615,7 +615,7 @@ void TTopicOperations::CacheSchemeCacheNavigate(const NSchemeCache::TSchemeCache
 void TTopicOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
 {
     for (auto& [_, operations] : Operations_) {
-        operations.BuildTopicTxs(txs, SkipConflictCheck);
+        operations.BuildTopicTxs(txs, SkipConflictCheck_);
     }
 }
 
@@ -645,7 +645,7 @@ TSet<ui64> TTopicOperations::GetSendingTabletIds() const
     TSet<ui64> ids;
     for (auto& [_, operations] : Operations_) {
         if (!operations.HasReadOperations() &&
-            operations.HasWriteOperations() && SkipConflictCheck) {
+            operations.HasWriteOperations() && SkipConflictCheck_) {
             continue;
         }
 
@@ -672,7 +672,7 @@ size_t TTopicOperations::GetSize() const
 
 void TTopicOperations::SetSkipConflictCheck(bool skipConflictCheck)
 {
-    SkipConflictCheck = skipConflictCheck;
+    SkipConflictCheck_ = skipConflictCheck;
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -223,7 +223,7 @@ void TTopicPartitionOperations::AddKafkaApiReadOperation(const TString& topic, u
     Operations_[consumerName].AddKafkaApiOffsetCommit(consumerName, offset);
 }
 
-void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
+void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, bool skipConflictCheck)
 {
     Y_ENSURE(TabletId_.Defined());
     Y_ENSURE(Partition_.Defined());
@@ -261,6 +261,7 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
         } else if (SupportivePartition_.Defined()) {
             o->SetSupportivePartition(*SupportivePartition_);
         }
+        o->SetSkipConflictCheck(skipConflictCheck);
         t.hasWrite = true;
     }
 }
@@ -614,7 +615,7 @@ void TTopicOperations::CacheSchemeCacheNavigate(const NSchemeCache::TSchemeCache
 void TTopicOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
 {
     for (auto& [_, operations] : Operations_) {
-        operations.BuildTopicTxs(txs);
+        operations.BuildTopicTxs(txs, SkipConflictCheck);
     }
 }
 
@@ -643,6 +644,11 @@ TSet<ui64> TTopicOperations::GetSendingTabletIds() const
 {
     TSet<ui64> ids;
     for (auto& [_, operations] : Operations_) {
+        if (!operations.HasReadOperations() &&
+            operations.HasWriteOperations() && SkipConflictCheck) {
+            continue;
+        }
+
         ids.insert(operations.GetTabletId());
     }
     return ids;
@@ -662,6 +668,11 @@ TMaybe<TString> TTopicOperations::GetTabletName(ui64 tabletId) const {
 size_t TTopicOperations::GetSize() const
 {
     return Operations_.size();
+}
+
+void TTopicOperations::SetSkipConflictCheck(bool skipConflictCheck)
+{
+    SkipConflictCheck = skipConflictCheck;
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -683,41 +683,19 @@ void TTopicOperations::SetTrackProducerId(bool trackProducerId)
     TrackProducerId_ = trackProducerId;
 }
 
-void TTopicOperations::MergeSkipConflictCheck(const TMaybe<bool>& rhs)
+void TTopicOperations::MergeSkipConflictCheck(bool rhs)
 {
-    if (!SkipConflictCheck_.Defined()) {
-        SkipConflictCheck_ = rhs;
-        return;
-    }
-
-    if (!rhs.Defined()) {
-        return;
-    }
-
-    SkipConflictCheck_ = *SkipConflictCheck_ && *rhs;
+    SkipConflictCheck_ = SkipConflictCheck_ && rhs;
 }
 
-void TTopicOperations::MergeTrackProducerId(const TMaybe<bool>& rhs)
+void TTopicOperations::MergeTrackProducerId(bool rhs)
 {
-    if (!TrackProducerId_.Defined()) {
-        TrackProducerId_ = rhs;
-        return;
-    }
-
-    if (!rhs.Defined()) {
-        return;
-    }
-
-    TrackProducerId_ = *TrackProducerId_ || *rhs;
+    TrackProducerId_ = TrackProducerId_ || rhs;
 }
 
 bool TTopicOperations::CalcSkipConflictCheck() const
 {
-    if (!TrackProducerId_.Defined() || !SkipConflictCheck_.Defined()) {
-        return false;
-    }
-
-    return !*TrackProducerId_ && *SkipConflictCheck_;
+    return !TrackProducerId_ && SkipConflictCheck_;
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -615,7 +615,7 @@ void TTopicOperations::CacheSchemeCacheNavigate(const NSchemeCache::TSchemeCache
 void TTopicOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
 {
     for (auto& [_, operations] : Operations_) {
-        operations.BuildTopicTxs(txs, SkipConflictCheck_);
+        operations.BuildTopicTxs(txs, CalcSkipConflictCheck());
     }
 }
 
@@ -629,6 +629,9 @@ void TTopicOperations::Merge(const TTopicOperations& rhs)
     HasReadOperations_ |= rhs.HasReadOperations_;
     HasWriteOperations_ |= rhs.HasWriteOperations_;
     HasKafkaOperations_ |= rhs.HasKafkaOperations_;
+
+    MergeSkipConflictCheck(rhs.SkipConflictCheck_);
+    MergeTrackProducerId(rhs.TrackProducerId_);
 }
 
 TSet<ui64> TTopicOperations::GetReceivingTabletIds() const
@@ -645,7 +648,7 @@ TSet<ui64> TTopicOperations::GetSendingTabletIds() const
     TSet<ui64> ids;
     for (auto& [_, operations] : Operations_) {
         if (!operations.HasReadOperations() &&
-            operations.HasWriteOperations() && SkipConflictCheck_) {
+            operations.HasWriteOperations() && CalcSkipConflictCheck()) {
             continue;
         }
 
@@ -673,6 +676,48 @@ size_t TTopicOperations::GetSize() const
 void TTopicOperations::SetSkipConflictCheck(bool skipConflictCheck)
 {
     SkipConflictCheck_ = skipConflictCheck;
+}
+
+void TTopicOperations::SetTrackProducerId(bool trackProducerId)
+{
+    TrackProducerId_ = trackProducerId;
+}
+
+void TTopicOperations::MergeSkipConflictCheck(const TMaybe<bool>& rhs)
+{
+    if (!SkipConflictCheck_.Defined()) {
+        SkipConflictCheck_ = rhs;
+        return;
+    }
+
+    if (!rhs.Defined()) {
+        return;
+    }
+
+    SkipConflictCheck_ = *SkipConflictCheck_ && *rhs;
+}
+
+void TTopicOperations::MergeTrackProducerId(const TMaybe<bool>& rhs)
+{
+    if (!TrackProducerId_.Defined()) {
+        TrackProducerId_ = rhs;
+        return;
+    }
+
+    if (!rhs.Defined()) {
+        return;
+    }
+
+    TrackProducerId_ = *TrackProducerId_ || *rhs;
+}
+
+bool TTopicOperations::CalcSkipConflictCheck() const
+{
+    if (!TrackProducerId_.Defined() || !SkipConflictCheck_.Defined()) {
+        return false;
+    }
+
+    return !*TrackProducerId_ && *SkipConflictCheck_;
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -185,8 +185,14 @@ public:
                      ui64 tabletId);
 
     void SetSkipConflictCheck(bool skipConflictCheck);
+    void SetTrackProducerId(bool trackProducerId);
 
 private:
+    void MergeSkipConflictCheck(const TMaybe<bool>& rhs);
+    void MergeTrackProducerId(const TMaybe<bool>& rhs);
+
+    bool CalcSkipConflictCheck() const;
+
     THashMap<TTopicPartition, TTopicPartitionOperations, TTopicPartition::THash> Operations_;
     bool HasReadOperations_ = false;
     bool HasWriteOperations_ = false;
@@ -197,7 +203,8 @@ private:
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
-    bool SkipConflictCheck_ = false;
+    TMaybe<bool> SkipConflictCheck_;
+    TMaybe<bool> TrackProducerId_;
 };
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -197,7 +197,7 @@ private:
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
-    bool SkipConflictCheck = false;
+    bool SkipConflictCheck_ = false;
 };
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -188,8 +188,8 @@ public:
     void SetTrackProducerId(bool trackProducerId);
 
 private:
-    void MergeSkipConflictCheck(const TMaybe<bool>& rhs);
-    void MergeTrackProducerId(const TMaybe<bool>& rhs);
+    void MergeSkipConflictCheck(bool rhs);
+    void MergeTrackProducerId(bool rhs);
 
     bool CalcSkipConflictCheck() const;
 
@@ -203,8 +203,8 @@ private:
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
-    TMaybe<bool> SkipConflictCheck_;
-    TMaybe<bool> TrackProducerId_;
+    bool SkipConflictCheck_ = true;
+    bool TrackProducerId_ = false;
 };
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -96,7 +96,7 @@ public:
 
     void AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset);
 
-    void BuildTopicTxs(TTopicOperationTransactions &txs);
+    void BuildTopicTxs(TTopicOperationTransactions &txs, bool skipConflictCheck);
 
     void Merge(const TTopicPartitionOperations& rhs);
 
@@ -184,6 +184,8 @@ public:
     void SetTabletId(const TString& topic, ui32 partition,
                      ui64 tabletId);
 
+    void SetSkipConflictCheck(bool skipConflictCheck);
+
 private:
     THashMap<TTopicPartition, TTopicPartitionOperations, TTopicPartition::THash> Operations_;
     bool HasReadOperations_ = false;
@@ -195,6 +197,7 @@ private:
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
+    bool SkipConflictCheck = false;
 };
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -142,6 +142,10 @@ Y_UNIT_TEST(ReadWriteOperations) {
     TestReadWriteOperations(false, false);
 }
 
+Y_UNIT_TEST(ReadWriteOperations_TrackProducerId) {
+    TestReadWriteOperations(false, true);
+}
+
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
     TestReadWriteOperations(true, false);
 }
@@ -189,6 +193,10 @@ Y_UNIT_TEST(OnlyWriteOperations) {
     TestOnlyWriteOperations(false, false);
 }
 
+Y_UNIT_TEST(OnlyWriteOperations_TrackProducerId) {
+    TestOnlyWriteOperations(false, true);
+}
+
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
     TestOnlyWriteOperations(true, false);
 }
@@ -233,6 +241,10 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProdu
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
     TestReadWriteOperationsOnePartition(false, false);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_TrackProducerId) {
+    TestReadWriteOperationsOnePartition(false, true);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -6,6 +6,11 @@ namespace NKikimr::NKqp {
 Y_UNIT_TEST_SUITE(KqpTopics) {
 
 static
+bool ShouldSkipConflictCheck(bool skipConflictCheck, bool trackProducerId) {
+    return skipConflictCheck && !trackProducerId;
+}
+
+static
 void AddReadOperation(NTopic::TTopicOperations& ops,
                       const TString& topic, ui32 partition,
                       const ui64 begin, const ui64 end,
@@ -91,16 +96,20 @@ Y_UNIT_TEST(OnlyReadOperations) {
     AssertReadOperation(txs, TABLETID, 1, 0);
 }
 
-Y_UNIT_TEST(ReadWriteOperations) {
+static
+void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     const TString TOPIC_A = "topic_A";
     const TString TOPIC_B = "topic_B";
     const ui32 PARTITION = 0;
     const ui64 TABLETID_A = 1'000'000;
     const ui64 TABLETID_B = 2'000'000;
 
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
+
     NTopic::TTopicOperations topicOps;
 
-    topicOps.SetSkipConflictCheck(false);
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
 
     AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
@@ -114,155 +123,94 @@ Y_UNIT_TEST(ReadWriteOperations) {
     UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
 
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
+    size_t expectedSendCount = shouldSkip ? 1 : 2;
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), expectedSendCount);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+    if (!shouldSkip) {
+        UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+    }
 
     NTopic::TTopicOperationTransactions txs;
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 2);
 
     AssertReadOperation(txs, TABLETID_A, 1, 0);
-    AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, shouldSkip);
+}
+
+Y_UNIT_TEST(ReadWriteOperations) {
+    TestReadWriteOperations(false, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
-    const TString TOPIC_A = "topic_A";
-    const TString TOPIC_B = "topic_B";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID_A = 1'000'000;
-    const ui64 TABLETID_B = 2'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(false);
-
-    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
-    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
-    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 2);
-
-    AssertReadOperation(txs, TABLETID_A, 1, 0);
-    AssertWriteOperation(txs, TABLETID_B, 1, 0, true);
+    TestReadWriteOperations(true, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
-    const TString TOPIC_A = "topic_A";
-    const TString TOPIC_B = "topic_B";
+    TestReadWriteOperations(true, true);
+}
+
+static
+void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
+    const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
-    const ui64 TABLETID_A = 1'000'000;
-    const ui64 TABLETID_B = 2'000'000;
+    const ui64 TABLETID = 1'000'000;
+
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
 
     NTopic::TTopicOperations topicOps;
 
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(true);
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
 
-    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
-    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
 
-    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
-    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
 
     const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
 
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+    size_t expectedSendCount = shouldSkip ? 0 : 1;
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), expectedSendCount);
+    if (!shouldSkip) {
+        UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+    }
 
     NTopic::TTopicOperationTransactions txs;
     topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 2);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
 
-    AssertReadOperation(txs, TABLETID_A, 1, 0);
-    AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
+    AssertWriteOperation(txs, TABLETID, 1, 0, shouldSkip);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(false);
-
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertWriteOperation(txs, TABLETID, 1, 0, false);
+    TestOnlyWriteOperations(false, false);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(false);
-
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT(sendTabletIds.empty());
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertWriteOperation(txs, TABLETID, 1, 0, true);
+    TestOnlyWriteOperations(true, false);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
+    TestOnlyWriteOperations(true, true);
+}
+
+static
+void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProducerId) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
 
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
+
     NTopic::TTopicOperations topicOps;
 
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(true);
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
 
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
 
     topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
@@ -279,99 +227,20 @@ Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 1);
 
-    AssertWriteOperation(txs, TABLETID, 1, 0, false);
+    AssertReadOperation(txs, TABLETID, 2, 0);
+    AssertWriteOperation(txs, TABLETID, 2, 1, shouldSkip);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(false);
-
-    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertReadOperation(txs, TABLETID, 2, 0);
-    AssertWriteOperation(txs, TABLETID, 2, 1, false);
+    TestReadWriteOperationsOnePartition(false, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(false);
-
-    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertReadOperation(txs, TABLETID, 2, 0);
-    AssertWriteOperation(txs, TABLETID, 2, 1, true);
+    TestReadWriteOperationsOnePartition(true, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(true);
-
-    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertReadOperation(txs, TABLETID, 2, 0);
-    AssertWriteOperation(txs, TABLETID, 2, 1, false);
+    TestReadWriteOperationsOnePartition(true, true);
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -70,6 +70,7 @@ Y_UNIT_TEST(OnlyReadOperations) {
     const ui64 TABLETID = 1'000'000;
 
     NTopic::TTopicOperations topicOps;
+
     topicOps.SetSkipConflictCheck(false);
 
     AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
@@ -163,6 +164,7 @@ Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
 
     AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
@@ -187,6 +189,42 @@ Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
     AssertWriteOperation(txs, TABLETID_B, 1, 0, true);
 }
 
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
+    const TString TOPIC_A = "topic_A";
+    const TString TOPIC_B = "topic_B";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID_A = 1'000'000;
+    const ui64 TABLETID_B = 2'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(true);
+
+    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
+    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 2);
+
+    AssertReadOperation(txs, TABLETID_A, 1, 0);
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
+}
+
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
@@ -195,6 +233,7 @@ Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
 
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
 
@@ -212,6 +251,35 @@ Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
     UNIT_ASSERT_EQUAL(txs.size(), 1);
 
     AssertWriteOperation(txs, TABLETID, 1, 0, true);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(true);
+
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertWriteOperation(txs, TABLETID, 1, 0, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
@@ -252,6 +320,7 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
 
     AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
@@ -272,6 +341,37 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
 
     AssertReadOperation(txs, TABLETID, 2, 0);
     AssertWriteOperation(txs, TABLETID, 2, 1, true);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(true);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 2, 0);
+    AssertWriteOperation(txs, TABLETID, 2, 1, false);
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -5,6 +5,7 @@ namespace NKikimr::NKqp {
 
 Y_UNIT_TEST_SUITE(KqpTopics) {
 
+static
 void AddReadOperation(NTopic::TTopicOperations& ops,
                       const TString& topic, ui32 partition,
                       const ui64 begin, const ui64 end,
@@ -23,6 +24,7 @@ void AddReadOperation(NTopic::TTopicOperations& ops,
                      "read-session");
 }
 
+static
 void AddWriteOperation(NTopic::TTopicOperations& ops,
                        const TString& topic, ui32 partition,
                        const ui32 supportivePartition)

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -33,13 +33,43 @@ void AddWriteOperation(NTopic::TTopicOperations& ops,
                      supportivePartition);
 }
 
+static
+void AssertReadOperation(const NTopic::TTopicOperationTransactions& txs,
+                         const ui64 tabletId,
+                         const size_t opsCount,
+                         const size_t opIndex)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& readOp = t.tx.GetOperations(opIndex);
+    UNIT_ASSERT(not readOp.HasSkipConflictCheck());
+}
+
+static
+void AssertWriteOperation(const NTopic::TTopicOperationTransactions& txs,
+                          const ui64 tabletId,
+                          const size_t opsCount,
+                          const size_t opIndex,
+                          const bool skipConflictCheck)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT(t.hasWrite);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& writeOp = t.tx.GetOperations(opIndex);
+    UNIT_ASSERT(writeOp.HasSkipConflictCheck());
+    UNIT_ASSERT_EQUAL(writeOp.GetSkipConflictCheck(), skipConflictCheck);
+}
+
 Y_UNIT_TEST(OnlyReadOperations) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
 
     NTopic::TTopicOperations topicOps;
-
     topicOps.SetSkipConflictCheck(false);
 
     AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
@@ -52,6 +82,12 @@ Y_UNIT_TEST(OnlyReadOperations) {
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 1, 0);
 }
 
 Y_UNIT_TEST(ReadWriteOperations) {
@@ -80,6 +116,13 @@ Y_UNIT_TEST(ReadWriteOperations) {
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
     UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 2);
+
+    AssertReadOperation(txs, TABLETID_A, 1, 0);
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations) {
@@ -102,6 +145,12 @@ Y_UNIT_TEST(OnlyWriteOperations) {
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertWriteOperation(txs, TABLETID, 1, 0, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
@@ -129,6 +178,13 @@ Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 2);
+
+    AssertReadOperation(txs, TABLETID_A, 1, 0);
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, true);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
@@ -150,6 +206,12 @@ Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
 
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT(sendTabletIds.empty());
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertWriteOperation(txs, TABLETID, 1, 0, true);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
@@ -173,6 +235,13 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 2, 0);
+    AssertWriteOperation(txs, TABLETID, 2, 1, false);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
@@ -196,6 +265,13 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
     UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 2, 0);
+    AssertWriteOperation(txs, TABLETID, 2, 1, true);
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -126,34 +126,6 @@ Y_UNIT_TEST(ReadWriteOperations) {
     AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations) {
-    const TString TOPIC = "topic";
-    const ui32 PARTITION = 0;
-    const ui64 TABLETID = 1'000'000;
-
-    NTopic::TTopicOperations topicOps;
-
-    topicOps.SetSkipConflictCheck(false);
-
-    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
-
-    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
-
-    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
-    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
-    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
-
-    const auto sendTabletIds = topicOps.GetSendingTabletIds();
-    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
-    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
-
-    NTopic::TTopicOperationTransactions txs;
-    topicOps.BuildTopicTxs(txs);
-    UNIT_ASSERT_EQUAL(txs.size(), 1);
-
-    AssertWriteOperation(txs, TABLETID, 1, 0, false);
-}
-
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
     const TString TOPIC_A = "topic_A";
     const TString TOPIC_B = "topic_B";
@@ -223,6 +195,34 @@ Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
 
     AssertReadOperation(txs, TABLETID_A, 1, 0);
     AssertWriteOperation(txs, TABLETID_B, 1, 0, false);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertWriteOperation(txs, TABLETID, 1, 0, false);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -1,13 +1,15 @@
 #include <ydb/core/kqp/topics/kqp_topics.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/maybe.h>
 
 namespace NKikimr::NKqp {
 
 Y_UNIT_TEST_SUITE(KqpTopics) {
 
 static
-bool ShouldSkipConflictCheck(bool skipConflictCheck, bool trackProducerId) {
-    return skipConflictCheck && !trackProducerId;
+bool ShouldSkipConflictCheck(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
+    bool effectiveTrackProducerId = trackProducerId.GetOrElse(true);
+    return skipConflictCheck && !effectiveTrackProducerId;
 }
 
 static
@@ -97,7 +99,7 @@ Y_UNIT_TEST(OnlyReadOperations) {
 }
 
 static
-void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
+void TestReadWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
     const TString TOPIC_A = "topic_A";
     const TString TOPIC_B = "topic_B";
     const ui32 PARTITION = 0;
@@ -109,7 +111,9 @@ void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    topicOps.SetTrackProducerId(trackProducerId);
+    if (trackProducerId) {
+        topicOps.SetTrackProducerId(*trackProducerId);
+    }
 
     AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
@@ -138,24 +142,32 @@ void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     AssertWriteOperation(txs, TABLETID_B, 1, 0, shouldSkip);
 }
 
-Y_UNIT_TEST(ReadWriteOperations) {
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperations(false, Nothing());
+}
+
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperations(false, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_TrackProducerId) {
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerIdTrue) {
     TestReadWriteOperations(false, true);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperations(true, Nothing());
+}
+
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperations(true, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerIdTrue) {
     TestReadWriteOperations(true, true);
 }
 
 static
-void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
+void TestOnlyWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
@@ -165,7 +177,9 @@ void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    topicOps.SetTrackProducerId(trackProducerId);
+    if (trackProducerId) {
+        topicOps.SetTrackProducerId(*trackProducerId);
+    }
 
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
 
@@ -189,24 +203,32 @@ void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     AssertWriteOperation(txs, TABLETID, 1, 0, shouldSkip);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations) {
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
+    TestOnlyWriteOperations(false, Nothing());
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestOnlyWriteOperations(false, false);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations_TrackProducerId) {
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerIdTrue) {
     TestOnlyWriteOperations(false, true);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_NoTrackProducerId) {
+    TestOnlyWriteOperations(true, Nothing());
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerIdFalse) {
     TestOnlyWriteOperations(true, false);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerIdTrue) {
     TestOnlyWriteOperations(true, true);
 }
 
 static
-void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProducerId) {
+void TestReadWriteOperationsOnePartition(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
@@ -216,7 +238,9 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProdu
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    topicOps.SetTrackProducerId(trackProducerId);
+    if (trackProducerId) {
+        topicOps.SetTrackProducerId(*trackProducerId);
+    }
 
     AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
@@ -239,19 +263,27 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProdu
     AssertWriteOperation(txs, TABLETID, 2, 1, shouldSkip);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperationsOnePartition(false, Nothing());
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperationsOnePartition(false, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_TrackProducerId) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerIdTrue) {
     TestReadWriteOperationsOnePartition(false, true);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperationsOnePartition(true, Nothing());
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperationsOnePartition(true, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerIdTrue) {
     TestReadWriteOperationsOnePartition(true, true);
 }
 

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -1,15 +1,13 @@
 #include <ydb/core/kqp/topics/kqp_topics.h>
 #include <library/cpp/testing/unittest/registar.h>
-#include <util/generic/maybe.h>
 
 namespace NKikimr::NKqp {
 
 Y_UNIT_TEST_SUITE(KqpTopics) {
 
 static
-bool ShouldSkipConflictCheck(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
-    bool effectiveTrackProducerId = trackProducerId.GetOrElse(true);
-    return skipConflictCheck && !effectiveTrackProducerId;
+bool ShouldSkipConflictCheck(bool skipConflictCheck, bool trackProducerId) {
+    return skipConflictCheck && !trackProducerId;
 }
 
 static
@@ -99,7 +97,7 @@ Y_UNIT_TEST(OnlyReadOperations) {
 }
 
 static
-void TestReadWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
+void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     const TString TOPIC_A = "topic_A";
     const TString TOPIC_B = "topic_B";
     const ui32 PARTITION = 0;
@@ -111,9 +109,7 @@ void TestReadWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackPr
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    if (trackProducerId) {
-        topicOps.SetTrackProducerId(*trackProducerId);
-    }
+    topicOps.SetTrackProducerId(trackProducerId);
 
     AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
@@ -143,31 +139,23 @@ void TestReadWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackPr
 }
 
 Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
-    TestReadWriteOperations(false, Nothing());
-}
-
-Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperations(false, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerId) {
     TestReadWriteOperations(false, true);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_NoTrackProducerId) {
-    TestReadWriteOperations(true, Nothing());
-}
-
-Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperations(true, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
     TestReadWriteOperations(true, true);
 }
 
 static
-void TestOnlyWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
+void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
@@ -177,9 +165,7 @@ void TestOnlyWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackPr
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    if (trackProducerId) {
-        topicOps.SetTrackProducerId(*trackProducerId);
-    }
+    topicOps.SetTrackProducerId(trackProducerId);
 
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
 
@@ -204,31 +190,23 @@ void TestOnlyWriteOperations(bool skipConflictCheck, const TMaybe<bool>& trackPr
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
-    TestOnlyWriteOperations(false, Nothing());
-}
-
-Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestOnlyWriteOperations(false, false);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerId) {
     TestOnlyWriteOperations(false, true);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_NoTrackProducerId) {
-    TestOnlyWriteOperations(true, Nothing());
-}
-
-Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerIdFalse) {
     TestOnlyWriteOperations(true, false);
 }
 
-Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
     TestOnlyWriteOperations(true, true);
 }
 
 static
-void TestReadWriteOperationsOnePartition(bool skipConflictCheck, const TMaybe<bool>& trackProducerId) {
+void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProducerId) {
     const TString TOPIC = "topic";
     const ui32 PARTITION = 0;
     const ui64 TABLETID = 1'000'000;
@@ -238,9 +216,7 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, const TMaybe<bo
     NTopic::TTopicOperations topicOps;
 
     topicOps.SetSkipConflictCheck(skipConflictCheck);
-    if (trackProducerId) {
-        topicOps.SetTrackProducerId(*trackProducerId);
-    }
+    topicOps.SetTrackProducerId(trackProducerId);
 
     AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
     AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
@@ -264,26 +240,18 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, const TMaybe<bo
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_NoTrackProducerId) {
-    TestReadWriteOperationsOnePartition(false, Nothing());
-}
-
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperationsOnePartition(false, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerId) {
     TestReadWriteOperationsOnePartition(false, true);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_NoTrackProducerId) {
-    TestReadWriteOperationsOnePartition(true, Nothing());
-}
-
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerIdFalse) {
     TestReadWriteOperationsOnePartition(true, false);
 }
 
-Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerIdTrue) {
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) {
     TestReadWriteOperationsOnePartition(true, true);
 }
 

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -1,0 +1,201 @@
+#include <ydb/core/kqp/topics/kqp_topics.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp {
+
+Y_UNIT_TEST_SUITE(KqpTopics) {
+
+void AddReadOperation(NTopic::TTopicOperations& ops,
+                      const TString& topic, ui32 partition,
+                      const ui64 begin, const ui64 end,
+                      const TString& consumer)
+{
+    NKikimrKqp::TTopicOperationsRequest_TopicOffsets_PartitionOffsets_OffsetsRange range;
+    range.set_start(begin);
+    range.set_end(end);
+
+    ops.AddOperation(topic, partition,
+                     consumer,
+                     range,
+                     false,
+                     false,
+                     false,
+                     "read-session");
+}
+
+void AddWriteOperation(NTopic::TTopicOperations& ops,
+                       const TString& topic, ui32 partition,
+                       const ui32 supportivePartition)
+{
+    ops.AddOperation(topic, partition,
+                     supportivePartition);
+}
+
+Y_UNIT_TEST(OnlyReadOperations) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+}
+
+Y_UNIT_TEST(ReadWriteOperations) {
+    const TString TOPIC_A = "topic_A";
+    const TString TOPIC_B = "topic_B";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID_A = 1'000'000;
+    const ui64 TABLETID_B = 2'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
+    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+}
+
+Y_UNIT_TEST(OnlyWriteOperations) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+}
+
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck) {
+    const TString TOPIC_A = "topic_A";
+    const TString TOPIC_B = "topic_B";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID_A = 1'000'000;
+    const ui64 TABLETID_B = 2'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+
+    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
+    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT(sendTabletIds.empty());
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(true);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+}
+
+}
+
+}

--- a/ydb/core/kqp/ut/topics/ya.make
+++ b/ydb/core/kqp/ut/topics/ya.make
@@ -1,0 +1,20 @@
+UNITTEST_FOR(ydb/core/kqp)
+
+FORK_SUBTESTS()
+SPLIT_FACTOR(50)
+
+SIZE(SMALL)
+
+SRCS(
+    kqp_topics_ut.cpp
+)
+
+PEERDIR(
+    ydb/core/kqp/ut/common
+    ydb/library/actors/wilson/test_util
+    yql/essentials/sql/pg_dummy
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/ut/topics/ya.make
+++ b/ydb/core/kqp/ut/topics/ya.make
@@ -11,7 +11,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/kqp/ut/common
-    ydb/library/actors/wilson/test_util
+    ydb/core/kqp/topics
     yql/essentials/sql/pg_dummy
 )
 

--- a/ydb/core/kqp/ut/ya.make
+++ b/ydb/core/kqp/ut/ya.make
@@ -24,6 +24,7 @@ RECURSE_FOR_TESTS(
     runtime
     sysview
     tli
+    topics
     tx
     view
     yql

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -331,6 +331,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         ev->Record.MutableRequest()->MutableTxControl()->set_tx_id(Opts.TxId);
 
         auto* operations = ev->Record.MutableRequest()->MutableTopicOperations();
+        operations->SetTrackProducerId(Opts.TrackProducerId);
         auto* topics = operations->AddTopics();
         topics->set_path(Opts.TopicPath);
         auto* partitions = topics->add_partitions();

--- a/ydb/core/persqueue/writer/writer.h
+++ b/ydb/core/persqueue/writer/writer.h
@@ -184,6 +184,7 @@ struct TPartitionWriterOpts {
     bool CheckState = false;
     bool AutoRegister = false;
     bool UseDeduplication = true;
+    bool TrackProducerId = true;
 
     TString SourceId;
     std::optional<ui32> ExpectedGeneration;
@@ -223,6 +224,7 @@ struct TPartitionWriterOpts {
     TPartitionWriterOpts& WithInitialSeqNo(const std::optional<ui64> value) { InitialSeqNo = value; return *this; }
     TPartitionWriterOpts& WithKafkaProducerInstanceId(const std::optional<NKafka::TProducerInstanceId>& value) { KafkaProducerInstanceId = value; return *this; }
     TPartitionWriterOpts& WithKafkaTransactionalId(const std::optional<TString>& value) { KafkaTransactionalId = value; return *this; }
+    TPartitionWriterOpts& WithTrackProducerId(bool value) { TrackProducerId = value; return *this; }
 };
 
 IActor* CreatePartitionWriter(const TActorId& client,

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -66,6 +66,7 @@ message TTopicOperationsRequest {
     repeated TopicOffsets Topics = 2;
     optional uint32 SupportivePartition = 3;
     optional uint64 TabletId = 4;
+    optional bool TrackProducerId = 5 [default = false];
 
     message TopicOffsets {
         // Topic path.

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -66,7 +66,7 @@ message TTopicOperationsRequest {
     repeated TopicOffsets Topics = 2;
     optional uint32 SupportivePartition = 3;
     optional uint64 TabletId = 4;
-    optional bool TrackProducerId = 5 [default = false];
+    optional bool TrackProducerId = 5 [default = true];
 
     message TopicOffsets {
         // Topic path.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The "skip conflict check" mode has been added to KQP. It is enabled only for PQ tablets. It is enabled by the feature flag.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
