### PR TITLE
Pessimistic lock support for unique indexes

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -359,6 +359,9 @@ message TTableDescription {
     optional TDropCdcStream DropSrcCdcStream = 48;
     // Coordinated schema version for backup operations - persisted with AlterData
     optional uint64 CoordinatedSchemaVersion = 49;
+
+    // For unique indexes - number of leading PK columns which should have unique values (for correct locking)
+    optional uint32 UniqueIndexKeySize = 50;
 }
 
 message TCompressionOptions {

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -258,6 +258,13 @@ TSelectRowVersionResult TDatabase::SelectRowVersion(
     return Require(table)->SelectRowVersion(key, Env, readFlags, visible, observer);
 }
 
+TSelectRowVersionResult TDatabase::SelectRowVersionByKeyPrefix(
+        ui32 table, TArrayRef<const TCell> key,
+        const ITransactionObserverPtr& observer) const
+{
+    return Require(table)->SelectRowVersionByKeyPrefix(key, Env, observer);
+}
+
 TSizeEnv TDatabase::CreateSizeEnv()
 {
     return TSizeEnv(Env);

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -135,6 +135,10 @@ public:
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const;
 
+    TSelectRowVersionResult SelectRowVersionByKeyPrefix(
+            ui32 table, TArrayRef<const TCell> key,
+            const ITransactionObserverPtr& observer = nullptr) const;
+
     TPrechargeResult Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
                         TTagsRef tags, ui64 readFlags, ui64 itemsLimit, ui64 bytesLimit,
                         EDirection direction = EDirection::Forward,

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -350,6 +350,7 @@ public:
 
     bool IsUncommitted() const;
     ui64 GetUncommittedTxId() const;
+    ui64 GetDeltaTxId() const;
     EReady SkipUncommitted();
     std::tuple<ELockMode, ui64> GetLockInfo() const;
     TRowVersion GetRowVersion() const;
@@ -723,6 +724,23 @@ inline ui64 TTableIterBase<TIteratorOps>::GetUncommittedTxId() const
 
     // Must only be called for uncommitted positions
     Y_DEBUG_ABORT_UNLESS(Delta && Uncommitted);
+
+    return DeltaTxId;
+}
+
+template<class TIteratorOps>
+inline ui64 TTableIterBase<TIteratorOps>::GetDeltaTxId() const
+{
+    // Must only be called after a fully successful Apply()
+    Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready == EReady::Data);
+
+    // There must be at least one active iterator
+    Y_DEBUG_ABORT_UNLESS(Active != Inactive);
+
+    // Must only be called for committed deltas
+    if (!Delta || Uncommitted) {
+        return 0;
+    }
 
     return DeltaTxId;
 }

--- a/ydb/core/tablet_flat/flat_row_eggs.h
+++ b/ydb/core/tablet_flat/flat_row_eggs.h
@@ -6,6 +6,8 @@
 #include <util/generic/ylimits.h>
 #include <util/generic/array_ref.h>
 
