### PR TITLE
YQ-5016 fixed streaming query timeout overflow

### DIFF
--- a/ydb/library/yql/dq/actors/protos/dq_events.proto
+++ b/ydb/library/yql/dq/actors/protos/dq_events.proto
@@ -126,7 +126,7 @@ message TRlPath {
 }
 
 message TComputeRuntimeSettings {
-    optional uint32 TimeoutMs = 1;
+    optional uint64 TimeoutMs = 1;
 
     enum EExecType {
         UNSPECIFIED = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed streaming query timeout overflow (timeout value is ui64, but saved into ui32 protobuf field)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Based on protobuf documentation: https://protobuf.dev/programming-guides/proto2/#updating

Changing of field type `ui32` -> `ui64` is compatible change:

<img width="1031" height="580" alt="image" src="https://github.com/user-attachments/assets/06975fde-6768-4a0b-8d54-22d2b44236d1" />

So during rolling restart large ui64 will be truncated to ui32 on protobuf receiver side (now they truncate on protobuf sender side)