### PR TITLE
Fixed sending AlterLogin requests to SchemeShard after getting error from PasswordHasher

### DIFF
--- a/ydb/core/kqp/gateway/actors/scheme.h
+++ b/ydb/core/kqp/gateway/actors/scheme.h
@@ -1,4 +1,4 @@
-#pragma once 
+#pragma once
 
 #include "kqp_ic_gateway_actors.h"
 #include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
@@ -134,6 +134,30 @@ public:
                         response.GetSchemeShardReason(), {}));
                     this->Die(ctx);
                 }
+                return;
+            }
+
+            case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::WrongRequest: {
+                NYql::TIssues issues;
+                if (!response.GetIssues().empty()) {
+                    NYql::IssuesFromMessage(response.GetIssues(), issues);
+                }
+
+                Promise.SetValue(NYql::NCommon::ResultFromIssues<TResult>(NYql::TIssuesIds::KIKIMR_BAD_REQUEST,
+                    "Bad scheme request", issues));
+                this->Die(ctx);
+                return;
+            }
+
+            case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::PreconditionFailed: {
+                NYql::TIssues issues;
+                if (!response.GetIssues().empty()) {
+                    NYql::IssuesFromMessage(response.GetIssues(), issues);
+                }
+
+                Promise.SetValue(NYql::NCommon::ResultFromIssues<TResult>(NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED,
+                    "", issues));
+                this->Die(ctx);
                 return;
             }
 

--- a/ydb/core/kqp/ut/scheme/kqp_user_management_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_user_management_ut.cpp
@@ -24,11 +24,31 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-            CREATE USER user1 PASSWORD NULL;
+            CREATE USER user2 PASSWORD NULL;
+            )";
+            auto session = db.CreateSession().GetValueSync().GetSession();
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto query = TStringBuilder() << R"(
+            --!syntax_v1
+            CREATE USER user3 PASSWORD 'pass-word';
             )";
             auto session = db.CreateSession().GetValueSync().GetSession();
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Password contains unacceptable characters");
+        }
+        {
+            auto query = TStringBuilder() << R"(
+            --!syntax_v1
+            CREATE USER user1 PASSWORD 'password2';
+            )";
+            auto session = db.CreateSession().GetValueSync().GetSession();
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "User already exists");
         }
     }
 
@@ -87,10 +107,9 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )";
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "WrongRequest");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported format of hashed password");
         }
-
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
@@ -102,10 +121,9 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )"; // incorrect json
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "WrongRequest");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported format of hashed password");
         }
-
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
@@ -258,7 +276,14 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user1;
+            CREATE USER user1 PASSWORD 'password1';
+            )";
+            auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto query = TStringBuilder() << R"(
+            --!syntax_v1
                 ALTER USER user1 HASH '{
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
@@ -272,8 +297,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user2;
-                ALTER USER user2 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "aGtsZm1rbW1tamh2",
                     "type": "argon2id"
@@ -287,8 +311,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user3;
-                ALTER USER user3 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "ZGl2aW5nbGVzc21pbmluZw==",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
                     "type": "argon2id"
@@ -302,8 +325,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user4;
-                ALTER USER user4 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
                     "type": "wrongtype"
@@ -311,15 +333,13 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )";
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "WrongRequest");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported format of hashed password");
         }
-
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user5;
-                ALTER USER user5 HASH '{{{{}}}
+                ALTER USER user1 HASH '{{{{}}}
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
                     "type": "argon2id"
@@ -327,15 +347,13 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )"; // incorrect json
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "WrongRequest");
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported format of hashed password");
         }
-
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user6;
-                ALTER USER user6 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
                     "type": "argon2id",
@@ -350,8 +368,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user7;
-                ALTER USER user7 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "Field not in base64 format",
                     "salt": "U+tzBtgo06EBQCjlARA6Jg==",
                     "type": "argon2id"
