### PR TITLE
Implement CREATE/ALTER TABLE with METRICS_LEVEL in Scheme Shard

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -451,7 +451,7 @@ message TTableDescription {
      * @note If the detailed metrics settings are not configured for a table,
      *       the default metrics settings from the parent database are used instead
      *       (by default, no detailed metrics settings are configured at the database
-     *       level). Setting the detailed metrics level to TABLE/PARITITION for a table,
+     *       level). Setting the detailed metrics level to TABLE/PARTITION for a table,
      *       enables detailed metrics for the given table regardless of the detailed
      *       metrics settings at the database level. Setting the detailed metrics
      *       level to DISABLED for a table, disables detailed metrics for the given table

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -312,9 +312,6 @@ message TTableDetailedMetricsSettings {
     message TConfigured {
         /**
          * The level at which detailed metrics are aggregated and reported.
-         *
-         * @note If this value is not set, the default value from the parent database
-         *       is used instead.
          */
         optional EMetricsLevel MetricsLevel = 1;
     }
@@ -450,6 +447,15 @@ message TTableDescription {
      *       with the TTableDetailedMetricsSettings.Configured field set to the desired settings.
      *       To remove the current detailed metrics settings, this field should be populated
      *       with the TTableDetailedMetricsSettings.NotConfigured field set.
+     *
+     * @note If the detailed metrics settings are not configured for a table,
+     *       the default metrics settings from the parent database are used instead
+     *       (by default, no detailed metrics settings are configured at the database
+     *       level). Setting the detailed metrics level to TABLE/PARITITION for a table,
+     *       enables detailed metrics for the given table regardless of the detailed
+     *       metrics settings at the database level. Setting the detailed metrics
+     *       level to DISABLED for a table, disables detailed metrics for the given table
+     *       regardless of the detailed metrics settings at the database level.
      */
     optional TTableDetailedMetricsSettings DetailedMetricsSettings = 51;
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -280,67 +280,63 @@ message TTTLSettings {
 /**
  * The parameters for the detailed metrics for the given table.
  */
-message TMetricsSettings {
+message TTableDetailedMetricsSettings {
     /**
-     * The level at which metrics are aggregated and reported.
+     * The level at which detailed metrics are aggregated and reported.
      */
     enum EMetricsLevel {
         /**
-         * The metrics level is not specified.
+         * The detailed metrics level is not specified.
          */
         MetricsLevelUnspecified = 0;
 
         /**
-         * All metrics are disabled.
+         * All detailed metrics are disabled for the given table.
          */
         MetricsLevelDisabled = 1;
 
         /**
-         * Metrics are aggregated and reported for the entire database.
+         * Detailed metrics are aggregated and reported for the entire table.
          */
-        MetricsLevelDatabase = 2;
+        MetricsLevelTable = 2;
 
         /**
-         * Metrics are aggregated and reported for individual tables.
+         * Detailed metrics are aggregated and reported for individual partitions.
          */
-        MetricsLevelTable = 3;
-
-        /**
-         * Metrics are aggregated and reported for individual partitions.
-         */
-        MetricsLevelPartition = 4;
+        MetricsLevelPartition = 3;
     }
 
     /**
-     * The container for the metrics settings, which are explicitly configured.
+     * The container for the detailed metrics settings, which are explicitly configured.
      */
     message TConfigured {
         /**
-         * The level at which metrics are aggregated and reported.
+         * The level at which detailed metrics are aggregated and reported.
          *
-         * @note If this value is not set, METRICS_LEVEL_DATABASE is assumed.
+         * @note If this value is not set, the default value from the parent database
+         *       is used instead.
          */
         optional EMetricsLevel MetricsLevel = 1;
     }
 
     /**
-     * The container for the metrics settings, which are explicitly removed.
+     * The container for the detailed metrics settings, which are explicitly removed.
      */
     message TNotConfigured {
     }
 
     oneof Status {
         /**
-         * Set, if the metrics settings are explicitly configured.
+         * Set, if the detailed metrics settings are explicitly configured.
          */
         TConfigured Configured = 1;
 
         /**
-         * Set, if the metrics settings are explicitly removed.
+         * Set, if the detailed metrics settings are explicitly removed.
          *
-         * @note This is used in ALTER TABLE requests to remove the metrics settings,
-         *       which are currently configured for the given table. If the metrics
-         *       settings are not configured, the corresponding TMetricsSettings field
+         * @note This is used in ALTER TABLE requests to remove the detailed metrics settings,
+         *       which are currently configured for the given table. If the detailed metrics
+         *       settings are not configured, the corresponding DetailedMetricsSettings field
          *       in the table description will not be set.
          */
         TNotConfigured NotConfigured = 2;
@@ -441,21 +437,21 @@ message TTableDescription {
     optional uint32 UniqueIndexKeySize = 50;
 
     /**
-     * The metrics settings for the given table.
+     * The detailed metrics settings for the given table.
      *
      * @note When returning the description for an existing table, this field
-     *       will be populated, if the metrics settings are explicitly configured
-     *       for the given table. If the metrics settings are not configured,
+     *       will be populated, if the detailed metrics settings are explicitly configured
+     *       for the given table. If the detailed metrics settings are not configured,
      *       this field will not be populated in the table description.
      *
      * @note When used for ALTER TABLE requests, this field should be left unset
-     *       to keep the current metrics settings for the given table.
-     *       To configure/change the metrics settings, this field should be populated
-     *       with the TMetricsSettings.Configured field set to the desired
-     *       settings. To remove the current metrics settings, this field should
-     *       be populated with the TMetricsSettings.NotConfigured field set.
+     *       to keep the current detailed metrics settings for the given table.
+     *       To configure/change the detailed metrics settings, this field should be populated
+     *       with the TTableDetailedMetricsSettings.Configured field set to the desired settings.
+     *       To remove the current detailed metrics settings, this field should be populated
+     *       with the TTableDetailedMetricsSettings.NotConfigured field set.
      */
-    optional TMetricsSettings MetricsSettings = 51;
+    optional TTableDetailedMetricsSettings DetailedMetricsSettings = 51;
 }
 
 message TCompressionOptions {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -277,6 +277,76 @@ message TTTLSettings {
     reserved 3;
 }
 
+/**
+ * The parameters for the detailed metrics for the given table.
+ */
+message TMetricsSettings {
+    /**
+     * The level at which metrics are aggregated and reported.
+     */
+    enum EMetricsLevel {
+        /**
+         * The metrics level is not specified.
+         */
+        MetricsLevelUnspecified = 0;
+
+        /**
+         * All metrics are disabled.
+         */
+        MetricsLevelDisabled = 1;
+
+        /**
+         * Metrics are aggregated and reported for the entire database.
+         */
+        MetricsLevelDatabase = 2;
+
+        /**
+         * Metrics are aggregated and reported for individual tables.
+         */
+        MetricsLevelTable = 3;
+
+        /**
+         * Metrics are aggregated and reported for individual partitions.
+         */
+        MetricsLevelPartition = 4;
+    }
+
+    /**
+     * The container for the metrics settings, which are explicitly configured.
+     */
+    message TConfigured {
+        /**
+         * The level at which metrics are aggregated and reported.
+         *
+         * @note If this value is not set, METRICS_LEVEL_DATABASE is assumed.
+         */
+        optional EMetricsLevel MetricsLevel = 1;
+    }
+
+    /**
+     * The container for the metrics settings, which are explicitly removed.
+     */
+    message TNotConfigured {
+    }
+
+    oneof Status {
+        /**
+         * Set, if the metrics settings are explicitly configured.
+         */
+        TConfigured Configured = 1;
+
+        /**
+         * Set, if the metrics settings are explicitly removed.
+         *
+         * @note This is used in ALTER TABLE requests to remove the metrics settings,
+         *       which are currently configured for the given table. If the metrics
+         *       settings are not configured, the corresponding TMetricsSettings field
+         *       in the table description will not be set.
+         */
+        TNotConfigured NotConfigured = 2;
+    }
+}
+
 message TTableReplicationConfig {
     enum EReplicationMode {
         REPLICATION_MODE_NONE = 0;
@@ -369,6 +439,23 @@ message TTableDescription {
 
     // For unique indexes - number of leading PK columns which should have unique values (for correct locking)
     optional uint32 UniqueIndexKeySize = 50;
+
+    /**
+     * The metrics settings for the given table.
+     *
+     * @note When returning the description for an existing table, this field
+     *       will be populated, if the metrics settings are explicitly configured
+     *       for the given table. If the metrics settings are not configured,
+     *       this field will not be populated in the table description.
+     *
+     * @note When used for ALTER TABLE requests, this field should be left unset
+     *       to keep the current metrics settings for the given table.
+     *       To configure/change the metrics settings, this field should be populated
+     *       with the TMetricsSettings.Configured field set to the desired
+     *       settings. To remove the current metrics settings, this field should
+     *       be populated with the TMetricsSettings.NotConfigured field set.
+     */
+    optional TMetricsSettings MetricsSettings = 51;
 }
 
 message TCompressionOptions {

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -338,7 +338,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::OwnerActorId>(""),
             rowSet.template GetValueOrDefault<typename SchemaTable::IncrementalBackupConfig>(),
             rowSet.template GetValueOrDefault<typename SchemaTable::IsRestore>(false),
-            rowSet.template GetValueOrDefault<typename SchemaTable::MetricsSettings>()
+            rowSet.template GetValueOrDefault<typename SchemaTable::DetailedMetricsSettings>()
         );
     }
 
@@ -1912,8 +1912,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     Y_ABORT_UNLESS(parseOk);
                 }
 
-                if (const auto metricsSettings = std::get<14>(rec)) {
-                    bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableMetricsSettings(), metricsSettings);
+                if (const auto detailedMetricsSettings = std::get<14>(rec)) {
+                    bool parseOk = ParseFromStringNoSizeLimit(
+                        tableInfo->MutableDetailedMetricsSettings(),
+                        detailedMetricsSettings
+                    );
+
                     Y_ABORT_UNLESS(parseOk);
                 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -319,7 +319,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         return true;
     }
 
-    typedef std::tuple<TPathId, ui32, ui64, TString, TString, TString, ui64, TString, bool, TString, bool, TString, TString, bool> TTableRec;
+    typedef std::tuple<TPathId, ui32, ui64, TString, TString, TString, ui64, TString, bool, TString, bool, TString, TString, bool, TString> TTableRec;
     typedef TDeque<TTableRec> TTableRows;
 
     template <typename SchemaTable, typename TRowSet>
@@ -337,7 +337,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::IsTemporary>(false),
             rowSet.template GetValueOrDefault<typename SchemaTable::OwnerActorId>(""),
             rowSet.template GetValueOrDefault<typename SchemaTable::IncrementalBackupConfig>(),
-            rowSet.template GetValueOrDefault<typename SchemaTable::IsRestore>(false)
+            rowSet.template GetValueOrDefault<typename SchemaTable::IsRestore>(false),
+            rowSet.template GetValueOrDefault<typename SchemaTable::MetricsSettings>()
         );
     }
 
@@ -1908,6 +1909,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (const auto ttlSettings = std::get<7>(rec)) {
                     bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableTTLSettings(), ttlSettings);
+                    Y_ABORT_UNLESS(parseOk);
+                }
+
+                if (const auto metricsSettings = std::get<14>(rec)) {
+                    bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableMetricsSettings(), metricsSettings);
                     Y_ABORT_UNLESS(parseOk);
                 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -97,7 +97,8 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         && !copyAlter.HasPartitionConfig()
         && !copyAlter.HasTTLSettings()
         && !copyAlter.HasReplicationConfig()
-        && !copyAlter.HasIncrementalBackupConfig())
+        && !copyAlter.HasIncrementalBackupConfig()
+        && !copyAlter.HasMetricsSettings())
     {
         errStr = Sprintf("No changes specified");
         status = NKikimrScheme::StatusInvalidParameter;
@@ -107,6 +108,19 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
     if (copyAlter.HasPartitionConfig() && copyAlter.GetPartitionConfig().HasFreezeState()) {
         if (hasSchemaChanges) {
             errStr = Sprintf("Mix freeze cmd with other options is forbidden");
+            status = NKikimrScheme::StatusInvalidParameter;
+            return nullptr;
+        }
+    }
+
+    if (copyAlter.HasMetricsSettings()) {
+        // New metrics settings are specified in the request,
+        // make sure the metrics settings are valid (correct metrics level etc)
+        if (!ValidateMetricsSettings(
+            false /* forCreate */,
+            copyAlter.GetMetricsSettings(),
+            errStr
+        )) {
             status = NKikimrScheme::StatusInvalidParameter;
             return nullptr;
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -98,7 +98,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         && !copyAlter.HasTTLSettings()
         && !copyAlter.HasReplicationConfig()
         && !copyAlter.HasIncrementalBackupConfig()
-        && !copyAlter.HasMetricsSettings())
+        && !copyAlter.HasDetailedMetricsSettings())
     {
         errStr = Sprintf("No changes specified");
         status = NKikimrScheme::StatusInvalidParameter;
@@ -113,12 +113,12 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         }
     }
 
-    if (copyAlter.HasMetricsSettings()) {
-        // New metrics settings are specified in the request,
-        // make sure the metrics settings are valid (correct metrics level etc)
-        if (!ValidateMetricsSettings(
+    if (copyAlter.HasDetailedMetricsSettings()) {
+        // New detailed metrics settings are specified in the request,
+        // make sure the detailed metrics settings are valid (correct metrics level etc)
+        if (!ValidateTableDetailedMetricsSettings(
             false /* forCreate */,
-            copyAlter.GetMetricsSettings(),
+            copyAlter.GetDetailedMetricsSettings(),
             errStr
         )) {
             status = NKikimrScheme::StatusInvalidParameter;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -546,6 +546,20 @@ public:
             return result;
         }
 
+        if (schema.HasMetricsSettings()) {
+            TString errorString;
+
+            // Make sure the metrics settings are valid (correct metrics level etc)
+            if (!ValidateMetricsSettings(
+                true /* forCreate */,
+                schema.GetMetricsSettings(),
+                errorString
+            )) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errorString);
+                return result;
+            }
+        }
+
         if (parentPath.Base()->IsTableIndex()) {
             LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                          "Creating private table for table index"

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -546,13 +546,13 @@ public:
             return result;
         }
 
-        if (schema.HasMetricsSettings()) {
+        if (schema.HasDetailedMetricsSettings()) {
             TString errorString;
 
-            // Make sure the metrics settings are valid (correct metrics level etc)
-            if (!ValidateMetricsSettings(
+            // Make sure the detailed metrics settings are valid (correct metrics level etc)
+            if (!ValidateTableDetailedMetricsSettings(
                 true /* forCreate */,
-                schema.GetMetricsSettings(),
+                schema.GetDetailedMetricsSettings(),
                 errorString
             )) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errorString);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3003,9 +3003,10 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
         Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->TTLSettings().SerializeToString(&ttlSettings);
     }
 
-    TString metricsSettings;
-    if (tableInfo->HasMetricsSettings()) {
-        Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->GetMetricsSettings().SerializeToString(&metricsSettings);
+    TString detailedMetricsSettings;
+    if (tableInfo->HasDetailedMetricsSettings()) {
+        Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->GetDetailedMetricsSettings()
+            .SerializeToString(&detailedMetricsSettings);
     }
 
     TString replicationConfig;
@@ -3032,7 +3033,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::Tables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::Tables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
             NIceDb::TUpdate<Schema::Tables::OwnerActorId>(incrementalBackupConfig),
-            NIceDb::TUpdate<Schema::Tables::MetricsSettings>(metricsSettings)
+            NIceDb::TUpdate<Schema::Tables::DetailedMetricsSettings>(detailedMetricsSettings)
         );
     } else {
         db.Table<Schema::MigratedTables>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -3048,7 +3049,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::MigratedTables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
             NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(incrementalBackupConfig),
-            NIceDb::TUpdate<Schema::MigratedTables::MetricsSettings>(metricsSettings)
+            NIceDb::TUpdate<Schema::MigratedTables::DetailedMetricsSettings>(detailedMetricsSettings)
         );
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3031,7 +3031,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::Tables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::Tables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::Tables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::Tables::IncrementalBackupConfig>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::Tables::OwnerActorId>(incrementalBackupConfig),
             NIceDb::TUpdate<Schema::Tables::MetricsSettings>(metricsSettings)
         );
     } else {
@@ -3047,7 +3047,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::MigratedTables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::MigratedTables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::MigratedTables::IncrementalBackupConfig>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(incrementalBackupConfig),
             NIceDb::TUpdate<Schema::MigratedTables::MetricsSettings>(metricsSettings)
         );
     }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3032,7 +3032,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::Tables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::Tables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::Tables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::Tables::OwnerActorId>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::Tables::IncrementalBackupConfig>(incrementalBackupConfig),
             NIceDb::TUpdate<Schema::Tables::DetailedMetricsSettings>(detailedMetricsSettings)
         );
     } else {
@@ -3048,7 +3048,7 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::MigratedTables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::MigratedTables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::MigratedTables::IncrementalBackupConfig>(incrementalBackupConfig),
             NIceDb::TUpdate<Schema::MigratedTables::DetailedMetricsSettings>(detailedMetricsSettings)
         );
     }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3003,6 +3003,11 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
         Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->TTLSettings().SerializeToString(&ttlSettings);
     }
 
