### PR TITLE
Revert "[Backport stable-26-1-1] You must always setup peername (#36337) (#36496)"

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -1820,7 +1820,7 @@ class TEvRequestAuthAndCheck
     : public IRequestProxyCtx
     , public TEventLocal<TEvRequestAuthAndCheck, TRpcServices::EvRequestAuthAndCheck> {
 public:
-    TEvRequestAuthAndCheck(const TString& database, const TMaybe<TString>& ydbToken, NActors::TActorId sender, TAuditMode auditMode, TString peerName)
+    TEvRequestAuthAndCheck(const TString& database, const TMaybe<TString>& ydbToken, NActors::TActorId sender, TAuditMode auditMode, TString peerName = {})
         : Database(database)
         , YdbToken(ydbToken)
         , Sender(sender)

--- a/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
+++ b/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
@@ -189,8 +189,7 @@ Y_UNIT_TEST(CanSetAllPermissions) {
         setup.DbPath,
         TMaybe<TString>(userToken),
         setup.FakeMonActor,
-        NGRpcService::TAuditMode::Modifying(NGRpcService::TAuditMode::TLogClassConfig::ClusterAdmin),
-        "192.168.0.101");
+        NGRpcService::TAuditMode::Modifying(NGRpcService::TAuditMode::TLogClassConfig::ClusterAdmin));
 
     setup.RequestCheckActor(std::move(ev));
 


### PR DESCRIPTION
This reverts commit 047c23ac86599b41a2a1c418cb72a69ca05b4d68, reversing changes made to 085370019b68ad11734d3928eaed525f8af5f2df.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://nda.ya.ru/t/LNqNKjNm7Xpnym
