### PR TITLE
Forwarding TPartition::TEvWrite to DeduplicationQueueActor

### DIFF
--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -61,6 +61,8 @@ namespace NKikimr::TEvPersQueue {
         EvBalancingUnsubscribe,
         EvBalancingSubscribeNotify,
         EvPartitionUpdateReadMetrics,
+        EvCheckMessageDeduplicationRequest,
+        EvCheckMessageDeduplicationResponse,
         EvResponse = EvRequest + 256,
         EvInternalEvents = EvResponse + 256,
         EvEnd
@@ -321,4 +323,19 @@ namespace NKikimr::TEvPersQueue {
         }
     };
 
+    struct TEvCheckMessageDeduplicationRequest: TEventPB<TEvCheckMessageDeduplicationRequest, NKikimrPQ::TEvCheckMessageDeduplicationRequest, EvCheckMessageDeduplicationRequest> {
+        TEvCheckMessageDeduplicationRequest() = default;
+
+        TEvCheckMessageDeduplicationRequest(ui32 partitionId, ui32 generation, const auto& messageDeduplicationIds) {
+            Record.SetPartitionId(partitionId);
+            Record.SetGeneration(generation);
+            for (const auto& id : messageDeduplicationIds) {
+                Record.AddMessageDeduplicationId(id);
+            }
+        }
+    };
+
+    struct TEvCheckMessageDeduplicationResponse: TEventPB<TEvCheckMessageDeduplicationResponse, NKikimrPQ::TEvCheckMessageDeduplicationResponse, EvCheckMessageDeduplicationResponse> {
+        TEvCheckMessageDeduplicationResponse() = default;
+    };
 } // namespace NKikimr::TEvPersQueue

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -249,6 +249,24 @@ struct TEvPQ {
     };
 
     struct TEvWrite : public TEventLocal<TEvWrite, EvWrite> {
+        enum class EWriteExternalDeduplicationStatus: i8 {
+            Unchecked,
+            Checked,
+            Error,
+        };
+
+        enum class EMessageExternalDeduplicationStatus: i8 {
+            Unchecked,
+            Duplicate,
+            Unique,
+            Error,
+        };
+
+        struct TMessageExternalDeduplicationInfo {
+            EMessageExternalDeduplicationStatus Status = EMessageExternalDeduplicationStatus::Unchecked;
+            std::optional<std::pair<ui32, ui64>> OriginalPartitionAndOffset;
+        };
+
         struct TMsg {
             TString SourceId;
             ui64 SeqNo;
@@ -274,9 +292,10 @@ struct TEvPQ {
             TMaybe<i16> ProducerEpoch;
 
             std::optional<TString> MessageDeduplicationId;
+            TMessageExternalDeduplicationInfo ExternalDeduplicationInfo;
         };
 
-        TEvWrite(const ui64 cookie, const ui64 messageNo, const TString& ownerCookie, const TMaybe<ui64> offset, TVector<TMsg> &&msgs, bool isDirectWrite, std::optional<ui64> initialSeqNo)
+        TEvWrite(const ui64 cookie, const ui64 messageNo, const TString& ownerCookie, const TMaybe<ui64> offset, TVector<TMsg> &&msgs, bool isDirectWrite, std::optional<ui64> initialSeqNo, EWriteExternalDeduplicationStatus externalDeduplicationStatus)
         : Cookie(cookie)
         , MessageNo(messageNo)
         , OwnerCookie(ownerCookie)
@@ -284,6 +303,7 @@ struct TEvPQ {
         , Msgs(std::move(msgs))
         , IsDirectWrite(isDirectWrite)
         , InitialSeqNo(initialSeqNo)
+        , ExternalDeduplicationStatus(externalDeduplicationStatus)
         {
         }
 
@@ -294,7 +314,7 @@ struct TEvPQ {
         TVector<TMsg> Msgs;
         bool IsDirectWrite;
         std::optional<ui64> InitialSeqNo;
-
+        EWriteExternalDeduplicationStatus ExternalDeduplicationStatus;
     };
 
     struct TEvReadTimeout : public TEventLocal<TEvReadTimeout, EvReadTimeout> {
@@ -1783,7 +1803,7 @@ struct TEvPQ {
             return Record.GetConsumer();
         }
     };
-    
+
     struct TEvMLPGetRuntimeAttributesResponse : TEventPB<TEvMLPGetRuntimeAttributesResponse, NKikimrPQ::TEvMLPGetRuntimeAttributesResponse, EvMLPGetRuntimeAttributesResponse> {
         TEvMLPGetRuntimeAttributesResponse() = default;
 

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -263,8 +263,12 @@ struct TEvPQ {
         };
 
         struct TMessageExternalDeduplicationInfo {
+            struct TPartitonAndOffset {
+                ui32 Partition;
+                ui64 Offset;
+            };
             EMessageExternalDeduplicationStatus Status = EMessageExternalDeduplicationStatus::Unchecked;
-            std::optional<std::pair<ui32, ui64>> OriginalPartitionAndOffset;
+            std::optional<TPartitonAndOffset> OriginalPartitionAndOffset;
         };
 
         struct TMsg {

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -661,6 +661,7 @@ struct TEvPQ {
         TString OwnerCookie;
         ui64 MessageNo;
         bool LastRequest;
+        bool FromDeduplicatedQueue = false;
     };
 
     struct TEvChangePartitionConfig : public TEventLocal<TEvChangePartitionConfig, EvChangePartitionConfig> {

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -254,6 +254,9 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
             for (const auto children : p.GetChildPartitionIds()) {
                 ap->MutableChildPartitionIds()->AddAlreadyReserved(children);
             }
+            if (p.HasCreationTimestamp()) {
+                ap->SetCreationTimestamp(p.GetCreationTimestamp());
+            }
         }
     }
 

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -254,8 +254,8 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
             for (const auto children : p.GetChildPartitionIds()) {
                 ap->MutableChildPartitionIds()->AddAlreadyReserved(children);
             }
-            if (p.HasCreationTimestamp()) {
-                ap->SetCreationTimestamp(p.GetCreationTimestamp());
+            if (p.HasCreationTimestampSeconds()) {
+                ap->SetCreationTimestampSeconds(p.GetCreationTimestampSeconds());
             }
         }
     }

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -9,6 +9,7 @@
 #include <ydb/library/actors/core/event_local.h>
 #include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
 #include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
+#include <util/generic/overloaded.h>
 #include <util/string/join.h>
 #include <ranges>
 
@@ -78,6 +79,16 @@ private:
         absl::flat_hash_set<TString> UnresolvedDeduplicationIds;
     };
 
+    struct TReserveBytesRequest {
+        explicit TReserveBytesRequest(TEvPQ::TEvReserveBytes::TPtr event)
+            : Event(std::move(event))
+        {
+        }
+        TEvPQ::TEvReserveBytes::TPtr Event;
+    };
+
+    using TQueueRequest = std::variant<TWriteRequest, TReserveBytesRequest>;
+
     struct TWriteRequestMessageIndex {
         TWriteRequest* RequestPtr;
         size_t MessageIndex = -1;
@@ -113,7 +124,7 @@ private:
     absl::flat_hash_map<ui64, TTabletInfo> TabletInfo;
     const TDuration MaxDeduplicationTimeInterval = TDuration::Minutes(5);
 
-    TDeque<TWriteRequest> Queue;
+    TDeque<TQueueRequest> Queue;
     using TDeduplicationInfoMap = absl::flat_hash_map<TString, TDeduplicationInfo>;
     TDeduplicationInfoMap DeduplicationInfo;
     bool BypassMode = false;
@@ -130,11 +141,18 @@ private:
         return true;
     }
 
-    void Handle(TEvPQ::TEvWrite::TPtr& ev) {
-        PQ_LOG_D("Handle TEvWrite: " << LabeledOutput(BypassMode));
+    bool TryBypass(auto& ev) {
         TryToSwitchToBypassMode();
         if (BypassMode) {
-            SendEvent(ev);
+            SendEvent(std::move(ev));
+            return true;
+        }
+        return false;
+    }
+
+    void Handle(TEvPQ::TEvWrite::TPtr& ev) {
+        PQ_LOG_D("Handle TEvWrite: " << LabeledOutput(BypassMode));
+        if (TryBypass(ev)) {
             return;
         }
 
@@ -155,8 +173,8 @@ private:
         for (const auto& [messageDeduplicationId, _] : messageIndices) {
             unresolvedDeduplicationIds.insert(messageDeduplicationId);
         }
-        Queue.emplace_back(std::move(ev), std::move(unresolvedDeduplicationIds));
-        TWriteRequest& record = Queue.back();
+        Queue.emplace_back(std::in_place_type<TWriteRequest>, std::move(ev), std::move(unresolvedDeduplicationIds));
+        TWriteRequest& record = std::get<TWriteRequest>(Queue.back());
         for (const auto& [messageDeduplicationId, indices] : messageIndices) {
             auto [deduplicationInfoIt, newDeduplicationId] = DeduplicationInfo.try_emplace(messageDeduplicationId);
             auto& deduplicationInfo = deduplicationInfoIt->second;
@@ -172,6 +190,16 @@ private:
         }
         ProcessQueue();
     }
+
+    void Handle(TEvPQ::TEvReserveBytes::TPtr& ev) {
+        PQ_LOG_D("Handle TEvReserveBytes: " << LabeledOutput(BypassMode));
+        if (TryBypass(ev)) {
+            return;
+        }
+        Queue.emplace_back(std::in_place_type<TReserveBytesRequest>, std::move(ev));
+        ProcessQueue();
+    }
+
 
     void SendRequests(const TDeduplicationInfoMap::iterator it) {
         auto& [messageDeduplicationId, info] = *it;
@@ -280,6 +308,7 @@ private:
     static bool SetChecked(EWriteExternalDeduplicationStatus& status) {
         if (status == EWriteExternalDeduplicationStatus::Unchecked) {
             status = EWriteExternalDeduplicationStatus::Checked;
+            return true;
         }
         return false;
     };
@@ -290,13 +319,32 @@ private:
         Forward(ev, PartitionActorId);
     }
 
+    void SendEvent(TEvPQ::TEvReserveBytes::TPtr ev) {
+        bool prevFromDeduplicatedQueue = std::exchange(ev->Get()->FromDeduplicatedQueue, true);
+        Y_ASSERT(prevFromDeduplicatedQueue == false);
+        PQ_LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << !prevFromDeduplicatedQueue);
+        Forward(ev, PartitionActorId);
+    }
+
     void ProcessQueue() {
         while (!Queue.empty()) {
             auto& req = Queue.front();
-            if (!req.UnresolvedDeduplicationIds.empty()) {
+            bool proceed = std::visit(TOverloaded{
+                [&](TWriteRequest& req) {
+                    if (!req.UnresolvedDeduplicationIds.empty()) {
+                        return false;
+                    }
+                    SendEvent(req.Event);
+                    return true;
+                },
+                [&](TReserveBytesRequest& req) {
+                    SendEvent(req.Event);
+                    return true;
+                }
+            }, req);
+            if (!proceed) {
                 break;
             }
-            SendEvent(req.Event);
             Queue.pop_front();
         }
         TryToSwitchToBypassMode();
@@ -342,6 +390,7 @@ private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvPQ::TEvWrite, Handle);
+            hFunc(TEvPQ::TEvReserveBytes, Handle);
             hFunc(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse, Handle);
             hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
             sFunc(TEvents::TEvPoison, PassAway);

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -19,14 +19,18 @@ namespace NKikimr::NPQ {
 using EWriteExternalDeduplicationStatus = TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus;
 using EMessageExternalDeduplicationStatus = TEvPQ::TEvWrite::EMessageExternalDeduplicationStatus;
 
-class TDeduplicationQueueActor: public NActors::TActorBootstrapped<TDeduplicationQueueActor> {
+class TDeduplicationQueueActor: public TBaseTabletActor<TDeduplicationQueueActor>
+                              , public TConstantLogPrefix {
 public:
     TDeduplicationQueueActor(
+        ui64 tabletId,
+        TActorId tabletActorId,
         TActorId partitionActorId,
         TString topicName,
         ui32 partitionId,
         TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions)
-        : PartitionActorId(partitionActorId)
+        : TBaseTabletActor(tabletId, tabletActorId, NKikimrServices::EServiceKikimr::PERSQUEUE)
+        , PartitionActorId(partitionActorId)
         , TopicName(std::move(topicName))
         , PartitionId(partitionId)
     {
@@ -49,10 +53,8 @@ public:
         Become(&TThis::StateWork);
     }
 
-    TString LogPrefix() const {
-        return TStringBuilder()
-               << "[TDeduplicationQueueActor topic=\"" << TopicName
-               << "\" partition=" << PartitionId << "\"] ";
+    TString BuildLogPrefix() const override {
+        return TStringBuilder() << "[DeduplicationQueue][" << PartitionId << "][" << TopicName << "] ";
     }
 
 private:
@@ -151,7 +153,7 @@ private:
     }
 
     void Handle(TEvPQ::TEvWrite::TPtr& ev) {
-        PQ_LOG_D("Handle TEvWrite: " << LabeledOutput(BypassMode));
+        LOG_D("Handle TEvWrite: " << LabeledOutput(BypassMode));
         if (TryBypass(ev)) {
             return;
         }
@@ -192,7 +194,7 @@ private:
     }
 
     void Handle(TEvPQ::TEvReserveBytes::TPtr& ev) {
-        PQ_LOG_D("Handle TEvReserveBytes: " << LabeledOutput(BypassMode));
+        LOG_D("Handle TEvReserveBytes: " << LabeledOutput(BypassMode));
         if (TryBypass(ev)) {
             return;
         }
@@ -211,7 +213,7 @@ private:
                 parentPartition.PartitionId,
                 tabletInfo.Generation,
                 TConstArrayRef(&messageDeduplicationId, 1));
-            PQ_LOG_D("Send TEvCheckMessageDeduplicationRequest: partition=" << parentPartition.PartitionId << "; tabletId=" << tabletId << "; messageDeduplicationId=" << messageDeduplicationId);
+            LOG_D("Send TEvCheckMessageDeduplicationRequest: partition=" << parentPartition.PartitionId << "; tabletId=" << tabletId << "; messageDeduplicationId=" << messageDeduplicationId);
             auto forward = std::make_unique<TEvPipeCache::TEvForward>(
                 ev.release(),
                 tabletId,
@@ -225,20 +227,20 @@ private:
 
     void Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
-        PQ_LOG_D("Handle TEvCheckMessageDeduplicationResponse: " << record.ShortUtf8DebugString());
+        LOG_D("Handle TEvCheckMessageDeduplicationResponse: " << record.ShortUtf8DebugString());
         for (const auto& [messageDeduplicationId, result] : record.GetResult()) {
             auto deduplicationInfoIt = DeduplicationInfo.find(messageDeduplicationId);
             if (deduplicationInfoIt == DeduplicationInfo.end()) {
-                PQ_LOG_D("Got unknown messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                LOG_D("Got unknown messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
                 continue;
             }
             auto& deduplicationInfo = deduplicationInfoIt->second;
             if (auto it = deduplicationInfo.RemainsPartitionWithGeneration.find(record.GetPartitionId());
                 it == deduplicationInfo.RemainsPartitionWithGeneration.end()) {
-                PQ_LOG_D("Got unknown partition for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                LOG_D("Got unknown partition for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
                 continue;
             } else if (it->second > record.GetGeneration()) {
-                PQ_LOG_D("Got wrong generation for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                LOG_D("Got wrong generation for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
                 continue;
             } else {
                 deduplicationInfo.RemainsPartitionWithGeneration.erase(it);
@@ -275,9 +277,9 @@ private:
             TWriteRequest* ptr = req.RequestPtr;
             ptr->UnresolvedDeduplicationIds.erase(deduplicateMessageId);
             auto& evWrite = *ptr->Event->Get();
-            Y_VERIFY_S(req.MessageIndex < evWrite.Msgs.size(), "Out of bounds access " << req.MessageIndex << "/" << evWrite.Msgs.size());
+            AFL_ENSURE(req.MessageIndex < evWrite.Msgs.size())("index", req.MessageIndex)("size", evWrite.Msgs.size());
             auto& msg = evWrite.Msgs[req.MessageIndex];
-            Y_VERIFY_S(msg.MessageDeduplicationId == deduplicateMessageId, "Wrong message deduplication id " << msg.MessageDeduplicationId << " != " << deduplicateMessageId);
+            AFL_ENSURE(msg.MessageDeduplicationId == deduplicateMessageId)("msg", msg.MessageDeduplicationId)("info", deduplicateMessageId);
             msg.ExternalDeduplicationInfo = messageExternalDeduplicationInfo;
             if (messageExternalDeduplicationInfo.Status == EMessageExternalDeduplicationStatus::Error) {
                 // propagate error to the whole evWrite
@@ -315,14 +317,14 @@ private:
 
     void SendEvent(TEvPQ::TEvWrite::TPtr ev) {
         bool update = SetChecked(ev->Get()->ExternalDeduplicationStatus);
-        PQ_LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << update);
+        LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << update);
         Forward(ev, PartitionActorId);
     }
 
     void SendEvent(TEvPQ::TEvReserveBytes::TPtr ev) {
         bool prevFromDeduplicatedQueue = std::exchange(ev->Get()->FromDeduplicatedQueue, true);
-        Y_ASSERT(prevFromDeduplicatedQueue == false);
-        PQ_LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << !prevFromDeduplicatedQueue);
+        AFL_ENSURE(prevFromDeduplicatedQueue == false);
+        LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << !prevFromDeduplicatedQueue);
         Forward(ev, PartitionActorId);
     }
 
@@ -357,7 +359,7 @@ private:
             TryFinalizeDeduplicationInfo(it);
         }
         ProcessQueue();
-        Y_ASSERT(Queue.empty());
+        AFL_VERIFY_DEBUG(Queue.empty())("size", Queue.size());
     }
 
     void PassAway() override {
@@ -379,8 +381,8 @@ private:
     }
 
     void SwitchToBypassMode() {
-        PQ_LOG_D("SwitchToBypassMode");
-        Y_VERIFY_S(Queue.empty(), "Queue is not empty");
+        LOG_D("SwitchToBypassMode");
+        AFL_ENSURE(Queue.empty())("size", Queue.size());
         if (!BypassMode) {
             Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
         }
@@ -395,18 +397,23 @@ private:
             hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
             sFunc(TEvents::TEvPoison, PassAway);
             default:
-                PQ_LOG_W("Unexpected event type " << ev->GetTypeRewrite());
+                LOG_E("Unexpected " << EventStr("StateWork", ev));
+                AFL_VERIFY_DEBUG(false)("Unexpected", EventStr("StateInit", ev));
         }
     }
 
 };
 
 NActors::IActor* CreateDeduplicationWriteQueueActor(
+    ui64 tabletId,
+    TActorId tabletActorId,
     TActorId partitionActorId,
     TString topicName,
     ui32 partitionId,
     TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions) {
     return new TDeduplicationQueueActor(
+        tabletId,
+        tabletActorId,
         partitionActorId,
         std::move(topicName),
         partitionId,

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -129,7 +129,9 @@ private:
     TDeque<TQueueRequest> Queue;
     using TDeduplicationInfoMap = absl::flat_hash_map<TString, TDeduplicationInfo>;
     TDeduplicationInfoMap DeduplicationInfo;
-    bool BypassMode = false;
+
+    using EBypassMode = NPrivate::EBypassMode;
+    EBypassMode BypassMode = EBypassMode::Disabled;
 
 private:
 
@@ -145,7 +147,7 @@ private:
 
     bool TryBypass(auto& ev) {
         TryToSwitchToBypassMode();
-        if (BypassMode) {
+        if (BypassMode == EBypassMode::Enabled) {
             SendEvent(std::move(ev));
             return true;
         }
@@ -157,9 +159,8 @@ private:
         if (TryBypass(ev)) {
             return;
         }
-
         absl::flat_hash_map<TString, TVector<size_t>> messageIndices;
-        {
+        if (BypassMode == EBypassMode::Disabled) {
             TEvPQ::TEvWrite& write = *ev->Get();
             if (write.ExternalDeduplicationStatus == EWriteExternalDeduplicationStatus::Unchecked) {
                 for (size_t i = 0; i < write.Msgs.size(); ++i) {
@@ -169,6 +170,9 @@ private:
                     }
                 }
             }
+        } else {
+            // Skip checking parent partitions,
+            // but still eunqueu to enforce proper order.
         }
         absl::flat_hash_set<TString> unresolvedDeduplicationIds;
         unresolvedDeduplicationIds.reserve(messageIndices.size());
@@ -368,25 +372,31 @@ private:
     }
 
     void TryToSwitchToBypassMode() {
-        if (BypassMode) {
+        TMaybe<EBypassMode> newMode;
+        switch (BypassMode) {
+            case EBypassMode::Disabled:
+                if (TAppData::TimeProvider->Now() < DisableTimestamp) [[likely]] {
+                    return;
+                }
+                newMode = EBypassMode::Pending;
+                [[fallthrough]];
+            case EBypassMode::Pending:
+                if (Queue.empty()) {
+                    newMode = EBypassMode::Enabled;
+                }
+                break;
+            case EBypassMode::Enabled:
+                [[likely]] return;
+        }
+        if (!newMode.Defined()) {
             return;
         }
-        if (!Queue.empty()) {
-            return;
-        }
-        if (TAppData::TimeProvider->Now() < DisableTimestamp) {
-            return;
-        }
-        SwitchToBypassMode();
-    }
-
-    void SwitchToBypassMode() {
-        LOG_D("SwitchToBypassMode");
-        AFL_ENSURE(Queue.empty())("size", Queue.size());
-        if (!BypassMode) {
+        AFL_ENSURE(newMode != BypassMode)("BypassMode", BypassMode)("NewMode", newMode);
+        LOG_D("SwitchToBypassMode " << *newMode);
+        if (newMode == EBypassMode::Enabled) {
             Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
         }
-        BypassMode = true;
+        BypassMode = *newMode;
     }
 
     STFUNC(StateWork) {

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -55,7 +55,7 @@ public:
         };
         const auto recentPartitionsIt = std::partition(ParentPartitions.begin(), ParentPartitions.end(), isRecentPartition);
         std::ranges::sort(ParentPartitions.begin(), recentPartitionsIt, std::greater<>{}, &TParentPartitionInfo::PartitionId); // oldest partitions at end
-        LOG_D("Partitions: " << JoinRange(", ", ParentPartitions.begin(), recentPartitionsIt) << "; OldPartitions " << JoinRange(", ", recentPartitionsIt, ParentPartitions.end()) << "; DisableTimestamp " << DisableTimestamp);
+        LOG_D("Partitions: " << JoinRange(", ", ParentPartitions.begin(), recentPartitionsIt) << "; OldPartitions " << JoinRange(", ", recentPartitionsIt, ParentPartitions.end()) << "; DisableTimestamp " << DisableTimestamp << "; InNSeconds=" << (DisableTimestamp - now).Seconds());
         ParentPartitions.erase(recentPartitionsIt, ParentPartitions.end());
     }
 
@@ -309,6 +309,7 @@ private:
                 evWrite.ExternalDeduplicationStatus = EWriteExternalDeduplicationStatus::Error;
             }
         }
+        DeduplicationInfo.erase(it);
     }
 
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
@@ -316,7 +317,7 @@ private:
         auto& tabletInfo = TabletInfo[record.TabletId];
         tabletInfo.Subscribed = false;
         tabletInfo.Generation += 1;
-        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end(); ++it) {
+        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end();) {
             auto& [messageDeduplicationId, deduplicationInfo] = *it;
             size_t affectedPartitions = 0;
             for (const ui32 partitionId : tabletInfo.Partitions) {
@@ -324,7 +325,9 @@ private:
             }
             if (affectedPartitions != 0) {
                 deduplicationInfo.PartitionErrors += affectedPartitions;
-                TryFinalizeDeduplicationInfo(it);
+                TryFinalizeDeduplicationInfo(it++);
+            } else {
+                ++it;
             }
         }
         ProcessQueue();
@@ -376,13 +379,14 @@ private:
     }
 
     void CancelQueue() {
-        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end(); ++it) {
+        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end();) {
             auto& [messageDeduplicationId, deduplicationInfo] = *it;
             deduplicationInfo.CancelIfNotReady();
-            TryFinalizeDeduplicationInfo(it);
+            TryFinalizeDeduplicationInfo(it++);
         }
         ProcessQueue();
         AFL_VERIFY_DEBUG(Queue.empty())("size", Queue.size());
+        AFL_VERIFY_DEBUG(DeduplicationInfo.empty())("size", DeduplicationInfo.size());
     }
 
     void PassAway() override {
@@ -402,6 +406,7 @@ private:
             case EBypassMode::Pending:
                 if (Queue.empty()) {
                     newMode = EBypassMode::Enabled;
+                    Y_ASSERT(DeduplicationInfo.empty());
                 }
                 break;
             case EBypassMode::Enabled:
@@ -411,7 +416,7 @@ private:
             return;
         }
         AFL_ENSURE(newMode != BypassMode)("BypassMode", BypassMode)("NewMode", newMode);
-        LOG_D("SwitchToBypassMode " << *newMode);
+        LOG_D("SwitchToBypassMode " << *newMode << "; Now=" << TAppData::TimeProvider->Now() << "; DisableTimestamp=" << DisableTimestamp << "; PassSeconds=" << (TAppData::TimeProvider->Now() - DisableTimestamp).Seconds());
         if (newMode == EBypassMode::Enabled) {
             Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
         }

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -191,7 +191,7 @@ private:
             }
         } else {
             // Skip checking parent partitions,
-            // but still eunqueu to enforce proper order.
+            // but still equeue messages to enforce proper order.
         }
         absl::flat_hash_set<TString> unresolvedDeduplicationIds;
         unresolvedDeduplicationIds.reserve(messageIndices.size());
@@ -226,7 +226,7 @@ private:
     }
 
 
