### PR TITLE
kafka_proxy/kafka_connection: fix u-a-f in NKafka::TKafkaConnection::HandleConnected(TEvPollerReady::TPtr, const TActorContext&)

### DIFF
--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -959,8 +959,8 @@ protected:
                 RetryingWriteToSocket = false;
                 auto& request = PendingRequestsQueue.front();
                 auto& header = request->Header;
-                OnRequestProcessed(request);
                 KAFKA_LOG_D("Sent reply (after retry): ApiKey=" << header.RequestApiKey << ", Version=" << header.RequestApiVersion << ", Correlation=" << header.CorrelationId);
+                OnRequestProcessed(request);
                 ProcessReplyQueue(ctx);
 
                 if (!CloseConnection && Step == INFLIGHT_CHECK) {


### PR DESCRIPTION
…AutoPtr<NActors::TEventHandle<NActors::TEvPollerReady>, TDelete>, NActors::TActorContext const&)

Noticed in asan test sanitizer failures:
ydb/tests/stress/kafka/tests/test_kafka_streams.py.TestYdbTopicWorkload.test
```
E   ==1297075==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c9d64ffdfa8 at pc 0x000057a619e4 bp 0x7bbd16b9a390 sp 0x7bbd16b9a388
E   READ of size 2 at 0x7c9d64ffdfa8 thread T53 (ydbd.User)
E   warning: address range table at offset 0x10c0 has a premature terminator entry at offset 0x10d0
E   #0 0x000057a619e3 in NKafka::TKafkaConnection::HandleConnected(TAutoPtr<NActors::TEventHandle<NActors::TEvPollerReady>, TDelete>, NActors::TActorContext const&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:963:17
E   #1 0x000057a5df0a in NKafka::TKafkaConnection::StateConnected(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:991:13
E   #2 0x00002340e587 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:355:17
E   #3 0x000023504b31 in NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) /-S/ydb/library/actors/core/executor_thread.cpp:267:28
E   #4 0x00002350e746 in NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const /-S/ydb/library/actors/core/executor_thread.cpp:455:39
E   #5 0x00002350dcfd in NActors::TExecutorThread::ProcessExecutorPool() /-S/ydb/library/actors/core/executor_thread.cpp:507:13
E   #6 0x00002350fd6e in NActors::TExecutorThread::ThreadProc() /-S/ydb/library/actors/core/executor_thread.cpp:533:9
E   #7 0x000020c87b04 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:245:20
E   #8 0x000020904e76 in asan_thread_start(void*) /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:239:28
E   #9 0x7fbd602ffac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
E   #10 0x7fbd603918cf  (/lib/x86_64-linux-gnu/libc.so.6+0x1268cf) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
E
E   0x7c9d64ffdfa8 is located 72 bytes inside of 152-byte region [0x7c9d64ffdf60,0x7c9d64ffdff8)
E   freed by thread T53 (ydbd.User) here:
E   #0 0x000020941fc2 in operator delete(void*, unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:155:3
E   #1 0x000057a6da03 in __release_shared /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_count.h:122:7
E   #2 0x000057a6da03 in ~shared_ptr /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:561:17
E   #3 0x000057a6da03 in destroy /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:156:87
E   #4 0x000057a6da03 in destroy<std::__y1::shared_ptr<NKafka::TKafkaConnection::Msg>, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:308:9
E   #5 0x000057a6da03 in pop_front /-S/contrib/libs/cxxsupp/libcxx/include/deque:2303:3
E   #6 0x000057a6da03 in NKafka::TKafkaConnection::OnRequestProcessed(std::__y1::shared_ptr<NKafka::TKafkaConnection::Msg> const&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:657:30
E   #7 0x000057a60135 in NKafka::TKafkaConnection::HandleConnected(TAutoPtr<NActors::TEventHandle<NActors::TEvPollerReady>, TDelete>, NActors::TActorContext const&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:962:17
E   #8 0x000057a5df0a in NKafka::TKafkaConnection::StateConnected(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:991:13
E   #9 0x00002340e587 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:355:17
E   #10 0x000023504b31 in NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) /-S/ydb/library/actors/core/executor_thread.cpp:267:28
E   #11 0x00002350e746 in NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const /-S/ydb/library/actors/core/executor_thread.cpp:455:39
E   #12 0x00002350dcfd in NActors::TExecutorThread::ProcessExecutorPool() /-S/ydb/library/actors/core/executor_thread.cpp:507:13
E   #13 0x00002350fd6e in NActors::TExecutorThread::ThreadProc() /-S/ydb/library/actors/core/executor_thread.cpp:533:9
E   #14 0x000020c87b04 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:245:20
E   #15 0x000020904e76 in asan_thread_start(void*) /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:239:28
E
E   previously allocated by thread T53 (ydbd.User) here:
E   #0 0x00002094135d in operator new(unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:86:3
E   #1 0x000057a684ee in __libcpp_operator_new<unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:37:10
E   #2 0x000057a684ee in __libcpp_allocate<std::__y1::__shared_ptr_emplace<NKafka::TKafkaConnection::Msg, std::__y1::allocator<NKafka::TKafkaConnection::Msg> > > /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:64:28
E   #3 0x000057a684ee in allocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:105:14
E   #4 0x000057a684ee in allocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:259:16
E   #5 0x000057a684ee in __allocation_guard<std::__y1::allocator<NKafka::TKafkaConnection::Msg> > /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocation_guard.h:55:16
E   #6 0x000057a684ee in allocate_shared<NKafka::TKafkaConnection::Msg, std::__y1::allocator<NKafka::TKafkaConnection::Msg>, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:735:46
E   #7 0x000057a684ee in make_shared<NKafka::TKafkaConnection::Msg, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:744:10
E   #8 0x000057a684ee in NKafka::TKafkaConnection::DoRead(NActors::TActorContext const&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:765:35
E   #9 0x000057a5f5ed in NKafka::TKafkaConnection::HandleConnected(TAutoPtr<NActors::TEventHandle<NActors::TEvPollerReady>, TDelete>, NActors::TActorContext const&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:932:22
E   #10 0x000057a5df0a in NKafka::TKafkaConnection::StateConnected(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/kafka_proxy/kafka_connection.cpp:991:13
E   #11 0x00002340e587 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:355:17
E   #12 0x000023504b31 in NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) /-S/ydb/library/actors/core/executor_thread.cpp:267:28
E   #13 0x00002350e746 in NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const /-S/ydb/library/actors/core/executor_thread.cpp:455:39
E   #14 0x00002350dcfd in NActors::TExecutorThread::ProcessExecutorPool() /-S/ydb/library/actors/core/executor_thread.cpp:507:13
E   #15 0x00002350fd6e in NActors::TExecutorThread::ThreadProc() /-S/ydb/library/actors/core/executor_thread.cpp:533:9
E   #16 0x000020c87b04 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:245:20
E   #17 0x000020904e76 in asan_thread_start(void*) /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:239:28
E
E   Thread T53 (ydbd.User) created by T0 here:
E   #0 0x0000208ebab1 in pthread_create /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:250:3
E   #1 0x000020c78505 in Start /-S/util/system/thread.cpp:230:27
E   #2 0x000020c78505 in TThread::Start() /-S/util/system/thread.cpp:315:34
E   #3 0x0000234d37bc in NActors::TBasicExecutorPool::Start() /-S/ydb/library/actors/core/executor_pool_basic.cpp:607:32
E   #4 0x00002346d903 in NActors::TCpuManager::Start() /-S/ydb/library/actors/core/cpu_manager.cpp:140:32
E   #5 0x000023428801 in NActors::TActorSystem::Start() /-S/ydb/library/actors/core/actorsystem.cpp:513:21
E   #6 0x0000433f1f66 in NKikimr::TKikimrRunner::KikimrStart() /-S/ydb/core/driver_lib/run/run.cpp:2211:22
E   #7 0x0000433f84b8 in NKikimr::MainRun(NKikimr::TKikimrRunConfig const&, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/run/run.cpp:2475:17
E   #8 0x00004068af8b in NKikimr::NDriverClient::TClientCommandServer::Run(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/core/driver_lib/cli_utils/cli_cmds_server.cpp:51:12
E   #9 0x0000403021e5 in NYdb::NConsoleClient::TClientCommandTree::Run(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:483:33
E   #10 0x0000402fc145 in NYdb::NConsoleClient::TClientCommand::Process(NYdb::NConsoleClient::TClientCommand::TConfig&) /-S/ydb/public/lib/ydb_cli/common/command.cpp:237:16
E   #11 0x0000402a0fa4 in NKikimr::NDriverClient::NewClient(int, char**, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp:218:26
E   #12 0x00004029cca7 in ParameterizedMain(int, char**, std::__y1::shared_ptr<NKikimr::TModuleFactories>) /-S/ydb/core/driver_lib/run/main.cpp:42:16
E   #13 0x0000208653e5 in main /-S/ydb/apps/ydbd/main.cpp:31:12
E   #14 0x7fbd60294d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
E
E   SUMMARY: AddressSanitizer: heap-use-after-free /-S/ydb/core/kafka_proxy/kafka_connection.cpp:963:17 in NKafka::TKafkaConnection::HandleConnected(TAutoPtr<NActors::TEventHandle<NActors::TEvPollerReady>, TDelete>, NActors::TActorContext const&)
```

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fire-and-forget. Regression from #21035. Probably related to muted test #24446 