@@ -365,8 +382,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         {
             auto query = TStringBuilder() << R"(
             --!syntax_v1
-                CREATE USER user8;
-                ALTER USER user8 HASH '{
+                ALTER USER user1 HASH '{
                     "hash": "p4ffeMugohqyBwyckYCK1TjJfz3LIHbKiGL+t+oEhzw=",
                     "salt": "Field not in base64 format",
                     "type": "argon2id"
@@ -387,8 +403,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )";
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user9;
-                ALTER USER user9 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -404,8 +419,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )"; // wrong scram hash format
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user10;
-                ALTER USER user10 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -422,8 +436,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )";
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user11;
-                ALTER USER user11 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -440,8 +453,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )";
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user12;
-                ALTER USER user12 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -458,8 +470,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )"; // wrong scram salt length
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user13;
-                ALTER USER user13 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -476,8 +487,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             )"; // wrong scram stored key length
             auto query = TStringBuilder() << Sprintf(R"(
             --!syntax_v1
-                CREATE USER user14;
-                ALTER USER user14 HASH '%s';
+                ALTER USER user1 HASH '%s';
             )", Base64Encode(hashes).c_str());
 
             auto result = client.ExecuteQuery(query, NQuery::TTxControl::NoTx()).GetValueSync();
@@ -672,7 +682,7 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
         }
     }
 
-    Y_UNIT_TEST(AlterUser) {
+    Y_UNIT_TEST(AlterUserWithPassword) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetTableClient();
         {
@@ -710,6 +720,16 @@ Y_UNIT_TEST_SUITE(KqpUserManagement) {
             auto session = db.CreateSession().GetValueSync().GetSession();
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto query = TStringBuilder() << R"(
+            --!syntax_v1
+            ALTER USER user1 WITH PASSWORD 'pass-word';
+            )";
+            auto session = db.CreateSession().GetValueSync().GetSession();
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Password contains unacceptable characters");
         }
     }
 

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1698,7 +1698,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     } else {
                         auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR,
                             "Unsupported format of hashed password");
-                        ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::WrongRequest, nullptr, &issue, ctx);
+                        ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::PreconditionFailed, nullptr, &issue, ctx);
                         return Die(ctx);
                     }
                 } else {
@@ -1721,7 +1721,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     } else {
                         auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR,
                             "Unsupported format of hashed password");
-                        ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::WrongRequest, nullptr, &issue, ctx);
+                        ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::PreconditionFailed, nullptr, &issue, ctx);
                         return Die(ctx);
                     }
                 } else if (targetUser.HasPassword()) {
@@ -1744,6 +1744,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         auto* computedHashes = ev->Get();
         if (!computedHashes->Error.empty()) {
             auto issue = MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, std::move(computedHashes->Error));
+            ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::PreconditionFailed, nullptr, &issue, ctx);
+            return Die(ctx);
         }
 
         auto& alterLogin = *GetModifyScheme().MutableAlterLogin();

--- a/ydb/core/ydb_convert/tx_proxy_status.cpp
+++ b/ydb/core/ydb_convert/tx_proxy_status.cpp
@@ -24,6 +24,9 @@ Ydb::StatusIds::StatusCode YdbStatusFromProxyStatus(TEvTxUserProxy::TEvProposeTr
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress: {
             return Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
         }
+        case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::PreconditionFailed: {
+            return Ydb::StatusIds::PRECONDITION_FAILED;
+        }
         case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::WrongRequest: {
             return Ydb::StatusIds::BAD_REQUEST;
         }
@@ -58,7 +61,7 @@ Ydb::StatusIds::StatusCode YdbStatusFromProxyStatus(TEvTxUserProxy::TEvProposeTr
             }
             default: {
                 return Ydb::StatusIds::GENERIC_ERROR;
-            } 
+            }
         }
         }
         default: {

--- a/ydb/public/lib/base/defs.h
+++ b/ydb/public/lib/base/defs.h
@@ -44,6 +44,7 @@ namespace NTxProxy {
     XX(ResolveError, 4) \
     XX(AccessDenied, 5) \
     XX(DomainLocalityError, 6) \
+    XX(PreconditionFailed, 7) \
     \
     XX(ProxyNotReady, 16) \
     XX(ProxyAccepted, 17) \


### PR DESCRIPTION
PasswordHasher checks password complexity of a desired password and return an error if suggested password doesn't correspond the complexity. TxProxy has to break the request processing after getting such an error from PasswordHasher.