### PR TITLE
Testowners from main without waiting of new runs

### DIFF
--- a/.github/scripts/analytics/testowners_utils.py
+++ b/.github/scripts/analytics/testowners_utils.py
@@ -37,6 +37,8 @@ def get_testowners_for_tests(tests_data):
     """
     For each test entry, set owners from repo ``.github/TESTOWNERS`` (``TESTOWNERS_FILE``).
 
+    Mutates each entry in ``tests_data`` and returns the same list (for chaining).
+
     Same owner string format as test_results: ``;;`` / ``:`` between tokens.
 
     Entry may be a dict with key ``suite_folder`` (upload pipeline) or any object with
@@ -45,11 +47,9 @@ def get_testowners_for_tests(tests_data):
     with open(TESTOWNERS_FILE, 'r') as file:
         data = file.readlines()
         owners_obj = CodeOwners(''.join(sort_codeowners_lines(data)))
-        tests_data_with_owners = []
         for test in tests_data:
             target_path = _suite_path_for_codeowners(test)
             owners = owners_obj.of(target_path)
             owners_str = ';;'.join([':'.join(x) for x in owners])
             _set_owners_field(test, owners_str)
-            tests_data_with_owners.append(test)
-        return tests_data_with_owners
+        return tests_data

--- a/.github/scripts/analytics/testowners_utils.py
+++ b/.github/scripts/analytics/testowners_utils.py
@@ -33,17 +33,16 @@ def _set_owners_field(test, owners_str: str) -> None:
         test.owners = owners_str
 
 
-def get_codeowners_for_tests(tests_data, *, codeowners_file_path=None):
+def get_testowners_for_tests(tests_data):
     """
-    For each test entry, set owners from TESTOWNERS (same string format as test_results: ;; / :).
+    For each test entry, set owners from repo ``.github/TESTOWNERS`` (``TESTOWNERS_FILE``).
+
+    Same owner string format as test_results: ``;;`` / ``:`` between tokens.
 
     Entry may be a dict with key ``suite_folder`` (upload pipeline) or any object with
     ``classname`` (e.g. generate-summary.TestResult — same path as suite_folder in JSON).
