### PR TITLE
Remove nfs check from grpc

### DIFF
--- a/ydb/core/grpc_services/rpc_export.cpp
+++ b/ydb/core/grpc_services/rpc_export.cpp
@@ -18,11 +18,6 @@
 #include <util/generic/ptr.h>
 #include <util/string/builder.h>
 
-#ifdef _linux_
-#include <sys/vfs.h>
-#include <linux/magic.h>
-#endif
-
 namespace NKikimr {
 namespace NGRpcService {
 

--- a/ydb/core/grpc_services/rpc_export.cpp
+++ b/ydb/core/grpc_services/rpc_export.cpp
@@ -583,16 +583,6 @@ public:
                     "base_path must be an absolute path");
             }
 
-#ifdef _linux_
-            struct statfs fsInfo;
-            if (statfs(settings.base_path().c_str(), &fsInfo) == 0) {
-                if (fsInfo.f_type != NFS_SUPER_MAGIC) {
-                    return this->Reply(StatusIds::BAD_REQUEST, TIssuesIds::DEFAULT_ERROR,
-                        "base_path must be on NFS filesystem");
-                }
-            }
-#endif
-
             TString error;
             if (!ValidateFsPath(settings.base_path(), "base_path", error)) {
                 return this->Reply(StatusIds::BAD_REQUEST, TIssuesIds::DEFAULT_ERROR, error);

--- a/ydb/core/grpc_services/rpc_import.cpp
+++ b/ydb/core/grpc_services/rpc_import.cpp
@@ -18,11 +18,6 @@
 #include <util/generic/ptr.h>
 #include <util/string/builder.h>
 
-#ifdef _linux_
-#include <sys/vfs.h>
-#include <linux/magic.h>
-#endif
-
 namespace NKikimr {
 namespace NGRpcService {
 

--- a/ydb/core/grpc_services/rpc_import.cpp
+++ b/ydb/core/grpc_services/rpc_import.cpp
@@ -191,16 +191,6 @@ public:
                     "base_path must be an absolute path");
             }
 
-#ifdef _linux_
-            struct statfs fsInfo;
-            if (statfs(settings.base_path().c_str(), &fsInfo) == 0) {
-                if (fsInfo.f_type != NFS_SUPER_MAGIC) {
-                    return this->Reply(StatusIds::BAD_REQUEST, TIssuesIds::DEFAULT_ERROR,
-                        "base_path must be on NFS filesystem");
-                }
-            }
-#endif
-
             TString error;
             if (!ValidateFsPath(settings.base_path(), "base_path", error)) {
                 return this->Reply(StatusIds::BAD_REQUEST, TIssuesIds::DEFAULT_ERROR, error);

--- a/ydb/services/ydb/backup_ut/fs_backup_validation_ut.cpp
+++ b/ydb/services/ydb/backup_ut/fs_backup_validation_ut.cpp
@@ -16,18 +16,6 @@
 
 using namespace NYdb;
 
-#ifdef _linux_
-#include <sys/vfs.h>
-#include <sys/statfs.h>
-#include <linux/magic.h>
-
-extern "C" int statfs(const char* path, struct statfs* buf) {
-    (void)path;
-    buf->f_type = NFS_SUPER_MAGIC;
-    return 0;
-}
-#endif
-
 class TFsBackupParamsValidationTestFixture : public NUnitTest::TBaseFixture {
 public:
     static constexpr TDuration DEFAULT_OPERATION_WAIT_TIME = NSan::PlainOrUnderSanitizer(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Для хоста nfs-сервера `base_path` не является nfs путем, ОСь считет его путём в локальной файловой системе. Если rpc запрос на экспорт или импорт будет принимать нода, запущенная на хосте nfs-сервере, эта проверка завершится неудачей. Способ лучше, чем прочитать конфиг файлы для nfs и понять является ли этот путь монтированным в nfs, я не знаю (он явно плохой, потому что требует наличия доступа к системным файлам у процесса `ydbd`), поэтому мы не будем выполнять эту проверку.