### PR TITLE
[q-stable-2025-05-15 only] generic lookup: workaround broken NYql::NArrow::ExtractUnboxedValue

### DIFF
--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -106,6 +106,7 @@ namespace NYql::NDq {
             , SelectResultType(MergeStructTypes(typeEnv, keyType, payloadType))
             , HolderFactory(holderFactory)
             , ColumnDestinations(CreateColumnDestination())
+            , ArrowTypes(CreateArrowTypes(typeEnv))
             , MaxKeysInRequest(std::min(maxKeysInRequest, size_t{100}))
             , IsMultiMatches(isMultiMatches)
             , RetryPolicy(
@@ -445,7 +446,7 @@ namespace NYql::NDq {
             std::vector<NKikimr::NMiniKQL::TUnboxedValueVector> columns(ColumnDestinations.size());
             for (size_t i = 0; i != columns.size(); ++i) {
                 Y_ABORT_UNLESS(value->column_name(i) == (ColumnDestinations[i].first == EColumnDestination::Key ? KeyType : PayloadType)->GetMemberName(ColumnDestinations[i].second));
-                columns[i] = NArrow::ExtractUnboxedValues(value->column(i), SelectResultType->GetMemberType(i), HolderFactory);
+                columns[i] = NArrow::ExtractUnboxedValues(value->column(i), ArrowTypes[i], HolderFactory);
             }
 
             auto height = columns[0].size();
@@ -532,6 +533,31 @@ namespace NYql::NDq {
             Key,
             Output
         };
+
+        std::vector<NKikimr::NMiniKQL::TType *> CreateArrowTypes(const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv) {
+            const auto count = SelectResultType->GetMembersCount();
+            std::vector<NKikimr::NMiniKQL::TType *> result(count);
+            auto ui8_type = NKikimr::NMiniKQL::TDataType::Create(NUdf::TDataType<ui8>::Id, typeEnv);
+            auto optional_ui8_type = NKikimr::NMiniKQL::TOptionalType::Create(ui8_type, typeEnv);
+            for (ui32 i = 0; i < count; ++i) {
+                auto type = SelectResultType->GetMemberType(i);
+                auto innerType = type;
+                if (type->IsOptional()) {
+                    innerType = static_cast<NKikimr::NMiniKQL::TOptionalType *>(type)->GetItemType();
+                }
+                if (innerType->IsData()) {
+                    if (static_cast<NKikimr::NMiniKQL::TDataType *>(innerType)->GetDataSlot() == NKikimr::NUdf::EDataSlot::Bool) {
+                        if (type != innerType) {
+                            type = optional_ui8_type;
+                        } else {
+                            type = ui8_type;
+                        }
+                    }
+                }
+                result[i] = type;
+            }
+            return result;
+        }
 
         std::vector<std::pair<EColumnDestination, size_t>> CreateColumnDestination() {
             THashMap<TStringBuf, size_t> keyColumns;
@@ -625,6 +651,7 @@ namespace NYql::NDq {
         const NKikimr::NMiniKQL::TStructType* const SelectResultType; // columns from KeyType + PayloadType
         const NKikimr::NMiniKQL::THolderFactory& HolderFactory;
         const std::vector<std::pair<EColumnDestination, size_t>> ColumnDestinations;
+        const std::vector<NKikimr::NMiniKQL::TType *> ArrowTypes;
         const size_t MaxKeysInRequest;
         const bool IsMultiMatches;
         ui32 LocalInFlight = 0;

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -866,6 +866,139 @@ TESTCASES = [
         "MaxDelayedRows",
         "100",
     ),
+    # 16
+    (
+        R'''
+            $input = SELECT * FROM myyds.`{input_topic}`
+                    WITH (
+                        FORMAT=json_each_row,
+                        SCHEMA (
+                            za Int32,
+                            zd Int32
+                        )
+                    )            ;
+
+            $enriched = select a, b, c, d, f, za, zd,
+                               is_odd, is_true, is_false,
+                               opt_odd, opt_true, opt_false, opt_null,
+                               CAST(ts AS String) AS tss, CAST(tsd AS String) AS tsds
+                               /*, CAST(dur AS String) AS durs -- NOT supported by fq_connector */
+                from
+                    $input as e
+                left join {streamlookup} any ydb_conn_{table_name}.db as u
+                on(e.za = u.a )
+            ;
+
+            insert into myyds.`{output_topic}`
+            select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
+            ''',
+        ResequenceId(
+            [
+                (
+                    '{"id":1,"za":1,"zd":101}',
+                    '''{
+                        "a":1,"b":"2","c":3,"d":4,"f":6,"za":1,"zd":101,
+                        "is_true":true,"is_false":false,"is_odd":true,
+                        "opt_true":true,"opt_false":false,"opt_odd":true,"opt_null":null,
+                        "tsds":"1970-01-05","tss":"1970-01-03T10:11:12Z"
+                    }''',
+                ),
+                (
+                    '{"id":2,"za":7,"zd":107}',
+                    '''{
+                        "a":7,"b":"8","c":9,"d":10,"f":12,"za":7,"zd":107,
+                        "is_true":true,"is_false":false,"is_odd":true,
+                        "opt_true":true,"opt_false":false,"opt_odd":true,"opt_null":null,
+                        "tsds":"1970-01-06","tss":"1970-01-03T10:11:13Z"
+                    }''',
+                ),
+                (
+                    '{"id":3,"za":33,"zd":133}',
+                    '''{
+                        "a":null,"b":null,"c":null,"d":null,"f":null,"za":33,"zd":133,
+                        "is_true":null,"is_false":null,"is_odd":null,
+                        "opt_true":null,"opt_false":null,"opt_odd":null,"opt_null":null,
+                        "tsds":null,"tss":null
+                    }''',
+                ),
+                (
+                    '{"id":2,"za":2,"zd":102}',
+                    '''{
+                        "a":2,"b":"3","c":6,"d":null,"f":9,"za":2,"zd":102,
+                        "is_true":true,"is_false":false,"is_odd":false,
+                        "opt_true":true,"opt_false":false,"opt_odd":false,"opt_null":null,
+                        "tsds":"1970-01-07","tss":"1970-01-03T10:11:14Z"
+                    }''',
+                ),
+                (
+                    '{"id":4,"za":4,"zd":104}',
+                    '''{
+                        "a":4,"b":"5","c":4,"d":15,"f":null,"za":4,"zd":104,
+                        "is_true":true,"is_false":false,"is_odd":false,
+                        "opt_true":true,"opt_false":false,"opt_odd":false,"opt_null":null,
+                        "tsds":"1970-01-08","tss":"1970-01-03T10:11:15Z"
+                    }''',
+                ),
+            ]
+            * 1000
+        ),
+        "TTL",
+        "1",
+    ),
+    # 17
+    (
+        R'''
+            $input = SELECT * FROM myyds.`{input_topic}`
+                    WITH (
+                        FORMAT=json_each_row,
+                        SCHEMA (
+                            za Int32,
+                            zd Int32
+                        )
+                    )            ;
+
+            $enriched = select a, b, c, d, f, za, zd,
+                               is_odd, is_true, is_false,
+                               opt_odd, opt_true, opt_false, opt_null
+                from
+                    $input as e
+                left join {streamlookup} any ydb_conn_{table_name}.db as u
+                on(e.za = u.a )
+            ;
+
+            insert into myyds.`{output_topic}`
+            select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
+            ''',
+        ResequenceId(
+            [
+                (
+                    '{"id":1,"za":1,"zd":101}',
+                    '{"a":1,"b":"2","c":3,"d":4,"f":6,"za":1,"zd":101,"is_true":true,"is_false":false,"is_odd":true,"opt_true":true,"opt_false":false,"opt_odd":true,"opt_null":null}',
+                ),
+                (
+                    '{"id":2,"za":7,"zd":107}',
+                    '{"a":7,"b":"8","c":9,"d":10,"f":12,"za":7,"zd":107,"is_true":true,"is_false":false,"is_odd":true,"opt_true":true,"opt_false":false,"opt_odd":true,"opt_null":null}',
+                ),
+                (
+                    '{"id":3,"za":33,"zd":133}',
+                    '{"a":null,"b":null,"c":null,"d":null,"f":null,"za":33,"zd":133,"is_true":null,"is_false":null,"is_odd":null,"opt_true":null,"opt_false":null,"opt_odd":null,"opt_null":null}',
+                ),
+                (
+                    '{"id":2,"za":2,"zd":102}',
+                    '{"a":2,"b":"3","c":6,"d":null,"f":9,"za":2,"zd":102,"is_true":true,"is_false":false,"is_odd":false,"opt_true":true,"opt_false":false,"opt_odd":false,"opt_null":null}',
+                ),
+                (
+                    '{"id":4,"za":4,"zd":104}',
+                    '{"a":4,"b":"5","c":4,"d":15,"f":null,"za":4,"zd":104,"is_true":true,"is_false":false,"is_odd":false,"opt_true":true,"opt_false":false,"opt_odd":false,"opt_null":null}',
+                ),
+            ]
+            * 1000
+        ),
+        "TTL",
+        "1",
+        "MaxCachedRows",
+        "4",
+    ),
 ]
 
 

--- a/ydb/tests/fq/generic/streaming/ydb/01_basic.sh
+++ b/ydb/tests/fq/generic/streaming/ydb/01_basic.sh
@@ -35,12 +35,15 @@ set -ex
       (56, 12, "2a02:1812:1713:4f00:517e:1d79:c88b:704", "Elena", 2),
       (18, 17, "ivalid ip", "newUser", 12);
     COMMIT;
-    CREATE TABLE db (b STRING NOT NULL, c Int32, a Int32 NOT NULL, d Int32, f Int32, e Int32, g Int32, h Int32, PRIMARY KEY(b, a));
+    CREATE TABLE db (b STRING NOT NULL, c Uint32, a Int32 NOT NULL, d Int8, f Int32, e Int64, g Int32, h Int32, is_odd Bool NOT NULL, is_true Bool NOT NULL, is_false Bool NOT NULL, opt_odd Bool, opt_true Bool, opt_false Bool, opt_null Bool, ts Timestamp, dur Interval, tsd Date, PRIMARY KEY(b, a));
     COMMIT;
-    INSERT INTO db (a, b, c, d, e, f) VALUES
-      (1, "2", 3, 4, 5, 6),
-      (7, "8", 9, 10, 11, 12);
+    INSERT INTO db (a, b, c, d, e, f, is_odd, is_true, is_false, opt_odd, opt_true, opt_false, opt_null, ts, dur, tsd) VALUES
+      (1, "2", 3, 4, 5, 6, true, true, false, true, true, false, NULL, Timestamp("1970-01-03T10:11:12Z"), Interval("PT13S"), Date("1970-01-05")),
+      (7, "8", 9, 10, 11, 12, true, true, false, true, true, false, NULL, Timestamp("1970-01-03T10:11:13Z"), Interval("PT14S"), Date("1970-01-06")),
+      (2, "3", 6, NULL, 8, 9, false, true, false, false, true, false, NULL, Timestamp("1970-01-03T10:11:14Z"), Interval("PT15S"), Date("1970-01-07")),
+      (4, "5", 4, 15, 17, NULL, false, true, false, false, true, false, NULL, Timestamp("1970-01-03T10:11:15Z"), Interval("PT16S"), Date("1970-01-08"));
     COMMIT;
+    SELECT * FROM db;
   '
 
 retVal=$?


### PR DESCRIPTION
…

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Internal Yql representation for BOOL is Uint8 array, not native arrow type (packed bitmap).
This commit is not needed for main/stable-25-4/stable-26-1 (already fixed differently; unfortunately, upstream change is too invasive and cannot be cleanly cherry-picked on this branch)