### PR TITLE
Fix minmax index not used in predicates like "col > 3" 

### DIFF
--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -5,14 +5,14 @@
 #include <ydb/core/formats/arrow/accessor/composite/accessor.h>
 
 #include <library/cpp/object_factory/object_factory.h>
+#include <yql/essentials/core/arrow_kernels/request/request.h>
 
 namespace NKikimr::NArrow::NSSA {
 
 enum class ECalculationHardness {
     JustAccessorUsage = 1,
     NotSpecified = 3,
-    LessOrGreater = 4,
-    Equals = 5,
+    Compare = 5,
     StringMatching = 10,
     Unknown = 8
 };
@@ -189,36 +189,6 @@ public:
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEndsWithIgnoreCase>(GetClassNameStatic());
 };
 
-// class TLogicEquals: public IKernelLogic {
-// private:
-//     using TBase = IKernelLogic;
-//     virtual TConclusion<bool> DoExecute(const std::vector<TColumnChainInfo>& /*input*/, const std::vector<TColumnChainInfo>& /*output*/,
-//         TAccessorsCollection& /*resources*/) const override {
-//         return false;
-//     }
-//     virtual std::optional<TIndexCheckOperation> DoGetIndexCheckerOperation() const override {
-//         return TIndexCheckOperation(TIndexCheckOperation::EOperation::Equals, true);
-//     }
-//     const bool IsSimpleFunction;
-
-//     virtual ECalculationHardness GetWeight() const override {
-//         return ECalculationHardness::Equals;
-//     }
-
-// public:
-//     TLogicEquals(const bool isSimpleFunction)
-//         : IsSimpleFunction(isSimpleFunction) {
-//     }
-
-//     virtual TString GetClassName() const override {
-//         return "EQUALS";
-//     }
-
-//     virtual bool IsBoolInResult() const override {
-//         return !IsSimpleFunction;
-//     }
-// };
-
 class TCompareKernel: public IKernelLogic {
 private:
     using TBase = IKernelLogic;
@@ -233,24 +203,42 @@ private:
     const TIndexCheckOperation::EOperation Op;
 
     virtual ECalculationHardness GetWeight() const override {
-        return ECalculationHardness::LessOrGreater;
+        return ECalculationHardness::Compare;
     }
 
 public:
     TCompareKernel(const bool isSimpleFunction, TIndexCheckOperation::EOperation op)
-        : IsSimpleFunction(isSimpleFunction)
-        , Op(op)
-    {
-        AFL_VERIFY(op == TIndexCheckOperation::EOperation::Less || 
-                   op == TIndexCheckOperation::EOperation::LessOrEqual || 
-                   op == TIndexCheckOperation::EOperation::Greater || 
-                   op == TIndexCheckOperation::EOperation::GreaterOrEqual ||
-                   op == TIndexCheckOperation::EOperation::Equals
+        : IKernelLogic([&] {
+            {
+                using enum TIndexCheckOperation::EOperation;
+                
+                AFL_VERIFY(op == Less || op == LessOrEqual || 
+                    op == Greater || op == GreaterOrEqual || op == Equals
                 );
-    }
+            }
+        
+
+            switch(op) {
+            case TIndexCheckOperation::EOperation::Equals:
+                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Equals;
+            case TIndexCheckOperation::EOperation::Less:
+                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Less;
+            case TIndexCheckOperation::EOperation::Greater:
+                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Greater;
+            case TIndexCheckOperation::EOperation::LessOrEqual:
+                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::LessOrEqual;
+            case TIndexCheckOperation::EOperation::GreaterOrEqual:
+                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::GreaterOrEqual;
+            default:
+                AFL_VERIFY(false);
+            }
+        }()),
+          IsSimpleFunction(isSimpleFunction)
+        , Op(op)
+    {}
 
     virtual TString GetClassName() const override {
-        return TStringBuilder() << "TLogicLessOrGreater{" << Op << "}";
+        return TStringBuilder() << "TCompareKernel{" << Op << "}";
     }
 
     virtual bool IsBoolInResult() const override {

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -217,20 +217,19 @@ public:
                 );
             }
         
-
             switch(op) {
-            case TIndexCheckOperation::EOperation::Equals:
-                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Equals;
-            case TIndexCheckOperation::EOperation::Less:
-                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Less;
-            case TIndexCheckOperation::EOperation::Greater:
-                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Greater;
-            case TIndexCheckOperation::EOperation::LessOrEqual:
-                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::LessOrEqual;
-            case TIndexCheckOperation::EOperation::GreaterOrEqual:
-                return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::GreaterOrEqual;
-            default:
-                AFL_VERIFY(false);
+                case TIndexCheckOperation::EOperation::Equals:
+                    return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Equals;
+                case TIndexCheckOperation::EOperation::Less:
+                    return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Less;
+                case TIndexCheckOperation::EOperation::Greater:
+                    return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Greater;
+                case TIndexCheckOperation::EOperation::LessOrEqual:
+                    return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::LessOrEqual;
+                case TIndexCheckOperation::EOperation::GreaterOrEqual:
+                    return (ui32)NYql::TKernelRequestBuilder::EBinaryOp::GreaterOrEqual;
+                default:
+                    AFL_VERIFY(false);
             }
         }()),
           IsSimpleFunction(isSimpleFunction)

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -189,37 +189,37 @@ public:
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEndsWithIgnoreCase>(GetClassNameStatic());
 };
 