+    TString metricsSettings;
+    if (tableInfo->HasMetricsSettings()) {
+        Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->GetMetricsSettings().SerializeToString(&metricsSettings);
+    }
+
     TString replicationConfig;
     if (tableInfo->HasReplicationConfig()) {
         Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->ReplicationConfig().SerializeToString(&replicationConfig);
@@ -3026,7 +3031,9 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::Tables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::Tables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::Tables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::Tables::IncrementalBackupConfig>(incrementalBackupConfig));
+            NIceDb::TUpdate<Schema::Tables::IncrementalBackupConfig>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::Tables::MetricsSettings>(metricsSettings)
+        );
     } else {
         db.Table<Schema::MigratedTables>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
             NIceDb::TUpdate<Schema::MigratedTables::NextColId>(tableInfo->NextColumnId),
@@ -3040,7 +3047,9 @@ void TSchemeShard::PersistTableAltered(NIceDb::TNiceDb& db, const TPathId pathId
             NIceDb::TUpdate<Schema::MigratedTables::ReplicationConfig>(replicationConfig),
             NIceDb::TUpdate<Schema::MigratedTables::IsTemporary>(tableInfo->IsTemporary),
             NIceDb::TUpdate<Schema::MigratedTables::OwnerActorId>(tableInfo->OwnerActorId.ToString()),
-            NIceDb::TUpdate<Schema::MigratedTables::IncrementalBackupConfig>(incrementalBackupConfig));
+            NIceDb::TUpdate<Schema::MigratedTables::IncrementalBackupConfig>(incrementalBackupConfig),
+            NIceDb::TUpdate<Schema::MigratedTables::MetricsSettings>(metricsSettings)
+        );
     }
 
     for (auto col : tableInfo->Columns) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -706,7 +706,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
 
         case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
             // The request asks for the current metrics settings to be dropped,