-
-    Uses ``TESTOWNERS_FILE`` from this module when ``codeowners_file_path`` is omitted.
     """
-    path = codeowners_file_path if codeowners_file_path is not None else TESTOWNERS_FILE
-    with open(path, 'r') as file:
+    with open(TESTOWNERS_FILE, 'r') as file:
         data = file.readlines()
         owners_obj = CodeOwners(''.join(sort_codeowners_lines(data)))
         tests_data_with_owners = []

--- a/.github/scripts/analytics/testowners_utils.py
+++ b/.github/scripts/analytics/testowners_utils.py
@@ -1,0 +1,56 @@
+"""TESTOWNERS resolution for analytics (test_results / testowners uploads)."""
+
+import os
+
+from codeowners import CodeOwners
+
+_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.normpath(os.path.join(_MODULE_DIR, '..', '..', '..'))
+TESTOWNERS_FILE = os.path.join(_REPO_ROOT, '.github', 'TESTOWNERS')
+
+
+def sort_codeowners_lines(codeowners_lines):
+    def path_specificity(line):
+        trimmed_line = line.strip()
+        if not trimmed_line or trimmed_line.startswith('#'):
+            return -1, -1
+        path = trimmed_line.split()[0]
+        return len(path.split('/')), len(path)
+
+    return sorted(codeowners_lines, key=path_specificity)
+
+
+def _suite_path_for_codeowners(test):
+    if isinstance(test, dict):
+        return test['suite_folder']
+    return getattr(test, 'classname', None) or getattr(test, 'suite_folder', '') or ''
+
+
+def _set_owners_field(test, owners_str: str) -> None:
+    if isinstance(test, dict):
+        test['owners'] = owners_str
+    else:
+        test.owners = owners_str
+
+
+def get_codeowners_for_tests(tests_data, *, codeowners_file_path=None):
+    """
+    For each test entry, set owners from TESTOWNERS (same string format as test_results: ;; / :).
+
+    Entry may be a dict with key ``suite_folder`` (upload pipeline) or any object with
+    ``classname`` (e.g. generate-summary.TestResult — same path as suite_folder in JSON).
+
+    Uses ``TESTOWNERS_FILE`` from this module when ``codeowners_file_path`` is omitted.
+    """
+    path = codeowners_file_path if codeowners_file_path is not None else TESTOWNERS_FILE
+    with open(path, 'r') as file:
+        data = file.readlines()
+        owners_obj = CodeOwners(''.join(sort_codeowners_lines(data)))
+        tests_data_with_owners = []
+        for test in tests_data:
+            target_path = _suite_path_for_codeowners(test)
+            owners = owners_obj.of(target_path)
+            owners_str = ';;'.join([':'.join(x) for x in owners])
+            _set_owners_field(test, owners_str)
+            tests_data_with_owners.append(test)
+        return tests_data_with_owners

--- a/.github/scripts/analytics/upload_testowners.py
+++ b/.github/scripts/analytics/upload_testowners.py
@@ -3,7 +3,7 @@
 import ydb
 from ydb_wrapper import YDBWrapper
 
-from testowners_utils import get_codeowners_for_tests
+from testowners_utils import get_testowners_for_tests
 
 
 def create_tables(ydb_wrapper, table_path):
@@ -78,7 +78,7 @@ def main():
                 'run_timestamp_last': row['run_timestamp_last'],
             })
 
-        test_list = get_codeowners_for_tests(test_list)
+        test_list = get_testowners_for_tests(test_list)
 
         print('upserting testowners')
         create_tables(ydb_wrapper, table_path)

--- a/.github/scripts/analytics/upload_testowners.py
+++ b/.github/scripts/analytics/upload_testowners.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import os
-import posixpath
-import time
 import ydb
-from collections import Counter
 from ydb_wrapper import YDBWrapper
+
+from upload_tests_results import get_codeowners_for_tests
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.normpath(os.path.join(_SCRIPT_DIR, '..', '..', '..'))
+TESTOWNERS_FILE = os.path.join(_REPO_ROOT, '.github', 'TESTOWNERS')
 
 
 def create_tables(ydb_wrapper, table_path):
@@ -81,10 +84,11 @@ def main():
                 'suite_folder': row['suite_folder'],
                 'test_name': row['test_name'],
                 'full_name': row['full_name'],
-                'owners': row['owners'],
                 'run_timestamp_last': row['run_timestamp_last'],
             })
-        
+
+        test_list = get_codeowners_for_tests(TESTOWNERS_FILE, test_list)
+
         print('upserting testowners')
         create_tables(ydb_wrapper, table_path)
         

--- a/.github/scripts/analytics/upload_testowners.py
+++ b/.github/scripts/analytics/upload_testowners.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 
-import os
 import ydb
 from ydb_wrapper import YDBWrapper
 
-from upload_tests_results import get_codeowners_for_tests
-
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-_REPO_ROOT = os.path.normpath(os.path.join(_SCRIPT_DIR, '..', '..', '..'))
-TESTOWNERS_FILE = os.path.join(_REPO_ROOT, '.github', 'TESTOWNERS')
+from testowners_utils import get_codeowners_for_tests
 
 
 def create_tables(ydb_wrapper, table_path):
@@ -40,18 +35,17 @@ def main():
         test_runs_table = ydb_wrapper.get_table_path("test_results")
         table_path = ydb_wrapper.get_table_path("testowners")    
 
-        query_get_owners = f"""
-   select 
-        DISTINCT test_name, 
-        suite_folder, 
-        suite_folder || '/' || test_name as full_name, 
-        FIRST_VALUE(owners) OVER w AS owners, 
-        FIRST_VALUE (run_timestamp) OVER w AS run_timestamp_last 
-        FROM 
-        `{test_runs_table}` 
-    WHERE 
-        run_timestamp >= CurrentUtcDate()- Interval("P1D") 
-        AND branch = 'main' 
+        query = f"""
+   select
+        DISTINCT test_name,
+        suite_folder,
+        suite_folder || '/' || test_name as full_name,
+        FIRST_VALUE (run_timestamp) OVER w AS run_timestamp_last
+        FROM
+        `{test_runs_table}`
+    WHERE
+        run_timestamp >= CurrentUtcDate()- Interval("P1D")
+        AND branch = 'main'
         and job_name in (
             'Nightly-run',
             'Regression-run',
@@ -59,23 +53,20 @@ def main():
             'Regression-run_Small_and_Medium',
             'Regression-run_compatibility',
             'Regression-whitelist-run',
-            'Postcommit_relwithdebinfo', 
+            'Postcommit_relwithdebinfo',
             'Postcommit_asan'
-        ) 
+        )
         and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
         WINDOW w AS (
-            PARTITION BY test_name, 
-            suite_folder 
-            ORDER BY 
-            run_timestamp DESC
-        ) 
-        order by 
-        run_timestamp_last desc
-        
+            PARTITION BY test_name,
+            suite_folder
+            ORDER BY
+                run_timestamp DESC
+        )
+        order by
+            run_timestamp_last desc
     """
