### PR TITLE
Support DML writes for JSON index

### DIFF
--- a/ydb/core/base/fulltext.h
+++ b/ydb/core/base/fulltext.h
@@ -6,6 +6,13 @@
 
 namespace NKikimr::NFulltext {
 
+enum class EIndexMode {
+    Invalid = 0,
+    Fulltext = 1,
+    JsonIndexOverJson = 2,
+    JsonIndexOverJsonDocument = 3,
+};
+
 void BuildNgrams(const TString& token, size_t lengthMin, size_t lengthMax, bool edge, TVector<TString>& ngrams);
 Ydb::Table::FulltextIndexSettings::Analyzers GetAnalyzersForQuery(Ydb::Table::FulltextIndexSettings::Analyzers analyzers);
 

--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -825,7 +825,8 @@
             "Match": {"Type": "Callable", "Name": "FulltextAnalyze"},
             "Children": [
                 {"Index": 0, "Name": "Text", "Type": "TCoAtom"},
-                {"Index": 1, "Name": "Settings", "Type": "TCoAtom"}
+                {"Index": 1, "Name": "Settings", "Type": "TCoAtom"},
+                {"Index": 2, "Name": "Mode", "Type": "TCoAtom"}
             ]
         },
         {

--- a/ydb/core/kqp/opt/kqp_type_ann.cpp
+++ b/ydb/core/kqp/opt/kqp_type_ann.cpp
@@ -2021,20 +2021,9 @@ TStatus AnnotateFulltextAnalyze(const TExprNode::TPtr& node, TExprContext& ctx) 
         return TStatus::Error;
     }
 
-    // Third argument: Mode (should be String - "0" (any fulltext), "1" (JI on Json) or "2" (JI on JsonDocument))
+    // Third argument: mode (should be Atom - "0" (any fulltext), "1" (JI on Json) or "2" (JI on JsonDocument))
     const auto* modeArg = node->Child(2);