-            // keep this as NotConfigured in the table description. It wlll be processed
+            // keep this as NotConfigured in the table description. It will be processed
             // and removed in FinishAlter().
             if (op.GetMetricsSettings().HasNotConfigured()) {
                 alterData->TableDescriptionFull->MutableMetricsSettings()->MutableNotConfigured();
@@ -3047,6 +3047,8 @@ bool ValidateMetricsSettings(
             }
         }
 
+        break;
+
     case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
         // Do not allow dropping the metrics settings in CREATE TABLE
         if (forCreate && metricsSettings.HasNotConfigured()) {
@@ -3055,6 +3057,7 @@ bool ValidateMetricsSettings(
         }
 
         break;
+
     default:
         // Neither Configured nor NotConfigured is set, just ignore this configuration
         break;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -676,6 +676,50 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->MutableTTLSettings()->CopyFrom(ttl);
     }
 
+    if (op.HasMetricsSettings()) {
+        switch (op.GetMetricsSettings().GetStatusCase()) {
+        case NKikimrSchemeOp::TMetricsSettings::kConfigured:
+            if (op.GetMetricsSettings().HasConfigured()) {
+                // The new metrics settings are explicitly specified,
+                // use them, but only if the new metrics level is valid
+                switch (op.GetMetricsSettings().GetConfigured().GetMetricsLevel()) {
+                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase:
+                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable:
+                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition:
+                    alterData->TableDescriptionFull
+                        ->MutableMetricsSettings()
+                        ->MutableConfigured()
+                        ->CopyFrom(op.GetMetricsSettings().GetConfigured());
+
+                    break;
+
+                default:
+                    // NOTE: The code, which parses CREATE TABLE and ALTER TABLE requests,
+                    //       should have already verified this and returned an error,
+                    //       if these conditions were not met. The check here is a precaution.
+                    errStr = "Only DATABASE, TABLE and PARTITION metrics levels are supported";
+                    return nullptr;
+                }
+            }
+
+            break;
+
+        case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
+            // The request asks for the current metrics settings to be dropped,
+            // keep this as NotConfigured in the table description. It wlll be processed
+            // and removed in FinishAlter().
+            if (op.GetMetricsSettings().HasNotConfigured()) {
+                alterData->TableDescriptionFull->MutableMetricsSettings()->MutableNotConfigured();
+            }
+
+            break;
+
+        default:
+            // Neither Configured nor NotConfigured is set, just ignore this configuration
+            break;
+        }
+    }
+
     if (op.HasReplicationConfig()) {
         const auto& cfg = op.GetReplicationConfig();
 
@@ -1743,6 +1787,33 @@ void TTableInfo::FinishAlter() {
     // Apply TTL params
     if (AlterData->TableDescriptionFull.Defined() && AlterData->TableDescriptionFull->HasTTLSettings()) {
         MutableTTLSettings().Swap(AlterData->TableDescriptionFull->MutableTTLSettings());
+    }
+
+    // Apply the new metrics settings (if specified) or drop the existing ones (if requested)
+    if (AlterData->TableDescriptionFull.Defined() && AlterData->TableDescriptionFull->HasMetricsSettings()) {
+        const auto& newMetricsSettings = AlterData->TableDescriptionFull->GetMetricsSettings();
+
+        switch (newMetricsSettings.GetStatusCase()) {
+        case NKikimrSchemeOp::TMetricsSettings::kConfigured:
+            if (newMetricsSettings.HasConfigured()) {
+                TableDescription.MutableMetricsSettings()
+                    ->MutableConfigured()
+                    ->CopyFrom(newMetricsSettings.GetConfigured());
+            }
+
+            break;
+
+        case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
+            if (newMetricsSettings.HasNotConfigured()) {
+                TableDescription.ClearMetricsSettings();
+            }
+
+            break;
+
+        default:
+            // Neither Configured nor NotConfigured is set, just ignore this configuration
+            break;
+        }
     }
 
     // Apply replication config
@@ -2953,6 +3024,43 @@ float TForcedCompactionInfo::CalcProgress() const {
 
 bool IsPathTypeTable(const NKikimr::NSchemeShard::TExportInfo::TItem& item) {
     return item.SourcePathType == NKikimrSchemeOp::EPathTypeTable || item.SourcePathType == NKikimrSchemeOp::EPathTypeColumnTable;
+}
+
+bool ValidateMetricsSettings(
+    bool forCreate,
+    const NKikimrSchemeOp::TMetricsSettings& metricsSettings,
+    TString& errorString
+) {
+    switch (metricsSettings.GetStatusCase()) {
+    case NKikimrSchemeOp::TMetricsSettings::kConfigured:
+        // Allow only DATABASE, TABLE and PARTITION levels
+        if (metricsSettings.HasConfigured()) {
+            switch (metricsSettings.GetConfigured().GetMetricsLevel()) {
+            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase:
+            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable:
+            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition:
+                break;
+
+            default:
+                errorString = "Only DATABASE, TABLE and PARTITION metrics levels are supported";
+                return false;
+            }
+        }
+
+    case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
+        // Do not allow dropping the metrics settings in CREATE TABLE
+        if (forCreate && metricsSettings.HasNotConfigured()) {
+            errorString = "Unable to remove the metrics settings in CREATE TABLE";
+            return false;
+        }
+
+        break;
+    default:
+        // Neither Configured nor NotConfigured is set, just ignore this configuration
+        break;
+    }
+
+    return true;
 }
 
 } // namespace NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -676,20 +676,20 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->MutableTTLSettings()->CopyFrom(ttl);
     }
 
-    if (op.HasMetricsSettings()) {
-        switch (op.GetMetricsSettings().GetStatusCase()) {
-        case NKikimrSchemeOp::TMetricsSettings::kConfigured:
-            if (op.GetMetricsSettings().HasConfigured()) {
-                // The new metrics settings are explicitly specified,
+    if (op.HasDetailedMetricsSettings()) {
+        switch (op.GetDetailedMetricsSettings().GetStatusCase()) {
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
+            if (op.GetDetailedMetricsSettings().HasConfigured()) {
+                // The new detailed metrics settings are explicitly specified,
                 // use them, but only if the new metrics level is valid
-                switch (op.GetMetricsSettings().GetConfigured().GetMetricsLevel()) {
-                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase:
-                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable:
-                case NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition:
+                switch (op.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel()) {
+                case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled:
+                case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+                case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
                     alterData->TableDescriptionFull
-                        ->MutableMetricsSettings()
+                        ->MutableDetailedMetricsSettings()
                         ->MutableConfigured()
-                        ->CopyFrom(op.GetMetricsSettings().GetConfigured());
+                        ->CopyFrom(op.GetDetailedMetricsSettings().GetConfigured());
 
                     break;
 
@@ -697,19 +697,21 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                     // NOTE: The code, which parses CREATE TABLE and ALTER TABLE requests,
                     //       should have already verified this and returned an error,
                     //       if these conditions were not met. The check here is a precaution.
-                    errStr = "Only DATABASE, TABLE and PARTITION metrics levels are supported";
+                    errStr = "Only DISABLED, TABLE and PARTITION detailed metrics levels are supported";
                     return nullptr;
                 }
             }
 
             break;
 
-        case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
-            // The request asks for the current metrics settings to be dropped,
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::kNotConfigured:
+            // The request asks for the current detailed metrics settings to be dropped,
             // keep this as NotConfigured in the table description. It will be processed
             // and removed in FinishAlter().
-            if (op.GetMetricsSettings().HasNotConfigured()) {
-                alterData->TableDescriptionFull->MutableMetricsSettings()->MutableNotConfigured();
+            if (op.GetDetailedMetricsSettings().HasNotConfigured()) {
+                alterData->TableDescriptionFull
+                    ->MutableDetailedMetricsSettings()
+                    ->MutableNotConfigured();
             }
 
             break;
@@ -1790,22 +1792,23 @@ void TTableInfo::FinishAlter() {
     }
 
     // Apply the new metrics settings (if specified) or drop the existing ones (if requested)
-    if (AlterData->TableDescriptionFull.Defined() && AlterData->TableDescriptionFull->HasMetricsSettings()) {
-        const auto& newMetricsSettings = AlterData->TableDescriptionFull->GetMetricsSettings();
+    if (AlterData->TableDescriptionFull.Defined()
+            && AlterData->TableDescriptionFull->HasDetailedMetricsSettings()) {
+        const auto& newMetricsSettings = AlterData->TableDescriptionFull->GetDetailedMetricsSettings();
 
         switch (newMetricsSettings.GetStatusCase()) {
-        case NKikimrSchemeOp::TMetricsSettings::kConfigured:
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
             if (newMetricsSettings.HasConfigured()) {
-                TableDescription.MutableMetricsSettings()
+                TableDescription.MutableDetailedMetricsSettings()
                     ->MutableConfigured()
                     ->CopyFrom(newMetricsSettings.GetConfigured());
             }
 
             break;
 
-        case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::kNotConfigured:
             if (newMetricsSettings.HasNotConfigured()) {
-                TableDescription.ClearMetricsSettings();
+                TableDescription.ClearDetailedMetricsSettings();
             }
 
             break;
@@ -3026,33 +3029,33 @@ bool IsPathTypeTable(const NKikimr::NSchemeShard::TExportInfo::TItem& item) {
     return item.SourcePathType == NKikimrSchemeOp::EPathTypeTable || item.SourcePathType == NKikimrSchemeOp::EPathTypeColumnTable;
 }
 
-bool ValidateMetricsSettings(
+bool ValidateTableDetailedMetricsSettings(
     bool forCreate,
-    const NKikimrSchemeOp::TMetricsSettings& metricsSettings,
+    const NKikimrSchemeOp::TTableDetailedMetricsSettings& metricsSettings,
     TString& errorString
 ) {
     switch (metricsSettings.GetStatusCase()) {
-    case NKikimrSchemeOp::TMetricsSettings::kConfigured:
-        // Allow only DATABASE, TABLE and PARTITION levels
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
+        // Allow only DISABLED, TABLE and PARTITION levels
         if (metricsSettings.HasConfigured()) {
             switch (metricsSettings.GetConfigured().GetMetricsLevel()) {
-            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase:
-            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable:
-            case NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition:
+            case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled:
+            case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+            case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
                 break;
 
             default:
-                errorString = "Only DATABASE, TABLE and PARTITION metrics levels are supported";
+                errorString = "Only DISABLED, TABLE and PARTITION detailed metrics levels are supported";
                 return false;
             }
         }
 
         break;
 
-    case NKikimrSchemeOp::TMetricsSettings::kNotConfigured:
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::kNotConfigured:
         // Do not allow dropping the metrics settings in CREATE TABLE
         if (forCreate && metricsSettings.HasNotConfigured()) {
-            errorString = "Unable to remove the metrics settings in CREATE TABLE";
+            errorString = "Unable to remove the detailed metrics settings in CREATE TABLE";
             return false;
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -715,35 +715,35 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
     }
 
     /**
-     * Determine if the metrics settings are configured for the given table.
+     * Determine if the detailed metrics settings are configured for the given table.
      *
-     * @return True, if the metrics settings are configured for the given table
+     * @return True, if the detailed metrics settings are configured for the given table
      */
-    bool HasMetricsSettings() const {
-        return TableDescription.HasMetricsSettings()
-            && (TableDescription.GetMetricsSettings().GetStatusCase()
-                    == NKikimrSchemeOp::TMetricsSettings::kConfigured)
-            && (TableDescription.GetMetricsSettings().HasConfigured());
+    bool HasDetailedMetricsSettings() const {
+        return TableDescription.HasDetailedMetricsSettings()
+            && (TableDescription.GetDetailedMetricsSettings().GetStatusCase()
+                    == NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured)
+            && (TableDescription.GetDetailedMetricsSettings().HasConfigured());
     };
 
     /**
-     * Return the metrics settings for the given table.
+     * Return the detailed metrics settings for the given table.
      *
-     * @warning This function should be called only if HasMetricsSettings() returns true.
+     * @warning This function should be called only if HasDetailedMetricsSettings() returns true.
      *
-     * @return The metrics settings for the given table
+     * @return The detailed metrics settings for the given table
      */
-    const NKikimrSchemeOp::TMetricsSettings::TConfigured& GetMetricsSettings() const {
-        return TableDescription.GetMetricsSettings().GetConfigured();
+    const NKikimrSchemeOp::TTableDetailedMetricsSettings::TConfigured& GetDetailedMetricsSettings() const {
+        return TableDescription.GetDetailedMetricsSettings().GetConfigured();
     }
 
     /**
-     * Return the modifiable version of the metrics settings for the given table.
+     * Return the modifiable version of the detailed metrics settings for the given table.
      *
-     * @return The modifiable version of the metrics settings for the given table
+     * @return The modifiable version of the detailed metrics settings for the given table
      */
-    NKikimrSchemeOp::TMetricsSettings::TConfigured& MutableMetricsSettings() {
-        return *TableDescription.MutableMetricsSettings()->MutableConfigured();
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::TConfigured& MutableDetailedMetricsSettings() {
+        return *TableDescription.MutableDetailedMetricsSettings()->MutableConfigured();
     }
 
     ui32 GetTTLColumnId() const {
@@ -3896,17 +3896,17 @@ bool ValidateTtlSettings(const NKikimrSchemeOp::TTTLSettings& ttl,
     const TSubDomainInfo& subDomain, TString& errStr);
 
 /**
- * Check if the given metrics settings are valid.
+ * Check if the given detailed metrics settings (for a table) are valid.
  *
  * @param[in] forCreate Indicates if this is for CREATE TABLE (ALTER TABLE otherwise)
- * @param[in] metricsSettings The metrics settings to validate
+ * @param[in] metricsSettings The detailed metrics settings to validate
  * @param[out] errorString Receives the error message, if the metrics settings are not valid
  *
- * @return Indicates if the metrics settings are valid
+ * @return Indicates if the detailed metrics settings are valid
  */
-bool ValidateMetricsSettings(
+bool ValidateTableDetailedMetricsSettings(
     bool forCreate,
-    const NKikimrSchemeOp::TMetricsSettings& metricsSettings,
+    const NKikimrSchemeOp::TTableDetailedMetricsSettings& metricsSettings,
     TString& errorString
 );
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -724,7 +724,7 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
             && (TableDescription.GetDetailedMetricsSettings().GetStatusCase()
                     == NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured)
             && (TableDescription.GetDetailedMetricsSettings().HasConfigured());
-    };
+    }
 
     /**
      * Return the detailed metrics settings for the given table.

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -714,6 +714,38 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
         return *TableDescription.MutableTTLSettings();
     }
 
+    /**
+     * Determine if the metrics settings are configured for the given table.
+     *
+     * @return True, if the metrics settings are configured for the given table
+     */
+    bool HasMetricsSettings() const {
+        return TableDescription.HasMetricsSettings()
+            && (TableDescription.GetMetricsSettings().GetStatusCase()
+                    == NKikimrSchemeOp::TMetricsSettings::kConfigured)
+            && (TableDescription.GetMetricsSettings().HasConfigured());
+    };
+
+    /**
+     * Return the metrics settings for the given table.
+     *
+     * @warning This function should be called only if HasMetricsSettings() returns true.
+     *
+     * @return The metrics settings for the given table
+     */
+    const NKikimrSchemeOp::TMetricsSettings::TConfigured& GetMetricsSettings() const {
+        return TableDescription.GetMetricsSettings().GetConfigured();
+    }
+
+    /**
+     * Return the modifiable version of the metrics settings for the given table.
+     *
+     * @return The modifiable version of the metrics settings for the given table
+     */
+    NKikimrSchemeOp::TMetricsSettings::TConfigured& MutableMetricsSettings() {
+        return *TableDescription.MutableMetricsSettings()->MutableConfigured();
+    }
+
     ui32 GetTTLColumnId() const {
         if (!IsTTLEnabled()) {
             return Max<ui32>();
@@ -3862,6 +3894,21 @@ bool ValidateTtlSettings(const NKikimrSchemeOp::TTTLSettings& ttl,
     const TMap<ui32, TTableInfo::TColumn>& alterColumns,
     const THashMap<TString, ui32>& colName2Id,
     const TSubDomainInfo& subDomain, TString& errStr);
+
+/**
+ * Check if the given metrics settings are valid.
+ *
+ * @param[in] forCreate Indicates if this is for CREATE TABLE (ALTER TABLE otherwise)
+ * @param[in] metricsSettings The metrics settings to validate
+ * @param[out] errorString Receives the error message, if the metrics settings are not valid
+ *
+ * @return Indicates if the metrics settings are valid
+ */
+bool ValidateMetricsSettings(
+    bool forCreate,
+    const NKikimrSchemeOp::TMetricsSettings& metricsSettings,
+    TString& errorString
+);
 
 TConclusion<TDuration> GetExpireAfter(const NKikimrSchemeOp::TTTLSettings::TEnabled& settings, const bool allowNonDeleteTiers);
 

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1414,8 +1414,9 @@ void TSchemeShard::DescribeTable(
         entry->MutableTTLSettings()->CopyFrom(tableInfo.TTLSettings());
     }
 
-    if (tableInfo.HasMetricsSettings()) {
-        entry->MutableMetricsSettings()->MutableConfigured()->CopyFrom(tableInfo.GetMetricsSettings());
+    if (tableInfo.HasDetailedMetricsSettings()) {
+        entry->MutableDetailedMetricsSettings()->MutableConfigured()
+            ->CopyFrom(tableInfo.GetDetailedMetricsSettings());
     }
 
     if (tableInfo.HasReplicationConfig()) {

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1414,6 +1414,10 @@ void TSchemeShard::DescribeTable(
         entry->MutableTTLSettings()->CopyFrom(tableInfo.TTLSettings());
     }
 
+    if (tableInfo.HasMetricsSettings()) {
+        entry->MutableMetricsSettings()->MutableConfigured()->CopyFrom(tableInfo.GetMetricsSettings());
+    }
+
     if (tableInfo.HasReplicationConfig()) {
         entry->MutableReplicationConfig()->CopyFrom(tableInfo.ReplicationConfig());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -140,7 +140,7 @@ struct Schema : NIceDb::Schema {
         struct IsTemporary : Column<11, NScheme::NTypeIds::Bool> {};
         struct OwnerActorId : Column<12, NScheme::NTypeIds::String> {}; // deprecated
         struct IncrementalBackupConfig : Column<13, NScheme::NTypeIds::String> {};
-        struct MetricsSettings : Column<15, NScheme::NTypeIds::String> {};
+        struct DetailedMetricsSettings : Column<15, NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<TabId>;
         using TColumns = TableColumns<
@@ -158,7 +158,7 @@ struct Schema : NIceDb::Schema {
             IsTemporary,
             OwnerActorId,
             IncrementalBackupConfig,
-            MetricsSettings
+            DetailedMetricsSettings
         >;
     };
 
@@ -178,8 +178,8 @@ struct Schema : NIceDb::Schema {
         struct ReplicationConfig :   Column<11, NScheme::NTypeIds::String> {};
         struct IsTemporary :         Column<12, NScheme::NTypeIds::Bool> {};
         struct OwnerActorId :        Column<13, NScheme::NTypeIds::String> {}; // deprecated
-        struct IncrementalBackupConfig :   Column<14, NScheme::NTypeIds::String> {};
-        struct MetricsSettings :     Column<16, NScheme::NTypeIds::String> {};
+        struct IncrementalBackupConfig : Column<14, NScheme::NTypeIds::String> {};
+        struct DetailedMetricsSettings : Column<16, NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<
@@ -198,7 +198,7 @@ struct Schema : NIceDb::Schema {
             IsTemporary,
             OwnerActorId,
             IncrementalBackupConfig,
-            MetricsSettings
+            DetailedMetricsSettings
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -140,6 +140,7 @@ struct Schema : NIceDb::Schema {
         struct IsTemporary : Column<11, NScheme::NTypeIds::Bool> {};
         struct OwnerActorId : Column<12, NScheme::NTypeIds::String> {}; // deprecated
         struct IncrementalBackupConfig : Column<13, NScheme::NTypeIds::String> {};
+        struct MetricsSettings : Column<15, NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<TabId>;
         using TColumns = TableColumns<
@@ -156,7 +157,8 @@ struct Schema : NIceDb::Schema {
             ReplicationConfig,
             IsTemporary,
             OwnerActorId,
-            IncrementalBackupConfig
+            IncrementalBackupConfig,
+            MetricsSettings
         >;
     };
 
@@ -177,6 +179,7 @@ struct Schema : NIceDb::Schema {
         struct IsTemporary :         Column<12, NScheme::NTypeIds::Bool> {};
         struct OwnerActorId :        Column<13, NScheme::NTypeIds::String> {}; // deprecated
         struct IncrementalBackupConfig :   Column<14, NScheme::NTypeIds::String> {};
+        struct MetricsSettings :     Column<16, NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<
@@ -194,7 +197,8 @@ struct Schema : NIceDb::Schema {
             ReplicationConfig,
             IsTemporary,
             OwnerActorId,
-            IncrementalBackupConfig
+            IncrementalBackupConfig,
+            MetricsSettings
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -1,0 +1,755 @@
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/test_env.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+namespace {
+
+/**
+ * Validate the description for the given table, restart Scheme Shard
+ * and make sure the table description is still valid.
+ *
+ * @param[in] runtime The test runtime
+ * @param[in] tableName The name of the table to verify
+ * @param[in] validTableChecks The validation checks to apply to the table description
+ */
+void VerifyTableDescriptionAndRestartSchemeShard(
+    TTestBasicRuntime& runtime,
+    const TString& tableName,
+    const TVector<NLs::TCheckFunc>& validTableChecks
+) {
+    // First, validate the current table description
+    auto describeResult = DescribePath(runtime, tableName);
+
+    Cerr << "TEST TEvDescribeSchemeResult:" << Endl
+        << describeResult.DebugString()
+        << Endl;
+
+    TestDescribeResult(describeResult, validTableChecks);
+
+    // Restart Scheme Shard and make sure the metrics settings are still valid
+    RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+    describeResult = DescribePath(runtime, tableName);
+
+    Cerr << "TEST TEvDescribeSchemeResult after restarting Scheme Shard:" << Endl
+        << describeResult.DebugString()
+        << Endl;
+
+    TestDescribeResult(describeResult, validTableChecks);
+}
+
+} // namespace <anonymous>
+
+/**
+ * Unit test for the logic in Scheme Shard, which configures metrics settings
+ * for individual tables.
+ */
+Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
+    /**
+     * Verify that CREATE TABLE without the metrics level specified works correctly.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across SchemeShard restarts.
+     */
+    Y_UNIT_TEST(CreateTableNoMetricsLevel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Make sure the metrics settings are not configured for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE with the metrics settings explicitly dropped
+     * is not allowed and fails with an error.
+     */
+    Y_UNIT_TEST(CreateTableDroppingMetricsSettingsNotAlllowed) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+                MetricsSettings {
+                    NotConfigured {
+                    }
+                }
+            )",
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "Unable to remove the metrics settings in CREATE TABLE",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the given invalid metrics
+     * level is specified in the request.
+     *
+     * @param[in] metricsLevel The metrics level to verify
+     */
+    void VerifyCreateTableInvalidMetricsLevel(
+        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            Sprintf(
+                R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    MetricsSettings {
+                        Configured {
+                            MetricsLevel: %s
+                        }
+                    }
+                )",
+                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+            ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "Only DATABASE, TABLE and PARTITION metrics levels are supported",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when an invalid metrics level
+     * is specified (UNSPECIFIED).
+     */
+    Y_UNIT_TEST(CreateTableInvalidMetricsLevelUnspecified) {
+        VerifyCreateTableInvalidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when an invalid metrics level
+     * is specified (DISABLED).
+     */
+    Y_UNIT_TEST(CreateTableInvalidMetricsLevelDisabled) {
+        VerifyCreateTableInvalidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE works correctly, when the given valid metrics
+     * level is specified in the request.
+     *
+     * @note This functions also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @param[in] metricsLevel The metrics level to verify
+     */
+    void VerifyCreateTableValidMetricsLevel(
+        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            Sprintf(
+                R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    MetricsSettings {
+                        Configured {
+                            MetricsLevel: %s
+                        }
+                    }
+                )",
+                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+            )
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Make sure the metrics settings are configured correctly for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [metricsLevel](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                    );
+
+                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        metricsLevel
+                    );
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE works correctly with a valid metrics level (DATABASE).
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(CreateTableValidMetricsLevelDatabase) {
+        VerifyCreateTableValidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE works correctly with a valid metrics level (TABLE).
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(CreateTableValidMetricsLevelTable) {
+        VerifyCreateTableValidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE works correctly with a valid metrics level (PARTITION).
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(CreateTableValidMetricsLevelPartition) {
+        VerifyCreateTableValidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE without the metrics level specified works correctly,
+     * when applied to a table, which does not have any metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetNoMetricsLevel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // First, create a table without any metrics settings
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE without specifying metrics settings
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                DropColumns { Name: "value" }
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 101);
+
+        // Make sure the metrics settings are not configured for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly.
+     *
+     * @note This functions also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @param[in] sourceHasMetricsLevel Indicates whether the source table has the metrics level configured
+     */
+    void VerifyAlterTableRemoveMetricsLevel(bool sourceHasMetricsLevel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // First, create a table with or without metrics settings configured
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            (!sourceHasMetricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                  )"
+                : R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    MetricsSettings {
+                        Configured {
+                            MetricsLevel: MetricsLevelPartition
+                        }
+                    }
+                  )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE with the metrics settings explicitly removed
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                MetricsSettings {
+                    NotConfigured {
+                    }
+                }
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 101);
+
+        // Make sure the metrics settings are not configured for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly,
+     * when applied to a table, which does not have any metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetRemoveMetricsLevel) {
+        VerifyAlterTableRemoveMetricsLevel(false /* sourceHasMetricsLevel */);
+    }
+
+    /**
+     * Verify that ALTER TABLE fails correctly, when the given invalid metrics
+     * level is specified in the request.
+     *
+     * @param[in] metricsLevel The metrics level to verify
+     */
+    void VerifyAlterTableInvalidMetricsLevel(
+        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // First, create a table without any metrics settings
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE with an invalid metrics level
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            Sprintf(
+                R"(
+                    Name: "TestTable"
+                    MetricsSettings {
+                        Configured {
+                            MetricsLevel: %s
+                        }
+                    }
+                )",
+                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+            ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "Only DATABASE, TABLE and PARTITION metrics levels are supported",
+            }}
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE fails correctly, when an invalid metrics level
+     * is specified (UNSPECIFIED).
+     */
+    Y_UNIT_TEST(AlterTableInvalidMetricsLevelUnspecified) {
+        VerifyAlterTableInvalidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE fails correctly, when an invalid metrics level
+     * is specified (DISABLED).
+     */
+    Y_UNIT_TEST(AlterTableInvalidMetricsLevelDisabled) {
+        VerifyAlterTableInvalidMetricsLevel(
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly, when the given valid metrics
+     * level is specified in the request.
+     *
+     * @note This functions also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @param[in] sourceHasMetricsLevel Indicates whether the source table has the metrics level configured
+     * @param[in] metricsLevel The metrics level to verify
+     */
+    void VerifyAlterTableValidMetricsLevel(
+        bool sourceHasMetricsLevel,
+        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // First, create a table with or without metrics settings configured
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            (!sourceHasMetricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                  )"
+                : Sprintf(
+                    R"(
+                        Name: "TestTable"
+                        Columns { Name: "key"   Type: "Uint64" }
+                        Columns { Name: "value" Type: "String" }
+                        KeyColumnNames: ["key"]
+                        MetricsSettings {
+                            Configured {
+                                MetricsLevel: %s
+                            }
+                        }
+                    )",
+                    NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(
+                        // NOTE: Use any valid level here, but it must be different
+                        //       from the requested target level to be able to detect
+                        //       the changes after ALTER TABLE is completed
+                        (metricsLevel == NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition)
+                            ? NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+                            : NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+                    ).c_str()
+                  )
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE with the metrics settings explicitly specified
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            Sprintf(
+                R"(
+                    Name: "TestTable"
+                    MetricsSettings {
+                        Configured {
+                            MetricsLevel: %s
+                        }
+                    }
+                )",
+                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+            )
+        );
+
+        env.TestWaitNotification(runtime, 101);
+
+        // Make sure the metrics settings are configured correctly for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [metricsLevel](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                    );
+
+                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        metricsLevel
+                    );
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (DATABASE),
+     * when applied to a table, which does not have any metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelDatabase) {
+        VerifyAlterTableValidMetricsLevel(
+            false /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (TABLE),
+     * when applied to a table, which does not have any metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelTable) {
+        VerifyAlterTableValidMetricsLevel(
+            false /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (PARTITION),
+     * when applied to a table, which does not have any metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelPartition) {
+        VerifyAlterTableValidMetricsLevel(
+            false /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE without the metrics level specified works correctly,
+     * when applied to a table, which has some metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetNoMetricsLevel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // First, create a table with some metrics settings configured
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+                MetricsSettings {
+                    Configured {
+                        MetricsLevel: MetricsLevelPartition
+                    }
+                }
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE without specifying metrics settings
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                DropColumns { Name: "value" }
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 101);
+
+        // Make sure the metrics settings are configured correctly for this table
+        VerifyTableDescriptionAndRestartSchemeShard(
+            runtime,
+            "/MyRoot/TestTable",
+            {
+                NLs::PathExist,
+                [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                    const auto& tableDescription = record.GetPathDescription().GetTable();
+
+                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                    );
+
+                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+
+                    UNIT_ASSERT_EQUAL(
+                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+                    );
+                },
+            }
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly,
+     * when applied to a table, which has some metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetRemoveMetricsLevel) {
+        VerifyAlterTableRemoveMetricsLevel(true /* sourceHasMetricsLevel */);
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (DATABASE),
+     * when applied to a table, which has some metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelDatabase) {
+        VerifyAlterTableValidMetricsLevel(
+            true /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (TABLE),
+     * when applied to a table, which has some metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelTable) {
+        VerifyAlterTableValidMetricsLevel(
+            true /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE works correctly with a valid metrics level (PARTITION),
+     * when applied to a table, which has some metrics settings configured.
+     *
+     * @note This test also verifies that the metrics settings are preserved
+     *       across Scheme Shard restarts.
+     */
+    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelPartition) {
+        VerifyAlterTableValidMetricsLevel(
+            true /* sourceHasMetricsLevel */,
+            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+        );
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -49,17 +49,17 @@ void VerifyTableDescriptionAndRestartSchemeShard(
 } // namespace <anonymous>
 
 /**
- * Unit test for the logic in Scheme Shard, which configures metrics settings
+ * Unit test for the logic in Scheme Shard, which configures detailed metrics settings
  * for individual tables.
  */
-Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
+Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
-     * Verify that CREATE TABLE without the metrics level specified works correctly.
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across SchemeShard restarts.
      */
-    Y_UNIT_TEST(CreateTableNoMetricsLevel) {
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
@@ -77,7 +77,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 100);
 
-        // Make sure the metrics settings are not configured for this table
+        // Make sure the detailed metrics settings are not configured for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -86,17 +86,17 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(!tableDescription.HasDetailedMetricsSettings());
                 },
             }
         );
     }
 
     /**
-     * Verify that CREATE TABLE with the metrics settings explicitly dropped
+     * Verify that CREATE TABLE with the detailed metrics settings explicitly dropped
      * is not allowed and fails with an error.
      */
-    Y_UNIT_TEST(CreateTableDroppingMetricsSettingsNotAllowed) {
+    Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowed) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
@@ -109,51 +109,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 Columns { Name: "key"   Type: "Uint64" }
                 Columns { Name: "value" Type: "String" }
                 KeyColumnNames: ["key"]
-                MetricsSettings {
+                DetailedMetricsSettings {
                     NotConfigured {
                     }
                 }
             )",
             {{
                 NKikimrScheme::StatusInvalidParameter,
-                "Unable to remove the metrics settings in CREATE TABLE",
-            }}
-        );
-    }
-
-    /**
-     * Verify that CREATE TABLE fails correctly, when the given invalid metrics
-     * level is specified in the request.
-     *
-     * @param[in] metricsLevel The metrics level to verify
-     */
-    void VerifyCreateTableInvalidMetricsLevel(
-        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
-    ) {
-        TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
-
-        TestCreateTable(
-            runtime,
-            100,
-            "/MyRoot",
-            Sprintf(
-                R"(
-                    Name: "TestTable"
-                    Columns { Name: "key"   Type: "Uint64" }
-                    Columns { Name: "value" Type: "String" }
-                    KeyColumnNames: ["key"]
-                    MetricsSettings {
-                        Configured {
-                            MetricsLevel: %s
-                        }
-                    }
-                )",
-                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
-            ),
-            {{
-                NKikimrScheme::StatusInvalidParameter,
-                "Only DATABASE, TABLE and PARTITION metrics levels are supported",
+                "Unable to remove the detailed metrics settings in CREATE TABLE",
             }}
         );
     }
@@ -162,33 +125,43 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
      * Verify that CREATE TABLE fails correctly, when an invalid metrics level
      * is specified (UNSPECIFIED).
      */
-    Y_UNIT_TEST(CreateTableInvalidMetricsLevelUnspecified) {
-        VerifyCreateTableInvalidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelUnspecified
+    Y_UNIT_TEST(CreateTableInvalidDetailedMetricsLevelUnspecified) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+                DetailedMetricsSettings {
+                    Configured {
+                        MetricsLevel: MetricsLevelUnspecified
+                    }
+                }
+            )",
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "Only DISABLED, TABLE and PARTITION detailed metrics levels are supported",
+            }}
         );
     }
 
     /**
-     * Verify that CREATE TABLE fails correctly, when an invalid metrics level
-     * is specified (DISABLED).
-     */
-    Y_UNIT_TEST(CreateTableInvalidMetricsLevelDisabled) {
-        VerifyCreateTableInvalidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDisabled
-        );
-    }
-
-    /**
-     * Verify that CREATE TABLE works correctly, when the given valid metrics
-     * level is specified in the request.
+     * Verify that CREATE TABLE works correctly, when the given valid
+     * detailed metrics level is specified in the request.
      *
-     * @note This functions also verifies that the metrics settings are preserved
+     * @note This functions also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      *
-     * @param[in] metricsLevel The metrics level to verify
+     * @param[in] metricsLevel The detailed metrics level to verify
      */
-    void VerifyCreateTableValidMetricsLevel(
-        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+    void VerifyCreateTableValidDetailedMetricsLevel(
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel metricsLevel
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -203,19 +176,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                     Columns { Name: "key"   Type: "Uint64" }
                     Columns { Name: "value" Type: "String" }
                     KeyColumnNames: ["key"]
-                    MetricsSettings {
+                    DetailedMetricsSettings {
                         Configured {
                             MetricsLevel: %s
                         }
                     }
                 )",
-                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+                NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
             )
         );
 
         env.TestWaitNotification(runtime, 100);
 
-        // Make sure the metrics settings are configured correctly for this table
+        // Make sure the detailed metrics settings are configured correctly for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -224,18 +197,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [metricsLevel](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(tableDescription.HasDetailedMetricsSettings());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetStatusCase(),
-                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                        tableDescription.GetDetailedMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured
                     );
 
-                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
-                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+                    UNIT_ASSERT(tableDescription.GetDetailedMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetDetailedMetricsSettings().HasNotConfigured());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        tableDescription.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel(),
                         metricsLevel
                     );
                 },
@@ -244,53 +217,56 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
     }
 
     /**
-     * Verify that CREATE TABLE works correctly with a valid metrics level (DATABASE).
+     * Verify that CREATE TABLE works correctly with a valid
+     * detailed metrics level (DISABLED).
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(CreateTableValidMetricsLevelDatabase) {
-        VerifyCreateTableValidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+    Y_UNIT_TEST(CreateTableValidDetailedMetricsLevelDisabled) {
+        VerifyCreateTableValidDetailedMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
         );
     }
 
     /**
-     * Verify that CREATE TABLE works correctly with a valid metrics level (TABLE).
+     * Verify that CREATE TABLE works correctly with a valid
+     * detailed metrics level (TABLE).
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(CreateTableValidMetricsLevelTable) {
-        VerifyCreateTableValidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+    Y_UNIT_TEST(CreateTableValidDetailedMetricsLevelTable) {
+        VerifyCreateTableValidDetailedMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
         );
     }
 
     /**
-     * Verify that CREATE TABLE works correctly with a valid metrics level (PARTITION).
+     * Verify that CREATE TABLE works correctly with a valid
+     * detailed metrics level (PARTITION).
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(CreateTableValidMetricsLevelPartition) {
-        VerifyCreateTableValidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+    Y_UNIT_TEST(CreateTableValidDetailedMetricsLevelPartition) {
+        VerifyCreateTableValidDetailedMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
         );
     }
 
     /**
-     * Verify that ALTER TABLE without the metrics level specified works correctly,
-     * when applied to a table, which does not have any metrics settings configured.
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetNoMetricsLevel) {
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        // First, create a table without any metrics settings
+        // First, create a table without any detailed metrics settings
         TestCreateTable(
             runtime,
             100,
@@ -305,7 +281,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 100);
 
-        // Second, execute ALTER TABLE without specifying metrics settings
+        // Second, execute ALTER TABLE without specifying detailed metrics settings
         TestAlterTable(
             runtime,
             101,
@@ -318,7 +294,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 101);
 
-        // Make sure the metrics settings are not configured for this table
+        // Make sure the detailed metrics settings are not configured for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -327,25 +303,27 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(!tableDescription.HasDetailedMetricsSettings());
                 },
             }
         );
     }
 
     /**
-     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly.
+     * Verify that ALTER TABLE with the detailed metrics level explicitly removed
+     * works correctly.
      *
-     * @note This functions also verifies that the metrics settings are preserved
+     * @note This functions also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      *
-     * @param[in] sourceHasMetricsLevel Indicates whether the source table has the metrics level configured
+     * @param[in] sourceHasMetricsLevel Indicates whether the source table has
+     *                                  the detailed metrics level configured
      */
-    void VerifyAlterTableRemoveMetricsLevel(bool sourceHasMetricsLevel) {
+    void VerifyAlterTableRemoveDetailedMetricsLevel(bool sourceHasMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        // First, create a table with or without metrics settings configured
+        // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
             runtime,
             100,
@@ -362,7 +340,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                     Columns { Name: "key"   Type: "Uint64" }
                     Columns { Name: "value" Type: "String" }
                     KeyColumnNames: ["key"]
-                    MetricsSettings {
+                    DetailedMetricsSettings {
                         Configured {
                             MetricsLevel: MetricsLevelPartition
                         }
@@ -372,14 +350,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 100);
 
-        // Second, execute ALTER TABLE with the metrics settings explicitly removed
+        // Second, execute ALTER TABLE with the detailed metrics settings explicitly removed
         TestAlterTable(
             runtime,
             101,
             "/MyRoot",
             R"(
                 Name: "TestTable"
-                MetricsSettings {
+                DetailedMetricsSettings {
                     NotConfigured {
                     }
                 }
@@ -388,7 +366,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 101);
 
-        // Make sure the metrics settings are not configured for this table
+        // Make sure the detailed metrics settings are not configured for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -397,36 +375,33 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(!tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(!tableDescription.HasDetailedMetricsSettings());
                 },
             }
         );
     }
 
     /**
-     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly,
-     * when applied to a table, which does not have any metrics settings configured.
+     * Verify that ALTER TABLE with the detailed metrics level explicitly removed
+     * works correctly, when applied to a table, which does not have
+     * any detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetRemoveMetricsLevel) {
-        VerifyAlterTableRemoveMetricsLevel(false /* sourceHasMetricsLevel */);
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetRemoveDetailedMetricsLevel) {
+        VerifyAlterTableRemoveDetailedMetricsLevel(false /* sourceHasMetricsLevel */);
     }
 
     /**
-     * Verify that ALTER TABLE fails correctly, when the given invalid metrics
-     * level is specified in the request.
-     *
-     * @param[in] metricsLevel The metrics level to verify
+     * Verify that ALTER TABLE fails correctly, when an invalid detailed metrics level
+     * is specified (UNSPECIFIED).
      */
-    void VerifyAlterTableInvalidMetricsLevel(
-        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
-    ) {
+    Y_UNIT_TEST(AlterTableInvalidDetailedMetricsLevelUnspecified) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        // First, create a table without any metrics settings
+        // First, create a table without any detailed metrics settings
         TestCreateTable(
             runtime,
             100,
@@ -441,67 +416,45 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 100);
 
-        // Second, execute ALTER TABLE with an invalid metrics level
+        // Second, execute ALTER TABLE with an invalid detailed metrics level
         TestAlterTable(
             runtime,
             101,
             "/MyRoot",
-            Sprintf(
-                R"(
-                    Name: "TestTable"
-                    MetricsSettings {
-                        Configured {
-                            MetricsLevel: %s
-                        }
+            R"(
+                Name: "TestTable"
+                DetailedMetricsSettings {
+                    Configured {
+                        MetricsLevel: MetricsLevelUnspecified
                     }
-                )",
-                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
-            ),
+                }
+            )",
             {{
                 NKikimrScheme::StatusInvalidParameter,
-                "Only DATABASE, TABLE and PARTITION metrics levels are supported",
+                "Only DISABLED, TABLE and PARTITION detailed metrics levels are supported",
             }}
         );
     }
 
     /**
-     * Verify that ALTER TABLE fails correctly, when an invalid metrics level
-     * is specified (UNSPECIFIED).
-     */
-    Y_UNIT_TEST(AlterTableInvalidMetricsLevelUnspecified) {
-        VerifyAlterTableInvalidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelUnspecified
-        );
-    }
-
-    /**
-     * Verify that ALTER TABLE fails correctly, when an invalid metrics level
-     * is specified (DISABLED).
-     */
-    Y_UNIT_TEST(AlterTableInvalidMetricsLevelDisabled) {
-        VerifyAlterTableInvalidMetricsLevel(
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDisabled
-        );
-    }
-
-    /**
-     * Verify that ALTER TABLE works correctly, when the given valid metrics
+     * Verify that ALTER TABLE works correctly, when the given valid detailed metrics
      * level is specified in the request.
      *
-     * @note This functions also verifies that the metrics settings are preserved
+     * @note This functions also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      *
-     * @param[in] sourceHasMetricsLevel Indicates whether the source table has the metrics level configured
+     * @param[in] sourceHasMetricsLevel Indicates whether the source table has
+     *                                  the detailed metrics level configured
      * @param[in] metricsLevel The metrics level to verify
      */
-    void VerifyAlterTableValidMetricsLevel(
+    void VerifyAlterTableValidDetailedMetricsLevel(
         bool sourceHasMetricsLevel,
-        NKikimrSchemeOp::TMetricsSettings::EMetricsLevel metricsLevel
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel metricsLevel
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        // First, create a table with or without metrics settings configured
+        // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
             runtime,
             100,
@@ -519,26 +472,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                         Columns { Name: "key"   Type: "Uint64" }
                         Columns { Name: "value" Type: "String" }
                         KeyColumnNames: ["key"]
-                        MetricsSettings {
+                        DetailedMetricsSettings {
                             Configured {
                                 MetricsLevel: %s
                             }
                         }
                     )",
-                    NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(
                         // NOTE: Use any valid level here, but it must be different
                         //       from the requested target level to be able to detect
                         //       the changes after ALTER TABLE is completed
-                        (metricsLevel == NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition)
-                            ? NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
-                            : NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+                        (metricsLevel == NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition)
+                            ? NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+                            : NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
                     ).c_str()
                   )
         );
 
         env.TestWaitNotification(runtime, 100);
 
-        // Second, execute ALTER TABLE with the metrics settings explicitly specified
+        // Second, execute ALTER TABLE with the detailed metrics settings explicitly specified
         TestAlterTable(
             runtime,
             101,
@@ -546,19 +499,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
             Sprintf(
                 R"(
                     Name: "TestTable"
-                    MetricsSettings {
+                    DetailedMetricsSettings {
                         Configured {
                             MetricsLevel: %s
                         }
                     }
                 )",
-                NKikimrSchemeOp::TMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
+                NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(metricsLevel).c_str()
             )
         );
 
         env.TestWaitNotification(runtime, 101);
 
-        // Make sure the metrics settings are configured correctly for this table
+        // Make sure the detailed metrics settings are configured correctly for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -567,18 +520,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [metricsLevel](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(tableDescription.HasDetailedMetricsSettings());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetStatusCase(),
-                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                        tableDescription.GetDetailedMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured
                     );
 
-                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
-                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+                    UNIT_ASSERT(tableDescription.GetDetailedMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetDetailedMetricsSettings().HasNotConfigured());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        tableDescription.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel(),
                         metricsLevel
                     );
                 },
@@ -587,59 +540,59 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (DATABASE),
-     * when applied to a table, which does not have any metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (DISABLED),
+     * when applied to a table, which does not have any detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelDatabase) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetValidDetailedMetricsLevelDisabled) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             false /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
         );
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (TABLE),
-     * when applied to a table, which does not have any metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (TABLE),
+     * when applied to a table, which does not have any detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelTable) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetValidDetailedMetricsLevelTable) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             false /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
         );
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (PARTITION),
-     * when applied to a table, which does not have any metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (PARTITION),
+     * when applied to a table, which does not have any detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceNoMetricsLevelTargetValidMetricsLevelPartition) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetValidDetailedMetricsLevelPartition) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             false /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
         );
     }
 
     /**
-     * Verify that ALTER TABLE without the metrics level specified works correctly,
-     * when applied to a table, which has some metrics settings configured.
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which has some detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetNoMetricsLevel) {
+    Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        // First, create a table with some metrics settings configured
+        // First, create a table with some detailed metrics settings configured
         TestCreateTable(
             runtime,
             100,
@@ -649,7 +602,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 Columns { Name: "key"   Type: "Uint64" }
                 Columns { Name: "value" Type: "String" }
                 KeyColumnNames: ["key"]
-                MetricsSettings {
+                DetailedMetricsSettings {
                     Configured {
                         MetricsLevel: MetricsLevelPartition
                     }
@@ -659,7 +612,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 100);
 
-        // Second, execute ALTER TABLE without specifying metrics settings
+        // Second, execute ALTER TABLE without specifying detailed metrics settings
         TestAlterTable(
             runtime,
             101,
@@ -672,7 +625,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
 
         env.TestWaitNotification(runtime, 101);
 
-        // Make sure the metrics settings are configured correctly for this table
+        // Make sure the detailed metrics settings are configured correctly for this table
         VerifyTableDescriptionAndRestartSchemeShard(
             runtime,
             "/MyRoot/TestTable",
@@ -681,19 +634,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
                 [](const NKikimrScheme::TEvDescribeSchemeResult& record) {
                     const auto& tableDescription = record.GetPathDescription().GetTable();
 
-                    UNIT_ASSERT(tableDescription.HasMetricsSettings());
+                    UNIT_ASSERT(tableDescription.HasDetailedMetricsSettings());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetStatusCase(),
-                        NKikimrSchemeOp::TMetricsSettings::kConfigured
+                        tableDescription.GetDetailedMetricsSettings().GetStatusCase(),
+                        NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured
                     );
 
-                    UNIT_ASSERT(tableDescription.GetMetricsSettings().HasConfigured());
-                    UNIT_ASSERT(!tableDescription.GetMetricsSettings().HasNotConfigured());
+                    UNIT_ASSERT(tableDescription.GetDetailedMetricsSettings().HasConfigured());
+                    UNIT_ASSERT(!tableDescription.GetDetailedMetricsSettings().HasNotConfigured());
 
                     UNIT_ASSERT_EQUAL(
-                        tableDescription.GetMetricsSettings().GetConfigured().GetMetricsLevel(),
-                        NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+                        tableDescription.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel(),
+                        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
                     );
                 },
             }
@@ -701,55 +654,56 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
     }
 
     /**
-     * Verify that ALTER TABLE with the metrics level explicitly removed works correctly,
-     * when applied to a table, which has some metrics settings configured.
+     * Verify that ALTER TABLE with the detailed metrics level explicitly removed
+     * works correctly,  when applied to a table, which has some detailed metrics
+     * settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetRemoveMetricsLevel) {
-        VerifyAlterTableRemoveMetricsLevel(true /* sourceHasMetricsLevel */);
+    Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetRemoveDetailedMetricsLevel) {
+        VerifyAlterTableRemoveDetailedMetricsLevel(true /* sourceHasMetricsLevel */);
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (DATABASE),
-     * when applied to a table, which has some metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (DISABLED),
+     * when applied to a table, which has some detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelDatabase) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetValidDetailedMetricsLevelDisabled) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             true /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelDatabase
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
         );
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (TABLE),
-     * when applied to a table, which has some metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (TABLE),
+     * when applied to a table, which has some detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelTable) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetValidDetailedMetricsLevelTable) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             true /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelTable
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
         );
     }
 
     /**
-     * Verify that ALTER TABLE works correctly with a valid metrics level (PARTITION),
-     * when applied to a table, which has some metrics settings configured.
+     * Verify that ALTER TABLE works correctly with a valid detailed metrics level (PARTITION),
+     * when applied to a table, which has some detailed metrics settings configured.
      *
-     * @note This test also verifies that the metrics settings are preserved
+     * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
      */
