### PR TITLE
Fix ConfiguredBootstrapper killing all tablet, when receive empty config

### DIFF
--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -105,7 +105,9 @@ class TConfiguredTabletBootstrapper : public TActorBootstrapped<TConfiguredTable
     }
 
     void ProcessTabletsFromConfig(const NKikimrConfig::TBootstrap &bootstrapConfig) {
-        LastBootstrapConfig.CopyFrom(bootstrapConfig);
+        NKikimrConfig::TBootstrap newLast;
+        newLast.CopyFrom(bootstrapConfig);
+        newLast.ClearTablet();
 
         // check if bootstrappers are disabled via ICB
         if (DisableLocalBootstrappers && !WasLocalBootstrappersDisabled) {
@@ -118,10 +120,32 @@ class TConfiguredTabletBootstrapper : public TActorBootstrapped<TConfiguredTable
 
         THashSet<ui64> currentTabletIds;
         for (const auto &tablet : bootstrapConfig.GetTablet()) {
-            ui64 tabletId = tablet.GetInfo().GetTabletID();
+            auto normalizedTablet = tablet;
+            RestoreTabletInfoFromStartupConfig(normalizedTablet);
+
+            if (!HasCompleteTabletChannels(normalizedTablet)) {
+                if (normalizedTablet.HasInfo() && normalizedTablet.GetInfo().HasTabletID()) {
+                    const ui64 tabletId = normalizedTablet.GetInfo().GetTabletID();
+                    if (const auto it = TabletStates.find(tabletId); it != TabletStates.end()) {
+                        currentTabletIds.insert(tabletId);
+                        newLast.AddTablet()->CopyFrom(it->second.Config);
+                    }
+                    LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BOOTSTRAPPER,
+                        "Skipping invalid tablet config update with incomplete channels for tablet "
+                        << tabletId << " on node " << SelfId().NodeId());
+                } else {
+                    LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BOOTSTRAPPER,
+                        "Skipping invalid tablet config update without tablet id on node " << SelfId().NodeId());
+                }
+                continue;
+            }
+
+            newLast.AddTablet()->CopyFrom(normalizedTablet);
+
+            const ui64 tabletId = normalizedTablet.GetInfo().GetTabletID();
             currentTabletIds.insert(tabletId);
             RegisterTabletBootstrapperControl(tabletId);
-            UpdateTablet(tablet);
+            UpdateTablet(normalizedTablet);
         }
 
         // remove tablets that are no longer in config
@@ -133,6 +157,8 @@ class TConfiguredTabletBootstrapper : public TActorBootstrapped<TConfiguredTable
                 ++it;
             }
         }
+
+        LastBootstrapConfig.Swap(&newLast);
     }
 
     void StopBootstrapper(ui64 tabletId, TTabletState& state) {
@@ -185,6 +211,49 @@ class TConfiguredTabletBootstrapper : public TActorBootstrapped<TConfiguredTable
         }
 
         ReconcileTablet(tabletId, state);