-    if (!EnsureComputable(*modeArg, ctx)) {
-        return TStatus::Error;
-    }
-
-    const TDataExprType* modeDataType;
-    if (!EnsureDataOrOptionalOfData(*modeArg, isOptional, modeDataType, ctx)) {
-        return TStatus::Error;
-    }
-
-    if (modeDataType->GetSlot() != EDataSlot::String) {
-        ctx.AddError(TIssue(ctx.GetPosition(modeArg->Pos()), TStringBuilder()
-            << "Expected String for Mode argument, but got: " << *modeArg->GetTypeAnn()));
+    if (!EnsureAtom(*modeArg, ctx)) {
         return TStatus::Error;
     }
 

--- a/ydb/core/kqp/opt/kqp_type_ann.cpp
+++ b/ydb/core/kqp/opt/kqp_type_ann.cpp
@@ -1975,11 +1975,11 @@ TStatus AnnotateKqpEnsure(const TExprNode::TPtr& node, TExprContext& ctx) {
 }
 
 TStatus AnnotateFulltextAnalyze(const TExprNode::TPtr& node, TExprContext& ctx) {
-    if (!EnsureArgsCount(*node, 2, ctx)) {
+    if (!EnsureArgsCount(*node, 3, ctx)) {
         return TStatus::Error;
     }
 
-    // First argument: text (should be String or Utf8)
+    // First argument: text (String, Utf8, Json, or JsonDocument — same payload as string for analyzers / tokenize)
     const auto* textArg = node->Child(0);
     if (!EnsureComputable(*textArg, ctx)) {
         return TStatus::Error;
@@ -1991,10 +1991,17 @@ TStatus AnnotateFulltextAnalyze(const TExprNode::TPtr& node, TExprContext& ctx) 
         return TStatus::Error;
     }
 
-    if (textDataType->GetSlot() != EDataSlot::String && textDataType->GetSlot() != EDataSlot::Utf8) {
-        ctx.AddError(TIssue(ctx.GetPosition(textArg->Pos()), TStringBuilder()
-            << "Expected String or Utf8 for text argument, but got: " << *textArg->GetTypeAnn()));
-        return TStatus::Error;
+    const auto textSlot = textDataType->GetSlot();
+    switch (textSlot) {
+        case EDataSlot::String:
+        case EDataSlot::Utf8:
+        case EDataSlot::Json:
+        case EDataSlot::JsonDocument:
+            break;
+        default:
+            ctx.AddError(TIssue(ctx.GetPosition(textArg->Pos()), TStringBuilder()
+            << "Expected String, Utf8, Json, or JsonDocument for text argument, but got: " << *textArg->GetTypeAnn()));
+            return TStatus::Error;
     }
 
     // Second argument: settings (should be String - serialized proto)
@@ -2014,8 +2021,26 @@ TStatus AnnotateFulltextAnalyze(const TExprNode::TPtr& node, TExprContext& ctx) 
         return TStatus::Error;
     }
 
+    // Third argument: Mode (should be String - "0" (any fulltext), "1" (JI on Json) or "2" (JI on JsonDocument))
+    const auto* modeArg = node->Child(2);
+    if (!EnsureComputable(*modeArg, ctx)) {
+        return TStatus::Error;
+    }
+
+    const TDataExprType* modeDataType;
+    if (!EnsureDataOrOptionalOfData(*modeArg, isOptional, modeDataType, ctx)) {
+        return TStatus::Error;
+    }
+
+    if (modeDataType->GetSlot() != EDataSlot::String) {
+        ctx.AddError(TIssue(ctx.GetPosition(modeArg->Pos()), TStringBuilder()
+            << "Expected String for Mode argument, but got: " << *modeArg->GetTypeAnn()));
+        return TStatus::Error;
+    }
+
     // Return type: List<Struct<__ydb_token:String or Utf8,__ydb_freq:Uint32>>
-    auto stringType = ctx.MakeType<TDataExprType>(textDataType->GetSlot());
+    const EDataSlot tokenSlot = (textSlot == EDataSlot::Json || textSlot == EDataSlot::JsonDocument) ? EDataSlot::String : textSlot;
+    auto stringType = ctx.MakeType<TDataExprType>(tokenSlot);
     TVector<const TItemExprType*> rowItems;
     rowItems.push_back(ctx.MakeType<TItemExprType>(NTableIndex::NFulltext::TokenColumn, stringType));
     rowItems.push_back(ctx.MakeType<TItemExprType>(NTableIndex::NFulltext::FreqColumn, ctx.MakeType<TDataExprType>(EDataSlot::Uint32)));

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
@@ -83,7 +83,6 @@ TExprBase BuildDeleteIndexStagesImpl(const TKikimrTableDescription& table,
         auto deleteIndexKeys = project(indexTableColumns);
 
         switch (indexDesc->Type) {
-            case TIndexDescription::EType::GlobalJson:
             case TIndexDescription::EType::GlobalAsync:
                 AFL_ENSURE(false);
             case TIndexDescription::EType::GlobalSync:
@@ -102,8 +101,9 @@ TExprBase BuildDeleteIndexStagesImpl(const TKikimrTableDescription& table,
                 break;
             }
             case TIndexDescription::EType::GlobalFulltextPlain:
-            case TIndexDescription::EType::GlobalFulltextRelevance: {
-                // For fulltext indexes, we need to tokenize the text and create deleted rows
+            case TIndexDescription::EType::GlobalFulltextRelevance:
+            case TIndexDescription::EType::GlobalJson: {
+                // For fulltext and JSON indexes, we need to tokenize the text and create deleted rows
                 const auto deletePrecompute = ReadInputToPrecompute(deleteIndexKeys, del.Pos(), ctx);
                 deleteIndexKeys = BuildFulltextIndexRows(table, indexDesc, deletePrecompute, indexTableColumnsSet, indexTableColumns,
                     true /*forDelete*/, del.Pos(), ctx);

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
@@ -12,7 +12,7 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
 {
     TString settingsProto;
     TString textColumn;
-    TString mode;
+    ui32 mode = 0;  // 0 = plain fulltext, 1 = JSON index over Json, 2 = JSON index over JsonDocument
 
     if (indexDesc->Type == TIndexDescription::EType::GlobalJson) {
         YQL_ENSURE(indexDesc->KeyColumns.size() == 1, "Expected single key column in JSON index");
@@ -32,12 +32,10 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
         auto slot = unpackedType->Cast<TDataExprType>()->GetSlot();
         switch (slot) {
             case EDataSlot::Json:
-                // JI over Json
-                mode = "1";
+                mode = 1;
                 break;
             case EDataSlot::JsonDocument:
-                // JI over JsonDocument
-                mode = "2";
+                mode = 2;
                 break;
             default:
                 YQL_ENSURE(false, "Unexpected data slot for JSON index column");
@@ -53,9 +51,6 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
         textColumn = settings.columns().at(0).column();
         const auto& analyzers = settings.columns().at(0).analyzers();
 
-        // Plain fulltext index (no JSON index semantics)
-        mode = "0";
-
         // Serialize analyzer settings for FulltextAnalyze
         YQL_ENSURE(analyzers.SerializeToString(&settingsProto));
     }
@@ -70,17 +65,15 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
         .Literal().Build(settingsProto)
         .Done();
 
-    auto modeLiteral = Build<TCoString>(ctx, pos)
-        .Literal().Build(mode)
-        .Done();
+    auto modeAtom = ctx.NewAtom(pos, ToString(mode));
 
     // Create callable for fulltext tokenization
-    // Format: FulltextAnalyze(text: String|Utf8|Json|JsonDocument, settings: String, mode: String) -> List<Struct<__ydb_token, __ydb_freq>>
+    // Format: FulltextAnalyze(text: String|Utf8|Json|JsonDocument, settings: String, mode: Atom) -> List<Struct<__ydb_token, __ydb_freq>>
     auto analyzeCallable = ctx.Builder(pos)
         .Callable("FulltextAnalyze")
             .Add(0, textMember.Ptr())
             .Add(1, settingsLiteral.Ptr())
-            .Add(2, modeLiteral.Ptr())
+            .Add(2, modeAtom)
         .Seal()
         .Build();
 

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
@@ -7,17 +7,58 @@ using namespace NYql;
 using namespace NYql::NDq;
 using namespace NYql::NNodes;
 
-TExprBase BuildFulltextAnalyze(const TExprBase& inputRow, const TIndexDescription* indexDesc, TPositionHandle pos, NYql::TExprContext& ctx)
+TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExprBase& inputRow,
+    const TIndexDescription* indexDesc, TPositionHandle pos, NYql::TExprContext& ctx)
 {
-    // Extract fulltext index settings
-    const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
-    YQL_ENSURE(fulltextDesc, "Expected fulltext index description");
+    TString settingsProto;
+    TString textColumn;
+    TString mode;
 
-    const auto& settings = fulltextDesc->GetSettings();
-    YQL_ENSURE(settings.columns().size() == 1, "Expected single text column in fulltext index");
+    if (indexDesc->Type == TIndexDescription::EType::GlobalJson) {
+        YQL_ENSURE(indexDesc->KeyColumns.size() == 1, "Expected single key column in JSON index");
+        textColumn = indexDesc->KeyColumns.at(0);
 
-    const TString textColumn = settings.columns().at(0).column();
-    const auto& analyzers = settings.columns().at(0).analyzers();
+        auto columnType = table.GetColumnType(textColumn);
+        YQL_ENSURE(columnType, "Failed to get column type for JSON index column");
+
+        const TTypeAnnotationNode* unpackedType = columnType;
+        if (unpackedType->GetKind() == ETypeAnnotationKind::Optional) {
+            unpackedType = unpackedType->Cast<TOptionalExprType>()->GetItemType();
+        }
+
+        YQL_ENSURE(unpackedType->GetKind() == ETypeAnnotationKind::Data,
+            "Expected data type for JSON index column");
+
+        auto slot = unpackedType->Cast<TDataExprType>()->GetSlot();
+        switch (slot) {
+            case EDataSlot::Json:
+                // JI over Json
+                mode = "1";
+                break;
+            case EDataSlot::JsonDocument:
+                // JI over JsonDocument
+                mode = "2";
+                break;
+            default:
+                YQL_ENSURE(false, "Unexpected data slot for JSON index column");
+        }
+    } else {
+        // Extract fulltext index settings
+        const auto* fulltextDesc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexDesc->SpecializedIndexDescription);
+        YQL_ENSURE(fulltextDesc, "Expected fulltext index description");
+
+        const auto& settings = fulltextDesc->GetSettings();
+        YQL_ENSURE(settings.columns().size() == 1, "Expected single text column in fulltext index");
+
+        textColumn = settings.columns().at(0).column();
+        const auto& analyzers = settings.columns().at(0).analyzers();
+
+        // Plain fulltext index (no JSON index semantics)
+        mode = "0";
+
+        // Serialize analyzer settings for FulltextAnalyze
+        YQL_ENSURE(analyzers.SerializeToString(&settingsProto));
+    }
 
     // Get text member from input row
     auto textMember = Build<TCoMember>(ctx, pos)
@@ -25,19 +66,21 @@ TExprBase BuildFulltextAnalyze(const TExprBase& inputRow, const TIndexDescriptio
         .Name().Build(textColumn)
         .Done();
 
-    // Serialize analyzer settings for FulltextAnalyze
-    TString settingsProto;
-    YQL_ENSURE(analyzers.SerializeToString(&settingsProto));
     auto settingsLiteral = Build<TCoString>(ctx, pos)
         .Literal().Build(settingsProto)
         .Done();
 
+    auto modeLiteral = Build<TCoString>(ctx, pos)
+        .Literal().Build(mode)
+        .Done();
+
     // Create callable for fulltext tokenization
-    // Format: FulltextAnalyze(text: String, settings: String) -> List<Struct<__ydb_token, __ydb_freq>>
+    // Format: FulltextAnalyze(text: String|Utf8|Json|JsonDocument, settings: String, mode: String) -> List<Struct<__ydb_token, __ydb_freq>>
     auto analyzeCallable = ctx.Builder(pos)
         .Callable("FulltextAnalyze")
             .Add(0, textMember.Ptr())
             .Add(1, settingsLiteral.Ptr())
+            .Add(2, modeLiteral.Ptr())
         .Seal()
         .Build();
 
@@ -124,7 +167,7 @@ TExprBase BuildFulltextIndexRows(const TKikimrTableDescription& table, const TIn
             .Build()
         .Done();
 
-    auto analyzeCallable = BuildFulltextAnalyze(inputRowArg, indexDesc, pos, ctx);
+    auto analyzeCallable = BuildFulltextAnalyze(table, inputRowArg, indexDesc, pos, ctx);
 
     auto analyzeStage = Build<TDqStage>(ctx, pos)
         .Inputs()
@@ -195,7 +238,7 @@ TExprBase BuildFulltextDocsRows(const TKikimrTableDescription& table, const TInd
         }
     }
 
-    auto analyzeCallable = BuildFulltextAnalyze(inputRowArg, indexDesc, pos, ctx);
+    auto analyzeCallable = BuildFulltextAnalyze(table, inputRowArg, indexDesc, pos, ctx);
 
     auto tokenArg = TCoArgument(ctx.NewArgument(pos, "token"));
     auto stateArg = TCoArgument(ctx.NewArgument(pos, "state"));

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_fulltext_index.cpp
@@ -1,4 +1,7 @@
 #include "kqp_opt_phy_effects_impl.h"
+
+#include <ydb/core/base/fulltext.h>
+
 #include <yql/essentials/providers/common/provider/yql_provider.h>
 
 namespace NKikimr::NKqp::NOpt {
@@ -12,7 +15,7 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
 {
     TString settingsProto;
     TString textColumn;
-    ui32 mode = 0;  // 0 = plain fulltext, 1 = JSON index over Json, 2 = JSON index over JsonDocument
+    NFulltext::EIndexMode mode = NFulltext::EIndexMode::Invalid;
 
     if (indexDesc->Type == TIndexDescription::EType::GlobalJson) {
         YQL_ENSURE(indexDesc->KeyColumns.size() == 1, "Expected single key column in JSON index");
@@ -32,10 +35,10 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
         auto slot = unpackedType->Cast<TDataExprType>()->GetSlot();
         switch (slot) {
             case EDataSlot::Json:
-                mode = 1;
+                mode = NFulltext::EIndexMode::JsonIndexOverJson;
                 break;
             case EDataSlot::JsonDocument:
-                mode = 2;
+                mode = NFulltext::EIndexMode::JsonIndexOverJsonDocument;
                 break;
             default:
                 YQL_ENSURE(false, "Unexpected data slot for JSON index column");
@@ -53,6 +56,8 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
 
         // Serialize analyzer settings for FulltextAnalyze
         YQL_ENSURE(analyzers.SerializeToString(&settingsProto));
+
+        mode = NFulltext::EIndexMode::Fulltext;
     }
 
     // Get text member from input row
@@ -65,7 +70,7 @@ TExprBase BuildFulltextAnalyze(const TKikimrTableDescription& table, const TExpr
         .Literal().Build(settingsProto)
         .Done();
 
-    auto modeAtom = ctx.NewAtom(pos, ToString(mode));
+    auto modeAtom = ctx.NewAtom(pos, ToString(static_cast<ui32>(mode)));
 
     // Create callable for fulltext tokenization
     // Format: FulltextAnalyze(text: String|Utf8|Json|JsonDocument, settings: String, mode: Atom) -> List<Struct<__ydb_token, __ydb_freq>>

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
@@ -112,9 +112,15 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
     const bool needPrecompute = !useStreamIndex
         || !abortOnError
         || std::any_of(indexes.begin(), indexes.end(), [](const auto& index) {
-            return index.second->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree
-                || index.second->Type == TIndexDescription::EType::GlobalFulltextPlain
-                || index.second->Type == TIndexDescription::EType::GlobalFulltextRelevance;
+            switch (index.second->Type) {
+                case TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+                case TIndexDescription::EType::GlobalFulltextPlain:
+                case TIndexDescription::EType::GlobalFulltextRelevance:
+                case TIndexDescription::EType::GlobalJson:
+                    return true;
+                default:
+                    return false;
+            }
         });
 
     TVector<TStringBuf> insertColumns;
@@ -204,7 +210,6 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
 
         std::optional<TExprBase> upsertIndexRows;
         switch (indexDesc->Type) {
-            case TIndexDescription::EType::GlobalJson:
             case TIndexDescription::EType::GlobalAsync:
                 AFL_ENSURE(false);
             case TIndexDescription::EType::GlobalSync:
@@ -235,8 +240,9 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
                 break;
             }
             case TIndexDescription::EType::GlobalFulltextPlain:
-            case TIndexDescription::EType::GlobalFulltextRelevance: {
-                // For fulltext indexes, we need to tokenize the text and create inserted rows
+            case TIndexDescription::EType::GlobalFulltextRelevance:
+            case TIndexDescription::EType::GlobalJson: {
+                // For fulltext and JSON indexes, we need to tokenize the text and create inserted rows
                 auto insertPrecompute = ReadInputToPrecompute(*insertRows, insert.Pos(), ctx);
                 upsertIndexRows = BuildFulltextIndexRows(table, indexDesc, insertPrecompute, inputColumnsSet, indexTableColumns,
                     false /*forDelete*/, insert.Pos(), ctx);

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -648,9 +648,15 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
     const bool needPrecompute = !useStreamIndex
         || !columnsWithDefaultsSet.empty()
         || std::any_of(indexes.begin(), indexes.end(), [](const auto& index) {
-            return index.second->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree
-                || index.second->Type == TIndexDescription::EType::GlobalFulltextPlain
-                || index.second->Type == TIndexDescription::EType::GlobalFulltextRelevance;
+            switch (index.second->Type) {
+                case TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+                case TIndexDescription::EType::GlobalFulltextPlain:
+                case TIndexDescription::EType::GlobalFulltextRelevance:
+                case TIndexDescription::EType::GlobalJson:
+                    return true;
+                default:
+                    return false;
+            }
         });
 
     if (!needPrecompute) {
@@ -781,158 +787,179 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
             }
         }
 
-        // Need to calc is the updated row in index same
-        TVector<TExprBase> payloadTuples;
-        TVector<TExprBase> keyTuples;
-        auto payloadSelectorArg = TCoArgument(ctx.NewArgument(pos, "payload_selector_row_for_index"));
-        auto payload_table_row = TCoArgument(ctx.NewArgument(pos, "payload_table_row"));
-
-        TVector<TExprBase> inputRowsForIndex;
-        inputRowsForIndex.reserve(indexTableColumns.size());
-
-        TVector<TExprBase> lookupRow;
-        lookupRow.reserve(indexTableColumns.size());
-
-        auto inputItem = TCoArgument(ctx.NewArgument(pos, "input_item_" + indexDesc->Name));
-        for (const auto& column : indexTableColumns) {
-            if (table.GetKeyColumnIndex(TString(column))) {
+        // Index key columns (e.g. JSON source column) participate in AggrNotEquals the same way
+        // as data columns, but are listed only in KeyColumns - include them in equatability check.
+        for (const auto& column : indexDesc->KeyColumns) {
+            // If column is not in input columns, skip it
+            if (!inputColumnsSet.contains(column)) {
                 continue;
             }
-            auto columnAtom = ctx.NewAtom(pos, column);
 
-            if (inputColumnsSet.contains(column)) {
-                inputRowsForIndex.emplace_back(
-                   Build<TCoNameValueTuple>(ctx, pos)
-                       .Name(columnAtom)
-                       .Value<TCoMember>()
-                           .Struct(inputItem)
-                           .Name(columnAtom)
-                           .Build()
-                   .Done());
-
-                 lookupRow.emplace_back(
-                     Build<TCoNameValueTuple>(ctx, pos)
-                         .Name(columnAtom)
-                         .Value<TCoMember>()
-                             .Struct(payload_table_row)
-                             .Name(columnAtom)
-                             .Build()
-                     .Done());
+            // If column is a key column, skip it
+            if (table.GetKeyColumnIndex(column)) {
+                continue;
             }
 
-            payloadTuples.emplace_back(
-                Build<TCoNameValueTuple>(ctx, pos)
-                    .Name(columnAtom)
-                    .Value<TCoMember>()
-                        .Struct<TCoNth>()
-                            .Tuple(payloadSelectorArg)
-                            .Index().Build(1)
-                            .Build()
+            auto t = table.GetColumnType(TString(column));
+            YQL_ENSURE(t);
+            optUpsert &= t->IsEquatable();
+        }
+
+        TDqPhyPrecompute lookupDictRecomputed = lookupDict.Cast();
+        if (optUpsert) {
+            // Need to calc is the updated row in index same
+            TVector<TExprBase> payloadTuples;
+            TVector<TExprBase> keyTuples;
+            auto payloadSelectorArg = TCoArgument(ctx.NewArgument(pos, "payload_selector_row_for_index"));
+            auto payload_table_row = TCoArgument(ctx.NewArgument(pos, "payload_table_row"));
+
+            TVector<TExprBase> inputRowsForIndex;
+            inputRowsForIndex.reserve(indexTableColumns.size());
+
+            TVector<TExprBase> lookupRow;
+            lookupRow.reserve(indexTableColumns.size());
+
+            auto inputItem = TCoArgument(ctx.NewArgument(pos, "input_item_" + indexDesc->Name));
+            for (const auto& column : indexTableColumns) {
+                if (table.GetKeyColumnIndex(TString(column))) {
+                    continue;
+                }
+                auto columnAtom = ctx.NewAtom(pos, column);
+
+                if (inputColumnsSet.contains(column)) {
+                    inputRowsForIndex.emplace_back(
+                    Build<TCoNameValueTuple>(ctx, pos)
                         .Name(columnAtom)
-                        .Build()
-                    .Done());
-        }
-
-        auto inputArg = TCoArgument(ctx.NewArgument(pos, "recalc_input_arg_" + indexDesc->Name));
-
-        auto cmp = ctx.Builder(pos)
-            .Callable("AggrNotEquals")
-                .Add(0, Build<TCoAsStruct>(ctx, pos)
-                    .Add(inputRowsForIndex)
-                    .Done().Ptr())
-                .Add(1, Build<TCoAsStruct>(ctx, pos)
-                    .Add(lookupRow)
-                    .Done().Ptr())
-            .Seal().Build();
-
-        for (const auto& key : pk) {
-            auto tuple = Build<TCoNameValueTuple>(ctx, pos)
-                .Name().Build(key)
-                .Value<TCoMember>()
-                    .Struct(inputItem)
-                    .Name().Build(key)
-                    .Build()
-                .Done();
-
-            keyTuples.emplace_back(tuple);
-        }
-
-        auto lookupDictArg = TCoArgument(ctx.NewArgument(pos, "recalc_dict_arg_" + indexDesc->Name));
-        auto reComputeDictStage = Build<TDqStage>(ctx, pos)
-            .Inputs()
-                .Add(rowsPrecompute.Cast()) // input rows
-                .Add(lookupDict.Cast()) // dict contains rows looked up from the table
-                .Build()
-            .Program()
-                .Args({inputArg, lookupDictArg})
-                .Body<TCoIterator>()
-                    .List<TCoMap>()
-                    .Input<TCoToList>()
-                        .Optional<TCoJust>()
-                            .Input(lookupDictArg)
+                        .Value<TCoMember>()
+                            .Struct(inputItem)
+                            .Name(columnAtom)
                             .Build()
+                    .Done());
+
+                    lookupRow.emplace_back(
+                        Build<TCoNameValueTuple>(ctx, pos)
+                            .Name(columnAtom)
+                            .Value<TCoMember>()
+                                .Struct(payload_table_row)
+                                .Name(columnAtom)
+                                .Build()
+                        .Done());
+                }
+
+                payloadTuples.emplace_back(
+                    Build<TCoNameValueTuple>(ctx, pos)
+                        .Name(columnAtom)
+                        .Value<TCoMember>()
+                            .Struct<TCoNth>()
+                                .Tuple(payloadSelectorArg)
+                                .Index().Build(1)
+                                .Build()
+                            .Name(columnAtom)
+                            .Build()
+                        .Done());
+            }
+
+            auto inputArg = TCoArgument(ctx.NewArgument(pos, "recalc_input_arg_" + indexDesc->Name));
+
+            auto cmp = ctx.Builder(pos)
+                .Callable("AggrNotEquals")
+                    .Add(0, Build<TCoAsStruct>(ctx, pos)
+                        .Add(inputRowsForIndex)
+                        .Done().Ptr())
+                    .Add(1, Build<TCoAsStruct>(ctx, pos)
+                        .Add(lookupRow)
+                        .Done().Ptr())
+                .Seal().Build();
+
+            for (const auto& key : pk) {
+                auto tuple = Build<TCoNameValueTuple>(ctx, pos)
+                    .Name().Build(key)
+                    .Value<TCoMember>()
+                        .Struct(inputItem)
+                        .Name().Build(key)
                         .Build()
-                    .Lambda()
-                        .Args({"collection"})
-                        .Body<TCoToDict>()
-                            .List<TCoFlatMap>()
-                                .Input(inputArg)
-                                .Lambda()
-                                    .Args({inputItem})
-                                    .Body<TCoMap>()
-                                        .Input<TCoLookup>()
-                                            .Collection("collection")
-                                            .Lookup<TCoAsStruct>()
-                                                .Add(keyTuples)
-                                                .Build()
-                                            .Build()
-                                        .Lambda<TCoLambda>()
-                                            .Args({payload_table_row})
-                                            .Body<TExprList>() // Key of tuple - key columns of index
-                                                .Add<TCoAsStruct>()
+                    .Done();
+
+                keyTuples.emplace_back(tuple);
+            }
+
+            auto lookupDictArg = TCoArgument(ctx.NewArgument(pos, "recalc_dict_arg_" + indexDesc->Name));
+            auto reComputeDictStage = Build<TDqStage>(ctx, pos)
+                .Inputs()
+                    .Add(rowsPrecompute.Cast()) // input rows
+                    .Add(lookupDict.Cast()) // dict contains rows looked up from the table
+                    .Build()
+                .Program()
+                    .Args({inputArg, lookupDictArg})
+                    .Body<TCoIterator>()
+                        .List<TCoMap>()
+                        .Input<TCoToList>()
+                            .Optional<TCoJust>()
+                                .Input(lookupDictArg)
+                                .Build()
+                            .Build()
+                        .Lambda()
+                            .Args({"collection"})
+                            .Body<TCoToDict>()
+                                .List<TCoFlatMap>()
+                                    .Input(inputArg)
+                                    .Lambda()
+                                        .Args({inputItem})
+                                        .Body<TCoMap>()
+                                            .Input<TCoLookup>()
+                                                .Collection("collection")
+                                                .Lookup<TCoAsStruct>()
                                                     .Add(keyTuples)
                                                     .Build()
-                                                .Add(payload_table_row) // rows read from main table
-                                                .Add(cmp) // comparation on rows from input and from index. true if not equal
+                                                .Build()
+                                            .Lambda<TCoLambda>()
+                                                .Args({payload_table_row})
+                                                .Body<TExprList>() // Key of tuple - key columns of index
+                                                    .Add<TCoAsStruct>()
+                                                        .Add(keyTuples)
+                                                        .Build()
+                                                    .Add(payload_table_row) // rows read from main table
+                                                    .Add(cmp) // comparation on rows from input and from index. true if not equal
+                                                    .Build()
                                                 .Build()
                                             .Build()
                                         .Build()
                                     .Build()
-                                .Build()
-                            .KeySelector(MakeTableKeySelector(table.Metadata, pos, ctx, 0))
-                            .PayloadSelector<TCoLambda>()
-                                .Args({payloadSelectorArg})
-                                .Body<TExprList>()
-                                    .Add<TCoNth>()
-                                        .Tuple(payloadSelectorArg)
-                                        .Index().Build(1)
-                                        .Build()
-                                    .Add<TCoNth>()
-                                        .Tuple(payloadSelectorArg)
-                                        .Index().Build(2)
+                                .KeySelector(MakeTableKeySelector(table.Metadata, pos, ctx, 0))
+                                .PayloadSelector<TCoLambda>()
+                                    .Args({payloadSelectorArg})
+                                    .Body<TExprList>()
+                                        .Add<TCoNth>()
+                                            .Tuple(payloadSelectorArg)
+                                            .Index().Build(1)
+                                            .Build()
+                                        .Add<TCoNth>()
+                                            .Tuple(payloadSelectorArg)
+                                            .Index().Build(2)
+                                            .Build()
                                         .Build()
                                     .Build()
-                                .Build()
-                            .Settings()
-                                .Add().Build("One")
-                                .Add().Build("Hashed")
+                                .Settings()
+                                    .Add().Build("One")
+                                    .Add().Build("Hashed")
+                                    .Build()
                                 .Build()
                             .Build()
                         .Build()
+                        .Build()
                     .Build()
-                    .Build()
-                .Build()
-            .Settings().Build()
-            .Done();
+                .Settings().Build()
+                .Done();
 
-        auto lookupDictRecomputed = Build<TDqPhyPrecompute>(ctx, pos)
-            .Connection<TDqCnValue>()
-                .Output()
-                    .Stage(reComputeDictStage)
-                    .Index().Build("0")
+            lookupDictRecomputed = Build<TDqPhyPrecompute>(ctx, pos)
+                .Connection<TDqCnValue>()
+                    .Output()
+                        .Stage(reComputeDictStage)
+                        .Index().Build("0")
+                        .Build()
                     .Build()
-                .Build()
-            .Done();
+                .Done();
+        }
 
         const TKikimrTableDescription *prefixTable = nullptr;
         if (indexDesc->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree && indexDesc->KeyColumns.size() > 1) {
@@ -956,8 +983,6 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                 : MakeRowsFromDict(lookupDict.Cast(), pk, indexTableColumnsWithoutData, pos, ctx);
 
             switch (indexDesc->Type) {
-                case TIndexDescription::EType::GlobalJson:
-                    YQL_ENSURE(false, "Not implemented");
                 case TIndexDescription::EType::GlobalSync:
                 case TIndexDescription::EType::GlobalAsync:
                 case TIndexDescription::EType::GlobalSyncUnique:
@@ -972,8 +997,9 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                     break;
                 }
                 case TIndexDescription::EType::GlobalFulltextPlain:
-                case TIndexDescription::EType::GlobalFulltextRelevance: {
-                    // For fulltext indexes, we need to tokenize the text and create deleted rows
+                case TIndexDescription::EType::GlobalFulltextRelevance:
+                case TIndexDescription::EType::GlobalJson: {
+                    // For fulltext and JSON indexes, we need to tokenize the text and create deleted rows
                     auto deleteKeysPrecompute = ReadInputToPrecompute(deleteIndexKeys, pos, ctx);
                     deleteIndexKeys = BuildFulltextIndexRows(table, indexDesc, deleteKeysPrecompute, indexTableColumnsSet,
                         indexTableColumnsWithoutData, true /*forDelete*/, pos, ctx);
@@ -1024,8 +1050,6 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                       inputColumnsSet, indexTableColumns, table, pos, ctx, false);
 
             switch (indexDesc->Type) {
-                case TIndexDescription::EType::GlobalJson:
-                    YQL_ENSURE(false, "Not implemented");
                 case TIndexDescription::EType::GlobalSync:
                 case TIndexDescription::EType::GlobalAsync:
                 case TIndexDescription::EType::GlobalSyncUnique:
@@ -1048,8 +1072,9 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                     break;
                 }
                 case TIndexDescription::EType::GlobalFulltextPlain:
-                case TIndexDescription::EType::GlobalFulltextRelevance: {
-                    // For fulltext indexes, we need to tokenize the text and create upserted rows
+                case TIndexDescription::EType::GlobalFulltextRelevance:
+                case TIndexDescription::EType::GlobalJson: {
+                    // For fulltext and JSON indexes, we need to tokenize the text and create upserted rows
                     auto upsertPrecompute = ReadInputToPrecompute(upsertIndexRows, pos, ctx);
                     upsertIndexRows = BuildFulltextIndexRows(table, indexDesc, upsertPrecompute, indexTableColumnsSet,
                         indexTableColumns, false /*forDelete*/, pos, ctx);

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -320,8 +320,8 @@ struct TIndexDescription {
                 return true;
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
-                return true;
             case EType::GlobalJson:
+                return true;
             case EType::LocalBloomFilter:
             case EType::LocalBloomNgramFilter:
                 return false;

--- a/ydb/core/kqp/query_compiler/kqp_mkql_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_mkql_compiler.cpp
@@ -537,7 +537,11 @@ TIntrusivePtr<IMkqlCallableCompiler> CreateKqlCompiler(const TKqlCompileContext&
 
             auto textArg = MkqlBuildExpr(*node.Child(0), buildCtx);
             auto settingsArg = MkqlBuildExpr(*node.Child(1), buildCtx);
-            auto modeArg = MkqlBuildExpr(*node.Child(2), buildCtx);
+
+            auto modeNode = node.Child(2);
+            YQL_ENSURE(modeNode->IsAtom(), "FulltextAnalyze mode should be an atom");
+            ui32 modeValue = FromString<ui32>(modeNode->Content());
+            auto modeArg = ctx.PgmBuilder().NewDataLiteral<ui32>(modeValue);
 
             return ctx.PgmBuilder().FulltextAnalyze(textArg, settingsArg, modeArg);
         });

--- a/ydb/core/kqp/query_compiler/kqp_mkql_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_mkql_compiler.cpp
@@ -533,12 +533,13 @@ TIntrusivePtr<IMkqlCallableCompiler> CreateKqlCompiler(const TKqlCompileContext&
 
     compiler->AddCallable("FulltextAnalyze",
         [&ctx](const TExprNode& node, TMkqlBuildContext& buildCtx) {
-            YQL_ENSURE(node.ChildrenSize() == 2, "FulltextAnalyze should have 2 arguments: text and settings");
+            YQL_ENSURE(node.ChildrenSize() == 3, "FulltextAnalyze should have 3 arguments: text, settings and mode");
 
             auto textArg = MkqlBuildExpr(*node.Child(0), buildCtx);
             auto settingsArg = MkqlBuildExpr(*node.Child(1), buildCtx);
+            auto modeArg = MkqlBuildExpr(*node.Child(2), buildCtx);
 
-            return ctx.PgmBuilder().FulltextAnalyze(textArg, settingsArg);
+            return ctx.PgmBuilder().FulltextAnalyze(textArg, settingsArg, modeArg);
         });
 
     return compiler;

--- a/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
+++ b/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
@@ -111,15 +111,16 @@ public:
     }
 
     EMode GetMode(TComputationContext& ctx) const {
-        auto mode = ModeArg->GetValue(ctx);
-        if (mode.AsStringRef() == TStringBuf("0")) {
-            return EMode::Fulltext;
-        } else if (mode.AsStringRef() == TStringBuf("1")) {
-            return EMode::JsonIndexOverJson;
-        } else if (mode.AsStringRef() == TStringBuf("2")) {
-            return EMode::JsonIndexOverJsonDocument;
+        switch (ModeArg->GetValue(ctx).Get<ui32>()) {
+            case 0:
+                return EMode::Fulltext;
+            case 1:
+                return EMode::JsonIndexOverJson;
+            case 2:
+                return EMode::JsonIndexOverJsonDocument;
+            default:
+                MKQL_ENSURE(false, "Invalid FulltextAnalyze mode");
         }
-        return EMode::Fulltext;
     }
 
 private:

--- a/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
+++ b/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/fulltext.h>
 
+#include <ydb/core/base/json_index.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_impl.h>
 #include <yql/essentials/minikql/mkql_node_cast.h>
@@ -24,11 +25,18 @@ class TFulltextAnalyzeWrapper : public TMutableComputationNode<TFulltextAnalyzeW
         Ydb::Table::FulltextIndexSettings::Analyzers Analyzers;
     };
 
+    enum class EMode {
+        Fulltext = 0,
+        JsonIndexOverJson = 1,
+        JsonIndexOverJsonDocument = 2,
+    };
+
 public:
-    TFulltextAnalyzeWrapper(TComputationMutables& mutables, IComputationNode* textArg, IComputationNode* settingsArg)
+    TFulltextAnalyzeWrapper(TComputationMutables& mutables, IComputationNode* textArg, IComputationNode* settingsArg, IComputationNode* modeArg)
         : TBaseComputation(mutables)
         , TextArg(textArg)
         , SettingsArg(settingsArg)
+        , ModeArg(modeArg)
         , CachedSettingsIndex(mutables.CurValueIndex++)
     {
     }
@@ -40,14 +48,28 @@ public:
             return ctx.HolderFactory.GetEmptyContainerLazy();
         }
 
-        auto& settings = GetSettings(ctx);
-        if (!settings.IsValid) {
-            // Failed to parse settings, return empty list
-            return ctx.HolderFactory.GetEmptyContainerLazy();
+        const auto mode = GetMode(ctx);
+
+        // Tokenize text
+        TVector<TString> tokens;
+        if (mode == EMode::Fulltext) {
+            auto& settings = GetSettings(ctx);
+            if (!settings.IsValid) {
+                // Failed to parse settings, return empty list
+                return ctx.HolderFactory.GetEmptyContainerLazy();
+            }
+            tokens = Analyze(TString(text.AsStringRef()), settings.Analyzers);
+        } else if (mode == EMode::JsonIndexOverJson) {
+            TString error;
+            tokens = NJsonIndex::TokenizeJson(text.AsStringRef(), error);
+            if (!error.empty()) {
+                // Failed to tokenize JSON, return empty list
+                return ctx.HolderFactory.GetEmptyContainerLazy();
+            }
+        } else if (mode == EMode::JsonIndexOverJsonDocument) {
+            tokens = NJsonIndex::TokenizeBinaryJson(text.AsStringRef());
         }
 
-        // Tokenize text using NKikimr::NFulltext::Analyze
-        TVector<TString> tokens = Analyze(TString(text.AsStringRef()), settings.Analyzers);
         THashMap<TString, ui32> tokenFreq;
         for (const auto& token : tokens) {
             tokenFreq[token]++;
@@ -82,32 +104,46 @@ public:
             // Return cached settings
             return GetSettings(cachedSettings);
         }
-    }    
+    }
 
     TSettings& GetSettings(auto& cachedSettings) const {
         return *static_cast<TSettings*>(cachedSettings.AsBoxed().Get());
+    }
+
+    EMode GetMode(TComputationContext& ctx) const {
+        auto mode = ModeArg->GetValue(ctx);
+        if (mode.AsStringRef() == TStringBuf("0")) {
+            return EMode::Fulltext;
+        } else if (mode.AsStringRef() == TStringBuf("1")) {
+            return EMode::JsonIndexOverJson;
+        } else if (mode.AsStringRef() == TStringBuf("2")) {
+            return EMode::JsonIndexOverJsonDocument;
+        }
+        return EMode::Fulltext;
     }
 
 private:
     void RegisterDependencies() const final {
         DependsOn(TextArg);
         DependsOn(SettingsArg);
+        DependsOn(ModeArg);
     }
 
     IComputationNode* const TextArg;
     IComputationNode* const SettingsArg;
+    IComputationNode* const ModeArg;
     const ui32 CachedSettingsIndex;
 };
 
 } // namespace
 
 IComputationNode* WrapFulltextAnalyze(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
-    MKQL_ENSURE(callable.GetInputsCount() == 2, "FulltextAnalyze requires exactly 2 arguments");
+    MKQL_ENSURE(callable.GetInputsCount() == 3, "FulltextAnalyze requires exactly 3 arguments");
 
     auto textArg = LocateNode(ctx.NodeLocator, callable, 0);
     auto settingsArg = LocateNode(ctx.NodeLocator, callable, 1);
-
-    return new TFulltextAnalyzeWrapper(ctx.Mutables, textArg, settingsArg);
+    auto modeArg = LocateNode(ctx.NodeLocator, callable, 2);
+    return new TFulltextAnalyzeWrapper(ctx.Mutables, textArg, settingsArg, modeArg);
 }
 
 } // namespace NMiniKQL

--- a/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
+++ b/ydb/core/kqp/runtime/kqp_fulltext_analyze.cpp
@@ -25,12 +25,6 @@ class TFulltextAnalyzeWrapper : public TMutableComputationNode<TFulltextAnalyzeW
         Ydb::Table::FulltextIndexSettings::Analyzers Analyzers;
     };
 
-    enum class EMode {
-        Fulltext = 0,
-        JsonIndexOverJson = 1,
-        JsonIndexOverJsonDocument = 2,
-    };
-
 public:
     TFulltextAnalyzeWrapper(TComputationMutables& mutables, IComputationNode* textArg, IComputationNode* settingsArg, IComputationNode* modeArg)
         : TBaseComputation(mutables)
@@ -48,26 +42,36 @@ public:
             return ctx.HolderFactory.GetEmptyContainerLazy();
         }
 
-        const auto mode = GetMode(ctx);
-
-        // Tokenize text
         TVector<TString> tokens;
-        if (mode == EMode::Fulltext) {
-            auto& settings = GetSettings(ctx);
-            if (!settings.IsValid) {
-                // Failed to parse settings, return empty list
-                return ctx.HolderFactory.GetEmptyContainerLazy();
+        switch (GetMode(ctx)) {
+            case NFulltext::EIndexMode::Fulltext: {
+                auto& settings = GetSettings(ctx);
+                if (!settings.IsValid) {
+                    // Failed to parse settings, return empty list
+                    return ctx.HolderFactory.GetEmptyContainerLazy();
+                }
+                tokens = Analyze(TString(text.AsStringRef()), settings.Analyzers);
+                break;
             }
-            tokens = Analyze(TString(text.AsStringRef()), settings.Analyzers);
-        } else if (mode == EMode::JsonIndexOverJson) {
-            TString error;
-            tokens = NJsonIndex::TokenizeJson(text.AsStringRef(), error);
-            if (!error.empty()) {
-                // Failed to tokenize JSON, return empty list
-                return ctx.HolderFactory.GetEmptyContainerLazy();
+
+            case NFulltext::EIndexMode::JsonIndexOverJson: {
+                TString error;
+                tokens = NJsonIndex::TokenizeJson(text.AsStringRef(), error);
+                if (!error.empty()) {
+                    // Failed to tokenize JSON, return empty list
+                    return ctx.HolderFactory.GetEmptyContainerLazy();
+                }
+                break;
             }
-        } else if (mode == EMode::JsonIndexOverJsonDocument) {
-            tokens = NJsonIndex::TokenizeBinaryJson(text.AsStringRef());
+
+            case NFulltext::EIndexMode::JsonIndexOverJsonDocument: {
+                tokens = NJsonIndex::TokenizeBinaryJson(text.AsStringRef());
+                break;
+            }
+
+            default: {
+                MKQL_ENSURE(false, "Invalid FulltextAnalyze mode");
+            }
         }
 
         THashMap<TString, ui32> tokenFreq;
@@ -110,17 +114,12 @@ public:
         return *static_cast<TSettings*>(cachedSettings.AsBoxed().Get());
     }
 
-    EMode GetMode(TComputationContext& ctx) const {
-        switch (ModeArg->GetValue(ctx).Get<ui32>()) {
-            case 0:
-                return EMode::Fulltext;
-            case 1:
-                return EMode::JsonIndexOverJson;
-            case 2:
-                return EMode::JsonIndexOverJsonDocument;
-            default:
-                MKQL_ENSURE(false, "Invalid FulltextAnalyze mode");
+    NFulltext::EIndexMode GetMode(TComputationContext& ctx) const {
+        auto mode = ModeArg->GetValue(ctx).Get<ui32>();
+        if (mode < 1 || mode > 3) {
+            return NFulltext::EIndexMode::Invalid;
         }
+        return static_cast<NFulltext::EIndexMode>(mode);
     }
 
 private:

--- a/ydb/core/kqp/runtime/kqp_program_builder.cpp
+++ b/ydb/core/kqp/runtime/kqp_program_builder.cpp
@@ -401,6 +401,12 @@ TRuntimeNode TKqpProgramBuilder::FulltextAnalyze(TRuntimeNode text, TRuntimeNode
     const auto& settingsTypeData = static_cast<const TDataType&>(*settingsType);
     MKQL_ENSURE(settingsTypeData.GetSchemeType() == NScheme::NTypeIds::String, "Expected string for settings.");
 
+    // Validate mode argument - should be Uint32
+    const auto& modeType = mode.GetStaticType();
+    MKQL_ENSURE(modeType->IsData(), "Expected data type for mode.");
+    const auto& modeTypeData = static_cast<const TDataType&>(*modeType);
+    MKQL_ENSURE(modeTypeData.GetSchemeType() == NUdf::TDataType<ui32>::Id, "Expected Uint32 for mode.");
+
     TCallableBuilder callableBuilder(Env, __func__, listType);
     callableBuilder.Add(text);
     callableBuilder.Add(settings);

--- a/ydb/core/kqp/runtime/kqp_program_builder.cpp
+++ b/ydb/core/kqp/runtime/kqp_program_builder.cpp
@@ -355,9 +355,9 @@ TRuntimeNode TKqpProgramBuilder::KqpIndexLookupJoin(const TRuntimeNode& input, c
     return TRuntimeNode(callableBuilder.Build(), false);
 }
 
-TRuntimeNode TKqpProgramBuilder::FulltextAnalyze(TRuntimeNode text, TRuntimeNode settings)
+TRuntimeNode TKqpProgramBuilder::FulltextAnalyze(TRuntimeNode text, TRuntimeNode settings, TRuntimeNode mode)
 {
-    // Validate text argument - should be a String or Utf8 or optional String or Utf8
+    // Validate text argument — String, Utf8, Json, JsonDocument (or optional of those)
     const auto& textType = text.GetStaticType();
     const TDataType* textDataType = nullptr;
 
@@ -371,11 +371,23 @@ TRuntimeNode TKqpProgramBuilder::FulltextAnalyze(TRuntimeNode text, TRuntimeNode
         textDataType = static_cast<const TDataType*>(textType);
     }
 
-    MKQL_ENSURE(textDataType->GetSchemeType() == NScheme::NTypeIds::String
-        || textDataType->GetSchemeType() == NScheme::NTypeIds::Utf8, "Expected String or Utf8 for text column.");
+    const auto textSchemeType = textDataType->GetSchemeType();
+    switch (textSchemeType) {
+        case NScheme::NTypeIds::String:
+        case NScheme::NTypeIds::Utf8:
+        case NScheme::NTypeIds::Json:
+        case NScheme::NTypeIds::JsonDocument:
+            break;
+        default:
+            MKQL_ENSURE(false, "Expected String, Utf8, Json, or JsonDocument for text column.");
+    }
 
     // Return type: List<Struct<__ydb_token:String or Utf8,__ydb_freq:Uint32>>
-    auto stringType = TDataType::Create(textDataType->GetSchemeType(), Env);
+    const auto tokenSchemeType = (textSchemeType == NScheme::NTypeIds::Json
+        || textSchemeType == NScheme::NTypeIds::JsonDocument)
+        ? NScheme::NTypeIds::String
+        : textSchemeType;
+    auto stringType = TDataType::Create(tokenSchemeType, Env);
     auto freqType = TDataType::Create(NUdf::TDataType<ui32>::Id, GetTypeEnvironment());
     TStructTypeBuilder rowTypeBuilder(GetTypeEnvironment());
     rowTypeBuilder.Add(NTableIndex::NFulltext::FreqColumn, freqType);
@@ -392,6 +404,7 @@ TRuntimeNode TKqpProgramBuilder::FulltextAnalyze(TRuntimeNode text, TRuntimeNode
     TCallableBuilder callableBuilder(Env, __func__, listType);
     callableBuilder.Add(text);
     callableBuilder.Add(settings);
+    callableBuilder.Add(mode);
     return TRuntimeNode(callableBuilder.Build(), false);
 }
 

--- a/ydb/core/kqp/runtime/kqp_program_builder.h
+++ b/ydb/core/kqp/runtime/kqp_program_builder.h
@@ -68,7 +68,7 @@ public:
 
     TRuntimeNode KqpIndexLookupJoin(const TRuntimeNode& input, const TString& joinType, const TString& leftLabel, const TString& rightLabel);
 
-    TRuntimeNode FulltextAnalyze(TRuntimeNode text, TRuntimeNode settings);
+    TRuntimeNode FulltextAnalyze(TRuntimeNode text, TRuntimeNode settings, TRuntimeNode mode);
 };
 
 } // namespace NMiniKQL

--- a/ydb/core/kqp/ut/batch_operations/kqp_batch_delete_ut.cpp
+++ b/ydb/core/kqp/ut/batch_operations/kqp_batch_delete_ut.cpp
@@ -909,6 +909,42 @@ Y_UNIT_TEST_SUITE(KqpBatchDelete) {
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync fulltext_relevance indexes (index: `idx`)");
         }
     }
+
+    Y_UNIT_TEST(TableWithJsonIndex) {
+        auto settings = GetTestSettings().SetWithSampleTables(false);
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableJsonIndex(true);
+        settings.SetFeatureFlags(featureFlags);
+
+        auto kikimr = TKikimrRunner(settings);
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE json_idx (
+                    k Uint64 NOT NULL,
+                    v1 Json,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL USING json ON (v1) COVER (v2)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH DELETE FROM json_idx;
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync json indexes (index: `idx`)");
+        }
+    }
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/ut/batch_operations/kqp_batch_update_ut.cpp
+++ b/ydb/core/kqp/ut/batch_operations/kqp_batch_update_ut.cpp
@@ -1115,6 +1115,42 @@ Y_UNIT_TEST_SUITE(KqpBatchUpdate) {
         }
         */
     }
+
+    Y_UNIT_TEST(TableWithJsonIndex) {
+        auto settings = GetTestSettings().SetWithSampleTables(false);
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableJsonIndex(true);
+        settings.SetFeatureFlags(featureFlags);
+
+        auto kikimr = TKikimrRunner(settings);
+
+        auto db = kikimr.GetQueryClient();
+        auto session = db.GetSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteQuery(R"(
+                CREATE TABLE json_idx (
+                    k Uint64 NOT NULL,
+                    v1 Json,
+                    v2 String,
+                    v3 String,
+                    PRIMARY KEY (k),
+                    INDEX idx GLOBAL USING json ON (v1) COVER (v2)
+                );
+            )", TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            const auto query = R"(
+                BATCH UPDATE json_idx SET v1 = "123";
+            )";
+
+            auto result = session.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "BATCH operations are not supported for tables with global sync json indexes (index: `idx`)");
+        }
+    }
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -271,6 +271,29 @@ void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
     body(db, jsonExists);
 }
 
+TExecuteQueryResult WriteJsonIndexWithKeys(TQueryClient& db, const std::string& stmt, const std::string& tableName,
+    const std::string& jsonType, const std::vector<std::pair<ui64, ui64>>& values, bool withReturning = false)
+{
+    TStringBuilder query;
+    query << stmt << " INTO " << tableName << " (Key, Text, Data) VALUES\n";
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        const auto [key, value] = values[i];
+        query << "(" << key << ", " << jsonType << "('{\"k" << value << "\": [\"v" << value << "\", " << value << ", " << (value % 2 == 0 ? "true" : "false") << "]}'), \"data " << value << "\")";
+        if (i + 1 < values.size()) {
+            query << ", ";
+        } else {
+            query << "\n";
+        }
+    }
+
+    if (withReturning) {
+        query << "RETURNING *";
+    }
+
+    return db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+}
+
 }  // namespace
 
 Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
@@ -438,6 +461,718 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             )";
             auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(UpsertJsonIndex, IsJsonDocument, WithReturning) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        auto jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType);
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "UPSERT", "TestTable", jsonType, {{1, 1}, {2, 2}, {3, 3}, {4, 4}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\":[\"v1\",1,false]}"]];
+                        [["data 2"];[2u];["{\"k2\":[\"v2\",2,true]}"]];
+                        [["data 3"];[3u];["{\"k3\":[\"v3\",3,false]}"]];
+                        [["data 4"];[4u];["{\"k4\":[\"v4\",4,true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\": [\"v1\", 1, false]}"]];
+                        [["data 2"];[2u];["{\"k2\": [\"v2\", 2, true]}"]];
+                        [["data 3"];[3u];["{\"k3\": [\"v3\", 3, false]}"]];
+                        [["data 4"];[4u];["{\"k4\": [\"v4\", 4, true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];""];
+                [[3u];"\2k3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "UPSERT", "TestTable", jsonType, {{1, 3}, {3, 2}, {5, 5}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 5"];[5u];["{\"k5\":[\"v5\",5,false]}"]];
+                        [["data 2"];[3u];["{\"k2\":[\"v2\",2,true]}"]];
+                        [["data 3"];[1u];["{\"k3\":[\"v3\",3,false]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 5"];[5u];["{\"k5\": [\"v5\", 5, false]}"]];
+                        [["data 2"];[3u];["{\"k2\": [\"v2\", 2, true]}"]];
+                        [["data 3"];[1u];["{\"k3\": [\"v3\", 3, false]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[1u];"\2k3\0\3v3"];
+                [[1u];"\2k3\0\0"];
+                [[1u];"\2k3"];
+                [[1u];""];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[3u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];"\2k2\0\3v2"];
+                [[3u];"\2k2\0\1"];
+                [[3u];"\2k2"];
+                [[3u];""];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[5u];""];
+                [[5u];"\2k5"];
+                [[5u];"\2k5\0\0"];
+                [[5u];"\2k5\0\3v5"];
+                [[5u];"\2k5\0\4\0\0\0\0\0\0\x14@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(ReplaceJsonIndex, IsJsonDocument, WithReturning) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        auto jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType);
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "REPLACE", "TestTable", jsonType, {{1, 1}, {2, 2}, {3, 3}, {4, 4}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\":[\"v1\",1,false]}"]];
+                        [["data 2"];[2u];["{\"k2\":[\"v2\",2,true]}"]];
+                        [["data 3"];[3u];["{\"k3\":[\"v3\",3,false]}"]];
+                        [["data 4"];[4u];["{\"k4\":[\"v4\",4,true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\": [\"v1\", 1, false]}"]];
+                        [["data 2"];[2u];["{\"k2\": [\"v2\", 2, true]}"]];
+                        [["data 3"];[3u];["{\"k3\": [\"v3\", 3, false]}"]];
+                        [["data 4"];[4u];["{\"k4\": [\"v4\", 4, true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];""];
+                [[3u];"\2k3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "REPLACE", "TestTable", jsonType, {{1, 3}, {3, 2}, {5, 5}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 5"];[5u];["{\"k5\":[\"v5\",5,false]}"]];
+                        [["data 2"];[3u];["{\"k2\":[\"v2\",2,true]}"]];
+                        [["data 3"];[1u];["{\"k3\":[\"v3\",3,false]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 5"];[5u];["{\"k5\": [\"v5\", 5, false]}"]];
+                        [["data 2"];[3u];["{\"k2\": [\"v2\", 2, true]}"]];
+                        [["data 3"];[1u];["{\"k3\": [\"v3\", 3, false]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[1u];"\2k3\0\3v3"];
+                [[1u];"\2k3\0\0"];
+                [[1u];"\2k3"];
+                [[1u];""];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[3u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];"\2k2\0\3v2"];
+                [[3u];"\2k2\0\1"];
+                [[3u];"\2k2"];
+                [[3u];""];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[5u];""];
+                [[5u];"\2k5"];
+                [[5u];"\2k5\0\0"];
+                [[5u];"\2k5\0\3v5"];
+                [[5u];"\2k5\0\4\0\0\0\0\0\0\x14@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(InsertJsonIndex, IsJsonDocument, WithReturning) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        auto jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType);
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "INSERT", "TestTable", jsonType, {{1, 1}, {2, 2}, {3, 3}, {4, 4}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\":[\"v1\",1,false]}"]];
+                        [["data 2"];[2u];["{\"k2\":[\"v2\",2,true]}"]];
+                        [["data 3"];[3u];["{\"k3\":[\"v3\",3,false]}"]];
+                        [["data 4"];[4u];["{\"k4\":[\"v4\",4,true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 1"];[1u];["{\"k1\": [\"v1\", 1, false]}"]];
+                        [["data 2"];[2u];["{\"k2\": [\"v2\", 2, true]}"]];
+                        [["data 3"];[3u];["{\"k3\": [\"v3\", 3, false]}"]];
+                        [["data 4"];[4u];["{\"k4\": [\"v4\", 4, true]}"]]
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];""];
+                [[3u];"\2k3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "INSERT", "TestTable", jsonType, {{5, 3}, {6, 2}}, WithReturning);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 3"];[5u];["{\"k3\":[\"v3\",3,false]}"]];
+                        [["data 2"];[6u];["{\"k2\":[\"v2\",2,true]}"]];
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 3"];[5u];["{\"k3\": [\"v3\", 3, false]}"]];
+                        [["data 2"];[6u];["{\"k2\": [\"v2\", 2, true]}"]];
+                    ])", FormatResultSetYson(writeResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\2k2\0\3v2"];
+                [[3u];""];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[5u];"\2k3"];
+                [[5u];"\2k3\0\0"];
+                [[5u];""];
+                [[5u];"\2k3\0\3v3"];
+                [[5u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[6u];"\2k2\0\1"];
+                [[6u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[6u];"\2k2"];
+                [[6u];""];
+                [[6u];"\2k2\0\3v2"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "INSERT", "TestTable", jsonType, {{1, 1}, {7, 7}}, WithReturning);
+            UNIT_ASSERT_C(!writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\2k2\0\3v2"];
+                [[3u];""];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[5u];"\2k3"];
+                [[5u];"\2k3\0\0"];
+                [[5u];""];
+                [[5u];"\2k3\0\3v3"];
+                [[5u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[6u];"\2k2\0\1"];
+                [[6u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[6u];"\2k2"];
+                [[6u];""];
+                [[6u];"\2k2\0\3v2"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(UpdateJsonIndex, IsJsonDocument, WithReturning) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        auto jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType);
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "INSERT", "TestTable", jsonType, {{1, 1}, {2, 2}, {3, 3}, {4, 4}}, /* withReturning */ false);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\2k2"];
+                [[2u];"\2k2\0\1"];
+                [[2u];"\2k2\0\3v2"];
+                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];""];
+                [[3u];"\2k3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {
+            TStringBuilder query;
+            query << "UPDATE `/Root/TestTable` "
+                  << "SET Text = " << jsonType << "('{\"k10\": [\"v10\", 10, true]}'), "
+                  << "Data = \"data 10\" "
+                  << "WHERE Key IN (2, 3)";
+            if (WithReturning) {
+                query << " RETURNING *";
+            }
+
+            auto updateResult = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(updateResult.IsSuccess(), updateResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 10"];[3u];["{\"k10\":[\"v10\",10,true]}"]];
+                        [["data 10"];[2u];["{\"k10\":[\"v10\",10,true]}"]]
+                    ])", FormatResultSetYson(updateResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 10"];[3u];["{\"k10\": [\"v10\", 10, true]}"]];
+                        [["data 10"];[2u];["{\"k10\": [\"v10\", 10, true]}"]]
+                    ])", FormatResultSetYson(updateResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[2u];""];
+                [[2u];"\3k10"];
+                [[2u];"\3k10\0\1"];
+                [[2u];"\3k10\0\3v10"];
+                [[2u];"\3k10\0\4\0\0\0\0\0\0$@"];
+                [[3u];""];
+                [[3u];"\3k10"];
+                [[3u];"\3k10\0\1"];
+                [[3u];"\3k10\0\3v10"];
+                [[3u];"\3k10\0\4\0\0\0\0\0\0$@"];
+                [[4u];""];
+                [[4u];"\2k4"];
+                [[4u];"\2k4\0\1"];
+                [[4u];"\2k4\0\3v4"];
+                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {
+            TStringBuilder query;
+            query << "UPDATE `/Root/TestTable` "
+                  << "SET Text = " << jsonType << "('{\"k100\": [\"v100\", 100, false]}'), "
+                  << "Data = \"data 100\"";
+            if (WithReturning) {
+                query << " RETURNING *";
+            }
+
+            auto updateResult = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(updateResult.IsSuccess(), updateResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 100"];[4u];["{\"k100\":[\"v100\",100,false]}"]];
+                        [["data 100"];[3u];["{\"k100\":[\"v100\",100,false]}"]];
+                        [["data 100"];[2u];["{\"k100\":[\"v100\",100,false]}"]];
+                        [["data 100"];[1u];["{\"k100\":[\"v100\",100,false]}"]]
+                    ])", FormatResultSetYson(updateResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 100"];[4u];["{\"k100\": [\"v100\", 100, false]}"]];
+                        [["data 100"];[3u];["{\"k100\": [\"v100\", 100, false]}"]];
+                        [["data 100"];[2u];["{\"k100\": [\"v100\", 100, false]}"]];
+                        [["data 100"];[1u];["{\"k100\": [\"v100\", 100, false]}"]]
+                    ])", FormatResultSetYson(updateResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\4k100"];
+                [[1u];"\4k100\0\0"];
+                [[1u];"\4k100\0\3v100"];
+                [[1u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[2u];""];
+                [[2u];"\4k100"];
+                [[2u];"\4k100\0\0"];
+                [[2u];"\4k100\0\3v100"];
+                [[2u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[3u];""];
+                [[3u];"\4k100"];
+                [[3u];"\4k100\0\0"];
+                [[3u];"\4k100\0\3v100"];
+                [[3u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[4u];""];
+                [[4u];"\4k100"];
+                [[4u];"\4k100\0\0"];
+                [[4u];"\4k100\0\3v100"];
+                [[4u];"\4k100\0\4\0\0\0\0\0\0Y@"]
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+    }
+
+    Y_UNIT_TEST_QUAD(DeleteJsonIndex, IsJsonDocument, WithReturning) {
+        auto kikimr = Kikimr();
+        auto db = kikimr.GetQueryClient();
+
+        auto jsonType = IsJsonDocument ? "JsonDocument" : "Json";
+
+        CreateTestTable(db, jsonType);
+
+        {
+            auto writeResult = WriteJsonIndexWithKeys(db, "INSERT", "TestTable", jsonType, {{1, 1}, {2, 2}, {3, 3}, {4, 4}}, /* withReturning */ false);
+            UNIT_ASSERT_C(writeResult.IsSuccess(), writeResult.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            TStringBuilder query;
+            query << "DELETE FROM `/Root/TestTable` WHERE Key IN (2, 4)";
+            if (WithReturning) {
+                query << " RETURNING *";
+            }
+
+            auto deleteResult = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(deleteResult.IsSuccess(), deleteResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 4"];[4u];["{\"k4\":[\"v4\",4,true]}"]];
+                        [["data 2"];[2u];["{\"k2\":[\"v2\",2,true]}"]]
+                    ])", FormatResultSetYson(deleteResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 4"];[4u];["{\"k4\": [\"v4\", 4, true]}"]];
+                        [["data 2"];[2u];["{\"k2\": [\"v2\", 2, true]}"]]
+                    ])", FormatResultSetYson(deleteResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson(R"([
+                [[1u];""];
+                [[1u];"\2k1"];
+                [[1u];"\2k1\0\0"];
+                [[1u];"\2k1\0\3v1"];
+                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[3u];""];
+                [[3u];"\2k3"];
+                [[3u];"\2k3\0\0"];
+                [[3u];"\2k3\0\3v3"];
+                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+            ])", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {
+            TStringBuilder query;
+            query << "DELETE FROM `/Root/TestTable`";
+            if (WithReturning) {
+                query << " RETURNING *";
+            }
+
+            auto deleteResult = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(deleteResult.IsSuccess(), deleteResult.GetIssues().ToString());
+
+            if (WithReturning) {
+                if (IsJsonDocument) {
+                    CompareYson(R"([
+                        [["data 3"];[3u];["{\"k3\":[\"v3\",3,false]}"]];
+                        [["data 1"];[1u];["{\"k1\":[\"v1\",1,false]}"]]
+                    ])", FormatResultSetYson(deleteResult.GetResultSet(0)));
+                } else {
+                    CompareYson(R"([
+                        [["data 3"];[3u];["{\"k3\": [\"v3\", 3, false]}"]];
+                        [["data 1"];[1u];["{\"k1\": [\"v1\", 1, false]}"]]
+                    ])", FormatResultSetYson(deleteResult.GetResultSet(0)));
+                }
+            }
+        }
+
+        {
+            std::string query = R"(
+                SELECT * FROM `/Root/TestTable/json_idx/indexImplTable` ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            CompareYson("[]", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -464,6 +464,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         }
     }
 
