### PR TITLE
[BHJ] Fix keys reorder

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
@@ -11,6 +11,9 @@
 
 #include <arrow/scalar.h>
 
+#include <algorithm>
+#include <numeric>
+
 #include "dq_join_common.h"
 
 namespace NKikimr::NMiniKQL {
@@ -32,7 +35,9 @@ struct TDqBlockJoinContext {
     // at runtime (inside DoCalculate) whose lifetime depends on the
     // TComputationContext – which may differ between iterations/retries.
     TSides<TVector<TType*>> UserTypes;
-    TVector<ui32> BuildColumnPermutation;
+    // Per-side column permutation that puts key pair i at position i.
+    // perm[newPos] = oldPos.  Empty when no reorder is needed.
+    TSides<TVector<ui32>> ColumnPermutation;
 };
 
 class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
@@ -45,7 +50,7 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
         , StreamValues_(Stream_->GetValue(ctx))
         , Buff_(ctx.MutableValues.get() + meta->TempStateIndes.SelectSide(side), meta->InputTypes.SelectSide(side).size())
         , ArrowBlockToInternalConverter_(converters.SelectSide(side).get())
-        , ColumnPermutation_(side == ESide::Build ? meta->BuildColumnPermutation : TVector<ui32>{})
+        , ColumnPermutation_(meta->ColumnPermutation.SelectSide(side))
     {}
 
     bool Finished() const {
@@ -430,59 +435,49 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
         }
     }
 
