### PR TITLE
Implement capacity alert metric for pdisk

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1067,6 +1067,8 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             UNIT_ASSERT_VALUES_EQUAL(pdiskInfo.GetSlotSizeInUnits(), expectedSlotSizeInUnits);
             UNIT_ASSERT(pdiskInfo.HasPDiskUsage());
             UNIT_ASSERT_VALUES_EQUAL(pdiskInfo.GetPDiskUsage(), 0.0);
+            UNIT_ASSERT(pdiskInfo.HasPDiskCapacityAlert());
+            UNIT_ASSERT_VALUES_EQUAL(pdiskInfo.GetPDiskCapacityAlert(), NKikimrBlobStorage::TPDiskSpaceColor::GREEN);
             break;
         }
 
@@ -1090,6 +1092,8 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
             UNIT_ASSERT_VALUES_EQUAL(metrics.GetSlotSizeInUnits(), expectedSlotSizeInUnits);
             UNIT_ASSERT(metrics.HasPDiskUsage());
             UNIT_ASSERT_VALUES_EQUAL(metrics.GetPDiskUsage(), 0.0);
+            UNIT_ASSERT(metrics.HasPDiskCapacityAlert());
+            UNIT_ASSERT_VALUES_EQUAL(metrics.GetPDiskCapacityAlert(), NKikimrBlobStorage::TPDiskSpaceColor::GREEN);
             break;
         }
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -439,6 +439,17 @@ public:
     i64 GetTotalHardLimit() const {
         return SharedQuota->GetHardLimit();
     }
+
+    TColor::E GetPDiskCapacityAlert() const {
+        double occupancy;
+        TColor::E sharedColor = SharedQuota->EstimateSpaceColor(0, &occupancy);
+        if (Params.SeparateCommonLog) {
+            TColor::E commonLogColor = GlobalQuota->EstimateSpaceColor(OwnerSystem, 0, &occupancy);
+            return Max(sharedColor, commonLogColor);
+        } else {
+            return sharedColor;
+        }
+    }
     /////////////////////////////////////////////////////
 
     i64 GetOwnerFree(TOwner owner, bool personal) const {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1704,6 +1704,10 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
         double pdiskUsage = Keeper.GetPDiskUsage();
         pDiskMetrics.SetPDiskUsage(pdiskUsage);
         pdiskState.SetPDiskUsage(pdiskUsage);
+
+        auto pdiskCapacityAlert = Keeper.GetPDiskCapacityAlert();
+        pDiskMetrics.SetPDiskCapacityAlert(pdiskCapacityAlert);
+        pdiskState.SetPDiskCapacityAlert(pdiskCapacityAlert);
     }
 
     PCtx->ActorSystem->Send(whiteboardReport.Sender, reportResult);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
@@ -156,6 +156,10 @@ public:
         return 100.0 * (totalHardLimit ? (double)totalUsed / totalHardLimit : 1.0);
     }
 
+    NKikimrBlobStorage::TPDiskSpaceColor::E GetPDiskCapacityAlert() const {
+        return ChunkTracker.GetPDiskCapacityAlert();
+    }
+
     double GetVDiskSlotUsage(TOwner owner) const {
         i64 used = ChunkTracker.GetOwnerUsed(owner);
         ui32 lightYellowLimit = ChunkTracker.ColorFlagLimit(owner, NKikimrBlobStorage::TPDiskSpaceColor::LIGHT_YELLOW);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -2047,6 +2047,55 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         CheckEvCheckSpace(testCtx, vdisk2, sharedFree, fairQuota, 0, 0.99, 0.0, 99.6, 3, 4, TColor::RED);
     }
 
