### PR TITLE
Monitoring viewer: distinguish access denied from missing path for database-scoped handlers

### DIFF
--- a/ydb/core/viewer/browse.h
+++ b/ydb/core/viewer/browse.h
@@ -30,6 +30,8 @@ class TBrowse : public TActorBootstrapped<TBrowse> {
     THolder<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult> DescribeResult;
     THashSet<TActorId> Handlers;
     TActorId TxProxy = MakeTxProxyID();
+    bool MissingChildSchemeDescribeProbe = false;
+    TString MissingChildSegmentName;
 
 public:
     IViewer::TBrowseContext BrowseContext;
@@ -283,10 +285,58 @@ public:
                 return StepOnPath(ctx, currentName);
             }
         }
+        // Segment missing from Children (ACL): Describe full path to get 403 vs missing-path 400.
+        if (!BrowseContext.UserToken.empty() && TxProxy) {
+            TString probePath = CurrentPath;
+            if (!probePath.EndsWith('/')) {
+                probePath += '/';
+            }
+            probePath += currentName;
+            MissingChildSchemeDescribeProbe = true;
+            MissingChildSegmentName = currentName;
+            THolder<TEvTxUserProxy::TEvNavigate> request(new TEvTxUserProxy::TEvNavigate());
+            request->Record.SetUserToken(BrowseContext.UserToken);
+            NKikimrSchemeOp::TDescribePath* record = request->Record.MutableDescribePath();
+            record->SetPath(probePath);
+            ctx.Send(TxProxy, request.Release(), IEventHandle::FlagTrackDelivery);
+            ++Requests;
+            ctx.Send(BrowseContext.Owner, new NViewerEvents::TEvBrowseRequestSent(TxProxy, TEvTxUserProxy::EvNavigate));
+            return;
+        }
         return HandleBadRequest(ctx, "The path is not found");
     }
 
     void Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr &ev, const TActorContext &ctx) {
+        if (MissingChildSchemeDescribeProbe) {
+            MissingChildSchemeDescribeProbe = false;
+            DescribeResult.Reset(ev->Release());
+            ++Responses;
+            ctx.Send(BrowseContext.Owner, new NViewerEvents::TEvBrowseRequestCompleted(TxProxy, TEvTxUserProxy::EvNavigate));
+            const auto& pbRecordProbe(DescribeResult->GetRecord());
+            if (pbRecordProbe.GetStatus() == NKikimrScheme::EStatus::StatusAccessDenied) {
+                return HandleAccessDenied(ctx, "Access denied");
+            }
+            if (pbRecordProbe.GetStatus() == NKikimrScheme::EStatus::StatusPathDoesNotExist) {
+                return HandleBadRequest(ctx, "The path is not found");
+            }
+            if (pbRecordProbe.GetStatus() != NKikimrScheme::EStatus::StatusSuccess) {
+                return HandleBadRequest(ctx, "Error getting schema information");
+            }
+            if (!pbRecordProbe.HasPathDescription() || !pbRecordProbe.GetPathDescription().HasSelf()) {
+                return HandleBadRequest(ctx, "The path is not found");
+            }
+            const auto& pbPathDescriptionProbe = pbRecordProbe.GetPathDescription();
+            const auto& pbSelfProbe = pbPathDescriptionProbe.GetSelf();
+            if (!CurrentPath.EndsWith('/')) {
+                CurrentPath += '/';
+            }
+            CurrentPath += MissingChildSegmentName;
+            CurrentType = GetPathTypeFromSchemeShardType(pbSelfProbe.GetPathType());
+            Final = (CurrentType == NKikimrViewer::EObjectType::Topic);
+            BrowseInfo.Clear();
+            MetaInfo.Clear();
+            return StepOnPath(ctx, MissingChildSegmentName);
+        }
         DescribeResult.Reset(ev->Release());
         ++Responses;
         ctx.Send(BrowseContext.Owner, new NViewerEvents::TEvBrowseRequestCompleted(TxProxy, TEvTxUserProxy::EvNavigate));
@@ -303,6 +353,8 @@ public:
                     }
                 }
             }
+        } else if (pbRecord.GetStatus() == NKikimrScheme::EStatus::StatusAccessDenied) {
+            return HandleAccessDenied(ctx, "Access denied");
         } else {
             return HandleBadRequest(ctx, "Error getting schema information");
         }
