### PR TITLE
[EXT-2042] Meta support links added grafana search source

### DIFF
--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -29,7 +29,10 @@ meta:
         title: Cluster Overview
         url: /d/ydb_cluster/overview
       - source: grafana/dashboard/search
-        tag: ydb-cluster
+        tag:
+          - ydb-cluster
+        folder:
+          - 8a91d4c7-2e5b-4f13-9c6a-1b7e52d4f8a1
     database:
       - source: grafana/dashboard
         title: Database Overview

--- a/ydb/mvp/meta/meta_support_links.h
+++ b/ydb/mvp/meta/meta_support_links.h
@@ -29,6 +29,7 @@
 namespace NMVP {
 
 inline constexpr TStringBuf SOURCE_META = "meta";
+inline constexpr TDuration SUPPORT_LINKS_REQUEST_TIMEOUT = TDuration::Seconds(10);
 
 class TMetaSupportLinksGetHandlerActor : private THandlerActorYdb, public NActors::TActorBootstrapped<TMetaSupportLinksGetHandlerActor> {
 public:
@@ -62,7 +63,7 @@ public:
     {}
 
     void Bootstrap() {
-        Become(&TMetaSupportLinksGetHandlerActor::StateWork, GetTimeout(Request, TDuration::Seconds(60)), new NActors::TEvents::TEvWakeup());
+        Become(&TMetaSupportLinksGetHandlerActor::StateWork, GetTimeout(Request, SUPPORT_LINKS_REQUEST_TIMEOUT), new NActors::TEvents::TEvWakeup());
 
         if (!ValidateAndInitEntityType()) {
             ReplyBadRequestAndDie();

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -18,10 +18,10 @@ message TMetaConfig {
             optional string Title = 2;
             // Source-specific URL. Can be absolute or relative, depending on source.
             optional string Url = 3;
-            // Grafana search tag filter (for source=grafana/dashboard/search).
-            optional string Tag = 4;
-            // Grafana folder UID filter (for source=grafana/dashboard/search).
-            optional string Folder = 5;
+            // Grafana search tag filters (for source=grafana/dashboard/search).
+            repeated string Tag = 4;
+            // Grafana folder UID filters (for source=grafana/dashboard/search).
+            repeated string Folder = 5;
         }
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;

--- a/ydb/mvp/meta/support_links/grafana_dashboard_common.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_common.h
@@ -7,27 +7,75 @@
 
 namespace NMVP::NSupportLinks {
 
-inline void ApplyGrafanaDashboardBindingPolicy(
-    TCgiParameters& queryParameters,
-    const THashMap<TString, TString>& clusterInfo,
-    const NHttp::TUrlParameters& requestUrlParameters)
-{
-    static constexpr TStringBuf WorkspaceKey = "k8s_namespace";
-    static constexpr TStringBuf DatasourceKey = "datasource";
+inline constexpr TStringBuf GRAFANA_WORKSPACE_KEY = "k8s_namespace";
+inline constexpr TStringBuf GRAFANA_DATASOURCE_KEY = "datasource";
 
-    const auto workspaceIt = clusterInfo.find(WorkspaceKey);
+inline void ApplyGrafanaDashboardClusterBindings(
+    TCgiParameters& queryParameters,
+    const THashMap<TString, TString>& clusterInfo)
+{
+    const auto workspaceIt = clusterInfo.find(GRAFANA_WORKSPACE_KEY);
     if (workspaceIt != clusterInfo.end() && !workspaceIt->second.empty()) {
         queryParameters.InsertUnescaped("var-workspace", workspaceIt->second);
     }
 
-    const auto datasourceIt = clusterInfo.find(DatasourceKey);
+    const auto datasourceIt = clusterInfo.find(GRAFANA_DATASOURCE_KEY);
     if (datasourceIt != clusterInfo.end() && !datasourceIt->second.empty()) {
         queryParameters.InsertUnescaped("var-ds", datasourceIt->second);
     }
+}
 
-    for (const auto& parameter : requestUrlParameters.Parameters) {
-        queryParameters.InsertUnescaped(TStringBuilder() << "var-" << parameter.first, requestUrlParameters[parameter.first]);
+inline std::pair<TString, TCgiParameters> BuildGrafanaDashboardUrlParts(
+    TStringBuf grafanaEndpoint,
+    TStringBuf url)
+{
+    TString resolvedUrl = IsAbsoluteUrl(url)
+        ? TString(url)
+        : JoinUrl(grafanaEndpoint, url);
+    TString path = TString(TStringBuf(resolvedUrl).Before('?'));
+    const TStringBuf queryString = TStringBuf(resolvedUrl).After('?');
+
+    TCgiParameters queryParameters;
+    if (!queryString.empty()) {
+        queryParameters.Scan(queryString);
     }
+
+    return {std::move(path), std::move(queryParameters)};
+}
+
+inline TCgiParameters BuildRequestQueryParameters(const NHttp::TUrlParameters& urlParameters)
+{
+    TCgiParameters queryParameters;
+    for (const auto& parameter : urlParameters.Parameters) {
+        queryParameters.InsertUnescaped(parameter.first, urlParameters[parameter.first]);
+    }
+    return queryParameters;
+}
+
+inline void ApplyGrafanaDashboardBindingPolicy(
+    TCgiParameters& queryParameters,
+    const THashMap<TString, TString>& clusterInfo,
+    const TCgiParameters& requestQueryParameters)
+{
+    ApplyGrafanaDashboardClusterBindings(queryParameters, clusterInfo);
+
+    for (const auto& [name, value] : requestQueryParameters) {
+        queryParameters.InsertUnescaped(TStringBuilder() << "var-" << name, value);
+    }
+}
+
+inline TString BuildGrafanaDashboardUrl(
+    TStringBuf grafanaEndpoint,
+    TStringBuf url,
+    const THashMap<TString, TString>& clusterInfo,
+    const TCgiParameters& requestQueryParameters)
+{
+    auto [path, queryParameters] = BuildGrafanaDashboardUrlParts(grafanaEndpoint, url);
+    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestQueryParameters);
+
+    return queryParameters.empty()
+        ? path
+        : TStringBuilder() << path << '?' << queryParameters.Print();
 }
 
 inline TString BuildGrafanaDashboardUrl(
@@ -36,21 +84,11 @@ inline TString BuildGrafanaDashboardUrl(
     const THashMap<TString, TString>& clusterInfo,
     const NHttp::TUrlParameters& requestUrlParameters)
 {
-    TString resolvedUrl = IsAbsoluteUrl(url)
-        ? TString(url)
-        : JoinUrl(grafanaEndpoint, url);
-    const TStringBuf path = TStringBuf(resolvedUrl).Before('?');
-    const TStringBuf queryString = TStringBuf(resolvedUrl).After('?');
-
-    TCgiParameters queryParameters;
-    if (!queryString.empty()) {
-        queryParameters.Scan(queryString);
-    }
-    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestUrlParameters);
-
-    return queryParameters.empty()
-        ? TString(path)
-        : TStringBuilder() << path << '?' << queryParameters.Print();
+    return BuildGrafanaDashboardUrl(
+        grafanaEndpoint,
+        url,
+        clusterInfo,
+        BuildRequestQueryParameters(requestUrlParameters));
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -80,11 +80,15 @@ private:
     TString BuildSearchUrl() const {
         TString url = Config.GetUrl().empty() ? TString("/api/search") : Config.GetUrl();
         url = IsAbsoluteUrl(url) ? url : JoinUrl(GrafanaEndpoint, url);
-        if (Config.HasTag() && !Config.GetTag().empty()) {
-            url = AppendQueryParam(url, "tag", Config.GetTag());
+        for (size_t i = 0; i < Config.TagSize(); ++i) {
+            if (!Config.GetTag(i).empty()) {
+                url = AppendQueryParam(url, "tag", Config.GetTag(i));
+            }
         }
-        if (Config.HasFolder() && !Config.GetFolder().empty()) {
-            url = AppendQueryParam(url, "folderUIDs", Config.GetFolder());
+        for (size_t i = 0; i < Config.FolderSize(); ++i) {
+            if (!Config.GetFolder(i).empty()) {
+                url = AppendQueryParam(url, "folderUIDs", Config.GetFolder(i));
+            }
         }
         return url;
     }
@@ -136,12 +140,12 @@ private:
             TString title;
             TString dashboardUrl;
             if (item.Has("title") && item["title"].GetType() == NJson::JSON_STRING) {
-                title = item["title"].GetStringRobust();
+                title = item["title"].GetString();
             }
             if (item.Has("url") && item["url"].GetType() == NJson::JSON_STRING) {
-                dashboardUrl = item["url"].GetStringRobust();
+                dashboardUrl = item["url"].GetString();
             } else if (item.Has("uri") && item["uri"].GetType() == NJson::JSON_STRING) {
-                dashboardUrl = item["uri"].GetStringRobust();
+                dashboardUrl = item["uri"].GetString();
             }
 
             if (dashboardUrl.empty()) {
@@ -167,7 +171,7 @@ private:
             return false;
         }
 
-        const TString type = item["type"].GetStringRobust();
+        const TString type = item["type"].GetString();
         return type == "dash-db" || type == "dashboard";
     }
 

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "events.h"
+#include "grafana_dashboard_common.h"
+#include "source_common.h"
+
+#include <ydb/mvp/core/appdata.h>
+#include <ydb/mvp/meta/mvp.h>
+#include <ydb/mvp/meta/support_links/source.h>
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/http/http.h>
+
+#include <library/cpp/json/json_reader.h>
+
+#include <util/generic/yexception.h>
+#include <util/string/cast.h>
+#include <util/string/strip.h>
+
+namespace NMVP::NSupportLinks {
+
+class TGrafanaDashboardSearchActor : public NActors::TActorBootstrapped<TGrafanaDashboardSearchActor> {
+public:
+    TGrafanaDashboardSearchActor(
+        TSupportLinkEntryConfig config,
+        TString grafanaEndpoint,
+        const THashMap<TString, TString>& clusterInfo,
+        TCgiParameters requestQueryParameters,
+        NActors::TActorId owner,
+        NActors::TActorId httpProxyId,
+        size_t place)
+        : Config(std::move(config))
+        , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , ClusterInfo(clusterInfo)
+        , RequestQueryParameters(std::move(requestQueryParameters))
+        , Owner(owner)
+        , HttpProxyId(httpProxyId)
+        , Place(place)
+    {}
+
+    void Bootstrap() {
+        const TString authHeaderValue = GetAuthorizationHeaderValue();
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet(BuildSearchUrl());
+        request->Set("Authorization", authHeaderValue);
+
+        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
+        Send(HttpProxyId, event.Release());
+        Become(&TGrafanaDashboardSearchActor::StateWork);
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
+        }
+    }
+
+private:
+    TSupportLinkEntryConfig Config;
+    TString GrafanaEndpoint;
+    THashMap<TString, TString> ClusterInfo;
+    TCgiParameters RequestQueryParameters;
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+    size_t Place = 0;
+    TVector<TResolvedLink> Links;
+    TVector<TSupportError> Errors;
+
+    TString GetAuthorizationHeaderValue() {
+        auto* appData = MVPAppData();
+        if (!appData || !appData->Tokenator) {
+            return {};
+        }
+        return StripString(appData->Tokenator->GetToken(TMVP::MetaDatabaseTokenName));
+    }
+
+    TString BuildSearchUrl() const {
+        TString url = Config.GetUrl().empty() ? TString("/api/search") : Config.GetUrl();
+        url = IsAbsoluteUrl(url) ? url : JoinUrl(GrafanaEndpoint, url);
+        if (Config.HasTag() && !Config.GetTag().empty()) {
+            url = AppendQueryParam(url, "tag", Config.GetTag());
+        }
+        if (Config.HasFolder() && !Config.GetFolder().empty()) {
+            url = AppendQueryParam(url, "folderUIDs", Config.GetFolder());
+        }
+        return url;
+    }
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
+        if (!event->Get()->Error.empty() || !event->Get()->Response || event->Get()->Response->Status != "200") {
+            TSupportError error;
+            error.Source = Config.GetSource();
+            if (!event->Get()->Error.empty()) {
+                error.Message = event->Get()->Error;
+            } else if (event->Get()->Response) {
+                ui32 status = 0;
+                if (TryFromString<ui32>(event->Get()->Response->Status, status)) {
+                    error.Status = status;
+                }
+                error.Reason = TString(event->Get()->Response->Message);
+                error.Message = TStringBuilder() << event->Get()->Response->Status << " " << event->Get()->Response->Message;
+            } else {
+                error.Message = "Unknown Grafana request error";
+            }
+            Errors.push_back(std::move(error));
+            ReplyAndDie();
+            return;
+        }
+
+        ParseSearchResponse(event->Get()->Response->Body);
+        ReplyAndDie();
+    }
+
+    void ParseSearchResponse(TStringBuf body) {
+        NJson::TJsonValue dashboardsJson;
+        NJson::TJsonReaderConfig jsonReaderConfig;
+        if (!NJson::ReadJsonTree(body, &jsonReaderConfig, &dashboardsJson) || dashboardsJson.GetType() != NJson::JSON_ARRAY) {
+            Errors.emplace_back(TSupportError{
+                .Source = Config.GetSource(),
+                .Message = "Invalid JSON from Grafana Search API",
+            });
+            return;
+        }
+
+        for (const auto& item : dashboardsJson.GetArray()) {
+            if (item.GetType() != NJson::JSON_MAP) {
+                continue;
+            }
+            if (!IsDashboardItem(item)) {
+                continue;
+            }
+
+            TString title;
+            TString dashboardUrl;
+            if (item.Has("title") && item["title"].GetType() == NJson::JSON_STRING) {
+                title = item["title"].GetStringRobust();
+            }
+            if (item.Has("url") && item["url"].GetType() == NJson::JSON_STRING) {
+                dashboardUrl = item["url"].GetStringRobust();
+            } else if (item.Has("uri") && item["uri"].GetType() == NJson::JSON_STRING) {
+                dashboardUrl = item["uri"].GetStringRobust();
+            }
+
+            if (dashboardUrl.empty()) {
+                continue;
+            }
+
+            const TString resolvedUrl = BuildGrafanaDashboardUrl(
+                GrafanaEndpoint,
+                dashboardUrl,
+                ClusterInfo,
+                RequestQueryParameters);
+            if (!resolvedUrl.empty()) {
+                Links.emplace_back(TResolvedLink{
+                    .Title = std::move(title),
+                    .Url = resolvedUrl,
+                });
+            }
+        }
+    }
+
+    static bool IsDashboardItem(const NJson::TJsonValue& item) {
+        if (!item.Has("type") || item["type"].GetType() != NJson::JSON_STRING) {
+            return false;
+        }
+
+        const TString type = item["type"].GetStringRobust();
+        return type == "dash-db" || type == "dashboard";
+    }
+
+    void ReplyAndDie() {
+        Send(Owner, new TEvPrivate::TEvSourceResponse(Place, std::move(Links), std::move(Errors)));
+        PassAway();
+    }
+};
+
+} // namespace NMVP::NSupportLinks
+
+namespace NMVP {
+
+class TGrafanaDashboardSearchSource : public ILinkSource {
+public:
+    TGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, TString grafanaEndpoint)
+        : Config(std::move(config))
+        , GrafanaEndpoint(std::move(grafanaEndpoint))
+    {}
+
+    TResolveOutput Resolve(const TLinkResolveInput& input, const TResolveContext& context) const override {
+        TResolveOutput result{
+            .Name = Config.GetSource(),
+        };
+        result.Actor = NActors::TActivationContext::Register(
+            new NSupportLinks::TGrafanaDashboardSearchActor(
+                Config,
+                GrafanaEndpoint,
+                input.ClusterInfo,
+                NSupportLinks::BuildRequestQueryParameters(input.UrlParameters),
+                context.Owner,
+                context.HttpProxyId,
+                context.Place),
+            context.Owner);
+        return result;
+    }
+
+private:
+    TSupportLinkEntryConfig Config;
+    TString GrafanaEndpoint;
+};
+
+inline void ValidateGrafanaDashboardSearchSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
+    if (metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
+        ythrow yexception() << "grafana.endpoint is required for source=" << config.GetSource();
+    }
+    if (TMVP::MetaDatabaseTokenName.empty()) {
+        ythrow yexception() << "meta.meta_database_token_name is required for source=" << config.GetSource();
+    }
+}
+
+inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
+    ValidateGrafanaDashboardSearchSourceConfig(config, metaSettings);
+    return std::make_shared<TGrafanaDashboardSearchSource>(
+        std::move(config),
+        metaSettings.SupportLinks.GrafanaEndpoint
+    );
+}
+
+} // namespace NMVP

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
@@ -1,7 +1,8 @@
-#include <ydb/mvp/core/mvp_test_runtime.h>
 #include <ydb/mvp/meta/mvp.h>
 #include <ydb/mvp/meta/support_links/events.h>
 #include <ydb/mvp/meta/support_links/grafana_dashboard_search_source.h>
+
+#include <ydb/mvp/core/mvp_test_runtime.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -9,7 +10,12 @@
 #include <ydb/library/actors/http/http_proxy.h>
 
 #include <library/cpp/cgiparam/cgiparam.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
 
 #include <utility>
 
@@ -44,17 +50,25 @@ NMVP::TMetaSettings MakeMetaSettings(TStringBuf grafanaEndpoint = "https://grafa
     return settings;
 }
 
-NMVP::TSupportLinkEntryConfig MakeConfig(TStringBuf url = TStringBuf(), TStringBuf tag = TStringBuf(), TStringBuf folder = TStringBuf()) {
+NMVP::TSupportLinkEntryConfig MakeConfig(
+    TStringBuf url = TStringBuf(),
+    const TVector<TString>& tag = {},
+    const TVector<TString>& folders = {})
+{
     NMVP::TSupportLinkEntryConfig config;
     config.SetSource("grafana/dashboard/search");
     if (!url.empty()) {
         config.SetUrl(TString(url));
     }
-    if (!tag.empty()) {
-        config.SetTag(TString(tag));
+    for (const TString& value : tag) {
+        if (!value.empty()) {
+            config.AddTag(value);
+        }
     }
-    if (!folder.empty()) {
-        config.SetFolder(TString(folder));
+    for (const TString& folder : folders) {
+        if (!folder.empty()) {
+            config.AddFolder(folder);
+        }
     }
     return config;
 }
@@ -136,10 +150,76 @@ public:
         const auto request = event->Get()->Request;
         const TString url(request->URL);
         const bool targetsSearchApi = url.Contains("/api/search");
-        const bool hasTag = url.Contains("tag=ydb-common");
-        const bool hasFolder = url.Contains("folderUIDs=team-folder");
-        const TString body = "[]";
-        const TString statusLine = (targetsSearchApi && hasTag && hasFolder)
+        TCgiParameters query;
+        const size_t queryPos = url.find('?');
+        if (queryPos != TString::npos) {
+            query.Scan(TStringBuf(url).SubStr(queryPos + 1));
+        }
+
+        THashSet<TString> requestTags;
+        for (const TString& value : query.Range("tag")) {
+            requestTags.insert(value);
+        }
+
+        THashSet<TString> requestFolders;
+        for (const TString& value : query.Range("folderUIDs")) {
+            requestFolders.insert(value);
+        }
+
+        struct TDashboardCandidate {
+            TString Title;
+            TString Url;
+            THashSet<TString> Tags;
+            TString FolderUid;
+        };
+
+        const TVector<TDashboardCandidate> dashboards = {
+            {
+                .Title = "YDB Cluster Overview",
+                .Url = "/d/matched/dashboard",
+                .Tags = {"ydb-common", "ydb-storage"},
+                .FolderUid = "ops-folder",
+            },
+            {
+                .Title = "YDB Database Overview",
+                .Url = "/d/missing-tag/dashboard",
+                .Tags = {"ydb-common"},
+                .FolderUid = "ops-folder",
+            },
+            {
+                .Title = "YDB Storage Overview",
+                .Url = "/d/wrong-folder/dashboard",
+                .Tags = {"ydb-common", "ydb-storage"},
+                .FolderUid = "other-folder",
+            },
+        };
+
+        NJson::TJsonValue responseJson(NJson::JSON_ARRAY);
+        if (targetsSearchApi) {
+            for (const auto& dashboard : dashboards) {
+                bool matchesTags = true;
+                for (const TString& tag : requestTags) {
+                    if (!dashboard.Tags.contains(tag)) {
+                        matchesTags = false;
+                        break;
+                    }
+                }
+
+                const bool matchesFolders = requestFolders.empty() || requestFolders.contains(dashboard.FolderUid);
+                if (!matchesTags || !matchesFolders) {
+                    continue;
+                }
+
+                NJson::TJsonValue item(NJson::JSON_MAP);
+                item["type"] = "dash-db";
+                item["title"] = dashboard.Title;
+                item["url"] = dashboard.Url;
+                responseJson.AppendValue(std::move(item));
+            }
+        }
+
+        TString body = NJson::WriteJson(responseJson, false);
+        const TString statusLine = targetsSearchApi
             ? "HTTP/1.1 200 OK"
             : "HTTP/1.1 400 Bad Request";
 
@@ -285,19 +365,21 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
             "meta.meta_database_token_name is required for source=grafana/dashboard/search");
     }
 
-    Y_UNIT_TEST(ResolveRequestsSearchApiWithTagAndFolder) {
+    Y_UNIT_TEST(ResolveUsesAllTagAndFolderFiltersInSearchRequest) {
         TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
         TTestActorRuntime runtime;
 
         auto source = NMVP::MakeGrafanaDashboardSearchSource(
-            MakeConfig("/api/search", "ydb-common", "team-folder"),
+            MakeConfig("/api/search", TVector<TString>{"ydb-common", "ydb-storage"}, TVector<TString>{"team-folder", "ops-folder"}),
             MakeMetaSettings());
         auto httpProxyId = runtime.Register(new TSearchApiRequestCheckActor());
 
         TAutoPtr<NActors::IEventHandle> handle;
         auto* response = ResolveSource(runtime, source, {}, MakeUrlParameters(""), httpProxyId, handle);
         UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Title, "YDB Cluster Overview");
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Url, "https://grafana.example.net/d/matched/dashboard");
     }
 
     Y_UNIT_TEST(ResolveBuildsDashboardLinksFromSearchResponse) {
@@ -311,7 +393,9 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
             {"title":"Skip me"}
         ])json";
         auto httpProxyId = runtime.Register(new TGrafanaSearchReplyActor(body));
-        auto source = NMVP::MakeGrafanaDashboardSearchSource(MakeConfig("/api/search", "ydb-common"), MakeMetaSettings());
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(
+            MakeConfig("/api/search", TVector<TString>{"ydb-common"}),
+            MakeMetaSettings());
 
         THashMap<TString, TString> clusterInfo;
         clusterInfo["k8s_namespace"] = "ydb-workspace";

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
@@ -1,0 +1,356 @@
+#include <ydb/mvp/core/mvp_test_runtime.h>
+#include <ydb/mvp/meta/mvp.h>
+#include <ydb/mvp/meta/support_links/events.h>
+#include <ydb/mvp/meta/support_links/grafana_dashboard_search_source.h>
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/http/http_proxy.h>
+
+#include <library/cpp/cgiparam/cgiparam.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <utility>
+
+namespace {
+
+class TTestActorRuntime : public TMvpTestRuntime {
+public:
+    TTestActorRuntime()
+        : TMvpTestRuntime(1, false)
+    {
+        Initialize();
+    }
+};
+
+class TMetaDatabaseTokenNameGuard {
+public:
+    explicit TMetaDatabaseTokenNameGuard(TString value)
+        : OldValue(std::exchange(NMVP::TMVP::MetaDatabaseTokenName, std::move(value)))
+    {}
+
+    ~TMetaDatabaseTokenNameGuard() {
+        NMVP::TMVP::MetaDatabaseTokenName = OldValue;
+    }
+
+private:
+    TString OldValue;
+};
+
+NMVP::TMetaSettings MakeMetaSettings(TStringBuf grafanaEndpoint = "https://grafana.example.net") {
+    NMVP::TMetaSettings settings;
+    settings.SupportLinks.GrafanaEndpoint = TString(grafanaEndpoint);
+    return settings;
+}
+
+NMVP::TSupportLinkEntryConfig MakeConfig(TStringBuf url = TStringBuf(), TStringBuf tag = TStringBuf(), TStringBuf folder = TStringBuf()) {
+    NMVP::TSupportLinkEntryConfig config;
+    config.SetSource("grafana/dashboard/search");
+    if (!url.empty()) {
+        config.SetUrl(TString(url));
+    }
+    if (!tag.empty()) {
+        config.SetTag(TString(tag));
+    }
+    if (!folder.empty()) {
+        config.SetFolder(TString(folder));
+    }
+    return config;
+}
+
+NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
+    NHttp::TUrlParametersBuilder builder;
+    for (TStringBuf param = query.NextTok('&'); !param.empty(); param = query.NextTok('&')) {
+        TStringBuf name = param.NextTok('=');
+        builder.Set(name, param);
+    }
+    return builder;
+}
+
+class TResolveRunnerActor : public NActors::TActorBootstrapped<TResolveRunnerActor> {
+public:
+    TResolveRunnerActor(
+        std::shared_ptr<NMVP::ILinkSource> source,
+        THashMap<TString, TString> clusterInfo,
+        NHttp::TUrlParametersBuilder urlParameters,
+        NActors::TActorId replyTo,
+        NActors::TActorId httpProxyId)
+        : Source(std::move(source))
+        , ClusterInfo(std::move(clusterInfo))
+        , UrlParameters(std::move(urlParameters))
+        , ReplyTo(replyTo)
+        , HttpProxyId(httpProxyId)
+    {}
+
+    void Bootstrap() {
+        auto result = Source->Resolve(
+            NMVP::ILinkSource::TLinkResolveInput{
+                .ClusterInfo = ClusterInfo,
+                .UrlParameters = UrlParameters,
+            },
+            NMVP::ILinkSource::TResolveContext{
+                .Place = 0,
+                .Owner = SelfId(),
+                .HttpProxyId = HttpProxyId,
+            });
+        if (!result.Actor) {
+            Send(ReplyTo, new NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse(0, std::move(result.Links), std::move(result.Errors)));
+            PassAway();
+            return;
+        }
+        Become(&TResolveRunnerActor::StateWork);
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse, Handle);
+        }
+    }
+
+    void Handle(NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse::TPtr event) {
+        Send(ReplyTo, new NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse(
+            event->Get()->Place,
+            std::move(event->Get()->Links),
+            std::move(event->Get()->Errors)));
+        PassAway();
+    }
+
+private:
+    std::shared_ptr<NMVP::ILinkSource> Source;
+    THashMap<TString, TString> ClusterInfo;
+    NHttp::TUrlParametersBuilder UrlParameters;
+    NActors::TActorId ReplyTo;
+    NActors::TActorId HttpProxyId;
+};
+
+class TSearchApiRequestCheckActor : public NActors::TActor<TSearchApiRequestCheckActor> {
+public:
+    using TBase = NActors::TActor<TSearchApiRequestCheckActor>;
+
+    TSearchApiRequestCheckActor()
+        : TBase(&TSearchApiRequestCheckActor::StateWork)
+    {}
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event) {
+        const auto request = event->Get()->Request;
+        const TString url(request->URL);
+        const bool targetsSearchApi = url.Contains("/api/search");
+        const bool hasTag = url.Contains("tag=ydb-common");
+        const bool hasFolder = url.Contains("folderUIDs=team-folder");
+        const TString body = "[]";
+        const TString statusLine = (targetsSearchApi && hasTag && hasFolder)
+            ? "HTTP/1.1 200 OK"
+            : "HTTP/1.1 400 Bad Request";
+
+        NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
+        EatWholeString(
+            response,
+            TStringBuilder()
+                << statusLine << "\r\n"
+                << "Connection: close\r\n"
+                << "Content-Type: application/json; charset=utf-8\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "\r\n"
+                << body);
+        Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest, Handle);
+        }
+    }
+};
+
+class TGrafanaSearchReplyActor : public NActors::TActor<TGrafanaSearchReplyActor> {
+public:
+    using TBase = NActors::TActor<TGrafanaSearchReplyActor>;
+
+    explicit TGrafanaSearchReplyActor(TString body)
+        : TBase(&TGrafanaSearchReplyActor::StateWork)
+        , Body(std::move(body))
+    {}
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event) {
+        const auto request = event->Get()->Request;
+        NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
+        EatWholeString(
+            response,
+            TStringBuilder()
+                << "HTTP/1.1 200 OK\r\n"
+                << "Connection: close\r\n"
+                << "Content-Type: application/json; charset=utf-8\r\n"
+                << "Content-Length: " << Body.size() << "\r\n"
+                << "\r\n"
+                << Body);
+        Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest, Handle);
+        }
+    }
+
+private:
+    TString Body;
+};
+
+class TForbiddenReplyActor : public NActors::TActor<TForbiddenReplyActor> {
+public:
+    using TBase = NActors::TActor<TForbiddenReplyActor>;
+
+    TForbiddenReplyActor()
+        : TBase(&TForbiddenReplyActor::StateWork)
+    {}
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event) {
+        const auto request = event->Get()->Request;
+        const TString body = R"({"message":"forbidden"})";
+        NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
+        EatWholeString(
+            response,
+            TStringBuilder()
+                << "HTTP/1.1 403 Forbidden\r\n"
+                << "Connection: close\r\n"
+                << "Content-Type: application/json; charset=utf-8\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "\r\n"
+                << body);
+        Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest, Handle);
+        }
+    }
+};
+
+NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse* ResolveSource(
+    TTestActorRuntime& runtime,
+    std::shared_ptr<NMVP::ILinkSource> source,
+    THashMap<TString, TString> clusterInfo,
+    NHttp::TUrlParametersBuilder urlParameters,
+    NActors::TActorId httpProxyId,
+    TAutoPtr<NActors::IEventHandle>& handle)
+{
+    const auto replyTo = runtime.AllocateEdgeActor();
+    runtime.Register(new TResolveRunnerActor(
+        std::move(source),
+        std::move(clusterInfo),
+        std::move(urlParameters),
+        replyTo,
+        httpProxyId));
+    return runtime.GrabEdgeEvent<NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse>(handle);
+}
+
+void AssertUrlQuery(TStringBuf actualUrl, TStringBuf expectedUrl) {
+    UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedUrl.Before('?'));
+
+    TCgiParameters actualQuery;
+    TCgiParameters expectedQuery;
+    actualQuery.Scan(actualUrl.After('?'));
+    expectedQuery.Scan(expectedUrl.After('?'));
+    UNIT_ASSERT_VALUES_EQUAL(actualQuery.Print(), expectedQuery.Print());
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
+    Y_UNIT_TEST(ValidationRejectsRelativeUrlWithoutGrafanaEndpoint) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        auto settings = MakeMetaSettings("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            NMVP::MakeGrafanaDashboardSearchSource(MakeConfig("/api/search"), settings),
+            yexception,
+            "grafana.endpoint is required for source=grafana/dashboard/search");
+    }
+
+    Y_UNIT_TEST(ValidationRejectsAbsoluteUrlWithoutGrafanaEndpoint) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        auto settings = MakeMetaSettings("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            NMVP::MakeGrafanaDashboardSearchSource(MakeConfig("https://grafana.example.net/api/search"), settings),
+            yexception,
+            "grafana.endpoint is required for source=grafana/dashboard/search");
+    }
+
+    Y_UNIT_TEST(ValidationRejectsMissingMetaDatabaseTokenName) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            NMVP::MakeGrafanaDashboardSearchSource(MakeConfig("/api/search"), MakeMetaSettings()),
+            yexception,
+            "meta.meta_database_token_name is required for source=grafana/dashboard/search");
+    }
+
+    Y_UNIT_TEST(ResolveRequestsSearchApiWithTagAndFolder) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(
+            MakeConfig("/api/search", "ydb-common", "team-folder"),
+            MakeMetaSettings());
+        auto httpProxyId = runtime.Register(new TSearchApiRequestCheckActor());
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* response = ResolveSource(runtime, source, {}, MakeUrlParameters(""), httpProxyId, handle);
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 0);
+    }
+
+    Y_UNIT_TEST(ResolveBuildsDashboardLinksFromSearchResponse) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        const TString body = R"json([
+            {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu"},
+            {"type":"dashboard","title":"DB overview","uri":"db/db-overview"},
+            {"type":"dash-folder","title":"Folder","url":"/dashboards/f/team-folder"},
+            {"title":"Skip me"}
+        ])json";
+        auto httpProxyId = runtime.Register(new TGrafanaSearchReplyActor(body));
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(MakeConfig("/api/search", "ydb-common"), MakeMetaSettings());
+
+        THashMap<TString, TString> clusterInfo;
+        clusterInfo["k8s_namespace"] = "ydb-workspace";
+        clusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* response = ResolveSource(
+            runtime,
+            source,
+            clusterInfo,
+            MakeUrlParameters("cluster=ydb-global&database=%2Froot%2Ftest"),
+            httpProxyId,
+            handle);
+
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Title, "CPU");
+        AssertUrlQuery(
+            response->Links[0].Url,
+            "https://grafana.example.net/d/ydb_cpu/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global&var-database=/root/test");
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[1].Title, "DB overview");
+        AssertUrlQuery(
+            response->Links[1].Url,
+            "https://grafana.example.net/db/db-overview?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global&var-database=/root/test");
+    }
+
+    Y_UNIT_TEST(ResolveReturnsHttpError) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        auto httpProxyId = runtime.Register(new TForbiddenReplyActor());
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(MakeConfig(), MakeMetaSettings());
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* response = ResolveSource(runtime, source, {}, MakeUrlParameters(""), httpProxyId, handle);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors[0].Source, "grafana/dashboard/search");
+        UNIT_ASSERT_VALUES_EQUAL(*response->Errors[0].Status, 403);
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors[0].Reason, "Forbidden");
+    }
+}

