### PR TITLE
[Optimizer] Fix extra copying of TKqpStatsStore

### DIFF
--- a/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
@@ -280,7 +280,7 @@ void InferStatisticsForKqpTable(
 void InferStatisticsForSteamLookup(
     const TExprNode::TPtr& input,
     TTypeAnnotationContext* /*typeCtx*/,
-    const TKqpOptimizeContext kqpCtx,
+    const TKqpOptimizeContext& kqpCtx,
     TKqpStatsStore* kqpStats
 ) {
     auto inputNode = TExprBase(input);


### PR DESCRIPTION
Since statistics is computed many times over, accidental copying of `TKqpStatsStore` led to a significant pessimization of perfomance on some tests with many tables. In particular, it lead to `KqpJoinOrder::Chain65Nodes` flakiness.

Flame graph of what used to happen https://github.com/user-attachments/assets/cef651d9-c911-42d0-a2ac-80398f5a8561.