### PR TITLE
EXT-2094 Fix race between node registration and group creation

### DIFF
--- a/ydb/core/blobstorage/nodewarden/ut_sequence/dsproxy_config_retrieval.cpp
+++ b/ydb/core/blobstorage/nodewarden/ut_sequence/dsproxy_config_retrieval.cpp
@@ -21,6 +21,16 @@ void SetupLogging(TTestBasicRuntime& runtime) {
 void SetupServices(TTestBasicRuntime& runtime) {
     TAppPrepare app;
 
+    THashSet<ui32> registeredNodeIds;
+    TTestActorRuntimeBase::TEventObserver prevObserver = runtime.SetObserverFunc(
+            [&](TAutoPtr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerRegisterNode::EventType) {
+            auto *msg = ev->Get<TEvBlobStorage::TEvControllerRegisterNode>();
+            registeredNodeIds.insert(msg->Record.GetNodeID());
+        }
+        return prevObserver(ev);
+    });
+
     app.ClearDomainsAndHive();
     auto dom = TDomainsInfo::TDomain::ConstructEmptyDomain("dom-1", 0);
     app.AddDomain(dom.Release());
@@ -99,6 +109,12 @@ void SetupServices(TTestBasicRuntime& runtime) {
     runtime.Initialize(app.Unwrap());
 
     CreateTestBootstrapper(runtime, CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController), &CreateFlatBsController);
+
+    runtime.WaitFor("all nodes registered in BS_CONTROLLER", [&] {
+        return registeredNodeIds.size() == runtime.GetNodeCount();
+    }, TDuration::Seconds(10));
+
+    runtime.SetObserverFunc(prevObserver);
 
     // setup box and storage pool for testing
     {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -633,6 +633,19 @@ namespace NKikimr::NBsController {
                 } else {
                     Y_DEBUG_ABORT_UNLESS(overlay->second->IsReady || overlay->second->IsInVSlotReadyTimestampQ());
                 }
+
+                // Keep node->group subscription in commit path: dynamic groups may appear
+                // after initial RegisterNode, and cleanup for the same index is done below.
+                if (overlay->second && !overlay->second->IsBeingDeleted()) {
+                    const TGroupId groupId = overlay->second->GroupId;
+                    if (NKikimr::IsDynamicGroup(groupId)) {
+                        const TNodeId nodeId = overlay->second->VSlotId.NodeId;
+                        auto& node = GetNode(nodeId);
+                        if (node.GroupsRequested.insert(groupId).second) {
+                            GroupToNode.emplace(groupId, nodeId);
+                        }
+                    }
+                }
             }
 
             for (auto&& [base, overlay] : state.Groups.Diff()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

A node could register before dynamic VSlots were committed, so GroupToNode / GroupsRequested was not always populated for that node. In this case, the node could miss later group generation updates (e.g. timeout in NodeWardenDsProxyConfigRetrieval::LocalGroupInfoUpdatesAfterMovingOut test).

This change updates dynamic group subscriptions in CommitConfigUpdates from state.VSlots.Diff() for non-deleted VSlots, while keeping cleanup in the same commit path for deleted groups.