-    
-        # Execute query using ydb_wrapper
-        results = ydb_wrapper.execute_scan_query(query_get_owners)
+        results = ydb_wrapper.execute_scan_query(query)
 
         print(f'testowners data captured, {len(results)} rows')
         test_list = []
@@ -87,7 +78,7 @@ def main():
                 'run_timestamp_last': row['run_timestamp_last'],
             })
 
-        test_list = get_codeowners_for_tests(TESTOWNERS_FILE, test_list)
+        test_list = get_codeowners_for_tests(test_list)
 
         print('upserting testowners')
         create_tables(ydb_wrapper, table_path)

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -8,7 +8,7 @@ import ydb
 
 from decimal import Decimal
 
-from testowners_utils import get_codeowners_for_tests
+from testowners_utils import get_testowners_for_tests
 from ydb_wrapper import YDBWrapper
 
 max_characters_for_status_description = int(7340032/3)  #workaround for error "cannot split batch in according to limits: there is row with size more then limit (7340032)"
@@ -350,7 +350,7 @@ def main():
             )
 
             # Add owner information
-            result_with_owners = get_codeowners_for_tests(results)
+            result_with_owners = get_testowners_for_tests(results)
             
             # Get table paths
             test_table_path = wrapper.get_table_path("test_results")

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -6,8 +6,9 @@ import os
 import sys
 import ydb
 
-from codeowners import CodeOwners
 from decimal import Decimal
+
+from testowners_utils import get_codeowners_for_tests
 from ydb_wrapper import YDBWrapper
 
 max_characters_for_status_description = int(7340032/3)  #workaround for error "cannot split batch in according to limits: there is row with size more then limit (7340032)"
@@ -193,32 +194,6 @@ def parse_build_results_report(test_results_file, build_type, job_name, job_id, 
     return results
 
 
-def sort_codeowners_lines(codeowners_lines):
-    def path_specificity(line):
-        # removing comments
-        trimmed_line = line.strip()
-        if not trimmed_line or trimmed_line.startswith('#'):
-            return -1, -1
-        path = trimmed_line.split()[0]
-        return len(path.split('/')), len(path)
-
-    sorted_lines = sorted(codeowners_lines, key=path_specificity)
-    return sorted_lines
-
-def get_codeowners_for_tests(codeowners_file_path, tests_data):
-    with open(codeowners_file_path, 'r') as file:
-        data = file.readlines()
-        owners_obj = CodeOwners(''.join(sort_codeowners_lines(data)))
-        tests_data_with_owners = []
-        for test in tests_data:
-            target_path = test["suite_folder"]
-            owners = owners_obj.of(target_path)
-            test["owners"] = ";;".join(
-                [(":".join(x)) for x in owners])
-            tests_data_with_owners.append(test)
-        return tests_data_with_owners
-
-
 def check_table_schema(wrapper, table_path):
     """Check table schema and return which columns exist (single table path)."""
     schema_check_query = f"SELECT * FROM `{table_path}` LIMIT 1"
@@ -361,10 +336,6 @@ def main():
 
     args = parser.parse_args()
 
-    dir_path = os.path.dirname(__file__)
-    git_root = f"{dir_path}/../../.."
-    codeowners = f"{git_root}/.github/TESTOWNERS"
-
     try:
         with YDBWrapper() as wrapper:
             # Check credentials
@@ -379,7 +350,7 @@ def main():
             )
 
             # Add owner information
-            result_with_owners = get_codeowners_for_tests(codeowners, results)
+            result_with_owners = get_codeowners_for_tests(results)
             
             # Get table paths
             test_table_path = wrapper.get_table_path("test_results")

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -229,6 +229,7 @@ def aggregate_test_data(all_data, period_days):
                     'mute_count': 0,
                     'skip_count': 0,
                     'owner': test.get('owner'),
+                    'owner_date': test.get('date_window'),
                     'is_muted': test.get('is_muted'),
                     'is_muted_date': test.get('date_window'),  # Store the date used for is_muted.
                     'state': test.get('state'),
@@ -251,7 +252,13 @@ def aggregate_test_data(all_data, period_days):
                 if to_days(test.get('date_window', 0)) > to_days(aggregated[full_name].get('is_muted_date', 0)):
                     aggregated[full_name]['is_muted'] = test.get('is_muted')
                     aggregated[full_name]['is_muted_date'] = test.get('date_window')
