### PR TITLE
Viewer: endpoints return stable errors with missing params 

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -3898,6 +3898,20 @@
         "Tenants": "3",
         "Versions": "not-empty-array"
     },
+    "test.TestViewer.test_viewer_content_and_tabletcounters_missing_params": {
+        "content_no_path": {
+            "status_code": 400,
+            "text": "Parameter 'path' is required"
+        },
+        "content_whitespace_path": {
+            "status_code": 400,
+            "text": "Parameter 'path' is required"
+        },
+        "tabletcounters_no_path_no_tablet": {
+            "status_code": 400,
+            "text": "Parameter 'path' or 'tablet_id' is required"
+        }
+    },
     "test.TestViewer.test_viewer_describe": {
         "/Root": {
             "LastExistedPrefixDescription": {},

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -726,6 +726,30 @@ class TestViewer(object):
         return result
 
     @classmethod
+    def test_viewer_content_and_tabletcounters_missing_params(cls):
+        """Stable 400 for missing path / tablet selector (avoid browse / scheme timeouts)."""
+        result = {}
+        result['content_no_path'] = cls.get_viewer("/viewer/content", {
+            'database': cls.dedicated_db,
+        })
+        result['content_whitespace_path'] = cls.get_viewer("/viewer/content", {
+            'database': cls.dedicated_db,
+            'path': '   ',
+        })
+        result['tabletcounters_no_path_no_tablet'] = cls.get_viewer("/viewer/tabletcounters", {
+            'database': cls.dedicated_db,
+        })
+        assert result['content_no_path'].get('status_code') == 400, result['content_no_path']
+        assert "Parameter 'path' is required" in result['content_no_path'].get('text', ''), result['content_no_path']
+        assert result['content_whitespace_path'].get('status_code') == 400, result['content_whitespace_path']
+        assert "Parameter 'path' is required" in result['content_whitespace_path'].get('text', ''), result['content_whitespace_path']
+        assert result['tabletcounters_no_path_no_tablet'].get('status_code') == 400, result['tabletcounters_no_path_no_tablet']
+        assert (
+            "Parameter 'path' or 'tablet_id' is required" in result['tabletcounters_no_path_no_tablet'].get('text', '')
+        ), result['tabletcounters_no_path_no_tablet']
+        return result
+
+    @classmethod
     def test_viewer_sysinfo(cls):
         result = cls.get_viewer_normalized("/viewer/sysinfo")
         return result

--- a/ydb/core/viewer/viewer_content.h
+++ b/ydb/core/viewer/viewer_content.h
@@ -41,6 +41,17 @@ public:
         if (!Event->Get()->UserToken.empty()) {
             ContentRequestContext.UserToken = Event->Get()->UserToken;
         }
+        ContentRequestContext.Path = Strip(ContentRequestContext.Path);
+        if (ContentRequestContext.Path.empty()) {
+            ctx.Send(
+                Initiator,
+                new NMon::TEvHttpInfoRes(
+                    Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Parameter 'path' is required"),
+                    0,
+                    NMon::IEvHttpInfoRes::EContentType::Custom));
+            Die(ctx);
+            return;
+        }
         BrowseStarted = ctx.Now();
         ctx.RegisterWithSameMailbox(new TBrowse(Viewer, ctx.SelfID, ContentRequestContext.Path, Event->Get()->UserToken));
 

--- a/ydb/core/viewer/viewer_tabletcounters.h
+++ b/ydb/core/viewer/viewer_tabletcounters.h
@@ -53,16 +53,6 @@ public:
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);
         Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
         Aggregate = FromStringWithDefault<bool>(params.Get("aggregate"), true);
-        if (!params.Has("path") && !params.Has("tablet_id")) {
-            ctx.Send(
-                Event->Sender,
-                new NMon::TEvHttpInfoRes(
-                    Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Parameter 'path' or 'tablet_id' is required"),
-                    0,
-                    NMon::IEvHttpInfoRes::EContentType::Custom));
-            Die(ctx);
-            return;
-        }
         if (params.Has("path")) {
             THolder<TEvTxUserProxy::TEvNavigate> request(new TEvTxUserProxy::TEvNavigate());
             if (!Event->Get()->UserToken.empty()) {
@@ -74,7 +64,7 @@ public:
             TActorId txproxy = MakeTxProxyID();
             ctx.Send(txproxy, request.Release());
             Become(&TThis::StateRequestedDescribe, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
-        } else {
+        } else if (params.Has("tablet_id")) {
             TTabletId tabletId = FromStringWithDefault<TTabletId>(params.Get("tablet_id"), 0);
             if (tabletId != 0) {
                 Tablets.emplace_back(tabletId);
@@ -87,6 +77,15 @@ public:
             if (PipeClients.empty()) {
                 ReplyAndDie(ctx);
             }
+        } else {
+            ctx.Send(
+                Event->Sender,
+                new NMon::TEvHttpInfoRes(
+                    Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Parameter 'path' or 'tablet_id' is required"),
+                    0,
+                    NMon::IEvHttpInfoRes::EContentType::Custom));
+            Die(ctx);
+            return;
         }
     }
 

--- a/ydb/core/viewer/viewer_tabletcounters.h
+++ b/ydb/core/viewer/viewer_tabletcounters.h
@@ -76,21 +76,17 @@ public:
             Become(&TThis::StateRequestedDescribe, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
         } else {
             TTabletId tabletId = FromStringWithDefault<TTabletId>(params.Get("tablet_id"), 0);
-            if (tabletId == 0) {
-                ctx.Send(
-                    Event->Sender,
-                    new NMon::TEvHttpInfoRes(
-                        Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Invalid 'tablet_id' value"),
-                        0,
-                        NMon::IEvHttpInfoRes::EContentType::Custom));
-                Die(ctx);
-                return;
+            if (tabletId != 0) {
+                Tablets.emplace_back(tabletId);
+                TActorId PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, GetPipeClientConfig()));
+                NTabletPipe::SendData(ctx, PipeClient, new TEvTablet::TEvGetCounters(), tabletId);
+                PipeClients.emplace_back(PipeClient);
+                Become(&TThis::StateRequestedGetCounters, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
             }
-            Tablets.emplace_back(tabletId);
-            TActorId PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, GetPipeClientConfig()));
-            NTabletPipe::SendData(ctx, PipeClient, new TEvTablet::TEvGetCounters(), tabletId);
-            PipeClients.emplace_back(PipeClient);
-            Become(&TThis::StateRequestedGetCounters, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
+
+            if (PipeClients.empty()) {
+                ReplyAndDie(ctx);
+            }
         }
     }
 

--- a/ydb/core/viewer/viewer_tabletcounters.h
+++ b/ydb/core/viewer/viewer_tabletcounters.h
@@ -53,6 +53,16 @@ public:
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);
         Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
         Aggregate = FromStringWithDefault<bool>(params.Get("aggregate"), true);
