### PR TITLE
scheme_board: fix path resolution for bad root schemeshard ids

### DIFF
--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -2559,7 +2559,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 << ", byPath# " << (byPath ? byPath->ToString() : "nullptr")
                 << ", byPathId# " << (byPathId ? byPathId->ToString() : "nullptr"));
 
-            if (byPath->GetPathId() < notify.PathId) {
+            if (PathIdLessThan(byPath->GetPathId(), notify.PathId)) {
                 return SwapSubscriberAndUpsert(byPath, notify.PathId, notify.Path);
             }
 
@@ -2614,7 +2614,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                       << ", byPath# " << (byPath ? byPath->ToString() : "nullptr")
                       << ", byPathId# " << (byPathId ? byPathId->ToString() : "nullptr"));
 
-            if (byPath->GetPathId() < notify.PathId) {
+            if (PathIdLessThan(byPath->GetPathId(), notify.PathId)) {
                 return SwapSubscriberAndUpsert(byPath, notify.PathId, notify.Path);
             }
 

--- a/ydb/core/tx/scheme_board/cache_ut.cpp
+++ b/ydb/core/tx/scheme_board/cache_ut.cpp
@@ -1,4 +1,5 @@
 #include "cache.h"
+#include "helpers.h"
 #include "ut_helpers.h"
 
 #include <ydb/core/base/counters.h>
@@ -27,13 +28,13 @@ protected:
     void BootSchemeCache() {
         TIntrusivePtr<TConfig> config = new TConfig();
         config->Counters = new ::NMonitoring::TDynamicCounters;
-        config->Roots.push_back(TConfig::TTagEntry(0, TTestTxConfig::SchemeShard, "Root"));
+        config->Roots.push_back(TConfig::TTagEntry(0, RootSchemeshardTabletId, "Root"));
         SchemeCache = Context->Register(CreateSchemeBoardSchemeCache(config.Get()));
         Context->EnableScheduleForActor(SchemeCache, true);
     }
 
     void AlterSubDomain() {
-        TestAlterSubDomain(*Context, 1, "/", R"(
+        TestAlterSubDomain(*Context, RootSchemeshardTabletId, 1, "/", R"(
             Name: "Root"
             StoragePools {
               Name: "pool-1"
@@ -173,11 +174,11 @@ TPathId TCacheTestBase::ExpectWatchDeleted(const TActorId& watcher) {
 }
 
 void TCacheTestBase::CreateAndMigrateWithoutDecision(ui64& txId) {
-    auto domainSSNotifier = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    auto domainSSNotifier = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
 
-    TestCreateSubDomain(*Context, ++txId,  "/Root",
+    TestCreateSubDomain(*Context, RootSchemeshardTabletId, ++txId,  "/Root",
                         "Name: \"USER_0\"");
-    TestAlterSubDomain(*Context, ++txId,  "/Root",
+    TestAlterSubDomain(*Context, RootSchemeshardTabletId, ++txId,  "/Root",
                        "Name: \"USER_0\" "
                        "PlanResolution: 50 "
                        "Coordinators: 1 "
@@ -185,8 +186,8 @@ void TCacheTestBase::CreateAndMigrateWithoutDecision(ui64& txId) {
                        "TimeCastBucketsPerMediator: 2 ");
     TestWaitNotification(*Context, {txId, txId - 1}, domainSSNotifier);
 
-    TestMkDir(*Context, ++txId, "/Root/USER_0", "DirA");
-    TestCreateTable(*Context, ++txId, "/Root/USER_0/DirA", R"(
+    TestMkDir(*Context, RootSchemeshardTabletId, ++txId, "/Root/USER_0", "DirA");
+    TestCreateTable(*Context, RootSchemeshardTabletId, ++txId, "/Root/USER_0/DirA", R"(
         Name: "Table1"
         Columns { Name: "key" Type: "Uint32" }
         KeyColumnNames: [ "key" ]
@@ -201,24 +202,24 @@ void TCacheTestBase::CreateAndMigrateWithoutDecision(ui64& txId) {
     {
         auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
     }
 
     {
         auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
     }
     {
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
     }
 
-    TestUpgradeSubDomain(*Context, ++txId,  "/Root", "USER_0");
+    TestUpgradeSubDomain(*Context, RootSchemeshardTabletId, ++txId,  "/Root", "USER_0");
 
     TestWaitNotification(*Context, {txId}, domainSSNotifier);
 }
@@ -286,7 +287,7 @@ void TCacheTest::Navigate() {
     ui64 txId = 100;
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     auto entry = TestNavigate("/Root/DirA", TNavigate::EStatus::Ok);
 
@@ -302,7 +303,7 @@ void TCacheTest::Attributes() {
 
     ui64 txId = 100;
     TestMkDir(*Context, ++txId, "/Root", "DirA", {NKikimrScheme::StatusAccepted}, attrs);
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     auto entry = TestNavigate("/Root/DirA", TNavigate::EStatus::Ok);
     UNIT_ASSERT_VALUES_EQUAL(entry.Attributes.size(), 1);
@@ -316,7 +317,7 @@ void TCacheTest::List() {
     TestMkDir(*Context, ++txId, "/Root", "DirA");
     TestMkDir(*Context, ++txId, "/Root/DirA", "DirB");
     TestMkDir(*Context, ++txId, "/Root/DirA", "DirC");
-    TestWaitNotification(*Context, {txId - 2, txId - 1, txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId - 2, txId - 1, txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     {
         auto entry = TestNavigate("/Root/DirA", TNavigate::EStatus::Ok);
@@ -334,18 +335,18 @@ void TCacheTest::Recreate() {
     ui64 txId = 100;
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     Context->CreateSubscriber<TSchemeBoardEvents::TEvNotifyUpdate>(edge, "/Root/DirA");
 
     TestRmDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     auto ev = Context->GrabEdgeEvent<TSchemeBoardEvents::TEvNotifyDelete>(edge);
     auto pathId = ev->Get()->PathId;
     TTableId tableId(pathId.OwnerId, pathId.LocalPathId);
     TestResolve(tableId, TResolve::EStatus::PathErrorNotExist);
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     Context->GrabEdgeEvent<TSchemeBoardEvents::TEvNotifyUpdate>(edge);
     TestNavigate("/Root/DirA", TNavigate::EStatus::Ok);
 }
@@ -385,7 +386,7 @@ void TCacheTest::RacyCreateAndSync() {
 
     ui64 txId = 100;
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     Context->TTestBasicRuntime::Send(delayedSyncRequest.Release(), 0, true);
     auto ev = Context->GrabEdgeEvent<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(edge);
@@ -398,11 +399,11 @@ void TCacheTest::RacyRecreateAndSync() {
     ui64 txId = 100;
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     TestNavigate("/Root/DirA", TNavigate::EStatus::Ok, "", TNavigate::EOp::OpPath, false, true, true);
 
     TestRmDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     TestNavigate("/Root/DirA", TNavigate::EStatus::PathErrorUnknown, "", TNavigate::EOp::OpPath, false, true, true);
 
     THolder<IEventHandle> delayedSyncRequest;
@@ -438,7 +439,7 @@ void TCacheTest::RacyRecreateAndSync() {
     Context->SetObserverFunc(prevObserver);
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     Context->TTestBasicRuntime::Send(delayedSyncRequest.Release(), 0, true);
     auto ev = Context->GrabEdgeEvent<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(edge);
@@ -490,7 +491,7 @@ void TCacheTest::SystemViews() {
 void TCacheTest::CheckSystemViewAccess() {
     ui64 txId = 100;
     TestModifyACL(*Context, ++txId, "/Root/.sys", "partition_stats", TString(), "user0@builtin");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     // anonymous user as cluster admin has exclusive rights
     auto entry = TestNavigate("/Root/.sys/partition_stats",
@@ -531,7 +532,7 @@ void TCacheTest::TableSchemaVersion() {
         }
     )", {NKikimrScheme::StatusAccepted});
 
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     {
         auto entry = TestNavigate("/Root/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_VALUES_EQUAL(entry.TableId.SchemaVersion, 1);
@@ -542,7 +543,7 @@ void TCacheTest::TableSchemaVersion() {
         Columns { Name: "added"  Type: "Uint64"}
     )");
 
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
     {
         auto entry = TestNavigate("/Root/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_VALUES_EQUAL(entry.TableId.SchemaVersion, 2);
@@ -560,20 +561,20 @@ void TCacheTest::MigrationCommon() {
         {
             auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
             UNIT_ASSERT_EQUAL(entry.TableId.PathId, TPathId(entry.DomainInfo->Params.GetSchemeShard(), 1));
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
     };
@@ -581,7 +582,7 @@ void TCacheTest::MigrationCommon() {
     checkMigratedPathes();
 
     // global ss do not wipe migrated pathes after restart
-    RebootTablet(*Context, (ui64)TTestTxConfig::SchemeShard, Context->AllocateEdgeActor());
+    RebootTablet(*Context, RootSchemeshardTabletId, Context->AllocateEdgeActor());
 
     checkMigratedPathes();
 }
@@ -597,34 +598,34 @@ void TCacheTest::MigrationCommit() {
         {
             auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
             UNIT_ASSERT_EQUAL(entry.TableId.PathId, TPathId(entry.DomainInfo->Params.GetSchemeShard(), 1));
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
     };
 
     checkMigratedPathes();
 
-    TestUpgradeSubDomainDecision(*Context, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
+    TestUpgradeSubDomainDecision(*Context, RootSchemeshardTabletId, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
 
-    auto domainSSNotifier = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    auto domainSSNotifier = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
     TestWaitNotification(*Context, {txId}, domainSSNotifier);
 
     checkMigratedPathes();
 
-    RebootTablet(*Context, (ui64)TTestTxConfig::SchemeShard, Context->AllocateEdgeActor());
+    RebootTablet(*Context, RootSchemeshardTabletId, Context->AllocateEdgeActor());
 
     checkMigratedPathes();
 }
@@ -640,29 +641,29 @@ void TCacheTest::MigrationLostMessage() {
         {
             auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
             UNIT_ASSERT_EQUAL(entry.TableId.PathId, TPathId(entry.DomainInfo->Params.GetSchemeShard(), 1));
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
     };
 
     checkMigratedPathes();
 
-    TestUpgradeSubDomainDecision(*Context, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
+    TestUpgradeSubDomainDecision(*Context, RootSchemeshardTabletId, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
 
-    auto domainSSNotifier = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    auto domainSSNotifier = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
     TestWaitNotification(*Context, {txId}, domainSSNotifier);
 
     checkMigratedPathes();
@@ -671,7 +672,7 @@ void TCacheTest::MigrationLostMessage() {
     {
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
 
         tenantSchemeShard = entry.DomainInfo->Params.GetSchemeShard();
@@ -700,7 +701,7 @@ void TCacheTest::MigrationLostMessage() {
     { // hang in chache
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
     }
 
@@ -711,7 +712,7 @@ void TCacheTest::MigrationLostMessage() {
     { // hang in chache
         auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         oldLocalPathId = entry.TableId.PathId.LocalPathId;
     }
@@ -732,7 +733,7 @@ void TCacheTest::MigrationLostMessage() {
     }
 
     {
-        TestNavigateByTableId(TTableId(TTestTxConfig::SchemeShard, oldLocalPathId), TNavigate::EStatus::Ok, "/Root/USER_0/DirA");
+        TestNavigateByTableId(TTableId(RootSchemeshardTabletId, oldLocalPathId), TNavigate::EStatus::Ok, "/Root/USER_0/DirA");
         TestNavigateByTableId(TTableId(tenantSchemeShard, newLocalPathId), TNavigate::EStatus::Ok, "/Root/USER_0/DirA");
     }
 
@@ -741,7 +742,7 @@ void TCacheTest::MigrationLostMessage() {
     { // hang in chache still
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
     }
 
@@ -773,48 +774,48 @@ void TCacheTest::MigrationUndo() {
         {
             auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
             UNIT_ASSERT_EQUAL(entry.TableId.PathId, TPathId(entry.DomainInfo->Params.GetSchemeShard(), 1));
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
         }
     };
 
     checkMigratedPathes();
 
-    TestUpgradeSubDomainDecision(*Context, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Undo);
+    TestUpgradeSubDomainDecision(*Context, RootSchemeshardTabletId, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Undo);
 
-    auto domainSSNotifier = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    auto domainSSNotifier = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
     TestWaitNotification(*Context, {txId}, domainSSNotifier);
 
     auto checkRevertedPathes = [&] () {
         {
             auto entry = TestNavigate("/Root/USER_0", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
         }
         {
             auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
             UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+            UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
             UNIT_ASSERT(!entry.DomainInfo->Params.HasSchemeShard());
         }
     };
@@ -822,7 +823,7 @@ void TCacheTest::MigrationUndo() {
 
     checkRevertedPathes();
 
-    RebootTablet(*Context, (ui64)TTestTxConfig::SchemeShard, Context->AllocateEdgeActor());
+    RebootTablet(*Context, RootSchemeshardTabletId, Context->AllocateEdgeActor());
 
     checkRevertedPathes();
 }
@@ -840,9 +841,9 @@ void TCacheTest::MigrationDeletedPathNavigate() {
 
     CreateAndMigrateWithoutDecision(txId);
 
-    TestUpgradeSubDomainDecision(*Context, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
+    TestUpgradeSubDomainDecision(*Context, RootSchemeshardTabletId, ++txId,  "/Root", "USER_0", NKikimrSchemeOp::TUpgradeSubDomain::Commit);
 
-    auto domainSSNotifier = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    auto domainSSNotifier = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
     TestWaitNotification(*Context, {txId}, domainSSNotifier);
 
     ui64 tenantSchemeShard = 0;
@@ -850,7 +851,7 @@ void TCacheTest::MigrationDeletedPathNavigate() {
     {
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_EQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
 
         tenantSchemeShard = entry.DomainInfo->Params.GetSchemeShard();
@@ -876,7 +877,7 @@ void TCacheTest::MigrationDeletedPathNavigate() {
     {
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
         UNIT_ASSERT(entry.DomainInfo->Params.HasSchemeShard());
     }
 
@@ -885,7 +886,7 @@ void TCacheTest::MigrationDeletedPathNavigate() {
 
         auto entry = TestNavigate("/Root/USER_0/DirA/Table1", TNavigate::EStatus::Ok);
         UNIT_ASSERT_EQUAL(JoinPath(entry.Path), "Root/USER_0/DirA/Table1");
-        UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, TTestTxConfig::SchemeShard);
+        UNIT_ASSERT_UNEQUAL(entry.TableId.PathId.OwnerId, RootSchemeshardTabletId);
     }
 
     {
@@ -894,7 +895,7 @@ void TCacheTest::MigrationDeletedPathNavigate() {
 }
 
 void TCacheTest::WatchRoot() {
-    auto watcher = TestWatch(TPathId(TTestTxConfig::SchemeShard, 1));
+    auto watcher = TestWatch(TPathId(RootSchemeshardTabletId, 1));
 
     {
         auto result = ExpectWatchUpdated(watcher, "/Root");
@@ -905,7 +906,7 @@ void TCacheTest::WatchRoot() {
     ui64 txId = 100;
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     // Ignore notification before create finished
     ExpectWatchUpdated(watcher);
@@ -923,7 +924,7 @@ void TCacheTest::WatchRoot() {
         }
     }
 
-    TestWatch(TPathId(TTestTxConfig::SchemeShard, dirPathId), watcher);
+    TestWatch(TPathId(RootSchemeshardTabletId, dirPathId), watcher);
 
     {
         auto result = ExpectWatchUpdated(watcher, "/Root/DirA");
@@ -932,7 +933,7 @@ void TCacheTest::WatchRoot() {
     }
 
     TestRmDir(*Context, ++txId, "/Root", "DirA");
-    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard));
+    TestWaitNotification(*Context, {txId}, CreateNotificationSubscriber(*Context, RootSchemeshardTabletId));
 
     {
         auto deleted = ExpectWatchDeleted(watcher);
@@ -954,7 +955,7 @@ void TCacheTest::WatchRoot() {
 
 void TCacheTest::PathBelongsToDomain() {
     ui64 txId = 100;
-    const auto rootSubscriber = CreateNotificationSubscriber(*Context, TTestTxConfig::SchemeShard);
+    const auto rootSubscriber = CreateNotificationSubscriber(*Context, RootSchemeshardTabletId);
 
     TestMkDir(*Context, ++txId, "/Root", "DirA");
     TestWaitNotification(*Context, {txId}, rootSubscriber);
@@ -1199,6 +1200,28 @@ public:
 }; // TCacheTestWithDrops
 
 UNIT_TEST_SUITE_REGISTRATION(TCacheTestWithDrops);
+
+// Tests that migration works correctly when the root schemeshard has a bad (misconfigured)
+// tablet id that is numerically higher than tenant schemeshard ids.
+// This exercises the PathIdLessThan branches in ResolveCacheItem (cache.cpp).
+// BAD_ROOT_SCHEMESHARD_ID_1 is used; BAD_ROOT_SCHEMESHARD_ID_2 is not tested separately
+// because both ids have the same high-bit pattern and PathIdLessThan treats them identically.
+class TCacheTestBadRootSchemeshard: public TCacheTest {
+public:
+    TCacheTestBadRootSchemeshard() {
+        RootSchemeshardTabletId = BAD_ROOT_SCHEMESHARD_ID_1;
+    }
+
+    UNIT_TEST_SUITE(TCacheTestBadRootSchemeshard);
+    UNIT_TEST(MigrationCommon);
+    UNIT_TEST(MigrationCommit);
+    UNIT_TEST(MigrationLostMessage);
+    UNIT_TEST(MigrationUndo);
+    UNIT_TEST(MigrationDeletedPathNavigate);
+    UNIT_TEST_SUITE_END();
+}; // TCacheTestBadRootSchemeshard
+
+UNIT_TEST_SUITE_REGISTRATION(TCacheTestBadRootSchemeshard);
 
 void TCacheTestWithDrops::LookupErrorUponEviction() {
     TestNavigate("/Root/with_sync", TNavigate::EStatus::LookupError, "", TNavigate::EOp::OpPath, false, true, true);

--- a/ydb/core/tx/scheme_board/helpers.h
+++ b/ydb/core/tx/scheme_board/helpers.h
@@ -77,6 +77,42 @@ struct TClusterState {
     void Out(IOutputStream& out) const;
 };
 
+// Two bad root schemeshard owner-ids that were misconfigured to have higher values than their tenants
+// These need special handling to be treated as "always lower" in path resolution
+constexpr ui64 BAD_ROOT_SCHEMESHARD_ID_1 = 72075186232723360ULL;
+constexpr ui64 BAD_ROOT_SCHEMESHARD_ID_2 = 72075186232623600ULL;
+
+// Returns true if lhs path id is less than rhs path id.
+// Bad root schemeshard owner-ids are treated as always less than any other non-zero owner-id,
+// to handle legacy misconfigured clusters where root schemeshard has a higher owner-id
+// than tenant schemeshards.
+// Otherwise behaves identically to the standard TPathId less-than comparison.
+inline bool PathIdLessThan(const TPathId& lhs, const TPathId& rhs) {
+    // Preserve standard less-than semantics when either OwnerId is zero.
+    // Bad root schemeshard ids are treated as "always less", which would invert
+    // the ordering against OwnerId == 0 compared to the standard operator<.
+    if (!lhs.OwnerId || !rhs.OwnerId) {
+        return lhs < rhs;
+    }
+
+    const bool lhsIsBad = lhs.OwnerId == BAD_ROOT_SCHEMESHARD_ID_1 || lhs.OwnerId == BAD_ROOT_SCHEMESHARD_ID_2;
+    const bool rhsIsBad = rhs.OwnerId == BAD_ROOT_SCHEMESHARD_ID_1 || rhs.OwnerId == BAD_ROOT_SCHEMESHARD_ID_2;
+
+    if (lhsIsBad && rhsIsBad) {
+        return lhs < rhs;
+    }
+
+    if (lhsIsBad) {
+        return true;
+    }
+
+    if (rhsIsBad) {
+        return false;
+    }
+
+    return lhs < rhs;
+}
+
 } // NSchemeBoard
 } // NKikimr
 

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -943,7 +943,7 @@ private:
 
             UpsertDescription(path, pathId, std::move(pathDescription));
             return AckUpdate(ev);
-        } else if (curDomainId < domainId) {
+        } else if (PathIdLessThan(curDomainId, domainId)) {
             log("Update description by newest path with newer domainId");
             Descriptions.DeleteIndex(path);
             RelinkSubscribers(desc, path);

--- a/ydb/core/tx/scheme_board/replica_ut.cpp
+++ b/ydb/core/tx/scheme_board/replica_ut.cpp
@@ -1,4 +1,5 @@
 #include "replica.h"
+#include "helpers.h"
 #include "ut_helpers.h"
 
 #include <ydb/core/scheme/scheme_pathid.h>
@@ -68,6 +69,8 @@ public:
     UNIT_TEST(AckNotifications);
     UNIT_TEST(AckNotificationsUponPathRecreation);
     UNIT_TEST(StrongNotificationAfterCommit);
+    UNIT_TEST(PathIdLessThanBadRootSchemeshardId1);
+    UNIT_TEST(PathIdLessThanBadRootSchemeshardId2);
     UNIT_TEST_SUITE_END();
 
     void Handshake();
@@ -95,6 +98,9 @@ public:
     void AckNotifications();
     void AckNotificationsUponPathRecreation();
     void StrongNotificationAfterCommit();
+    void PathIdLessThanImpl(ui64 badRootSchemeshardId);
+    void PathIdLessThanBadRootSchemeshardId1();
+    void PathIdLessThanBadRootSchemeshardId2();
 
 private:
     THolder<TTestContext> Context;
@@ -883,6 +889,60 @@ void TReplicaCombinationTest::UpdatesCombinationsMigratedPath() {
             }
         }
     }
+}
+
+void TReplicaTest::PathIdLessThanImpl(ui64 badRootSchemeshardId) {
+    // Verify PathIdLessThan(curSubdomainId, subdomainId) branch in replica.cpp:
+    // on a misconfigured cluster the bad root schemeshard owner-id is numerically higher than
+    // the tenant schemeshard owner-id, so without the fix the TSS update would be dropped.
+
+    constexpr ui64 tenantSchemeshardId = 100ULL;
+    constexpr auto path = "/Root/Tenant/table";
+
+    // Subdomain roots have local-path-id 1; inner paths have local-path-id > 1.
+    const TPathId gssSubdomainId{badRootSchemeshardId, 2};
+    const TPathId gssPathId{badRootSchemeshardId, 5};
+    const TPathId tssSubdomainId{tenantSchemeshardId, 1};
+    const TPathId tssPathId{tenantSchemeshardId, 5};
+
+    const TActorId edge = Context->AllocateEdgeActor();
+
+    const TActorId gssPopulator = Context->AllocateEdgeActor();
+    Context->HandshakeReplica(Replica, gssPopulator, badRootSchemeshardId, 1);
+
+    Context->SubscribeReplica(Replica, edge, path);
+
+    // GSS update: after this curPathId = gssPathId, curSubdomainId = gssSubdomainId.
+    auto describeGSS = GenerateDescribe(path, gssPathId, 1, gssSubdomainId);
+    Context->Send(Replica, gssPopulator, GenerateUpdate(describeGSS, badRootSchemeshardId, 1));
+    {
+        auto ev = Context->GrabEdgeEvent<NInternalEvents::TEvNotify>(edge);
+        UNIT_ASSERT_VALUES_EQUAL(path, ev->Get()->GetRecord().GetPath());
+        UNIT_ASSERT_VALUES_EQUAL(badRootSchemeshardId, ev->Get()->GetRecord().GetPathOwnerId());
+    }
+
+    const TActorId tssPopulator = Context->AllocateEdgeActor();
+    Context->HandshakeReplica(Replica, tssPopulator, tenantSchemeshardId, 1);
+
+    // TSS update reaches PathIdLessThan(curSubdomainId, tssSubdomainId) because:
+    // curPathId.OwnerId != tssPathId.OwnerId, curPathId != tssSubdomainId,
+    // curSubdomainId != tssPathId, curSubdomainId != tssSubdomainId.
+    // PathIdLessThan returns true (bad ID treated as lower) -> TSS wins.
+    auto describeTSS = GenerateDescribe(path, tssPathId, 1, tssSubdomainId);
+    Context->Send(Replica, tssPopulator, GenerateUpdate(describeTSS, tenantSchemeshardId, 1));
+    {
+        auto ev = Context->GrabEdgeEvent<NInternalEvents::TEvNotify>(edge);
+        UNIT_ASSERT_VALUES_EQUAL(path, ev->Get()->GetRecord().GetPath());
+        UNIT_ASSERT_VALUES_EQUAL(tenantSchemeshardId, ev->Get()->GetRecord().GetPathOwnerId());
+    }
+}
+
+void TReplicaTest::PathIdLessThanBadRootSchemeshardId1() {
+    PathIdLessThanImpl(BAD_ROOT_SCHEMESHARD_ID_1);
+}
+
+void TReplicaTest::PathIdLessThanBadRootSchemeshardId2() {
+    PathIdLessThanImpl(BAD_ROOT_SCHEMESHARD_ID_2);
 }
 
 } // NSchemeBoard

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -328,7 +328,7 @@ namespace {
 
                 reason = "Path was updated to new version";
                 return true;
-            } else  if (DomainId < other.DomainId) {
+            } else if (PathIdLessThan(DomainId, other.DomainId)) {
                 reason = "New domain is detected, it is newer path then we know";
                 return true;
             } else {

--- a/ydb/core/tx/scheme_board/subscriber_ut.cpp
+++ b/ydb/core/tx/scheme_board/subscriber_ut.cpp
@@ -1,3 +1,4 @@
+#include "helpers.h"
 #include "ut_helpers.h"
 
 #include <ydb/core/scheme/scheme_pathid.h>
@@ -272,11 +273,16 @@ class TSubscriberCombinationsTest: public NUnitTest::TTestBase {
     UNIT_TEST(CombinationsRootDomain);
     UNIT_TEST(MigratedPathRecreation);
     UNIT_TEST(CombinationsMigratedPath);
+    UNIT_TEST(PathIdLessThanBadRootSchemeshardId1);
+    UNIT_TEST(PathIdLessThanBadRootSchemeshardId2);
     UNIT_TEST_SUITE_END();
 
     void CombinationsRootDomain();
     void MigratedPathRecreation();
     void CombinationsMigratedPath();
+    void PathIdLessThanImpl(ui64 badRootSchemeshardId);
+    void PathIdLessThanBadRootSchemeshardId1();
+    void PathIdLessThanBadRootSchemeshardId2();
 }; // TSubscriberCombinationsTest
 
 UNIT_TEST_SUITE_REGISTRATION(TSubscriberCombinationsTest);
@@ -923,6 +929,68 @@ Y_UNIT_TEST_SUITE(TSubscriberSyncQuorumTest) {
         // No additional sync responses.
         UNIT_ASSERT_VALUES_EQUAL(CountEvents<NInternalEvents::TEvSyncResponse>(runtime, false, edge), 0);
     }
+}
+
+void TSubscriberCombinationsTest::PathIdLessThanImpl(ui64 badRootSchemeshardId) {
+    // Verify PathIdLessThan(DomainId, other.DomainId) branch in subscriber.cpp:
+    // on a misconfigured cluster the bad root schemeshard owner-id is numerically higher than
+    // the tenant schemeshard owner-id, so without the fix the TSS update would be dropped.
+
+    constexpr ui64 tenantSchemeshardId = 100ULL;
+    constexpr auto path = "/Root/Tenant/table";
+
+    // Subdomain roots have local-path-id 1; inner paths have local-path-id > 1.
+    const TPathId gssSubdomainId{badRootSchemeshardId, 2};
+    const TPathId gssPathId{badRootSchemeshardId, 5};
+    const TPathId tssSubdomainId{tenantSchemeshardId, 1};
+    const TPathId tssPathId{tenantSchemeshardId, 5};
+
+    auto context = CreateContext();
+    TVector<TActorId> replicas = ResolveReplicas(*context);
+    Y_ASSERT(replicas.size() >= 2);
+
+    // GSS populator on replica[0]
+    const TActorId gssPopulator = context->AllocateEdgeActor();
+    context->HandshakeReplica(replicas[0], gssPopulator, badRootSchemeshardId, 1);
+    context->CommitReplica(replicas[0], gssPopulator, badRootSchemeshardId, 1);
+
+    // TSS populator on replica[1]
+    const TActorId tssPopulator = context->AllocateEdgeActor();
+    context->HandshakeReplica(replicas[1], tssPopulator, tenantSchemeshardId, 1);
+    context->CommitReplica(replicas[1], tssPopulator, tenantSchemeshardId, 1);
+
+    const TActorId edge = context->AllocateEdgeActor();
+    context->CreateSubscriber<TSchemeBoardEvents::TEvNotifyDelete>(edge, path);
+
+    // GSS update: inner path with bad subdomain ID.
+    context->Send(replicas[0], gssPopulator,
+        GenerateUpdate(GenerateDescribe(path, gssPathId, 1, gssSubdomainId), badRootSchemeshardId, 1));
+    {
+        auto ev = context->GrabEdgeEvent<TSchemeBoardEvents::TEvNotifyUpdate>(edge);
+        UNIT_ASSERT(ev->Get());
+        UNIT_ASSERT_VALUES_EQUAL(path, ev->Get()->Path);
+        UNIT_ASSERT_VALUES_EQUAL(gssPathId, ev->Get()->PathId);
+    }
+
+    // TSS update: inner path with tenant subdomain ID.
+    // PathIdLessThan(gssSubdomainId, tssSubdomainId) returns true (bad ID treated as lower)
+    // -> subscriber picks TSS update.
+    context->Send(replicas[1], tssPopulator,
+        GenerateUpdate(GenerateDescribe(path, tssPathId, 1, tssSubdomainId), tenantSchemeshardId, 1));
+    {
+        auto ev = context->GrabEdgeEvent<TSchemeBoardEvents::TEvNotifyUpdate>(edge);
+        UNIT_ASSERT(ev->Get());
+        UNIT_ASSERT_VALUES_EQUAL(path, ev->Get()->Path);
+        UNIT_ASSERT_VALUES_EQUAL(tssPathId, ev->Get()->PathId);
+    }
+}
+
+void TSubscriberCombinationsTest::PathIdLessThanBadRootSchemeshardId1() {
+    PathIdLessThanImpl(BAD_ROOT_SCHEMESHARD_ID_1);
+}
+
+void TSubscriberCombinationsTest::PathIdLessThanBadRootSchemeshardId2() {
+    PathIdLessThanImpl(BAD_ROOT_SCHEMESHARD_ID_2);
 }
 
 } // NSchemeBoard

--- a/ydb/core/tx/scheme_board/ut_helpers.h
+++ b/ydb/core/tx/scheme_board/ut_helpers.h
@@ -200,13 +200,13 @@ class TTestWithSchemeshard: public NUnitTest::TTestBase {
         app.AddHive(hiveTabletId);
     }
 
-    static void SetupRuntime(TTestActorRuntime& runtime) {
+    void SetupRuntime(TTestActorRuntime& runtime) {
         for (ui32 i : xrange(runtime.GetNodeCount())) {
             SetupStateStorage(runtime, i, 0);
         }
 
         TAppPrepare app;
-        AddDomain(runtime, app, "Root", 0, TTestTxConfig::Hive, TTestTxConfig::SchemeShard);
+        AddDomain(runtime, app, "Root", 0, TTestTxConfig::Hive, RootSchemeshardTabletId);
         SetupChannelProfiles(app, 1);
         SetupTabletServices(runtime, &app, true);
     }
@@ -241,7 +241,6 @@ class TTestWithSchemeshard: public NUnitTest::TTestBase {
         BootFakeHive(runtime, tabletId, HiveState);
     }
 
-protected:
     virtual TTestContext::TEventObserver ObserverFunc() {
         return TTestContext::DefaultObserverFunc;
     }
@@ -279,7 +278,7 @@ public:
             AddSysViewsRosterUpdateObserver();
         }
 
-        BootSchemeShard(*Context, TTestTxConfig::SchemeShard);
+        BootSchemeShard(*Context, RootSchemeshardTabletId);
         BootTxAllocator(*Context, TTestTxConfig::TxAllocator);
         BootCoordinator(*Context, TTestTxConfig::Coordinator);
         BootHive(*Context, TTestTxConfig::Hive);
@@ -302,7 +301,7 @@ public:
 
         TActorId sender = Context->AllocateEdgeActor();
         TVector<ui64> tabletIds;
-        tabletIds.push_back((ui64)TTestTxConfig::SchemeShard);
+        tabletIds.push_back(RootSchemeshardTabletId);
         for (auto x: xrange(TTestTxConfig::FakeHiveTablets,  TTestTxConfig::FakeHiveTablets + 10)) {
             tabletIds.push_back(x);
         }
@@ -311,7 +310,7 @@ public:
 
         // make schemeShard visible for ScheduledEventsGuard
         // trigger actor resolving for existed tablet
-        RebootTablet(*Context, (ui64)TTestTxConfig::SchemeShard, sender);
+        RebootTablet(*Context, RootSchemeshardTabletId, sender);
     }
 
     void TearDown() override {
@@ -321,6 +320,9 @@ public:
         SysViewsRosterUpdateObserver.Remove();
         Context.Reset();
     }
+
+public:
+    ui64 RootSchemeshardTabletId = TTestTxConfig::SchemeShard;
 
 protected:
     THolder<TTestContext> Context;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1904,8 +1904,8 @@ namespace NSchemeShardUT_Private {
         return tableDescription;
     }
 
-    TEvSchemeShard::TEvModifySchemeTransaction *UpgradeSubDomainRequest(ui64 txId, const TString &parentPath, const TString &name) {
-        auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(txId, TTestTxConfig::SchemeShard);
+    TEvSchemeShard::TEvModifySchemeTransaction *UpgradeSubDomainRequest(ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name) {
+        auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(txId, schemeShard);
         auto transaction = evTx->Record.AddTransaction();
         transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpUpgradeSubDomain);
         transaction->SetWorkingDir(parentPath);
@@ -1913,9 +1913,23 @@ namespace NSchemeShardUT_Private {
         return evTx;
     }
 
+    void AsyncUpgradeSubDomain(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name) {
+        auto evTx = UpgradeSubDomainRequest(schemeShard, txId, parentPath, name);
+        AsyncSend(runtime, schemeShard, evTx);
+    }
+
     void AsyncUpgradeSubDomain(TTestActorRuntime &runtime, ui64 txId, const TString &parentPath, const TString &name) {
-        auto evTx = UpgradeSubDomainRequest(txId, parentPath, name);
-        AsyncSend(runtime, TTestTxConfig::SchemeShard, evTx);
+        AsyncUpgradeSubDomain(runtime, TTestTxConfig::SchemeShard, txId, parentPath, name);
+    }
+
+    void TestUpgradeSubDomain(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name, const TVector<TExpectedResult> &expectedResults) {
+        AsyncUpgradeSubDomain(runtime, schemeShard, txId, parentPath, name);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
+    void TestUpgradeSubDomain(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name) {
+        AsyncUpgradeSubDomain(runtime, schemeShard, txId, parentPath, name);
+        TestModificationResults(runtime, txId, {{TEvSchemeShard::EStatus::StatusAccepted, ""}});
     }
 
     void TestUpgradeSubDomain(TTestActorRuntime &runtime, ui64 txId, const TString &parentPath, const TString &name, const TVector<TExpectedResult> &expectedResults) {
@@ -1928,8 +1942,8 @@ namespace NSchemeShardUT_Private {
         TestModificationResults(runtime, txId, {{TEvSchemeShard::EStatus::StatusAccepted, ""}});
     }
 
-    TEvSchemeShard::TEvModifySchemeTransaction *UpgradeSubDomainDecisionRequest(ui64 txId, const TString &parentPath, const TString &name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
-        auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(txId, TTestTxConfig::SchemeShard);
+    TEvSchemeShard::TEvModifySchemeTransaction *UpgradeSubDomainDecisionRequest(ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
+        auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(txId, schemeShard);
         auto transaction = evTx->Record.AddTransaction();
         transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpUpgradeSubDomainDecision);
         transaction->SetWorkingDir(parentPath);
@@ -1938,9 +1952,23 @@ namespace NSchemeShardUT_Private {
         return evTx;
     }
 
+    void AsyncUpgradeSubDomainDecision(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
+        auto evTx = UpgradeSubDomainDecisionRequest(schemeShard, txId, parentPath, name, decision);
+        AsyncSend(runtime, schemeShard, evTx);
+    }
+
     void AsyncUpgradeSubDomainDecision(TTestActorRuntime &runtime, ui64 txId, const TString &parentPath, const TString &name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
-        auto evTx = UpgradeSubDomainDecisionRequest(txId, parentPath, name, decision);
-        AsyncSend(runtime, TTestTxConfig::SchemeShard, evTx);
+        AsyncUpgradeSubDomainDecision(runtime, TTestTxConfig::SchemeShard, txId, parentPath, name, decision);
+    }
+
+    void TestUpgradeSubDomainDecision(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name, const TVector<TExpectedResult> &expectedResults, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
+        AsyncUpgradeSubDomainDecision(runtime, schemeShard, txId, parentPath, name, decision);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
+    void TestUpgradeSubDomainDecision(TTestActorRuntime &runtime, ui64 schemeShard, ui64 txId, const TString &parentPath, const TString &name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {
+        AsyncUpgradeSubDomainDecision(runtime, schemeShard, txId, parentPath, name, decision);
+        TestModificationResults(runtime, txId, {{TEvSchemeShard::EStatus::StatusAccepted, ""}});
     }
 
     void TestUpgradeSubDomainDecision(TTestActorRuntime &runtime, ui64 txId, const TString &parentPath, const TString &name, const TVector<TExpectedResult> &expectedResults, NKikimrSchemeOp::TUpgradeSubDomain::EDecision decision) {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -363,13 +363,19 @@ namespace NSchemeShardUT_Private {
     void TestModifyACL(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, TString parentPath, TString name, const TString& diffAcl, const TString& newOwner, TEvSchemeShard::EStatus expectedResult = NKikimrScheme::StatusSuccess, const TApplyIf& applyIf = {});
 
     // upgrade subdomain
-    TEvTx* UpgradeSubDomainRequest(ui64 txId, const TString& parentPath, const TString& name);
+    TEvTx* UpgradeSubDomainRequest(ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name);
+    void AsyncUpgradeSubDomain(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name);
     void AsyncUpgradeSubDomain(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name);
+    void TestUpgradeSubDomain(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name, const TVector<TExpectedResult>& expectedResults);
+    void TestUpgradeSubDomain(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name);
     void TestUpgradeSubDomain(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name, const TVector<TExpectedResult>& expectedResults);
     void TestUpgradeSubDomain(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name);
 
-    TEvTx* UpgradeSubDomainDecisionRequest(ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
+    TEvTx* UpgradeSubDomainDecisionRequest(ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
+    void AsyncUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
     void AsyncUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
+    void TestUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name, const TVector<TExpectedResult>& expectedResults, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
+    void TestUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
     void TestUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name, const TVector<TExpectedResult>& expectedResults, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
     void TestUpgradeSubDomainDecision(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& name, NKikimrSchemeOp::TUpgradeSubDomain::EDecision taskType);
 


### PR DESCRIPTION
On some misconfigured clusters, root schemeshard tablet ids (72075186232723360, 72075186232623600) are numerically higher than some tenant schemeshard tablet ids. Schemeshard tablet id serves as path's owner id. Since scheme-board resolves path ownership by comparing owner ids (higher wins), root updates incorrectly overrode tenant updates.

Fix: treat these two root schemeshard owner ids as always less than any tenant owner id.

New tests for scheme_board replica, subscriber, scheme-cache layers.

Fixes #32539.