-            
+
+                # Owner must follow the latest day in the window (tests_monitor owner can change
+                # when TESTOWNERS is updated); the first row is the earliest date due to sort order.
+                if to_days(test.get('date_window', 0)) > to_days(aggregated[full_name].get('owner_date', 0)):
+                    aggregated[full_name]['owner'] = test.get('owner')
+                    aggregated[full_name]['owner_date'] = test.get('date_window')
+
             # Accumulate aggregated counters.
             aggregated[full_name]['pass_count'] += test.get('pass_count', 0)
             aggregated[full_name]['fail_count'] += test.get('fail_count', 0)
@@ -261,6 +268,7 @@ def aggregate_test_data(all_data, period_days):
     # Compute success_rate, build summary, and collapse state history for each test.
     date_window_range = f"{start_date.strftime('%Y-%m-%d')}:{today.strftime('%Y-%m-%d')}"
     for test_data in aggregated.values():
+        test_data.pop('owner_date', None)
         test_data['date_window'] = date_window_range
         total_runs = test_data['pass_count'] + test_data['fail_count'] + test_data['mute_count'] + test_data['skip_count']
         if total_runs > 0:

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -7,12 +7,16 @@ import os
 import re
 import sys
 import traceback
-from codeowners import CodeOwners
 from enum import Enum
 from operator import attrgetter
 from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from get_test_history import get_test_history
+
+_ANALYTICS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'analytics'))
+if _ANALYTICS_DIR not in sys.path:
+    sys.path.insert(0, _ANALYTICS_DIR)
+from testowners_utils import get_codeowners_for_tests  # noqa: E402
 
 
 def load_owner_area_mapping():
@@ -357,10 +361,7 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
     # get testowners
     all_tests = [test for status in status_order for test in status_test.get(status)]
         
-    dir = os.path.dirname(__file__)
-    git_root = f"{dir}/../../.."
-    codeowners = f"{git_root}/.github/TESTOWNERS"
-    get_codeowners_for_tests(codeowners, all_tests)
+    get_codeowners_for_tests(all_tests)
     
     # statuses for history
     status_for_history = [TestStatus.FAIL, TestStatus.MUTE, TestStatus.ERROR]
@@ -563,20 +564,6 @@ def write_summary(summary: TestSummary):
 
     if summary_fn:
         fp.close()
-
-
-def get_codeowners_for_tests(codeowners_file_path, tests_data):
-    with open(codeowners_file_path, 'r') as file:
-        data = file.read()
-        owners_odj = CodeOwners(data)
-
-        tests_data_with_owners = []
-        for test in tests_data:
-            target_path = test.classname
-            owners = owners_odj.of(target_path)
-            test.owners = joined_owners = ";;".join(
-                [(":".join(x)) for x in owners])
-            tests_data_with_owners.append(test)
 
 
 def iter_build_results_files(path):

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -16,7 +16,7 @@ from get_test_history import get_test_history
 _ANALYTICS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'analytics'))
 if _ANALYTICS_DIR not in sys.path:
     sys.path.insert(0, _ANALYTICS_DIR)
-from testowners_utils import get_codeowners_for_tests  # noqa: E402
+from testowners_utils import get_testowners_for_tests  # noqa: E402
 
 
 def load_owner_area_mapping():
@@ -361,7 +361,7 @@ def render_testlist_html(rows, fn, build_preset, branch, pr_number=None, workflo
     # get testowners
     all_tests = [test for status in status_order for test in status_test.get(status)]
         
-    get_codeowners_for_tests(all_tests)
+    get_testowners_for_tests(all_tests)
     
     # statuses for history
     status_for_history = [TestStatus.FAIL, TestStatus.MUTE, TestStatus.ERROR]


### PR DESCRIPTION
Ускоряем попадание обновленного овнера TESTOWNERS во все аналитические представления

- **`testowners_utils.py`** — чтение `TESTOWNERS`, **сортировка строк по специфичности пути**, разбор как у CODEOWNERS (`python-codeowners`), **`get_testowners_for_tests()`** проставляет `owners` (формат `;;` / `:`).
- **`upload_testowners.py`** — перешли на testowners_utils.py чтобы в аналитике актуальные testowners брались напрямую `TESTOWNERS`, чтобы не ждать когда upload_tests_results.py пришлет запуски по тестам с новым owner
- **`upload_tests_results.py`** — так же перешли на testowners_utils.py
- **`generate-summary.py`** — так же перешли на testowners_utils.py

В **`create_new_muted_ya.py`** при агрегации по дням для одного теста в итог берем  **owner с последней даты** в окне (чтобы не показывать старого владелеца после смены `TESTOWNERS`).


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
