### PR TITLE
streamlookup join: prevent assert on zero-size lru cache

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -73,7 +73,8 @@ public:
         , OutputRowColumnOrder(std::move(outputRowColumnOrder))
         , WatermarksTracker(watermarksTracker)
         , InputFlowFetchStatus(NUdf::EFetchStatus::Yield)
-        , LruCache(std::make_unique<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl>(Settings.GetCacheLimit(), lookupKeyType))
+        , LruCache(std::make_unique<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl>(std::max(Settings.GetCacheLimit(), ui64(1)), lookupKeyType))
+        , DisableLruCache(Settings.GetCacheLimit() < 1)
         , MaxDelayedRows(Settings.GetMaxDelayedRows())
         , CacheTtl(std::chrono::seconds(Settings.GetCacheTtlSeconds()))
         , IsMultiMatches(Settings.GetIsMultiMatches())
@@ -280,6 +281,7 @@ protected:
     TDqComputeActorWatermarks* WatermarksTracker;
     NUdf::EFetchStatus InputFlowFetchStatus;
     std::unique_ptr<NKikimr::NMiniKQL::TUnboxedKeyValueLruCacheWithTtl> LruCache;
+    const bool DisableLruCache;
     size_t MaxDelayedRows;
     std::chrono::seconds CacheTtl;
     static constexpr auto MinFullscanFailureTtl = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::hours(1)); // TODO make tuneable
@@ -399,9 +401,11 @@ private:
 #if 0 // TODO
             // Opportunistially populate LRU cache with partial fullscan results
             // (again, in case of MultiMatches, we cannot use partial results)
-            for (auto& [k, v]: *lookupResult) {
-                Y_DEBUG_ABORT_UNLESS(v);
-                LruCache->Update<true>(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
+            if (!DisableLruCache) {
+                for (auto& [k, v]: *lookupResult) {
+                    Y_DEBUG_ABORT_UNLESS(v);
+                    LruCache->Update<true>(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
+                }
             }
 #endif
         }
@@ -422,7 +426,7 @@ private:
         } else {
             Y_ABORT_UNLESS(lookupResult == KeysForLookup);
             lookupResult.reset();
-            if (!FullscanReady) { // don't populate LRU cache when we have (complete) fullscan results
+            if (!FullscanReady && !DisableLruCache) { // don't populate LRU cache when we have (complete) fullscan results
                 for (auto& [k, v]: *KeysForLookup) {
                     LruCache->Update(NUdf::TUnboxedValue(k), std::move(v), now + CacheTtl);
                 }
@@ -651,8 +655,10 @@ private: //events
         } else {
             PushReadyWatermark();
         }
-        for (auto&& [k, v]: *lookupResult) {
-            LruCache->Update(NUdf::TUnboxedValue(const_cast<NUdf::TUnboxedValue&&>(k)), std::move(v), now + CacheTtl);
+        if (!DisableLruCache) {
+            for (auto&& [k, v]: *lookupResult) {
+                LruCache->Update(NUdf::TUnboxedValue(const_cast<NUdf::TUnboxedValue&&>(k)), std::move(v), now + CacheTtl);
+            }
         }
         KeysForLookup->clear();
         auto deltaLruSize = (i64)LruCache->Size() - LastLruSize;

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -741,6 +741,8 @@ TESTCASES = [
         ),
         "MultiGet",
         "true",
+        "MaxCachedRows",
+        "0",
     ),
     # 14
     (


### PR DESCRIPTION
TUnboxedKeyValueLruCacheWithTtl depends on size being non-zero

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-5206