-class TLogicEquals: public IKernelLogic {
-private:
-    using TBase = IKernelLogic;
-    virtual TConclusion<bool> DoExecute(const std::vector<TColumnChainInfo>& /*input*/, const std::vector<TColumnChainInfo>& /*output*/,
-        TAccessorsCollection& /*resources*/) const override {
-        return false;
-    }
-    virtual std::optional<TIndexCheckOperation> DoGetIndexCheckerOperation() const override {
-        return TIndexCheckOperation(TIndexCheckOperation::EOperation::Equals, true);
-    }
-    const bool IsSimpleFunction;
+// class TLogicEquals: public IKernelLogic {
+// private:
+//     using TBase = IKernelLogic;
+//     virtual TConclusion<bool> DoExecute(const std::vector<TColumnChainInfo>& /*input*/, const std::vector<TColumnChainInfo>& /*output*/,
+//         TAccessorsCollection& /*resources*/) const override {
+//         return false;
+//     }
+//     virtual std::optional<TIndexCheckOperation> DoGetIndexCheckerOperation() const override {
+//         return TIndexCheckOperation(TIndexCheckOperation::EOperation::Equals, true);
+//     }
+//     const bool IsSimpleFunction;
 
-    virtual ECalculationHardness GetWeight() const override {
-        return ECalculationHardness::Equals;
-    }
+//     virtual ECalculationHardness GetWeight() const override {
+//         return ECalculationHardness::Equals;
+//     }
 
-public:
-    TLogicEquals(const bool isSimpleFunction)
-        : IsSimpleFunction(isSimpleFunction) {
-    }
+// public:
+//     TLogicEquals(const bool isSimpleFunction)
+//         : IsSimpleFunction(isSimpleFunction) {
+//     }
 
-    virtual TString GetClassName() const override {
-        return "EQUALS";
-    }
+//     virtual TString GetClassName() const override {
+//         return "EQUALS";
+//     }
 
-    virtual bool IsBoolInResult() const override {
-        return !IsSimpleFunction;
-    }
-};
+//     virtual bool IsBoolInResult() const override {
+//         return !IsSimpleFunction;
+//     }
+// };
 
