### PR TITLE
Fix flaky TLI tests: propagate VictimQuerySpanId for STATUS_LOCKS_BROKEN without TxLocks

### DIFF
--- a/ydb/core/kqp/common/kqp_locks_tli_helpers.h
+++ b/ydb/core/kqp/common/kqp_locks_tli_helpers.h
@@ -2,24 +2,31 @@
 
 #include <ydb/core/kqp/common/kqp_tx_manager.h>
 #include <ydb/core/protos/data_events.pb.h>
+#include <ydb/core/protos/query_stats.pb.h>
 
 namespace NKikimr {
 namespace NKqp {
 
-// Helper: look up VictimQuerySpanId from broken locks stored in TxManager and set it.
-// Used when STATUS_LOCKS_BROKEN is received and we need to find
-// the victim's QuerySpanId from TxManager's stored lock entries.
+// Helper: resolve VictimQuerySpanId from broken locks and set it on TxManager.
 template <typename TLockCollection>
 inline void SetVictimQuerySpanIdFromBrokenLocks(
     ui64 shardId,
     const TLockCollection& locks,
-    const IKqpTransactionManagerPtr& txManager)
+    const IKqpTransactionManagerPtr& txManager,
+    const NKikimrDataEvents::TEvWriteResult* writeResult = nullptr)
 {
+    // Try to look up from TxManager's stored lock entries via the provided locks.
     for (const auto& lock : locks) {
         if (auto victimSpanId = txManager->LookupVictimQuerySpanId(shardId, lock)) {
             txManager->SetVictimQuerySpanId(*victimSpanId);
             return;
         }
+    }
+    // Fallback to DeferredVictimQuerySpanId from TxStats, set by the shard when TxLocks
+    // are not populated (e.g. EnsureCurrentLock or serialization conflict paths).
+    if (writeResult && writeResult->HasTxStats()
+            && writeResult->GetTxStats().HasDeferredVictimQuerySpanId()) {
+        txManager->SetVictimQuerySpanId(writeResult->GetTxStats().GetDeferredVictimQuerySpanId());
     }
 }
 

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1014,7 +1014,7 @@ public:
             TxManager->BreakLock(brokenShardId);
             YQL_ENSURE(TxManager->BrokenLocks());
 
-            SetVictimQuerySpanIdFromBrokenLocks(brokenShardId, ev->Get()->Record.GetTxLocks(), TxManager);
+            SetVictimQuerySpanIdFromBrokenLocks(brokenShardId, ev->Get()->Record.GetTxLocks(), TxManager, &ev->Get()->Record);
             if (TableWriteActorSpan) {
                 TableWriteActorSpan.EndError("LOCKS_BROKEN");
             }
@@ -4590,7 +4590,7 @@ public:
             CollectTliStats(ev->Get()->Record);
             TxManager->BreakLock(ev->Get()->Record.GetOrigin());
             YQL_ENSURE(TxManager->BrokenLocks());
-            SetVictimQuerySpanIdFromBrokenLocks(ev->Get()->Record.GetOrigin(), ev->Get()->Record.GetTxLocks(), TxManager);
+            SetVictimQuerySpanIdFromBrokenLocks(ev->Get()->Record.GetOrigin(), ev->Get()->Record.GetTxLocks(), TxManager, &ev->Get()->Record);
             if (TryDeferLocksBrokenError(ev->Get()->Record.GetOrigin(), MakeLockIssues(TxManager, getIssues()))) {
                 return;
             }

--- a/ydb/core/protos/query_stats.proto
+++ b/ydb/core/protos/query_stats.proto
@@ -49,6 +49,7 @@ message TTxStats {
     repeated uint64 BreakerQuerySpanIds = 9; // QuerySpanIds of queries that wrote to this shard and broke other locks
     repeated uint64 DeferredBreakerQuerySpanIds = 10; // QuerySpanIds of breakers found via deferred lock validation at commit
     repeated uint32 DeferredBreakerNodeIds = 11; // Node IDs matching DeferredBreakerQuerySpanIds
+    optional uint64 DeferredVictimQuerySpanId = 12; // Victim's QuerySpanId set by the shard for STATUS_LOCKS_BROKEN paths that don't populate TxLocks
 
     // TODO:
     // optional uint64 CommitLatencyUsec = 3;

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -41,7 +41,7 @@ public:
         return !op->HasRuntimeConflicts();
     }
 
-    void FillDeferredBreakerInfo(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
+    void FillDeferredFields(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
         if (auto victimSpanId = DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId)) {
             txStats->SetDeferredVictimQuerySpanId(*victimSpanId);
         }
@@ -254,7 +254,7 @@ public:
                                               lockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing(),
                                               querySpanId ? TMaybe<ui64>(querySpanId) : Nothing());
             if (lockTxId) {
-                FillDeferredBreakerInfo(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
+                FillDeferredFields(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
             }
         } else {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
@@ -480,7 +480,7 @@ public:
                     NDataIntegrity::LogVictimDetected(ctx, tabletId, "Write transaction was a victim of broken locks",
                                                       DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId),
                                                       guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
-                    FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                    FillDeferredFields(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
                     return EExecutionStatus::Executed;
                 };
 
@@ -543,7 +543,7 @@ public:
                 {
                     auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
                     for (const auto& brokenLock : brokenLocks) {
-                        FillDeferredBreakerInfo(brokenLock.GetLockId(), txStats);
+                        FillDeferredFields(brokenLock.GetLockId(), txStats);
                     }
                 }
 
@@ -743,7 +743,7 @@ public:
                                               guardLocks.LockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId) : Nothing(),
                                               guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
             if (guardLocks.LockTxId) {
-                FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                FillDeferredFields(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
             }
 
             ResetChanges(userDb, txc);

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -52,6 +52,15 @@ public:
         }
     }
 
+    void FillDeferredVictimQuerySpanId(ui64 lockTxId, ui64 querySpanId, NKikimrQueryStats::TTxStats* txStats) {
+        auto victimSpanId = lockTxId
+            ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing();
+        ui64 value = victimSpanId ? *victimSpanId : querySpanId;
+        if (value) {
+            txStats->SetDeferredVictimQuerySpanId(value);
+        }
+    }
+
     // Filter out self-breaks from locksBrokenByTx, log breaker TLI events, and update TxStats.
     // Returns the count of locks broken by OTHER transactions (excluding self-breaks).
     size_t HandleBreakerLocks(
@@ -250,9 +259,11 @@ public:
             NDataIntegrity::LogVictimDetected(ctx, DataShard.TabletID(), "Write transaction was a victim of broken locks",
                                               lockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing(),
                                               querySpanId ? TMaybe<ui64>(querySpanId) : Nothing());
+            auto* txStats = writeOp.GetWriteResult()->Record.MutableTxStats();
             if (lockTxId) {
-                FillDeferredBreakerInfo(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
+                FillDeferredBreakerInfo(lockTxId, txStats);
             }
+            FillDeferredVictimQuerySpanId(lockTxId, querySpanId, txStats);
         } else {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
             writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Conflict with existing key.");
@@ -473,11 +484,13 @@ public:
                 auto abortLock = [&]() {
                     LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because it cannot acquire locks");
                     writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because it cannot acquire locks");
-                    writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
+                    auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
+                    txStats->SetLocksBrokenAsVictim(1);
                     NDataIntegrity::LogVictimDetected(ctx, tabletId, "Write transaction was a victim of broken locks",
                                                       DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId),
                                                       guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
-                    FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                    FillDeferredBreakerInfo(guardLocks.LockTxId, txStats);
+                    FillDeferredVictimQuerySpanId(guardLocks.LockTxId, guardLocks.QuerySpanId, txStats);
                     return EExecutionStatus::Executed;
                 };
 
@@ -735,13 +748,15 @@ public:
 
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with another transaction.");
             writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Write conflict with concurrent transaction.");
-            writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
+            auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
+            txStats->SetLocksBrokenAsVictim(1);
             NDataIntegrity::LogVictimDetected(ctx, DataShard.TabletID(), "Write transaction was a victim of broken locks",
                                               guardLocks.LockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId) : Nothing(),
                                               guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
             if (guardLocks.LockTxId) {
-                FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                FillDeferredBreakerInfo(guardLocks.LockTxId, txStats);
             }
+            FillDeferredVictimQuerySpanId(guardLocks.LockTxId, guardLocks.QuerySpanId, txStats);
 
             ResetChanges(userDb, txc);
 

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -42,6 +42,9 @@ public:
     }
 
     void FillDeferredBreakerInfo(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
+        if (auto victimSpanId = DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId)) {
+            txStats->SetDeferredVictimQuerySpanId(*victimSpanId);
+        }
         auto lockInfo = DataShard.SysLocksTable().GetRawLock(lockTxId);
         if (!lockInfo || !lockInfo->GetBreakVersion()) {
             return;
@@ -49,15 +52,6 @@ public:
         if (lockInfo->GetBreakerQuerySpanId() && !lockInfo->IsBreakerConsumed()) {
             txStats->AddDeferredBreakerQuerySpanIds(lockInfo->GetBreakerQuerySpanId());
             txStats->AddDeferredBreakerNodeIds(lockInfo->GetBreakerNodeId());
-        }
-    }
-
-    void FillDeferredVictimQuerySpanId(ui64 lockTxId, ui64 querySpanId, NKikimrQueryStats::TTxStats* txStats) {
-        auto victimSpanId = lockTxId
-            ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing();
-        ui64 value = victimSpanId ? *victimSpanId : querySpanId;
-        if (value) {
-            txStats->SetDeferredVictimQuerySpanId(value);
         }
     }
 
@@ -259,11 +253,9 @@ public:
             NDataIntegrity::LogVictimDetected(ctx, DataShard.TabletID(), "Write transaction was a victim of broken locks",
                                               lockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing(),
                                               querySpanId ? TMaybe<ui64>(querySpanId) : Nothing());
-            auto* txStats = writeOp.GetWriteResult()->Record.MutableTxStats();
             if (lockTxId) {
-                FillDeferredBreakerInfo(lockTxId, txStats);
+                FillDeferredBreakerInfo(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
             }
-            FillDeferredVictimQuerySpanId(lockTxId, querySpanId, txStats);
         } else {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
             writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Conflict with existing key.");
@@ -484,13 +476,11 @@ public:
                 auto abortLock = [&]() {
                     LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because it cannot acquire locks");
                     writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because it cannot acquire locks");
-                    auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
-                    txStats->SetLocksBrokenAsVictim(1);
+                    writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
                     NDataIntegrity::LogVictimDetected(ctx, tabletId, "Write transaction was a victim of broken locks",
                                                       DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId),
                                                       guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
-                    FillDeferredBreakerInfo(guardLocks.LockTxId, txStats);
-                    FillDeferredVictimQuerySpanId(guardLocks.LockTxId, guardLocks.QuerySpanId, txStats);
+                    FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
                     return EExecutionStatus::Executed;
                 };
 
@@ -748,15 +738,13 @@ public:
 
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with another transaction.");
             writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Write conflict with concurrent transaction.");
-            auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
-            txStats->SetLocksBrokenAsVictim(1);
+            writeOp->GetWriteResult()->Record.MutableTxStats()->SetLocksBrokenAsVictim(1);
             NDataIntegrity::LogVictimDetected(ctx, DataShard.TabletID(), "Write transaction was a victim of broken locks",
                                               guardLocks.LockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId) : Nothing(),
                                               guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
             if (guardLocks.LockTxId) {
-                FillDeferredBreakerInfo(guardLocks.LockTxId, txStats);
+                FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
             }
-            FillDeferredVictimQuerySpanId(guardLocks.LockTxId, guardLocks.QuerySpanId, txStats);
 
             ResetChanges(userDb, txc);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When a datashard returns STATUS_LOCKS_BROKEN via the EnsureCurrentLock, OnUniqueConstrainException, or TSerializableIsolationException paths, the response does not include TxLocks. The KQP layer then fails to resolve VictimQuerySpanId from stored locks, resulting in a missing VictimQuerySpanId in the SessionActor TLI log.

Added DeferredVictimQuerySpanId field to TTxStats so the DataShard can pass the victim's span ID directly in these paths. The KQP helper reads it as a fallback when TxLocks-based lookup finds nothing.

Fixes: #36414

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
