### PR TITLE
Viewer: require administration access when force=true for vdisk/pdisk endpoints

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -629,6 +629,15 @@ void TViewerPipeClient::ApplyForceMode(TEvBlobStorage::TEvControllerConfigReques
     }
 }
 
+bool TViewerPipeClient::RequireAdminIfForce(bool& force, TStringBuf forceParamName) {
+    force = FromStringWithDefault<bool>(Params.Get(forceParamName), force);
+    if (force && !Viewer->CheckAccessAdministration(GetRequest())) {
+        ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Administration access required when force=true"));
+        return false;
+    }
+    return true;
+}
+
 TViewerPipeClient::TRequestResponse<TEvBlobStorage::TEvControllerConfigResponse> TViewerPipeClient::RequestBSControllerPDiskRestart(ui32 nodeId, ui32 pdiskId, bool force) {
     THolder<TEvBlobStorage::TEvControllerConfigRequest> request = MakeHolder<TEvBlobStorage::TEvControllerConfigRequest>();
     auto* restartPDisk = request->Record.MutableRequest()->AddCommand()->MutableRestartPDisk();

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -342,6 +342,7 @@ protected:
     void BuildParamsFromJson(TStringBuf data);
     void BuildParamsFromFormData(TStringBuf data);
     void SetupTracing(const TString& handlerName);
+    bool RequireAdminIfForce(bool& force, TStringBuf forceParamName = "force");
     void ApplyForceMode(TEvBlobStorage::TEvControllerConfigRequest& request);
 
     template<typename TJson>

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -29,9 +29,8 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
-        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
-            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        if (!RequireAdminIfForce(Force)) {
+            return;
         }
         ui32 nodeId = 0;
         ui32 pDiskId = 0;

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -29,6 +29,10 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
+        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
+        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
+            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        }
         ui32 nodeId = 0;
         ui32 pDiskId = 0;
         TVector<TString> parts = StringSplitter(Params.Get("pdisk_id")).Split('-').SkipEmpty();
@@ -45,7 +49,6 @@ public:
         if (nodeId == 0 || pDiskId == 0) {
             return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Unable to parse the 'pdisk_id' parameter"));
         }
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
         Response = RequestBSControllerPDiskRestart(nodeId, pDiskId, Force);
 
         TBase::Become(&TThis::StateWork, Timeout, new TEvents::TEvWakeup());

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -33,6 +33,10 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
+        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
+        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
+            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        }
         ui32 nodeId = 0;
         ui32 pDiskId = 0;
         TVector<TString> parts = StringSplitter(Params.Get("pdisk_id")).Split('-').SkipEmpty();
@@ -51,7 +55,6 @@ public:
         }
         DriveStatus.MutableHostKey()->SetNodeId(nodeId);
         DriveStatus.SetPDiskId(pDiskId);
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
         if (PostData.IsMap()) {
             if (PostData.Has("decommit_status")) {
                 NKikimrBlobStorage::EDecommitStatus decommitStatus = NKikimrBlobStorage::EDecommitStatus::DECOMMIT_UNSET;

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -33,9 +33,8 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
-        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
-            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        if (!RequireAdminIfForce(Force)) {
+            return;
         }
         ui32 nodeId = 0;
         ui32 pDiskId = 0;

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -711,9 +711,8 @@
             "result": false
         },
         "restart_pdisk_monitoring_force": {
-            "debugMessage": "text",
-            "error": "Running this operation will cause at least 4 groups (2181038080, 2181038081, 2181038082, ...) to become unavailable",
-            "result": false
+            "status_code": 403,
+            "text": "Access denied"
         },
         "restart_pdisk_root": {
             "debugMessage": "text",

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -697,6 +697,10 @@
             "status_code": 403,
             "text": "<html><body><h1>403 Forbidden</h1><p><main>: Error: SID is not allowed\n</p></body></html>"
         },
+        "evict_vdisk_monitoring_force": {
+            "status_code": 403,
+            "text": "Access denied"
+        },
         "restart_pdisk_database": {
             "status_code": 403,
             "text": "<html><body><h1>403 Forbidden</h1><p><main>: Error: SID is not allowed\n</p></body></html>"
@@ -729,6 +733,10 @@
             "text": "Access denied"
         },
         "restart_pdisk_viewer_force": {
+            "status_code": 403,
+            "text": "Access denied"
+        },
+        "status_pdisk_monitoring_force": {
             "status_code": 403,
             "text": "Access denied"
         },

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -699,7 +699,7 @@
         },
         "evict_vdisk_monitoring_force": {
             "status_code": 403,
-            "text": "Access denied"
+            "text": "Administration access required when force=true"
         },
         "restart_pdisk_database": {
             "status_code": 403,
@@ -716,7 +716,7 @@
         },
         "restart_pdisk_monitoring_force": {
             "status_code": 403,
-            "text": "Access denied"
+            "text": "Administration access required when force=true"
         },
         "restart_pdisk_root": {
             "debugMessage": "text",
@@ -738,7 +738,7 @@
         },
         "status_pdisk_monitoring_force": {
             "status_code": 403,
-            "text": "Access denied"
+            "text": "Administration access required when force=true"
         },
         "storage_nodes_database": {
             "FieldsAvailable": "0000010000000110011000000110100000011",

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1653,6 +1653,7 @@ class TestViewer(object):
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.root_session_id,
         }), ['debugMessage'])