-    {
-        const auto& probeKeys = meta.KeyColumns.Probe;
-        const auto& buildKeys = meta.KeyColumns.Build;
-        const ui32 numDataCols = meta.InputTypes.Build.size() - 1;
+    for (ESide side : EachSide) {
+        auto& keyColumns = meta.KeyColumns.SelectSide(side);
+        const ui32 numDataCols = meta.InputTypes.SelectSide(side).size() - 1;
+        const ui32 numKeys = keyColumns.size();
 
         bool needsReorder = false;
-        for (size_t i = 0; i < probeKeys.size(); ++i) {
-            if (probeKeys[i] != buildKeys[i]) {
+        for (ui32 i = 0; i < numKeys; ++i) {
+            if (keyColumns[i] != static_cast<int>(i)) {
                 needsReorder = true;
                 break;
             }
         }
+        if (!needsReorder) {
+            continue;
+        }
 
-        if (needsReorder) {
-            TVector<ui32> buildPerm(numDataCols);
-            TVector<bool> usedOld(numDataCols, false);
-            TVector<bool> usedNew(numDataCols, false);
+        TVector<ui32> perm(numDataCols);
+        std::iota(perm.begin(), perm.end(), 0);
+        for (ui32 i = 0; i < numKeys; ++i) {
+            auto it = std::find(perm.begin(), perm.end(), static_cast<ui32>(keyColumns[i]));
+            std::swap(perm[i], *it);
+        }
 
-            for (size_t i = 0; i < probeKeys.size(); ++i) {
-                buildPerm[probeKeys[i]] = buildKeys[i];
-                usedOld[buildKeys[i]] = true;
-                usedNew[probeKeys[i]] = true;
+        meta.ColumnPermutation.SelectSide(side) = perm;
+
+        auto origTypes = TVector<TBlockType*>(meta.InputTypes.SelectSide(side).begin(),
+                                              meta.InputTypes.SelectSide(side).begin() + numDataCols);
+        for (ui32 j = 0; j < numDataCols; ++j) {
+            meta.InputTypes.SelectSide(side)[j] = origTypes[perm[j]];
+        }
+
+        TVector<ui32> inv(numDataCols);
+        for (ui32 j = 0; j < numDataCols; ++j) {
+            inv[perm[j]] = j;
+        }
+        for (auto& rename : meta.Renames) {
+            if (rename.Side == side) {
+                rename.Index = inv[rename.Index];
             }
+        }
 
-            ui32 nextOld = 0;
-            for (ui32 j = 0; j < numDataCols; ++j) {
-                if (!usedNew[j]) {
-                    while (usedOld[nextOld]) nextOld++;
-                    buildPerm[j] = nextOld;
-                    usedOld[nextOld] = true;
-                }
-            }
-
-            meta.BuildColumnPermutation = buildPerm;
-
-            TVector<ui32> inversePerm(numDataCols);
-            for (ui32 j = 0; j < numDataCols; ++j) {
-                inversePerm[buildPerm[j]] = j;
-            }
-
-            TVector<TBlockType*> origTypes(meta.InputTypes.Build.begin(),
-                                           meta.InputTypes.Build.begin() + numDataCols);
-            for (ui32 j = 0; j < numDataCols; ++j) {
-                meta.InputTypes.Build[j] = origTypes[buildPerm[j]];
-            }
-
-            meta.KeyColumns.Build = TVector<int>(probeKeys.begin(), probeKeys.end());
-
-            for (auto& rename : meta.Renames) {
-                if (rename.Side == ESide::Build) {
-                    rename.Index = inversePerm[rename.Index];
-                }
-            }
+        for (ui32 i = 0; i < numKeys; ++i) {
+            keyColumns[i] = i;
         }
     }
 

--- a/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
@@ -32,6 +32,7 @@ struct TDqBlockJoinContext {
     // at runtime (inside DoCalculate) whose lifetime depends on the
     // TComputationContext – which may differ between iterations/retries.
     TSides<TVector<TType*>> UserTypes;
+    TVector<ui32> BuildColumnPermutation;
 };
 
 class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
@@ -44,6 +45,7 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
         , StreamValues_(Stream_->GetValue(ctx))
         , Buff_(ctx.MutableValues.get() + meta->TempStateIndes.SelectSide(side), meta->InputTypes.SelectSide(side).size())
         , ArrowBlockToInternalConverter_(converters.SelectSide(side).get())
+        , ColumnPermutation_(side == ESide::Build ? meta->BuildColumnPermutation : TVector<ui32>{})
     {}
 
     bool Finished() const {
@@ -68,6 +70,13 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
         }
         const size_t cols = UserDataCols();
         TVector<arrow::Datum> columns = ArrowFromUV({Buff_.data(), cols});
+        if (!ColumnPermutation_.empty()) {
+            TVector<arrow::Datum> permuted(cols);
+            for (size_t j = 0; j < cols; ++j) {
+                permuted[j] = std::move(columns[ColumnPermutation_[j]]);
+            }
+            columns = std::move(permuted);
+        }
         IBlockLayoutConverter::TPackResult result;
         ArrowBlockToInternalConverter_->Pack(columns, result);
         return One{std::move(result)};
@@ -88,6 +97,7 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
     NYql::NUdf::TUnboxedValue StreamValues_;
     std::span<NYql::NUdf::TUnboxedValue> Buff_;
     IBlockLayoutConverter* ArrowBlockToInternalConverter_;
+    TVector<ui32> ColumnPermutation_;
 };
 
 template<EJoinKind Kind>
@@ -417,6 +427,62 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
         std::swap(meta.KeyColumns.Build, meta.KeyColumns.Probe);
         for (auto& rename : meta.Renames) {
             rename.Side = (rename.Side == ESide::Build) ? ESide::Probe : ESide::Build;
+        }
+    }
+
+    {
+        const auto& probeKeys = meta.KeyColumns.Probe;
+        const auto& buildKeys = meta.KeyColumns.Build;
+        const ui32 numDataCols = meta.InputTypes.Build.size() - 1;
+
+        bool needsReorder = false;
+        for (size_t i = 0; i < probeKeys.size(); ++i) {
+            if (probeKeys[i] != buildKeys[i]) {
+                needsReorder = true;
+                break;
+            }
+        }
+
+        if (needsReorder) {
+            TVector<ui32> buildPerm(numDataCols);
+            TVector<bool> usedOld(numDataCols, false);
+            TVector<bool> usedNew(numDataCols, false);
+
+            for (size_t i = 0; i < probeKeys.size(); ++i) {
+                buildPerm[probeKeys[i]] = buildKeys[i];
+                usedOld[buildKeys[i]] = true;
+                usedNew[probeKeys[i]] = true;
+            }
+
+            ui32 nextOld = 0;
+            for (ui32 j = 0; j < numDataCols; ++j) {
+                if (!usedNew[j]) {
+                    while (usedOld[nextOld]) nextOld++;
+                    buildPerm[j] = nextOld;
+                    usedOld[nextOld] = true;
+                }
+            }
+
+            meta.BuildColumnPermutation = buildPerm;
+
+            TVector<ui32> inversePerm(numDataCols);
+            for (ui32 j = 0; j < numDataCols; ++j) {
+                inversePerm[buildPerm[j]] = j;
+            }
+
+            TVector<TBlockType*> origTypes(meta.InputTypes.Build.begin(),
+                                           meta.InputTypes.Build.begin() + numDataCols);
+            for (ui32 j = 0; j < numDataCols; ++j) {
+                meta.InputTypes.Build[j] = origTypes[buildPerm[j]];
+            }
+
+            meta.KeyColumns.Build = TVector<int>(probeKeys.begin(), probeKeys.end());
+
+            for (auto& rename : meta.Renames) {
+                if (rename.Side == ESide::Build) {
+                    rename.Index = inversePerm[rename.Index];
+                }
+            }
         }
     }
 

--- a/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_block_hash_join.cpp
@@ -11,9 +11,6 @@
 
 #include <arrow/scalar.h>
 
-#include <algorithm>
-#include <numeric>
-
 #include "dq_join_common.h"
 
 namespace NKikimr::NMiniKQL {
@@ -35,9 +32,7 @@ struct TDqBlockJoinContext {
     // at runtime (inside DoCalculate) whose lifetime depends on the
     // TComputationContext – which may differ between iterations/retries.
     TSides<TVector<TType*>> UserTypes;
-    // Per-side column permutation that puts key pair i at position i.
-    // perm[newPos] = oldPos.  Empty when no reorder is needed.
-    TSides<TVector<ui32>> ColumnPermutation;
+    TSides<TVector<int>> ColumnPermutation;
 };
 
 class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
@@ -102,7 +97,7 @@ class TBlockPackedTupleSource : public NNonCopyable::TMoveOnly {
     NYql::NUdf::TUnboxedValue StreamValues_;
     std::span<NYql::NUdf::TUnboxedValue> Buff_;
     IBlockLayoutConverter* ArrowBlockToInternalConverter_;
-    TVector<ui32> ColumnPermutation_;
+    TVector<int> ColumnPermutation_;
 };
 
 template<EJoinKind Kind>
@@ -437,12 +432,12 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
 
     for (ESide side : EachSide) {
         auto& keyColumns = meta.KeyColumns.SelectSide(side);
-        const ui32 numDataCols = meta.InputTypes.SelectSide(side).size() - 1;
-        const ui32 numKeys = keyColumns.size();
+        int numDataCols = meta.InputTypes.SelectSide(side).size() - 1;
+        int numKeys = keyColumns.size();
 
         bool needsReorder = false;
-        for (ui32 i = 0; i < numKeys; ++i) {
-            if (keyColumns[i] != static_cast<int>(i)) {
+        for (int i = 0; i < numKeys; ++i) {
+            if (keyColumns[i] != i) {
                 needsReorder = true;
                 break;
             }
@@ -451,10 +446,10 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
             continue;
         }
 
-        TVector<ui32> perm(numDataCols);
+        TVector<int> perm(numDataCols);
         std::iota(perm.begin(), perm.end(), 0);
-        for (ui32 i = 0; i < numKeys; ++i) {
-            auto it = std::find(perm.begin(), perm.end(), static_cast<ui32>(keyColumns[i]));
+        for (int i = 0; i < numKeys; ++i) {
+            auto it = std::find(perm.begin(), perm.end(), keyColumns[i]);
             std::swap(perm[i], *it);
         }
 
@@ -462,13 +457,13 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
 
         auto origTypes = TVector<TBlockType*>(meta.InputTypes.SelectSide(side).begin(),
                                               meta.InputTypes.SelectSide(side).begin() + numDataCols);
-        for (ui32 j = 0; j < numDataCols; ++j) {
-            meta.InputTypes.SelectSide(side)[j] = origTypes[perm[j]];
+        for (int i = 0; i < numDataCols; ++i) {
+            meta.InputTypes.SelectSide(side)[i] = origTypes[perm[i]];
         }
 
-        TVector<ui32> inv(numDataCols);
-        for (ui32 j = 0; j < numDataCols; ++j) {
-            inv[perm[j]] = j;
+        TVector<int> inv(numDataCols);
+        for (int i = 0; i < numDataCols; ++i) {
+            inv[perm[i]] = i;
         }
         for (auto& rename : meta.Renames) {
             if (rename.Side == side) {
@@ -476,7 +471,7 @@ IComputationNode* WrapDqBlockHashJoin(TCallable& callable, const TComputationNod
             }
         }
 
-        for (ui32 i = 0; i < numKeys; ++i) {
+        for (int i = 0; i < numKeys; ++i) {
             keyColumns[i] = i;
         }
     }

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_hash_join_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_hash_join_ut.cpp
@@ -768,6 +768,64 @@ TJoinTestData InnerJoinIntAndOptionalIntKeyTestData() {
     return td;
 }
 
+TJoinTestData SwappedKeyColumnsInnerTestData() {
+    TJoinTestData td;
+    auto& setup = *td.Setup;
+
+    TVector<ui64> leftCol0 = {10, 20, 30};
+    TVector<ui64> leftCol1 = {100, 200, 300};
+    TVector<TString> leftCol2 = {"a", "b", "c"};
+
+    TVector<ui64> rightCol0 = {100, 200, 999};
+    TVector<ui64> rightCol1 = {10, 20, 99};
+    TVector<TString> rightCol2 = {"x", "y", "z"};
+
+    TVector<ui64> expLeftCol0 = {10, 20};
+    TVector<ui64> expLeftCol1 = {100, 200};
+    TVector<TString> expLeftCol2 = {"a", "b"};
+    TVector<ui64> expRightCol0 = {100, 200};
+    TVector<ui64> expRightCol1 = {10, 20};
+    TVector<TString> expRightCol2 = {"x", "y"};
+
+    td.Left = ConvertVectorsToTuples(setup, leftCol0, leftCol1, leftCol2);
+    td.Right = ConvertVectorsToTuples(setup, rightCol0, rightCol1, rightCol2);
+    td.Result = ConvertVectorsToTuples(setup, expLeftCol0, expLeftCol1, expLeftCol2,
+                                       expRightCol0, expRightCol1, expRightCol2);
+
+    td.LeftKeyColmns = {0, 1};
+    td.RightKeyColmns = {1, 0};
+    td.Renames = {{0, EJoinSide::kLeft}, {1, EJoinSide::kLeft}, {2, EJoinSide::kLeft},
+                  {0, EJoinSide::kRight}, {1, EJoinSide::kRight}, {2, EJoinSide::kRight}};
+    td.Kind = EJoinKind::Inner;
+    return td;
+}
+
+TJoinTestData SwappedKeyColumnsLeftSemiTestData() {
+    TJoinTestData td;
+    auto& setup = *td.Setup;
+
+    TVector<ui64> leftCol0 = {10, 20, 30};
+    TVector<ui64> leftCol1 = {100, 200, 300};
+    TVector<TString> leftCol2 = {"a", "b", "c"};
+
+    TVector<ui64> rightCol0 = {100, 200, 999};
+    TVector<ui64> rightCol1 = {10, 20, 99};
+
+    TVector<ui64> expLeftCol0 = {10, 20};
+    TVector<ui64> expLeftCol1 = {100, 200};
+    TVector<TString> expLeftCol2 = {"a", "b"};
+
+    td.Left = ConvertVectorsToTuples(setup, leftCol0, leftCol1, leftCol2);
+    td.Right = ConvertVectorsToTuples(setup, rightCol0, rightCol1);
+    td.Result = ConvertVectorsToTuples(setup, expLeftCol0, expLeftCol1, expLeftCol2);
+
+    td.LeftKeyColmns = {0, 1};
+    td.RightKeyColmns = {1, 0};
+    td.Renames = {{0, EJoinSide::kLeft}, {1, EJoinSide::kLeft}, {2, EJoinSide::kLeft}};
+    td.Kind = EJoinKind::LeftSemi;
+    return td;
+}
+
 TJoinTestData SpillingTestData() {
     TJoinTestData td;
     auto& setup = *td.Setup;
@@ -1052,6 +1110,14 @@ Y_UNIT_TEST_SUITE(TDqHashJoinBasicTest) {
     // }
     Y_UNIT_TEST_TWIN(TestInnerRenamesKind, BlockJoin) {
         Test(InnerJoinRenamesTestData(), BlockJoin);
+    }
+
+    Y_UNIT_TEST(TestSwappedKeyColumnsInner) {
+        Test(SwappedKeyColumnsInnerTestData(), true);
+    }
+
+    Y_UNIT_TEST(TestSwappedKeyColumnsLeftSemi) {
+        Test(SwappedKeyColumnsLeftSemiTestData(), true);
     }
 
     Y_UNIT_TEST(TestBlockSpilling) { 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix incorrect handling of key column order in join
Previously, joins produced wrong results when the list of key columns was provided in a shuffled way.

For columns a, b, c and key columns [1, 0] (instead of [0, 1]), the join logic produced incorrect results, because key was ab instead of ba.

This PR fixes the issue by reordering columns according to the order specified in the key.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
