### PR TITLE
Forbid requests with empty database to static nodes P.2

### DIFF
--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -207,7 +207,7 @@ class TDefaultNodeBrokerClient
             const TString& nodeRegistrationToken,
             const IEnv& env)
     {
-        NYdb::TDriverConfig config = CreateDriverConfig(grpcSettings, addr, env, nodeRegistrationToken);
+        NYdb::TDriverConfig config = CreateDriverConfig(grpcSettings, addr, env, settings.DomainPath_, nodeRegistrationToken);
         auto connection = NYdb::TDriver(config);
 
         auto client = NYdb::NDiscovery::TDiscoveryClient(connection);
@@ -353,11 +353,11 @@ RetryResult RetryWithJitter(
         ui64 multiplier = 1ULL << exponent;
         TDuration delay = baseDelay * multiplier;
         delay = Min(delay, maxDelay);
-        
+
         ui64 maxMs = delay.MilliSeconds();
         ui64 jitteredMs = RandomNumber<ui64>(maxMs + 1);
         TDuration jitteredDelay = TDuration::MilliSeconds(jitteredMs);
-        
+
         env.Sleep(jitteredDelay);
     };
 
@@ -370,22 +370,22 @@ RetryResult RetryWithJitter(
         for (const auto& addr : addrs) {
             success = attempt(addr);
             ++totalAttempts;
-            
+
             if (success) {
                 break;
             }
-            
+
             // Exponential delay between individual addresses - delay grows with each address in the round
             if (addrs.size() > 1) {
                 sleepWithJitteredExponentialDelay(baseAddressDelay, maxIntraAddrDelay, Max(addressIndex, round));
             }
-            
+
             ++addressIndex;
         }
-        
+
         if (!success) {
             ++round;
-            
+
             if (round < maxRounds) {
                 sleepWithJitteredExponentialDelay(baseRoundDelay, maxDelay, round - 1);
             }
@@ -462,8 +462,8 @@ public:
         const auto result = RetryWithJitter(addrs, env, attempt);
 
         if (!result.Success) {
-            logger.Err() << "WARNING: couldn't load config from Console after " 
-                        << result.TotalAttempts << " attempts across " << result.Rounds 
+            logger.Err() << "WARNING: couldn't load config from Console after "
+                        << result.TotalAttempts << " attempts across " << result.Rounds
                         << " rounds: " << error << Endl;
         }
 
@@ -475,7 +475,7 @@ class TConfigResultWrapper
     : public IStorageConfigResult
 {
 public:
-    TConfigResultWrapper(const NYdb::NConfig::TFetchConfigResult& result, const TString& sourceAddress = TString()) 
+    TConfigResultWrapper(const NYdb::NConfig::TFetchConfigResult& result, const TString& sourceAddress = TString())
         : Success(result.IsSuccess())
         , TransportError(result.IsTransportError())
         , Endpoint(result.GetEndpoint())
@@ -599,8 +599,8 @@ private:
         const auto retryResult = RetryWithJitter(addrs, env, attempt);
 
         if (!retryResult.Success) {
-             logger.Err() << "WARNING: couldn't fetch config from Console after " 
-                        << retryResult.TotalAttempts << " attempts across " << retryResult.Rounds 
+             logger.Err() << "WARNING: couldn't fetch config from Console after "
+                        << retryResult.TotalAttempts << " attempts across " << retryResult.Rounds
                         << " rounds. Last error: " << static_cast<NYdb::TStatus>(*result) << Endl;
         }
         return {*result, sourceAddress};
@@ -971,7 +971,7 @@ void UpdateConfigUpdateTracer(
     }
 }
 
-NYdb::TDriverConfig CreateDriverConfig(const TGrpcSslSettings& grpcSettings, const TString& addr, const IEnv& env, const std::optional<TString>& authToken) {
+NYdb::TDriverConfig CreateDriverConfig(const TGrpcSslSettings& grpcSettings, const TString& addr, const IEnv& env, const std::string& database, const std::optional<TString>& authToken) {
     TCommandConfig::TServerEndpoint endpoint = TCommandConfig::ParseServerAddress(addr);
     NYdb::TDriverConfig config;
     if (endpoint.EnableSsl.Defined() && endpoint.EnableSsl.GetRef()) {
@@ -984,6 +984,7 @@ NYdb::TDriverConfig CreateDriverConfig(const TGrpcSslSettings& grpcSettings, con
             config.UseClientCertificate(certificate.c_str(), privateKey.c_str());
         }
     }
+    config.SetDatabase(database);
     if (authToken) {
         config.SetAuthToken(authToken.value());
     }

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1150,7 +1150,7 @@ TMaybe<NKikimrConfig::TAppConfig> GetActualDynConfig(
 void UpdateConfigUpdateTracer(
     IConfigUpdateTracer& ConfigUpdateTracer);
 
-NYdb::TDriverConfig CreateDriverConfig(const TGrpcSslSettings& settings, const TString& addrs, const IEnv& env, const std::optional<TString>& authToken = std::nullopt);
+NYdb::TDriverConfig CreateDriverConfig(const TGrpcSslSettings& settings, const TString& addrs, const IEnv& env, const std::string& database = "", const std::optional<TString>& authToken = std::nullopt);
 
 // =====
 

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1744,7 +1744,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         NYdb::TDriverConfig driverCfg;
         TString topicPath = "/Root/topic1";
         driverCfg.SetEndpoint(TStringBuilder() << "localhost:" << grpcPort)
-                .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
+            .SetDatabase("/Root")
+            .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
 
         TString consumerName = "consumer1";
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.cpp
@@ -7,7 +7,7 @@ namespace NKikimr::NPersQueueTests {
     using namespace NYdb::NPersQueue;
 
     std::shared_ptr<NYdb::NPersQueue::IWriteSession> CreateWriter(
-        NYdb::TDriver& driver,
+        const NYdb::TDriver& driver,
         const NYdb::NPersQueue::TWriteSessionSettings& settings,
         std::shared_ptr<NYdb::ICredentialsProviderFactory> creds
     ) {
@@ -17,7 +17,7 @@ namespace NKikimr::NPersQueueTests {
     }
 
     std::shared_ptr<NYdb::NPersQueue::IWriteSession> CreateWriter(
-        NYdb::TDriver& driver,
+        const NYdb::TDriver& driver,
         const TString& topic,
         const TString& sourceId,
         std::optional<ui32> partitionGroup,

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.h
@@ -10,13 +10,13 @@
 namespace NKikimr::NPersQueueTests {
 
     std::shared_ptr<NYdb::NPersQueue::IWriteSession> CreateWriter(
-        NYdb::TDriver& driver,
+        const NYdb::TDriver& driver,
         const NYdb::NPersQueue::TWriteSessionSettings& settings,
         std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = nullptr
     );
 
     std::shared_ptr<NYdb::NPersQueue::IWriteSession> CreateWriter(
-        NYdb::TDriver& driver,
+        const NYdb::TDriver& driver,
         const TString& topic,
         const TString& sourceId,
         std::optional<ui32> partitionGroup = {},

--- a/ydb/services/discovery/grpc_service.cpp
+++ b/ydb/services/discovery/grpc_service.cpp
@@ -19,7 +19,7 @@ void TGRpcDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_DISCOVERY_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, discovery, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_DISCOVERY_METHOD(WhoAmI, DoWhoAmIRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_DISCOVERY_METHOD(NodeRegistration, DoNodeRegistrationRequest, RLSWITCH(Rps), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::NodeRegistration));

--- a/ydb/services/local_discovery/grpc_service.cpp
+++ b/ydb/services/local_discovery/grpc_service.cpp
@@ -75,7 +75,7 @@ void TGRpcLocalDiscoveryService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logg
         requestType,                                          \
         YDB_API_DEFAULT_COUNTER_BLOCK(discovery, methodName), \
         auditMode,                                            \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,             \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,           \
         COMMON,                                               \
         operationCallClass,                                   \
         GRpcRequestProxyId_,                                  \

--- a/ydb/services/persqueue_v1/persqueue.cpp
+++ b/ydb/services/persqueue_v1/persqueue.cpp
@@ -57,7 +57,7 @@ void TGRpcPersQueueService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                                 \
         YDB_API_DEFAULT_COUNTER_BLOCK(persistent_queue, methodName), \
         auditMode,                                                   \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                    \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                  \
         COMMON,                                                      \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,          \
         GRpcRequestProxyId_,                                         \
@@ -76,7 +76,7 @@ void TGRpcPersQueueService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                                        \
             YDB_API_DEFAULT_STREAM_COUNTER_BLOCK(persistent_queue, methodName), \
             auditMode,                                                          \
-            EEmptyDatabaseMode::EmptyDatabaseAllowed,                           \
+            EEmptyDatabaseMode::EmptyDatabaseForbidden,                         \
             operationCallClass,                                                 \
             GRpcRequestProxyId_,                                                \
             CQ_,                                                                \

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -3594,10 +3594,10 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         writer.Write(SHORT_TOPIC_NAME, {"valuevaluevalue1"}, true, TString()); // Fail if user set empty token
         writer.Write(SHORT_TOPIC_NAME, {"valuevaluevalue1"}, true, "topic1@" BUILTIN_ACL_DOMAIN);
 
-        auto driver = server.AnnoyingClient->GetDriver();
+        const auto& driver = server.GetDriver();
 
 
-        ModifyTopicACL(driver, "/Root/PQ/" + DEFAULT_TOPIC_NAME, {{"topic1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.write"}}});
+        ModifyTopicACL(&driver, "/Root/PQ/" + DEFAULT_TOPIC_NAME, {{"topic1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.write"}}});
 
 
         writer2.Write(SHORT_TOPIC_NAME, {"valuevaluevalue1"}, false, "topic1@" BUILTIN_ACL_DOMAIN);
@@ -3608,7 +3608,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = std::make_shared<TTestCredentialsProviderFactory>("topic1@" BUILTIN_ACL_DOMAIN);
             dynamic_cast<TTestCredentialsProviderFactory*>(creds.get())->SetToken("topic1@" BUILTIN_ACL_DOMAIN);
 
-            auto writer = CreateWriter(*driver, SHORT_TOPIC_NAME, "123", {}, {}, {}, creds);
+            auto writer = CreateWriter(driver, SHORT_TOPIC_NAME, "123", {}, {}, {}, creds);
 
             auto msg = writer->GetEvent(true);
             UNIT_ASSERT(msg); // ReadyToAcceptEvent
@@ -3678,9 +3678,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
 
         server.CleverServer->GetRuntime()->GetAppData().PQConfig.SetRequireCredentialsInNewProtocol(true);
 
-        auto driver = server.AnnoyingClient->GetDriver();
+        const auto& driver = server.GetDriver();
 
-        ModifyTopicACL(driver, "/Root/PQ/" + topic2, {{"1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}},
+        ModifyTopicACL(&driver, "/Root/PQ/" + topic2, {{"1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}},
                                                       {"2@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}},
                                                       {"user1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}},
                                                       {"user2@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}}});
@@ -3699,7 +3699,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         writer.Read(shortTopic2Name, "user5", ticket1, true, false, true);
         writer.Read(shortTopic2Name, "user5", ticket2, true, false, true);
 
-        ModifyTopicACL(driver, "/Root/PQ/" + topic2, {{"user3@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}}});
+        ModifyTopicACL(&driver, "/Root/PQ/" + topic2, {{"user3@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}}});
 
 
         Cerr << "==== Writer - read\n";
@@ -3754,6 +3754,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             request.set_get_only_original(true);
             request.add_topics()->set_path(shortTopic2Name);
             grpc::ClientContext rcontext;
+            rcontext.AddMetadata("x-ydb-database", "/Root");
             if (i == 0) {
                 rcontext.AddMetadata("x-ydb-auth-ticket", "user_without_rights@" BUILTIN_ACL_DOMAIN);
             }
@@ -5703,6 +5704,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             request.set_path(TStringBuilder() << "/Root/PQ/" << topic3);
 
             grpc::ClientContext rcontext;
+            rcontext.AddMetadata("x-ydb-database", "/Root");
             rcontext.AddMetadata("x-ydb-auth-ticket", "user@" BUILTIN_ACL_DOMAIN);
 
             auto status = TopicStubP_->CreateTopic(&rcontext, request, &response);
@@ -5770,6 +5772,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             Ydb::Topic::AlterTopicResponse response;
 
             grpc::ClientContext rcontext;
+            rcontext.AddMetadata("x-ydb-database", "/Root");
             if (auth)
                 rcontext.AddMetadata("x-ydb-auth-ticket", "user@" BUILTIN_ACL_DOMAIN);
 
@@ -5954,6 +5957,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             Ydb::Topic::DescribeTopicResponse response;
             request.set_path(TStringBuilder() << "/Root/PQ/" << topic3);
             grpc::ClientContext rcontext;
+            rcontext.AddMetadata("x-ydb-database", "/Root");
             rcontext.AddMetadata("x-ydb-auth-ticket", "user@" BUILTIN_ACL_DOMAIN);
 
             auto status = TopicStubP_->DescribeTopic(&rcontext, request, &response);
@@ -8137,6 +8141,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         StubP_ = Ydb::Topic::V1::TopicService::NewStub(Channel_);
 
         grpc::ClientContext rcontext;
+        rcontext.AddMetadata("x-ydb-database", "/Root");
         rcontext.AddMetadata("x-ydb-auth-ticket", "user@" BUILTIN_ACL_DOMAIN);
         auto readStream = StubP_->StreamRead(&rcontext);
         UNIT_ASSERT(readStream);

--- a/ydb/services/persqueue_v1/topic.cpp
+++ b/ydb/services/persqueue_v1/topic.cpp
@@ -86,7 +86,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                                                                      \
         YDB_API_DEFAULT_COUNTER_BLOCK(topic, methodName),                                                 \
         auditMode,                                                                                        \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                                         \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                                                       \
         COMMON,                                                                                           \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                                               \
         GRpcRequestProxyId_,                                                                              \
@@ -102,7 +102,7 @@ void TGRpcTopicService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
             requestType,                                             \
             YDB_API_DEFAULT_STREAM_COUNTER_BLOCK(topic, methodName), \
             auditMode,                                               \
-            EEmptyDatabaseMode::EmptyDatabaseAllowed,                \
+            EEmptyDatabaseMode::EmptyDatabaseForbidden,              \
             operationCallClass,                                      \
             GRpcRequestProxyId_,                                     \
             CQ_,                                                     \

--- a/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
@@ -16,7 +16,7 @@
 
 namespace NKikimr::NPersQueueTests {
 
-static void ModifyTopicACL(NYdb::TDriver* driver, const TString& topic, const std::vector<std::pair<std::string, std::vector<std::string>>>& acl) {
+static void ModifyTopicACL(const NYdb::TDriver* driver, const TString& topic, const std::vector<std::pair<std::string, std::vector<std::string>>>& acl) {
 
     NYdb::NScheme::TSchemeClient schemeClient(*driver);
     auto modifyPermissionsSettings = NYdb::NScheme::TModifyPermissionsSettings();

--- a/ydb/services/persqueue_v1/ut/pq_data_writer.h
+++ b/ydb/services/persqueue_v1/ut/pq_data_writer.h
@@ -16,6 +16,7 @@ public:
     TPQDataWriter(const TString& sourceId, NPersQueue::TTestServer& server, const TString& testTopicPath = "topic1")
         : SourceId_(sourceId)
         , Port_(server.GrpcPort)
+        , Database("/" + server.ServerSettings.DomainName)
         , Client(*server.AnnoyingClient)
         , Runtime(server.CleverServer->GetRuntime())
     {
@@ -28,6 +29,7 @@ public:
         Y_UNUSED(Runtime); //TODO: use them to restart PERSQUEUE tablets
 
         grpc::ClientContext context;
+        context.AddMetadata("x-ydb-database", Database);
 
         if (!ticket.empty())
             context.AddMetadata("x-ydb-auth-ticket", ticket);
@@ -230,6 +232,7 @@ public:
 private:
     ui32 WriteImpl(const TString& topic, const TVector<TString>& data, bool error, const TMaybe<TString>& ticket) {
         grpc::ClientContext context;
+        context.AddMetadata("x-ydb-database", Database);
 
         if (ticket)
             context.AddMetadata("x-ydb-auth-ticket", *ticket);
@@ -365,6 +368,7 @@ private:
 private:
     const TString SourceId_;
     const ui16 Port_;
+    const TString Database;
 
     TFlatMsgBusPQClient& Client;
     TTestActorRuntime *Runtime;

--- a/ydb/services/ydb/ydb_clickhouse_internal.cpp
+++ b/ydb/services/ydb/ydb_clickhouse_internal.cpp
@@ -44,7 +44,7 @@ void TGRpcYdbClickhouseInternalService::SetupIncomingRequests(NYdbGrpc::TLoggerP
         requestType,                                                                \
         YDB_API_DEFAULT_COUNTER_BLOCK(clickhouse_internal, methodName),             \
         auditMode,                                                                  \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                   \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                                 \
         COMMON,                                                                     \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall,                         \
         GRpcRequestProxyId_,                                                        \

--- a/ydb/services/ydb/ydb_object_storage.cpp
+++ b/ydb/services/ydb/ydb_object_storage.cpp
@@ -26,7 +26,7 @@ void TGRpcYdbObjectStorageService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr lo
         requestType,                                                    \
         YDB_API_DEFAULT_COUNTER_BLOCK(object-storage-list, methodName), \
         auditMode,                                                      \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                       \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                     \
         COMMON,                                                         \
         TGrpcRequestNoOperationCall,                                    \
         GRpcRequestProxyId_,                                            \

--- a/ydb/services/ydb/ydb_object_storage_ut.cpp
+++ b/ydb/services/ydb/ydb_object_storage_ut.cpp
@@ -10,7 +10,11 @@ using namespace NYdb;
 Y_UNIT_TEST_SUITE(YdbS3Internal) {
 
     void PrepareData(TString location) {
-        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+        TDriverConfig driverCfg;
+        driverCfg.SetDatabase("/Root")
+            .SetEndpoint(location);
+
+        auto connection = NYdb::TDriver(driverCfg);
 
         NYdb::NTable::TTableClient client(connection);
         auto session = client.GetSession().ExtractValueSync().GetSession();
@@ -99,7 +103,11 @@ Y_UNIT_TEST_SUITE(YdbS3Internal) {
     }
 
     void SetPermissions(TString location) {
-        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+        TDriverConfig driverCfg;
+        driverCfg.SetDatabase("/Root")
+            .SetEndpoint(location);
+
+        auto connection = NYdb::TDriver(driverCfg);
         auto scheme = NYdb::NScheme::TSchemeClient(connection);
         auto status = scheme.ModifyPermissions("/Root/ListingObjects",
                                                NYdb::NScheme::TModifyPermissionsSettings()
@@ -121,7 +129,12 @@ Y_UNIT_TEST_SUITE(YdbS3Internal) {
     }
 
     NYdb::EStatus MakeListingRequest(TString location, TString userToken) {
-        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        TDriverConfig driverCfg;
+        driverCfg.SetDatabase("/Root")
+            .SetEndpoint(location)
+            .SetAuthToken(userToken);
+
+        auto connection = NYdb::TDriver(driverCfg);
         NObjectStorage::TObjectStorageClient s3conn(connection);
 
         TValueBuilder keyPrefix;

--- a/ydb/services/ydb/ydb_register_node_ut.cpp
+++ b/ydb/services/ydb/ydb_register_node_ut.cpp
@@ -179,12 +179,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_EmptyAllowedSids) 
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -199,12 +201,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_EmptyAllowedSids) 
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -225,12 +229,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -245,12 +251,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -271,12 +279,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_AllowOnlyDefaultGr
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -291,12 +301,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_AllowOnlyDefaultGr
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -316,12 +328,14 @@ Y_UNIT_TEST(ServerWithIssuerVerification_ClientWithSameIssuer) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -335,12 +349,14 @@ Y_UNIT_TEST(ServerWithIssuerVerification_ClientWithSameIssuer) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
@@ -360,12 +376,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesEmptyClientCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(noCert.Certificate.c_str(),noCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -380,12 +398,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesEmptyClientCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(noCert.Certificate.c_str(),noCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -403,12 +423,14 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesCorrectCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -421,12 +443,14 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesCorrectCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -444,12 +468,14 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesEmptyClientCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(noCert.Certificate.c_str(),noCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -462,12 +488,14 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesEmptyClientCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(noCert.Certificate.c_str(),noCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -488,12 +516,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvideIncorrectCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Cannot create token from certificate. Client certificate failed verification");
@@ -509,12 +539,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvideIncorrectCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -532,11 +564,13 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideAnyCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
-        config.SetEndpoint(location);
+        config.SetDatabase(database)
+            .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
         CheckAccessDenied(RegisterNode(config), expectedError);
@@ -551,11 +585,13 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideAnyCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
-        config.SetEndpoint(location);
+        config.SetDatabase(database)
+            .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
         CheckAccessDenied(RegisterNode(config), expectedError);
@@ -575,12 +611,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(serverCert.Certificate.c_str(),serverCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
@@ -596,12 +634,14 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(serverCert.Certificate.c_str(),serverCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
@@ -623,12 +663,14 @@ void TestCorruptedClientAuthData(const TCertAndKey& caCert, const TCertAndKey& c
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config, timeout), expectedStatus);
@@ -672,6 +714,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
@@ -681,6 +724,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
@@ -696,6 +740,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
@@ -705,6 +750,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         const TString expectedError = "connections to all backends failing";
@@ -723,6 +769,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
@@ -732,6 +779,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -744,6 +792,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
@@ -753,6 +802,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
             .UseClientCertificate(clientServerCert.Certificate.c_str(), clientServerCert.PrivateKey.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -771,11 +821,13 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideClientCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -790,11 +842,13 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideClientCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -811,11 +865,13 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientDoesNotProvideClientCerts) {
         });
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + server.ServerSettings->DomainName;
 
         SetLogPriority(server);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
@@ -828,11 +884,13 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientDoesNotProvideClientCerts) {
         });
         ui16 grpc = serverDoesNotRequireToken.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+        const TString database = "/" + serverDoesNotRequireToken.ServerSettings->DomainName;
 
         SetLogPriority(serverDoesNotRequireToken);
 
         TDriverConfig config;
         config.UseSecureConnection(caCert.Certificate.c_str())
+            .SetDatabase(database)
             .SetEndpoint(location);
 
         CheckAccessDeniedRegisterNode(RegisterNode(config), "Cannot authorize node. Access denied");
@@ -860,21 +918,25 @@ Y_UNIT_TEST(ServerWithCertVerification_AuthNotRequired) {
     });
     ui16 grpc = server.GetPort();
     TString location = TStringBuilder() << "localhost:" << grpc;
+    const TString database = "/" + server.ServerSettings->DomainName;
 
     SetLogPriority(server);
 
     TDriverConfig secureConnectionConfig;
     secureConnectionConfig.UseSecureConnection(caCert.Certificate.c_str())
         .UseClientCertificate(clientServerCert.Certificate.c_str(),clientServerCert.PrivateKey.c_str())
+        .SetDatabase(database)
         .SetEndpoint(location);
 
     TDriverConfig insecureConnectionConfig;
     insecureConnectionConfig.UseSecureConnection(caCert.Certificate.c_str())
+        .SetDatabase(database)
         .SetEndpoint(location);
 
     TDriverConfig enemyConnectionConfig;
     enemyConnectionConfig.UseSecureConnection(caCert.Certificate.c_str())
         .UseClientCertificate(clientServerEnemyCert.Certificate.c_str(),clientServerEnemyCert.PrivateKey.c_str())
+        .SetDatabase(database)
         .SetEndpoint(location);
 
     CheckGood(RegisterNode(secureConnectionConfig));

--- a/ydb/services/ymq/grpc_service.cpp
+++ b/ydb/services/ymq/grpc_service.cpp
@@ -29,7 +29,7 @@ void TGRpcYmqService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         requestType,                                        \
         YDB_API_DEFAULT_COUNTER_BLOCK(ymq, methodName),     \
         auditMode,                                          \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,           \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,         \
         COMMON,                                             \
         ::NKikimr::NGRpcService::TGrpcRequestOperationCall, \
         GRpcRequestProxyId_,                                \


### PR DESCRIPTION
Requests with empty database name were forbidden for next grpc services:

- DiscoveryService
- LocalDiscoveryService
- PersQueueService
- TopicService
- YdbClickhouseInternalService
- YdbObjectStorageService
- YmqService

