### PR TITLE
added check permissions

### DIFF
--- a/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
+++ b/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
@@ -760,6 +760,96 @@ Y_UNIT_TEST_SUITE(S3AwsCredentials) {
         }
     }
 
+    Y_UNIT_TEST(TieringCreateTableWithTtlRequiresSecretAccess) {
+        const TString tierPath = "/Root/tier1";
+        const TString accessKeySecretName = "/Root/create-ttl-access-key-secret";
+        const TString secretKeySecretName = "/Root/create-ttl-secret-key-secret";
+        const TString tablePath = "/Root/ttl_create_acl_check";
+        const TString user = "root1@builtin";
+
+        auto kikimr = MakeS3TieringKikimrRunner(false, true);
+        auto adminClient = kikimr->GetTableClient();
+        auto adminSession = adminClient.CreateSession().GetValueSync().GetSession();
+
+        {
+            const TString query = fmt::format(R"(
+                CREATE SECRET `{access_key_secret}` WITH (value = "minio");
+                CREATE SECRET `{secret_key_secret}` WITH (value = "minio123");
+            )",
+                "access_key_secret"_a = accessKeySecretName,
+                "secret_key_secret"_a = secretKeySecretName
+            );
+
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString minioLocation = "http://localhost:" + GetExternalPort("minio", "9000") + "/datalake/";
+        CreateTierExternalDataSource(
+            adminSession,
+            tierPath,
+            minioLocation,
+            accessKeySecretName,
+            secretKeySecretName,
+            false /*replace*/);
+
+        {
+            const TString query = fmt::format(R"(
+                GRANT CREATE TABLE, DESCRIBE SCHEMA ON `/Root` TO `{user}`;
+                GRANT DESCRIBE SCHEMA ON `{tier_path}` TO `{user}`;
+            )",
+                "user"_a = user,
+                "tier_path"_a = tierPath
+            );
+
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto userClient = kikimr->GetTableClient(NYdb::NTable::TClientSettings().AuthToken(user));
+        auto userSession = userClient.CreateSession().GetValueSync().GetSession();
+
+        const TString createTableQuery = fmt::format(R"(
+            CREATE TABLE `{table_path}` (
+                `timestamp` Timestamp NOT NULL,
+                `uid` Uint64 NOT NULL,
+                `value` String,
+                PRIMARY KEY (`timestamp`, `uid`)
+            ) WITH (
+                STORE = COLUMN,
+                TTL = Interval("PT1H") TO EXTERNAL DATA SOURCE `{tier_path}` ON `timestamp`
+            );
+        )",
+            "table_path"_a = tablePath,
+            "tier_path"_a = tierPath
+        );
+
+        {
+            auto result = userSession.ExecuteSchemeQuery(createTableQuery).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::UNAUTHORIZED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Access denied", result.GetIssues().ToString());
+        }
+
+        {
+            const TString query = fmt::format(R"(
+                GRANT SELECT ROW ON `{access_key_secret}` TO `{user}`;
+                GRANT SELECT ROW ON `{secret_key_secret}` TO `{user}`;
+            )",
+                "access_key_secret"_a = accessKeySecretName,
+                "secret_key_secret"_a = secretKeySecretName,
+                "user"_a = user
+            );
+
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = userSession.ExecuteSchemeQuery(createTableQuery).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    }
+
     Y_UNIT_TEST(TieringInvalidSecrets) {
         const TString tablePath = "/Root/olapStore/olapTable";
         const TString tierPath = "/Root/tier1";

--- a/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
+++ b/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
@@ -675,6 +675,91 @@ Y_UNIT_TEST_SUITE(S3AwsCredentials) {
         }
     }
 
