### PR TITLE
Add levelStr field in JSON logger for Y.Deploy compatibility

### DIFF
--- a/ydb/library/actors/core/log.cpp
+++ b/ydb/library/actors/core/log.cpp
@@ -594,6 +594,10 @@ namespace NActors {
                     .WriteKey("revision")
                     .WriteInt(GetProgramSvnRevision());
 
+                if (Settings->AddLevelInJson) {
+                    j.WriteKey("levelStr").WriteString(PriorityToString(priority));
+                }
+
                 if (fileName) {
                     TStringBuilder location;
                     location << fileName << ":" << lineNumber;

--- a/ydb/library/actors/core/log_settings.h
+++ b/ydb/library/actors/core/log_settings.h
@@ -95,6 +95,8 @@ namespace NActors {
             TString TenantName;
             TString MessagePrefix;
             ui32 NodeId;
+            // Add levelStr field in JSON for Y.Deploy log format
+            bool AddLevelInJson = false;
 
             // The best way to provide minVal, maxVal and func is to have
             // protobuf enumeration of components. In this case protoc


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

New parameter adds `levelStr` field to JSON logger output which makes it compatible with Y.Deploy log parser