+    }
+
+    void RestoreTabletInfoFromStartupConfig(NKikimrConfig::TBootstrap::TTablet& tabletConfig) const {
+        if (!tabletConfig.HasInfo() || !tabletConfig.GetInfo().HasTabletID()) {
+            return;
+        }
+
+        auto* info = tabletConfig.MutableInfo();
+
+        for (const auto& startupTablet : InitialBootstrapConfig.GetTablet()) {
+            if (startupTablet.HasInfo() && startupTablet.GetInfo().HasTabletID() && startupTablet.GetInfo().GetTabletID() == info->GetTabletID()) {
+                info->MutableChannels()->CopyFrom(startupTablet.GetInfo().GetChannels());
+                return;
+            }
+        }
+    }
+
+    static bool HasCompleteTabletChannels(const NKikimrConfig::TBootstrap::TTablet& tabletConfig) {
+        if (!tabletConfig.HasInfo() || !tabletConfig.GetInfo().HasTabletID()) {
+            return false;
+        }
+
+        const auto& info = tabletConfig.GetInfo();
+        if (!info.ChannelsSize()) {
+            return false;
+        }
+
+        for (const auto& channelInfo : info.GetChannels()) {
+            const bool hasChannelType = channelInfo.HasChannelType();
+            const bool hasErasureNameField = channelInfo.HasChannelErasureName();
+            const bool hasValidErasureName = hasErasureNameField && !channelInfo.GetChannelErasureName().empty();
+            if (hasChannelType && hasErasureNameField) {
+                return false;
+            }
+            if (!hasChannelType && !hasValidErasureName) {
+                return false;
+            }
+            if (!channelInfo.HistorySize()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     void StartBootstrapper(ui64 tabletId, TTabletState &state) {

--- a/ydb/core/tablet/bootstrapper_ut.cpp
+++ b/ydb/core/tablet/bootstrapper_ut.cpp
@@ -421,6 +421,16 @@ void FillDummyTabletChannels(NKikimrTabletBase::TTabletStorageInfo* info) {
     }
 }
 
+void FillDummyTabletChannelsWithoutErasure(NKikimrTabletBase::TTabletStorageInfo* info) {
+    for (ui32 channel = 0; channel < 5; ++channel) {
+        auto* channelInfo = info->AddChannels();
+        channelInfo->SetChannel(channel);
+        auto* history = channelInfo->AddHistory();
+        history->SetFromGeneration(0);
+        history->SetGroupID(0);
+    }
+}
+
 void SendConfigUpdate(TTestBasicRuntime& runtime,
                         const TVector<TActorId>& bootstrappers,
                         const NKikimrConfig::TBootstrap& config) {
@@ -600,6 +610,111 @@ Y_UNIT_TEST_SUITE(ConfiguredTabletBootstrapperTest) {
 
         auto responseEvent = runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(configDispatcher);
         UNIT_ASSERT(responseEvent);
+    }
+
+    Y_UNIT_TEST(FillMissingChannelErasureFromStartupBootstrapConfig) {
+        TTestBasicRuntime runtime(1);
+        SetupTabletServices(runtime);
+        runtime.SetLogPriority(NKikimrServices::BOOTSTRAPPER, NActors::NLog::PRI_DEBUG);
+        bool gotClientDestroyed = false;
+
+        NKikimrConfig::TBootstrap initialConfig;
+        AddDummyTablet(initialConfig, runtime, BootstrapperTestTabletId0, {0});
+
+        auto configuredBootstrapper = StartConfiguredBootstrapper(runtime, initialConfig, 0);
+        Y_UNUSED(configuredBootstrapper);
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(100));
+
+        auto clientDestroyedObserver = runtime.AddObserver<TEvTabletPipe::TEvClientDestroyed>([&](TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+            if (ev->Get()->TabletId == BootstrapperTestTabletId0) {
+                gotClientDestroyed = true;
+            }
+        });
+        Y_UNUSED(clientDestroyedObserver);
+
+        auto initialObserver = runtime.AllocateEdgeActor(0);
+        ConnectAndExpectOk(runtime, BootstrapperTestTabletId0, initialObserver, 0);
+
+        NKikimrConfig::TBootstrap updatedConfig;
+        auto* updatedTablet = updatedConfig.AddTablet();
+        updatedTablet->SetType(NKikimrConfig::TBootstrap::TX_DUMMY);
+        updatedTablet->MutableInfo()->SetTabletID(BootstrapperTestTabletId0);
+        updatedTablet->SetAllowDynamicConfiguration(true);
+        updatedTablet->AddNode(runtime.GetNodeId(0));
+        FillDummyTabletChannelsWithoutErasure(updatedTablet->MutableInfo());
+
+        auto configDispatcher = runtime.AllocateEdgeActor(0);
+        auto notification = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        notification->Record.MutableConfig()->MutableBootstrapConfig()->CopyFrom(updatedConfig);
+        notification->Record.SetLocal(true);
+        notification->Record.AddItemKinds((ui32)NKikimrConsole::TConfigItem::BootstrapConfigItem);
+
+        runtime.Send(new IEventHandle(configuredBootstrapper, configDispatcher, notification.Release(), 0, 1));
+
+        auto responseEvent = runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(configDispatcher);
+        UNIT_ASSERT(responseEvent);
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(200));
+        UNIT_ASSERT_C(!gotClientDestroyed, "Normalized bootstrap config update must not restart tablet");
+
+        auto observerAfterUpdate = runtime.AllocateEdgeActor(0);
+        ConnectAndExpectOk(runtime, BootstrapperTestTabletId0, observerAfterUpdate, 0);
+    }
+
+    Y_UNIT_TEST(SkipInvalidTabletUpdateWithIncompleteChannels) {
+        TTestBasicRuntime runtime(1);
+        SetupTabletServices(runtime);
+        runtime.SetLogPriority(NKikimrServices::BOOTSTRAPPER, NActors::NLog::PRI_DEBUG);
+        bool gotClientDestroyed = false;
+
+        NKikimrConfig::TBootstrap initialConfig;
+        AddDummyTablet(initialConfig, runtime, BootstrapperTestTabletId0, {0});
+
+        auto configuredBootstrapper = StartConfiguredBootstrapper(runtime, initialConfig, 0);
+        Y_UNUSED(configuredBootstrapper);
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(100));
+
+        auto clientDestroyedObserver = runtime.AddObserver<TEvTabletPipe::TEvClientDestroyed>([&](TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+            if (ev->Get()->TabletId == BootstrapperTestTabletId0) {
+                gotClientDestroyed = true;
+            }
+        });
+        Y_UNUSED(clientDestroyedObserver);
+
+        auto initialObserver = runtime.AllocateEdgeActor(0);
+        ConnectAndExpectOk(runtime, BootstrapperTestTabletId0, initialObserver, 0);
+
+        NKikimrConfig::TBootstrap updatedConfig;
+        AddDummyTablet(updatedConfig, runtime, BootstrapperTestTabletId0, {0});
+
+        auto* invalidTablet = updatedConfig.AddTablet();
+        invalidTablet->SetType(NKikimrConfig::TBootstrap::TX_DUMMY);
+        invalidTablet->MutableInfo()->SetTabletID(BootstrapperTestTabletId1);
+        invalidTablet->SetAllowDynamicConfiguration(true);
+        invalidTablet->AddNode(runtime.GetNodeId(0));
+        FillDummyTabletChannelsWithoutErasure(invalidTablet->MutableInfo());
+
+        auto configDispatcher = runtime.AllocateEdgeActor(0);
+        auto notification = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        notification->Record.MutableConfig()->MutableBootstrapConfig()->CopyFrom(updatedConfig);
+        notification->Record.SetLocal(true);
+        notification->Record.AddItemKinds((ui32)NKikimrConsole::TConfigItem::BootstrapConfigItem);
+
+        runtime.Send(new IEventHandle(configuredBootstrapper, configDispatcher, notification.Release(), 0, 1));
+
+        auto responseEvent = runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(configDispatcher);
+        UNIT_ASSERT(responseEvent);
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(200));
+        UNIT_ASSERT_C(!gotClientDestroyed, "Invalid tablet update must not restart existing tablet");
+
+        auto observerAfterUpdate = runtime.AllocateEdgeActor(0);
+        ConnectAndExpectOk(runtime, BootstrapperTestTabletId0, observerAfterUpdate, 0);
+
+        auto invalidTabletObserver = runtime.AllocateEdgeActor(0);
+        ConnectAndExpectNotOk(runtime, BootstrapperTestTabletId1, invalidTabletObserver, 0);
     }
 
     Y_UNIT_TEST(NodeListChange) {

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -1416,10 +1416,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
         {
             auto* appData = AppData(ctx);
             NKikimrSharedCache::TSharedCacheConfig config;
-            if (record.GetConfig().HasBootstrapConfig()) {
-                if (record.GetConfig().GetBootstrapConfig().HasSharedCacheConfig()) {
-                    config.MergeFrom(record.GetConfig().GetBootstrapConfig().GetSharedCacheConfig());
-                }
+            if (record.GetConfig().HasBootstrapConfig() && record.GetConfig().GetBootstrapConfig().HasSharedCacheConfig()) {
+                config.MergeFrom(record.GetConfig().GetBootstrapConfig().GetSharedCacheConfig());
             } else if (appData->BootstrapConfig.HasSharedCacheConfig()) {
                 config.MergeFrom(appData->BootstrapConfig.GetSharedCacheConfig());
             }

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
@@ -1,6 +1,7 @@
 #include <shared_cache_counters.h>
 #include <shared_cache_events.h>
 #include <shared_sausagecache.h>
+#include <ydb/core/cms/console/console.h>
 #include <ydb/core/base/counters.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/actors/wait_events.h>
@@ -152,6 +153,17 @@ struct TSharedPageCacheMock {
         Send(Sender1, limit);
 
         TWaitForFirstEvent<NMemory::TEvConsumerLimit> waiter(Runtime);
+        waiter.Wait();
+
+        return *this;
+    }
+
+    TSharedPageCacheMock& UpdateConfig(const NKikimrConfig::TAppConfig& appConfig) {
+        auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
+        request->Record.MutableConfig()->CopyFrom(appConfig);
+        Send(Sender1, request.Release());
+
+        TWaitForFirstEvent<NConsole::TEvConsole::TEvConfigNotificationRequest> waiter(Runtime);
         waiter.Wait();
 
         return *this;
@@ -1535,6 +1547,24 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheHitPages->Val(), 4);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheMissPages->Val(), 2);
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->CacheMissInMemoryPages->Val(), 2);
+    }
+
+    Y_UNIT_TEST(ConfigUpdate_PartialBootstrapPreservesBootstrapSharedCacheConfig) {
+        TSharedPageCacheMock sharedCache;
+
+        const ui64 bootstrapSharedCacheLimit = 2 * PAGE_TOTAL_SIZE;
+        sharedCache.Runtime.GetAppData().BootstrapConfig.MutableSharedCacheConfig()->SetMemoryLimit(bootstrapSharedCacheLimit);
+
+        NKikimrConfig::TAppConfig update;
+        auto* tablet = update.MutableBootstrapConfig()->AddTablet();
+        tablet->MutableInfo()->SetTabletID(1);
+
+        sharedCache.UpdateConfig(update);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            sharedCache.Counters->ConfigLimitBytes->Val(),
+            bootstrapSharedCacheLimit,
+            "Partial bootstrap update should preserve bootstrap-level shared cache config");
     }
 
     Y_UNIT_TEST(InMemory_Enabling) {

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -1496,7 +1496,7 @@ endDiskTypeCheck:   ;
             return;
         }
 
-        if (relaxed && (!ephemeralConfig.HasSystemTablets() || !ephemeralConfig.HasStaticErasure())) {
+        if (relaxed && !ephemeralConfig.HasSystemTablets()) {
             return;
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix ConfiguredBootstrapper killing all tablet, when receive empty config

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