+#include <ydb/core/scheme/scheme_tablecell.h>
+
 namespace NKikimr {
 namespace NTable {
 

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -1259,9 +1259,16 @@ TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, 
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const
 {
-    Y_ENSURE(ColdParts.empty(), "Cannot iterate with cold parts");
-
     const TCelled key(key_, *Scheme->Keys, false);
+    return Iterate(key, tags, env, seek, snapshot, visible, observer);
+}
+
+TAutoPtr<TTableIter> TTable::Iterate(const TCelled& key, TTagsRef tags, IPages* env, ESeek seek,
+        TRowVersion snapshot,
+        const ITransactionMapPtr& visible,
+        const ITransactionObserverPtr& observer) const
+{
+    Y_ENSURE(ColdParts.empty(), "Cannot iterate with cold parts");
     const ui64 limit = seek == ESeek::Exact ? 1 : Max<ui64>();
 
     TAutoPtr<TTableIter> dbIter(new TTableIter(Scheme.Get(), tags, limit, snapshot,
@@ -1601,6 +1608,68 @@ TSelectRowVersionResult TTable::SelectRowVersion(
     }
 
     return augment(ready ? EReady::Gone : EReady::Page);
+}
+
+TSelectRowVersionResult TTable::SelectRowVersionByKeyPrefix(
+        TArrayRef<const TCell> keyPrefix, IPages* env,
+        const ITransactionObserverPtr& observer) const
+{
+    if (keyPrefix.size() == Scheme->Keys->Size()) {
+        // A full key, not a prefix
+        return SelectRowVersion(keyPrefix, env, 0, nullptr, observer);
+    }
+
+    const TCelled key(keyPrefix, *Scheme->Keys, true);
+    TSelectRowVersionResult res(NTable::EReady::Gone);
+
+    auto iter = Iterate(key, {} /*tags*/, env, ESeek::Lower, TRowVersion::Max(), nullptr, nullptr);
+
+    EReady ready;
+    while ((ready = iter->Next(NTable::ENext::Uncommitted)) == NTable::EReady::Data) {
+        if (!TCellVectorsEquals{}(iter->GetKey().Cells().Slice(0, keyPrefix.size()), keyPrefix)) {
+            break;
+        }
+        while (ready == NTable::EReady::Data && iter->IsUncommitted()) {
+            if (iter->Row().GetRowState() != ERowOp::Absent) {
+                // non-lock-only deltas are pushed to OnSkipUncommitted() to result in an optimistic conflict
+                if (observer) {
+                    observer.OnSkipUncommitted(iter->GetUncommittedTxId());
+                }
+            } else {
+                // live lock-only deltas are processed to wait for a pessimistic lock on them
+                auto [lockMode, lockTxId] = iter->GetLockInfo();
+                // Lock is only valid as long as it's not committed or removed
+                if (!CommittedTransactions.Contains(lockTxId) && !RemovedTransactions.Contains(lockTxId)) {
+                    res.LockMode = lockMode;
+                    res.LockTxId = lockTxId;
+                }
+            }
+            ready = iter->SkipUncommitted();
+        }
+        if (ready == NTable::EReady::Page) {
+            break;
+        }
+        // If there is an active pessimistic lock - return it anyway, even if the row does not exist
+        if (res.LockMode != ELockMode::None) {
+            res.Ready = ready;
+            if (ready != NTable::EReady::Gone) {
+                res.RowVersion = iter->GetRowVersion();
+                res.RowTxId = iter->GetDeltaTxId();
+            }
+            return res;
+        }
+        // If there is no pessimistic lock - we'll return any non-removed row from the range
+        if (ready != NTable::EReady::Gone &&
+            iter->Row().GetRowState() != ERowOp::Erase) {
+            res.Ready = NTable::EReady::Data;
+            res.RowVersion = iter->GetRowVersion();
+            res.RowTxId = iter->GetDeltaTxId();
+        }
+    }
+    if (ready == NTable::EReady::Page) {
+        return TSelectRowVersionResult(ready);
+    }
+    return res;
 }
 
 void TTable::DebugDump(IOutputStream& str, IPages* env, const NScheme::TTypeRegistry& reg) const

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -142,6 +142,10 @@ public:
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const;
+    TAutoPtr<TTableIter> Iterate(const TCelled& key, TTagsRef tags, IPages* env, ESeek seek,
+            TRowVersion snapshot,
+            const ITransactionMapPtr& visible = nullptr,
+            const ITransactionObserverPtr& observer = nullptr) const;
     TAutoPtr<TTableReverseIter> IterateReverse(TRawVals key, TTagsRef tags, IPages* env, ESeek,
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
@@ -163,6 +167,14 @@ public:
             const TCelled& key, IPages* env, ui64 readFlags,
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const;
+    // Works in the same way as SelectRowVersion, but for a range specified
+    // by key prefix. Used to check row conflicts in unique indexes.
+    // Returns either the first locked row or any non-deleted committed row
+    // from the range if no rows are locked in range. Feeds uncommitted
+    // non-lock-only deltas to the specified observer.
+    TSelectRowVersionResult SelectRowVersionByKeyPrefix(
+            TArrayRef<const TCell> keyPrefix, IPages* env,
+            const ITransactionObserverPtr& observer) const;
 
     TPrechargeResult Precharge(TRawVals minKey, TRawVals maxKey, TTagsRef tags,
                      IPages* env, ui64 flg,

--- a/ydb/core/tablet_flat/ut/ut_rowlocks.cpp
+++ b/ydb/core/tablet_flat/ut/ut_rowlocks.cpp
@@ -11,6 +11,34 @@ Y_UNIT_TEST_SUITE(DBRowLocks) {
 
     using namespace NTest;
 
+    class TTestLockObserver : public NTable::ITransactionObserver {
+    public:
+        TVector<ui64> Skips;
+
+        TTestLockObserver() {
+        }
+
+        void OnSkipUncommitted(ui64 txId) override {
+            Skips.push_back(txId);
+        }
+
+        void OnSkipCommitted(const TRowVersion&) override {
+            Y_ENSURE(false, "unreachable");
+        }
+
+        void OnSkipCommitted(const TRowVersion&, ui64) override {
+            Y_ENSURE(false, "unreachable");
+        }
+
+        void OnApplyCommitted(const TRowVersion&) override {
+            Y_ENSURE(false, "unreachable");
+        }
+
+        void OnApplyCommitted(const TRowVersion&, ui64) override {
+            Y_ENSURE(false, "unreachable");
+        }
+    };
+
     Y_UNIT_TEST(LockSurvivesCompactions) {
         TDbExec me;
 
@@ -585,6 +613,100 @@ Y_UNIT_TEST_SUITE(DBRowLocks) {
         UNIT_ASSERT(!me->HasTxData(table1, 101u));
         UNIT_ASSERT(!me->HasTxData(table1, 102u));
         UNIT_ASSERT(!me->HasTxData(table1, 103u));
+    }
+
+    Y_UNIT_TEST(UniqueIndexRowLocks) {
+        TDbExec me;
+
+        const ui32 table1 = 1;
+
+        me.ToLine().Begin();
+        me.ToLine().Apply(*TAlter()
+            .AddTable("me_1", table1)
+            .AddColumn(table1, "uniq", 1, ETypes::Uint64, false, false)
+            .AddColumn(table1, "pk",   2, ETypes::Uint64, false, false)
+            .AddColumnToKey(table1, 1)
+            .AddColumnToKey(table1, 2));
+        me.ToLine().Commit();
+
+        // Uncommitted row lock
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(101).LockRowN(table1, ELockMode::Exclusive, 1_u64, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine()->SelectRowVersionByKeyPrefix(table1, TVector<TCell>{TCell::Make(1_u64)}, nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Gone);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::Exclusive);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 101u);
+        }
+        me.ToLine().Commit();
+
+        // Simple committed version
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 11}).PutN(table1, 1_u64, 1_u64).CommitTx(table1, 101u);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine()->SelectRowVersionByKeyPrefix(table1, TVector<TCell>{TCell::Make(1_u64)}, nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 11));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 0);
+        }
+        me.ToLine().Commit();
+
+        // Delete + add row
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(102).LockRowN(table1, ELockMode::Exclusive, 1_u64, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(103).EraseN(table1, 1_u64, 1_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(104).PutN(table1, 1_u64, 2_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        me.ToLine().WriteVer({1, 12}).CommitTx(table1, 102u);
+        me.ToLine().WriteVer({1, 13}).CommitTx(table1, 103u);
+        me.ToLine().WriteVer({1, 14}).CommitTx(table1, 104u);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto r = me.ToLine()->SelectRowVersionByKeyPrefix(table1, TVector<TCell>{TCell::Make(1_u64)}, nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 14));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 0);
+        }
+        me.ToLine().Commit();
+
+        // Uncommitted delta + observer
+
+        me.ToLine().Begin();
+        me.ToLine().WriteTx(105).EraseN(table1, 1_u64, 2_u64);
+        me.ToLine().Commit();
+
+        me.ToLine().Begin();
+        {
+            auto observer = MakeIntrusive<TTestLockObserver>();
+            auto r = me.ToLine()->SelectRowVersionByKeyPrefix(table1, TVector<TCell>{TCell::Make(1_u64)}, observer);
+            UNIT_ASSERT_VALUES_EQUAL(observer->Skips, TVector<ui64>{105});
+            UNIT_ASSERT_VALUES_EQUAL(r.Ready, EReady::Data);
+            UNIT_ASSERT_VALUES_EQUAL(r.RowVersion, TRowVersion(1, 14));
+            UNIT_ASSERT_VALUES_EQUAL(r.LockMode, ELockMode::None);
+            UNIT_ASSERT_VALUES_EQUAL(r.LockTxId, 0);
+        }
+        me.ToLine().Commit();
     }
 
 } // Y_UNIT_TEST_SUITE(DBRowLocks)

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4739,6 +4739,7 @@ private:
     TBreakWriteConflictsTxObserver* const Observer;
 };
 
