### PR TITLE
[Backport stable-25-4] [CBO] Fix interesting orderings lookup: make it order-sensitive, i.e. shuffle [A, B] != [B, A]

### DIFF
--- a/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
@@ -208,7 +208,7 @@ void InferStatisticsForKqpTable(
         for (auto& column: shuffledBy) {
             column.RelName = alias;
         }
-        auto shuffling = TShuffling(shuffledBy).SetNatural();
+        auto shuffling = TShuffling(shuffledBy);
         std::int64_t orderingIdx = orderingsFSM->FDStorage.FindShuffling(shuffling, nullptr);
         stats->LogicalOrderings = orderingsFSM->CreateState(orderingIdx);
     }
@@ -1014,7 +1014,7 @@ private:
                     for (auto& column: shuffledBy) {
                         column.RelName = *stats->Aliases->begin();
                     }
-                    auto shuffling = TShuffling(shuffledBy).SetNatural();
+                    auto shuffling = TShuffling(shuffledBy);
                     TString idx = ToString(FDStorage.AddShuffling(shuffling, nullptr));
                     shufflingOrderingIdxes.push_back(std::move(idx));
                 }
@@ -1027,7 +1027,7 @@ private:
                 }
             } else {
                 if (stats->ShuffledByColumns) {
-                    auto shuffling = TShuffling(stats->ShuffledByColumns->Data).SetNatural();
+                    auto shuffling = TShuffling(stats->ShuffledByColumns->Data);
                     TString idx = ToString(FDStorage.AddShuffling(shuffling, nullptr));
                     shufflingOrderingIdxes.push_back(std::move(idx));
                 }

--- a/ydb/core/kqp/ut/join/data/join_order/reuse_shuffle_with_wrong_order_bug_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/reuse_shuffle_with_wrong_order_bug_column_store.json
@@ -1,0 +1,49 @@
+{
+  "op_name":"InnerJoin (Grace)",
+  "args":
+    [
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"LeftSemiJoin (Grace)",
+              "args":
+                [
+                  {
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"customer"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"oorder"
+                        }
+                      ]
+                  }
+                ]
+            }
+          ]
+      },
+      {
+        "op_name":"HashShuffle",
+        "args":
+          [
+            {
+              "op_name":"TableFullScan",
+              "table":"new_order"
+            }
+          ]
+      }
+    ]
+}
+

--- a/ydb/core/kqp/ut/join/data/join_order/tpcds78_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpcds78_1000s_column_store.json
@@ -39,8 +39,14 @@
                                   ]
                               },
                               {
-                                "op_name":"TableFullScan",
-                                "table":"store_returns"
+                                "op_name":"HashShuffle",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"store_returns"
+                                    }
+                                  ]
                               }
                             ]
                         }
@@ -65,8 +71,14 @@
                                 "args":
                                   [
                                     {
-                                      "op_name":"TableFullScan",
-                                      "table":"web_sales"
+                                      "op_name":"HashShuffle",
+                                      "args":
+                                        [
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"web_sales"
+                                          }
+                                        ]
                                     },
                                     {
                                       "op_name":"HashShuffle",
@@ -109,8 +121,14 @@
                           "args":
                             [
                               {
-                                "op_name":"TableFullScan",
-                                "table":"catalog_sales"
+                                "op_name":"HashShuffle",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"catalog_sales"
+                                    }
+                                  ]
                               },
                               {
                                 "op_name":"HashShuffle",

--- a/ydb/core/kqp/ut/join/data/queries/reuse_shuffle_with_wrong_order_bug.sql
+++ b/ydb/core/kqp/ut/join/data/queries/reuse_shuffle_with_wrong_order_bug.sql
@@ -1,0 +1,15 @@
+PRAGMA TablePathPrefix = "/Root/test/tpcc/";
+
+$semi_join = (
+    SELECT *
+    FROM customer c
+    LEFT SEMI JOIN oorder o
+      ON c.C_W_ID = o.O_W_ID
+     AND c.C_D_ID = o.O_D_ID
+);
+
+SELECT s.C_W_ID, s.C_D_ID, n.NO_O_ID
+FROM $semi_join s
+INNER JOIN new_order as n
+  ON s.C_W_ID = n.NO_W_ID
+ AND s.C_D_ID = n.NO_D_ID;

--- a/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
@@ -1280,6 +1280,14 @@ Y_UNIT_TEST_SUITE(KqpJoinOrder) {
         );
     }
 
+    Y_UNIT_TEST(CanonizedJoinOrderReuseShuffleWithWrongOrderBug) {
+        CanonizedJoinOrderTest(
+            "queries/reuse_shuffle_with_wrong_order_bug.sql",
+            "stats/tpcc.json",
+            "join_order/reuse_shuffle_with_wrong_order_bug.json", false, true
+        );
+    }
+
 }
 }
 }