@@ -364,6 +416,11 @@ public:
 
     void HandleBadRequest(const TActorContext& ctx, const TString& error) {
         ctx.Send(Owner, new NMon::TEvHttpInfoRes(TString("HTTP/1.1 400 Bad Request\r\n\r\n") + error, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+        Die(ctx);
+    }
+
+    void HandleAccessDenied(const TActorContext& ctx, const TString& error) {
+        ctx.Send(Owner, new NMon::TEvHttpInfoRes(TString("HTTP/1.1 403 Forbidden\r\n\r\n") + error, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
         Die(ctx);
     }
 
@@ -508,6 +565,11 @@ public:
 
     void HandleBadRequest(const TActorContext& ctx, const TString& error) {
         ctx.Send(Owner, new NMon::TEvHttpInfoRes(TString("HTTP/1.1 400 Bad Request\r\n\r\n") + error, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+        Die(ctx);
+    }
+
+    void HandleAccessDenied(const TActorContext& ctx, const TString& error) {
+        ctx.Send(Owner, new NMon::TEvHttpInfoRes(TString("HTTP/1.1 403 Forbidden\r\n\r\n") + error, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
         Die(ctx);
     }
 

--- a/ydb/core/viewer/browse_db.h
+++ b/ydb/core/viewer/browse_db.h
@@ -47,6 +47,8 @@ public:
             switch (DescribeResult->GetRecord().GetStatus()) {
                 case NKikimrScheme::EStatus::StatusPathDoesNotExist:
                     return HandleBadRequest(ctx, "The path is not found");
+                case NKikimrScheme::EStatus::StatusAccessDenied:
+                    return HandleAccessDenied(ctx, "Access denied");
                 default:
                     return HandleBadRequest(ctx, "Error getting schema information");
             }

--- a/ydb/core/viewer/browse_pq.h
+++ b/ydb/core/viewer/browse_pq.h
@@ -90,6 +90,8 @@ public:
             switch (DescribeResult->GetRecord().GetStatus()) {
                 case NKikimrScheme::EStatus::StatusPathDoesNotExist:
                     return HandleBadRequest(ctx, "The path is not found");
+                case NKikimrScheme::EStatus::StatusAccessDenied:
+                    return HandleAccessDenied(ctx, "Access denied");
                 default:
                     return HandleBadRequest(ctx, "Error getting schema information");
             }

--- a/ydb/core/viewer/viewer_put_record.h
+++ b/ydb/core/viewer/viewer_put_record.h
@@ -136,13 +136,21 @@ public:
             return;
         }
         if (SchemeCacheResponse->IsError()) {
-            ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "SchemeCacheNavigate request finished with error: " + SchemeCacheResponse->GetError()));
+            if (SchemeCacheResponse->GetError() == "AccessDenied") {
+                ReplyAndPassAway(TBase::GETHTTPACCESSDENIED("text/plain", "Access denied"));
+            } else {
+                ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "SchemeCacheNavigate request finished with error: " + SchemeCacheResponse->GetError()));
+            }
             return RequestDone();
         }
         auto navigate = *SchemeCacheResponse->Get()->Request;
         auto& info = navigate.ResultSet.front();
         if (info.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
-            ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "TEvNavigateKeySet finished with unsuccessful status. Check if topic exists or if you have UpdateRow access rights."));
+            if (info.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied) {
+                ReplyAndPassAway(TBase::GETHTTPACCESSDENIED("text/plain", "Access denied"));
+            } else {
+                ReplyAndPassAway(TBase::GetHTTPBADREQUEST("text/plain", "TEvNavigateKeySet finished with unsuccessful status. Check if topic exists or if you have UpdateRow access rights."));
+            }
             return RequestDone();
         }
 

--- a/ydb/core/viewer/viewer_topic_data.cpp
+++ b/ydb/core/viewer/viewer_topic_data.cpp
@@ -12,6 +12,9 @@ void TTopicData::HandleDescribe(TEvTxProxySchemeCache::TEvNavigateKeySetResult::
     }
     NavigateResponse->Set(std::move(ev));
     if (NavigateResponse->IsError()) {
+        if (NavigateResponse->GetError() == "AccessDenied") {
+            return ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        }
         return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", NavigateResponse->GetError()));
     }
     Y_ABORT_UNLESS(NavigateResponse->Get());


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Implemented handling for access denied errors in browse_db.h, browse_pq.h, and browse.h to return appropriate responses.
- Enhanced viewer_put_record.h to differentiate between access denied and other errors in SchemeCacheNavigate requests.
- Updated viewer_topic_data.cpp to handle access denied errors in navigation responses.