+        cls.assert_force_retry_possible(result['restart_pdisk_root'], True, 'restart_pdisk_root')
         result['restart_pdisk_monitoring'] = cls.replace_values_by_key(cls.post_viewer("/pdisk/restart", body={
             'pdisk_id': '1-1',
         }, headers={
@@ -1697,7 +1698,20 @@ class TestViewer(object):
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.root_session_id,
         }), ['debugMessage'])
-        cls.assert_force_retry_possible(result['restart_pdisk_root'], True, 'restart_pdisk_root')
+
+        result['status_pdisk_monitoring_force'] = cls.post_viewer("/pdisk/status", body={
+            'pdisk_id': '1-1',
+            'force': '1',
+        }, headers={
+            'Cookie': 'ydb_session_id=' + cls.monitoring_session_id,
+        })
+        cls.assert_access_denied(result['status_pdisk_monitoring_force'], 'status_pdisk_monitoring_force')
+        result['evict_vdisk_monitoring_force'] = cls.post_viewer("/vdisk/evict", body={
+            'force': '1',
+        }, headers={
+            'Cookie': 'ydb_session_id=' + cls.monitoring_session_id,
+        })
+        cls.assert_access_denied(result['evict_vdisk_monitoring_force'], 'evict_vdisk_monitoring_force')
         return result
 
     @classmethod

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1521,7 +1521,10 @@ class TestViewer(object):
     @classmethod
     def assert_access_denied(cls, response, case_name):
         assert response.get('status_code') == 403, f"{case_name}: expected status_code=403, got {response}"
-        assert response.get('text') == 'Access denied', f"{case_name}: expected plain 'Access denied', got {response}"
+        text = response.get('text', '')
+        assert text == 'Access denied' or 'SID is not allowed' in text, (
+            f"{case_name}: expected plain 'Access denied' or HTML SID rejection, got {response}"
+        )
 
     @classmethod
     def assert_force_retry_possible(cls, response, expected, case_name):

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1522,8 +1522,12 @@ class TestViewer(object):
     def assert_access_denied(cls, response, case_name):
         assert response.get('status_code') == 403, f"{case_name}: expected status_code=403, got {response}"
         text = response.get('text', '')
