### PR TITLE
Add owner for `/ydb/library/security/util.h` – @ydb-platform/Security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,8 +117,9 @@
 /ydb/core/security @ydb-platform/Security
 /ydb/core/tx/schemeshard/ut_login* @ydb-platform/Security
 /ydb/core/tx/schemeshard/ut_login_large @ydb-platform/Security
-/ydb/library/login @ydb-platform/Security
 /ydb/library/aclib @ydb-platform/Security
+/ydb/library/login @ydb-platform/Security
+/ydb/library/security @ydb-platform/Security
 /ydb/services/ydb/ydb_ldap_login_ut.cpp @ydb-platform/Security
 /ydb/services/ydb/ydb_register_node_ut.cpp @ydb-platform/Security
 /ydb/core/sys_view/common/registry.h @ydb-platform/Security


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)