+    Y_UNIT_TEST(DisabledFlagRejectCreate) {
+        auto kikimr = Kikimr(/* enableJsonIndex */ false);
+        auto db = kikimr.GetQueryClient();
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key Uint64,
+                    Text Json,
+                    Data Utf8,
+                    PRIMARY KEY (Key),
+                    INDEX `json_idx` GLOBAL USING json ON (Text)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
+    }
+
     Y_UNIT_TEST_QUAD(UpsertJsonIndex, IsJsonDocument, WithReturning) {
         auto kikimr = Kikimr();
         auto db = kikimr.GetQueryClient();
@@ -1173,25 +1192,6 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 
             CompareYson("[]", FormatResultSetYson(result.GetResultSet(0)));
-        }
-    }
-
-    Y_UNIT_TEST(DisabledFlagRejectCreate) {
-        auto kikimr = Kikimr(/* enableJsonIndex */ false);
-        auto db = kikimr.GetQueryClient();
-
-        {
-            std::string query = R"(
-                CREATE TABLE `/Root/TestTable` (
-                    Key Uint64,
-                    Text Json,
-                    Data Utf8,
-                    PRIMARY KEY (Key),
-                    INDEX `json_idx` GLOBAL USING json ON (Text)
-                );
-            )";
-            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Supported new operations for `JSON` index. Implemented new tests with and without `RETURNING` for these statements:
- `INSERT INTO`
- `UPSERT INTO`
- `REPLACE INTO`
- `UPDATE`
- `DELETE FROM`

Implemented tests for `BATCH UPDATE` and `BATCH DELETE` operations: they are not supported for tables with `JSON` indexes.

...

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Because `JSON` index doesn't have its own Analyzer to execute `FulltextAnalyze`, this computation node has been extended with a new argument `Mode` to choose how to tokenize the expressions:

- Mode `0`: fulltext (plain/relevance), it is used for basic `Analyze` calls;
- Mode `1`: json index on `Json`, it is used for `TokenizeJson`;
- Mode `2`: json index on `JsonDocument`, it is used for `TokenizeBinaryJson`.

Additionally, the first argument of the `FulltextAnalyze` function can be of type `Json` or `JsonDocument`.

...