-    Y_UNIT_TEST(AlterTableSourceWithMetricsLevelTargetValidMetricsLevelPartition) {
-        VerifyAlterTableValidMetricsLevel(
+    Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetValidDetailedMetricsLevelPartition) {
+        VerifyAlterTableValidDetailedMetricsLevel(
             true /* sourceHasMetricsLevel */,
-            NKikimrSchemeOp::TMetricsSettings::MetricsLevelPartition
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
         );
     }
 }

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -96,7 +96,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableMetricsSettingsTest) {
      * Verify that CREATE TABLE with the metrics settings explicitly dropped
      * is not allowed and fails with an error.
      */
-    Y_UNIT_TEST(CreateTableDroppingMetricsSettingsNotAlllowed) {
+    Y_UNIT_TEST(CreateTableDroppingMetricsSettingsNotAllowed) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 

--- a/ydb/core/tx/schemeshard/ut_metrics/ya.make
+++ b/ydb/core/tx/schemeshard/ut_metrics/ya.make
@@ -1,0 +1,22 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(60)
+
+SIZE(SMALL)
+
+SRCS(
+    ut_table_metrics_settings.cpp
+)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/core/testlib/pg
+    ydb/core/tx/schemeshard/ut_helpers
+    yql/essentials/public/udf/service/exception_policy
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -37,6 +37,7 @@ RECURSE_FOR_TESTS(
     ut_index_build_reboots
     ut_login
     ut_login_large
+    ut_metrics
     ut_move
     ut_move_reboots
     ut_olap

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -390,6 +390,11 @@
                 "ColumnId": 14,
                 "ColumnName": "IsRestore",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "MetricsSettings",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
@@ -409,7 +414,8 @@
                     11,
                     12,
                     13,
-                    14
+                    14,
+                    15
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -3985,6 +3991,11 @@
                 "ColumnId": 15,
                 "ColumnName": "IsRestore",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 16,
+                "ColumnName": "MetricsSettings",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
@@ -4005,7 +4016,8 @@
                     12,
                     13,
                     14,
-                    15
+                    15,
+                    16
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -393,7 +393,7 @@
             },
             {
                 "ColumnId": 15,
-                "ColumnName": "MetricsSettings",
+                "ColumnName": "DetailedMetricsSettings",
                 "ColumnType": "String"
             }
         ],
@@ -3994,7 +3994,7 @@
             },
             {
                 "ColumnId": 16,
-                "ColumnName": "MetricsSettings",
+                "ColumnName": "DetailedMetricsSettings",
                 "ColumnType": "String"
             }
         ],


### PR DESCRIPTION
### Changelog entry

* Implement CREATE/ALTER TABLE with METRICS_LEVEL in Scheme Shard

### Changelog category

* New feature

### Description for reviewers

* Added metrics settings to TTableDescription
* Added METRICS_LEVEL support to CREATE TABLE in Scheme Shard
* Added METRICS_LEVEL support to ALTER TABLE in Scheme Shard (including RESET)
* Added unit tests for CREATE/ALTER TABLE with METRICS_LEVEL