+    Y_UNIT_TEST(PDiskCapacityAlertWithFullCommonLog) {
+        using TColor = NKikimrBlobStorage::TPDiskSpaceColor;
+
+        TActorTestContext testCtx({
+            .IsBad = false,
+            .DiskSize = 1_GB,
+            .ChunkSize = 1_MB,
+        });
+
+        const ui32 firstNodeId = testCtx.GetRuntime()->GetFirstNodeId();
+        testCtx.GetRuntime()->SetDispatchTimeout(10 * TDuration::MilliSeconds(testCtx.GetPDiskConfig()->StatisticsUpdateIntervalMs));
+        testCtx.GetRuntime()->RegisterService(NNodeWhiteboard::MakeNodeWhiteboardServiceId(firstNodeId), testCtx.Sender);
+
+        TVDiskMock vdisk(&testCtx);
+        vdisk.InitFull();
+        vdisk.SendEvLogSync();
+
+        // Fill the CommonLog by writing large log entries
+        TRcBuf buf(TString(64_MB, 'a'));
+        auto writeLog = [&]() {
+            testCtx.Send(new NPDisk::TEvLog(vdisk.PDiskParams->Owner, vdisk.PDiskParams->OwnerRound, 0,
+                        buf, vdisk.GetLsnSeg(), nullptr));
+            const auto logRes = testCtx.Recv<NPDisk::TEvLogResult>();
+            return logRes->Status;
+        };
+
+        while (writeLog() == NKikimrProto::OK) {}
+
+        // State 1: VDisk is empty while CommonLog is full
+        auto evCheckSpaceResult = testCtx.TestResponse<NPDisk::TEvCheckSpaceResult>(
+            new NPDisk::TEvCheckSpace(vdisk.PDiskParams->Owner, vdisk.PDiskParams->OwnerRound),
+            NKikimrProto::OK);
+        Cerr << (TStringBuilder() << "Got " << evCheckSpaceResult->ToString() << Endl);
+        UNIT_ASSERT_VALUES_EQUAL(evCheckSpaceResult->UsedChunks, 0);
+        UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(evCheckSpaceResult->StatusFlags), TColor::GREEN);
+        UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(evCheckSpaceResult->LogStatusFlags), TColor::ORANGE);
+
+        for (int num_inspect = 10; num_inspect > 0; --num_inspect) {
+            const auto evPDiskStateUpdate = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate>();
+            NKikimrWhiteboard::TPDiskStateInfo pdiskInfo = evPDiskStateUpdate.Get()->Record;
+            Cerr << (TStringBuilder() << "Got EvPDiskStateUpdate {" << pdiskInfo.ShortDebugString() << "}" << Endl);
+            if (!pdiskInfo.HasPDiskCapacityAlert()) {
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(pdiskInfo.GetPDiskCapacityAlert(), TColor::ORANGE);
+            break;
+        }
+    }
+
     Y_UNIT_TEST(TestChunkWriteCrossOwner) {
         TActorTestContext testCtx{{}};
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -2084,6 +2084,7 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
         UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(evCheckSpaceResult->StatusFlags), TColor::GREEN);
         UNIT_ASSERT_VALUES_EQUAL(StatusFlagToSpaceColor(evCheckSpaceResult->LogStatusFlags), TColor::ORANGE);
 
+        bool foundPDiskCapacityAlert = false;
         for (int num_inspect = 10; num_inspect > 0; --num_inspect) {
             const auto evPDiskStateUpdate = testCtx.Recv<NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate>();
             NKikimrWhiteboard::TPDiskStateInfo pdiskInfo = evPDiskStateUpdate.Get()->Record;
@@ -2092,8 +2093,10 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
                 continue;
             }
             UNIT_ASSERT_VALUES_EQUAL(pdiskInfo.GetPDiskCapacityAlert(), TColor::ORANGE);
+            foundPDiskCapacityAlert = true;
             break;
         }
+        UNIT_ASSERT_C(foundPDiskCapacityAlert, "No TEvPDiskStateUpdate with PDiskCapacityAlert received");
     }
 
     Y_UNIT_TEST(TestChunkWriteCrossOwner) {

--- a/ydb/core/protos/blobstorage_disk.proto
+++ b/ydb/core/protos/blobstorage_disk.proto
@@ -93,4 +93,5 @@ message TPDiskMetrics {
     optional uint64 SlotCount = 12;
     optional uint32 SlotSizeInUnits = 13;
     optional double PDiskUsage = 14;  // 100.0 * SharedQuota.Used / SharedQuota.HardLimit
+    optional NKikimrBlobStorage.TPDiskSpaceColor.E PDiskCapacityAlert = 15;  // Max(SharedQuota.Color, CommonLog.Color)
 }

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -152,6 +152,7 @@ message TPDiskStateInfo {
     optional uint32 NumActiveSlots = 24 [(DefaultField) = true];
     optional uint32 SlotSizeInUnits = 25;
     optional double PDiskUsage = 26; // 100.0 * SharedQuota.Used / SharedQuota.HardLimit
+    optional NKikimrBlobStorage.TPDiskSpaceColor.E PDiskCapacityAlert = 27; // Max(SharedQuota.Color, CommonLog.Color)
 }
 
 message TEvPDiskStateRequest {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Fulfill the needs of https://github.com/ydb-platform/ydb-embedded-ui/issues/3665#issuecomment-4135240797
- This patch provides a new metric PDiskCapacityAlert calculated as `Max(SharedQuota.Color, CommonLog.Color)` of pdisk 