### PR TITLE
Rename subgroup name to "schedulerPool"

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
@@ -106,7 +106,7 @@ TPool::TPool(const TPoolId& id, const TIntrusivePtr<TKqpCounters>& counters, con
         return;
     }
 
-    auto group = counters->GetKqpCounters()->GetSubgroup("scheduler/pool", id);
+    auto group = counters->GetKqpCounters()->GetSubgroup("schedulerPool", id);
 
     // TODO: since counters don't support float-point values, then use CPU * 1'000'000 to account with microsecond precision
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)