--- a/yql/essentials/core/cbo/cbo_interesting_orderings.cpp
+++ b/yql/essentials/core/cbo/cbo_interesting_orderings.cpp
@@ -379,17 +379,15 @@ void TFDStorage::ApplyNaturalOrderings() {
 
 std::size_t TFDStorage::FindSorting(
     const TSorting& sorting,
-    TTableAliasMap* tableAliases
-) {
-    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(sorting.Ordering, sorting.Directions, TOrdering::ESorting, false, true, tableAliases);
+    TTableAliasMap* tableAliases) {
+    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(sorting.Ordering, sorting.Directions, TOrdering::ESorting, false, /*isNatural=*/true, tableAliases);
     return orderingIdx;
 }
 
 std::size_t TFDStorage::FindShuffling(
     const TShuffling& shuffling,
-    TTableAliasMap* tableAliases
-) {
-    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(shuffling.Ordering, {}, TOrdering::EShuffle, false, shuffling.IsNatural, tableAliases);
+    TTableAliasMap* tableAliases) {
+    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(shuffling.Ordering, {}, TOrdering::EShuffle, false, /*isNatural=*/true, tableAliases);
     return orderingIdx;
 }
 
@@ -402,9 +400,8 @@ std::size_t TFDStorage::AddSorting(
 
 std::size_t TFDStorage::AddShuffling(
     const TShuffling& shuffling,
-    TTableAliasMap* tableAliases
-) {
-    return AddInterestingOrdering(shuffling.Ordering, TOrdering::EShuffle, std::vector<TOrdering::TItem::EDirection>{}, shuffling.IsNatural, tableAliases);
+    TTableAliasMap* tableAliases) {
+    return AddInterestingOrdering(shuffling.Ordering, TOrdering::EShuffle, std::vector<TOrdering::TItem::EDirection>{}, /*isNatural=*/true, tableAliases);
 }
 
 std::size_t TFDStorage::AddInterestingOrdering(

--- a/yql/essentials/core/cbo/cbo_interesting_orderings.cpp
+++ b/yql/essentials/core/cbo/cbo_interesting_orderings.cpp
@@ -313,9 +313,8 @@ std::size_t TFDStorage::AddEquivalence(
 i64 TFDStorage::FindInterestingOrderingIdx(
     const std::vector<TJoinColumn>& interestingOrdering,
     TOrdering::EType type,
-    TTableAliasMap* tableAliases
-) {
-    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(interestingOrdering, {}, type, false, false, tableAliases);
+    TTableAliasMap* tableAliases) {
+    const auto& [_, orderingIdx] = ConvertColumnsAndFindExistingOrdering(interestingOrdering, {}, type, /*createIfNotExists=*/false, /*isNatural=*/true, tableAliases);
     return orderingIdx;
 }
 
@@ -397,9 +396,8 @@ std::size_t TFDStorage::FindShuffling(
 
 std::size_t TFDStorage::AddSorting(
     const TSorting& sorting,
-    TTableAliasMap* tableAliases
-) {
-    return AddInterestingOrdering(sorting.Ordering, TOrdering::ESorting, sorting.Directions, true, tableAliases);
+    TTableAliasMap* tableAliases) {
+    return AddInterestingOrdering(sorting.Ordering, TOrdering::ESorting, sorting.Directions, /*isNatural=*/true, tableAliases);
 }
 
 std::size_t TFDStorage::AddShuffling(
@@ -442,7 +440,17 @@ std::size_t TFDStorage::AddInterestingOrdering(
         return std::numeric_limits<std::size_t>::max();
     }
 
-    auto [items, foundIdx] = ConvertColumnsAndFindExistingOrdering(interestingOrdering, {}, type, true, false, tableAliases);
+    // At the time of writing this, only shuffles and sortings are supported,
+    // both of them are order sensitive, i.e. shuffle (A, B) != (B, A),
+    // the same is also true for sortings (A, B) != (B, A).
+
+    // It's not true, though, for groupings, where (A, B) does equal (B, A).
+    // If groupings are ever added to this enum, we will have to set
+    // isNatural=false for them (as opposed to isNatural=true for sortings and shuffles)
+    // to NOT account for relative order of columns inside the grouping.
+    Y_ENSURE(type == TOrdering::EType::EShuffle || type == TOrdering::EType::ESorting);
+
+    auto [items, foundIdx] = ConvertColumnsAndFindExistingOrdering(interestingOrdering, {}, type, /*createIfNotExists=*/true, /*isNatural=*/true, tableAliases);
 
     if (foundIdx >= 0) {
         return static_cast<std::size_t>(foundIdx);

--- a/yql/essentials/core/cbo/cbo_interesting_orderings.h
+++ b/yql/essentials/core/cbo/cbo_interesting_orderings.h
@@ -181,10 +181,7 @@ struct TShuffling {
         : Ordering(std::move(ordering))
     {}
 
-    TShuffling& SetNatural() { IsNatural = true; return *this; }
-
     std::vector<TJoinColumn> Ordering;
-    bool IsNatural = false; // look at the IsNatural field at the Ordering struct
 };
 
 /*


### PR DESCRIPTION
Backport #35609 to stable-25-4