### PR TITLE
Add NBS team ownership and update area mapping

### DIFF
--- a/.github/TESTOWNERS
+++ b/.github/TESTOWNERS
@@ -151,4 +151,8 @@
 /ydb/core/viewer @ydb-platform/ui-backend
 /ydb/core/protos/node_whiteboard.proto @ydb-platform/ui-backend
 
+#NBS / Network Blockstore TEAM:@ydb-platform/nbs
+/ydb/core/nbs @ydb-platform/nbs
+/ydb/tests/functional/nbs @ydb-platform/nbs
+
 /ydb/tests/sql @slonn

--- a/.github/config/owner_area_mapping.json
+++ b/.github/config/owner_area_mapping.json
@@ -19,5 +19,6 @@
   "engineering": "area/engineering",
   "postgres-compatibility": "area/pg",
   "security": "area/security",
-  "changelog-reviewers": "area/changelog"
+  "changelog-reviewers": "area/changelog",
+  "nbs": "area/nbs"
 }


### PR DESCRIPTION
- Added ownership for Network Blockstore (NBS) team in TESTOWNERS file.
- Updated owner_area_mapping.json to include mapping for NBS area.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
