### PR TITLE
Add flow control to system tablet backup

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3007,7 +3007,7 @@ message TSystemTabletBackupConfig {
 
     enum EFailBehaviour {
         RETRY_BACKUP = 0;
-        TABLET_CRASH = 1;
+        TABLET_RESTART = 1;
     }
     optional EFailBehaviour FailBehaviour = 6 [default = RETRY_BACKUP];
     optional uint32 RetryBackupTimeoutSeconds = 7 [default = 60];

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3003,6 +3003,14 @@ message TSystemTabletBackupConfig {
     repeated fixed64 ExcludeTabletIds = 2;
     optional uint64 NewBackupChangelogMinBytes = 3 [default = 524288000]; // 500 MB
     optional uint64 MaxBackupsLimit = 4 [default = 3];
+    optional uint64 ChangelogInFlightBytesLimit = 5 [default = 536870912]; // 512 MB
+
+    enum EFailBehaviour {
+        RETRY_BACKUP = 0;
+        TABLET_CRASH = 1;
+    }
+    optional EFailBehaviour FailBehaviour = 6 [default = RETRY_BACKUP];
+    optional uint32 RetryBackupTimeoutSeconds = 7 [default = 60];
 }
 
 message TClusterDiagnosticsConfig {

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -96,15 +96,17 @@ namespace NTabletFlatExecutor {
                 }
 
                 auto ev = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs);
-                ui64 evTotalSize = ev->GetTotalSize();
-                if (InFlightBytes + evTotalSize <= InFlightBytesLimit) {
-                    InFlightBytes += evTotalSize;
+                ui64 evSize = ev->GetTotalSize();
+                if (evSize <= InFlightBytesLimit - InFlightBytes) {
+                    InFlightBytes += evSize;
                     Ops->Send(Writer, ev.Release());
                 } else {
                     InFlightOverflow = true;
                     auto error = TStringBuilder()
                         << "Backup changelog in flight bytes limit exceeded: "
-                        << InFlightBytes + evTotalSize << " > " << InFlightBytesLimit;
+                        << "InFlightBytes# " << InFlightBytes << ", "
+                        << "evSize# " << evSize << ", "
+                        << "InFlightBytesLimit# " << InFlightBytesLimit;
                     TActivationContext::Send(new IEventHandle(Owner, Writer, new NBackup::TEvChangelogFailed(error)));
                 }
             }

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -69,7 +69,7 @@ namespace NTabletFlatExecutor {
 
             void Stop() {
                 if (Running) {
-                    Ops->Send(Owner, new TEvents::TEvPoisonPill);
+                    Ops->Send(Writer, new TEvents::TEvPoisonPill);
                 }
                 *this = TBackupLogic();
             }

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -105,7 +105,7 @@ namespace NTabletFlatExecutor {
                     auto error = TStringBuilder()
                         << "Backup changelog in flight bytes limit exceeded: "
                         << InFlightBytes + evTotalSize << " > " << InFlightBytesLimit;
-                    Ops->Send(Owner, new NBackup::TEvChangelogFailed(error));
+                    TActivationContext::Send(new IEventHandle(Owner, Writer, new NBackup::TEvChangelogFailed(error)));
                 }
             }
 

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -57,21 +57,79 @@ namespace NTabletFlatExecutor {
         using TGcLogic = TExecutorGCLogic;
         using TEvCommit = TEvTablet::TEvCommit;
 
-        struct TBackupState {
+        class TBackupLogic {
+        public:
+            void Start(IOps *ops, TActorId owner, TActorId changelogWriter, ui64 inFlightBytesLimit) {
+                Ops = ops;
+                Owner = owner;
+                Writer = changelogWriter;
+                InFlightBytesLimit = inFlightBytesLimit;
+                Running = true;
+            }
+
+            void Stop() {
+                if (Running) {
+                    Ops->Send(Owner, new TEvents::TEvPoisonPill);
+                }
+                *this = TBackupLogic();
+            }
+
+            bool IsRunning() const {
+                return Running;
+            }
+
+            bool ShouldBackupCommit(const TLogCommit &commit) const {
+                if (!Running) {
+                    return false;
+                }
+
+                if (InFlightOverflow) {
+                    return false;
+                }
+
+                return commit.Type == ECommit::Redo;
+            }
+
+            void BackupCommit(const TLogCommit &commit) {
+                if (!ShouldBackupCommit(commit)) {
+                    return;
+                }
+
+                auto ev = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs);
+                ui64 evTotalSize = ev->GetTotalSize();
+                if (InFlightBytes + evTotalSize <= InFlightBytesLimit) {
+                    InFlightBytes += evTotalSize;
+                    Ops->Send(Writer, ev.Release());
+                } else {
+                    InFlightOverflow = true;
+                    auto error = TStringBuilder()
+                        << "Backup changelog in flight bytes limit exceeded: "
+                        << InFlightBytes + evTotalSize << " > " << InFlightBytesLimit;
+                    Ops->Send(Owner, new NBackup::TEvChangelogFailed(error));
+                }
+            }
+
+            void OnProcessedBytes(ui64 bytes) {
+                Y_ENSURE(InFlightBytes >= bytes);
+                InFlightBytes -= bytes;
+            }
+
+            void OnSnapshotCompleted(NBackup::TEvSnapshotCompleted::TPtr& ev) {
+                Ops->Send(Writer, ev->ReleaseBase().Release());
+            }
+
+            TActorId GetWriter() const {
+                return Writer;
+            }
+
+        private:
+            IOps* Ops = nullptr;
             TActorId Owner;
             TActorId Writer;
-            ui64 SeqNo = 0;
+            bool Running = false;
             ui64 InFlightBytes = 0;
             ui64 InFlightBytesLimit = Max<ui64>();
-
-            TBackupState() = default;
-            TBackupState(TActorId owner, TActorId writer, ui64 seqNo, ui64 inFlightBytesLimit)
-                : Owner(owner)
-                , Writer(writer)
-                , SeqNo(seqNo)
-                , InFlightBytes(0)
-                , InFlightBytesLimit(inFlightBytesLimit)
-            {}
+            bool InFlightOverflow = false;
         };
 
         TCommitManager(NBoot::TSteppedCookieAllocatorFactory &steppedCookieAllocatorFactory, TIntrusivePtr<NSnap::TWaste> waste, TGcLogic *logic)
@@ -106,31 +164,13 @@ namespace NTabletFlatExecutor {
             *Step0 = Head = Tail = 1;
         }
 
-        void Stop() const
+        void Stop()
         {
             Y_ENSURE(Ops, "Commit manager is not started");
-            Ops->Send(BackupState.Writer, new TEvents::TEvPoisonPill());
+            BackupLogic.Stop();
         }
 
         void SetTactic(ETactic tactic) noexcept { Tactic = tactic; }
-
-        void StartBackup(TActorId backupOwner, TActorId backupWriter, ui64 seqNo, ui64 inFlightBytesLimit) {
-            StopBackup();
-            BackupState = TBackupState(backupOwner, backupWriter, seqNo, inFlightBytesLimit);
-        }
-
-        void StopBackup() {
-            if (BackupState.Writer) {
-                Y_ENSURE(Ops, "Commit manager is not started");
-                Ops->Send(BackupState.Writer, new TEvents::TEvPoisonPill());
-            }
-            BackupState = TBackupState();
-        }
-
-        void DecBackupInFlight(ui64 bytes) {
-            Y_ENSURE(BackupState.InFlightBytes >= bytes);
-            BackupState.InFlightBytes -= bytes;
-        }
 
         ui64 Stamp() const noexcept
         {
@@ -207,20 +247,7 @@ namespace NTabletFlatExecutor {
 
         void SendCommitEv(TLogCommit &commit)
         {
-            if (BackupState.Writer && commit.Type == ECommit::Redo) {
-                auto backupEv = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs);
-                ui64 backupEvSize = backupEv->GetTotalSize();
-                if (BackupState.InFlightBytes + backupEvSize <= BackupState.InFlightBytesLimit) {
-                    BackupState.InFlightBytes += backupEvSize;
-                    Ops->Send(BackupState.Writer, backupEv.Release());
-                } else {
-                    auto error = TStringBuilder()
-                        << "Backup changelog in flight bytes limit exceeded: "
-                        << BackupState.InFlightBytes + backupEvSize << " > " << BackupState.InFlightBytesLimit;
-                    Ops->Send(BackupState.Owner, new NBackup::TEvChangelogFailed(BackupState.SeqNo, error));
-                    StopBackup();
-                }
-            }
+            BackupLogic.BackupCommit(commit);
 
             const bool snap = (commit.Type == ECommit::Snap);
 
@@ -255,10 +282,10 @@ namespace NTabletFlatExecutor {
         TGcLogic * const GcLogic = nullptr;
         TMonCo * MonCo = nullptr;
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Turns_;
-        TBackupState BackupState;
     public:
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Annex;
         NPageCollection::TSlicer Turns;
+        TBackupLogic BackupLogic;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -123,11 +123,12 @@ namespace NTabletFlatExecutor {
             if (BackupState.Writer) {
                 Y_ENSURE(Ops, "Commit manager is not started");
                 Ops->Send(BackupState.Writer, new TEvents::TEvPoisonPill());
-                BackupState = TBackupState();
             }
+            BackupState = TBackupState();
         }
 
         void DecBackupInFlight(ui64 bytes) {
+            Y_ENSURE(BackupState.InFlightBytes >= bytes);
             BackupState.InFlightBytes -= bytes;
         }
 

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -97,16 +97,28 @@ namespace NTabletFlatExecutor {
 
         void SetTactic(ETactic tactic) noexcept { Tactic = tactic; }
 
-        void SetBackupWriter(TActorId backupWriter) {
+        void StartBackup(TActorId backupOwner, TActorId backupWriter, ui64 seqNo, ui64 inFlightBytesLimit) {
+            StopBackup();
+            BackupOwner = backupOwner;
+            BackupWriter = backupWriter;
+            BackupSeqNo = seqNo;
+            BackupInFlightBytesLimit = inFlightBytesLimit;
+        }
+
+        void StopBackup() {
             if (BackupWriter) {
                 Y_ENSURE(Ops, "Commit manager is not started");
                 Ops->Send(BackupWriter, new TEvents::TEvPoisonPill());
             }
-            BackupWriter = backupWriter;
+            BackupOwner = TActorId();
+            BackupWriter = TActorId();
+            BackupInFlightBytes = 0;
+            BackupSeqNo = 0;
+            BackupInFlightBytesLimit = Max<ui64>();
         }
 
-        TActorId GetBackupWriter() const noexcept {
-            return BackupWriter;
+        void DecBackupInFlight(ui64 bytes) {
+            BackupInFlightBytes -= bytes;
         }
 
         ui64 Stamp() const noexcept
@@ -185,7 +197,14 @@ namespace NTabletFlatExecutor {
         void SendCommitEv(TLogCommit &commit)
         {
             if (BackupWriter && commit.Type == ECommit::Redo) {
-                Ops->Send(BackupWriter, new NBackup::TEvWriteChangelog(commit.Step, commit.Embedded, commit.Refs));
+                auto backupEv = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs);
+                if (BackupInFlightBytes + backupEv->GetTotalSize() <= BackupInFlightBytesLimit) {
+                    BackupInFlightBytes += backupEv->GetTotalSize();
+                    Ops->Send(BackupWriter, backupEv.Release());
+                } else {
+                    Ops->Send(BackupOwner, new NBackup::TEvChangelogFailed(BackupSeqNo, "Backup changelog in flight bytes limit exceeded"));
+                    StopBackup();
+                }
             }
 
             const bool snap = (commit.Type == ECommit::Snap);
@@ -221,8 +240,12 @@ namespace NTabletFlatExecutor {
         TGcLogic * const GcLogic = nullptr;
         TMonCo * MonCo = nullptr;
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Turns_;
-        TActorId BackupWriter;
 
+        TActorId BackupOwner;
+        TActorId BackupWriter;
+        ui64 BackupSeqNo = 0;
+        ui64 BackupInFlightBytes = 0;
+        ui64 BackupInFlightBytesLimit = Max<ui64>();
     public:
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Annex;
         NPageCollection::TSlicer Turns;

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -57,6 +57,23 @@ namespace NTabletFlatExecutor {
         using TGcLogic = TExecutorGCLogic;
         using TEvCommit = TEvTablet::TEvCommit;
 
+        struct TBackupState {
+            TActorId Owner;
+            TActorId Writer;
+            ui64 SeqNo = 0;
+            ui64 InFlightBytes = 0;
+            ui64 InFlightBytesLimit = Max<ui64>();
+
+            TBackupState() = default;
+            TBackupState(TActorId owner, TActorId writer, ui64 seqNo, ui64 inFlightBytesLimit)
+                : Owner(owner)
+                , Writer(writer)
+                , SeqNo(seqNo)
+                , InFlightBytes(0)
+                , InFlightBytesLimit(inFlightBytesLimit)
+            {}
+        };
+
         TCommitManager(NBoot::TSteppedCookieAllocatorFactory &steppedCookieAllocatorFactory, TIntrusivePtr<NSnap::TWaste> waste, TGcLogic *logic)
             : Tablet(steppedCookieAllocatorFactory.Tablet)
             , Gen(steppedCookieAllocatorFactory.Gen)
@@ -92,33 +109,26 @@ namespace NTabletFlatExecutor {
         void Stop() const
         {
             Y_ENSURE(Ops, "Commit manager is not started");
-            Ops->Send(BackupWriter, new TEvents::TEvPoisonPill());
+            Ops->Send(BackupState.Writer, new TEvents::TEvPoisonPill());
         }
 
         void SetTactic(ETactic tactic) noexcept { Tactic = tactic; }
 
         void StartBackup(TActorId backupOwner, TActorId backupWriter, ui64 seqNo, ui64 inFlightBytesLimit) {
             StopBackup();
-            BackupOwner = backupOwner;
-            BackupWriter = backupWriter;
-            BackupSeqNo = seqNo;
-            BackupInFlightBytesLimit = inFlightBytesLimit;
+            BackupState = TBackupState(backupOwner, backupWriter, seqNo, inFlightBytesLimit);
         }
 
         void StopBackup() {
-            if (BackupWriter) {
+            if (BackupState.Writer) {
                 Y_ENSURE(Ops, "Commit manager is not started");
-                Ops->Send(BackupWriter, new TEvents::TEvPoisonPill());
+                Ops->Send(BackupState.Writer, new TEvents::TEvPoisonPill());
+                BackupState = TBackupState();
             }
-            BackupOwner = TActorId();
-            BackupWriter = TActorId();
-            BackupInFlightBytes = 0;
-            BackupSeqNo = 0;
-            BackupInFlightBytesLimit = Max<ui64>();
         }
 
         void DecBackupInFlight(ui64 bytes) {
-            BackupInFlightBytes -= bytes;
+            BackupState.InFlightBytes -= bytes;
         }
 
         ui64 Stamp() const noexcept
@@ -196,13 +206,17 @@ namespace NTabletFlatExecutor {
 
         void SendCommitEv(TLogCommit &commit)
         {
-            if (BackupWriter && commit.Type == ECommit::Redo) {
+            if (BackupState.Writer && commit.Type == ECommit::Redo) {
                 auto backupEv = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs);
-                if (BackupInFlightBytes + backupEv->GetTotalSize() <= BackupInFlightBytesLimit) {
-                    BackupInFlightBytes += backupEv->GetTotalSize();
-                    Ops->Send(BackupWriter, backupEv.Release());
+                ui64 backupEvSize = backupEv->GetTotalSize();
+                if (BackupState.InFlightBytes + backupEvSize <= BackupState.InFlightBytesLimit) {
+                    BackupState.InFlightBytes += backupEvSize;
+                    Ops->Send(BackupState.Writer, backupEv.Release());
                 } else {
-                    Ops->Send(BackupOwner, new NBackup::TEvChangelogFailed(BackupSeqNo, "Backup changelog in flight bytes limit exceeded"));
+                    auto error = TStringBuilder()
+                        << "Backup changelog in flight bytes limit exceeded: "
+                        << BackupState.InFlightBytes + backupEvSize << " > " << BackupState.InFlightBytesLimit;
+                    Ops->Send(BackupState.Owner, new NBackup::TEvChangelogFailed(BackupState.SeqNo, error));
                     StopBackup();
                 }
             }
@@ -240,12 +254,7 @@ namespace NTabletFlatExecutor {
         TGcLogic * const GcLogic = nullptr;
         TMonCo * MonCo = nullptr;
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Turns_;
-
-        TActorId BackupOwner;
-        TActorId BackupWriter;
-        ui64 BackupSeqNo = 0;
-        ui64 BackupInFlightBytes = 0;
-        ui64 BackupInFlightBytesLimit = Max<ui64>();
+        TBackupState BackupState;
     public:
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Annex;
         NPageCollection::TSlicer Turns;

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5171,57 +5171,58 @@ void TExecutor::StartNewBackup() {
     const auto& tables = scheme.Tables;
     auto exclusion = Owner->BackupExclusion();
 
-    // Ensure that no backup snapshot is in progress
-    Y_ENSURE(!BackupInfo.SnapshotWriter);
-    BackupInfo.SnapshotCompleted = false;
+    Y_ENSURE(!BackupSnapshotInProgress);
 
     // Stop the old backup changelog
-    CommitManager->StopBackup();
-    ++BackupInfo.ChangelogWriterSeqNo;
-    BackupInfo.ChangelogWriter = TActorId();
+    CommitManager->BackupLogic.Stop();
 
     auto* snapshotWriter = NBackup::CreateSnapshotWriter(SelfId(), backupConfig, tables, tabletType,
         tabletId, Generation0, Step0, scheme.GetSnapshot(), exclusion);
-    auto* changelogWriter = NBackup::CreateChangelogWriter(SelfId(), BackupInfo.ChangelogWriterSeqNo, backupConfig, tabletType,
+    auto* changelogWriter = NBackup::CreateChangelogWriter(SelfId(), backupConfig, tabletType,
         tabletId, Generation0, Step0, scheme, exclusion);
 
     if (snapshotWriter && changelogWriter) {
-        BackupInfo.SnapshotWriter = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
+        auto snapshotWriterActor = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
         for (const auto& [tableId, table] : tables) {
             if (exclusion && exclusion->HasTable(tableId)) {
                 continue;
             }
 
             auto opts = TScanOptions().SetResourceBroker("system_tablet_backup", 10);
-            QueueScan(tableId, NBackup::CreateSnapshotScan(BackupInfo.SnapshotWriter, tableId, table.Columns, exclusion), 0, opts);
+            QueueScan(tableId, NBackup::CreateSnapshotScan(snapshotWriterActor, tableId, table.Columns, exclusion), 0, opts);
         }
-        BackupInfo.ChangelogWriter = Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
-        auto inFlightLimit = backupConfig.GetChangelogInFlightBytesLimit();
-        CommitManager->StartBackup(SelfId(), BackupInfo.ChangelogWriter, BackupInfo.ChangelogWriterSeqNo, inFlightLimit);
+        BackupSnapshotInProgress = true;
+
+        auto changelogWriterActor = Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
+        CommitManager->BackupLogic.Start(this, SelfId(), changelogWriterActor, backupConfig.GetChangelogInFlightBytesLimit());
     }
 }
 
 void TExecutor::Handle(NBackup::TEvWriteChangelogAck::TPtr& ev) {
-    if (ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+    if (ev->Sender != CommitManager->BackupLogic.GetWriter()) {
         return;
     }
 
-    CommitManager->DecBackupInFlight(ev->Get()->ProcessedBytes);
+    CommitManager->BackupLogic.OnProcessedBytes(ev->Get()->ProcessedBytes);
 }
 
 void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
-    BackupInfo.SnapshotWriter = TActorId();
-    BackupInfo.SnapshotCompleted = true;
+    BackupSnapshotInProgress = false;
     if (ev->Get()->Success) {
         Owner->BackupSnapshotComplete(OwnerCtx());
-        Forward(ev, BackupInfo.ChangelogWriter);
+
+        if (CommitManager->BackupLogic.IsRunning()) {
+            CommitManager->BackupLogic.OnSnapshotCompleted(ev);
+        } else {
+            ScheduleRetryBackup();
+        }
     } else {
         FailBackup("Backup snapshot failed: " + ev->Get()->Error);
     }
 }
 
 void TExecutor::Handle(NBackup::TEvChangelogFailed::TPtr& ev) {
-    if (ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+    if (ev->Sender != SelfId() && ev->Sender != CommitManager->BackupLogic.GetWriter()) {
         return;
     }
 
@@ -5236,18 +5237,19 @@ void TExecutor::FailBackup(const TString& error) {
     }
 
     LOG_ERROR_S(*TlsActivationContext, NKikimrServices::LOCAL_DB_BACKUP, error);
-    CommitManager->StopBackup();
-    ++BackupInfo.ChangelogWriterSeqNo;
-    BackupInfo.ChangelogWriter = TActorId();
+    CommitManager->BackupLogic.Stop();
+    ScheduleRetryBackup();
+}
 
-    if (BackupInfo.SnapshotCompleted) {
-        auto retryTimeout = TDuration::Seconds(backupConfig.GetRetryBackupTimeoutSeconds());
+void TExecutor::ScheduleRetryBackup() const {
+    if (!BackupSnapshotInProgress) {
+        auto retryTimeout = TDuration::Seconds(AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
         Schedule(retryTimeout, new NBackup::TEvStartNewBackup);
     }
 }
 
 void TExecutor::Handle(NBackup::TEvStartNewBackup::TPtr& ev) {
-    if (ev->Get()->SeqNo && ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+    if (ev->Sender != SelfId() && ev->Sender != CommitManager->BackupLogic.GetWriter()) {
         return;
     }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5222,7 +5222,7 @@ void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
 }
 
 void TExecutor::Handle(NBackup::TEvChangelogFailed::TPtr& ev) {
-    if (ev->Sender != SelfId() && ev->Sender != CommitManager->BackupLogic.GetWriter()) {
+    if (ev->Sender != CommitManager->BackupLogic.GetWriter()) {
         return;
     }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5224,7 +5224,7 @@ void TExecutor::Handle(NBackup::TEvChangelogFailed::TPtr& ev) {
 void TExecutor::FailBackup(const TString& error) {
     const auto& backupConfig = AppData()->SystemTabletBackupConfig;
 
-    if (backupConfig.GetFailBehaviour() == NKikimrConfig::TSystemTabletBackupConfig::TABLET_CRASH) {
+    if (backupConfig.GetFailBehaviour() == NKikimrConfig::TSystemTabletBackupConfig::TABLET_RESTART) {
         Y_TABLET_ERROR(error);
     }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5171,8 +5171,14 @@ void TExecutor::StartNewBackup() {
     const auto& tables = scheme.Tables;
     auto exclusion = Owner->BackupExclusion();
 
-    ++BackupInfo.ChangelogWriterSeqNo;
+    // Ensure that no backup snapshot is in progress
+    Y_ENSURE(!BackupInfo.SnapshotWriter);
     BackupInfo.SnapshotCompleted = false;
+
+    // Stop the old backup changelog
+    CommitManager->StopBackup();
+    ++BackupInfo.ChangelogWriterSeqNo;
+    BackupInfo.ChangelogWriter = TActorId();
 
     auto* snapshotWriter = NBackup::CreateSnapshotWriter(SelfId(), backupConfig, tables, tabletType,
         tabletId, Generation0, Step0, scheme.GetSnapshot(), exclusion);
@@ -5204,6 +5210,7 @@ void TExecutor::Handle(NBackup::TEvWriteChangelogAck::TPtr& ev) {
 }
 
 void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
+    BackupInfo.SnapshotWriter = TActorId();
     BackupInfo.SnapshotCompleted = true;
     if (ev->Get()->Success) {
         Owner->BackupSnapshotComplete(OwnerCtx());
@@ -5231,6 +5238,7 @@ void TExecutor::FailBackup(const TString& error) {
     LOG_ERROR_S(*TlsActivationContext, NKikimrServices::LOCAL_DB_BACKUP, error);
     CommitManager->StopBackup();
     ++BackupInfo.ChangelogWriterSeqNo;
+    BackupInfo.ChangelogWriter = TActorId();
 
     if (BackupInfo.SnapshotCompleted) {
         auto retryTimeout = TDuration::Seconds(backupConfig.GetRetryBackupTimeoutSeconds());

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4380,7 +4380,8 @@ STFUNC(TExecutor::StateWork) {
         hFunc(TEvTablet::TEvGcForStepAckResponse, Handle);
         hFunc(NBackup::TEvSnapshotCompleted, Handle);
         hFunc(NBackup::TEvChangelogFailed, Handle);
-        cFunc(NBackup::TEvStartNewBackup::EventType, StartNewBackup);
+        hFunc(NBackup::TEvStartNewBackup, Handle);
+        hFunc(NBackup::TEvWriteChangelogAck, Handle);
     default:
         break;
     }
@@ -5170,36 +5171,79 @@ void TExecutor::StartNewBackup() {
     const auto& tables = scheme.Tables;
     auto exclusion = Owner->BackupExclusion();
 
+    ++BackupInfo.ChangelogWriterSeqNo;
+    BackupInfo.SnapshotCompleted = false;
+
     auto* snapshotWriter = NBackup::CreateSnapshotWriter(SelfId(), backupConfig, tables, tabletType,
         tabletId, Generation0, Step0, scheme.GetSnapshot(), exclusion);
-    auto* changelogWriter = NBackup::CreateChangelogWriter(SelfId(), backupConfig, tabletType,
+    auto* changelogWriter = NBackup::CreateChangelogWriter(SelfId(), BackupInfo.ChangelogWriterSeqNo, backupConfig, tabletType,
         tabletId, Generation0, Step0, scheme, exclusion);
 
     if (snapshotWriter && changelogWriter) {
-        auto snapshotWriterActor = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
+        BackupInfo.SnapshotWriter = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
         for (const auto& [tableId, table] : tables) {
             if (exclusion && exclusion->HasTable(tableId)) {
                 continue;
             }
 
             auto opts = TScanOptions().SetResourceBroker("system_tablet_backup", 10);
-            QueueScan(tableId, NBackup::CreateSnapshotScan(snapshotWriterActor, tableId, table.Columns, exclusion), 0, opts);
+            QueueScan(tableId, NBackup::CreateSnapshotScan(BackupInfo.SnapshotWriter, tableId, table.Columns, exclusion), 0, opts);
         }
-        CommitManager->SetBackupWriter(Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId));
+        BackupInfo.ChangelogWriter = Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
+        auto inFlightLimit = backupConfig.GetChangelogInFlightBytesLimit();
+        CommitManager->StartBackup(SelfId(), BackupInfo.ChangelogWriter, BackupInfo.ChangelogWriterSeqNo, inFlightLimit);
     }
 }
 
-void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
-    Y_ENSURE(ev->Get()->Success, "Backup snapshot failed: " + ev->Get()->Error);
-    Owner->BackupSnapshotComplete(OwnerCtx());
+void TExecutor::Handle(NBackup::TEvWriteChangelogAck::TPtr& ev) {
+    if (ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+        return;
+    }
 
-    if (CommitManager) {
-        Forward(ev, CommitManager->GetBackupWriter());
+    CommitManager->DecBackupInFlight(ev->Get()->ProcessedBytes);
+}
+
+void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
+    BackupInfo.SnapshotCompleted = true;
+    if (ev->Get()->Success) {
+        Owner->BackupSnapshotComplete(OwnerCtx());
+        Forward(ev, BackupInfo.ChangelogWriter);
+    } else {
+        FailBackup("Backup snapshot failed: " + ev->Get()->Error);
     }
 }
 
 void TExecutor::Handle(NBackup::TEvChangelogFailed::TPtr& ev) {
-    Y_TABLET_ERROR("Backup changelog failed: " + ev->Get()->Error);
+    if (ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+        return;
+    }
+
+    FailBackup("Backup changelog failed: " + ev->Get()->Error);
+}
+
+void TExecutor::FailBackup(const TString& error) {
+    const auto& backupConfig = AppData()->SystemTabletBackupConfig;
+
+    if (backupConfig.GetFailBehaviour() == NKikimrConfig::TSystemTabletBackupConfig::TABLET_CRASH) {
+        Y_TABLET_ERROR(error);
+    }
+
+    LOG_ERROR_S(*TlsActivationContext, NKikimrServices::LOCAL_DB_BACKUP, error);
+    CommitManager->StopBackup();
+    ++BackupInfo.ChangelogWriterSeqNo;
+
+    if (BackupInfo.SnapshotCompleted) {
+        auto retryTimeout = TDuration::Seconds(backupConfig.GetRetryBackupTimeoutSeconds());
+        Schedule(retryTimeout, new NBackup::TEvStartNewBackup);
+    }
+}
+
+void TExecutor::Handle(NBackup::TEvStartNewBackup::TPtr& ev) {
+    if (ev->Get()->SeqNo && ev->Get()->SeqNo != BackupInfo.ChangelogWriterSeqNo) {
+        return;
+    }
+
+    StartNewBackup();
 }
 
 }

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -503,7 +503,7 @@ class TExecutor
     ui64 UsedTabletMemory = 0;
     ui64 TransactionPagesMemory = 0;
 
-    NBackup::TBackupInfo BackupInfo;
+    bool BackupSnapshotInProgress = false;
 
     TActorContext SelfCtx() const;
     TActorContext OwnerCtx() const;
@@ -560,6 +560,7 @@ class TExecutor
     void DropPageCollection(const TLogoBlobID& pageCollectionId);
     void StartNewBackup();
     void FailBackup(const TString& error);
+    void ScheduleRetryBackup() const;
 
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
     void UpdateCachePagesForDatabase(bool pendingOnly = false);

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -503,6 +503,8 @@ class TExecutor
     ui64 UsedTabletMemory = 0;
     ui64 TransactionPagesMemory = 0;
 
+    NBackup::TBackupInfo BackupInfo;
+
     TActorContext SelfCtx() const;
     TActorContext OwnerCtx() const;
 
@@ -557,6 +559,7 @@ class TExecutor
     void DropPartStorePageCollections(const NTable::TPart &part);
     void DropPageCollection(const TLogoBlobID& pageCollectionId);
     void StartNewBackup();
+    void FailBackup(const TString& error);
 
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
     void UpdateCachePagesForDatabase(bool pendingOnly = false);
@@ -613,6 +616,8 @@ class TExecutor
     void Handle(TEvTablet::TEvGcForStepAckResponse::TPtr &ev);
     void Handle(NBackup::TEvSnapshotCompleted::TPtr &ev);
     void Handle(NBackup::TEvChangelogFailed::TPtr &ev);
+    void Handle(NBackup::TEvWriteChangelogAck::TPtr &ev);
+    void Handle(NBackup::TEvStartNewBackup::TPtr &ev);
 
     void UpdateUsedTabletMemory();
     void UpdateCounters(const TActorContext &ctx);

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -766,10 +766,9 @@ class TChangelogWriter : public TActorBootstrapped<TChangelogWriter>, public IAc
         };
     };
 public:
-    TChangelogWriter(TActorId owner, ui64 seqNo, const TFsPath& path, const TScheme& schema,
+    TChangelogWriter(TActorId owner, const TFsPath& path, const TScheme& schema,
                      TIntrusiveConstPtr<TBackupExclusion> exclusion)
         : Owner(owner)
-        , SeqNo(seqNo)
         , ChangelogPath(path.Child("changelog.json"))
         , ChangelogChecksumPath(path.Child("changelog.json.sha256"))
         , Schema(schema)
@@ -813,7 +812,7 @@ public:
         NJsonWriter::TBuf b(NJsonWriter::HEM_RELAXED, &out);
 
         const auto* msg = ev->Get();
-        ui64 msgSize = msg->GetTotalSize();
+        const ui64 msgSize = msg->GetTotalSize();
 
         TString dataUpdate;
         TString schemeUpdate;
@@ -910,12 +909,9 @@ public:
 
             size_t changesSize = Buffer.Size() - changesStart;
             Checksum.Update(Buffer.data() + changesStart, changesSize);
-
-            InFlightRedoBytes += msgSize;
-        } else {
-            // generated no new changes, send ack immediately
-            Send(Owner, new TEvWriteChangelogAck(SeqNo, msgSize));
         }
+
+        Send(Owner, new TEvWriteChangelogAck(msgSize));
 
         if (Buffer.Size() >= 1_MB) {
             Flush();
@@ -965,11 +961,8 @@ public:
                 return;
             }
 
-            Send(Owner, new TEvWriteChangelogAck(SeqNo, InFlightRedoBytes));
-            InFlightRedoBytes = 0;
-
             if (NeedNewBackup()) {
-                Send(Owner, new TEvStartNewBackup(SeqNo));
+                Send(Owner, new TEvStartNewBackup());
             }
         }
         Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
@@ -983,7 +976,7 @@ public:
 
     void ReplyAndDie(const TString& error) {
         if (!Dying) {
-            Send(Owner, new TEvChangelogFailed(SeqNo, error));
+            Send(Owner, new TEvChangelogFailed(error));
             PassAway();
         }
     }
@@ -1004,7 +997,6 @@ public:
 
 private:
     TActorId Owner;
-    ui64 SeqNo;
 
     TFsPath ChangelogPath;
     TFsPath ChangelogChecksumPath;
@@ -1017,7 +1009,6 @@ private:
     ui64 ExpectedFlushCookie = 0;
 
     bool Dying = false;
-    ui64 InFlightRedoBytes = 0;
     ui64 WrittenBytes = 0;
     std::optional<ui64> SnapshotWrittenBytes;
 
@@ -1044,14 +1035,14 @@ IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<
     return new TBackupSnapshotScan(snapshotWriter, tableId, columns, exclusion);
 }
 
-IActor* CreateChangelogWriter(TActorId owner, ui64 seqNo, const NKikimrConfig::TSystemTabletBackupConfig& config,
+IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                               TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                               const TScheme& schema, TIntrusiveConstPtr<TBackupExclusion> exclusion)
 {
     if (config.HasFilesystem()) {
         auto path = TFsPath(config.GetFilesystem().GetPath())
             .Child(CreateBackupPath(tabletType, tabletId, generation, step));
-        return new TChangelogWriter(owner, seqNo, path, schema, exclusion);
+        return new TChangelogWriter(owner, path, schema, exclusion);
     } else {
         return nullptr;
     }

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -751,14 +751,12 @@ private:
 class TChangelogWriter : public TActorBootstrapped<TChangelogWriter>, public IActorExceptionHandler {
     struct TEvPrivate {
         enum EEv {
-            EvMailboxCleaned = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
-            EvFlush,
+            EvFlush = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
             EvEnd
         };
 
         static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE));
 
-        struct TEvMailboxCleaned : TEventLocal<TEvMailboxCleaned, EvMailboxCleaned> {};
         struct TEvFlush : TEventLocal<TEvFlush, EvFlush> {
             TEvFlush(ui64 cookie)
                 : Cookie(cookie)
@@ -768,9 +766,10 @@ class TChangelogWriter : public TActorBootstrapped<TChangelogWriter>, public IAc
         };
     };
 public:
-    TChangelogWriter(TActorId owner, const TFsPath& path, const TScheme& schema,
+    TChangelogWriter(TActorId owner, ui64 seqNo, const TFsPath& path, const TScheme& schema,
                      TIntrusiveConstPtr<TBackupExclusion> exclusion)
         : Owner(owner)
+        , SeqNo(seqNo)
         , ChangelogPath(path.Child("changelog.json"))
         , ChangelogChecksumPath(path.Child("changelog.json.sha256"))
         , Schema(schema)
@@ -801,8 +800,7 @@ public:
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvWriteChangelog, Handle);
             hFunc(TEvPrivate::TEvFlush, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, CleanMailbox);
-            cFunc(TEvPrivate::TEvMailboxCleaned::EventType, FlushAndDie);
+            cFunc(TEvents::TEvPoisonPill::EventType, FlushAndDie);
             hFunc(TEvSnapshotCompleted, Handle);
         }
     }
@@ -815,6 +813,7 @@ public:
         NJsonWriter::TBuf b(NJsonWriter::HEM_RELAXED, &out);
 
         const auto* msg = ev->Get();
+        ui64 msgSize = msg->GetTotalSize();
 
         TString dataUpdate;
         TString schemeUpdate;
@@ -911,6 +910,11 @@ public:
 
             size_t changesSize = Buffer.Size() - changesStart;
             Checksum.Update(Buffer.data() + changesStart, changesSize);
+
+            InFlightRedoBytes += msgSize;
+        } else {
+            // generated no new changes, send ack immediately
+            Send(Owner, new TEvWriteChangelogAck(SeqNo, msgSize));
         }
 
         if (Buffer.Size() >= 1_MB) {
@@ -961,26 +965,27 @@ public:
                 return;
             }
 
+            Send(Owner, new TEvWriteChangelogAck(SeqNo, InFlightRedoBytes));
+            InFlightRedoBytes = 0;
+
             if (NeedNewBackup()) {
-                Send(Owner, new TEvStartNewBackup);
+                Send(Owner, new TEvStartNewBackup(SeqNo));
             }
         }
         Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
     }
 
-    void CleanMailbox() {
-        Dying = true;
-        Send(SelfId(), new TEvPrivate::TEvMailboxCleaned());
-    }
-
     void FlushAndDie() {
+        Dying = true;
         Flush();
         PassAway();
     }
 
     void ReplyAndDie(const TString& error) {
-        Send(Owner, new TEvChangelogFailed(error));
-        PassAway();
+        if (!Dying) {
+            Send(Owner, new TEvChangelogFailed(SeqNo, error));
+            PassAway();
+        }
     }
 
     void WriteChangelogChecksum() {
@@ -999,6 +1004,7 @@ public:
 
 private:
     TActorId Owner;
+    ui64 SeqNo;
 
     TFsPath ChangelogPath;
     TFsPath ChangelogChecksumPath;
@@ -1011,6 +1017,7 @@ private:
     ui64 ExpectedFlushCookie = 0;
 
     bool Dying = false;
+    ui64 InFlightRedoBytes = 0;
     ui64 WrittenBytes = 0;
     std::optional<ui64> SnapshotWrittenBytes;
 
@@ -1037,14 +1044,14 @@ IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<
     return new TBackupSnapshotScan(snapshotWriter, tableId, columns, exclusion);
 }
 
-IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
+IActor* CreateChangelogWriter(TActorId owner, ui64 seqNo, const NKikimrConfig::TSystemTabletBackupConfig& config,
                               TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                               const TScheme& schema, TIntrusiveConstPtr<TBackupExclusion> exclusion)
 {
     if (config.HasFilesystem()) {
         auto path = TFsPath(config.GetFilesystem().GetPath())
             .Child(CreateBackupPath(tabletType, tabletId, generation, step));
-        return new TChangelogWriter(owner, path, schema, exclusion);
+        return new TChangelogWriter(owner, seqNo, path, schema, exclusion);
     } else {
         return nullptr;
     }

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -91,42 +91,22 @@ struct TEvWriteChangelog : public TEventLocal<TEvWriteChangelog, EvWriteChangelo
 };
 
 struct TEvWriteChangelogAck : public TEventLocal<TEvWriteChangelogAck, EvWriteChangelogAck> {
-    TEvWriteChangelogAck(ui64 seqNo, ui64 processedBytes)
-        : SeqNo(seqNo)
-        , ProcessedBytes(processedBytes)
+    TEvWriteChangelogAck(ui64 processedBytes)
+        : ProcessedBytes(processedBytes)
     {}
 
-    ui64 SeqNo;
     ui64 ProcessedBytes;
 };
 
 struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFailed> {
-    TEvChangelogFailed(ui64 seqNo, const TString& error)
-        : SeqNo(seqNo)
-        , Error(error)
+    TEvChangelogFailed(const TString& error)
+        : Error(error)
     {}
 
-    ui64 SeqNo;
     TString Error;
 };
 
-struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBackup> {
-    TEvStartNewBackup() = default;
-
-    TEvStartNewBackup(ui64 seqNo)
-        : SeqNo(seqNo)
-    {}
-
-    ui64 SeqNo = 0;
-};
-
-struct TBackupInfo {
-    ui64 ChangelogWriterSeqNo = 0;
-    bool SnapshotCompleted = false;
-
-    TActorId SnapshotWriter;
-    TActorId ChangelogWriter;
-};
+struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBackup> {};
 
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, NTable::TScheme::TTableInfo>& tables,
@@ -136,7 +116,7 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
 NTable::IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, NTable::TColumn>& columns,
                                   TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
-IActor* CreateChangelogWriter(TActorId owner, ui64 seqNo, const NKikimrConfig::TSystemTabletBackupConfig& config,
+IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                               TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                               const NTable::TScheme& schema, TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -22,6 +22,7 @@ enum EEv {
     EvSnapshotCompleted,
 
     EvWriteChangelog,
+    EvWriteChangelogAck,
     EvChangelogFailed,
 
     EvStartNewBackup,
@@ -76,20 +77,56 @@ struct TEvWriteChangelog : public TEventLocal<TEvWriteChangelog, EvWriteChangelo
         , References(references)
     {}
 
+    ui64 GetTotalSize() const {
+        ui64 totalSize = EmbeddedLogBody.size();
+        for (const auto& ref : References) {
+            totalSize += ref.Buffer.size();
+        }
+        return totalSize;
+    }
+
     ui32 Step;
     TString EmbeddedLogBody;
     TVector<TEvTablet::TLogEntryReference> References;
 };
 
-struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFailed> {
-    TEvChangelogFailed(const TString& error)
-        : Error(error)
+struct TEvWriteChangelogAck : public TEventLocal<TEvWriteChangelogAck, EvWriteChangelogAck> {
+    TEvWriteChangelogAck(ui64 seqNo, ui64 processedBytes)
+        : SeqNo(seqNo)
+        , ProcessedBytes(processedBytes)
     {}
 
+    ui64 SeqNo;
+    ui64 ProcessedBytes;
+};
+
+struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFailed> {
+    TEvChangelogFailed(ui64 seqNo, const TString& error)
+        : SeqNo(seqNo)
+        , Error(error)
+    {}
+
+    ui64 SeqNo;
     TString Error;
 };
 
-struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBackup> {};
+struct TEvStartNewBackup : public TEventLocal<TEvStartNewBackup, EvStartNewBackup> {
+    TEvStartNewBackup() = default;
+
+    TEvStartNewBackup(ui64 seqNo)
+        : SeqNo(seqNo)
+    {}
+
+    ui64 SeqNo = 0;
+};
+
+struct TBackupInfo {
+    ui64 ChangelogWriterSeqNo = 0;
+    bool SnapshotCompleted = false;
+
+    TActorId SnapshotWriter;
+    TActorId ChangelogWriter;
+};
 
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                              const THashMap<ui32, NTable::TScheme::TTableInfo>& tables,
@@ -99,7 +136,7 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
 NTable::IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, NTable::TColumn>& columns,
                                   TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
-IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
+IActor* CreateChangelogWriter(TActorId owner, ui64 seqNo, const NKikimrConfig::TSystemTabletBackupConfig& config,
                               TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,
                               const NTable::TScheme& schema, TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -976,13 +976,60 @@ Y_UNIT_TEST_SUITE(Backup) {
         TEnv env;
 
         TFsPath(env->GetTempDir()).Child("dummy").MkDir(S_IRUSR);
-        env->GetAppData().FeatureFlags.SetEnableTabletRestartOnUnhandledExceptions(true);
+
+        TBlockEvents<TEvChangelogFailed> blockChangelog(env.Env);
+        TBlockEvents<TEvSnapshotCompleted> blockSnapshot(env.Env, [](const TEvSnapshotCompleted::TPtr& ev) {
+            return !ev->Get()->Success;
+        });
 
         Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);
 
-        Cerr << "...waiting tablet death" << Endl;
-        env.WaitForGone(); // crash on IO error
+        env->WaitFor("snapshot completed with error", [&]{ return !blockSnapshot.empty(); });
+        blockSnapshot.Stop().Unblock();
+        blockChangelog.Stop().Unblock();
+
+        Cerr << "...verifying tablet is alive" << Endl;
+        env.InitSchema();
+        env.WriteValue(1, 10);
+        UNIT_ASSERT_VALUES_EQUAL(env.ReadValue<TSchema::Data::Value>(1), 10);
+
+        TFsPath(env->GetTempDir()).Child("dummy").ForceDelete();
+
+        Cerr << "...backup retry should start automatically" << Endl;
+        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        env.Env.AdvanceCurrentTime(retryTimeout);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+    }
+
+    Y_UNIT_TEST(ChangelogIOError) {
+        TEnv env;
+
+        TFsPath(env->GetTempDir()).Child("dummy").MkDir(S_IRUSR);
+
+        TBlockEvents<TEvChangelogFailed> blockChangelog(env.Env);
+        TBlockEvents<TEvSnapshotCompleted> blockSnapshot(env.Env, [](const TEvSnapshotCompleted::TPtr& ev) {
+            return !ev->Get()->Success;
+        });
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+
+        env->WaitFor("changelog failed", [&]{ return !blockChangelog.empty(); });
+        blockChangelog.Stop().Unblock();
+        blockSnapshot.Stop().Unblock();
+
+        Cerr << "...verifying tablet is alive" << Endl;
+        env.InitSchema();
+        env.WriteValue(1, 10);
+        UNIT_ASSERT_VALUES_EQUAL(env.ReadValue<TSchema::Data::Value>(1), 10);
+
+        TFsPath(env->GetTempDir()).Child("dummy").ForceDelete();
+
+        Cerr << "...backup retry should start automatically" << Endl;
+        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        env.Env.AdvanceCurrentTime(retryTimeout);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
     }
 
     Y_UNIT_TEST(EmptyData) {
@@ -3110,6 +3157,59 @@ Y_UNIT_TEST_SUITE(Backup) {
         env.DryRunRestoreBackup(backup,  /*skipChecksumValidation=*/ true);
         env.RestartTablet(TestTabletFlags);
         assertState();
+    }
+
+    Y_UNIT_TEST(ChangelogInFlightLimitExceeded) {
+        TEnv env;
+        env->GetAppData().SystemTabletBackupConfig.SetChangelogInFlightBytesLimit(1);
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        TBlockEvents<TEvChangelogFailed> block(env.Env);
+
+        Cerr << "...writing data (should exceed in-flight limit)" << Endl;
+        env.InitSchema();
+        env.WriteValue(1, 10);
+
+        env->WaitFor("changelog failed", [&]{ return !block.empty(); });
+        block.Stop().Unblock();
+
+        Cerr << "...verifying tablet is alive" << Endl;
+        env.WriteValue(3, 30);
+        UNIT_ASSERT_VALUES_EQUAL(env.ReadValue<TSchema::Data::Value>(3), 30);
+
+        Cerr << "...backup retry should start automatically" << Endl;
+        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        env.Env.AdvanceCurrentTime(retryTimeout);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+    }
+
+    Y_UNIT_TEST(ChangelogInFlightLimit) {
+        TEnv env;
+        env->GetAppData().SystemTabletBackupConfig.SetChangelogInFlightBytesLimit(1_MB);
+
+        Cerr << "...starting tablet" << Endl;
+        env.FireDummyTablet(TestTabletFlags);
+        env.WaitFor<NFake::TEvSnapshotBackedUp>();
+
+        Cerr << "...initing schema" << Endl;
+        env.InitSchema();
+
+        bool changelogFailed = false;
+        auto failObserver = env.Env.AddObserver<TEvChangelogFailed>(
+            [&changelogFailed](TEvChangelogFailed::TPtr&) {
+                changelogFailed = true;
+        });
+
+        Cerr << "...writing data in many commits" << Endl;
+        TString data(1'000, 'a'); // make commit large enough
+        for (int i = 0; i < 1'000; ++i) {
+            env.WriteBinaryValue(i, data);
+        }
+
+        UNIT_ASSERT_C(!changelogFailed, "In-flight limit must not be exceeded");
     }
 }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR aims to introduce flow control/backpressure for system tablet backups by tracking “in-flight” changelog bytes and acknowledging processed bytes from the changelog writer, with additional configuration knobs for limits and failure behavior.