+        if (!params.Has("path") && !params.Has("tablet_id")) {
+            ctx.Send(
+                Event->Sender,
+                new NMon::TEvHttpInfoRes(
+                    Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Parameter 'path' or 'tablet_id' is required"),
+                    0,
+                    NMon::IEvHttpInfoRes::EContentType::Custom));
+            Die(ctx);
+            return;
+        }
         if (params.Has("path")) {
             THolder<TEvTxUserProxy::TEvNavigate> request(new TEvTxUserProxy::TEvNavigate());
             if (!Event->Get()->UserToken.empty()) {
@@ -64,19 +74,23 @@ public:
             TActorId txproxy = MakeTxProxyID();
             ctx.Send(txproxy, request.Release());
             Become(&TThis::StateRequestedDescribe, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
-        } else if (params.Has("tablet_id")) {
+        } else {
             TTabletId tabletId = FromStringWithDefault<TTabletId>(params.Get("tablet_id"), 0);
-            if (tabletId != 0) {
-                Tablets.emplace_back(tabletId);
-                TActorId PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, GetPipeClientConfig()));
-                NTabletPipe::SendData(ctx, PipeClient, new TEvTablet::TEvGetCounters(), tabletId);
-                PipeClients.emplace_back(PipeClient);
-                Become(&TThis::StateRequestedGetCounters, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
+            if (tabletId == 0) {
+                ctx.Send(
+                    Event->Sender,
+                    new NMon::TEvHttpInfoRes(
+                        Viewer->GetHTTPBADREQUEST(Event->Get(), "text/plain", "Invalid 'tablet_id' value"),
+                        0,
+                        NMon::IEvHttpInfoRes::EContentType::Custom));
+                Die(ctx);
+                return;
             }
-
-            if (PipeClients.empty()) {
-                ReplyAndDie(ctx);
-            }
+            Tablets.emplace_back(tabletId);
+            TActorId PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, tabletId, GetPipeClientConfig()));
+            NTabletPipe::SendData(ctx, PipeClient, new TEvTablet::TEvGetCounters(), tabletId);
+            PipeClients.emplace_back(PipeClient);
+            Become(&TThis::StateRequestedGetCounters, ctx, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
         }
     }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

GET /viewer/content without a usable path started TBrowse, which on empty path sent TEvHttpInfoRes 400 to the parent TJsonContent. The parent only handled TEvBrowseResponse and never forwarded that HTTP response to the client, so the request sat until the content handler’s timeout → 504 Gateway Timeout from the client’s perspective.

GET /viewer/tabletcounters with neither path nor tablet_id ran Bootstrap without Become() and without sending any HTTP response, which led to timeouts / flaky behavior depending on proxies and clients.