+    Y_UNIT_TEST(TieringSetTtlRequiresSecretAccess) {
+        const TString tablePath = "/Root/olapStore/olapTable";
+        const TString tierPath = "/Root/tier1";
+        const TString accessKeySecretName = "/Root/ttl-access-key-secret";
+        const TString secretKeySecretName = "/Root/ttl-secret-key-secret";
+        const TString columnName = "timestamp";
+        const TString user = "root1@builtin";
+
+        auto kikimr = MakeS3TieringKikimrRunner(false, true);
+        auto adminClient = kikimr->GetTableClient();
+        auto adminSession = adminClient.CreateSession().GetValueSync().GetSession();
+
+        CreateTestOlapTableForTiering(*kikimr);
+        ConfigureOlapStoreTieringCompaction(adminSession, "/Root/olapStore");
+
+        {
+            const TString query = fmt::format(R"(
+                CREATE SECRET `{access_key_secret}` WITH (value = "minio");
+                CREATE SECRET `{secret_key_secret}` WITH (value = "minio123");
+            )",
+                "access_key_secret"_a = accessKeySecretName,
+                "secret_key_secret"_a = secretKeySecretName
+            );
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString minioLocation = "http://localhost:" + GetExternalPort("minio", "9000") + "/datalake/";
+        CreateTierExternalDataSource(
+            adminSession,
+            tierPath,
+            minioLocation,
+            accessKeySecretName,
+            secretKeySecretName,
+            false /*replace*/);
+
+        {
+            const TString query = fmt::format(R"(
+                GRANT DESCRIBE SCHEMA, ALTER SCHEMA ON `{table_path}` TO `{user}`;
+                GRANT DESCRIBE SCHEMA ON `{tier_path}` TO `{user}`;
+            )",
+                "table_path"_a = tablePath,
+                "tier_path"_a = tierPath,
+                "user"_a = user
+            );
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        auto userClient = kikimr->GetTableClient(NYdb::NTable::TClientSettings().AuthToken(user));
+        auto userSession = userClient.CreateSession().GetValueSync().GetSession();
+
+        const TString alterTtlQuery = fmt::format(R"(
+            ALTER TABLE `{table_path}` SET TTL Interval("P10D") TO EXTERNAL DATA SOURCE `{tier_path}` ON `{column_name}`
+        )",
+            "table_path"_a = tablePath,
+            "tier_path"_a = tierPath,
+            "column_name"_a = columnName
+        );
+
+        {
+            auto result = userSession.ExecuteSchemeQuery(alterTtlQuery).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::UNAUTHORIZED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Access denied", result.GetIssues().ToString());
+        }
+
+        {
+            const TString query = fmt::format(R"(
+                GRANT SELECT ROW ON `{access_key_secret}` TO `{user}`;
+                GRANT SELECT ROW ON `{secret_key_secret}` TO `{user}`;
+            )",
+                "access_key_secret"_a = accessKeySecretName,
+                "secret_key_secret"_a = secretKeySecretName,
+                "user"_a = user
+            );
+            auto result = adminSession.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = userSession.ExecuteSchemeQuery(alterTtlQuery).GetValueSync();
+            UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    }
+
     Y_UNIT_TEST(TieringInvalidSecrets) {
         const TString tablePath = "/Root/olapStore/olapTable";
         const TString tierPath = "/Root/tier1";

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1805,6 +1805,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         }
 
         if (!isTierSecretAclPass) {
+            // Check doc-api restrictions on operations
             if (IsDocApiRestricted(SchemeRequest->Ev->Get()->Record)) {
                 if (!CheckDocApi(navigate->ResultSet, ctx)) {
                     return Die(ctx);

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -25,6 +25,7 @@
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 
+#include <algorithm>
 #include <util/string/cast.h>
 
 namespace {
@@ -63,6 +64,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     struct TPathToResolve {
         const NKikimrSchemeOp::TModifyScheme& ModifyScheme;
         ui32 RequireAccess = NACLib::EAccessRights::NoAccess;
+        bool IsTierExternalDataSource = false;
 
         // Params for NSchemeCache::TSchemeCacheNavigate::TEntry
         TVector<TString> Path;
@@ -75,6 +77,12 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     };
 
     TVector<TPathToResolve> ResolveForACL;
+    enum class EAclResolveStage {
+        Primary,
+        TierSecrets
+    };
+
+    EAclResolveStage AclResolveStage = EAclResolveStage::Primary;
 
     std::optional<NACLib::TUserToken> UserToken;
     bool CheckAdministrator = false;
@@ -759,6 +767,127 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         return true;
     }
 
+    static TVector<TString> ExtractTierExternalDataSourcePaths(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme) {
+        TVector<TString> result;
+        switch (pbModifyScheme.GetOperationType()) {
+            case NKikimrSchemeOp::ESchemeOpAlterTable: {
+                const auto& alterTable = pbModifyScheme.GetAlterTable();
+                if (!alterTable.HasTTLSettings() || !alterTable.GetTTLSettings().HasEnabled()) {
+                    break;
+                }
+
+                for (auto&& tier : alterTable.GetTTLSettings().GetEnabled().GetTiers()) {
+                    if (tier.HasEvictToExternalStorage()) {
+                        result.emplace_back(tier.GetEvictToExternalStorage().GetStorage());
+                    }
+                }
+
+                break;
+            }
+            case NKikimrSchemeOp::ESchemeOpAlterColumnTable: {
+                const auto& alterColumnTable = pbModifyScheme.GetAlterColumnTable();
+                if (!alterColumnTable.HasAlterTtlSettings() || !alterColumnTable.GetAlterTtlSettings().HasEnabled()) {
+                    break;
+                }
+
+                for (auto&& tier : alterColumnTable.GetAlterTtlSettings().GetEnabled().GetTiers()) {
+                    if (tier.HasEvictToExternalStorage()) {
+                        result.emplace_back(tier.GetEvictToExternalStorage().GetStorage());
+                    }
+                }
+
+                break;
+            }
+            default:
+                break;
+        }
+
+        return result;
+    }
+
+    void AddTierExternalDataSourceResolveTasks(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const TVector<TString>& workingDir) {
+        THashSet<TString> uniquePaths;
+        for (auto&& tierStoragePath : ExtractTierExternalDataSourcePaths(pbModifyScheme)) {
+            TVector<TString> path = tierStoragePath.StartsWith("/")
+                ? SplitPath(tierStoragePath)
+                : Merge(workingDir, SplitPath(tierStoragePath));
+
+            const TString canonicalPath = CanonizePath(JoinPath(path));
+            if (!uniquePaths.emplace(canonicalPath).second) {
+                continue;
+            }
+
+            auto toResolve = TPathToResolve(pbModifyScheme);
+            toResolve.Path = std::move(path);
+            toResolve.RequireAccess = NACLib::EAccessRights::DescribeSchema;
+            toResolve.IsTierExternalDataSource = true;
+            ResolveForACL.push_back(std::move(toResolve));
+        }
+    }
+
+    static void CollectSecretNamesFromAuth(const NKikimrSchemeOp::TAuth& auth, TVector<TString>& out) {
+        switch (auth.identity_case()) {
+            case NKikimrSchemeOp::TAuth::kServiceAccount:
+                out.emplace_back(auth.GetServiceAccount().GetSecretName());
+                return;
+            case NKikimrSchemeOp::TAuth::kBasic:
+                out.emplace_back(auth.GetBasic().GetPasswordSecretName());
+                return;
+            case NKikimrSchemeOp::TAuth::kMdbBasic:
+                out.emplace_back(auth.GetMdbBasic().GetServiceAccountSecretName());
+                out.emplace_back(auth.GetMdbBasic().GetPasswordSecretName());
+                return;
+            case NKikimrSchemeOp::TAuth::kAws:
+                out.emplace_back(auth.GetAws().GetAwsAccessKeyIdSecretName());
+                out.emplace_back(auth.GetAws().GetAwsSecretAccessKeySecretName());
+                return;
+            case NKikimrSchemeOp::TAuth::kToken:
+                out.emplace_back(auth.GetToken().GetTokenSecretName());
+                return;
+            case NKikimrSchemeOp::TAuth::kNone:
+            case NKikimrSchemeOp::TAuth::IDENTITY_NOT_SET:
+                return;
+        }
+    }
+
+    TVector<TPathToResolve> BuildTierSecretResolveTasks(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const NSchemeCache::TSchemeCacheNavigate::TResultSet& resolvedEntries) const {
+        THashSet<TString> uniqueSecrets;
+        TVector<TString> secretNames;
+        const size_t size = std::min(ResolveForACL.size(), resolvedEntries.size());
+        for (size_t i = 0; i < size; ++i) {
+            const auto& request = ResolveForACL[i];
+            if (!request.IsTierExternalDataSource) {
+                continue;
+            }
+
+            const auto& entry = resolvedEntries[i];
+            if (!entry.ExternalDataSourceInfo) {
+                continue;
+            }
+
+            CollectSecretNamesFromAuth(entry.ExternalDataSourceInfo->Description.GetAuth(), secretNames);
+        }
+
+        TVector<TPathToResolve> result;
+        for (auto&& secretName : secretNames) {
+            if (!secretName.StartsWith("/")) {
+                continue;
+            }
+
+            if (!uniqueSecrets.emplace(secretName).second) {
+                continue;
+            }
+
+            auto toResolve = TPathToResolve(pbModifyScheme);
+            toResolve.Path = SplitPath(secretName);
+            toResolve.RequireAccess = NACLib::EAccessRights::SelectRow;
+            toResolve.RequireRedirect = false;
+            result.push_back(std::move(toResolve));
+        }
+
+        return result;
+    }
+
     bool ExtractResolveForACL(NKikimrSchemeOp::TModifyScheme& pbModifyScheme) {
         ui32 accessToUserAttrs = pbModifyScheme.HasAlterUserAttributes() ? NACLib::EAccessRights::WriteUserAttributes : NACLib::EAccessRights::NoAccess;
         auto workingDir = SplitPath(pbModifyScheme.GetWorkingDir());
@@ -806,6 +935,14 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             break;
         }
         case NKikimrSchemeOp::ESchemeOpAlterTable:
+        case NKikimrSchemeOp::ESchemeOpAlterColumnTable: {
+            auto toResolve = TPathToResolve(pbModifyScheme);
+            toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));
+            toResolve.RequireAccess = NACLib::EAccessRights::AlterSchema | accessToUserAttrs;
+            ResolveForACL.push_back(toResolve);
+            AddTierExternalDataSourceResolveTasks(pbModifyScheme, workingDir);
+            break;
+        }
         case NKikimrSchemeOp::ESchemeOpDropIndex:
         case NKikimrSchemeOp::ESchemeOpCreateCdcStream:
         case NKikimrSchemeOp::ESchemeOpAlterCdcStream:
@@ -819,7 +956,6 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpBackup:
         case NKikimrSchemeOp::ESchemeOpAlterSolomonVolume:
         case NKikimrSchemeOp::ESchemeOpAlterColumnStore:
-        case NKikimrSchemeOp::ESchemeOpAlterColumnTable:
         case NKikimrSchemeOp::ESchemeOpAlterSequence:
         case NKikimrSchemeOp::ESchemeOpAlterReplication:
         case NKikimrSchemeOp::ESchemeOpAlterBlobDepot:
@@ -1654,6 +1790,10 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         Y_ABORT_UNLESS(!navigate->ResultSet.empty());
         Y_ABORT_UNLESS(navigate->ResultSet.size() == ResolveForACL.size());
 
+        if (AclResolveStage == EAclResolveStage::Primary) {
+            SchemeshardIdToRequest = GetShardToRequest(*navigate->ResultSet.begin(), *ResolveForACL.begin());
+        }
+
         // Check user access level, permissions on scheme objects and other restrictions/permissions
         if (UserToken) {
             if (!CheckAccess(navigate->ResultSet, ctx)) {
@@ -1661,14 +1801,26 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
         }
 
-        // Check doc-api restrictions on operations
-        if (IsDocApiRestricted(SchemeRequest->Ev->Get()->Record)) {
-            if (!CheckDocApi(navigate->ResultSet, ctx)) {
-                return Die(ctx);
+        if (AclResolveStage == EAclResolveStage::Primary) {
+            if (IsDocApiRestricted(SchemeRequest->Ev->Get()->Record)) {
+                if (!CheckDocApi(navigate->ResultSet, ctx)) {
+                    return Die(ctx);
+                }
+            }
+
+            if (GetRequestEv().HasModifyScheme()) {
+                auto secretResolveTasks = BuildTierSecretResolveTasks(GetModifyScheme(), navigate->ResultSet);
+                if (!secretResolveTasks.empty()) {
+                    ResolveForACL = std::move(secretResolveTasks);
+                    auto resolveRequest = ResolveRequestForACL();
+                    if (resolveRequest) {
+                        AclResolveStage = EAclResolveStage::TierSecrets;
+                        ctx.Send(Services.SchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(resolveRequest.Release()));
+                        return;
+                    }
+                }
             }
         }
-
-        SchemeshardIdToRequest = GetShardToRequest(*navigate->ResultSet.begin(), *ResolveForACL.begin());
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_PROXY,
                     "Actor# " << ctx.SelfID.ToString()

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1776,6 +1776,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev, const TActorContext &ctx) {
         NSchemeCache::TSchemeCacheNavigate *navigate = ev->Get()->Request.Get();
+        const bool isTierSecretAclPass = WaitingTierSecretAcl;
 
         TxProxyMon->CacheRequestLatency->Collect((ctx.Now() - WallClockStarted).MilliSeconds());
 
@@ -1792,13 +1793,9 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             return Die(ctx);
         }
 
-        const auto& activeResolveTasks = WaitingTierSecretACL ? TierSecretResolveForACL : ResolveForACL;
+        const auto& activeResolveTasks = isTierSecretAclPass ? TierSecretResolveForACL : ResolveForACL;
         Y_ABORT_UNLESS(!navigate->ResultSet.empty());
         Y_ABORT_UNLESS(navigate->ResultSet.size() == activeResolveTasks.size());
-
-        if (!WaitingTierSecretACL) {
-            SchemeshardIdToRequest = GetShardToRequest(*navigate->ResultSet.begin(), *ResolveForACL.begin());
-        }
 
         // Check user access level, permissions on scheme objects and other restrictions/permissions
         if (UserToken) {
@@ -1807,7 +1804,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
         }
 
-        if (!WaitingTierSecretACL) {
+        if (!isTierSecretAclPass) {
             if (IsDocApiRestricted(SchemeRequest->Ev->Get()->Record)) {
                 if (!CheckDocApi(navigate->ResultSet, ctx)) {
                     return Die(ctx);
@@ -1829,6 +1826,10 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         } else {
             WaitingTierSecretACL = false;
             TierSecretResolveForACL.clear();
+        }
+
+        if (!isTierSecretAclPass) {
+            SchemeshardIdToRequest = GetShardToRequest(*navigate->ResultSet.begin(), *ResolveForACL.begin());
         }
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_PROXY,

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -766,13 +766,13 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     static TVector<TString> ExtractTierExternalDataSourcePaths(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme) {
         TVector<TString> result;
         switch (pbModifyScheme.GetOperationType()) {
-            case NKikimrSchemeOp::ESchemeOpAlterTable: {
-                const auto& alterTable = pbModifyScheme.GetAlterTable();
-                if (!alterTable.HasTTLSettings() || !alterTable.GetTTLSettings().HasEnabled()) {
+            case NKikimrSchemeOp::ESchemeOpCreateColumnTable: {
+                const auto& createColumnTable = pbModifyScheme.GetCreateColumnTable();
+                if (!createColumnTable.HasTtlSettings() || !createColumnTable.GetTtlSettings().HasEnabled()) {
                     break;
                 }
 
-                for (auto&& tier : alterTable.GetTTLSettings().GetEnabled().GetTiers()) {
+                for (auto&& tier : createColumnTable.GetTtlSettings().GetEnabled().GetTiers()) {
                     if (tier.HasEvictToExternalStorage()) {
                         result.emplace_back(tier.GetEvictToExternalStorage().GetStorage());
                     }
@@ -931,7 +931,6 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             ResolveForACL.push_back(toResolve);
             break;
         }
-        case NKikimrSchemeOp::ESchemeOpAlterTable:
         case NKikimrSchemeOp::ESchemeOpAlterColumnTable: {
             auto toResolve = TPathToResolve(pbModifyScheme);
             toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));
@@ -940,6 +939,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             AddTierExternalDataSourceResolveTasks(pbModifyScheme, workingDir);
             break;
         }
+        case NKikimrSchemeOp::ESchemeOpAlterTable:
         case NKikimrSchemeOp::ESchemeOpDropIndex:
         case NKikimrSchemeOp::ESchemeOpCreateCdcStream:
         case NKikimrSchemeOp::ESchemeOpAlterCdcStream:
@@ -1085,7 +1085,6 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         }
         case NKikimrSchemeOp::ESchemeOpCreateIndexedTable:
         case NKikimrSchemeOp::ESchemeOpCreateColumnStore:
-        case NKikimrSchemeOp::ESchemeOpCreateColumnTable:
         case NKikimrSchemeOp::ESchemeOpCreateBlockStoreVolume:
         case NKikimrSchemeOp::ESchemeOpCreateFileStore:
         case NKikimrSchemeOp::ESchemeOpCreateRtmrVolume:
@@ -1105,6 +1104,15 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             toResolve.Path = workingDir;
             toResolve.RequireAccess = NACLib::EAccessRights::CreateTable | accessToUserAttrs;
             ResolveForACL.push_back(toResolve);
+            break;
+        }
+        case NKikimrSchemeOp::ESchemeOpCreateColumnTable:
+        {
+            auto toResolve = TPathToResolve(pbModifyScheme);
+            toResolve.Path = workingDir;
+            toResolve.RequireAccess = NACLib::EAccessRights::CreateTable | accessToUserAttrs;
+            ResolveForACL.push_back(toResolve);
+            AddTierExternalDataSourceResolveTasks(pbModifyScheme, workingDir);
             break;
         }
         case NKikimrSchemeOp::ESchemeOpCreateTransfer:

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1776,7 +1776,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev, const TActorContext &ctx) {
         NSchemeCache::TSchemeCacheNavigate *navigate = ev->Get()->Request.Get();
-        const bool isTierSecretAclPass = WaitingTierSecretAcl;
+        const bool isTierSecretAclPass = WaitingTierSecretACL;
 
         TxProxyMon->CacheRequestLatency->Collect((ctx.Now() - WallClockStarted).MilliSeconds());
 

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -64,7 +64,6 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     struct TPathToResolve {
         const NKikimrSchemeOp::TModifyScheme& ModifyScheme;
         ui32 RequireAccess = NACLib::EAccessRights::NoAccess;
-        bool IsTierExternalDataSource = false;
 
         // Params for NSchemeCache::TSchemeCacheNavigate::TEntry
         TVector<TString> Path;
@@ -77,12 +76,9 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     };
 
     TVector<TPathToResolve> ResolveForACL;
-    enum class EAclResolveStage {
-        Primary,
-        TierSecrets
-    };
-
-    EAclResolveStage AclResolveStage = EAclResolveStage::Primary;
+    THashSet<TString> TierExternalDataSourcePathsForACL;
+    TVector<TPathToResolve> TierSecretResolveForACL;
+    bool WaitingTierSecretACL = false;
 
     std::optional<NACLib::TUserToken> UserToken;
     bool CheckAdministrator = false;
@@ -820,8 +816,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             auto toResolve = TPathToResolve(pbModifyScheme);
             toResolve.Path = std::move(path);
             toResolve.RequireAccess = NACLib::EAccessRights::DescribeSchema;
-            toResolve.IsTierExternalDataSource = true;
             ResolveForACL.push_back(std::move(toResolve));
+            TierExternalDataSourcePathsForACL.emplace(canonicalPath);
         }
     }
 
@@ -850,13 +846,14 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         }
     }
 
-    TVector<TPathToResolve> BuildTierSecretResolveTasks(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const NSchemeCache::TSchemeCacheNavigate::TResultSet& resolvedEntries) const {
+    TVector<TPathToResolve> BuildTierSecretResolveTasks(const NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const TVector<TPathToResolve>& resolveTasks, const NSchemeCache::TSchemeCacheNavigate::TResultSet& resolvedEntries) const {
         THashSet<TString> uniqueSecrets;
         TVector<TString> secretNames;
-        const size_t size = std::min(ResolveForACL.size(), resolvedEntries.size());
+        const size_t size = std::min(resolveTasks.size(), resolvedEntries.size());
         for (size_t i = 0; i < size; ++i) {
-            const auto& request = ResolveForACL[i];
-            if (!request.IsTierExternalDataSource) {
+            const auto& request = resolveTasks[i];
+            const TString canonicalPath = CanonizePath(JoinPath(request.Path));
+            if (!TierExternalDataSourcePathsForACL.contains(canonicalPath)) {
                 continue;
             }
 
@@ -1320,11 +1317,15 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     }
 
     THolder<NSchemeCache::TSchemeCacheNavigate> ResolveRequestForACL() {
-        if (!ResolveForACL) {
+        return ResolveRequestForACL(ResolveForACL);
+    }
+
+    THolder<NSchemeCache::TSchemeCacheNavigate> ResolveRequestForACL(const TVector<TPathToResolve>& resolveTasks) {
+        if (!resolveTasks) {
             return {};
         }
 
-        for(auto& toReq: ResolveForACL) {
+        for (auto&& toReq: resolveTasks) {
             if (toReq.Path.empty()) {
                 return {};
             }
@@ -1333,7 +1334,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         TAutoPtr<NSchemeCache::TSchemeCacheNavigate> request(new NSchemeCache::TSchemeCacheNavigate());
         request->DatabaseName = GetRequestProto().GetDatabaseName();
 
-        for(auto& toReq: ResolveForACL) {
+        for (auto&& toReq: resolveTasks) {
             NSchemeCache::TSchemeCacheNavigate::TEntry entry;
             entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
             entry.Path = toReq.Path;
@@ -1445,13 +1446,17 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     }
 
     bool CheckAccess(const NSchemeCache::TSchemeCacheNavigate::TResultSet& resolveSet, const TActorContext &ctx) {
+        return CheckAccess(resolveSet, ResolveForACL, ctx);
+    }
+
+    bool CheckAccess(const NSchemeCache::TSchemeCacheNavigate::TResultSet& resolveSet, const TVector<TPathToResolve>& resolveTasks, const TActorContext &ctx) {
         const bool checkAdmin = (CheckAdministrator || CheckDatabaseAdministrator);
         const bool isAdmin = (IsClusterAdministrator || IsDatabaseAdministrator);
 
         auto resolveIt = resolveSet.begin();
-        auto requestIt = ResolveForACL.begin();
+        auto requestIt = resolveTasks.begin();
 
-        while (resolveIt != resolveSet.end() && requestIt != ResolveForACL.end()) {
+        while (resolveIt != resolveSet.end() && requestIt != resolveTasks.end()) {
             const NSchemeCache::TSchemeCacheNavigate::TEntry& entry = *resolveIt;
             const TPathToResolve& request = *requestIt;
             const auto& modifyScheme = request.ModifyScheme;
@@ -1787,21 +1792,22 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             return Die(ctx);
         }
 
+        const auto& activeResolveTasks = WaitingTierSecretACL ? TierSecretResolveForACL : ResolveForACL;
         Y_ABORT_UNLESS(!navigate->ResultSet.empty());
-        Y_ABORT_UNLESS(navigate->ResultSet.size() == ResolveForACL.size());
+        Y_ABORT_UNLESS(navigate->ResultSet.size() == activeResolveTasks.size());
 
-        if (AclResolveStage == EAclResolveStage::Primary) {
+        if (!WaitingTierSecretACL) {
             SchemeshardIdToRequest = GetShardToRequest(*navigate->ResultSet.begin(), *ResolveForACL.begin());
         }
 
         // Check user access level, permissions on scheme objects and other restrictions/permissions
         if (UserToken) {
-            if (!CheckAccess(navigate->ResultSet, ctx)) {
+            if (!CheckAccess(navigate->ResultSet, activeResolveTasks, ctx)) {
                 return Die(ctx);
             }
         }
 
-        if (AclResolveStage == EAclResolveStage::Primary) {
+        if (!WaitingTierSecretACL) {
             if (IsDocApiRestricted(SchemeRequest->Ev->Get()->Record)) {
                 if (!CheckDocApi(navigate->ResultSet, ctx)) {
                     return Die(ctx);
@@ -1809,17 +1815,20 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
 
             if (GetRequestEv().HasModifyScheme()) {
-                auto secretResolveTasks = BuildTierSecretResolveTasks(GetModifyScheme(), navigate->ResultSet);
+                auto secretResolveTasks = BuildTierSecretResolveTasks(GetModifyScheme(), ResolveForACL, navigate->ResultSet);
                 if (!secretResolveTasks.empty()) {
-                    ResolveForACL = std::move(secretResolveTasks);
-                    auto resolveRequest = ResolveRequestForACL();
+                    TierSecretResolveForACL = std::move(secretResolveTasks);
+                    auto resolveRequest = ResolveRequestForACL(TierSecretResolveForACL);
                     if (resolveRequest) {
-                        AclResolveStage = EAclResolveStage::TierSecrets;
+                        WaitingTierSecretACL = true;
                         ctx.Send(Services.SchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(resolveRequest.Release()));
                         return;
                     }
                 }
             }
+        } else {
+            WaitingTierSecretACL = false;
+            TierSecretResolveForACL.clear();
         }
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_PROXY,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Пользователь, который навешивает tiering на таблицу с EDS на schema-secrets, должен иметь доступ на чтение этих секретов. Раньше этой проверки не было

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