-class TLogicLessOrGreater: public IKernelLogic {
+class TCompareKernel: public IKernelLogic {
 private:
     using TBase = IKernelLogic;
     virtual TConclusion<bool> DoExecute(const std::vector<TColumnChainInfo>& /*input*/, const std::vector<TColumnChainInfo>& /*output*/,
@@ -237,14 +237,15 @@ private:
     }
 
 public:
-    TLogicLessOrGreater(const bool isSimpleFunction, TIndexCheckOperation::EOperation op)
+    TCompareKernel(const bool isSimpleFunction, TIndexCheckOperation::EOperation op)
         : IsSimpleFunction(isSimpleFunction)
         , Op(op)
     {
         AFL_VERIFY(op == TIndexCheckOperation::EOperation::Less || 
                    op == TIndexCheckOperation::EOperation::LessOrEqual || 
                    op == TIndexCheckOperation::EOperation::Greater || 
-                   op == TIndexCheckOperation::EOperation::GreaterOrEqual
+                   op == TIndexCheckOperation::EOperation::GreaterOrEqual ||
+                   op == TIndexCheckOperation::EOperation::Equals
                 );
     }
 

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -282,8 +282,7 @@ private:
     public:
         TDescription(const std::shared_ptr<NAccessor::IChunkedArray>& inputAccessor, const std::string_view jsonPath)
             : InputAccessor(inputAccessor)
-            , JsonPath(jsonPath)
-        {
+            , JsonPath(jsonPath) {
         }
 
         const std::shared_ptr<NAccessor::IChunkedArray>& GetInputAccessor() const {

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -11,6 +11,7 @@ namespace NKikimr::NArrow::NSSA {
 enum class ECalculationHardness {
     JustAccessorUsage = 1,
     NotSpecified = 3,
+    LessOrGreater = 4,
     Equals = 5,
     StringMatching = 10,
     Unknown = 8
@@ -211,6 +212,42 @@ public:
 
     virtual TString GetClassName() const override {
         return "EQUALS";
+    }
+
+    virtual bool IsBoolInResult() const override {
+        return !IsSimpleFunction;
+    }
+};
+
+class TLogicLessOrGreater: public IKernelLogic {
+private:
+    using TBase = IKernelLogic;
+    virtual TConclusion<bool> DoExecute(const std::vector<TColumnChainInfo>& /*input*/, const std::vector<TColumnChainInfo>& /*output*/,
+        TAccessorsCollection& /*resources*/) const override {
+        return false;
+    }
+    virtual std::optional<TIndexCheckOperation> DoGetIndexCheckerOperation() const override {
+        return TIndexCheckOperation(Op, true);
+    }
+    const bool IsSimpleFunction;
+    const TIndexCheckOperation::EOperation Op;
+
+    virtual ECalculationHardness GetWeight() const override {
+        return ECalculationHardness::LessOrGreater;
+    }
+
+public:
+    TLogicLessOrGreater(const bool isSimpleFunction, TIndexCheckOperation::EOperation op)
+        : IsSimpleFunction(isSimpleFunction), Op(op) {
+        AFL_VERIFY(op == TIndexCheckOperation::EOperation::Less || 
+                   op == TIndexCheckOperation::EOperation::LessOrEqual || 
+                   op == TIndexCheckOperation::EOperation::Greater || 
+                   op == TIndexCheckOperation::EOperation::GreaterOrEqual
+                );
+    }
+
+    virtual TString GetClassName() const override {
+        return TStringBuilder() << "TLogicLessOrGreater{" << Op << "}";
     }
 
     virtual bool IsBoolInResult() const override {

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -34,8 +34,7 @@ public:
     IKernelLogic() = default;
 
     IKernelLogic(const ui32 yqlOperationId)
-        : YqlOperationId(yqlOperationId)
-    {
+        : YqlOperationId(yqlOperationId) {
     }
 
     virtual ~IKernelLogic() = default;
@@ -77,8 +76,7 @@ private:
 public:
     TSimpleKernelLogic() = default;
     TSimpleKernelLogic(const ui32 yqlOperationId)
-        : TBase(yqlOperationId)
-    {
+        : TBase(yqlOperationId) {
     }
 
     virtual TString SignalDescription() const override;
@@ -123,8 +121,7 @@ public:
     TLogicMatchString(const TIndexCheckOperation::EOperation operation, const bool caseSensitive, const bool isSimpleFunction)
         : Operation(operation)
         , CaseSensitive(caseSensitive)
-        , IsSimpleFunction(isSimpleFunction)
-    {
+        , IsSimpleFunction(isSimpleFunction) {
     }
 
     virtual TString SignalDescription() const override {
@@ -148,8 +145,7 @@ private:
 
 public:
     TLogicMatchAsciiEqualsIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false)
-    {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEqualsIgnoreCase>(GetClassNameStatic());
 };
@@ -162,8 +158,7 @@ private:
 
 public:
     TLogicMatchAsciiContainsIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false)
-    {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiContainsIgnoreCase>(GetClassNameStatic());
 };
@@ -176,8 +171,7 @@ private:
 
 public:
     TLogicMatchAsciiStartsWithIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::StartsWith, false, false)
-    {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::StartsWith, false, false) {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiStartsWithIgnoreCase>(GetClassNameStatic());
 };
@@ -190,8 +184,7 @@ private:
 
 public:
     TLogicMatchAsciiEndsWithIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::EndsWith, false, false)
-    {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::EndsWith, false, false) {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEndsWithIgnoreCase>(GetClassNameStatic());
 };
@@ -214,8 +207,7 @@ private:
 
 public:
     TLogicEquals(const bool isSimpleFunction)
-        : IsSimpleFunction(isSimpleFunction)
-    {
+        : IsSimpleFunction(isSimpleFunction) {
     }
 
     virtual TString GetClassName() const override {

--- a/ydb/core/formats/arrow/program/kernel_logic.h
+++ b/ydb/core/formats/arrow/program/kernel_logic.h
@@ -34,7 +34,8 @@ public:
     IKernelLogic() = default;
 
     IKernelLogic(const ui32 yqlOperationId)
-        : YqlOperationId(yqlOperationId) {
+        : YqlOperationId(yqlOperationId)
+    {
     }
 
     virtual ~IKernelLogic() = default;
@@ -76,7 +77,8 @@ private:
 public:
     TSimpleKernelLogic() = default;
     TSimpleKernelLogic(const ui32 yqlOperationId)
-        : TBase(yqlOperationId) {
+        : TBase(yqlOperationId)
+    {
     }
 
     virtual TString SignalDescription() const override;
@@ -121,7 +123,8 @@ public:
     TLogicMatchString(const TIndexCheckOperation::EOperation operation, const bool caseSensitive, const bool isSimpleFunction)
         : Operation(operation)
         , CaseSensitive(caseSensitive)
-        , IsSimpleFunction(isSimpleFunction) {
+        , IsSimpleFunction(isSimpleFunction)
+    {
     }
 
     virtual TString SignalDescription() const override {
@@ -145,7 +148,8 @@ private:
 
 public:
     TLogicMatchAsciiEqualsIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false)
+    {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEqualsIgnoreCase>(GetClassNameStatic());
 };
@@ -158,7 +162,8 @@ private:
 
 public:
     TLogicMatchAsciiContainsIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false) {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::Contains, false, false)
+    {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiContainsIgnoreCase>(GetClassNameStatic());
 };
@@ -171,7 +176,8 @@ private:
 
 public:
     TLogicMatchAsciiStartsWithIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::StartsWith, false, false) {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::StartsWith, false, false)
+    {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiStartsWithIgnoreCase>(GetClassNameStatic());
 };
@@ -184,7 +190,8 @@ private:
 
 public:
     TLogicMatchAsciiEndsWithIgnoreCase()
-        : TLogicMatchString(TIndexCheckOperation::EOperation::EndsWith, false, false) {
+        : TLogicMatchString(TIndexCheckOperation::EOperation::EndsWith, false, false)
+    {
     }
     static const inline auto Registrator = TFactory::TRegistrator<TLogicMatchAsciiEndsWithIgnoreCase>(GetClassNameStatic());
 };
@@ -207,7 +214,8 @@ private:
 
 public:
     TLogicEquals(const bool isSimpleFunction)
-        : IsSimpleFunction(isSimpleFunction) {
+        : IsSimpleFunction(isSimpleFunction)
+    {
     }
 
     virtual TString GetClassName() const override {
@@ -238,7 +246,9 @@ private:
 
 public:
     TLogicLessOrGreater(const bool isSimpleFunction, TIndexCheckOperation::EOperation op)
-        : IsSimpleFunction(isSimpleFunction), Op(op) {
+        : IsSimpleFunction(isSimpleFunction)
+        , Op(op)
+    {
         AFL_VERIFY(op == TIndexCheckOperation::EOperation::Less || 
                    op == TIndexCheckOperation::EOperation::LessOrEqual || 
                    op == TIndexCheckOperation::EOperation::Greater || 
@@ -280,7 +290,8 @@ private:
     public:
         TDescription(const std::shared_ptr<NAccessor::IChunkedArray>& inputAccessor, const std::string_view jsonPath)
             : InputAccessor(inputAccessor)
-            , JsonPath(jsonPath) {
+            , JsonPath(jsonPath)
+        {
         }
 
         const std::shared_ptr<NAccessor::IChunkedArray>& GetInputAccessor() const {

--- a/ydb/core/formats/arrow/ut/ut_program_step.cpp
+++ b/ydb/core/formats/arrow/ut/ut_program_step.cpp
@@ -579,7 +579,7 @@ Y_UNIT_TEST_SUITE(ProgramStep) {
         }
         {
             auto proc = TCalculationProcessor::Build(TColumnChainInfo::BuildVector({1, 3}), TColumnChainInfo(1003), std::make_shared<TSimpleFunction>(EOperation::Equal),
-                std::make_shared<TLogicEquals>(false)).DetachResult();
+                std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::Equals)).DetachResult();
             builder.Add(proc);
         }
         {

--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -222,7 +222,7 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
 
 
         CompareYson(runNonSchemeQuery(R"(
-            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` < "Value_500000";
+            SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` < "Value_500000";
         )"), "[[944450u]]");
         Cerr << "not built indexes: " << csController->GetIndexesSkippedNoData().Val() << '\n';
 
@@ -230,21 +230,21 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
         CompareYson(runNonSchemeQuery(R"(
-            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` > "Value_500000";
+            SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` > "Value_500000";
         )"), "[[555549u]]");
 
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
         CompareYson(runNonSchemeQuery(R"(
-            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` <= "Value_500000";
+            SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` <= "Value_500000";
         )"), "[[944451u]]");
 
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
         CompareYson(runNonSchemeQuery(R"(
-            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` >= "Value_500000";
+            SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` >= "Value_500000";
         )"), "[[555550u]]");
 
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);

--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         }
     }
 
-    Y_UNIT_TEST(MinMaxIndexUsedInQueries) {
+    Y_UNIT_TEST_DUO(MinMaxIndexUsedInQueries, UseQueryService) {
         auto settings = TKikimrSettings()
             .SetColumnShardAlterObjectEnabled(true)
             .SetWithSampleTables(false);
@@ -164,27 +164,39 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         csController->SetOverrideMemoryLimitForPortionReading(1e+10);
         csController->SetOverrideBlobSplitSettings(NOlap::NSplitter::TSplitSettings());
 
-        auto runSchemeQuery = [&](TString query) {
-            auto session = tableClient.CreateSession().GetValueSync().GetSession();
-            return session.ExecuteSchemeQuery(query).GetValueSync();
-        };
 
-        auto assertSchemeQueryOk = [&](TString query) {
-            auto res = runSchemeQuery(query);
-            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), NYdb::EStatus::SUCCESS, res.GetIssues().ToString());
-        };
-
-        auto runNonSchemeQuery = [&](TString query) -> TString {
-
-            auto result = queryServiceCLient.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            if (result.GetResultSets().empty()) {
-                return "[]";
+        auto assertDDLQueryOk = [&](TString query) {
+            if (UseQueryService) {
+                auto result = queryServiceCLient.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            } else {
+                auto session = tableClient.CreateSession().GetValueSync().GetSession();
+                auto res = session.ExecuteSchemeQuery(query).GetValueSync();
+                UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
             }
-            return FormatResultSetYson(result.GetResultSet(0));
         };
 
-        assertSchemeQueryOk(R"(
+
+        auto runDMLQuery = [&] (TString query) -> TString {
+            if (/*UseQueryService*/ true) {
+                auto result = queryServiceCLient.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+                if (result.GetResultSets().empty()) {
+                    return "[]";
+                }
+                return FormatResultSetYson(result.GetResultSet(0));
+            } else {
+                NYdb::NTable::TDataQueryResult result = tableClient.CreateSession().GetValueSync().GetSession().ExecuteDataQuery(query, NYdb::NTable::TTxControl::BeginTx().CommitTx()).GetValueSync();
+
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+                if (result.GetResultSets().empty()) {
+                    return "[]";
+                }
+                return FormatResultSetYson(result.GetResultSet(0));
+            }
+        };
+
+        assertDDLQueryOk(R"(
             CREATE TABLE `/Root/minmax_test_applied_applied` (
                 `key` Int32 NOT NULL,
                 `value` String NOT NULL,
@@ -196,22 +208,22 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
             );
         )");
 
-        assertSchemeQueryOk(R"(
+        assertDDLQueryOk(R"(
             ALTER OBJECT `/Root/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION=UPSERT_INDEX, NAME=value_mm, TYPE=MINMAX, FEATURES=`{"column_name" : "value"}`);
 
         )");
 
-        assertSchemeQueryOk(R"(
+        assertDDLQueryOk(R"(
             ALTER OBJECT `/Root/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`);
         )");
 
-        runNonSchemeQuery(R"(
+        runDMLQuery(R"(
             $data1 = ListMap(ListFromRange(1, 1500001), ($x) -> { RETURN AsStruct($x AS item); });
             UPSERT INTO `/Root/minmax_test_applied_applied` (`key`, `value`)
             SELECT CAST(item AS Int32) AS `key`, "Value_" || CAST(item+1 AS String) AS `value` FROM AS_TABLE($data1);
         )");
 
-        runNonSchemeQuery(R"(
+        runDMLQuery(R"(
             $data2 = ListMap(ListFromRange(1, 1500001), ($x) -> { RETURN AsStruct($x AS item); });
             UPSERT INTO `/Root/minmax_test_applied_applied` (`key`, `value`)
             SELECT CAST(item AS Int32) AS `key`, "Value_" || CAST(item AS String) AS `value` FROM AS_TABLE($data2);
@@ -221,7 +233,7 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         auto skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
 
-        CompareYson(runNonSchemeQuery(R"(
+        CompareYson(runDMLQuery(R"(
             SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` < "Value_500000";
         )"), "[[944450u]]");
         Cerr << "not built indexes: " << csController->GetIndexesSkippedNoData().Val() << '\n';
@@ -229,21 +241,21 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
-        CompareYson(runNonSchemeQuery(R"(
+        CompareYson(runDMLQuery(R"(
             SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` > "Value_500000";
         )"), "[[555549u]]");
 
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
-        CompareYson(runNonSchemeQuery(R"(
+        CompareYson(runDMLQuery(R"(
             SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` <= "Value_500000";
         )"), "[[944451u]]");
 
         UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
-        CompareYson(runNonSchemeQuery(R"(
+        CompareYson(runDMLQuery(R"(
             SELECT COUNT(*) FROM `/Root/minmax_test_applied_applied` WHERE `value` >= "Value_500000";
         )"), "[[555550u]]");
 

--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -153,8 +153,16 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
             .SetWithSampleTables(false);
         TKikimrRunner kikimr(settings);
 
-        TLocalHelper(kikimr).CreateTestOlapStandaloneTable();
+        auto helper = TLocalHelper(kikimr);
+        helper.CreateTestOlapStandaloneTable();
+        helper.SetForcedCompaction();
         auto tableClient = kikimr.GetTableClient();
+        auto queryServiceCLient = kikimr.GetQueryClient();
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        csController->SetOverrideLagForCompactionBeforeTierings(TDuration::Seconds(1));
+        csController->SetOverrideMemoryLimitForPortionReading(1e+10);
+        csController->SetOverrideBlobSplitSettings(NOlap::NSplitter::TSplitSettings());
 
         auto runSchemeQuery = [&](TString query) {
             auto session = tableClient.CreateSession().GetValueSync().GetSession();
@@ -166,43 +174,80 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
             UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), NYdb::EStatus::SUCCESS, res.GetIssues().ToString());
         };
 
-        auto runNonSchemeQuery = [&](TString query) {
-            auto session = tableClient.CreateSession().GetValueSync().GetSession();
-            return session.ExecuteDataQuery(query, NYdb::NTable::TTxControl::BeginTx().CommitTx());
+        auto runNonSchemeQuery = [&](TString query) -> TString {
+
+            auto result = queryServiceCLient.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            if (result.GetResultSets().empty()) {
+                return "[]";
+            }
+            return FormatResultSetYson(result.GetResultSet(0));
         };
 
-        
-
-
-
         assertSchemeQueryOk(R"(
-            CREATE TABLE `minmax_test_applied_applied` (
+            CREATE TABLE `/Root/minmax_test_applied_applied` (
                 `key` Int32 NOT NULL,
-                `value` Utf8 NOT NULL,
+                `value` String NOT NULL,
                 PRIMARY KEY (`key`)
             )
             PARTITION BY HASH (`key`)
             WITH (
                 STORE = COLUMN
             );
+        )");
 
-            ALTER OBJECT `/Root/db1/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_INDEX, NAME = value_mm);
-            ALTER OBJECT `/Root/db1/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`);
+        assertSchemeQueryOk(R"(
+            ALTER OBJECT `/Root/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION=UPSERT_INDEX, NAME=value_mm, TYPE=MINMAX, FEATURES=`{"column_name" : "value"}`);
 
         )");
 
-        runNonSchemeQuery(R"(            
-            UPSERT INTO my_table (id, name, status)
-            SELECT CAST(value AS Int32) AS id, "Value_" || CAST(value AS Utf8) AS value FROM AS_TABLE(ListFromRange(500001, 1500001));
+        assertSchemeQueryOk(R"(
+            ALTER OBJECT `/Root/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`);
+        )");
 
-            UPSERT INTO my_table (id, name, status)
-            SELECT CAST(value AS Int32) AS id, "Value_" || CAST(value AS Utf8) AS value FROM AS_TABLE(ListFromRange(1, 1000001));
-        )")
+        runNonSchemeQuery(R"(
+            $data1 = ListMap(ListFromRange(1, 1500001), ($x) -> { RETURN AsStruct($x AS item); });
+            UPSERT INTO `/Root/minmax_test_applied_applied` (`key`, `value`)
+            SELECT CAST(item AS Int32) AS `key`, "Value_" || CAST(item+1 AS String) AS `value` FROM AS_TABLE($data1);
+        )");
+
+        runNonSchemeQuery(R"(
+            $data2 = ListMap(ListFromRange(1, 1500001), ($x) -> { RETURN AsStruct($x AS item); });
+            UPSERT INTO `/Root/minmax_test_applied_applied` (`key`, `value`)
+            SELECT CAST(item AS Int32) AS `key`, "Value_" || CAST(item AS String) AS `value` FROM AS_TABLE($data2);
+        )");
+        csController->WaitCompactions(TDuration::Seconds(5));
+
+        auto skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
 
+        CompareYson(runNonSchemeQuery(R"(
+            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` < "Value_500000";
+        )"), "[[944450u]]");
+        Cerr << "not built indexes: " << csController->GetIndexesSkippedNoData().Val() << '\n';
 
-        
+        UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
+        skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
 
+        CompareYson(runNonSchemeQuery(R"(
+            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` > "Value_500000";
+        )"), "[[555549u]]");
+
+        UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
+        skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
+
+        CompareYson(runNonSchemeQuery(R"(
+            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` <= "Value_500000";
+        )"), "[[944451u]]");
+
+        UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
+        skipped_and_approved = csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val();
+
+        CompareYson(runNonSchemeQuery(R"(
+            SELECT COUNT(*) FROM `minmax_test_applied_applied` WHERE `value` >= "Value_500000";
+        )"), "[[555550u]]");
+
+        UNIT_ASSERT_GT(csController->GetIndexesSkippingOnSelect().Val() + csController->GetIndexesApprovedOnSelect().Val(), skipped_and_approved);
         
     }
 

--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -147,6 +147,65 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
         }
     }
 
+    Y_UNIT_TEST(MinMaxIndexUsedInQueries) {
+        auto settings = TKikimrSettings()
+            .SetColumnShardAlterObjectEnabled(true)
+            .SetWithSampleTables(false);
+        TKikimrRunner kikimr(settings);
+
+        TLocalHelper(kikimr).CreateTestOlapStandaloneTable();
+        auto tableClient = kikimr.GetTableClient();
+
+        auto runSchemeQuery = [&](TString query) {
+            auto session = tableClient.CreateSession().GetValueSync().GetSession();
+            return session.ExecuteSchemeQuery(query).GetValueSync();
+        };
+
+        auto assertSchemeQueryOk = [&](TString query) {
+            auto res = runSchemeQuery(query);
+            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), NYdb::EStatus::SUCCESS, res.GetIssues().ToString());
+        };
+
+        auto runNonSchemeQuery = [&](TString query) {
+            auto session = tableClient.CreateSession().GetValueSync().GetSession();
+            return session.ExecuteDataQuery(query, NYdb::NTable::TTxControl::BeginTx().CommitTx());
+        };
+
+        
+
+
+
+        assertSchemeQueryOk(R"(
+            CREATE TABLE `minmax_test_applied_applied` (
+                `key` Int32 NOT NULL,
+                `value` Utf8 NOT NULL,
+                PRIMARY KEY (`key`)
+            )
+            PARTITION BY HASH (`key`)
+            WITH (
+                STORE = COLUMN
+            );
+
+            ALTER OBJECT `/Root/db1/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_INDEX, NAME = value_mm);
+            ALTER OBJECT `/Root/db1/minmax_test_applied_applied` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`);
+
+        )");
+
+        runNonSchemeQuery(R"(            
+            UPSERT INTO my_table (id, name, status)
+            SELECT CAST(value AS Int32) AS id, "Value_" || CAST(value AS Utf8) AS value FROM AS_TABLE(ListFromRange(500001, 1500001));
+
+            UPSERT INTO my_table (id, name, status)
+            SELECT CAST(value AS Int32) AS id, "Value_" || CAST(value AS Utf8) AS value FROM AS_TABLE(ListFromRange(1, 1000001));
+        )")
+
+
+
+        
+
+        
+    }
+
     Y_UNIT_TEST_DUO(CreateTableThenAddAndDropLocalBloomIndexesWithSqlSyntax, UseQueryService) {
         auto settings = TKikimrSettings().SetWithSampleTables(false).SetColumnShardAlterObjectEnabled(true);
         settings.AppConfig.MutableFeatureFlags()->SetEnableLocalBloomFilterIndex(true);

--- a/ydb/core/tx/program/builder.cpp
+++ b/ydb/core/tx/program/builder.cpp
@@ -37,7 +37,7 @@ TConclusion<std::shared_ptr<IStepFunction>> TProgramBuilder::MakeFunction(const 
 
     if (func.GetFunctionType() == NKikimrSSA::TProgram::EFunctionType::TProgram_EFunctionType_YQL_KERNEL) {
         if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Equals) {
-            kernelLogic = std::make_shared<TLogicEquals>(false);
+            kernelLogic = std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::Equals);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::StringContains) {
             kernelLogic = std::make_shared<TLogicMatchString>(TIndexCheckOperation::EOperation::Contains, true, false);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::StartsWith) {
@@ -45,13 +45,13 @@ TConclusion<std::shared_ptr<IStepFunction>> TProgramBuilder::MakeFunction(const 
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::EndsWith) {
             kernelLogic = std::make_shared<TLogicMatchString>(TIndexCheckOperation::EOperation::EndsWith, true, false);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Less) {
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::Less);
+            kernelLogic = std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::Less);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::LessOrEqual) {
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::LessOrEqual);
+            kernelLogic = std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::LessOrEqual);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Greater) {
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::Greater);
+            kernelLogic = std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::Greater);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::GreaterOrEqual) {
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::GreaterOrEqual);
+            kernelLogic = std::make_shared<TCompareKernel>(false, TIndexCheckOperation::EOperation::GreaterOrEqual);
         }
         auto kernelFunction = KernelsRegistry.GetFunction(func.GetKernelIdx());
         if (!kernelFunction) {
@@ -85,21 +85,21 @@ TConclusion<std::shared_ptr<IStepFunction>> TProgramBuilder::MakeFunction(const 
 
     switch (func.GetId()) {
         case TId::FUNC_CMP_EQUAL:
-            kernelLogic = std::make_shared<TLogicEquals>(true);
+            kernelLogic = std::make_shared<TCompareKernel>(true, TIndexCheckOperation::EOperation::Equals);
             return std::make_shared<TSimpleFunction>(EOperation::Equal);
         case TId::FUNC_CMP_NOT_EQUAL:
             return std::make_shared<TSimpleFunction>(EOperation::NotEqual);
         case TId::FUNC_CMP_LESS:
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::Less);
+            kernelLogic = std::make_shared<TCompareKernel>(true, TIndexCheckOperation::EOperation::Less);
             return std::make_shared<TSimpleFunction>(EOperation::Less);
         case TId::FUNC_CMP_LESS_EQUAL:
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::LessOrEqual);
+            kernelLogic = std::make_shared<TCompareKernel>(true, TIndexCheckOperation::EOperation::LessOrEqual);
             return std::make_shared<TSimpleFunction>(EOperation::LessEqual);
         case TId::FUNC_CMP_GREATER:
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::Greater);
+            kernelLogic = std::make_shared<TCompareKernel>(true, TIndexCheckOperation::EOperation::Greater);
             return std::make_shared<TSimpleFunction>(EOperation::Greater);
         case TId::FUNC_CMP_GREATER_EQUAL:
-            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::GreaterOrEqual);
+            kernelLogic = std::make_shared<TCompareKernel>(true, TIndexCheckOperation::EOperation::GreaterOrEqual);
             return std::make_shared<TSimpleFunction>(EOperation::GreaterEqual);
         case TId::FUNC_IS_NULL:
             return std::make_shared<TSimpleFunction>(EOperation::IsNull);

--- a/ydb/core/tx/program/builder.cpp
+++ b/ydb/core/tx/program/builder.cpp
@@ -44,6 +44,14 @@ TConclusion<std::shared_ptr<IStepFunction>> TProgramBuilder::MakeFunction(const 
             kernelLogic = std::make_shared<TLogicMatchString>(TIndexCheckOperation::EOperation::StartsWith, true, false);
         } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::EndsWith) {
             kernelLogic = std::make_shared<TLogicMatchString>(TIndexCheckOperation::EOperation::EndsWith, true, false);
+        } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Less) {
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::Less);
+        } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::LessOrEqual) {
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::LessOrEqual);
+        } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::Greater) {
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::Greater);
+        } else if (func.GetYqlOperationId() == (ui32)NYql::TKernelRequestBuilder::EBinaryOp::GreaterOrEqual) {
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(false, TIndexCheckOperation::EOperation::GreaterOrEqual);
         }
         auto kernelFunction = KernelsRegistry.GetFunction(func.GetKernelIdx());
         if (!kernelFunction) {
@@ -82,12 +90,16 @@ TConclusion<std::shared_ptr<IStepFunction>> TProgramBuilder::MakeFunction(const 
         case TId::FUNC_CMP_NOT_EQUAL:
             return std::make_shared<TSimpleFunction>(EOperation::NotEqual);
         case TId::FUNC_CMP_LESS:
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::Less);
             return std::make_shared<TSimpleFunction>(EOperation::Less);
         case TId::FUNC_CMP_LESS_EQUAL:
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::LessOrEqual);
             return std::make_shared<TSimpleFunction>(EOperation::LessEqual);
         case TId::FUNC_CMP_GREATER:
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::Greater);
             return std::make_shared<TSimpleFunction>(EOperation::Greater);
         case TId::FUNC_CMP_GREATER_EQUAL:
+            kernelLogic = std::make_shared<TLogicLessOrGreater>(true, TIndexCheckOperation::EOperation::GreaterOrEqual);
             return std::make_shared<TSimpleFunction>(EOperation::GreaterEqual);
         case TId::FUNC_IS_NULL:
             return std::make_shared<TSimpleFunction>(EOperation::IsNull);


### PR DESCRIPTION
minmax index was used only in equality(=) predicates, now it is used in =, >, <, >=, <= predicates as it should be
fixes: #36874 
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