-        assert text == 'Access denied' or 'SID is not allowed' in text, (
-            f"{case_name}: expected plain 'Access denied' or HTML SID rejection, got {response}"
+        assert (
+            text == 'Access denied'
+            or text == 'Administration access required when force=true'
+            or 'SID is not allowed' in text
+        ), (
+            f"{case_name}: expected access denied/admin-force message or HTML SID rejection, got {response}"
         )
 
     @classmethod

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1519,6 +1519,22 @@ class TestViewer(object):
         return result
 
     @classmethod
+    def assert_access_denied(cls, response, case_name):
+        assert response.get('status_code') == 403, f"{case_name}: expected status_code=403, got {response}"
+        assert response.get('text') == 'Access denied', f"{case_name}: expected plain 'Access denied', got {response}"
+
+    @classmethod
+    def assert_force_retry_possible(cls, response, expected, case_name):
+        has_force_retry_possible = 'forceRetryPossible' in response
+        assert has_force_retry_possible == expected, (
+            f"{case_name}: expected forceRetryPossible present={expected}, got {response}"
+        )
+        if expected:
+            assert response.get('forceRetryPossible') is True, (
+                f"{case_name}: expected forceRetryPossible=true, got {response}"
+            )
+
+    @classmethod
     def test_security(cls):
         result = {}
         result['database_nodes_root'] = cls.get_viewer_normalized("/viewer/nodes", params={
@@ -1639,6 +1655,7 @@ class TestViewer(object):
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.monitoring_session_id,
         }), ['debugMessage'])
+        cls.assert_force_retry_possible(result['restart_pdisk_monitoring'], False, 'restart_pdisk_monitoring')
         result['restart_pdisk_viewer'] = cls.replace_values_by_key(cls.post_viewer("/pdisk/restart", body={
             'pdisk_id': '1-1',
         }, headers={
@@ -1656,24 +1673,28 @@ class TestViewer(object):
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.database_session_id,
         }), ['debugMessage'])
+        cls.assert_access_denied(result['restart_pdisk_database_force'], 'restart_pdisk_database_force')
         result['restart_pdisk_viewer_force'] = cls.replace_values_by_key(cls.post_viewer("/pdisk/restart", body={
             'pdisk_id': '1-1',
             'force': '1',
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.viewer_session_id,
         }), ['debugMessage'])
+        cls.assert_access_denied(result['restart_pdisk_viewer_force'], 'restart_pdisk_viewer_force')
         result['restart_pdisk_monitoring_force'] = cls.replace_values_by_key(cls.post_viewer("/pdisk/restart", body={
             'pdisk_id': '1-1',
             'force': '1',
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.monitoring_session_id,
         }), ['debugMessage'])
+        cls.assert_access_denied(result['restart_pdisk_monitoring_force'], 'restart_pdisk_monitoring_force')
         result['restart_pdisk_root_force'] = cls.replace_values_by_key(cls.post_viewer("/pdisk/restart", body={
             'pdisk_id': '1-1',
             'force': '1',
         }, headers={
             'Cookie': 'ydb_session_id=' + cls.root_session_id,
         }), ['debugMessage'])
+        cls.assert_force_retry_possible(result['restart_pdisk_root'], True, 'restart_pdisk_root')
         return result
 
     @classmethod

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -48,6 +48,10 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
+        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
+        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
+            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        }
         ui32 groupId = 0;
         ui32 groupGeneration = 0;
         ui32 failRealmIdx = 0;
@@ -76,8 +80,6 @@ public:
             return;
             //return TBase::ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Parameter 'vdisk_id' is required"), "BadRequest");
         }
-
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
 
         Response = RequestBSControllerVDiskEvict(groupId, groupGeneration, failRealmIdx, failDomainIdx, vDiskIdx, Force);
         TBase::Become(&TThis::StateWork, Timeout, new TEvents::TEvWakeup());

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -48,9 +48,8 @@ public:
         if (!Viewer->CheckAccessMonitoring(GetRequest())) {
             return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
         }
-        Force = FromStringWithDefault<bool>(Params.Get("force"), Force);
-        if (Force && !Viewer->CheckAccessAdministration(GetRequest())) {
-            return TBase::ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Access denied"));
+        if (!RequireAdminIfForce(Force)) {
+            return;
         }
         ui32 groupId = 0;
         ui32 groupGeneration = 0;


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Для force=true viewer теперь, сразу после проверки monitoring-доступа, дополнительно требует административный доступ --CheckAccessAdministration, чтобы отсутствие прав давало явный 403, а не зарывалось за 400-ым статус кодом на параметрах.