### PR TITLE
Fix thread-safety and token expiry parsing in IAM credentials provider

### DIFF
--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -8,7 +8,7 @@
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/http/simple/http_client.h>
 
-#include <util/system/spinlock.h>
+#include <mutex>
 
 using namespace yandex::cloud::iam::v1;
 
@@ -28,13 +28,15 @@ public:
     std::string GetAuthInfo() const override {
         std::string ticket;
         TInstant nextTicketUpdate;
-        with_lock (Lock_) {
+        {
+            std::lock_guard lock(Lock_);
             ticket = Ticket_;
             nextTicketUpdate = NextTicketUpdate_;
         }
         if (TInstant::Now() >= nextTicketUpdate) {
             GetTicket();
-            with_lock (Lock_) {
+            {
+                std::lock_guard lock(Lock_);
                 ticket = Ticket_;
             }
         }
@@ -48,7 +50,7 @@ public:
 private:
     TSimpleHttpClient HttpClient_;
     std::string Request_;
-    mutable TAdaptiveLock Lock_;
+    mutable std::mutex Lock_;
     mutable std::string Ticket_;
     mutable TInstant NextTicketUpdate_;
     TDuration RefreshPeriod_;
@@ -70,25 +72,33 @@ private:
             else if (ticket = it->second.GetStringSafe(); ticket.empty())
                 ythrow yexception() << "Got empty ticket";
 
+            const auto now = TInstant::Now();
             TInstant nextUpdate;
             TDuration expiresIn;
-            if (auto it = respMap.find("expires_in"); it != respMap.end() && it->second.GetUInteger() > 0) {
-                expiresIn = TDuration::Seconds(it->second.GetUInteger());
+            if (auto it = respMap.find("expires_in"); it != respMap.end()) {
+                auto seconds = it->second.GetUInteger();
+                if (seconds > 0) {
+                    expiresIn = TDuration::Seconds(seconds);
+                }
             } else if (auto it = respMap.find("expiry"); it != respMap.end()) {
-                TInstant expiry;
-                if (TInstant::TryParseIso8601(it->second.GetStringSafe(), expiry) && expiry > TInstant::Now()) {
-                    expiresIn = expiry - TInstant::Now();
+                try {
+                    TInstant expiry;
+                    if (TInstant::TryParseIso8601(it->second.GetStringSafe(), expiry) && expiry > now) {
+                        expiresIn = expiry - now;
+                    }
+                } catch (...) {
                 }
             }
             if (expiresIn > TDuration::Zero()) {
                 const auto halfLife = expiresIn / 2;
                 const auto interval = std::max(std::min(halfLife, RefreshPeriod_), TDuration::MilliSeconds(100));
-                nextUpdate = TInstant::Now() + interval;
+                nextUpdate = now + interval;
             } else {
-                nextUpdate = TInstant::Now() + std::min(RefreshPeriod_, TDuration::Minutes(30));
+                nextUpdate = now + std::min(RefreshPeriod_, TDuration::Minutes(30));
             }
 
-            with_lock (Lock_) {
+            {
+                std::lock_guard lock(Lock_);
                 Ticket_ = std::move(ticket);
                 NextTicketUpdate_ = nextUpdate;
             }

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -8,6 +8,8 @@
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/http/simple/http_client.h>
 
+#include <util/system/spinlock.h>
+
 using namespace yandex::cloud::iam::v1;
 
 namespace NYdb::inline Dev {
@@ -24,10 +26,19 @@ public:
     }
 
     std::string GetAuthInfo() const override {
-        if (TInstant::Now() >= NextTicketUpdate_) {
-            GetTicket();
+        std::string ticket;
+        TInstant nextTicketUpdate;
+        with_lock (Lock_) {
+            ticket = Ticket_;
+            nextTicketUpdate = NextTicketUpdate_;
         }
-        return Ticket_;
+        if (TInstant::Now() >= nextTicketUpdate) {
+            GetTicket();
+            with_lock (Lock_) {
+                ticket = Ticket_;
+            }
+        }
+        return ticket;
     }
 
     bool IsValid() const override {
@@ -37,6 +48,7 @@ public:
 private:
     TSimpleHttpClient HttpClient_;
     std::string Request_;
+    mutable TAdaptiveLock Lock_;
     mutable std::string Ticket_;
     mutable TInstant NextTicketUpdate_;
     TDuration RefreshPeriod_;
@@ -52,21 +64,33 @@ private:
 
             auto respMap = resp.GetMap();
 
+            std::string ticket;
             if (auto it = respMap.find("access_token"); it == respMap.end())
                 ythrow yexception() << "Result doesn't contain access_token";
-            else if (std::string ticket = it->second.GetStringSafe(); ticket.empty())
+            else if (ticket = it->second.GetStringSafe(); ticket.empty())
                 ythrow yexception() << "Got empty ticket";
-            else
+
+            TInstant nextUpdate;
+            TDuration expiresIn;
+            if (auto it = respMap.find("expires_in"); it != respMap.end() && it->second.GetUInteger() > 0) {
+                expiresIn = TDuration::Seconds(it->second.GetUInteger());
+            } else if (auto it = respMap.find("expiry"); it != respMap.end()) {
+                TInstant expiry;
+                if (TInstant::TryParseIso8601(it->second.GetStringSafe(), expiry) && expiry > TInstant::Now()) {
+                    expiresIn = expiry - TInstant::Now();
+                }
+            }
+            if (expiresIn > TDuration::Zero()) {
+                const auto halfLife = expiresIn / 2;
+                const auto interval = std::max(std::min(halfLife, RefreshPeriod_), TDuration::MilliSeconds(100));
+                nextUpdate = TInstant::Now() + interval;
+            } else {
+                nextUpdate = TInstant::Now() + std::min(RefreshPeriod_, TDuration::Minutes(30));
+            }
+
+            with_lock (Lock_) {
                 Ticket_ = std::move(ticket);
-
-            if (auto it = respMap.find("expires_in"); it == respMap.end())
-                ythrow yexception() << "Result doesn't contain expires_in";
-            else {
-                const TDuration expiresIn = TDuration::Seconds(it->second.GetUInteger()) / 2;
-
-                const auto interval = std::max(std::min(expiresIn, RefreshPeriod_), TDuration::MilliSeconds(100));
-
-                NextTicketUpdate_ = TInstant::Now() + interval;
+                NextTicketUpdate_ = nextUpdate;
             }
         } catch (...) {
         }

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -38,7 +38,7 @@ public:
 
     TMetadataServer()
         : PortHolder(NTesting::GetFreePort())
-        , Port(static_cast<ui16>(PortHolder))
+        , Port(static_cast<std::uint16_t>(PortHolder))
         , HttpOptions(Port)
         , HttpServer(this, HttpOptions)
     {
@@ -53,7 +53,7 @@ public:
         return new TRequest(this);
     }
 
-    void SetResponse(HttpCodes code, const TString& response) {
+    void SetResponse(HttpCodes code, const std::string& response) {
         StatusCode = code;
         Response = response;
     }
@@ -73,7 +73,7 @@ public:
     THttpServer::TOptions HttpOptions;
     THttpServer HttpServer;
     HttpCodes StatusCode = HTTP_OK;
-    TString Response;
+    std::string Response;
     mutable std::mutex Lock;
     int RequestCount = 0;
 };

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -3,10 +3,13 @@
 #include <library/cpp/http/server/http.h>
 #include <library/cpp/http/server/response.h>
 #include <library/cpp/json/json_writer.h>
-#include <library/cpp/testing/unittest/registar.h>
+
 #include <library/cpp/testing/unittest/tests_data.h>
 
-#include <util/system/thread.h>
+#include <gtest/gtest.h>
+
+#include <mutex>
+#include <thread>
 
 using namespace NYdb;
 
@@ -19,7 +22,8 @@ public:
         {}
 
         bool DoReply(const TReplyParams& params) override {
-            with_lock (Server->Lock) {
+            {
+                std::lock_guard lock(Server->Lock);
                 ++Server->RequestCount;
             }
 
@@ -48,21 +52,19 @@ public:
         return new TRequest(this);
     }
 
-    void SetResponse(HttpCodes code, const TString& response) {
+    void SetResponse(HttpCodes code, const std::string& response) {
         StatusCode = code;
         Response = response;
     }
 
     int GetRequestCount() const {
-        with_lock (Lock) {
-            return RequestCount;
-        }
+        std::lock_guard lock(Lock);
+        return RequestCount;
     }
 
     void ResetRequestCount() {
-        with_lock (Lock) {
-            RequestCount = 0;
-        }
+        std::lock_guard lock(Lock);
+        RequestCount = 0;
     }
 
     TPortManager PortManager;
@@ -70,12 +72,12 @@ public:
     THttpServer::TOptions HttpOptions;
     THttpServer HttpServer;
     HttpCodes StatusCode = HTTP_OK;
-    TString Response;
-    mutable TAdaptiveLock Lock;
+    std::string Response;
+    mutable std::mutex Lock;
     int RequestCount = 0;
 };
 
-static TString MakeTokenResponse(const TString& token, int expiresIn) {
+static std::string MakeTokenResponse(const std::string& token, int expiresIn) {
     TStringStream ss;
     NJson::TJsonWriter w(&ss, false);
     w.OpenMap();
@@ -90,7 +92,7 @@ static TString MakeTokenResponse(const TString& token, int expiresIn) {
     return ss.Str();
 }
 
-static TString MakeTokenResponseWithExpiry(const TString& token, const TInstant& expiry) {
+static std::string MakeTokenResponseWithExpiry(const std::string& token, const TInstant& expiry) {
     TStringStream ss;
     NJson::TJsonWriter w(&ss, false);
     w.OpenMap();
@@ -105,7 +107,7 @@ static TString MakeTokenResponseWithExpiry(const TString& token, const TInstant&
     return ss.Str();
 }
 
-static TString MakeTokenResponseNoExpiry(const TString& token) {
+static std::string MakeTokenResponseNoExpiry(const std::string& token) {
     TStringStream ss;
     NJson::TJsonWriter w(&ss, false);
     w.OpenMap();
@@ -118,117 +120,114 @@ static TString MakeTokenResponseNoExpiry(const TString& token) {
     return ss.Str();
 }
 
-Y_UNIT_TEST_SUITE(IamCredentialsProvider) {
-    Y_UNIT_TEST(BasicTokenFetch) {
-        TMetadataServer server;
-        server.SetResponse(HTTP_OK, MakeTokenResponse("test-token-123", 3600));
+TEST(IamCredentialsProvider, BasicTokenFetch) {
+    TMetadataServer server;
+    server.SetResponse(HTTP_OK, MakeTokenResponse("test-token-123", 3600));
 
-        TIamHost params;
-        params.Host = "localhost";
-        params.Port = server.Port;
-        params.RefreshPeriod = TDuration::Hours(1);
+    TIamHost params;
+    params.Host = "localhost";
+    params.Port = server.Port;
+    params.RefreshPeriod = TDuration::Hours(1);
 
-        auto factory = CreateIamCredentialsProviderFactory(params);
-        auto provider = factory->CreateProvider();
+    auto factory = CreateIamCredentialsProviderFactory(params);
+    auto provider = factory->CreateProvider();
 
-        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "test-token-123");
-    }
+    EXPECT_EQ(provider->GetAuthInfo(), "test-token-123");
+}
 
-    Y_UNIT_TEST(ExpiryFieldSupport) {
-        TMetadataServer server;
-        auto expiry = TInstant::Now() + TDuration::Hours(12);
-        server.SetResponse(HTTP_OK, MakeTokenResponseWithExpiry("expiry-token", expiry));
+TEST(IamCredentialsProvider, ExpiryFieldSupport) {
+    TMetadataServer server;
+    auto expiry = TInstant::Now() + TDuration::Hours(12);
+    server.SetResponse(HTTP_OK, MakeTokenResponseWithExpiry("expiry-token", expiry));
 
-        TIamHost params;
-        params.Host = "localhost";
-        params.Port = server.Port;
-        params.RefreshPeriod = TDuration::Hours(1);
+    TIamHost params;
+    params.Host = "localhost";
+    params.Port = server.Port;
+    params.RefreshPeriod = TDuration::Hours(1);
 
-        auto factory = CreateIamCredentialsProviderFactory(params);
-        auto provider = factory->CreateProvider();
+    auto factory = CreateIamCredentialsProviderFactory(params);
+    auto provider = factory->CreateProvider();
 
-        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "expiry-token");
+    EXPECT_EQ(provider->GetAuthInfo(), "expiry-token");
 
-        // Second call should not trigger refresh (token is still valid)
-        int countBefore = server.GetRequestCount();
-        provider->GetAuthInfo();
-        UNIT_ASSERT_VALUES_EQUAL(server.GetRequestCount(), countBefore);
-    }
+    // Second call should not trigger refresh (token is still valid)
+    int countBefore = server.GetRequestCount();
+    provider->GetAuthInfo();
+    EXPECT_EQ(server.GetRequestCount(), countBefore);
+}
 
-    Y_UNIT_TEST(NoExpiryFieldFallback) {
-        TMetadataServer server;
-        server.SetResponse(HTTP_OK, MakeTokenResponseNoExpiry("no-expiry-token"));
+TEST(IamCredentialsProvider, NoExpiryFieldFallback) {
+    TMetadataServer server;
+    server.SetResponse(HTTP_OK, MakeTokenResponseNoExpiry("no-expiry-token"));
 
-        TIamHost params;
-        params.Host = "localhost";
-        params.Port = server.Port;
-        params.RefreshPeriod = TDuration::Hours(1);
+    TIamHost params;
+    params.Host = "localhost";
+    params.Port = server.Port;
+    params.RefreshPeriod = TDuration::Hours(1);
 
-        auto factory = CreateIamCredentialsProviderFactory(params);
-        auto provider = factory->CreateProvider();
+    auto factory = CreateIamCredentialsProviderFactory(params);
+    auto provider = factory->CreateProvider();
 
-        // Token should be saved even without expires_in/expiry
-        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "no-expiry-token");
+    // Token should be saved even without expires_in/expiry
+    EXPECT_EQ(provider->GetAuthInfo(), "no-expiry-token");
 
-        // Should not immediately refresh (fallback interval should be > 0)
-        int countBefore = server.GetRequestCount();
-        provider->GetAuthInfo();
-        UNIT_ASSERT_VALUES_EQUAL(server.GetRequestCount(), countBefore);
-    }
+    // Should not immediately refresh (fallback interval should be > 0)
+    int countBefore = server.GetRequestCount();
+    provider->GetAuthInfo();
+    EXPECT_EQ(server.GetRequestCount(), countBefore);
+}
 
-    Y_UNIT_TEST(ServerError) {
-        TMetadataServer server;
-        server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
+TEST(IamCredentialsProvider, ServerError) {
+    TMetadataServer server;
+    server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
 
-        TIamHost params;
-        params.Host = "localhost";
-        params.Port = server.Port;
+    TIamHost params;
+    params.Host = "localhost";
+    params.Port = server.Port;
 
-        auto factory = CreateIamCredentialsProviderFactory(params);
-        auto provider = factory->CreateProvider();
+    auto factory = CreateIamCredentialsProviderFactory(params);
+    auto provider = factory->CreateProvider();
 
-        // Constructor GetTicket() fails, token should be empty
-        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "");
-    }
+    // Constructor GetTicket() fails, token should be empty
+    EXPECT_EQ(provider->GetAuthInfo(), "");
+}
 
-    Y_UNIT_TEST(ConcurrentAccess) {
-        TMetadataServer server;
-        server.SetResponse(HTTP_OK, MakeTokenResponse("concurrent-token", 3600));
+TEST(IamCredentialsProvider, ConcurrentAccess) {
+    TMetadataServer server;
+    server.SetResponse(HTTP_OK, MakeTokenResponse("concurrent-token", 3600));
 
-        TIamHost params;
-        params.Host = "localhost";
-        params.Port = server.Port;
-        params.RefreshPeriod = TDuration::MilliSeconds(1); // Force frequent refreshes
+    TIamHost params;
+    params.Host = "localhost";
+    params.Port = server.Port;
+    params.RefreshPeriod = TDuration::MilliSeconds(1); // Force frequent refreshes
 
-        auto factory = CreateIamCredentialsProviderFactory(params);
-        auto provider = factory->CreateProvider();
+    auto factory = CreateIamCredentialsProviderFactory(params);
+    auto provider = factory->CreateProvider();
 
-        constexpr int NUM_THREADS = 8;
-        constexpr int ITERATIONS = 100;
+    constexpr int NUM_THREADS = 8;
+    constexpr int ITERATIONS = 100;
 
-        std::vector<THolder<TThread>> threads;
-        std::atomic<int> errors{0};
+    std::vector<std::unique_ptr<std::thread>> threads;
+    std::atomic<int> errors{0};
 
-        for (int i = 0; i < NUM_THREADS; ++i) {
-            threads.push_back(MakeHolder<TThread>([&]() {
-                for (int j = 0; j < ITERATIONS; ++j) {
-                    try {
-                        auto token = provider->GetAuthInfo();
-                        if (token != "concurrent-token") {
-                            errors.fetch_add(1);
-                        }
-                    } catch (...) {
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        threads.push_back(std::make_unique<std::thread>([&]() {
+            for (int j = 0; j < ITERATIONS; ++j) {
+                try {
+                    auto token = provider->GetAuthInfo();
+                    if (token != "concurrent-token") {
                         errors.fetch_add(1);
                     }
+                } catch (...) {
+                    errors.fetch_add(1);
                 }
-            }));
-            threads.back()->Start();
-        }
-
-        for (auto& t : threads) {
-            t->Join();
-        }
-
-        UNIT_ASSERT_VALUES_EQUAL(errors.load(), 0);
+            }
+        }));
     }
+
+    for (auto& t : threads) {
+        t->join();
+    }
+
+    EXPECT_EQ(errors.load(), 0);
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -28,7 +28,7 @@ public:
             }
 
             THttpResponse resp(Server->StatusCode);
-            resp.SetContent(Server->Response);
+            resp.SetContent(TString{Server->Response});
             resp.OutTo(params.Output);
             return true;
         }

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -8,8 +8,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 using namespace NYdb;
 

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -4,7 +4,7 @@
 #include <library/cpp/http/server/response.h>
 #include <library/cpp/json/json_writer.h>
 
-#include <library/cpp/testing/unittest/tests_data.h>
+#include <library/cpp/testing/common/network.h>
 
 #include <gtest/gtest.h>
 
@@ -37,7 +37,8 @@ public:
     };
 
     TMetadataServer()
-        : Port(PortManager.GetPort())
+        : PortHolder(NTesting::GetFreePort())
+        , Port(static_cast<ui16>(PortHolder))
         , HttpOptions(Port)
         , HttpServer(this, HttpOptions)
     {
@@ -52,7 +53,7 @@ public:
         return new TRequest(this);
     }
 
-    void SetResponse(HttpCodes code, const std::string& response) {
+    void SetResponse(HttpCodes code, const TString& response) {
         StatusCode = code;
         Response = response;
     }
@@ -67,12 +68,12 @@ public:
         RequestCount = 0;
     }
 
-    TPortManager PortManager;
+    NTesting::TPortHolder PortHolder;
     uint16_t Port;
     THttpServer::TOptions HttpOptions;
     THttpServer HttpServer;
     HttpCodes StatusCode = HTTP_OK;
-    std::string Response;
+    TString Response;
     mutable std::mutex Lock;
     int RequestCount = 0;
 };

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/iam_ut.cpp
@@ -1,0 +1,234 @@
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/iam.h>
+
+#include <library/cpp/http/server/http.h>
+#include <library/cpp/http/server/response.h>
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+#include <util/system/thread.h>
+
+using namespace NYdb;
+
+class TMetadataServer : public THttpServer::ICallBack {
+public:
+    class TRequest : public TRequestReplier {
+    public:
+        explicit TRequest(TMetadataServer* server)
+            : Server(server)
+        {}
+
+        bool DoReply(const TReplyParams& params) override {
+            with_lock (Server->Lock) {
+                ++Server->RequestCount;
+            }
+
+            THttpResponse resp(Server->StatusCode);
+            resp.SetContent(Server->Response);
+            resp.OutTo(params.Output);
+            return true;
+        }
+
+        TMetadataServer* Server = nullptr;
+    };
+
+    TMetadataServer()
+        : Port(PortManager.GetPort())
+        , HttpOptions(Port)
+        , HttpServer(this, HttpOptions)
+    {
+        HttpServer.Start();
+    }
+
+    ~TMetadataServer() {
+        HttpServer.Stop();
+    }
+
+    TClientRequest* CreateClient() override {
+        return new TRequest(this);
+    }
+
+    void SetResponse(HttpCodes code, const TString& response) {
+        StatusCode = code;
+        Response = response;
+    }
+
+    int GetRequestCount() const {
+        with_lock (Lock) {
+            return RequestCount;
+        }
+    }
+
+    void ResetRequestCount() {
+        with_lock (Lock) {
+            RequestCount = 0;
+        }
+    }
+
+    TPortManager PortManager;
+    uint16_t Port;
+    THttpServer::TOptions HttpOptions;
+    THttpServer HttpServer;
+    HttpCodes StatusCode = HTTP_OK;
+    TString Response;
+    mutable TAdaptiveLock Lock;
+    int RequestCount = 0;
+};
+
+static TString MakeTokenResponse(const TString& token, int expiresIn) {
+    TStringStream ss;
+    NJson::TJsonWriter w(&ss, false);
+    w.OpenMap();
+    w.WriteKey("access_token");
+    w.Write(token);
+    w.WriteKey("token_type");
+    w.Write("Bearer");
+    w.WriteKey("expires_in");
+    w.Write(expiresIn);
+    w.CloseMap();
+    w.Flush();
+    return ss.Str();
+}
+
+static TString MakeTokenResponseWithExpiry(const TString& token, const TInstant& expiry) {
+    TStringStream ss;
+    NJson::TJsonWriter w(&ss, false);
+    w.OpenMap();
+    w.WriteKey("access_token");
+    w.Write(token);
+    w.WriteKey("token_type");
+    w.Write("Bearer");
+    w.WriteKey("expiry");
+    w.Write(expiry.FormatGmTime("%Y-%m-%dT%H:%M:%S.000000000Z"));
+    w.CloseMap();
+    w.Flush();
+    return ss.Str();
+}
+
+static TString MakeTokenResponseNoExpiry(const TString& token) {
+    TStringStream ss;
+    NJson::TJsonWriter w(&ss, false);
+    w.OpenMap();
+    w.WriteKey("access_token");
+    w.Write(token);
+    w.WriteKey("token_type");
+    w.Write("Bearer");
+    w.CloseMap();
+    w.Flush();
+    return ss.Str();
+}
+
+Y_UNIT_TEST_SUITE(IamCredentialsProvider) {
+    Y_UNIT_TEST(BasicTokenFetch) {
+        TMetadataServer server;
+        server.SetResponse(HTTP_OK, MakeTokenResponse("test-token-123", 3600));
+
+        TIamHost params;
+        params.Host = "localhost";
+        params.Port = server.Port;
+        params.RefreshPeriod = TDuration::Hours(1);
+
+        auto factory = CreateIamCredentialsProviderFactory(params);
+        auto provider = factory->CreateProvider();
+
+        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "test-token-123");
+    }
+
+    Y_UNIT_TEST(ExpiryFieldSupport) {
+        TMetadataServer server;
+        auto expiry = TInstant::Now() + TDuration::Hours(12);
+        server.SetResponse(HTTP_OK, MakeTokenResponseWithExpiry("expiry-token", expiry));
+
+        TIamHost params;
+        params.Host = "localhost";
+        params.Port = server.Port;
+        params.RefreshPeriod = TDuration::Hours(1);
+
+        auto factory = CreateIamCredentialsProviderFactory(params);
+        auto provider = factory->CreateProvider();
+
+        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "expiry-token");
+
+        // Second call should not trigger refresh (token is still valid)
+        int countBefore = server.GetRequestCount();
+        provider->GetAuthInfo();
+        UNIT_ASSERT_VALUES_EQUAL(server.GetRequestCount(), countBefore);
+    }
+
+    Y_UNIT_TEST(NoExpiryFieldFallback) {
+        TMetadataServer server;
+        server.SetResponse(HTTP_OK, MakeTokenResponseNoExpiry("no-expiry-token"));
+
+        TIamHost params;
+        params.Host = "localhost";
+        params.Port = server.Port;
+        params.RefreshPeriod = TDuration::Hours(1);
+
+        auto factory = CreateIamCredentialsProviderFactory(params);
+        auto provider = factory->CreateProvider();
+
+        // Token should be saved even without expires_in/expiry
+        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "no-expiry-token");
+
+        // Should not immediately refresh (fallback interval should be > 0)
+        int countBefore = server.GetRequestCount();
+        provider->GetAuthInfo();
+        UNIT_ASSERT_VALUES_EQUAL(server.GetRequestCount(), countBefore);
+    }
+
+    Y_UNIT_TEST(ServerError) {
+        TMetadataServer server;
+        server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
+
+        TIamHost params;
+        params.Host = "localhost";
+        params.Port = server.Port;
+
+        auto factory = CreateIamCredentialsProviderFactory(params);
+        auto provider = factory->CreateProvider();
+
+        // Constructor GetTicket() fails, token should be empty
+        UNIT_ASSERT_VALUES_EQUAL(provider->GetAuthInfo(), "");
+    }
+
+    Y_UNIT_TEST(ConcurrentAccess) {
+        TMetadataServer server;
+        server.SetResponse(HTTP_OK, MakeTokenResponse("concurrent-token", 3600));
+
+        TIamHost params;
+        params.Host = "localhost";
+        params.Port = server.Port;
+        params.RefreshPeriod = TDuration::MilliSeconds(1); // Force frequent refreshes
+
+        auto factory = CreateIamCredentialsProviderFactory(params);
+        auto provider = factory->CreateProvider();
+
+        constexpr int NUM_THREADS = 8;
+        constexpr int ITERATIONS = 100;
+
+        std::vector<THolder<TThread>> threads;
+        std::atomic<int> errors{0};
+
+        for (int i = 0; i < NUM_THREADS; ++i) {
+            threads.push_back(MakeHolder<TThread>([&]() {
+                for (int j = 0; j < ITERATIONS; ++j) {
+                    try {
+                        auto token = provider->GetAuthInfo();
+                        if (token != "concurrent-token") {
+                            errors.fetch_add(1);
+                        }
+                    } catch (...) {
+                        errors.fetch_add(1);
+                    }
+                }
+            }));
+            threads.back()->Start();
+        }
+
+        for (auto& t : threads) {
+            t->Join();
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(errors.load(), 0);
+    }
+}

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
@@ -1,4 +1,4 @@
-UNITTEST()
+GTEST()
 
 SRCS(
     iam_ut.cpp
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     library/cpp/http/server
     library/cpp/json
+    library/cpp/testing/unittest
     ydb/public/sdk/cpp/src/client/iam
 )
 

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
@@ -7,7 +7,7 @@ SRCS(
 PEERDIR(
     library/cpp/http/server
     library/cpp/json
-    library/cpp/testing/unittest
+    library/cpp/testing/common
     ydb/public/sdk/cpp/src/client/iam
 )
 

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
@@ -1,5 +1,14 @@
 GTEST()
 
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+FORK_SUBTESTS()
+
 SRCS(
     iam_ut.cpp
 )

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/ya.make
@@ -1,0 +1,13 @@
+UNITTEST()
+
+SRCS(
+    iam_ut.cpp
+)
+
+PEERDIR(
+    library/cpp/http/server
+    library/cpp/json
+    ydb/public/sdk/cpp/src/client/iam
+)
+
+END()

--- a/ydb/public/sdk/cpp/tests/unit/client/ya.make
+++ b/ydb/public/sdk/cpp/tests/unit/client/ya.make
@@ -5,6 +5,7 @@ RECURSE(
     draft
     driver
     endpoints
+    iam
     oauth2_token_exchange
     params
     result


### PR DESCRIPTION
## Summary

- **Thread-safety**: `GetAuthInfo()` and `GetTicket()` mutate `mutable Ticket_` and `NextTicketUpdate_` without synchronization. Concurrent calls from multiple threads cause data races on `std::string` (double-free crashes observed in production). Added `TAdaptiveLock` to protect shared mutable state.

- **Token expiry parsing**: Yandex Cloud metadata service returns `"expiry"` (ISO 8601 timestamp) instead of `"expires_in"` (seconds). The current code throws an exception when `expires_in` is missing, which is caught by `catch(...){}` — silently discarding the already-extracted valid `access_token`. Added support for the `"expiry"` field and a fallback refresh interval.

- **Atomic update**: Both `Ticket_` and `NextTicketUpdate_` are now updated together under a single lock, preventing inconsistent state.

## Test plan

- [ ] Verify IAM token refresh works with metadata responses containing `expires_in` (GCP format)
- [ ] Verify IAM token refresh works with metadata responses containing `expiry` (Yandex Cloud format)
- [ ] Verify fallback behavior when neither field is present
- [ ] Verify no crashes under concurrent `GetAuthInfo()` calls from multiple threads