-    void SendRequests(const TString messageDeduplicationId, TDeduplicationInfo& info) {
+    void SendRequests(const TString& messageDeduplicationId, TDeduplicationInfo& info) {
         for (auto& parentPartition : ParentPartitions) {
             const ui64 tabletId = parentPartition.TabletId;
             auto& tabletInfo = TabletInfo[tabletId];

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -64,7 +64,7 @@ public:
     }
 
     TString BuildLogPrefix() const override {
-        return TStringBuilder() << "[DeduplicationQueue][" << PartitionId << "][" << TopicName << "] ";
+        return TStringBuilder() << "[DeduplicationQueue][" << TopicName << "][" << PartitionId << "] ";
     }
 
     size_t GetRecentPartitionsCount() const {
@@ -204,7 +204,7 @@ private:
             auto [deduplicationInfoIt, newDeduplicationId] = DeduplicationInfo.try_emplace(messageDeduplicationId);
             auto& deduplicationInfo = deduplicationInfoIt->second;
             if (newDeduplicationId) {
-                SendRequests(deduplicationInfoIt);
+                SendRequests(messageDeduplicationId, deduplicationInfo);
             }
             for (auto index : indices) {
                 deduplicationInfo.RequestsInQueue.push_back(TWriteRequestMessageIndex{
@@ -226,9 +226,7 @@ private:
     }
 
 
-    void SendRequests(const TDeduplicationInfoMap::iterator it) {
-        auto& [messageDeduplicationId, info] = *it;
-
+    void SendRequests(const TString messageDeduplicationId, TDeduplicationInfo& info) {
         for (auto& parentPartition : ParentPartitions) {
             const ui64 tabletId = parentPartition.TabletId;
             auto& tabletInfo = TabletInfo[tabletId];

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -37,9 +37,10 @@ public:
         DisableTimestamp = TInstant::Zero();
         const auto* partition = partitionGraph.GetPartition(partitionId);
         AFL_ENSURE(partition)("partitionId", partitionId);
+        ParentPartitions.reserve(partition->AllParents.size());
         for (const TPartitionGraph::Node* parentPartition : partition->AllParents) {
             TParentPartitionInfo info{
-                .CreationTime = TInstant::Max(), // TODO: Get from partition graph/config
+                .CreationTime = parentPartition->CreationTime,
                 .TabletId = parentPartition->TabletId,
                 .PartitionId = parentPartition->Id,
             };
@@ -47,8 +48,15 @@ public:
             TabletInfo[info.TabletId].Partitions.push_back(info.PartitionId);
             ParentPartitions.push_back(std::move(info));
         }
-        std::ranges::sort(ParentPartitions.begin(), ParentPartitions.end(), std::greater<>{}, &TParentPartitionInfo::PartitionId); // oldest partitions at end
-        LOG_D("Partitions: " << JoinSeq(", ", ParentPartitions));
+        // filter partitions
+        const TInstant now = TAppData::TimeProvider->Now();
+        const auto isRecentPartition = [this, now](const TParentPartitionInfo& info) -> bool {
+            return info.CreationTime + MaxDeduplicationTimeInterval >= now;
+        };
+        const auto recentPartitionsIt = std::partition(ParentPartitions.begin(), ParentPartitions.end(), isRecentPartition);
+        std::ranges::sort(ParentPartitions.begin(), recentPartitionsIt, std::greater<>{}, &TParentPartitionInfo::PartitionId); // oldest partitions at end
+        LOG_D("Partitions: " << JoinRange(", ", ParentPartitions.begin(), recentPartitionsIt) << "; OldPartitions " << JoinRange(", ", recentPartitionsIt, ParentPartitions.end()) << "; DisableTimestamp " << DisableTimestamp);
+        ParentPartitions.erase(recentPartitionsIt, ParentPartitions.end());
     }
 
     void Bootstrap() {
@@ -58,6 +66,15 @@ public:
     TString BuildLogPrefix() const override {
         return TStringBuilder() << "[DeduplicationQueue][" << PartitionId << "][" << TopicName << "] ";
     }
+
+    size_t GetRecentPartitionsCount() const {
+        return ParentPartitions.size();
+    }
+
+    TInstant GetDisableTimestamp() const {
+        return DisableTimestamp;
+    }
+
 
 private:
     struct TParentPartitionInfo {
@@ -415,14 +432,15 @@ private:
     }
 };
 
-NActors::IActor* CreateDeduplicationWriteQueueActor(
+TCreateDeduplicationWriteQueueActorResult CreateDeduplicationWriteQueueActor(
     ui64 tabletId,
     TActorId tabletActorId,
     TActorId partitionActorId,
     TString topicName,
     ui32 partitionId,
     const TPartitionGraph& partitionGraph) {
-    return new TDeduplicationQueueActor(
+
+    THolder h = MakeHolder<TDeduplicationQueueActor>(
         tabletId,
         tabletActorId,
         partitionActorId,
@@ -430,6 +448,14 @@ NActors::IActor* CreateDeduplicationWriteQueueActor(
         partitionId,
         partitionGraph
     );
+
+    TCreateDeduplicationWriteQueueActorResult result{
+        .RecentPartitionsCount = h->GetRecentPartitionsCount(),
+        .DisableTimestamp = h->GetDisableTimestamp(),
+        .Actor = std::move(h),
+    };
+
+    return result;
 }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -28,25 +28,27 @@ public:
         TActorId partitionActorId,
         TString topicName,
         ui32 partitionId,
-        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions)
+        const TPartitionGraph& partitionGraph)
         : TBaseTabletActor(tabletId, tabletActorId, NKikimrServices::EServiceKikimr::PERSQUEUE)
         , PartitionActorId(partitionActorId)
         , TopicName(std::move(topicName))
         , PartitionId(partitionId)
     {
         DisableTimestamp = TInstant::Zero();
-        ParentPartitions.reserve(parentPartitions.size());
-        for (const auto& partition : parentPartitions) {
+        const auto* partition = partitionGraph.GetPartition(partitionId);
+        AFL_ENSURE(partition)("partitionId", partitionId);
+        for (const TPartitionGraph::Node* parentPartition : partition->AllParents) {
             TParentPartitionInfo info{
                 .CreationTime = TInstant::Max(), // TODO: Get from partition graph/config
-                .TabletId = partition.GetTabletId(),
-                .PartitionId = partition.GetPartitionId(),
+                .TabletId = parentPartition->TabletId,
+                .PartitionId = parentPartition->Id,
             };
             DisableTimestamp = Max(DisableTimestamp, info.CreationTime + MaxDeduplicationTimeInterval);
+            TabletInfo[info.TabletId].Partitions.push_back(info.PartitionId);
             ParentPartitions.push_back(std::move(info));
-            TabletInfo[info.TabletId].Partitions.push_back(partition.GetPartitionId());
         }
         std::ranges::sort(ParentPartitions.begin(), ParentPartitions.end(), std::greater<>{}, &TParentPartitionInfo::PartitionId); // oldest partitions at end
+        LOG_D("Partitions: " << JoinSeq(", ", ParentPartitions));
     }
 
     void Bootstrap() {
@@ -411,7 +413,6 @@ private:
                 AFL_VERIFY_DEBUG(false)("Unexpected", EventStr("StateInit", ev));
         }
     }
-
 };
 
 NActors::IActor* CreateDeduplicationWriteQueueActor(
@@ -420,14 +421,20 @@ NActors::IActor* CreateDeduplicationWriteQueueActor(
     TActorId partitionActorId,
     TString topicName,
     ui32 partitionId,
-    TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions) {
+    const TPartitionGraph& partitionGraph) {
     return new TDeduplicationQueueActor(
         tabletId,
         tabletActorId,
         partitionActorId,
         std::move(topicName),
         partitionId,
-        std::move(parentPartitions));
+        partitionGraph
+    );
 }
 
 } // namespace NKikimr::NPQ
+
+template <>
+void Out<NKikimr::NPQ::TDeduplicationQueueActor::TParentPartitionInfo>(IOutputStream& out, const NKikimr::NPQ::TDeduplicationQueueActor::TParentPartitionInfo& info) {
+    out << "{TabletId: " << info.TabletId << ", PartitionId: " << info.PartitionId << ", CreationTime: " << info.CreationTime << "}";
+}

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.cpp
@@ -1,0 +1,367 @@
+#include "deduplication_write_queue.h"
+
+#include <ydb/core/persqueue/pqtablet/common/logging.h>
+
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/persqueue/common/actor.h>
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/events/internal.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
+#include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
+#include <util/string/join.h>
+#include <ranges>
+
+namespace NKikimr::NPQ {
+
+
+using EWriteExternalDeduplicationStatus = TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus;
+using EMessageExternalDeduplicationStatus = TEvPQ::TEvWrite::EMessageExternalDeduplicationStatus;
+
+class TDeduplicationQueueActor: public NActors::TActorBootstrapped<TDeduplicationQueueActor> {
+public:
+    TDeduplicationQueueActor(
+        TActorId partitionActorId,
+        TString topicName,
+        ui32 partitionId,
+        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions)
+        : PartitionActorId(partitionActorId)
+        , TopicName(std::move(topicName))
+        , PartitionId(partitionId)
+    {
+        DisableTimestamp = TInstant::Zero();
+        ParentPartitions.reserve(parentPartitions.size());
+        for (const auto& partition : parentPartitions) {
+            TParentPartitionInfo info{
+                .CreationTime = TInstant::Max(), // TODO: Get from partition graph/config
+                .TabletId = partition.GetTabletId(),
+                .PartitionId = partition.GetPartitionId(),
+            };
+            DisableTimestamp = Max(DisableTimestamp, info.CreationTime + MaxDeduplicationTimeInterval);
+            ParentPartitions.push_back(std::move(info));
+            TabletInfo[info.TabletId].Partitions.push_back(partition.GetPartitionId());
+        }
+        std::ranges::sort(ParentPartitions.begin(), ParentPartitions.end(), std::greater<>{}, &TParentPartitionInfo::PartitionId); // oldest partitions at end
+    }
+
+    void Bootstrap() {
+        Become(&TThis::StateWork);
+    }
+
+    TString LogPrefix() const {
+        return TStringBuilder()
+               << "[TDeduplicationQueueActor topic=\"" << TopicName
+               << "\" partition=" << PartitionId << "\"] ";
+    }
+
+private:
+    struct TParentPartitionInfo {
+        TInstant CreationTime;
+        ui64 TabletId;
+        ui32 PartitionId;
+    };
+
+    struct TTabletInfo {
+        TVector<ui32> Partitions;
+        bool Subscribed = false;
+        ui32 Generation = 0;
+    };
+
+    struct TWriteRequest {
+        explicit TWriteRequest(TEvPQ::TEvWrite::TPtr event, absl::flat_hash_set<TString> unresolvedDeduplicationIds)
+            : Event(std::move(event))
+            , UnresolvedDeduplicationIds(std::move(unresolvedDeduplicationIds))
+        {
+        }
+
+        TEvPQ::TEvWrite::TPtr Event;
+        absl::flat_hash_set<TString> UnresolvedDeduplicationIds;
+    };
+
+    struct TWriteRequestMessageIndex {
+        TWriteRequest* RequestPtr;
+        size_t MessageIndex = -1;
+    };
+
+    struct TDeduplicationInfo {
+        TVector<TWriteRequestMessageIndex> RequestsInQueue;
+
+        absl::flat_hash_map<ui32, ui32> RemainsPartitionWithGeneration;
+
+        ui32 PartitionErrors = 0;
+
+        bool IsReady() const {
+            return RemainsPartitionWithGeneration.empty() || PartitionErrors;
+        }
+
+        void CancelIfNotReady() {
+            PartitionErrors += RemainsPartitionWithGeneration.size();
+            RemainsPartitionWithGeneration.clear();
+        }
+
+        bool IsDuplicate = false;
+        ui64 Offset = 0;
+        ui32 PartitionId = 0;
+    };
+
+private:
+    const TActorId PartitionActorId;
+    const TString TopicName;
+    const ui32 PartitionId;
+    TInstant DisableTimestamp = TInstant::Zero();
+    TVector<TParentPartitionInfo> ParentPartitions;
+    absl::flat_hash_map<ui64, TTabletInfo> TabletInfo;
+    const TDuration MaxDeduplicationTimeInterval = TDuration::Minutes(5);
+
+    TDeque<TWriteRequest> Queue;
+    using TDeduplicationInfoMap = absl::flat_hash_map<TString, TDeduplicationInfo>;
+    TDeduplicationInfoMap DeduplicationInfo;
+    bool BypassMode = false;
+
+private:
+
+    static bool IsUncheckedMsg(const TEvPQ::TEvWrite::TMsg& msg) {
+        if (msg.ExternalDeduplicationInfo.Status != TEvPQ::TEvWrite::EMessageExternalDeduplicationStatus::Unchecked) {
+            return false;
+        }
+        if (!msg.MessageDeduplicationId.has_value()) {
+            return false;
+        }
+        return true;
+    }
+
+    void Handle(TEvPQ::TEvWrite::TPtr& ev) {
+        PQ_LOG_D("Handle TEvWrite: " << LabeledOutput(BypassMode));
+        TryToSwitchToBypassMode();
+        if (BypassMode) {
+            SendEvent(ev);
+            return;
+        }
+
+        absl::flat_hash_map<TString, TVector<size_t>> messageIndices;
+        {
+            TEvPQ::TEvWrite& write = *ev->Get();
+            if (write.ExternalDeduplicationStatus == EWriteExternalDeduplicationStatus::Unchecked) {
+                for (size_t i = 0; i < write.Msgs.size(); ++i) {
+                    const auto& msg = write.Msgs[i];
+                    if (IsUncheckedMsg(msg)) {
+                        messageIndices[msg.MessageDeduplicationId.value()].push_back(i);
+                    }
+                }
+            }
+        }
+        absl::flat_hash_set<TString> unresolvedDeduplicationIds;
+        unresolvedDeduplicationIds.reserve(messageIndices.size());
+        for (const auto& [messageDeduplicationId, _] : messageIndices) {
+            unresolvedDeduplicationIds.insert(messageDeduplicationId);
+        }
+        Queue.emplace_back(std::move(ev), std::move(unresolvedDeduplicationIds));
+        TWriteRequest& record = Queue.back();
+        for (const auto& [messageDeduplicationId, indices] : messageIndices) {
+            auto [deduplicationInfoIt, newDeduplicationId] = DeduplicationInfo.try_emplace(messageDeduplicationId);
+            auto& deduplicationInfo = deduplicationInfoIt->second;
+            if (newDeduplicationId) {
+                SendRequests(deduplicationInfoIt);
+            }
+            for (auto index : indices) {
+                deduplicationInfo.RequestsInQueue.push_back(TWriteRequestMessageIndex{
+                    .RequestPtr = &record,
+                    .MessageIndex = index,
+                });
+            }
+        }
+        ProcessQueue();
+    }
+
+    void SendRequests(const TDeduplicationInfoMap::iterator it) {
+        auto& [messageDeduplicationId, info] = *it;
+
+        for (auto& parentPartition : ParentPartitions) {
+            const ui64 tabletId = parentPartition.TabletId;
+            auto& tabletInfo = TabletInfo[tabletId];
+            auto ev = std::make_unique<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest>(
+                parentPartition.PartitionId,
+                tabletInfo.Generation,
+                TConstArrayRef(&messageDeduplicationId, 1));
+            PQ_LOG_D("Send TEvCheckMessageDeduplicationRequest: partition=" << parentPartition.PartitionId << "; tabletId=" << tabletId << "; messageDeduplicationId=" << messageDeduplicationId);
+            auto forward = std::make_unique<TEvPipeCache::TEvForward>(
+                ev.release(),
+                tabletId,
+                !tabletInfo.Subscribed,
+                tabletId);
+            tabletInfo.Subscribed = true;
+            info.RemainsPartitionWithGeneration[parentPartition.PartitionId] = tabletInfo.Generation;
+            Send(MakePipePerNodeCacheID(false), forward.release(), IEventHandle::FlagTrackDelivery);
+        }
+    }
+
+    void Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        PQ_LOG_D("Handle TEvCheckMessageDeduplicationResponse: " << record.ShortUtf8DebugString());
+        for (const auto& [messageDeduplicationId, result] : record.GetResult()) {
+            auto deduplicationInfoIt = DeduplicationInfo.find(messageDeduplicationId);
+            if (deduplicationInfoIt == DeduplicationInfo.end()) {
+                PQ_LOG_D("Got unknown messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                continue;
+            }
+            auto& deduplicationInfo = deduplicationInfoIt->second;
+            if (auto it = deduplicationInfo.RemainsPartitionWithGeneration.find(record.GetPartitionId());
+                it == deduplicationInfo.RemainsPartitionWithGeneration.end()) {
+                PQ_LOG_D("Got unknown partition for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                continue;
+            } else if (it->second > record.GetGeneration()) {
+                PQ_LOG_D("Got wrong generation for messageDeduplicationId=" << messageDeduplicationId << " in TEvCheckMessageDeduplicationResponse");
+                continue;
+            } else {
+                deduplicationInfo.RemainsPartitionWithGeneration.erase(it);
+            }
+            if (record.GetStatus() != NKikimrPQ::EStatus::OK) {
+                deduplicationInfo.PartitionErrors += 1;
+            } else {
+                if (result.GetIsDuplicate()) {
+                    deduplicationInfo.IsDuplicate = true;
+                    deduplicationInfo.Offset = result.GetOffset();
+                    deduplicationInfo.PartitionId = record.GetPartitionId();
+                }
+            }
+            TryFinalizeDeduplicationInfo(deduplicationInfoIt);
+        }
+        ProcessQueue();
+    }
+
+    void TryFinalizeDeduplicationInfo(const TDeduplicationInfoMap::iterator it) {
+        auto& [deduplicateMessageId, info] = *it;
+        if (!info.RemainsPartitionWithGeneration.empty() && info.PartitionErrors == 0) {
+            return;
+        }
+        TEvPQ::TEvWrite::TMessageExternalDeduplicationInfo messageExternalDeduplicationInfo;
+        if (info.PartitionErrors != 0) {
+            messageExternalDeduplicationInfo.Status = EMessageExternalDeduplicationStatus::Error;
+        } else if (info.IsDuplicate) {
+            messageExternalDeduplicationInfo.Status = EMessageExternalDeduplicationStatus::Duplicate;
+            messageExternalDeduplicationInfo.OriginalPartitionAndOffset.emplace(info.PartitionId, info.Offset);
+        } else {
+            messageExternalDeduplicationInfo.Status = EMessageExternalDeduplicationStatus::Unique;
+        }
+        for (const TWriteRequestMessageIndex req : info.RequestsInQueue) {
+            TWriteRequest* ptr = req.RequestPtr;
+            ptr->UnresolvedDeduplicationIds.erase(deduplicateMessageId);
+            auto& evWrite = *ptr->Event->Get();
+            Y_VERIFY_S(req.MessageIndex < evWrite.Msgs.size(), "Out of bounds access " << req.MessageIndex << "/" << evWrite.Msgs.size());
+            auto& msg = evWrite.Msgs[req.MessageIndex];
+            Y_VERIFY_S(msg.MessageDeduplicationId == deduplicateMessageId, "Wrong message deduplication id " << msg.MessageDeduplicationId << " != " << deduplicateMessageId);
+            msg.ExternalDeduplicationInfo = messageExternalDeduplicationInfo;
+            if (messageExternalDeduplicationInfo.Status == EMessageExternalDeduplicationStatus::Error) {
+                // propagate error to the whole evWrite
+                evWrite.ExternalDeduplicationStatus = EWriteExternalDeduplicationStatus::Error;
+            }
+        }
+    }
+
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
+        const TEvPipeCache::TEvDeliveryProblem& record = *ev->Get();
+        auto& tabletInfo = TabletInfo[record.TabletId];
+        tabletInfo.Subscribed = false;
+        tabletInfo.Generation += 1;
+        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end(); ++it) {
+            auto& [messageDeduplicationId, deduplicationInfo] = *it;
+            size_t affectedPartitions = 0;
+            for (const ui32 partitionId : tabletInfo.Partitions) {
+                affectedPartitions += deduplicationInfo.RemainsPartitionWithGeneration.erase(partitionId);
+            }
+            if (affectedPartitions != 0) {
+                deduplicationInfo.PartitionErrors += affectedPartitions;
+                TryFinalizeDeduplicationInfo(it);
+            }
+        }
+        ProcessQueue();
+    }
+
+    static bool SetChecked(EWriteExternalDeduplicationStatus& status) {
+        if (status == EWriteExternalDeduplicationStatus::Unchecked) {
+            status = EWriteExternalDeduplicationStatus::Checked;
+        }
+        return false;
+    };
+
+    void SendEvent(TEvPQ::TEvWrite::TPtr ev) {
+        bool update = SetChecked(ev->Get()->ExternalDeduplicationStatus);
+        PQ_LOG_D("Forward event " << ev->GetTypeRewrite() << " to " << PartitionActorId << "; update=" << update);
+        Forward(ev, PartitionActorId);
+    }
+
+    void ProcessQueue() {
+        while (!Queue.empty()) {
+            auto& req = Queue.front();
+            if (!req.UnresolvedDeduplicationIds.empty()) {
+                break;
+            }
+            SendEvent(req.Event);
+            Queue.pop_front();
+        }
+        TryToSwitchToBypassMode();
+    }
+
+    void CancelQueue() {
+        for (auto it = DeduplicationInfo.begin(); it != DeduplicationInfo.end(); ++it) {
+            auto& [messageDeduplicationId, deduplicationInfo] = *it;
+            deduplicationInfo.CancelIfNotReady();
+            TryFinalizeDeduplicationInfo(it);
+        }
+        ProcessQueue();
+        Y_ASSERT(Queue.empty());
+    }
+
+    void PassAway() override {
+        CancelQueue();
+        TActorBootstrapped::PassAway();
+    }
+
+    void TryToSwitchToBypassMode() {
+        if (BypassMode) {
+            return;
+        }
+        if (!Queue.empty()) {
+            return;
+        }
+        if (TAppData::TimeProvider->Now() < DisableTimestamp) {
+            return;
+        }
+        SwitchToBypassMode();
+    }
+
+    void SwitchToBypassMode() {
+        PQ_LOG_D("SwitchToBypassMode");
+        Y_VERIFY_S(Queue.empty(), "Queue is not empty");
+        if (!BypassMode) {
+            Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
+        }
+        BypassMode = true;
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvPQ::TEvWrite, Handle);
+            hFunc(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse, Handle);
+            hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
+            sFunc(TEvents::TEvPoison, PassAway);
+            default:
+                PQ_LOG_W("Unexpected event type " << ev->GetTypeRewrite());
+        }
+    }
+
+};
+
+NActors::IActor* CreateDeduplicationWriteQueueActor(
+    TActorId partitionActorId,
+    TString topicName,
+    ui32 partitionId,
+    TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions) {
+    return new TDeduplicationQueueActor(
+        partitionActorId,
+        std::move(topicName),
+        partitionId,
+        std::move(parentPartitions));
+}
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -7,7 +7,13 @@
 
 namespace NKikimr::NPQ {
 
-    NActors::IActor* CreateDeduplicationWriteQueueActor(
+    struct TCreateDeduplicationWriteQueueActorResult {
+        size_t RecentPartitionsCount = 0;
+        TInstant DisableTimestamp;
+        THolder<NActors::IActor> Actor;
+    };
+
+    TCreateDeduplicationWriteQueueActorResult CreateDeduplicationWriteQueueActor(
         ui64 tabletId,
         NActors::TActorId tabletActorId,
         NActors::TActorId partitionActorId,

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -14,4 +14,11 @@ namespace NKikimr::NPQ {
         ui32 partitionId,
         TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions);
 
+    namespace NPrivate {
+        enum class EBypassMode {
+            Disabled,
+            Pending, // wait for queue
+            Enabled,
+        };
+    }
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -6,7 +6,9 @@
 
 namespace NKikimr::NPQ {
 
-NActors::IActor* CreateDeduplicationWriteQueueActor(
+    NActors::IActor* CreateDeduplicationWriteQueueActor(
+        ui64 tabletId,
+        NActors::TActorId tabletActorId,
         NActors::TActorId partitionActorId,
         TString topicName,
         ui32 partitionId,

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/library/actors/core/actor.h>
+#include <util/generic/string.h>
+
+namespace NKikimr::NPQ {
+
+NActors::IActor* CreateDeduplicationWriteQueueActor(
+        NActors::TActorId partitionActorId,
+        TString topicName,
+        ui32 partitionId,
+        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions);
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <util/generic/string.h>
@@ -12,7 +13,7 @@ namespace NKikimr::NPQ {
         NActors::TActorId partitionActorId,
         TString topicName,
         ui32 partitionId,
-        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions);
+        const TPartitionGraph& partitionGraph);
 
     namespace NPrivate {
         enum class EBypassMode {

--- a/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
+++ b/ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h
@@ -24,7 +24,7 @@ namespace NKikimr::NPQ {
     namespace NPrivate {
         enum class EBypassMode {
             Disabled,
-            Pending, // wait for queue
+            Pending, // wait for deduplication responses, but stop sending requests for new messages
             Enabled,
         };
     }

--- a/ydb/core/persqueue/pqtablet/partition/message_id_deduplicator.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/message_id_deduplicator.cpp
@@ -56,6 +56,15 @@ std::optional<ui64> TMessageIdDeduplicator::AddMessage(const TString& deduplicat
     return std::nullopt;
 }
 
+std::optional<ui64> TMessageIdDeduplicator::CheckMessageId(const TString& deduplicationId) {
+    Compact(); // remove obsolete messages
+    auto* message = MapFindPtr(Messages, deduplicationId);
+    if (message) {
+        return *message;
+    }
+    return std::nullopt;
+}
+
 size_t TMessageIdDeduplicator::Compact() {
     const auto now = TimeProvider->Now();
     size_t removed = 0;

--- a/ydb/core/persqueue/pqtablet/partition/message_id_deduplicator.h
+++ b/ydb/core/persqueue/pqtablet/partition/message_id_deduplicator.h
@@ -31,6 +31,7 @@ public:
     TDuration GetDeduplicationWindow() const;
 
     std::optional<ui64> AddMessage(const TString& deduplicationId, const ui64 offset);
+    std::optional<ui64> CheckMessageId(const TString& deduplicationId);
     size_t Compact();
 
     void Commit();

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
@@ -11,8 +11,6 @@
 
 namespace NKikimr::NPQ::NMLP {
 
-Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplit) {
-
 static void CreateSetupFIFOTopic(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& topicName) {
     auto status = CreateTopic(setup, topicName, NYdb::NTopic::TCreateTopicSettings()
         .BeginConfigurePartitioningSettings()
@@ -60,6 +58,8 @@ static size_t WaitForPartitionCount(std::shared_ptr<TTopicSdkTestSetup>& setup, 
     driver.Stop(true);
     return partitionCount;
 }
+
+Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplit) {
 
 static void DumpStorageState(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& topicName, const TString& consumerName, const TSet<ui32>& partitions) {
     TStringStream output;
@@ -1044,6 +1044,458 @@ Y_UNIT_TEST(DoubleSplit_ReadAfterFirstWrite) {
 
     VerifyFIFOOrdering(allMessages, expectedCounts, "DoubleSplit_ReadAfterFirstWrite");
 
+}
+
+}
+
+Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplitDedup) {
+
+struct TDedupWriteSpec {
+    TString Body;
+    std::optional<TString> DedupId;
+    std::optional<TString> GroupId;
+};
+
+struct TDedupStage {
+    std::vector<TDedupWriteSpec> Write;
+};
+
+static TMap<TString, TString> ComputeExpectedMessages(const std::vector<TDedupStage>& stages) {
+    TMap<TString, TString> expected;
+    TSet<TString> seenDedupIds;
+    for (const auto& stage : stages) {
+        for (const auto& msg : stage.Write) {
+            if (msg.DedupId) {
+                if (seenDedupIds.insert(*msg.DedupId).second) {
+                    expected[msg.Body] = *msg.DedupId;
+                }
+            } else {
+                expected[msg.Body] = "";
+            }
+        }
+    }
+    return expected;
+}
+
+struct TWriteResult {
+    Ydb::StatusIds::StatusCode Status;
+    TMessageId MessageId;
+};
+
+static TMap<TString, TWriteResult> WriteDedupStage(
+    NActors::TTestActorRuntime& runtime,
+    const TString& topicName,
+    std::vector<TDedupWriteSpec> messages,
+    TStringBuf phase
+) {
+    TMap<TString, TWriteResult> bodyStatuses;
+    for (int writeIteration = 0; !messages.empty(); ++writeIteration) {
+        TSet<TString> usedGroups;
+        TSet<TString> usedDedupIds;
+        std::vector<TDedupWriteSpec> messagesNext;
+        std::vector<TWriterSettings::TMessage> writerMessages;
+
+        for (auto& m : messages) {
+            bool use = true; // write messages in non-overlapping groups
+            use = use && (!m.DedupId.has_value() || usedDedupIds.insert(m.DedupId.value()).second);
+            use = use && (!m.GroupId.has_value() || usedGroups.insert(m.GroupId.value()).second);
+            if (use) {
+                writerMessages.push_back({
+                    .Index = writerMessages.size(),
+                    .MessageBody = m.Body,
+                    .MessageGroupId = m.GroupId,
+                    .MessageDeduplicationId = m.DedupId,
+                });
+            } else {
+                messagesNext.push_back(std::move(m));
+            }
+        }
+        Cerr << "Write iteration " << writeIteration << ": " << writerMessages.size() << " messages:" << Endl;
+        for (const auto& m : writerMessages) {
+            Cerr << "  " << LabeledOutput(m.Index, m.MessageBody, m.MessageGroupId, m.MessageDeduplicationId) << Endl;
+        }
+
+        CreateWriterActor(runtime, {
+            .DatabasePath = "/Root",
+            .TopicName = topicName,
+            .Messages = writerMessages,
+        });
+        auto writeResp = GetWriteResponse(runtime);
+        UNIT_ASSERT_C(writeResp, phase << ": write response timeout");
+        Cerr << "Write iteration " << writeIteration << " response: " << writeResp->Messages.size() << " messages:" << Endl;
+        for (size_t i = 0; i < writeResp->Messages.size(); ++i) {
+            auto toString = [](const std::optional<TMessageId>& id) -> TString {
+                if (id.has_value()) {
+                    return TStringBuilder() << LabeledOutput(id->PartitionId, id->Offset);
+                }
+                return "<none>";
+            };
+            Cerr << "  " << LabeledOutput(i, writeResp->Messages[i].Index, writeResp->Messages[i].Status) << " " << toString(writeResp->Messages[i].MessageId) << Endl;
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), writerMessages.size(), phase);
+
+        for (size_t i = 0; i < writeResp->Messages.size(); ++i) {
+            const auto& body = writerMessages[i].MessageBody;
+            const auto& resp = writeResp->Messages[i];
+            UNIT_ASSERT_C(
+                resp.Status == Ydb::StatusIds::SUCCESS || resp.Status == Ydb::StatusIds::ALREADY_EXISTS,
+                phase << ": unexpected write status " << Ydb::StatusIds::StatusCode_Name(resp.Status)
+                      << " for body=" << body);
+            UNIT_ASSERT_C(!bodyStatuses.contains(body), phase << ": duplicate body in stage: " << body);
+            UNIT_ASSERT_C(resp.MessageId.has_value(), phase << ": no message id for body=" << body);
+            bodyStatuses[body] = {.Status = resp.Status, .MessageId = resp.MessageId.value()};
+        }
+
+        messagesNext.swap(messages);
+    }
+
+    return bodyStatuses;
+}
+
+static TMap<TString, TString> ReadAllDedupAndCommit(
+    NActors::TTestActorRuntime& runtime,
+    const TString& topicName,
+    const TString& consumer,
+    int retries = 100
+) {
+    TMap<TString, TString> readMessages;
+
+    for (;;) {
+        CreateReaderActor(runtime, {
+            .DatabasePath = "/Root",
+            .TopicName = topicName,
+            .Consumer = consumer,
+            .WaitTime = TDuration::MilliSeconds(100),
+            .ProcessingTimeout = TDuration::Seconds(300),
+            .MaxNumberOfMessage = 20,
+        });
+        auto readResult = GetReadResponse(runtime);
+        UNIT_ASSERT_C(readResult, "ReadAllDedupAndCommit: read response timeout");
+        UNIT_ASSERT_VALUES_EQUAL(readResult->Status, Ydb::StatusIds::SUCCESS);
+
+        if (readResult->Messages.empty()) {
+            if (--retries < 0) {
+                break;
+            }
+            continue;
+        }
+
+        std::vector<TMessageId> toCommit;
+        for (const auto& msg : readResult->Messages) {
+            Cerr << ">>>>> ReadAllDedupAndCommit: data=" << msg.Data
+                 << " dedupId=" << msg.MessageDeduplicationId
+                 << " group=" << msg.MessageGroupId
+                 << " partition=" << msg.MessageId.PartitionId
+                 << " offset=" << msg.MessageId.Offset << Endl;
+            readMessages[msg.Data] =  msg.MessageDeduplicationId;
+            toCommit.push_back(msg.MessageId);
+        }
+
+        CreateCommitterActor(runtime, {
+            .DatabasePath = "/Root",
+            .TopicName = topicName,
+            .Consumer = consumer,
+            .Messages = toCommit,
+        });
+        auto commitResult = GetChangeResponse(runtime);
+        UNIT_ASSERT_C(commitResult, "ReadAllDedupAndCommit: commit response timeout");
+        UNIT_ASSERT_VALUES_EQUAL(commitResult->Status, Ydb::StatusIds::SUCCESS);
+    }
+
+    return readMessages;
+}
+
+static void VerifyDedupResult(
+    const TMap<TString, TString>& readMessages,
+    const TMap<TString, TString>& expectedMessages,
+    TStringBuf testName
+) {
+
+    for (const auto& [body, dedupId] : readMessages) {
+        const auto* expectedDedupId = expectedMessages.FindPtr(body);
+        UNIT_ASSERT_C(expectedDedupId,
+            testName << ": unexpected body=" << body << " in read result");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            dedupId, *expectedDedupId,
+            testName << ": dedupId mismatch for body=" << body);
+    }
+    UNIT_ASSERT_VALUES_EQUAL_C(readMessages.size(), expectedMessages.size(), testName << ": total message count mismatch");
+
+}
+
+static void VerifyWriteStatuses(
+    const TMap<TString, TWriteResult>& bodyStatuses,
+    const std::vector<TDedupWriteSpec>& messages,
+    TMap<TString, TMessageId>& firstMessageIdByDedupId,  // in/out: first successful MessageId per dedupId
+    TStringBuf phase
+) {
+    for (const auto& spec : messages) {
+        const auto* result = bodyStatuses.FindPtr(spec.Body);
+        UNIT_ASSERT_C(result, phase << ": no write status recorded for body=" << spec.Body);
+        if (spec.DedupId && firstMessageIdByDedupId.contains(*spec.DedupId)) {
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::ALREADY_EXISTS,
+                phase << ": expected ALREADY_EXISTS for body=" << spec.Body
+                      << " dedupId=" << *spec.DedupId);
+            const auto* firstId = firstMessageIdByDedupId.FindPtr(*spec.DedupId);
+            UNIT_ASSERT_C(firstId, phase << ": no first MessageId recorded for dedupId=" << *spec.DedupId);
+            // TODO: fix the CalculateReplyOffset fn
+            // UNIT_ASSERT_VALUES_EQUAL_C(result->MessageId.PartitionId, firstId->PartitionId, phase << ": PartitionId mismatch for ALREADY_EXISTS body=" << spec.Body << " dedupId=" << *spec.DedupId);
+            // UNIT_ASSERT_VALUES_EQUAL_C(result->MessageId.Offset, firstId->Offset, phase << ": Offset mismatch for ALREADY_EXISTS body=" << spec.Body << " dedupId=" << *spec.DedupId);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS,
+                phase << ": expected SUCCESS for body=" << spec.Body
+                      << " dedupId=" << spec.DedupId.value_or("<none>"));
+            if (spec.DedupId) {
+                firstMessageIdByDedupId.try_emplace(*spec.DedupId, result->MessageId);
+            }
+        }
+    }
+}
+
+struct TLeafPartition {
+    ui32 Id;
+    unsigned char Lo;
+    unsigned char Hi;
+};
+
+static void RunDedupTest(const TString& testName, const std::vector<TDedupStage>& stages) {
+    UNIT_ASSERT_C(!stages.empty(), "RunDedupTest: no stages");
+
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    CreateSetupFIFOTopic(setup, "/Root/topic1");
+
+    const auto expectedMessages = ComputeExpectedMessages(stages);
+
+    std::vector<TLeafPartition> leaves = {{0, 0x00, 0xFF}};
+    size_t totalPartitions = 1;
+    TMap<TString, TMessageId> firstMessageIdByDedupId;
+    for (size_t stageIdx = 0; stageIdx < stages.size(); ++stageIdx) {
+        TStringBuilder phase;
+        phase << testName << " stage=" << stageIdx;
+
+        Cerr << ">>>>> " << phase << ": writing " << stages[stageIdx].Write.size() << " messages" << Endl;
+        auto bodyStatuses = WriteDedupStage(runtime, "/Root/topic1", stages[stageIdx].Write, phase);
+        VerifyWriteStatuses(bodyStatuses, stages[stageIdx].Write, firstMessageIdByDedupId, phase);
+
+
+        if (stageIdx + 1 < stages.size()) {
+            std::map<ui32, TString> splitBoundaries;
+            for (const auto& leaf : leaves) {
+                unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
+                splitBoundaries[leaf.Id] = TString(1, (char)mid);
+                Cerr << ">>>>> " << phase << ": split partition " << leaf.Id
+                     << " at 0x" << Hex((ui32)mid) << Endl;
+            }
+
+            ui64 txId = 1006 + stageIdx;
+            NKikimr::NPQ::NTest::SplitPartitions(runtime, txId, "/Root", "topic1", splitBoundaries);
+
+            std::vector<TLeafPartition> newLeaves;
+            for (size_t i = 0; i < leaves.size(); ++i) {
+                const auto& leaf = leaves[i];
+                unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
+                ui32 leftId = (ui32)(totalPartitions + i * 2);
+                ui32 rightId = (ui32)(totalPartitions + i * 2 + 1);
+                newLeaves.push_back({leftId, leaf.Lo, mid});
+                newLeaves.push_back({rightId, (unsigned char)(mid + 1), leaf.Hi});
+            }
+            totalPartitions += leaves.size() * 2;
+            leaves = std::move(newLeaves);
+
+            auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", totalPartitions);
+            UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, totalPartitions,
+                phase << ": expected " << totalPartitions << " partitions after split");
+        }
+    }
+
+    Cerr << ">>>>> " << testName << ": reading all messages" << Endl;
+    auto readMessages = ReadAllDedupAndCommit(runtime, "/Root/topic1", "mlp-consumer");
+    VerifyDedupResult(readMessages, expectedMessages, testName);
+
+    Cerr << ">>>>> " << testName << ": done" << Endl;
+}
+
+Y_UNIT_TEST(Dedup_NoSplit_WithGroup) {
+    RunDedupTest("Dedup_NoSplit_WithGroup", {
+        {.Write = {
+            {.Body = "first-body", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "second-body", .DedupId = "dedupA", .GroupId = "group-X"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_NoSplit_NoGroup) {
+    RunDedupTest("Dedup_NoSplit_NoGroup", {
+        {.Write = {
+            {.Body = "first-body", .DedupId = "dedupA"},
+            {.Body = "second-body", .DedupId = "dedupA"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_AllNew) {
+    RunDedupTest("Dedup_WithGroup_AllNew", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupC", .DedupId = "dedupC", .GroupId = "group-X"},
+            {.Body = "s1-dedupD", .DedupId = "dedupD", .GroupId = "group-X"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_SameIds1) {
+    RunDedupTest("Dedup_WithGroup_SameIds", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_SameIds) {
+    RunDedupTest("Dedup_WithGroup_SameIds", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_PartialOverlap) {
+    RunDedupTest("Dedup_WithGroup_PartialOverlap", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupC", .DedupId = "dedupC", .GroupId = "group-X"},
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_PartialOverlapWithNonDedup) {
+    std::vector<TDedupStage> stages;
+    auto& s0 = stages.emplace_back();
+    for (size_t i = 0; i < 5; ++i) {
+        s0.Write.push_back({.Body = TStringBuilder() << "s0-nodedup-" << i, .GroupId = "group-X"});
+    }
+    s0.Write.push_back({.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"});
+    s0.Write.push_back({.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"});
+
+    auto& s1 = stages.emplace_back();
+    for (size_t i = 0; i < 5; ++i) {
+        s1.Write.push_back({.Body = TStringBuilder() << "s1-nodedup-" << i, .GroupId = "group-X"});
+    }
+    s1.Write.push_back({.Body = "s1-dedupC", .DedupId = "dedupC", .GroupId = "group-X"});
+    s1.Write.push_back({.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"});
+
+    RunDedupTest("Dedup_WithGroup_PartialOverlapWithNonDedup", stages);
+}
+
+Y_UNIT_TEST(Dedup_NoGroup_AllNew) {
+    RunDedupTest("Dedup_NoGroup_AllNew", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupC", .DedupId = "dedupC"},
+            {.Body = "s1-dedupD", .DedupId = "dedupD"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_NoGroup_SameIds) {
+    RunDedupTest("Dedup_NoGroup_SameIds", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_NoGroup_PartialOverlap) {
+    RunDedupTest("Dedup_NoGroup_PartialOverlap", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupC", .DedupId = "dedupC"},
+            {.Body = "s1-dedupA", .DedupId = "dedupA"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_NoGroup_PartialOverlapWithNonDedup) {
+    std::vector<TDedupStage> stages;
+    auto& s0 = stages.emplace_back();
+    for (size_t i = 0; i < 5; ++i) {
+        s0.Write.push_back({.Body = TStringBuilder() << "s0-nodedup-" << i});
+    }
+    s0.Write.push_back({.Body = "s0-dedupA", .DedupId = "dedupA"});
+    s0.Write.push_back({.Body = "s0-dedupB", .DedupId = "dedupB"});
+
+    auto& s1 = stages.emplace_back();
+    for (size_t i = 0; i < 5; ++i) {
+        s1.Write.push_back({.Body = TStringBuilder() << "s1-nodedup-" << i});
+    }
+    s1.Write.push_back({.Body = "s1-dedupC", .DedupId = "dedupC"});
+    s1.Write.push_back({.Body = "s1-dedupA", .DedupId = "dedupA"});
+
+    RunDedupTest("Dedup_NoGroup_PartialOverlapWithNonDedup", stages);
+}
+
+Y_UNIT_TEST(Dedup_MixedGroup_PartialOverlap) {
+    RunDedupTest("Dedup_MixedGroup_PartialOverlap", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupC", .DedupId = "dedupC", .GroupId = "group-X"},
+            {.Body = "s1-dedupA", .DedupId = "dedupA"},
+        }},
+    });
+}
+
+Y_UNIT_TEST(Dedup_DoubleSplit) {
+    if ("x-fail") {
+        // TODO: fix GetParentPartitions
+        return;
+    }
+    RunDedupTest("Dedup_DoubleSplit", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-X"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-X"},
+        }},
+    });
 }
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
@@ -7,9 +7,56 @@
 #include <ydb/library/actors/core/mon.h>
 #include <library/cpp/iterator/iterate_values.h>
 #include <util/string/split.h>
+#include <atomic>
 #include <span>
 
 namespace NKikimr::NPQ::NMLP {
+
+namespace {
+
+    struct TLeapTimeProvider: public ITimeProvider {
+        TInstant Now() override {
+            TInstant r = TInstant::Now();
+            if (i64 offset = Offset.load(); offset >= 0) {
+                return r + TDuration::MicroSeconds(offset);
+            } else {
+                return r - TDuration::MicroSeconds(-offset);
+            }
+        }
+
+        void Add(TDuration duration) {
+            Offset.fetch_add(duration.MicroSeconds());
+        }
+
+        std::atomic<i64> Offset = 0;
+    };
+
+    class TBufferedCerr: TNonCopyable {
+    public:
+        TBufferedCerr()
+            : Out(Buffer)
+        {
+        }
+
+        ~TBufferedCerr() noexcept(false) {
+            Cerr << Buffer;
+        }
+
+        TString Buffer;
+        TStringOutput Out;
+    };
+    template <class T>
+    TBufferedCerr& operator<<(TBufferedCerr& os Y_LIFETIME_BOUND, const T& t) {
+        os.Out << t;
+        return os;
+    }
+    template <class T>
+    TBufferedCerr&& operator<<(TBufferedCerr&& os Y_LIFETIME_BOUND, const T& t) {
+        os.Out << t;
+        return std::move(os);
+    }
+#define ACerr (TBufferedCerr{})
+} // namespace
 
 static void CreateSetupFIFOTopic(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& topicName) {
     auto status = CreateTopic(setup, topicName, NYdb::NTopic::TCreateTopicSettings()
@@ -48,7 +95,7 @@ static size_t WaitForPartitionCount(std::shared_ptr<TTopicSdkTestSetup>& setup, 
         UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
 
         partitionCount = describeResult.GetTopicDescription().GetPartitions().size();
-        Cerr << ">>>>> Partition count: " << partitionCount << " (expected " << expectedCount << ")" << Endl;
+        ACerr << ">>>>> Partition count: " << partitionCount << " (expected " << expectedCount << ")" << Endl;
 
         if (partitionCount >= expectedCount) {
             break;
@@ -59,13 +106,63 @@ static size_t WaitForPartitionCount(std::shared_ptr<TTopicSdkTestSetup>& setup, 
     return partitionCount;
 }
 
+struct TLeafPartition {
+    ui32 Id;
+    unsigned char Lo;
+    unsigned char Hi;
+};
+
+class TPartitionSplitter {
+public:
+    TPartitionSplitter()
+        : Leaves_({{0, 0x00, 0xFF}})
+        , TotalPartitions_(1)
+    {}
+
+    size_t TotalPartitions() const { return TotalPartitions_; }
+    const std::vector<TLeafPartition>& Leaves() const { return Leaves_; }
+
+    void SplitAllPartitions(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& dir, const TString& topic) {
+        std::map<ui32, TString> boundaries;
+        for (const auto& leaf : Leaves_) {
+            unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
+            boundaries[leaf.Id] = TString(1, (char)mid);
+            ACerr << ">>>>> split partition " << leaf.Id << " at 0x" << Hex((ui32)mid) << Endl;
+        }
+        NKikimr::NPQ::NTest::SplitPartitions(runtime, txId, dir, topic, boundaries);
+        AdvanceLeaves();
+    }
+
+    void SplitLeaf(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& dir, const TString& topic, ui32 leafId, TString boundary) {
+        NKikimr::NPQ::NTest::SplitPartition(runtime, txId, dir, topic, leafId, std::move(boundary));
+        AdvanceLeaves();
+    }
+
+private:
+    void AdvanceLeaves() {
+        std::vector<TLeafPartition> newLeaves;
+        for (size_t i = 0; i < Leaves_.size(); ++i) {
+            const auto& leaf = Leaves_[i];
+            unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
+            ui32 leftId = (ui32)(TotalPartitions_ + i * 2);
+            ui32 rightId = (ui32)(TotalPartitions_ + i * 2 + 1);
+            newLeaves.push_back({leftId, leaf.Lo, mid});
+            newLeaves.push_back({rightId, (unsigned char)(mid + 1), leaf.Hi});
+        }
+        TotalPartitions_ += Leaves_.size() * 2;
+        Leaves_ = std::move(newLeaves);
+    }
+
+    std::vector<TLeafPartition> Leaves_;
+    size_t TotalPartitions_;
+};
+
 Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplit) {
 
 static void DumpStorageState(std::shared_ptr<TTopicSdkTestSetup>& setup, const TString& topicName, const TString& consumerName, const TSet<ui32>& partitions) {
     TStringStream output;
     Y_DEFER {
-        output << "\n";
-        Cerr << output.Str();
+        ACerr << output.Str() << "\n";
     };
     for (const ui32 partition : partitions) {
         auto result = GetConsumerState(setup, "/Root", topicName, consumerName, partition);
@@ -106,7 +203,7 @@ static TString JoinMessageIds(std::span<const TMessageId> messages) {
 }
 
 static auto Commit(NActors::TTestActorRuntime& runtime, const TString& topicName, const TString& consumer, const std::vector<TMessageId>& messagesToCommit) {
-    Cerr << "Commiting messages: " << JoinMessageIds(messagesToCommit) << "\n";
+    ACerr << "Commiting messages: " << JoinMessageIds(messagesToCommit) << "\n";
     CreateCommitterActor(runtime, {
                                       .DatabasePath = "/Root",
                                       .TopicName = topicName,
@@ -118,7 +215,7 @@ static auto Commit(NActors::TTestActorRuntime& runtime, const TString& topicName
 }
 
 static auto Unlock(NActors::TTestActorRuntime& runtime, const TString& topicName, const TString& consumer, const std::vector<TMessageId>& messagesToUnlock) {
-    Cerr << "Unlocking messages: " << JoinMessageIds(messagesToUnlock) << "\n";
+    ACerr << "Unlocking messages: " << JoinMessageIds(messagesToUnlock) << "\n";
     CreateUnlockerActor(runtime, {
                                       .DatabasePath = "/Root",
                                       .TopicName = topicName,
@@ -155,7 +252,7 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
                 }
             }
             sb << "\n";
-            Cerr << sb << Endl;
+            ACerr << sb << Endl;
         }
         const size_t toRead = [&]() {
             size_t r = 0;
@@ -187,7 +284,7 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
         std::vector<TMessageId> messagesToCommit;
         for (auto& msg : readResult->Messages) {
             const TString& groupId = msg.MessageGroupId;
-            Cerr << ">>>>> " << phase << " ReadAndCommitFIFOExceptLast read: " << msg.Data
+            ACerr << ">>>>> " << phase << " ReadAndCommitFIFOExceptLast read: " << msg.Data
                  << " group=" << groupId
                  << " partition=" << msg.MessageId.PartitionId
                  << " offset=" << msg.MessageId.Offset << Endl;
@@ -270,18 +367,18 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
     auto setup = CreateSetup();
     auto& runtime = setup->GetRuntime();
 
-    Cerr << ">>>>> Phase 1: Create topic with autoscaling and shared consumer with KeepMessageOrder(true)" << Endl;
+    ACerr << ">>>>> Phase 1: Create topic with autoscaling and shared consumer with KeepMessageOrder(true)" << Endl;
 
-    Cerr << ">>>>> groups:\n";
+    ACerr << ">>>>> groups:\n";
     for (const auto& [g, desc] : groups) {
-        Cerr << "  " << g << ": "
+        ACerr << "  " << g << ": "
              << LabeledOutput(desc.SizeBeforeSplit, desc.SizeAfterSplit,
                               desc.ReadBeforeSplit.ReadCount, desc.ReadBeforeSplit.CommitLast) << "\n";
     }
-    Cerr << Endl;
+    ACerr << Endl;
     CreateSetupFIFOTopic(setup, "/Root/topic1");
 
-    Cerr << ">>>>> Phase 2: Write messages to parent partition (partition 0)" << Endl;
+    ACerr << ">>>>> Phase 2: Write messages to parent partition (partition 0)" << Endl;
 
     for (const auto& [groupId, desc] : groups) {
         if (desc.SizeBeforeSplit == 0) {
@@ -312,7 +409,7 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
     }
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
 
-    Cerr << ">>>>> Phase 3: Read and commit/unlock messages before split" << Endl;
+    ACerr << ">>>>> Phase 3: Read and commit/unlock messages before split" << Endl;
 
     TMap<TString, TReadCommitCount> readBeforeSplit;
     for (const auto& [groupId, desc] : groups) {
@@ -323,19 +420,20 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
     auto inflyMessages = ReadAndCommitFIFO(runtime, "/Root/topic1", "mlp-consumer", readBeforeSplit, "phase 3");
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
 
-    Cerr << ">>>>> Phase 4: Force partition split" << Endl;
+    ACerr << ">>>>> Phase 4: Force partition split" << Endl;
 
+    TPartitionSplitter splitter;
     ui64 txId = 1006;
-    NKikimr::NPQ::NTest::SplitPartition(runtime, ++txId, "/Root", "topic1", 0, "\x80");
+    splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
 
-    Cerr << ">>>>> Phase 4b: Wait for child partitions to be created and verify partition count" << Endl;
+    ACerr << ">>>>> Phase 4b: Wait for child partitions to be created and verify partition count" << Endl;
 
-    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", 3);
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, 3, "Expected 3 partitions after split (1 parent + 2 children)");
+    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after split");
 
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
-    Cerr << ">>>>> Phase 5: Write messages to child partitions" << Endl;
+    ACerr << ">>>>> Phase 5: Write messages to child partitions" << Endl;
 
     for (const auto& [groupId, desc] : groups) {
         if (desc.SizeAfterSplit == 0) {
@@ -368,11 +466,11 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
     for (ui32 partitionId : partitionsToRestart) {
-        Cerr << ">>>>> Restart partition " << partitionId << Endl;
+        ACerr << ">>>>> Restart partition " << partitionId << Endl;
         ReloadPQTablet(setup, "/Root", "/Root/topic1", partitionId);
     }
 
-    Cerr << ">>>>> Phase 6: Verify that we cannot read any messages written to the child partitions, if not all messages from the parent partition was commited" << Endl;
+    ACerr << ">>>>> Phase 6: Verify that we cannot read any messages written to the child partitions, if not all messages from the parent partition was commited" << Endl;
 
     // Determine which groups have all parent messages committed.
     // A group is "fully committed in parent" if effective CommitCount >= SizeBeforeSplit.
@@ -392,8 +490,8 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
         }
     }
 
-    Cerr << ">>>>> Phase 6: groupsFullyCommittedInParent: " << JoinSeq(", ", groupsFullyCommittedInParent) << "\n";
-    Cerr << ">>>>> Phase 6: groupsWithUncommittedParent: " << JoinSeq(", ", groupsWithUncommittedParent) << "\n";
+    ACerr << ">>>>> Phase 6: groupsFullyCommittedInParent: " << JoinSeq(", ", groupsFullyCommittedInParent) << "\n";
+    ACerr << ">>>>> Phase 6: groupsWithUncommittedParent: " << JoinSeq(", ", groupsWithUncommittedParent) << "\n";
 
     // Probe read: attempt to read messages and verify FIFO invariant.
     // We do a single read with MaxNumberOfMessage=10 to see what's available.
@@ -423,7 +521,7 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
                 << " in single read response");
             seenGroups.insert(msg.MessageGroupId);
 
-            Cerr << ">>>>> Phase 6 read: " << msg.Data
+            ACerr << ">>>>> Phase 6 read: " << msg.Data
                  << " group=" << msg.MessageGroupId
                  << " partition=" << msg.MessageId.PartitionId
                  << " offset=" << msg.MessageId.Offset << Endl;
@@ -457,14 +555,14 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
 
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
-    Cerr << ">>>>> Phase 7: Commit all remaining messages from the parent partition" << Endl;
+    ACerr << ">>>>> Phase 7: Commit all remaining messages from the parent partition" << Endl;
 
     // First, commit any inflight messages from Phase 3
     if (!inflyMessages.empty()) {
         std::vector<TMessageId> messagesToCommit;
         for (const auto& [groupId, messageId] : inflyMessages) {
             messagesToCommit.push_back(messageId);
-            Cerr << ">>>>> Phase 7: Committing inflight message from Phase 3: group=" << groupId
+            ACerr << ">>>>> Phase 7: Committing inflight message from Phase 3: group=" << groupId
                  << " partition=" << messageId.PartitionId
                  << " offset=" << messageId.Offset << Endl;
         }
@@ -496,7 +594,7 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
 
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
-    Cerr << ">>>>> Phase 8: Verify that we can read all remaining messages from child partitions" << Endl;
+    ACerr << ">>>>> Phase 8: Verify that we can read all remaining messages from child partitions" << Endl;
 
     // Now all parent messages are committed. All child messages should be readable.
     {
@@ -531,7 +629,7 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
             "Expected no more messages, but got " << finalRead->Messages.size());
     }
 
-    Cerr << ">>>>> All phases completed successfully" << Endl;
+    ACerr << ">>>>> All phases completed successfully" << Endl;
 }
 
 // Case 1: All written messages committed before split.
@@ -745,7 +843,7 @@ static void WriteGroups(
     size_t phaseIndex,
     TMap<TString, size_t>& expectedCounts
 ) {
-    Cerr << "Phase " << phaseIndex << " Write " << groupCount << " groups x " << messagesPerGroup << "\n";
+    ACerr << "Phase " << phaseIndex << " Write " << groupCount << " groups x " << messagesPerGroup << "\n";
     for (size_t g = 0; g < groupCount; ++g) {
         TString groupId = TStringBuilder() << "group-" << g;
         std::vector<TWriterSettings::TMessage> messages;
@@ -803,7 +901,7 @@ static std::vector<TCollectedMessage> ReadAllAndCommit(
             for (auto& [g, n] : remainingReads) {
                 sb << "  " << g << ": remaining=" << n << Endl;
             }
-            Cerr << sb << Endl;
+            ACerr << sb << Endl;
         }
         if (TotalExpectedMessages(remainingReads) == 0) {
             break;
@@ -830,7 +928,7 @@ static std::vector<TCollectedMessage> ReadAllAndCommit(
         THashSet<TString> seenGroupsInBatch;
         std::vector<TMessageId> messagesToCommit;
         for (auto& msg : readResult->Messages) {
-            Cerr << ">>>>> " << phase << " batch=" << batchIndex
+            ACerr << ">>>>> " << phase << " batch=" << batchIndex
                  << " read: " << msg.Data
                  << " group=" << msg.MessageGroupId
                  << " partition=" << msg.MessageId.PartitionId
@@ -890,7 +988,7 @@ static std::vector<TCollectedMessage> ReadOnceAndCommit(
     std::vector<TMessageId> messagesToCommit;
 
     for (auto& msg : readResult->Messages) {
-        Cerr << ">>>>> " << phase << " ReadOnce: " << msg.Data
+        ACerr << ">>>>> " << phase << " ReadOnce: " << msg.Data
              << " group=" << msg.MessageGroupId
              << " partition=" << msg.MessageId.PartitionId
              << " offset=" << msg.MessageId.Offset << Endl;
@@ -949,35 +1047,36 @@ Y_UNIT_TEST(DoubleSplit_ReadCommitAtEnd) {
     CreateSetupFIFOTopic(setup, "/Root/topic1");
     auto& runtime = setup->GetRuntime();
 
+    TPartitionSplitter splitter;
     TMap<TString, size_t> expectedCounts;
-        Cerr << ">>>>> DoubleSplit Phase 1" << Endl;
+    ui64 txId = 1006;
+
+    ACerr << ">>>>> DoubleSplit Phase 1" << Endl;
     WriteGroups(runtime, "/Root/topic1", 5, 2, 1, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
 
-    Cerr << ">>>>> DoubleSplit Phase 2: Split partition 0 at 0x80" << Endl;
-    ui64 txId = 1006;
-    NKikimr::NPQ::NTest::SplitPartition(runtime, ++txId, "/Root", "topic1", 0, "\x80");
+    ACerr << ">>>>> DoubleSplit Phase 2: Split all leaves" << Endl;
+    splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after first split");
 
-    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", 3);
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, 3, "Expected 3 partitions after first split");
-
-    Cerr << ">>>>> DoubleSplit Phase 2" << Endl;
+    ACerr << ">>>>> DoubleSplit Phase 2" << Endl;
     WriteGroups(runtime, "/Root/topic1", 10, 2, 2, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
-    Cerr << ">>>>> DoubleSplit Phase 3: Split partitions" << Endl;
-    NKikimr::NPQ::NTest::SplitPartitions(runtime, ++txId, "/Root", "topic1", {{1, "\x40"}, {2, "\xC0"}});
-    partitionCount = WaitForPartitionCount(setup, "/Root/topic1", 7);
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, 7, "Expected 7 partitions after double split");
+    ACerr << ">>>>> DoubleSplit Phase 3: Split all leaves" << Endl;
+    splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+    partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after double split");
 
-    Cerr << ">>>>> DoubleSplit Phase 4" << Endl;
+    ACerr << ">>>>> DoubleSplit Phase 4" << Endl;
     WriteGroups(runtime, "/Root/topic1", 15, 2, 3, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2, 3, 4, 5, 6});
 
-    Cerr << ">>>>> DoubleSplit_ReadCommitAtEnd: Reading and committing all messages" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadCommitAtEnd: Reading and committing all messages" << Endl;
     auto allMessages = ReadAllAndCommit(runtime, "/Root/topic1", "mlp-consumer", expectedCounts, "DoubleSplit_ReadCommitAtEnd");
 
-    Cerr << ">>>>> DoubleSplit_ReadCommitAtEnd: Verifying FIFO ordering" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadCommitAtEnd: Verifying FIFO ordering" << Endl;
     size_t expectedTotal = TotalExpectedMessages(expectedCounts);
     UNIT_ASSERT_VALUES_EQUAL_C(allMessages.size(), expectedTotal,
         "DoubleSplit_ReadCommitAtEnd: expected " << expectedTotal << " messages but got " << allMessages.size());
@@ -992,38 +1091,39 @@ Y_UNIT_TEST(DoubleSplit_ReadAfterFirstWrite) {
     CreateSetupFIFOTopic(setup, "/Root/topic1");
     auto& runtime = setup->GetRuntime();
 
+    TPartitionSplitter splitter;
     TMap<TString, size_t> expectedCounts;
+    ui64 txId = 1006;
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 1: Write 5 groups x 2 messages to partition 0" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 1: Write 5 groups x 2 messages to partition 0" << Endl;
     WriteGroups(runtime, "/Root/topic1", 5, 2, 1, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Early read + commit after first write" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Early read + commit after first write" << Endl;
     auto earlyMessages = ReadOnceAndCommit(runtime, "/Root/topic1", "mlp-consumer",
         "DoubleSplit_ReadAfterFirstWrite_early");
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Early read got " << earlyMessages.size() << " messages" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Early read got " << earlyMessages.size() << " messages" << Endl;
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 2: Split partition 0 at 0x80" << Endl;
-    ui64 txId = 1006;
-    NKikimr::NPQ::NTest::SplitPartition(runtime, ++txId, "/Root", "topic1", 0, "\x80");
-    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", 3);
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, 3, "Expected 3 partitions after first split");
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 2: Split all leaves" << Endl;
+    splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after first split");
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 2: Write 10 groups x 3 messages" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 2: Write 10 groups x 3 messages" << Endl;
     WriteGroups(runtime, "/Root/topic1", 10, 3, 2, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 3: Split partitions" << Endl;
-    NKikimr::NPQ::NTest::SplitPartitions(runtime, ++txId, "/Root", "topic1", {{1, "\x40"}, {2, "\xC0"}});
-    partitionCount = WaitForPartitionCount(setup, "/Root/topic1", 7);
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, 7, "Expected 7 partitions after double split");
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 3: Split all leaves" << Endl;
+    splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+    partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after double split");
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 3: Write 15 groups x 3 messages" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite Phase 3: Write 15 groups x 3 messages" << Endl;
     WriteGroups(runtime, "/Root/topic1", 15, 3, 3, expectedCounts);
     DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2, 3, 4, 5, 6});
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Reading and committing remaining messages" << Endl;
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Reading and committing remaining messages" << Endl;
     TMap<TString, size_t> remainingReads = expectedCounts;
     for (const auto& msg : earlyMessages) {
         remainingReads[msg.GroupId]--;
@@ -1034,7 +1134,7 @@ Y_UNIT_TEST(DoubleSplit_ReadAfterFirstWrite) {
     allMessages.insert(allMessages.end(), earlyMessages.begin(), earlyMessages.end());
     allMessages.insert(allMessages.end(), remainingMessages.begin(), remainingMessages.end());
 
-    Cerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Verifying FIFO ordering ("
+    ACerr << ">>>>> DoubleSplit_ReadAfterFirstWrite: Verifying FIFO ordering ("
          << earlyMessages.size() << " early + " << remainingMessages.size() << " remaining = "
          << allMessages.size() << " total)" << Endl;
 
@@ -1048,13 +1148,22 @@ Y_UNIT_TEST(DoubleSplit_ReadAfterFirstWrite) {
 
 }
 
-Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplitDedup) {
-
 struct TDedupWriteSpec {
     TString Body;
     std::optional<TString> DedupId;
     std::optional<TString> GroupId;
 };
+
+struct TWriteResult {
+    Ydb::StatusIds::StatusCode Status;
+    TMessageId MessageId;
+    size_t StageIdx = 0;
+    TDuration WriteTimestampOffset;
+};
+
+Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplitDedup) {
+
+static constexpr TDuration DEDUP_WINDOW = TDuration::Minutes(5);
 
 struct TDedupStage {
     std::vector<TDedupWriteSpec> Write;
@@ -1077,16 +1186,13 @@ static TMap<TString, TString> ComputeExpectedMessages(const std::vector<TDedupSt
     return expected;
 }
 
-struct TWriteResult {
-    Ydb::StatusIds::StatusCode Status;
-    TMessageId MessageId;
-};
-
 static TMap<TString, TWriteResult> WriteDedupStage(
     NActors::TTestActorRuntime& runtime,
     const TString& topicName,
     std::vector<TDedupWriteSpec> messages,
-    TStringBuf phase
+    TStringBuf phase,
+    size_t stage,
+    TDuration elapsed
 ) {
     TMap<TString, TWriteResult> bodyStatuses;
     for (int writeIteration = 0; !messages.empty(); ++writeIteration) {
@@ -1110,9 +1216,9 @@ static TMap<TString, TWriteResult> WriteDedupStage(
                 messagesNext.push_back(std::move(m));
             }
         }
-        Cerr << "Write iteration " << writeIteration << ": " << writerMessages.size() << " messages:" << Endl;
+        ACerr << "Write iteration " << writeIteration << ": " << writerMessages.size() << " messages:" << Endl;
         for (const auto& m : writerMessages) {
-            Cerr << "  " << LabeledOutput(m.Index, m.MessageBody, m.MessageGroupId, m.MessageDeduplicationId) << Endl;
+            ACerr << "  " << LabeledOutput(m.Index, m.MessageBody, m.MessageGroupId, m.MessageDeduplicationId) << Endl;
         }
 
         CreateWriterActor(runtime, {
@@ -1122,7 +1228,7 @@ static TMap<TString, TWriteResult> WriteDedupStage(
         });
         auto writeResp = GetWriteResponse(runtime);
         UNIT_ASSERT_C(writeResp, phase << ": write response timeout");
-        Cerr << "Write iteration " << writeIteration << " response: " << writeResp->Messages.size() << " messages:" << Endl;
+        ACerr << "Write iteration " << writeIteration << " response: " << writeResp->Messages.size() << " messages:" << Endl;
         for (size_t i = 0; i < writeResp->Messages.size(); ++i) {
             auto toString = [](const std::optional<TMessageId>& id) -> TString {
                 if (id.has_value()) {
@@ -1130,7 +1236,7 @@ static TMap<TString, TWriteResult> WriteDedupStage(
                 }
                 return "<none>";
             };
-            Cerr << "  " << LabeledOutput(i, writeResp->Messages[i].Index, writeResp->Messages[i].Status) << " " << toString(writeResp->Messages[i].MessageId) << Endl;
+            ACerr << "  " << LabeledOutput(i, writeResp->Messages[i].Index, writeResp->Messages[i].Status) << " " << toString(writeResp->Messages[i].MessageId) << Endl;
         }
         UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), writerMessages.size(), phase);
 
@@ -1143,7 +1249,7 @@ static TMap<TString, TWriteResult> WriteDedupStage(
                       << " for body=" << body);
             UNIT_ASSERT_C(!bodyStatuses.contains(body), phase << ": duplicate body in stage: " << body);
             UNIT_ASSERT_C(resp.MessageId.has_value(), phase << ": no message id for body=" << body);
-            bodyStatuses[body] = {.Status = resp.Status, .MessageId = resp.MessageId.value()};
+            bodyStatuses[body] = {.Status = resp.Status, .MessageId = resp.MessageId.value(), .StageIdx = stage, .WriteTimestampOffset = elapsed};
         }
 
         messagesNext.swap(messages);
@@ -1182,7 +1288,7 @@ static TMap<TString, TString> ReadAllDedupAndCommit(
 
         std::vector<TMessageId> toCommit;
         for (const auto& msg : readResult->Messages) {
-            Cerr << ">>>>> ReadAllDedupAndCommit: data=" << msg.Data
+            ACerr << ">>>>> ReadAllDedupAndCommit: data=" << msg.Data
                  << " dedupId=" << msg.MessageDeduplicationId
                  << " group=" << msg.MessageGroupId
                  << " partition=" << msg.MessageId.PartitionId
@@ -1210,7 +1316,6 @@ static void VerifyDedupResult(
     const TMap<TString, TString>& expectedMessages,
     TStringBuf testName
 ) {
-
     for (const auto& [body, dedupId] : readMessages) {
         const auto* expectedDedupId = expectedMessages.FindPtr(body);
         UNIT_ASSERT_C(expectedDedupId,
@@ -1226,94 +1331,83 @@ static void VerifyDedupResult(
 static void VerifyWriteStatuses(
     const TMap<TString, TWriteResult>& bodyStatuses,
     const std::vector<TDedupWriteSpec>& messages,
-    TMap<TString, TMessageId>& firstMessageIdByDedupId,  // in/out: first successful MessageId per dedupId
+    TMap<TString, TVector<TWriteResult>>& historyByDedupId,  // in/out: first successful MessageId per dedupId
     TStringBuf phase
 ) {
     for (const auto& spec : messages) {
         const auto* result = bodyStatuses.FindPtr(spec.Body);
         UNIT_ASSERT_C(result, phase << ": no write status recorded for body=" << spec.Body);
-        if (spec.DedupId && firstMessageIdByDedupId.contains(*spec.DedupId)) {
-            UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::ALREADY_EXISTS,
-                phase << ": expected ALREADY_EXISTS for body=" << spec.Body
-                      << " dedupId=" << *spec.DedupId);
-            const auto* firstId = firstMessageIdByDedupId.FindPtr(*spec.DedupId);
-            UNIT_ASSERT_C(firstId, phase << ": no first MessageId recorded for dedupId=" << *spec.DedupId);
-            // TODO: fix the CalculateReplyOffset fn
-            // UNIT_ASSERT_VALUES_EQUAL_C(result->MessageId.PartitionId, firstId->PartitionId, phase << ": PartitionId mismatch for ALREADY_EXISTS body=" << spec.Body << " dedupId=" << *spec.DedupId);
-            // UNIT_ASSERT_VALUES_EQUAL_C(result->MessageId.Offset, firstId->Offset, phase << ": Offset mismatch for ALREADY_EXISTS body=" << spec.Body << " dedupId=" << *spec.DedupId);
-        } else {
-            UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS,
-                phase << ": expected SUCCESS for body=" << spec.Body
-                      << " dedupId=" << spec.DedupId.value_or("<none>"));
-            if (spec.DedupId) {
-                firstMessageIdByDedupId.try_emplace(*spec.DedupId, result->MessageId);
+        if (spec.DedupId) {
+            TBufferedCerr log;
+            log << "spec=" << spec << "\n";
+            log << "this=" << *result << "\n";
+            auto& history = historyByDedupId[*spec.DedupId];
+            log << "history=[" << JoinSeq(", ", history) << "]\n";
+            auto lastSuccessIt = std::ranges::find(history.rbegin(), history.rend(), Ydb::StatusIds::SUCCESS, &TWriteResult::Status);
+            bool firstWrite = (lastSuccessIt == history.rend());
+            TMaybe<TDuration> sinceLastSuccess = lastSuccessIt == history.rend() ? Nothing() : MakeMaybe(result->WriteTimestampOffset - lastSuccessIt->WriteTimestampOffset);
+            TMaybe<TDuration> sinceLastAttempt = history.empty() ? Nothing() : MakeMaybe(result->WriteTimestampOffset - history.back().WriteTimestampOffset);
+            bool lastSuccessExpired = sinceLastSuccess.Defined() && (*sinceLastSuccess > DEDUP_WINDOW);
+            bool lastAttemptRecent = sinceLastAttempt.Defined() && (*sinceLastAttempt <= DEDUP_WINDOW);
+            int indexFromLast = lastSuccessIt - history.rbegin();
+            // When last SUCCESS expired but there were recent ALREADY_EXISTS attempts, the outcome is ambiguous — skip assertion.
+            bool ambiguous = lastSuccessExpired && lastAttemptRecent;
+            log << LabeledOutput(firstWrite, lastSuccessExpired, lastAttemptRecent, ambiguous, indexFromLast) << "\n";
+            log << LabeledOutput(sinceLastSuccess, sinceLastAttempt) << "\n";
+            if (!ambiguous) {
+                bool expectedWrite = firstWrite || lastSuccessExpired;
+                UNIT_ASSERT_VALUES_EQUAL_C(result->Status, (expectedWrite ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::ALREADY_EXISTS), phase << ": unexpected status for body=" << spec.Body << " dedupId=" << *spec.DedupId << "\n" << log.Buffer);
             }
+            history.push_back(*result);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Status, Ydb::StatusIds::SUCCESS, phase << ": expected SUCCESS for body=" << spec.Body << " dedupId=" << spec.DedupId.value_or("<none>"));
         }
     }
 }
 
-struct TLeafPartition {
-    ui32 Id;
-    unsigned char Lo;
-    unsigned char Hi;
-};
-
-static void RunDedupTest(const TString& testName, const std::vector<TDedupStage>& stages) {
+static void RunDedupTest(const TString& testName, const std::vector<TDedupStage>& stages, TDuration writeDuration = TDuration::Zero()) {
     UNIT_ASSERT_C(!stages.empty(), "RunDedupTest: no stages");
-
+    const auto leapTimeProvider = MakeIntrusive<TLeapTimeProvider>();
     auto setup = CreateSetup();
+    setup->GetServer().EnableLogs({
+            NKikimrServices::PERSQUEUE,
+        },
+        NActors::NLog::PRI_DEBUG
+    );
     auto& runtime = setup->GetRuntime();
+    for (ui32 i = 0; i < runtime.GetNodeCount(); ++i) {
+        runtime.GetAppData(i).TimeProvider = leapTimeProvider;
+    }
     CreateSetupFIFOTopic(setup, "/Root/topic1");
-
-    const auto expectedMessages = ComputeExpectedMessages(stages);
-
-    std::vector<TLeafPartition> leaves = {{0, 0x00, 0xFF}};
-    size_t totalPartitions = 1;
-    TMap<TString, TMessageId> firstMessageIdByDedupId;
+    TPartitionSplitter splitter;
+    TMap<TString, TVector<TWriteResult>> messagesByDedupId;
+    TDuration elapsed;
     for (size_t stageIdx = 0; stageIdx < stages.size(); ++stageIdx) {
         TStringBuilder phase;
         phase << testName << " stage=" << stageIdx;
 
-        Cerr << ">>>>> " << phase << ": writing " << stages[stageIdx].Write.size() << " messages" << Endl;
-        auto bodyStatuses = WriteDedupStage(runtime, "/Root/topic1", stages[stageIdx].Write, phase);
-        VerifyWriteStatuses(bodyStatuses, stages[stageIdx].Write, firstMessageIdByDedupId, phase);
+        ACerr << ">>>>> " << phase << ": writing " << stages[stageIdx].Write.size() << " messages (elapsed=" << elapsed << ")" << Endl;
+        auto bodyStatuses = WriteDedupStage(runtime, "/Root/topic1", stages[stageIdx].Write, phase, stageIdx, elapsed);
+        VerifyWriteStatuses(bodyStatuses, stages[stageIdx].Write, messagesByDedupId, phase);
 
+        leapTimeProvider->Add(writeDuration);
+        elapsed += writeDuration;
 
         if (stageIdx + 1 < stages.size()) {
-            std::map<ui32, TString> splitBoundaries;
-            for (const auto& leaf : leaves) {
-                unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
-                splitBoundaries[leaf.Id] = TString(1, (char)mid);
-                Cerr << ">>>>> " << phase << ": split partition " << leaf.Id
-                     << " at 0x" << Hex((ui32)mid) << Endl;
-            }
-
             ui64 txId = 1006 + stageIdx;
-            NKikimr::NPQ::NTest::SplitPartitions(runtime, txId, "/Root", "topic1", splitBoundaries);
-
-            std::vector<TLeafPartition> newLeaves;
-            for (size_t i = 0; i < leaves.size(); ++i) {
-                const auto& leaf = leaves[i];
-                unsigned char mid = (unsigned char)(((unsigned)leaf.Lo + (unsigned)leaf.Hi) / 2);
-                ui32 leftId = (ui32)(totalPartitions + i * 2);
-                ui32 rightId = (ui32)(totalPartitions + i * 2 + 1);
-                newLeaves.push_back({leftId, leaf.Lo, mid});
-                newLeaves.push_back({rightId, (unsigned char)(mid + 1), leaf.Hi});
-            }
-            totalPartitions += leaves.size() * 2;
-            leaves = std::move(newLeaves);
-
-            auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", totalPartitions);
-            UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, totalPartitions,
-                phase << ": expected " << totalPartitions << " partitions after split");
+            splitter.SplitAllPartitions(runtime, txId, "/Root", "topic1");
+            auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+            UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), phase << ": expected " << splitter.TotalPartitions() << " partitions after split");
         }
     }
 
-    Cerr << ">>>>> " << testName << ": reading all messages" << Endl;
+    ACerr << ">>>>> " << testName << ": reading all messages" << Endl;
     auto readMessages = ReadAllDedupAndCommit(runtime, "/Root/topic1", "mlp-consumer");
-    VerifyDedupResult(readMessages, expectedMessages, testName);
-
-    Cerr << ">>>>> " << testName << ": done" << Endl;
+    if (writeDuration == TDuration::Zero()) {
+        const auto expectedMessages = ComputeExpectedMessages(stages);
+        VerifyDedupResult(readMessages, expectedMessages, testName);
+    }
+    ACerr << ">>>>> " << testName << ": done" << Endl;
 }
 
 Y_UNIT_TEST(Dedup_NoSplit_WithGroup) {
@@ -1494,6 +1588,72 @@ Y_UNIT_TEST(Dedup_DoubleSplit) {
     });
 }
 
+Y_UNIT_TEST(Dedup_DoubleSplit_3min) {
+    RunDedupTest("Dedup_DoubleSplit_3min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+        }},
+    }, TDuration::Minutes(3));
+}
+
+Y_UNIT_TEST(Dedup_DoubleSplit_6min) {
+    RunDedupTest("Dedup_DoubleSplit_6min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+        }},
+    }, TDuration::Minutes(6));
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_SameIds_3min) {
+    RunDedupTest("Dedup_WithGroup_SameIds_3min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+    }, TDuration::Minutes(3));
+}
+
+Y_UNIT_TEST(Dedup_WithGroup_SameIds_6min) {
+    RunDedupTest("Dedup_WithGroup_SameIds_6min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
+        }},
+    }, TDuration::Minutes(6));
+}
+
 Y_UNIT_TEST(Dedup_TripleSplit) {
     RunDedupTest("Dedup_TripleSplit", {
         {.Write = {
@@ -1524,7 +1684,171 @@ Y_UNIT_TEST(Dedup_TripleSplit) {
     });
 }
 
+Y_UNIT_TEST(Dedup_TripleSplit_3min) {
+    RunDedupTest("Dedup_TripleSplit_3min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+            {.Body = "s0-dedupI", .DedupId = "dedupI", .GroupId = "group-I"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s0-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+        }},
+        {.Write = {
+            {.Body = "s3-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s3-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s3-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s3-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+            {.Body = "s3-dedupH", .DedupId = "dedupH", .GroupId = "group-H"},
+        }},
+    }, TDuration::Minutes(3));
+}
+
+Y_UNIT_TEST(Dedup_TripleSplit_6min) {
+    RunDedupTest("Dedup_TripleSplit_6min", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+            {.Body = "s0-dedupI", .DedupId = "dedupI", .GroupId = "group-I"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s0-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+        }},
+        {.Write = {
+            {.Body = "s3-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s3-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s3-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s3-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+            {.Body = "s3-dedupH", .DedupId = "dedupH", .GroupId = "group-H"},
+        }},
+    }, TDuration::Minutes(6));
+}
+
+struct TSplitSpec {
+    size_t Count = 1;
+    TDuration PauseBetween = TDuration::Zero();
+};
+
+static void RunRepeatedDedupWithSplits(TStringBuf testName, TDuration writePause, size_t numIterations, TSplitSpec splitSpec = {}) {
+    const TString groupId = "group-X";
+    const TString dedupId = "dedupA";
+
+    const auto leapTimeProvider = MakeIntrusive<TLeapTimeProvider>();
+    auto setup = CreateSetup();
+    setup->GetServer().EnableLogs({NKikimrServices::PERSQUEUE}, NActors::NLog::PRI_DEBUG);
+    auto& runtime = setup->GetRuntime();
+    for (ui32 i = 0; i < runtime.GetNodeCount(); ++i) {
+        runtime.GetAppData(i).TimeProvider = leapTimeProvider;
+    }
+    CreateSetupFIFOTopic(setup, "/Root/topic1");
+
+    TPartitionSplitter splitter;
+    ui64 txId = 1006;
+    size_t bodyCounter = 0;
+    TDuration elapsed;
+
+    for (size_t iter = 0; iter < numIterations; ++iter) {
+        TStringBuilder phase;
+        phase << testName << " iteration=" << iter;
+        ACerr << ">>>>> " << phase << " start (elapsed=" << elapsed << ")" << Endl;
+
+        int gotSuccess = 0;
+        int gotAlreadyExists = 0;
+        while (!(gotSuccess == 1 && gotAlreadyExists >= 1)) {
+            TString body = TStringBuilder() << "body-" << bodyCounter++;
+            ACerr << ">>>>> " << phase << " write body=" << body << " elapsed=" << elapsed << Endl;
+
+            CreateWriterActor(runtime, {
+                .DatabasePath = "/Root",
+                .TopicName = "/Root/topic1",
+                .Messages = {{.Index = 0, .MessageBody = body, .MessageGroupId = groupId, .MessageDeduplicationId = dedupId}},
+            });
+            auto writeResp = GetWriteResponse(runtime);
+            UNIT_ASSERT_C(writeResp, phase << ": write response timeout");
+            UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), 1u, phase);
+            auto status = writeResp->Messages[0].Status;
+            UNIT_ASSERT_C(status == Ydb::StatusIds::SUCCESS || status == Ydb::StatusIds::ALREADY_EXISTS, phase << ": unexpected status " << Ydb::StatusIds::StatusCode_Name(status));
+            ACerr << ">>>>> " << phase << " body=" << body << " status=" << Ydb::StatusIds::StatusCode_Name(status) << Endl;
+
+            gotSuccess += (status == Ydb::StatusIds::SUCCESS);
+            gotAlreadyExists += (status == Ydb::StatusIds::ALREADY_EXISTS);
+            UNIT_ASSERT_LE_C(gotSuccess, 1, phase);
+            leapTimeProvider->Add(writePause);
+            elapsed += writePause;
+        }
+
+        if (iter + 1 < numIterations) {
+            for (size_t s = 0; s < splitSpec.Count; ++s) {
+                if (s > 0) {
+                    leapTimeProvider->Add(splitSpec.PauseBetween);
+                    elapsed += splitSpec.PauseBetween;
+                }
+                ACerr << ">>>>> " << phase << " split " << s << " (elapsed=" << elapsed << ")" << Endl;
+                splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+                auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+                UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), phase << ": partition count mismatch after split " << s);
+            }
+        }
+    }
+
+    ACerr << ">>>>> " << testName << ": reading all messages" << Endl;
+    auto readMessages = ReadAllDedupAndCommit(runtime, "/Root/topic1", "mlp-consumer");
+    UNIT_ASSERT_C(!readMessages.empty(), testName << ": expected at least one message");
+    for (const auto& [body, readDedupId] : readMessages) {
+        UNIT_ASSERT_VALUES_EQUAL_C(readDedupId, dedupId, testName << ": dedupId mismatch for body=" << body);
+    }
+    ACerr << ">>>>> " << testName << ": done, read " << readMessages.size() << " messages" << Endl;
+    UNIT_ASSERT_VALUES_EQUAL(readMessages.size(), numIterations);
+}
+
+Y_UNIT_TEST(Dedup_RepeatedWriteUntilWindowCloses) {
+    RunRepeatedDedupWithSplits("Dedup_RepeatedWriteUntilWindowCloses", TDuration::Seconds(47), 4);
+}
+
+Y_UNIT_TEST(Dedup_RepeatedWriteUntilWindowCloses_DoubleSplit) {
+    RunRepeatedDedupWithSplits("Dedup_RepeatedWriteUntilWindowCloses_DoubleSplit", TDuration::Seconds(47), 4, {.Count = 2, .PauseBetween = TDuration::Seconds(80)});
+}
 
 }
 
 } // namespace NKikimr::NPQ::NMLP
+
+
+template <>
+void Out<NKikimr::NPQ::NMLP::TWriteResult>(IOutputStream& os, const NKikimr::NPQ::NMLP::TWriteResult& w) {
+    os << "{";
+    os << "Status=" << w.Status << ", ";
+    os << "MessageId=" << w.MessageId.PartitionId << "-" << w.MessageId.Offset << ", ";
+    os << "StageIdx=" << w.StageIdx << ", ";
+    os << "WriteTimestampOffset=" << w.WriteTimestampOffset;
+    os << "}";
+}
+
+template <>
+void Out<NKikimr::NPQ::NMLP::TDedupWriteSpec>(IOutputStream& os, const NKikimr::NPQ::NMLP::TDedupWriteSpec& w) {
+    os << "{";
+    os << "Body=" << w.Body << ", ";
+    os << "DedupId=" << w.DedupId << ", ";
+    os << "GroupId=" << w.GroupId;
+    os << "}";
+}

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
@@ -1475,28 +1475,55 @@ Y_UNIT_TEST(Dedup_MixedGroup_PartialOverlap) {
 }
 
 Y_UNIT_TEST(Dedup_DoubleSplit) {
-    if ("x-fail") {
-        // TODO: fix GetParentPartitions
-        return;
-    }
     RunDedupTest("Dedup_DoubleSplit", {
         {.Write = {
-            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
-            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
-            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-X"},
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
         }},
         {.Write = {
-            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
-            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-X"},
-            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-X"},
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
         }},
         {.Write = {
-            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-X"},
-            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-X"},
-            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-X"},
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
         }},
     });
 }
+
+Y_UNIT_TEST(Dedup_TripleSplit) {
+    RunDedupTest("Dedup_TripleSplit", {
+        {.Write = {
+            {.Body = "s0-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s0-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+            {.Body = "s0-dedupI", .DedupId = "dedupI", .GroupId = "group-I"},
+        }},
+        {.Write = {
+            {.Body = "s1-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s1-dedupB", .DedupId = "dedupB", .GroupId = "group-B"},
+            {.Body = "s1-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s0-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+        }},
+        {.Write = {
+            {.Body = "s2-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s2-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s2-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s0-dedupC", .DedupId = "dedupC", .GroupId = "group-C"},
+        }},
+        {.Write = {
+            {.Body = "s3-dedupA", .DedupId = "dedupA", .GroupId = "group-A"},
+            {.Body = "s3-dedupE", .DedupId = "dedupE", .GroupId = "group-E"},
+            {.Body = "s3-dedupF", .DedupId = "dedupF", .GroupId = "group-F"},
+            {.Body = "s3-dedupG", .DedupId = "dedupG", .GroupId = "group-G"},
+            {.Body = "s3-dedupH", .DedupId = "dedupH", .GroupId = "group-H"},
+        }},
+    });
+}
+
 
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -787,7 +787,7 @@ void TPartition::InitComplete(const TActorContext& ctx) {
         TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions;
         for (const auto& parentPartitionId : PartitionConfig->GetParentPartitionIds()) {
             const NKikimrPQ::TPQTabletConfig::TPartition* configPtr = NPQ::GetPartitionConfigFromAllPartitions(Config, parentPartitionId);
-            Y_VERIFY_S(configPtr != 0, "Unable to get partition #" << parentPartitionId << " config");
+            AFL_ENSURE(configPtr != nullptr)("parentPartitionId", parentPartitionId);
             if (configPtr) {
                 // TODO: check creation time of parent partitions
                 parentPartitions.push_back(*configPtr);

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/persqueue/pqtablet/common/logging.h>
 #include <ydb/core/persqueue/pqtablet/common/tracing_support.h>
 #include <ydb/core/persqueue/pqtablet/partition/autopartitioning_manager.h>
+#include <ydb/core/persqueue/pqtablet/partition/deduplication_write_queue.h>
 #include <ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer_factory.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
 #include <ydb/core/protos/counters_pq.pb.h>
@@ -689,6 +690,10 @@ void TPartition::DestroyActor(const TActorContext& ctx)
         Send(OffloadActor, new TEvents::TEvPoisonPill());
     }
 
+    if (DeduplicationQueueActor) {
+        Send(DeduplicationQueueActor, new TEvents::TEvPoisonPill());
+    }
+
     Die(ctx);
 }
 
@@ -777,6 +782,23 @@ void TPartition::InitComplete(const TActorContext& ctx) {
 
     if (MirroringEnabled(Config)) {
         CreateMirrorerActor();
+    }
+    if (PartitionConfig != nullptr && PartitionConfig->ParentPartitionIdsSize() > 0 && !IsSupportive()) {
+        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions;
+        for (const auto& parentPartitionId : PartitionConfig->GetParentPartitionIds()) {
+            const NKikimrPQ::TPQTabletConfig::TPartition* configPtr = NPQ::GetPartitionConfigFromAllPartitions(Config, parentPartitionId);
+            Y_VERIFY_S(configPtr != 0, "Unable to get partition #" << parentPartitionId << " config");
+            if (configPtr) {
+                // TODO: check creation time of parent partitions
+                parentPartitions.push_back(*configPtr);
+            }
+        }
+        DeduplicationQueueActor = ctx.Register(CreateDeduplicationWriteQueueActor(
+            ctx.SelfID,
+            TopicName(),
+            Partition.OriginalPartitionId,
+            std::move(parentPartitions)
+        ));
     }
 
     ProcessMLPPendingEvents();
@@ -4691,6 +4713,42 @@ void TPartition::ResetDetailedMetrics() {
 
 bool IsImportant(const NKikimrPQ::TPQTabletConfig::TConsumer& consumer) {
     return consumer.GetImportant() || consumer.GetType() == NKikimrPQ::TPQTabletConfig::CONSUMER_TYPE_MLP;
+}
+
+void TPartition::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest::TPtr& ev) {
+    auto& record = ev->Get()->Record;
+    const ui32 partitionId = record.GetPartitionId();
+    LOG_T("TEvCheckMessageDeduplicationRequest for partition " << partitionId
+        << ", deduplication IDs count: " << record.MessageDeduplicationIdSize()
+        << ". Topic: \"" << TopicName() << "\""
+        << ". Partition: " << Partition);
+   if (Partition.InternalPartitionId != partitionId) {
+        LOG_W("TEvCheckMessageDeduplicationRequest for wrong partition " << partitionId
+            << ". Topic: \"" << TopicName() << "\""
+            << ". Partition: " << Partition);
+        return;
+    }
+    auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();
+    response->Record.SetPartitionId(Partition.InternalPartitionId);
+    response->Record.SetGeneration(record.GetGeneration());
+    if (IsActive()) {
+        for (const auto& messageId : record.GetMessageDeduplicationId()) {
+            response->Record.MutableResult()->try_emplace(messageId);
+        }
+        response->Record.SetStatus(NKikimrPQ::EStatus::ERROR);
+        Send(ev->Sender, response.Release());
+        return;
+    }
+    for (const auto& messageId : record.GetMessageDeduplicationId()) {
+        std::optional offset = MessageIdDeduplicator.CheckMessageId(messageId);
+        auto& result = (*response->Record.MutableResult())[messageId];
+        result.SetIsDuplicate(offset.has_value());
+        if (offset.has_value()) {
+            result.SetOffset(*offset);
+        }
+    }
+    response->Record.SetStatus(NKikimrPQ::EStatus::OK);
+    Send(ev->Sender, response.Release());
 }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -784,15 +784,17 @@ void TPartition::InitComplete(const TActorContext& ctx) {
         CreateMirrorerActor();
     }
     if (PartitionConfig != nullptr && PartitionConfig->ParentPartitionIdsSize() > 0 && !IsSupportive()) {
-        // TODO: check creation time of parent partitions
-        DeduplicationQueueActor = ctx.Register(CreateDeduplicationWriteQueueActor(
+        TCreateDeduplicationWriteQueueActorResult writeQueue = CreateDeduplicationWriteQueueActor(
             this->TabletId,
             this->TabletActorId,
             ctx.SelfID,
             TopicName(),
             Partition.OriginalPartitionId,
             PartitionGraph
-        ));
+        );
+        if (writeQueue.RecentPartitionsCount != 0 && writeQueue.Actor) {
+            DeduplicationQueueActor = ctx.Register(writeQueue.Actor.Release());
+        }
     }
 
     ProcessMLPPendingEvents();

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -784,22 +784,14 @@ void TPartition::InitComplete(const TActorContext& ctx) {
         CreateMirrorerActor();
     }
     if (PartitionConfig != nullptr && PartitionConfig->ParentPartitionIdsSize() > 0 && !IsSupportive()) {
-        TVector<NKikimrPQ::TPQTabletConfig::TPartition> parentPartitions;
-        for (const auto& parentPartitionId : PartitionConfig->GetParentPartitionIds()) {
-            const NKikimrPQ::TPQTabletConfig::TPartition* configPtr = NPQ::GetPartitionConfigFromAllPartitions(Config, parentPartitionId);
-            AFL_ENSURE(configPtr != nullptr)("parentPartitionId", parentPartitionId);
-            if (configPtr) {
-                // TODO: check creation time of parent partitions
-                parentPartitions.push_back(*configPtr);
-            }
-        }
+        // TODO: check creation time of parent partitions
         DeduplicationQueueActor = ctx.Register(CreateDeduplicationWriteQueueActor(
             this->TabletId,
             this->TabletActorId,
             ctx.SelfID,
             TopicName(),
             Partition.OriginalPartitionId,
-            std::move(parentPartitions)
+            PartitionGraph
         ));
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -794,6 +794,8 @@ void TPartition::InitComplete(const TActorContext& ctx) {
             }
         }
         DeduplicationQueueActor = ctx.Register(CreateDeduplicationWriteQueueActor(
+            this->TabletId,
+            this->TabletActorId,
             ctx.SelfID,
             TopicName(),
             Partition.OriginalPartitionId,

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -1294,6 +1294,7 @@ private:
     TMessageIdDeduplicator MessageIdDeduplicator;
     bool AddMessageDeduplicatorKeys(TEvKeyValue::TEvRequest* request);
     std::optional<ui64> DeduplicateByMessageId(const TEvPQ::TEvWrite::TMsg& msg, const ui64 offset);
+    bool ShouldUseDeduplicationQueue() const;
     TActorId DeduplicationQueueActor;
 
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -513,6 +513,7 @@ private:
     // void DestroyReadSession(const TReadSessionKey& key);
 
     void Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest::TPtr& ev);
 
     void ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus);
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
@@ -640,6 +641,7 @@ private:
             hFuncTraced(TEvPQ::TEvMLPConsumerMonRequest, Handle);
             hFuncTraced(TEvPQ::TEvMLPConsumerStatus, Handle);
             hFuncTraced(TEvPQ::TEvMLPUpdateExternalLockedMessageGroupsId, Handle);
+            hFuncTraced(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest, Handle);
         default:
             if (!Initializer.Handle(ev)) {
                 ALOG_ERROR(NKikimrServices::PERSQUEUE, "Unexpected " << EventStr("StateInit", ev));
@@ -720,6 +722,7 @@ private:
             hFuncTraced(TEvPQ::TEvMLPConsumerMonRequest, Handle);
             hFuncTraced(TEvPQ::TEvMLPConsumerStatus, Handle);
             hFuncTraced(TEvPQ::TEvMLPUpdateExternalLockedMessageGroupsId, Handle);
+            hFuncTraced(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest, Handle);
         default:
             ALOG_ERROR(NKikimrServices::PERSQUEUE, "Unexpected " << EventStr("StateIdle", ev));
             break;
@@ -1291,6 +1294,8 @@ private:
     TMessageIdDeduplicator MessageIdDeduplicator;
     bool AddMessageDeduplicatorKeys(TEvKeyValue::TEvRequest* request);
     std::optional<ui64> DeduplicateByMessageId(const TEvPQ::TEvWrite::TMsg& msg, const ui64 offset);
+    TActorId DeduplicationQueueActor;
+
 
     bool IsCommitOffsetForbiddenForMLPConsumer(const TString& consumer, bool explicitMLPAction) const;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -1322,8 +1322,8 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
 
     std::optional<ui64> deduplicationResult;
     if (p.Msg.ExternalDeduplicationInfo.Status == TEvPQ::TEvWrite::EMessageExternalDeduplicationStatus::Duplicate) {
-        if (const auto po = p.Msg.ExternalDeduplicationInfo.OriginalPartitionAndOffset; po.has_value()) {
-            deduplicationResult = po->second;
+        if (const auto originalMessage = p.Msg.ExternalDeduplicationInfo.OriginalPartitionAndOffset; originalMessage.has_value()) {
+            deduplicationResult = originalMessage->Offset;
         } else {
             Y_VERIFY_DEBUG_S(false, "Duplicate has no source info");
             deduplicationResult = 0;

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -641,11 +641,17 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
         return;
     }
 
+    const bool mirroredPartition = MirroringEnabled(Config);
+
+    if (DeduplicationQueueActor && !mirroredPartition && ev->Get()->ExternalDeduplicationStatus == TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked) {
+        LOG_D("Forwarding TPartition::TEvWrite to DeduplicationQueueActor");
+        Forward(ev, DeduplicationQueueActor);
+        return;
+    }
+
     ui32 sz = std::accumulate(ev->Get()->Msgs.begin(), ev->Get()->Msgs.end(), 0u, [](ui32 sum, const TEvPQ::TEvWrite::TMsg& msg) {
         return sum + msg.Data.size();
     });
-
-    bool mirroredPartition = MirroringEnabled(Config);
 
     if (mirroredPartition && !ev->Get()->OwnerCookie.empty()) {
         ReplyError(ctx, ev->Get()->Cookie, NPersQueue::NErrorCode::BAD_REQUEST,
@@ -678,6 +684,13 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
         if (it->second.OwnerCookie != ev->Get()->OwnerCookie) {
             ReplyError(ctx, ev->Get()->Cookie, NPersQueue::NErrorCode::WRONG_COOKIE,
                         TStringBuilder() << "incorrect ownerCookie " << ev->Get()->OwnerCookie << ", must be " << it->second.OwnerCookie);
+            return;
+        }
+
+        if (ev->Get()->ExternalDeduplicationStatus == TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Error) {
+            ReplyError(ctx, ev->Get()->Cookie, NPersQueue::NErrorCode::BAD_REQUEST,
+                TStringBuilder() << "Unable to check duplication info in parent partition");
+            DropOwner(it, ctx);
             return;
         }
 
@@ -1298,7 +1311,17 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
         curOffset = poffset;
     }
 
-    auto deduplicationResult = DeduplicateByMessageId(p.Msg, curOffset);
+    std::optional<ui64> deduplicationResult;
+    if (p.Msg.ExternalDeduplicationInfo.Status == TEvPQ::TEvWrite::EMessageExternalDeduplicationStatus::Duplicate) {
+        if (const auto po = p.Msg.ExternalDeduplicationInfo.OriginalPartitionAndOffset; po.has_value()) {
+            deduplicationResult = po->second;
+        } else {
+            Y_VERIFY_DEBUG_S(false, "Duplicate has no source info");
+            deduplicationResult = 0;
+        }
+    } else {
+        deduplicationResult = DeduplicateByMessageId(p.Msg, curOffset);
+    }
     if (deduplicationResult) {
         LOG_D("Deduplicate message " << p.Msg.SeqNo << " by MessageDeduplicationId");
         p.DeduplicatedByMessageId = true;

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -221,6 +221,11 @@ void TPartition::UpdateWriteBufferIsFullState(const TInstant& now) {
 void TPartition::Handle(TEvPQ::TEvReserveBytes::TPtr& ev, const TActorContext& ctx) {
     LOG_T("TPartition::HandleOnWrite TEvReserveBytes.");
 
+    if (ShouldUseDeduplicationQueue() && !ev->Get()->FromDeduplicatedQueue) {
+        Forward(ev, DeduplicationQueueActor);
+        return;
+    }
+
     const TString& ownerCookie = ev->Get()->OwnerCookie;
     TStringBuf owner = TOwnerInfo::GetOwnerFromOwnerCookie(ownerCookie);
     const ui64& messageNo = ev->Get()->MessageNo;
@@ -632,6 +637,10 @@ void TPartition::ChangeScaleStatusIfNeeded(NKikimrPQ::EScaleStatus scaleStatus) 
     Send(TabletActorId, std::move(ev));
 }
 
+bool TPartition::ShouldUseDeduplicationQueue() const {
+    return DeduplicationQueueActor && !MirroringEnabled(Config);
+}
+
 void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& ctx) {
     LOG_D("Received TPartition::TEvWrite");
 
@@ -643,7 +652,7 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
 
     const bool mirroredPartition = MirroringEnabled(Config);
 
-    if (DeduplicationQueueActor && !mirroredPartition && ev->Get()->ExternalDeduplicationStatus == TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked) {
+    if (ShouldUseDeduplicationQueue() && ev->Get()->ExternalDeduplicationStatus == TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked) {
         LOG_D("Forwarding TPartition::TEvWrite to DeduplicationQueueActor");
         Forward(ev, DeduplicationQueueActor);
         return;

--- a/ydb/core/persqueue/pqtablet/partition/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ya.make
@@ -50,6 +50,8 @@ PEERDIR(
     ydb/library/persqueue/topic_parser
 )
 
+GENERATE_ENUM_SERIALIZATION(deduplication_write_queue.h)
+
 END()
 
 RECURSE(

--- a/ydb/core/persqueue/pqtablet/partition/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ya.make
@@ -4,6 +4,7 @@ SRCS(
     autopartitioning_manager.cpp
     partitioning_keys_manager.cpp
     consumer_offset_tracker.cpp
+    deduplication_write_queue.cpp
     message_id_deduplicator.cpp
     offload_actor.cpp
     ownerinfo.cpp

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -1240,6 +1240,7 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
 
     if (!partitionId.IsSupportivePartition()) {
         ProcessCheckPartitionStatusRequests(partitionId);
+        ProcessCheckMessageDeduplicationRequests(partitionId);
     }
 
     if (allInitialized) {
@@ -2115,10 +2116,16 @@ void TPersQueue::HandleWriteRequest(const ui64 responseCookie, NWilson::TTraceId
         initialSeqNo = req.GetInitialSeqNo();
     }
     THolder<TEvPQ::TEvWrite> event =
-        MakeHolder<TEvPQ::TEvWrite>(responseCookie, req.GetMessageNo(),
-                                    req.HasOwnerCookie() ? req.GetOwnerCookie() : "",
-                                    req.HasCmdWriteOffset() ? req.GetCmdWriteOffset() : TMaybe<ui64>(),
-                                    std::move(msgs), req.GetIsDirectWrite(), initialSeqNo);
+        MakeHolder<TEvPQ::TEvWrite>(
+            responseCookie,
+            req.GetMessageNo(),
+            req.HasOwnerCookie() ? req.GetOwnerCookie() : "",
+            req.HasCmdWriteOffset() ? req.GetCmdWriteOffset() : TMaybe<ui64>(),
+            std::move(msgs),
+            req.GetIsDirectWrite(),
+            initialSeqNo,
+            TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked
+        );
     ctx.Send(partActor, event.Release(), 0, 0, std::move(traceId));
 }
 
@@ -5228,6 +5235,20 @@ void TPersQueue::ProcessCheckPartitionStatusRequests(const TPartitionId& partiti
     }
 }
 
+void TPersQueue::ProcessCheckMessageDeduplicationRequests(const TPartitionId& partitionId)
+{
+    PQ_ENSURE(!partitionId.WriteId.Defined());
+    ui32 originalPartitionId = partitionId.OriginalPartitionId;
+    auto sit = CheckMessageDeduplicationRequests.find(originalPartitionId);
+    if (sit != CheckMessageDeduplicationRequests.end()) {
+        auto it = Partitions.find(partitionId);
+        for (auto& r : sit->second) {
+            Forward(r, it->second.Actor);
+        }
+        CheckMessageDeduplicationRequests.erase(sit);
+    }
+}
+
 void TPersQueue::Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev)
 {
     PQ_LOG_TX_D("Handle TEvLongTxService::TEvLockStatus " << ev->Get()->Record.ShortDebugString());
@@ -5481,6 +5502,29 @@ void TPersQueue::Handle(TEvPQ::TEvMLPUpdateExternalLockedMessageGroupsId::TPtr& 
     ForwardToPartition(ev->Get()->GetPartitionId(), ev);
 }
 
+void TPersQueue::Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest::TPtr& ev) {
+    auto& record = ev->Get()->Record;
+    auto partitionId = record.GetPartitionId();
+    auto* p = Partitions.FindPtr(TPartitionId{partitionId});
+    if (p == nullptr) [[unlikely]] {
+        PQ_LOG_I("TEvCheckMessageDeduplicationRequest: unknown partition " << partitionId);
+        auto response = MakeHolder<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationResponse>();
+        response->Record.SetPartitionId(partitionId);
+        response->Record.SetGeneration(record.GetGeneration());
+        response->Record.SetStatus(NKikimrPQ::EStatus::ERROR);
+        for (const auto& messageId : record.GetMessageDeduplicationId()) {
+            response->Record.MutableResult()->try_emplace(messageId);
+        }
+        Send(ev->Sender, response.Release());
+        return;
+    }
+    if (!p->InitDone) [[unlikely]] {
+        CheckMessageDeduplicationRequests[partitionId].push_back(std::move(ev));
+        return;
+    }
+    Forward(ev, p->Actor);
+}
+
 template<typename TEventHandle>
 bool TPersQueue::ForwardToPartition(ui32 partitionId, TAutoPtr<TEventHandle>& ev) {
     auto it = Partitions.find(TPartitionId{partitionId});
@@ -5568,6 +5612,7 @@ bool TPersQueue::HandleHook(STFUNC_SIG)
         hFuncTraced(TEvPQ::TEvGetMLPConsumerStateRequest, Handle);
         hFuncTraced(TEvPQ::TEvMLPConsumerStatus, Handle);
         hFuncTraced(TEvPQ::TEvMLPUpdateExternalLockedMessageGroupsId, Handle);
+        hFuncTraced(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest, Handle);
         default:
             return false;
     }

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -104,6 +104,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     void Handle(TEvPQ::TEvGetMLPConsumerStateRequest::TPtr&);
     void Handle(TEvPQ::TEvMLPConsumerStatus::TPtr&);
     void Handle(TEvPQ::TEvMLPUpdateExternalLockedMessageGroupsId::TPtr&);
+    void Handle(NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest::TPtr&);
 
     template<typename TEventHandle>
     bool ForwardToPartition(ui32 partitionId, TAutoPtr<TEventHandle>& ev);
@@ -201,6 +202,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
 
     void Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const TActorContext& ctx);
     void ProcessCheckPartitionStatusRequests(const TPartitionId& partitionId);
+    void ProcessCheckMessageDeduplicationRequests(const TPartitionId& partitionId);
 
     void Handle(TEvPQ::TEvPartitionScaleStatusChanged::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPQ::TBroadcastPartitionError::TPtr& ev, const TActorContext& ctx);
@@ -524,6 +526,7 @@ private:
     void ProcessStatusRequests(const TActorContext &ctx);
 
     THashMap<ui32, TVector<TEvPQ::TEvCheckPartitionStatusRequest::TPtr>> CheckPartitionStatusRequests;
+    THashMap<ui32, TVector<NKikimr::TEvPersQueue::TEvCheckMessageDeduplicationRequest::TPtr>> CheckMessageDeduplicationRequests;
     TMaybe<ui64> TabletGeneration;
 
     TMaybe<TPartitionId> FindPartitionId(const NKikimrPQ::TDataTransaction& txBody) const;

--- a/ydb/core/persqueue/public/utils.cpp
+++ b/ydb/core/persqueue/public/utils.cpp
@@ -284,7 +284,7 @@ std::unordered_map<ui32, TPartitionGraph::Node> BuildGraph(const TCollection& pa
     }
 
     for (const auto& p : partitions) {
-        result.emplace(GetPartitionId(p), TPartitionGraph::Node(GetPartitionId(p), p.GetTabletId(), p.GetKeyRange().GetFromBound(), p.GetKeyRange().GetToBound(), TInstant::Seconds(p.GetCreationTimestamp())));
+        result.emplace(GetPartitionId(p), TPartitionGraph::Node(GetPartitionId(p), p.GetTabletId(), p.GetKeyRange().GetFromBound(), p.GetKeyRange().GetToBound(), TInstant::Seconds(p.GetCreationTimestampSeconds())));
     }
 
     std::deque<TPartitionGraph::Node*> queue;

--- a/ydb/core/persqueue/public/utils.cpp
+++ b/ydb/core/persqueue/public/utils.cpp
@@ -284,7 +284,7 @@ std::unordered_map<ui32, TPartitionGraph::Node> BuildGraph(const TCollection& pa
     }
 
     for (const auto& p : partitions) {
-        result.emplace(GetPartitionId(p), TPartitionGraph::Node(GetPartitionId(p), p.GetTabletId(), p.GetKeyRange().GetFromBound(), p.GetKeyRange().GetToBound()));
+        result.emplace(GetPartitionId(p), TPartitionGraph::Node(GetPartitionId(p), p.GetTabletId(), p.GetKeyRange().GetFromBound(), p.GetKeyRange().GetToBound(), TInstant::Seconds(p.GetCreationTimestamp())));
     }
 
     std::deque<TPartitionGraph::Node*> queue;
@@ -346,11 +346,13 @@ std::unordered_map<ui32, TPartitionGraph::Node> BuildGraph(const TCollection& pa
     return result;
 }
 
-TPartitionGraph::Node::Node(ui32 id, ui64 tabletId, const TString& from, const TString& to)
+TPartitionGraph::Node::Node(ui32 id, ui64 tabletId, const TString& from, const TString& to, TInstant creationTime)
     : Id(id)
     , TabletId(tabletId)
     , From(from)
-    , To(to) {
+    , To(to)
+    , CreationTime(creationTime)
+{
 }
 
 bool TPartitionGraph::Node::IsRoot() const {

--- a/ydb/core/persqueue/public/utils.h
+++ b/ydb/core/persqueue/public/utils.h
@@ -43,12 +43,13 @@ public:
         Node() = default;
         Node(Node&&) = default;
         Node(ui32 id, ui64 tabletId);
-        Node(ui32 id, ui64 tabletId, const TString& from, const TString& to);
+        Node(ui32 id, ui64 tabletId, const TString& from, const TString& to, TInstant creationTime);
 
         ui32 Id;
         ui64 TabletId;
         TString From;
         TString To;
+        TInstant CreationTime;
 
         // Direct parents of this node
         std::vector<Node*> DirectParents;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -679,7 +679,7 @@ void TPartitionFixture::SendWrite
     TVector<TEvPQ::TEvWrite::TMsg> msgs;
     msgs.push_back(msg);
 
-    auto event = MakeHolder<TEvPQ::TEvWrite>(cookie, messageNo, ownerCookie, offset, std::move(msgs), isDirectWrite, std::nullopt);
+    auto event = MakeHolder<TEvPQ::TEvWrite>(cookie, messageNo, ownerCookie, offset, std::move(msgs), isDirectWrite, std::nullopt, TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked);
     Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
 }
 
@@ -1868,7 +1868,7 @@ ui64 TPartitionTxTestHelper::AddAndSendNormalWrite(
             msgs.push_back(makeMsg( sourceId, seqNo));
         }
     }
-    auto event = MakeHolder<TEvPQ::TEvWrite>(id, messageNo, act.OwnerCookie, id * 10, std::move(msgs), false, std::nullopt);
+    auto event = MakeHolder<TEvPQ::TEvWrite>(id, messageNo, act.OwnerCookie, id * 10, std::move(msgs), false, std::nullopt, TEvPQ::TEvWrite::EWriteExternalDeduplicationStatus::Unchecked);
     SendEvent(event.Release());
     UserActs.emplace(id, act);
     messageNo++;

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1445,7 +1445,7 @@ message TPersQueueGroupAllocate {
         optional NKikimrPQ.ETopicPartitionStatus Status = 6;
         repeated uint32 ParentPartitionIds = 7;
         optional NKikimrPQ.TPartitionKeyRange KeyRange = 10;
-        optional uint64 CreationTimestamp = 11;
+        optional uint64 CreationTimestampSeconds = 11;
     }
 
     optional string Name = 1;
@@ -1476,7 +1476,7 @@ message TPersQueueGroupDescription {
         optional NKikimrPQ.ETopicPartitionStatus Status = 4;
         repeated uint32 ParentPartitionIds = 5;
         repeated uint32 ChildPartitionIds = 6;
-        optional uint64 CreationTimestamp = 7;
+        optional uint64 CreationTimestampSeconds = 7;
     }
 
     optional string Name = 1; // mandatory

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1445,6 +1445,7 @@ message TPersQueueGroupAllocate {
         optional NKikimrPQ.ETopicPartitionStatus Status = 6;
         repeated uint32 ParentPartitionIds = 7;
         optional NKikimrPQ.TPartitionKeyRange KeyRange = 10;
+        optional uint64 CreationTimestamp = 11;
     }
 
     optional string Name = 1;
@@ -1475,6 +1476,7 @@ message TPersQueueGroupDescription {
         optional NKikimrPQ.ETopicPartitionStatus Status = 4;
         repeated uint32 ParentPartitionIds = 5;
         repeated uint32 ChildPartitionIds = 6;
+        optional uint64 CreationTimestamp = 7;
     }
 
     optional string Name = 1; // mandatory

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -442,6 +442,7 @@ message TPQTabletConfig {
         repeated uint32 ChildPartitionIds = 5;
         optional uint64 CreateVersion = 6;
         optional uint64 TabletId = 7;
+        optional uint64 CreationTimestamp = 8;
     }
     repeated TPartition Partitions = 31; // filled by schemeshard
 

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -442,7 +442,7 @@ message TPQTabletConfig {
         repeated uint32 ChildPartitionIds = 5;
         optional uint64 CreateVersion = 6;
         optional uint64 TabletId = 7;
-        optional uint64 CreationTimestamp = 8;
+        optional uint64 CreationTimestampSeconds = 8;
     }
     repeated TPartition Partitions = 31; // filled by schemeshard
 

--- a/ydb/core/protos/pqevents_global.proto
+++ b/ydb/core/protos/pqevents_global.proto
@@ -37,6 +37,7 @@ message TUpdateBalancerConfig { //for schemeshard use only
         repeated uint32 ParentPartitionIds = 6;
         repeated uint32 ChildPartitionIds = 7;
         optional uint64 CreateVersion = 8;
+        optional uint64 CreationTimestamp = 9;
     }
 
     repeated TPartition Partitions = 6;

--- a/ydb/core/protos/pqevents_global.proto
+++ b/ydb/core/protos/pqevents_global.proto
@@ -306,3 +306,20 @@ message TEvBalancingSubscribeNotify {
     optional string Consumer = 4;
     optional EStatus Status = 5;
 }
+
+message TEvCheckMessageDeduplicationRequest {
+    optional uint32 PartitionId = 1;
+    optional uint32 Generation = 2;
+    repeated string MessageDeduplicationId = 3;
+}
+
+message TEvCheckMessageDeduplicationResponse {
+    optional uint32 PartitionId = 1;
+    optional uint32 Generation = 2;
+    message TMessageDeduplicationResult {
+        optional bool IsDuplicate = 1;
+        optional uint64 Offset = 2;
+    }
+    optional EStatus Status = 3;
+    map<string, TMessageDeduplicationResult> Result = 4;
+}

--- a/ydb/core/protos/pqevents_global.proto
+++ b/ydb/core/protos/pqevents_global.proto
@@ -37,7 +37,7 @@ message TUpdateBalancerConfig { //for schemeshard use only
         repeated uint32 ParentPartitionIds = 6;
         repeated uint32 ChildPartitionIds = 7;
         optional uint64 CreateVersion = 8;
-        optional uint64 CreationTimestamp = 9;
+        optional uint64 CreationTimestampSeconds = 9;
     }
 
     repeated TPartition Partitions = 6;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2682,8 +2682,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     pqInfo->ParentPartitionIds.insert(rowset.GetValue<Schema::PersQueues::AdjacentParent>());
                 }
 
-                if (rowset.HaveValue<Schema::PersQueues::CreationTimestamp>()) {
-                    pqInfo->CreationTimestamp = TInstant::Seconds(rowset.GetValue<Schema::PersQueues::CreationTimestamp>());
+                if (rowset.HaveValue<Schema::PersQueues::CreationTimestampSeconds>()) {
+                    pqInfo->CreationTimestamp = TInstant::Seconds(rowset.GetValue<Schema::PersQueues::CreationTimestampSeconds>());
                 }
 
                 auto it = Self->Topics.find(pathId);

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2683,7 +2683,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (rowset.HaveValue<Schema::PersQueues::CreationTimestamp>()) {
-                    pqInfo->CreationTimestamp = rowset.GetValue<Schema::PersQueues::CreationTimestamp>();
+                    pqInfo->CreationTimestamp = TInstant::Seconds(rowset.GetValue<Schema::PersQueues::CreationTimestamp>());
                 }
 
                 auto it = Self->Topics.find(pathId);

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2683,7 +2683,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (rowset.HaveValue<Schema::PersQueues::CreationTimestamp>()) {
-                    pqInfo->CreationTimestamp = TInstant::Seconds(rowset.GetValue<Schema::PersQueues::CreationTimestamp>());
+                    pqInfo->CreationTimestamp = rowset.GetValue<Schema::PersQueues::CreationTimestamp>();
                 }
 
                 auto it = Self->Topics.find(pathId);

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2682,6 +2682,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     pqInfo->ParentPartitionIds.insert(rowset.GetValue<Schema::PersQueues::AdjacentParent>());
                 }
 
+                if (rowset.HaveValue<Schema::PersQueues::CreationTimestamp>()) {
+                    pqInfo->CreationTimestamp = TInstant::Seconds(rowset.GetValue<Schema::PersQueues::CreationTimestamp>());
+                }
+
                 auto it = Self->Topics.find(pathId);
                 Y_ABORT_UNLESS(it != Self->Topics.end());
                 Y_ABORT_UNLESS(it->second);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
@@ -516,6 +516,7 @@ public:
             partition->AlterVersion = alterVersion;
             partition->CreateVersion = alterVersion;
             partition->Status = NKikimrPQ::ETopicPartitionStatus::Active;
+            partition->CreationTimestamp = TInstant::Seconds(TAppData::TimeProvider->Now().Seconds());
             for (const auto parent : p.ParentPartitionIds) {
                 partition->ParentPartitionIds.emplace(parent);
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
@@ -41,6 +41,9 @@ void FillPartition(NKikimrPQ::TPQTabletConfig::TPartition& partition, const TTop
         partition.MutableChildPartitionIds()->AddAlreadyReserved(children);
     }
     partition.SetTabletId(tabletId);
+    if (pq->CreationTimestamp) {
+        partition.SetCreationTimestamp(pq->CreationTimestamp.Seconds());
+    }
 }
 
 struct TPartitionsGraphTraverse {
@@ -579,6 +582,9 @@ bool TConfigureParts::ProgressState(TOperationContext& context) {
                     info->MutableChildPartitionIds()->Reserve(pq->ChildPartitionIds.size());
                     for (const auto children : pq->ChildPartitionIds) {
                         info->MutableChildPartitionIds()->AddAlreadyReserved(children);
+                    }
+                    if (pq->CreationTimestamp) {
+                        info->SetCreationTimestamp(pq->CreationTimestamp.Seconds());
                     }
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
@@ -5,7 +5,7 @@
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/protos/pqdata_transaction.pb.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
-
+#include <library/cpp/iterator/iterate_keys.h>
 
 namespace NKikimr::NSchemeShard::NPQState {
 
@@ -43,6 +43,47 @@ void FillPartition(NKikimrPQ::TPQTabletConfig::TPartition& partition, const TTop
     partition.SetTabletId(tabletId);
 }
 
+struct TPartitionsGraphTraverse {
+    const TTopicInfo& PqGroup;
+    using TVisitedMap = THashMap<ui32, bool>;
+    TVector<ui32> Queue;
+    TVisitedMap Visited;
+
+    explicit TPartitionsGraphTraverse(const TTopicInfo& pqGroup)
+        : PqGroup(pqGroup)
+    {}
+
+    void Add(ui32 partitionId) {
+        if (!PqGroup.Partitions.contains(partitionId)) {
+            return;
+        }
+        auto [_, ins] = Visited.emplace(partitionId, false);
+        if (ins) {
+            Queue.push_back(partitionId);
+        }
+    }
+
+    auto Traverse() Y_LIFETIME_BOUND {
+        while (!Queue.empty()) {
+            const ui32 partitionId = Queue.back();
+            Queue.pop_back();
+            auto& visited = Visited[partitionId];
+            if (std::exchange(visited, true)) {
+                continue;
+            }
+            auto it = PqGroup.Partitions.FindPtr(partitionId);
+            if (it == nullptr) {
+                continue;
+            }
+            for (ui32 pp : (*it)->ParentPartitionIds) {
+                Add(pp);
+            }
+        }
+        return IterateKeys(Visited);
+    }
+};
+
+
 void MakePQTabletConfig(const TOperationContext& context,
                                 NKikimrPQ::TPQTabletConfig& config,
                                 const TTopicInfo& pqGroup,
@@ -72,6 +113,7 @@ void MakePQTabletConfig(const TOperationContext& context,
     }
 
     THashSet<ui32> linkedPartitions;
+    TPartitionsGraphTraverse parentPartitions(pqGroup);
 
     for(const auto& pq : pqShard.Partitions) {
         config.AddPartitionIds(pq->PqId);
@@ -89,6 +131,10 @@ void MakePQTabletConfig(const TOperationContext& context,
             }
             linkedPartitions.insert(it->second->ParentPartitionIds.begin(), it->second->ParentPartitionIds.end());
         }
+        parentPartitions.Add(pq->PqId);
+    }
+    for (const ui32 p : parentPartitions.Traverse()) {
+        linkedPartitions.insert(p);
     }
 
     for(auto lp : linkedPartitions) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
@@ -42,7 +42,7 @@ void FillPartition(NKikimrPQ::TPQTabletConfig::TPartition& partition, const TTop
     }
     partition.SetTabletId(tabletId);
     if (pq->CreationTimestamp) {
-        partition.SetCreationTimestamp(pq->CreationTimestamp.Seconds());
+        partition.SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
     }
 }
 
@@ -584,7 +584,7 @@ bool TConfigureParts::ProgressState(TOperationContext& context) {
                         info->MutableChildPartitionIds()->AddAlreadyReserved(children);
                     }
                     if (pq->CreationTimestamp) {
-                        info->SetCreationTimestamp(pq->CreationTimestamp.Seconds());
+                        info->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
                     }
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -243,6 +243,7 @@ void ApplySharding(TTxId txId,
         partition->AlterVersion = 1;
         partition->CreateVersion = 1;
         partition->Status = NKikimrPQ::ETopicPartitionStatus::Active;
+        partition->CreationTimestamp = TInstant::Seconds(TAppData::TimeProvider->Now().Seconds());
 
         pqGroup->AddPartition(idx, partition.Release());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3212,7 +3212,7 @@ void TSchemeShard::PersistPersQueue(NIceDb::TNiceDb &db, TPathId pathId, TShardI
 
     if (partitionInfo.CreationTimestamp) {
         db.Table<Schema::PersQueues>().Key(pathId.LocalPathId, partitionInfo.PqId).Update(
-            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp.Seconds()));
+            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp));
     }
 
     if (partitionInfo.KeyRange) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3212,7 +3212,7 @@ void TSchemeShard::PersistPersQueue(NIceDb::TNiceDb &db, TPathId pathId, TShardI
 
     if (partitionInfo.CreationTimestamp) {
         db.Table<Schema::PersQueues>().Key(pathId.LocalPathId, partitionInfo.PqId).Update(
-            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp));
+            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp.Seconds()));
     }
 
     if (partitionInfo.KeyRange) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3212,7 +3212,7 @@ void TSchemeShard::PersistPersQueue(NIceDb::TNiceDb &db, TPathId pathId, TShardI
 
     if (partitionInfo.CreationTimestamp) {
         db.Table<Schema::PersQueues>().Key(pathId.LocalPathId, partitionInfo.PqId).Update(
-            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp.Seconds()));
+            NIceDb::TUpdate<Schema::PersQueues::CreationTimestampSeconds>(partitionInfo.CreationTimestamp.Seconds()));
     }
 
     if (partitionInfo.KeyRange) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3210,6 +3210,11 @@ void TSchemeShard::PersistPersQueue(NIceDb::TNiceDb &db, TPathId pathId, TShardI
                 NIceDb::TUpdate<Schema::PersQueues::Parent>(parent),
                 NIceDb::TUpdate<Schema::PersQueues::AdjacentParent>(adjacentParent));
 
+    if (partitionInfo.CreationTimestamp) {
+        db.Table<Schema::PersQueues>().Key(pathId.LocalPathId, partitionInfo.PqId).Update(
+            NIceDb::TUpdate<Schema::PersQueues::CreationTimestamp>(partitionInfo.CreationTimestamp.Seconds()));
+    }
+
     if (partitionInfo.KeyRange) {
         if (partitionInfo.KeyRange->FromBound) {
             db.Table<Schema::PersQueues>().Key(pathId.LocalPathId, partitionInfo.PqId).Update(

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1274,6 +1274,7 @@ struct TTopicTabletInfo : TSimpleRefCount<TTopicTabletInfo> {
         TSet<ui32> ChildPartitionIds;
 
         TShardIdx ShardIdx;
+        TInstant CreationTimestamp;
 
         void SetStatus(const TActorContext& ctx, ui32 value) {
             if (value >= NKikimrPQ::ETopicPartitionStatus::Active &&

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -692,7 +692,7 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                     partition.AddChildPartitionIds(child);
                 }
                 if (desc.Info->CreationTimestamp) {
-                    partition.SetCreationTimestamp(desc.Info->CreationTimestamp.Seconds());
+                    partition.SetCreationTimestampSeconds(desc.Info->CreationTimestamp.Seconds());
                 }
             }
 
@@ -733,7 +733,7 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                         pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
                     }
                     if (pq->CreationTimestamp) {
-                        partition->SetCreationTimestamp(pq->CreationTimestamp.Seconds());
+                        partition->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
                     }
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -691,6 +691,9 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                 for (const auto child : desc.Info->ChildPartitionIds) {
                     partition.AddChildPartitionIds(child);
                 }
+                if (desc.Info->CreationTimestamp) {
+                    partition.SetCreationTimestamp(desc.Info->CreationTimestamp.Seconds());
+                }
             }
 
             Y_PROTOBUF_SUPPRESS_NODISCARD preSerializedResult.SerializeToString(&pqGroupInfo->PreSerializedPartitionsDescription);
@@ -728,6 +731,9 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                     }
                     if (pq->KeyRange) {
                         pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
+                    }
+                    if (pq->CreationTimestamp) {
+                        partition->SetCreationTimestamp(pq->CreationTimestamp.Seconds());
                     }
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -512,11 +512,23 @@ struct Schema : NIceDb::Schema {
         struct Parent:          Column<10, NScheme::NTypeIds::Uint32> {};
         // Adjacent parent partition for merge operation
         struct AdjacentParent:  Column<11, NScheme::NTypeIds::Uint32> {};
-        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Uint64> {};
+        struct CreationTimestampSeconds: Column<12, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<PathId, PqId>;
-        using TColumns = TableColumns<PathId, PqId, ShardIdx, AlterVersion, GroupId, RangeBegin, RangeEnd,
-                                      CreateVersion, Status, Parent, AdjacentParent, CreationTimestamp>;
+        using TColumns = TableColumns<
+            PathId,
+            PqId,
+            ShardIdx,
+            AlterVersion,
+            GroupId,
+            RangeBegin,
+            RangeEnd,
+            CreateVersion,
+            Status,
+            Parent,
+            AdjacentParent,
+            CreationTimestampSeconds
+        >;
     };
 
     struct RtmrVolumes : Table<20> {

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -512,11 +512,23 @@ struct Schema : NIceDb::Schema {
         struct Parent:          Column<10, NScheme::NTypeIds::Uint32> {};
         // Adjacent parent partition for merge operation
         struct AdjacentParent:  Column<11, NScheme::NTypeIds::Uint32> {};
-        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Uint64> {};
+        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Timestamp> { using Type = TInstant; };
 
         using TKey = TableKey<PathId, PqId>;
-        using TColumns = TableColumns<PathId, PqId, ShardIdx, AlterVersion, GroupId, RangeBegin, RangeEnd,
-                                      CreateVersion, Status, Parent, AdjacentParent, CreationTimestamp>;
+        using TColumns = TableColumns<
+            PathId,
+            PqId,
+            ShardIdx,
+            AlterVersion,
+            GroupId,
+            RangeBegin,
+            RangeEnd,
+            CreateVersion,
+            Status,
+            Parent,
+            AdjacentParent,
+            CreationTimestamp
+        >;
     };
 
     struct RtmrVolumes : Table<20> {

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -512,10 +512,11 @@ struct Schema : NIceDb::Schema {
         struct Parent:          Column<10, NScheme::NTypeIds::Uint32> {};
         // Adjacent parent partition for merge operation
         struct AdjacentParent:  Column<11, NScheme::NTypeIds::Uint32> {};
+        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<PathId, PqId>;
         using TColumns = TableColumns<PathId, PqId, ShardIdx, AlterVersion, GroupId, RangeBegin, RangeEnd,
-                                      CreateVersion, Status, Parent, AdjacentParent>;
+                                      CreateVersion, Status, Parent, AdjacentParent, CreationTimestamp>;
     };
 
     struct RtmrVolumes : Table<20> {

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -512,23 +512,11 @@ struct Schema : NIceDb::Schema {
         struct Parent:          Column<10, NScheme::NTypeIds::Uint32> {};
         // Adjacent parent partition for merge operation
         struct AdjacentParent:  Column<11, NScheme::NTypeIds::Uint32> {};
-        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Timestamp> { using Type = TInstant; };
+        struct CreationTimestamp: Column<12, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<PathId, PqId>;
-        using TColumns = TableColumns<
-            PathId,
-            PqId,
-            ShardIdx,
-            AlterVersion,
-            GroupId,
-            RangeBegin,
-            RangeEnd,
-            CreateVersion,
-            Status,
-            Parent,
-            AdjacentParent,
-            CreationTimestamp
-        >;
+        using TColumns = TableColumns<PathId, PqId, ShardIdx, AlterVersion, GroupId, RangeBegin, RangeEnd,
+                                      CreateVersion, Status, Parent, AdjacentParent, CreationTimestamp>;
     };
 
     struct RtmrVolumes : Table<20> {

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -351,6 +351,7 @@ PEERDIR(
     contrib/libs/protobuf
     library/cpp/deprecated/enum_codegen
     library/cpp/html/pcdata
+    library/cpp/iterator
     library/cpp/json
     library/cpp/protobuf/json
     library/cpp/regex/pcre

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -808,6 +808,11 @@
                 "ColumnId": 11,
                 "ColumnName": "AdjacentParent",
                 "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "CreationTimestamp",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -824,7 +829,8 @@
                     8,
                     9,
                     10,
-                    11
+                    11,
+                    12
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -811,7 +811,7 @@
             },
             {
                 "ColumnId": 12,
-                "ColumnName": "CreationTimestamp",
+                "ColumnName": "CreationTimestampSeconds",
                 "ColumnType": "Uint64"
             }
         ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Появляется актор TDeduplicationQueueActor, который задерживает запросы на запись, пока для них не будет известен статус дедупликации.

* Создаётся в дочерних партициях (не support, не зеркалирование).
* Принимает сообщения EvWrite, TEvReserveBytes перед обработкой в партиции.
* Для EvWrite опрашивает родительские партиции (новые сообщения         EvCheckMessageDeduplicationRequest, EvCheckMessageDeduplicationResponse);
* Пересылает их с сохранением порядка в партицию, устанавливая флаг с результатами проверки;
* Через 5 минут начинает пересылать обратно сообщения без изменений.
* При ошибке опроса родительских партиций, фейлит запись.
* Работа актора пропускается, если нет недавних родительских партиций.

Также
* SS заполняет время создания партии в create и в alter при разделении партиции и появлении дочерних;
* в конфиге в AllPartitions передаются и все родители;

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
 LOGBROKER-10341