--- a/ydb/mvp/meta/support_links/source.cpp
+++ b/ydb/mvp/meta/support_links/source.cpp
@@ -1,5 +1,6 @@
 #include "source.h"
 #include "grafana_dashboard_source.h"
+#include "grafana_dashboard_search_source.h"
 
 #include <util/generic/yexception.h>
 
@@ -23,6 +24,10 @@ void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMeta
         ValidateGrafanaDashboardSourceConfig(config, metaSettings);
         return;
     }
+    if (config.GetSource() == "grafana/dashboard/search") {
+        ValidateGrafanaDashboardSearchSourceConfig(config, metaSettings);
+        return;
+    }
 
     ythrow yexception() << "unsupported support_links source: " << config.GetSource();
 }
@@ -32,6 +37,9 @@ std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config, cons
 
     if (config.GetSource() == "grafana/dashboard") {
         return MakeGrafanaDashboardSource(std::move(config), metaSettings);
+    }
+    if (config.GetSource() == "grafana/dashboard/search") {
+        return MakeGrafanaDashboardSearchSource(std::move(config), metaSettings);
     }
 
     ythrow yexception() << "unsupported support_links source: " << config.GetSource();

--- a/ydb/mvp/meta/support_links/ut/ya.make
+++ b/ydb/mvp/meta/support_links/ut/ya.make
@@ -4,6 +4,7 @@ SIZE(SMALL)
 
 SRCS(
     grafana_dashboard_source_ut.cpp
+    grafana_dashboard_search_source_ut.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds a new support-links source that resolves Grafana dashboards via Grafana’s Search API, wiring it into the support-links factory and adding unit test coverage for the new source.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Add a new grafana/dashboard/search link source implementation (actor-based HTTP call to /api/search) and register it in the source factory/validator.
- Add tests for the new search-based source.