### PR TITLE
fq checkpoint storage: fix u-a-f

### DIFF
--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
@@ -473,8 +473,8 @@ TFuture<IStateStorage::TSaveStateResult> TStateStorage::SaveState(
     context->Callback = [promise, context, size, thisPtr = TIntrusivePtr(this)] (TFuture<TStatus> upsertRowStatus) mutable {
         TStatus status = upsertRowStatus.GetValue();
         if (!status.IsSuccess()) {
-            context->Callback = nullptr;
             promise.SetValue(TSaveStateResult(0, StatusToIssues(status)));
+            context->Callback = nullptr;
             return;
         }
         auto& taskInfo = context->Tasks[context->CurrentProcessingTaskIndex];
@@ -486,8 +486,8 @@ TFuture<IStateStorage::TSaveStateResult> TStateStorage::SaveState(
             nextFuture.Subscribe(context->Callback);
             return;
         }
-        context->Callback = nullptr;
         promise.SetValue(TSaveStateResult(size, StatusToIssues(status)));
+        context->Callback = nullptr;
     };
     future.Subscribe(context->Callback);
     return promise.GetFuture();
@@ -933,8 +933,8 @@ TFuture<TStatus> TStateStorage::ReadRows(const TContextPtr& context) {
                         taskInfo.CurrentProcessingRow = 0;
                     }
                     else {
-                        context->Callback = nullptr;
                         promise.SetValue(TStatus{EStatus::SUCCESS, NYdb::NIssue::TIssues{}});
+                        context->Callback = nullptr;
                         return;
                     }
                 }


### PR DESCRIPTION
discovered by asan (on q-stable-2025-05-15 branch):
```
kikimr/yq/tests/cloud
test_quotas.py::TestQuotas
test_quoted_time_limit[kikimr0]
==716690==ERROR: AddressSanitizer: heap-use-after-free on address 0x504003ca5868 at pc 0x00005983a31c bp 0x7fd325567890 sp 0x7fd325567888
E   READ of size 8 at 0x504003ca5868 thread T54 (kikimr.User)
E   #0 0x5983a31b in pair<unsigned long &, NYql::TIssues, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__utility/pair.h:163:15
E   #1 0x5983a31b in operator() /-S/contrib/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp:503:26
...
E   0x504003ca5868 is located 24 bytes inside of 40-byte region [0x504003ca5850,0x504003ca5878)
E   freed by thread T54 (kikimr.User) here:
E   #0 0x262b6fcd in operator delete(void*) /-S/contrib/libs/clang18-rt/lib/asan/asan_new_delete.cpp:143:3
E   #1 0x59839cfa in operator= /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h
E   #2 0x59839cfa in operator= /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:969:8
E   #3 0x59839cfa in operator() /-S/contrib/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp:502:27
```
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
