### PR TITLE
generic lookup: don't ABORT on external errors (arrow parsing/etc)

### DIFF
--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -228,7 +228,7 @@ namespace NYql::NDq {
 
         void Handle(TEvListSplitsPart::TPtr ev) {
             auto response = std::move(ev->Get()->Response);
-            Y_ENSURE(response.splits_size() == 1);
+            Y_ENSURE(response.splits_size() == 1, response.splits_size() << " == " << 1);
             auto& split = response.splits(0);
             NConnector::NApi::TReadSplitsRequest readRequest;
 
@@ -449,10 +449,11 @@ namespace NYql::NDq {
                 return;
             }
             NKikimr::NArrow::NSerialization::TSerializerContainer deser = NKikimr::NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer(); // todo move to class' member
+            Y_ENSURE(!resp.arrow_ipc_streaming().empty());
             const auto& data = deser->Deserialize(resp.arrow_ipc_streaming());
-            Y_ENSURE(data.ok());
+            Y_ENSURE(data.ok(), data.status().ToString());
             const auto& value = data.ValueOrDie();
-            Y_ENSURE(static_cast<ui32>(value->num_columns()) == ColumnDestinations.size());
+            Y_ENSURE(static_cast<ui32>(value->num_columns()) == ColumnDestinations.size(), value->num_columns() << " == " << ColumnDestinations.size());
             std::vector<NKikimr::NMiniKQL::TUnboxedValueVector> columns(ColumnDestinations.size());
             for (size_t i = 0; i != columns.size(); ++i) {
                 Y_ENSURE(value->column_name(i) == (ColumnDestinations[i].first == EColumnDestination::Key ? KeyType : PayloadType)->GetMemberName(ColumnDestinations[i].second));

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -228,7 +228,7 @@ namespace NYql::NDq {
 
         void Handle(TEvListSplitsPart::TPtr ev) {
             auto response = std::move(ev->Get()->Response);
-            Y_ABORT_UNLESS(response.splits_size() == 1);
+            Y_ENSURE(response.splits_size() == 1);
             auto& split = response.splits(0);
             NConnector::NApi::TReadSplitsRequest readRequest;
 
@@ -434,7 +434,7 @@ namespace NYql::NDq {
 
         void ProcessReceivedData(const NConnector::NApi::TReadSplitsResponse& resp, TLookupState::TPtr state) {
             auto startCycleCount = GetCycleCountFast();
-            Y_ABORT_UNLESS(resp.payload_case() == NConnector::NApi::TReadSplitsResponse::PayloadCase::kArrowIpcStreaming);
+            Y_ENSURE(resp.payload_case() == NConnector::NApi::TReadSplitsResponse::PayloadCase::kArrowIpcStreaming);
             if (ResultChunks) {
                 ResultChunks->Inc();
                 if (resp.has_stats()) {
@@ -450,12 +450,12 @@ namespace NYql::NDq {
             }
             NKikimr::NArrow::NSerialization::TSerializerContainer deser = NKikimr::NArrow::NSerialization::TSerializerContainer::GetDefaultSerializer(); // todo move to class' member
             const auto& data = deser->Deserialize(resp.arrow_ipc_streaming());
-            Y_ABORT_UNLESS(data.ok());
+            Y_ENSURE(data.ok());
             const auto& value = data.ValueOrDie();
-            Y_ABORT_UNLESS(static_cast<ui32>(value->num_columns()) == ColumnDestinations.size());
+            Y_ENSURE(static_cast<ui32>(value->num_columns()) == ColumnDestinations.size());
             std::vector<NKikimr::NMiniKQL::TUnboxedValueVector> columns(ColumnDestinations.size());
             for (size_t i = 0; i != columns.size(); ++i) {
-                Y_ABORT_UNLESS(value->column_name(i) == (ColumnDestinations[i].first == EColumnDestination::Key ? KeyType : PayloadType)->GetMemberName(ColumnDestinations[i].second));
+                Y_ENSURE(value->column_name(i) == (ColumnDestinations[i].first == EColumnDestination::Key ? KeyType : PayloadType)->GetMemberName(ColumnDestinations[i].second));
                 columns[i] = NArrow::ExtractUnboxedValues(value->column(i), SelectResultType->GetMemberType(i), HolderFactory);
             }
 


### PR DESCRIPTION
Still keep internal contract violations and debug-only aborts

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

If connector sent broken respose, it is not a valid reason to ABORT
YQ-5208