+// FIXME: This function is very similar to CheckWriteConflicts. Review/rename/merge them.
 bool TDataShard::BreakWriteConflicts(NTable::TDatabase& db, const TTableId& tableId,
         TArrayRef<const TCell> keyCells, absl::flat_hash_set<ui64>& volatileDependencies)
 {
@@ -4762,10 +4763,7 @@ bool TDataShard::BreakWriteConflicts(NTable::TDatabase& db, const TTableId& tabl
 
     // We are not actually interested in the row version, we only need to
     // detect uncommitted transaction skips on the path to that version.
-    auto res = db.SelectRowVersion(
-        localTid, keyCells, /* readFlags */ 0,
-        nullptr,
-        BreakWriteConflictsTxObserver);
+    auto res = db.SelectRowVersionByKeyPrefix(localTid, keyCells, BreakWriteConflictsTxObserver);
 
     if (res.Ready == NTable::EReady::Page) {
         return false;
@@ -4778,6 +4776,7 @@ bool TDataShard::BreakWriteConflicts(NTable::TDatabase& db, const TTableId& tabl
     return true;
 }
 
+// FIXME: There are two BreakWriteConflict functions, here and in datashard_user_db. Leave only one.
 void TDataShard::BreakWriteConflict(ui64 txId, absl::flat_hash_set<ui64>& volatileDependencies) {
     if (auto* info = GetVolatileTxManager().FindByCommitTxId(txId)) {
         if (info->State != EVolatileTxState::Aborting) {

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -441,8 +441,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
         co_return;
     }
 
-    auto checkSchema = [&]() -> ui32 {
-        auto tableInfo = FindUserTable(tableId.PathId);
+    auto checkSchema = [&](TUserTable::TCPtr tableInfo) -> ui32 {
         if (!tableInfo) {
             state.Result = makeError(NKikimrDataEvents::TEvLockRowsResult::STATUS_SCHEME_ERROR, TStringBuilder()
                 << "Table '" << tableId << "' doesn't exist at shard " << TabletID());
@@ -567,7 +566,8 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
             }
 
             // Schema may have changed, must recheck on every iteration
-            ui32 localTid = checkSchema();
+            auto userTablePtr = FindUserTable(tableId.PathId);
+            ui32 localTid = checkSchema(userTablePtr);
             if (!localTid) {
                 Y_ENSURE(state.Result);
                 return ETxLockRows::Rollback;
@@ -620,8 +620,11 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 // changes, including undecided volatile transactions.
                 auto observer = MakeIntrusive<TLockRowsTxObserver>(*this);
 
-                // Probe the key until the first persistently committed version
-                auto row = txc.DB.SelectRowVersion(localTid, key, /* readFlags */ 0, /* tx map */ nullptr, observer);
+                ui32 uniqueColumnCount = userTablePtr->UniqueIndexKeySize;
+                TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(key, uniqueColumnCount);
+
+                // Probe the key or unique prefix until the first persistently committed version
+                auto row = txc.DB.SelectRowVersionByKeyPrefix(localTid, uniqueKey, observer);
 
                 // Handle page fault by restarting or rescheduling
                 if (row.Ready == NTable::EReady::Page) {
@@ -651,10 +654,9 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                             typedKey.emplace_back(key[i].Data(), key[i].Size(), typeId);
                         }
                     }
-
                     GetConflictsCache().GetTableCache(localTid).AddUncommittedWrite(key, txId, txc.DB);
                     txc.DB.LockRowTx(localTid, newLockMode, typedKey, txId);
-                    SysLocksTable().SetWriteLock(tableId, key);
+                    SysLocksTable().SetWriteLock(tableId, uniqueKey);
                     advanced = true;
                 };
 
@@ -767,7 +769,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     // do that for different (related) locks. When implementing
                     // safepoints we would need to group all locks from the same
                     // transaction, not just having the same LockId.
-                    runtimeLock = SysLocksTable().AddRuntimeLock(tableId, key);
+                    runtimeLock = SysLocksTable().AddRuntimeLock(tableId, uniqueKey);
                     Y_ENSURE(runtimeLock.IsValid());
                     if (!runtimeLock.IsOwner()) {
                         if (skipLocked) {
@@ -978,6 +980,19 @@ void TDataShard::StartLockRowsBrokenWatcher(TLockRowsRequestId requestId, TTable
             UpdateProposeQueueSize();
         }
     }
+}
+
+TConstArrayRef<TCell> GetUniqueIndexKey(TConstArrayRef<TCell> cells, ui32 count) {
+    if (!count || count >= cells.size()) {
+        return cells;
+    }
+    for (ui32 i = 0; i < count; i++) {
+        if (cells[i].IsNull()) {
+            // Unique keys with NULL never conflict with anything - original key should be used
+            return cells;
+        }
+    }
+    return cells.Slice(0, count);
 }
 
 } // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/datashard__lock_rows.h
+++ b/ydb/core/tx/datashard/datashard__lock_rows.h
@@ -42,6 +42,13 @@ namespace NKikimr::NDataShard {
         {}
     };
 
+    // Unique index tables have PK = (index columns, original table PK columns).
+    // This method returns a prefix of it which must be unique and should be used
+    // to check for write conflicts. NULL semantics imply that NULLs don't conflict
+    // with each other so the method returns all <cells> if there are NULLs in first
+    // <count> columns.
+    TConstArrayRef<TCell> GetUniqueIndexKey(TConstArrayRef<TCell> cells, ui32 count);
+
 } // namespace NKikimr::NDataShard
 
 template<>

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -315,7 +315,8 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
         if (UseStepTxId(record)) {
             txc.DB.Update(tableInfo.LocalTid, rop, Key, Value, TRowVersion(record.GetStep(), record.GetTxId()));
         } else {
-            Self->SysLocksTable().BreakLocks(tableId, KeyCells.GetCells()); // probably redundant, we expect target table to be locked until complete restore
+            TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(KeyCells.GetCells(), tableInfo.UniqueIndexKeySize);
+            Self->SysLocksTable().BreakLocks(tableId, uniqueKey); // probably redundant, we expect target table to be locked until complete restore
             txc.DB.Update(tableInfo.LocalTid, rop, Key, Value, *MvccVersion);
         }
 

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -209,14 +209,16 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             // note, that for upsertIfExists mode we must break locks, because otherwise we can
             // produce inconsistency.
             if (BreakLocks) {
+                TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(keyCells.GetCells(), tableInfo.UniqueIndexKeySize);
+
                 if (breakWriteConflicts) {
-                    if (!self->BreakWriteConflicts(txc.DB, fullTableId, keyCells.GetCells(), volatileDependencies)) {
+                    if (!self->BreakWriteConflicts(txc.DB, fullTableId, uniqueKey, volatileDependencies)) {
                         pageFault = true;
                     }
                 }
 
                 if (!pageFault) {
-                    self->SysLocksTable().BreakLocks(fullTableId, keyCells.GetCells());
+                    self->SysLocksTable().BreakLocks(fullTableId, uniqueKey);
                 }
             }
 

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -139,8 +139,10 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             }
         }
 
+        TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(keyCells.GetCells(), tableInfo.UniqueIndexKeySize);
+
         if (breakWriteConflicts) {
-            if (!self->BreakWriteConflicts(params.Txc->DB, fullTableId, keyCells.GetCells(), volatileDependencies)) {
+            if (!self->BreakWriteConflicts(params.Txc->DB, fullTableId, uniqueKey, volatileDependencies)) {
                 pageFault = true;
             }
         }
@@ -165,7 +167,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             continue;
         }
 
-        self->SysLocksTable().BreakLocks(fullTableId, keyCells.GetCells());
+        self->SysLocksTable().BreakLocks(fullTableId, uniqueKey);
 
         if (!volatileDependencies.empty()) {
             if (!params.GlobalTxId) {

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -365,12 +365,15 @@ void TDataShardUserDb::UpsertRowInt(
 {
     TSmallVec<TCell> keyCells = ConvertTableKeys(key);
 
-    CheckWriteConflicts(tableId, keyCells);
+    const TUserTable& tableInfo = *Self.GetUserTables().at(tableId.PathId.LocalPathId);
+    TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(keyCells, tableInfo.UniqueIndexKeySize);
+
+    CheckWriteConflicts(tableId, uniqueKey);
 
     if (LockTxId) {
-        Self.SysLocksTable().SetWriteLock(tableId, keyCells);
+        Self.SysLocksTable().SetWriteLock(tableId, uniqueKey);
     } else {
-        Self.SysLocksTable().BreakLocks(tableId, keyCells);
+        Self.SysLocksTable().BreakLocks(tableId, uniqueKey);
     }
     Self.SetTableUpdateTime(tableId, Now);
 
@@ -733,7 +736,7 @@ private:
     bool SelfFound = false;
 };
 
-void TDataShardUserDb::CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) {
+void TDataShardUserDb::CheckWriteConflicts(const TTableId& tableId, TConstArrayRef<const TCell> keyCells) {
     auto localTableId = Self.GetLocalTableId(tableId);
     Y_ENSURE(localTableId != 0, "Unexpected CheckWriteConflicts for an unknown table");
 
@@ -796,10 +799,7 @@ void TDataShardUserDb::CheckWriteConflicts(const TTableId& tableId, TArrayRef<co
 
     // We are not actually interested in the row version, we only need to
     // detect uncommitted transaction skips on the path to that version.
-    auto res = Db.SelectRowVersion(
-        localTableId, keyCells, /* readFlags */ 0,
-        nullptr, txObserver
-    );
+    auto res = Db.SelectRowVersionByKeyPrefix(localTableId, keyCells, txObserver);
 
     if (res.Ready == NTable::EReady::Page) {
         if (mustFindConflicts || LockTxId) {

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -95,7 +95,7 @@ public:
     virtual void CheckReadConflict(const TRowVersion& rowVersion) = 0;
     virtual void CheckReadDependency(ui64 txId) = 0;
 
-    virtual void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) = 0;
+    virtual void CheckWriteConflicts(const TTableId& tableId, TConstArrayRef<const TCell> keyCells) = 0;
 
     /**
      * Called to handle new uncommitted writes potentially conflicting with
@@ -209,7 +209,7 @@ public:
     void CheckReadConflict(const TRowVersion& rowVersion) override;
     void CheckReadDependency(ui64 txId) override;
 
-    void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) override;
+    void CheckWriteConflicts(const TTableId& tableId, TConstArrayRef<const TCell> keyCells) override;
     void AddWriteConflict(ui64 txId) override;
     bool BreakWriteConflict(ui64 txId) override;
 

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -326,6 +326,7 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
     IsBackup = descr.GetIsBackup();
     ReplicationConfig = TReplicationConfig(descr.GetReplicationConfig());
     IncrementalBackupConfig = TIncrementalBackupConfig(descr.GetIncrementalBackupConfig());
+    UniqueIndexKeySize = descr.GetUniqueIndexKeySize();
 
     CheckSpecialColumns();
 

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -461,6 +461,7 @@ struct TUserTable : public TThrRefBase {
     TReplicationConfig ReplicationConfig;
     TIncrementalBackupConfig IncrementalBackupConfig;
     bool IsBackup = false;
+    ui32 UniqueIndexKeySize = 0;
 
     TMap<TPathId, TTableIndex> Indexes;
 

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -112,21 +112,26 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
     class TKeysBuilder {
     public:
-        TKeysBuilder() = default;
+        TKeysBuilder(uint32_t cols = 1): Cols(cols)
+        { }
 
         TKeysBuilder&& Add(i32 key) && {
             Cells.push_back(TCell::Make(key));
-            ++Rows;
+            return std::move(*this);
+        }
+
+        TKeysBuilder&& AddNull() && {
+            Cells.emplace_back();
             return std::move(*this);
         }
 
         TSerializedCellMatrix Build() && {
-            return TSerializedCellMatrix(TSerializedCellMatrix::Serialize(Cells, Rows, 1));
+            return TSerializedCellMatrix(TSerializedCellMatrix::Serialize(Cells, Cells.size()/Cols, Cols));
         }
 
     private:
         TVector<TCell> Cells;
-        size_t Rows = 0;
+        const size_t Cols;
     };
 
     class TLockRowsHelper {
@@ -1503,6 +1508,216 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
 
         // Uncommitted: none left
         UNIT_ASSERT_VALUES_EQUAL(pipe.GetOpenTxs(tableId).size(), 0u);
+    }
+
+    Y_UNIT_TEST_TWIN(UniqueIndexBasic, OnAdd) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+        serverSettings.FeatureFlags.SetEnableAddUniqueIndex(true);
+        serverSettings.FeatureFlags.SetEnableOnlineAddUniqueIndex(true);
+        auto [runtime, server, sender] = TestCreateServer(pm, serverSettings);
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        if (OnAdd) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSchemeExec(runtime, R"(
+                    CREATE TABLE `/Root/table` (uniq int, pk int, PRIMARY KEY (uniq, pk));
+                )"),
+                "SUCCESS");
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSchemeExec(runtime, R"(
+                    ALTER TABLE `/Root/table` ADD INDEX idx GLOBAL UNIQUE ON (uniq);
+                )", "/Root"),
+                "SUCCESS");
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSchemeExec(runtime, R"(
+                    CREATE TABLE `/Root/table` (uniq int, pk int, PRIMARY KEY (uniq, pk), INDEX idx GLOBAL UNIQUE ON (uniq));
+                )"),
+                "SUCCESS");
+        }
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table/idx/indexImplTable");
+        const auto shards = GetTableShards(server, sender, "/Root/table/idx/indexImplTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        auto sendRequestWithUniq = [&](const TLockHandle& lock, TSerializedCellMatrix keys) {
+            return lockRows.SendRequest(lock, tableId, keys, [&](auto* req) {
+                req->Record.AddColumnIds(2);
+            });
+        };
+
+        // Unique indexes should have UniqueIndexKeySize = number of unique key columns
+
+        // Lock (1, 1) by lock 1
+        auto req1 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(1).Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Try locking (1, 2) by lock 2 - should conflict
+        auto req2 = sendRequestWithUniq(lock2, TKeysBuilder(2).Add(1).Add(2).Build());
+        lockRows.ExpectNoResult();
+
+        // Try locking (1, 2) by lock 1 - should be OK, the same lock is already taken
+        auto req3 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(1).Add(1).Build());
+        lockRows.ExpectResult(req3);
+
+        // Try waiting for lock 2 some more
+        lockRows.ExpectNoResult();
+
+        // Destroy lock 1 handle, it must rollback all changes
+        lock1.Reset();
+
+        // Try waiting for lock 2 result now
+        lockRows.ExpectResult(req2);
+    }
+
+    Y_UNIT_TEST(UniqueIndexNulls) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (uniq int, pk int, PRIMARY KEY (uniq, pk), INDEX idx GLOBAL UNIQUE ON (uniq));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table/idx/indexImplTable");
+        const auto shards = GetTableShards(server, sender, "/Root/table/idx/indexImplTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        auto sendRequestWithUniq = [&](const TLockHandle& lock, TSerializedCellMatrix keys) {
+            return lockRows.SendRequest(lock, tableId, keys, [&](auto* req) {
+                req->Record.AddColumnIds(2);
+            });
+        };
+
+        // Lock (null, 1) by lock 1
+        auto req1 = sendRequestWithUniq(lock1, TKeysBuilder(2).AddNull().Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Try locking (null, 2) by lock 2 - should not conflict
+        auto req2 = sendRequestWithUniq(lock2, TKeysBuilder(2).AddNull().Add(2).Build());
+        lockRows.ExpectResult(req2);
+    }
+
+    Y_UNIT_TEST(UniqueIndexOverUncommittedThenCommit) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (uniq int, pk int, PRIMARY KEY (uniq, pk), INDEX idx GLOBAL UNIQUE ON (uniq));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table/idx/indexImplTable");
+        const auto shards = GetTableShards(server, sender, "/Root/table/idx/indexImplTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        auto sendRequestWithUniq = [&](const TLockHandle& lock, TSerializedCellMatrix keys) {
+            return lockRows.SendRequest(lock, tableId, keys, [&](auto* req) {
+                req->Record.AddColumnIds(2);
+            });
+        };
+
+        // Write an uncommitted row (1, 101)
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                UPSERT INTO `/Root/table` (uniq, pk) VALUES (1, 101);
+                SELECT uniq, pk FROM `/Root/table` WHERE uniq = 1;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 101 } }");
+
+        // Lock (1, 1) by lock 1
+        auto req1 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(1).Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Commit the previous transaction
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Lock (2, 1) by lock 1 (lock must be broken now)
+        auto req2 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(2).Add(1).Build());
+        lockRows.ExpectResult(req2, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
+    }
+
+    Y_UNIT_TEST(UniqueIndexUncommittedOverLock) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (uniq int, pk int, PRIMARY KEY (uniq, pk), INDEX idx GLOBAL UNIQUE ON (uniq));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table/idx/indexImplTable");
+        const auto shards = GetTableShards(server, sender, "/Root/table/idx/indexImplTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        auto sendRequestWithUniq = [&](const TLockHandle& lock, TSerializedCellMatrix keys) {
+            return lockRows.SendRequest(lock, tableId, keys, [&](auto* req) {
+                req->Record.AddColumnIds(2);
+            });
+        };
+
+        // Lock (1, 1) by lock 1
+        auto req1 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(1).Add(1).Build());
+        lockRows.ExpectResult(req1);
+
+        // Write an uncommitted row (1, 101)
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                UPSERT INTO `/Root/table` (uniq, pk) VALUES (1, 101);
+                SELECT uniq, pk FROM `/Root/table` WHERE uniq = 1;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 101 } }");
+
+        // Lock (2, 1) by lock 1 (lock not broken yet)
+        auto req2 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(2).Add(1).Build());
+        lockRows.ExpectResult(req2);
+
+        // Commit the previous transaction
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "{ items { int32_value: 1 } }");
+
+        // Lock (3, 1) by lock 1 (lock must be broken now)
+        auto req3 = sendRequestWithUniq(lock1, TKeysBuilder(2).Add(3).Add(1).Build());
+        lockRows.ExpectResult(req3, NKikimrDataEvents::TEvLockRowsResult::STATUS_LOCKS_BROKEN);
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -158,8 +158,10 @@ public:
                 key.emplace_back(TRawTypeValue(cell.AsRef(), vtype));
             }
 
+            TConstArrayRef<TCell> uniqueKey = GetUniqueIndexKey(keyCells.GetCells(), tableInfo.UniqueIndexKeySize);
+
             if (breakWriteConflicts || checkVolatileDependencies) {
-                if (!DataShard.BreakWriteConflicts(txc.DB, fullTableId, keyCells.GetCells(), volatileDependencies)) {
+                if (!DataShard.BreakWriteConflicts(txc.DB, fullTableId, uniqueKey, volatileDependencies)) {
                     if (breakWriteConflicts) {
                         pageFault = true;
                     } else if (checkVolatileDependencies) {
@@ -186,7 +188,7 @@ public:
                 continue;
             }
 
-            DataShard.SysLocksTable().BreakLocks(fullTableId, keyCells.GetCells());
+            DataShard.SysLocksTable().BreakLocks(fullTableId, uniqueKey);
 
             if (!volatileDependencies.empty() || volatileOrdered) {
                 txc.DB.UpdateTx(tableInfo.LocalTid, NTable::ERowOp::Erase, key, {}, globalTxId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -193,7 +193,9 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             if (indexDesc.IndexImplTableDescriptionsSize() == 1) {
                 indexTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
             }
-            auto implTableDesc = CalcImplTableDesc(tableInfo, implTableColumns, indexTableDesc);
+            const auto uniqueKeySize = indexType == NKikimrSchemeOp::EIndexTypeGlobalUnique
+                ? indexDesc.GetKeyColumnNames().size() : 0;
+            auto implTableDesc = CalcImplTableDesc(tableInfo, implTableColumns, indexTableDesc, uniqueKeySize);
             // TODO if keep erase markers also speedup compaction or something else we can enable it for other impl tables too
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
             result.push_back(createImplTable(std::move(implTableDesc)));

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -323,7 +323,9 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     // This description provided by user to override partition policy
                     userIndexDesc = indexDescription.GetIndexImplTableDescriptions(0);
                 }
-                result.push_back(createIndexImplTable(CalcImplTableDesc(baseTableDescription, implTableColumns, userIndexDesc)));
+                const auto uniqueKeySize = indexType == NKikimrSchemeOp::EIndexTypeGlobalUnique
+                    ? indexDescription.GetKeyColumnNames().size() : 0;
+                result.push_back(createIndexImplTable(CalcImplTableDesc(baseTableDescription, implTableColumns, userIndexDesc, uniqueKeySize)));
                 break;
             }
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {

--- a/ydb/core/tx/schemeshard/schemeshard_index_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_index_utils.cpp
@@ -285,7 +285,8 @@ const auto& GetColumns(const NKikimrSchemeOp::TTableDescription& tableDescr) {
 auto CalcImplTableDescImpl(
     const auto& baseTable,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    ui32 uniqueKeySize)
 {
     NKikimrSchemeOp::TTableDescription implTableDesc;
     implTableDesc.SetName(NTableIndex::ImplTable);
@@ -294,6 +295,10 @@ auto CalcImplTableDescImpl(
     FillIndexImplTableColumns(GetColumns(baseTable), implTableColumns.Keys, implTableColumns.Columns, implTableDesc);
     if (indexTableDesc.HasReplicationConfig()) {
         implTableDesc.MutableReplicationConfig()->CopyFrom(indexTableDesc.GetReplicationConfig());
+    }
+    if (uniqueKeySize > 0 && uniqueKeySize < implTableColumns.Keys.size()) {
+        // Unique key may contain all PK columns, then the prefix is not required
+        implTableDesc.SetUniqueIndexKeySize(uniqueKeySize);
     }
 
     return implTableDesc;
@@ -586,17 +591,19 @@ void FillIndexTableColumns(
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    ui32 uniqueKeySize)
 {
-    return CalcImplTableDescImpl(baseTableInfo, implTableColumns, indexTableDesc);
+    return CalcImplTableDescImpl(baseTableInfo, implTableColumns, indexTableDesc, uniqueKeySize);
 }
 
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDescr,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    ui32 uniqueKeySize)
 {
-    return CalcImplTableDescImpl(baseTableDescr, implTableColumns, indexTableDesc);
+    return CalcImplTableDescImpl(baseTableDescr, implTableColumns, indexTableDesc, uniqueKeySize);
 }
 
 NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeLevelImplTableDesc(

--- a/ydb/core/tx/schemeshard/schemeshard_index_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_index_utils.h
@@ -28,12 +28,14 @@ TIndexObjectCounts GetIndexObjectCounts(const NKikimrSchemeOp::TIndexCreationCon
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    ui32 uniqueKeySize);
 
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDesc,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    ui32 uniqueKeySize);
 
 NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeLevelImplTableDesc(
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -761,6 +761,17 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         return nullptr;
     }
 
+    if (op.GetUniqueIndexKeySize()) {
+        if (op.GetUniqueIndexKeySize() >= keyColIds.size()) {
+            errStr = TStringBuilder()
+                << "Too many unique key prefix columns"
+                << ": " << op.GetUniqueIndexKeySize()
+                << ", max: " << (keyColIds.size()-1);
+            return nullptr;
+        }
+        alterData->TableDescriptionFull->SetUniqueIndexKeySize(op.GetUniqueIndexKeySize());
+    }
+
     if (source) {
         // key columns reorder or deletion is not supported
         const TVector<ui32>& oldColIds = source->KeyColumnIds;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

1) В локальную базу добавлена функция SelectUniqueRowVersion(), которая действует аналогично SelectRowVersion(), но для префикса ключа. Она вызывает OnSkipUncommitted для не lock-only незакоммиченных дельт и возвращает либо любую строку с активной пессимистичной блокировкой из диапазона, либо если таких нет - то любую существующую закоммиченную строку. В случае, если в SelectUniqueRowVersion передаётся полный первичный ключ, она просто прозрачно вызывает обычную SelectRowVersion.
2) В описание таблиц добавлено поле UniqueKeyPrefixSize, которое устанавливается на таблицах уникальных индексов равным числу ключевых колонок. Сначала хотел обойтись новым полем в TEvLockRows, но так нельзя, т.к. в этом случае Serializable транзакции, начатые после взятия пессимистичной ReadCommitted блокировки, не могут её сломать, т.к. они не знают, что залочен префикс, а не полный ключ (тест-кейс UniqueIndexUncommittedOverLock).
3) В datashard сделано, чтобы при установке пессимистичных блокировок и проверке конфликтов (CheckWriteConflicts/BreakWriteConflicts, SetWriteLock/BreakLocks) использовался уникальный префикс ключа, если в нём нет значений NULL. Если такие есть, то используется полный ключ.

Итого предполагаемый способ использования - для выполнения read committed транзакции с уникальными индексами KQP должен, аналогично обычным таблицам, просто заблокировать все строки через TEvLockRows. Единственный нюанс - индексы, созданные в прошлых версиях, то есть без поля UniqueKeyPrefixSize. Для таких индексов, мне кажется, единственный путь - это добавить в будущем коде KQP проверку, что это поле у индексной таблицы заполнено. Если оно не заполнено, Read Committed транзакции на таком уникальном индексе нужно запрещать.