### PR TITLE
Reduce amount of stats written by BSC

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1683,8 +1683,8 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
         pDiskMetrics.SetAvailableSize(availableSize);
         pDiskMetrics.SetMaxReadThroughput(DriveModel.Speed(TDriveModel::OP_TYPE_READ));
         pDiskMetrics.SetMaxWriteThroughput(DriveModel.Speed(TDriveModel::OP_TYPE_WRITE));
-        pDiskMetrics.SetNonRealTimeMs(AtomicGet(NonRealTimeMs));
-        pDiskMetrics.SetSlowDeviceMs(Max((ui64)AtomicGet(SlowDeviceMs), (ui64)*Mon.DeviceNonperformanceMs));
+        //pDiskMetrics.SetNonRealTimeMs(AtomicGet(NonRealTimeMs));
+        //pDiskMetrics.SetSlowDeviceMs(Max((ui64)AtomicGet(SlowDeviceMs), (ui64)*Mon.DeviceNonperformanceMs));
         pDiskMetrics.SetMaxIOPS(DriveModel.IOPS());
 
         i64 minSlotSize = Max<i64>();

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -1000,7 +1000,6 @@ STFUNC(TBlobStorageController::StateWork) {
         hFunc(TEvBlobStorage::TEvControllerDistconfRequest, Handle);
         fFunc(TEvBlobStorage::EvControllerShredRequest, EnqueueIncomingEvent);
         cFunc(TEvPrivate::EvUpdateShredState, ShredState.HandleUpdateShredState);
-        cFunc(TEvPrivate::EvCommitMetrics, CommitMetrics);
         hFunc(NStorage::TEvNodeConfigInvokeOnRootResult, Handle);
         cFunc(TEvPrivate::EvCheckSyncerDisconnectedNodes, CheckSyncerDisconnectedNodes);
         hFunc(TEvBlobStorage::TEvControllerUpdateSyncerState, Handle);

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -635,6 +635,7 @@ namespace NKikimr::NBsController {
                     if (pdisk.PDiskMetrics) {
                         x->MutablePDiskMetrics()->CopyFrom(*pdisk.PDiskMetrics);
                         x->MutablePDiskMetrics()->ClearPDiskId();
+                        x->MutablePDiskMetrics()->SetUpdateTimestamp(pdisk.PDiskMetricsUpdateTimestamp.GetValue());
                     }
                 }
             }

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -578,6 +578,11 @@ namespace NKikimr::NBsController {
             for (auto&& [base, overlay] : state.PDisks.Diff()) {
                 if (!overlay->second) {
                     db.Table<Schema::PDiskMetrics>().Key(overlay->first.GetKey()).Delete();
+                } else if (!base) {
+                    Y_ABORT_UNLESS(overlay->second);
+                    if (const auto& m = overlay->second->PersistedMetrics; m.ByteSizeLong()) {
+                        db.Table<Schema::PDiskMetrics>().Key(overlay->first.GetKey()).Update<Schema::PDiskMetrics::Metrics>(m);
+                    }
                 }
             }
 
@@ -1150,6 +1155,7 @@ namespace NKikimr::NBsController {
             pb->SetDecommitStatus(pdisk.DecommitStatus);
             pb->MutablePDiskMetrics()->CopyFrom(pdisk.Metrics);
             pb->MutablePDiskMetrics()->ClearPDiskId();
+            pb->MutablePDiskMetrics()->SetUpdateTimestamp(pdisk.MetricsUpdateTimestamp.GetValue());
             pb->SetExpectedSerial(pdisk.ExpectedSerial);
             pb->SetLastSeenSerial(pdisk.LastSeenSerial);
             pb->SetReadOnly(pdisk.Mood == TPDiskMood::ReadOnly);

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -319,13 +319,13 @@ namespace NKikimr {
                     // no, we haven't; see if it is mentioned in static configuration
                     ui32 staticSlotUsage = 0;
                     Schema::PDisk::Guid::Type guid{};
-                    std::optional<NKikimrBlobStorage::TPDiskMetrics> staticMetrics;
+                    const NKikimrBlobStorage::TPDiskMetrics *staticMetrics = nullptr;
                     if (auto pdiskIdOptional = NKikimr::NBsController::FindStaticPDisk(disk, state)) {
                         // yes, take some data from static configuration
                         pdiskId = *pdiskIdOptional;
                         guid = GetGuidAndValidateStaticPDisk(pdiskId, disk, state, staticSlotUsage);
-                        if (auto it = state.StaticPDisks.find(pdiskId); it != state.StaticPDisks.end()) {
-                            staticMetrics = it->second.PDiskMetrics;
+                        if (auto it = state.StaticPDisks.find(pdiskId); it != state.StaticPDisks.end() && it->second.PDiskMetrics) {
+                            staticMetrics = &it->second.PDiskMetrics.value();
                         }
                     } else if (auto info = state.DrivesSerials.Find(disk.Serial); info && info->Guid) {
                         pdiskId = FindFirstEmptyPDiskId(state.PDisks, disk.NodeId);
@@ -347,8 +347,9 @@ namespace NKikimr {
 
                     // Preserve metrics from static PDisk
                     if (staticMetrics) {
+                        newPDisk->PersistedMetrics.CopyFrom(*staticMetrics);
                         newPDisk->Metrics.CopyFrom(*staticMetrics);
-                        newPDisk->MetricsDirty = true;
+                        newPDisk->MetricsCommitted = true;
                     }
 
                     // Set PDiskId and Guid in DrivesSerials

--- a/ydb/core/mind/bscontroller/disk_metrics.cpp
+++ b/ydb/core/mind/bscontroller/disk_metrics.cpp
@@ -3,9 +3,15 @@
 namespace NKikimr::NBsController {
 
 class TBlobStorageController::TTxUpdateDiskMetrics : public TTransactionBase<TBlobStorageController> {
+    std::vector<TPDiskId> PDiskIds;
+    std::vector<TVSlotId> VSlotIds;
+
 public:
-    TTxUpdateDiskMetrics(TBlobStorageController *controller)
+    TTxUpdateDiskMetrics(TBlobStorageController *controller, std::vector<TPDiskId> pdiskIds,
+            std::vector<TVSlotId> vslotIds)
         : TBase(controller)
+        , PDiskIds(std::move(pdiskIds))
+        , VSlotIds(std::move(vslotIds))
     {}
 
     TTxType GetTxType() const override { return NBlobStorageController::TXTYPE_UPDATE_DISK_METRICS; }
@@ -15,46 +21,36 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
 
-        for (const auto& [pdiskId, pdisk] : Self->PDisks) {
-            if (std::exchange(pdisk->MetricsDirty, false)) {
-                auto&& key = pdiskId.GetKey();
-                auto value = pdisk->Metrics;
-                value.ClearPDiskId();
-                db.Table<Schema::PDiskMetrics>().Key(key).Update<Schema::PDiskMetrics::Metrics>(value);
-                Self->SysViewChangedPDisks.insert(pdiskId);
+        for (const TPDiskId& pdiskId : PDiskIds) {
+            if (TPDiskInfo *pdisk = Self->FindPDisk(pdiskId)) {
+                using T = Schema::PDiskMetrics;
+                db.Table<T>().Key(pdiskId.GetKey()).Update<T::Metrics>(pdisk->PersistedMetrics);
             }
         }
 
-        for (const auto& [vslotId, v] : Self->VSlots) {
-            if (std::exchange(v->MetricsDirty, false)) {
-                auto groupId = v->GroupId.GetRawId();
-                auto&& key = std::tie(groupId, v->GroupGeneration, v->RingIdx, v->FailDomainIdx, v->VDiskIdx);
-                auto value = v->Metrics;
-                value.ClearVDiskId();
-                db.Table<Schema::VDiskMetrics>().Key(key).Update<Schema::VDiskMetrics::Metrics>(value);
-                Self->SysViewChangedVSlots.insert(vslotId);
-                Self->SysViewChangedGroups.insert(v->GroupId); // TODO(alexvru): really necessary?
+        for (const TVSlotId& vslotId : VSlotIds) {
+            auto updateVSlot = [&](TVDiskID vdiskId, const NKikimrBlobStorage::TVDiskMetrics& metrics) {
+                using T = Schema::VDiskMetrics;
+                db.Table<T>().Key(vdiskId.GroupID.GetRawId(), vdiskId.GroupGeneration, vdiskId.FailRealm,
+                    vdiskId.FailDomain, vdiskId.VDisk).Update<T::Metrics>(metrics);
+            };
+
+            if (TVSlotInfo *vslot = Self->FindVSlot(vslotId)) {
+                updateVSlot(vslot->GetVDiskId(), vslot->PersistedMetrics);
+            } else if (const auto it = Self->StaticVSlots.find(vslotId); it != Self->StaticVSlots.end()) {
+                TStaticVSlotInfo& vslot = it->second;
+                if (const auto& m = vslot.PersistedVDiskMetrics) {
+                    updateVSlot(vslot.VDiskId, *m);
+                } else {
+                    Y_DEBUG_ABORT();
+                }
             }
         }
 
-        for (auto& [vslotId, v] : Self->StaticVSlots) {
-            if (std::exchange(v.MetricsDirty, false)) {
-                auto vdiskId = v.VDiskId;
-                auto groupId = vdiskId.GroupID.GetRawId();
-                auto&& key = std::tie(groupId, vdiskId.GroupGeneration, vdiskId.FailRealm, vdiskId.FailDomain, vdiskId.VDisk);
-                auto value = v.VDiskMetrics;
-                value->ClearVDiskId();
-                db.Table<Schema::VDiskMetrics>().Key(key).Update<Schema::VDiskMetrics::Metrics>(*value);
-                Self->SysViewChangedVSlots.insert(vslotId);
-            }
-        }
         return true;
     }
 
-    void Complete(const TActorContext&) override {
-        TActivationContext::Schedule(TDuration::Seconds(15), new IEventHandle(TEvPrivate::EvCommitMetrics, 0,
-            Self->SelfId(), TActorId(), nullptr, 0));
-    }
+    void Complete(const TActorContext&) override {}
 };
 
 void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr &ev) {
@@ -64,6 +60,8 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
     const TInstant now = TActivationContext::Now();
     auto& record = ev->Get()->Record;
     THashSet<TGroupId> groupsToCheck;
+    std::vector<TPDiskId> pdiskIds;
+    std::vector<TVSlotId> vslotIds;
 
     STLOG(PRI_DEBUG, BS_CONTROLLER, BSCTXUDM01, "Updating disk status", (Record, record));
 
@@ -72,6 +70,17 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
     for (const auto& m : record.GetVDisksMetrics()) {
         const TVDiskID vdiskId = VDiskIDFromVDiskID(m.GetVDiskId());
         if (const auto *slot = FindVSlot(vdiskId)) {
+            // process persistent metrics
+            NKikimrBlobStorage::TVDiskMetrics newMetrics(slot->PersistedMetrics);
+            newMetrics.MergeFrom(m);
+            newMetrics.DiscardUnknownFields();
+            if (CompareMetrics(slot->PersistedMetrics, newMetrics, slot->MetricsCommitted)) {
+                newMetrics.Swap(&slot->PersistedMetrics);
+                slot->MetricsCommitted = true;
+                vslotIds.push_back(slot->VSlotId);
+            }
+
+            // update in-memory metrics
             i64 allocatedSizeIncrement;
             if (slot->UpdateVDiskMetrics(m, &allocatedSizeIncrement) && slot->Group) {
                 dirtyGroups.insert(slot->Group);
@@ -82,10 +91,34 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
                 Y_ABORT_UNLESS(group);
                 StoragePoolStat->UpdateAllocatedSize(TStoragePoolStat::ConvertId(group->StoragePoolId), allocatedSizeIncrement);
             }
+
+            // mark vslots and groups as changed in sysviews
+            SysViewChangedVSlots.insert(slot->VSlotId);
+            SysViewChangedGroups.insert(slot->GroupId);
         } else if (const auto it = StaticVDiskMap.find(vdiskId); it != StaticVDiskMap.end()) {
             TStaticVSlotInfo& info = StaticVSlots.at(it->second);
-            info.VDiskMetrics = m;
-            info.MetricsDirty = true;
+
+            NKikimrBlobStorage::TVDiskMetrics metrics;
+            if (info.PersistedVDiskMetrics) {
+                metrics.CopyFrom(*info.PersistedVDiskMetrics);
+            }
+            metrics.MergeFrom(m);
+            metrics.DiscardUnknownFields();
+            if (!info.PersistedVDiskMetrics || CompareMetrics(*info.PersistedVDiskMetrics, metrics, info.MetricsCommitted)) {
+                info.PersistedVDiskMetrics = std::move(metrics);
+                info.MetricsCommitted = true;
+                vslotIds.push_back(it->second);
+            }
+
+            if (!info.VDiskMetrics) {
+                info.VDiskMetrics.emplace(std::move(m));
+            } else {
+                info.VDiskMetrics->MergeFrom(m);
+            }
+            info.VDiskMetrics->DiscardUnknownFields();
+
+            SysViewChangedVSlots.insert(it->second);
+            SysViewChangedGroups.insert(vdiskId.GroupID);
         } else {
             STLOG(PRI_NOTICE, BS_CONTROLLER, BSCTXUDM02, "VDisk not found", (VDiskId, vdiskId));
         }
@@ -100,6 +133,12 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
     for (const auto& m : record.GetPDisksMetrics()) {
         const TPDiskId pdiskId(ev->Sender.NodeId(), m.GetPDiskId());
         if (auto *pdisk = FindPDisk(pdiskId)) {
+            if (CompareMetrics(pdisk->PersistedMetrics, m, pdisk->MetricsCommitted)) {
+                pdisk->PersistedMetrics.CopyFrom(m);
+                pdisk->MetricsCommitted = true;
+                pdiskIds.push_back(pdiskId);
+            }
+
             if (pdisk->UpdatePDiskMetrics(m, now)) {
                 for (auto& [id, slot] : pdisk->VSlotsOnPDisk) {
                     if (slot->Group) {
@@ -108,10 +147,11 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
                 }
             }
             pdisk->UpdateOperational(true);
+
             SysViewChangedPDisks.insert(pdiskId);
         } else if (const auto it = StaticPDisks.find(pdiskId); it != StaticPDisks.end()) {
             it->second.PDiskMetrics = m;
-            it->second.PDiskMetrics->SetUpdateTimestamp(now.GetValue());
+            it->second.PDiskMetricsUpdateTimestamp = now;
         } else {
             STLOG(PRI_NOTICE, BS_CONTROLLER, BSCTXUDM03, "PDisk not found", (PDiskId, pdiskId));
         }
@@ -121,10 +161,78 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
 
     // process VDisk status
     ProcessVDiskStatus(record.GetVDiskStatus());
+
+    Execute(new TTxUpdateDiskMetrics(this, std::move(pdiskIds), std::move(vslotIds)));
 }
 
-void TBlobStorageController::CommitMetrics() {
-    Execute(new TTxUpdateDiskMetrics(this));
+bool TBlobStorageController::CompareMetrics(const NKikimrBlobStorage::TPDiskMetrics& prev,
+        const NKikimrBlobStorage::TPDiskMetrics& cur, bool committedAtLeastOnce) {
+    if (prev.HasPDiskUsage() != cur.HasPDiskUsage()) {
+        return true; // PDiskUsage field has been set or unset
+    } else if (prev.HasPDiskUsage() && abs(prev.GetPDiskUsage() - cur.GetPDiskUsage()) >= 1.0) {
+        return true; // significant change to persist
+    }
+
+    if (prev.HasAvailableSize() != cur.HasAvailableSize() || prev.HasTotalSize() != cur.HasTotalSize()) {
+        return true;
+    } else if (prev.HasTotalSize() && prev.HasAvailableSize() && prev.GetTotalSize() && cur.GetTotalSize()) {
+        const double r1 = (double)prev.GetAvailableSize() / prev.GetTotalSize();
+        const double r2 = (double)cur.GetAvailableSize() / cur.GetTotalSize();
+        if (abs(r1 - r2) >= 0.01) {
+            return true;
+        }
+    }
+
+    google::protobuf::util::MessageDifferencer diff;
+    if (committedAtLeastOnce) {
+        diff.IgnoreField(prev.GetDescriptor()->FindFieldByNumber(NKikimrBlobStorage::TPDiskMetrics::kAvailableSizeFieldNumber));
+        diff.IgnoreField(prev.GetDescriptor()->FindFieldByNumber(NKikimrBlobStorage::TPDiskMetrics::kPDiskUsageFieldNumber));
+    }
+    return !diff.Compare(prev, cur);
+}
+
+bool TBlobStorageController::CompareMetrics(const NKikimrBlobStorage::TVDiskMetrics& prev,
+        const NKikimrBlobStorage::TVDiskMetrics& cur, bool committedAtLeastOnce) {
+#define COMPARE_FIELD(NAME, MARGIN) \
+    if (prev.Has##NAME() != cur.Has##NAME() || (prev.Has##NAME() && abs(prev.Get##NAME() - cur.Get##NAME()) >= MARGIN)) { \
+        return true; \
+    }
+    COMPARE_FIELD(NormalizedOccupancy, 0.01)
+    COMPARE_FIELD(VDiskSlotUsage, 1.0)
+    COMPARE_FIELD(VDiskRawUsage, 1.0)
+#undef COMPARE_FIELD
+
+    if (prev.HasAvailableSize() != cur.HasAvailableSize() || prev.HasAllocatedSize() != cur.HasAllocatedSize()) {
+        return true;
+    }
+    const ui64 prevTotalSize = prev.GetAvailableSize() + prev.GetAllocatedSize();
+    const ui64 curTotalSize = cur.GetAvailableSize() + cur.GetAllocatedSize();
+    if (prevTotalSize != curTotalSize) {
+        return true;
+    }
+    if (prevTotalSize && curTotalSize) {
+        const double r1 = (double)prev.GetAllocatedSize() / prevTotalSize;
+        const double r2 = (double)cur.GetAllocatedSize() / curTotalSize;
+        if (abs(r1 - r2) >= 0.01) {
+            return true;
+        }
+    }
+
+    if (prev.HasSatisfactionRank() != cur.HasSatisfactionRank()) {
+        return true;
+    }
+
+    google::protobuf::util::MessageDifferencer diff;
+    if (committedAtLeastOnce) {
+        auto *desc = prev.GetDescriptor();
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kSatisfactionRankFieldNumber));
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kAvailableSizeFieldNumber));
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kAllocatedSizeFieldNumber));
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kNormalizedOccupancyFieldNumber));
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kVDiskSlotUsageFieldNumber));
+        diff.IgnoreField(desc->FindFieldByNumber(NKikimrBlobStorage::TVDiskMetrics::kVDiskRawUsageFieldNumber));
+    }
+    return !diff.Compare(prev, cur);
 }
 
 } // NKikimr::NBsController

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -61,7 +61,6 @@ public:
     class TTxMonEvent_SetDown;
     class TTxMonEvent_GetDown;
     class TTxUpdateDiskMetrics;
-    class TTxUpdateGroupLatencies;
     class TTxGroupMetricsExchange;
     class TTxNodeReport;
     class TTxUpdateSeenOperational;
@@ -121,8 +120,9 @@ public:
         Table::PersistentBufferRefs::Type PersistentBufferRefs;
 
         // volatile state
+        mutable NKikimrBlobStorage::TVDiskMetrics PersistedMetrics;
         mutable NKikimrBlobStorage::TVDiskMetrics Metrics;
-        mutable bool MetricsDirty = false;
+        mutable bool MetricsCommitted = false; // at least once since restart
         mutable TResourceRawValues DiskResourceValues;
         mutable TResourceRawValues MaximumResourceValues{
             1ULL << 40, // 1 TB
@@ -312,7 +312,6 @@ public:
             const ui32 prevStatusFlags = Metrics.GetStatusFlags();
             Metrics.MergeFrom(vDiskMetrics);
             Metrics.DiscardUnknownFields();
-            MetricsDirty = true;
             UpdateVDiskMetrics();
             *allocatedSizeIncrementPtr = Metrics.GetAllocatedSize() - allocatedSizeBefore;
             return prevStatusFlags != Metrics.GetStatusFlags();
@@ -367,8 +366,10 @@ public:
 
         bool Operational = false; // set to true when both containing node is connected and Operational is reported in Metrics
 
-        NKikimrBlobStorage::TPDiskMetrics Metrics;
-        bool MetricsDirty = false;
+        NKikimrBlobStorage::TPDiskMetrics PersistedMetrics; // metrics persisted to storage
+        NKikimrBlobStorage::TPDiskMetrics Metrics; // metrics kept in-memory
+        TInstant MetricsUpdateTimestamp; // last time of update
+        bool MetricsCommitted = false; // at least once since restart
 
         NKikimrBlobStorage::EDriveStatus Status;
         TInstant StatusTimestamp;
@@ -496,8 +497,7 @@ public:
         bool UpdatePDiskMetrics(const NKikimrBlobStorage::TPDiskMetrics& pDiskMetrics, TInstant now) {
             const bool hadMetrics = HasFullMetrics();
             Metrics.CopyFrom(pDiskMetrics);
-            Metrics.SetUpdateTimestamp(now.GetValue());
-            MetricsDirty = true;
+            MetricsUpdateTimestamp = now;
             return !hadMetrics && HasFullMetrics(); // true if metrics have just arrived
         }
 
@@ -1572,7 +1572,6 @@ private:
             EvProcessIncomingEvent,
             EvUpdateHostRecords,
             EvUpdateShredState,
-            EvCommitMetrics,
             EvCheckSyncerDisconnectedNodes,
         };
 
@@ -1816,8 +1815,6 @@ private:
     THostRecordMap HostRecords;
     void Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev);
     void SetHostRecords(THostRecordMap hostRecords);
-
-    void CommitMetrics();
 
 public:
     // Self-heal actor's main purpose is to monitor FAULTY pdisks and to slightly move groups out of them; every move
@@ -2262,7 +2259,6 @@ public:
         }
 
         ShredState.Initialize();
-        CommitMetrics();
         CheckSyncerDisconnectedNodes();
     }
 
@@ -2475,11 +2471,12 @@ public:
         const TVDiskID VDiskId;
         const NKikimrBlobStorage::TVDiskKind::EVDiskKind VDiskKind;
 
+        std::optional<NKikimrBlobStorage::TVDiskMetrics> PersistedVDiskMetrics;
         std::optional<NKikimrBlobStorage::TVDiskMetrics> VDiskMetrics;
         std::optional<NKikimrBlobStorage::EVDiskStatus> VDiskStatus;
         TMonotonic VDiskStatusTimestamp;
         TMonotonic ReadySince = TMonotonic::Max(); // when IsReady becomes true for this disk; Max() in non-READY state
-        bool MetricsDirty = false;
+        bool MetricsCommitted = false;
 
         TStaticVSlotInfo(const NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk& vdisk,
                 const std::map<TVSlotId, TStaticVSlotInfo>& prev, TMonotonic mono)
@@ -2490,7 +2487,9 @@ public:
             const TVSlotId vslotId(loc.GetNodeID(), loc.GetPDiskID(), loc.GetVDiskSlotID());
             if (const auto it = prev.find(vslotId); it != prev.end()) {
                 const TStaticVSlotInfo& item = it->second;
+                PersistedVDiskMetrics = item.PersistedVDiskMetrics;
                 VDiskMetrics = item.VDiskMetrics;
+                MetricsCommitted = item.MetricsCommitted;
                 VDiskStatus = item.VDiskStatus;
                 VDiskStatusTimestamp = item.VDiskStatusTimestamp;
                 ReadySince = item.ReadySince;
@@ -2516,6 +2515,7 @@ public:
         // runtime info
         ui32 StaticSlotUsage = 0;
         std::optional<NKikimrBlobStorage::TPDiskMetrics> PDiskMetrics;
+        TInstant PDiskMetricsUpdateTimestamp;
 
         TStaticPDiskInfo(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk,
                 const std::map<TPDiskId, TStaticPDiskInfo>& prev)
@@ -2537,6 +2537,7 @@ public:
             if (const auto it = prev.find(pdiskId); it != prev.end()) {
                 const TStaticPDiskInfo& item = it->second;
                 PDiskMetrics = item.PDiskMetrics;
+                PDiskMetricsUpdateTimestamp = item.PDiskMetricsUpdateTimestamp;
             }
         }
 
@@ -2596,6 +2597,12 @@ public:
 
     static NKikimrBlobStorage::TGroupStatus::E DeriveStatus(const TBlobStorageGroupInfo::TTopology *topology,
         const TBlobStorageGroupInfo::TGroupVDisks& failed);
+
+    static bool CompareMetrics(const NKikimrBlobStorage::TPDiskMetrics& prev, const NKikimrBlobStorage::TPDiskMetrics& cur,
+        bool committedAtLeastOnce);
+
+    static bool CompareMetrics(const NKikimrBlobStorage::TVDiskMetrics& prev, const NKikimrBlobStorage::TVDiskMetrics& cur,
+        bool committedAtLeastOnce);
 };
 
 } // NBsController

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -374,7 +374,7 @@ public:
             while (!table.EndOfSet()) {
                 const TPDiskId pdiskId(table.GetValue<Table::NodeID>(), table.GetValue<Table::PDiskID>());
                 if (TPDiskInfo *pdisk = Self->FindPDisk(pdiskId)) {
-                    pdisk->Metrics = table.GetValueOrDefault<Table::Metrics>();
+                    pdisk->PersistedMetrics = pdisk->Metrics = table.GetValueOrDefault<Table::Metrics>();
                 } else {
                     pdiskMetricsToDelete.push_back(table.GetKey());
                 }
@@ -447,7 +447,7 @@ public:
                 const TVDiskID key(TGroupId::FromValue(table.GetValue<Table::GroupID>()), table.GetValue<Table::GroupGeneration>(),
                     table.GetValue<Table::Ring>(), table.GetValue<Table::FailDomain>(), table.GetValue<Table::VDisk>());
                 if (TVSlotInfo *slot = Self->FindVSlot(key)) {
-                    slot->Metrics = table.GetValueOrDefault<Table::Metrics>();
+                    slot->PersistedMetrics = slot->Metrics = table.GetValueOrDefault<Table::Metrics>();
                     slot->UpdateVDiskMetrics();
                 } else {
                     vdiskMetricsToDelete.push_back(table.GetKey());

--- a/ydb/core/mind/bscontroller/update_group_latencies.cpp
+++ b/ydb/core/mind/bscontroller/update_group_latencies.cpp
@@ -1,80 +1,15 @@
 #include "impl.h"
 
-namespace NKikimr {
-namespace NBsController {
-
-class TBlobStorageController::TTxUpdateGroupLatencies : public TTransactionBase<TBlobStorageController> {
-    THashSet<TGroupId> Ids;
-
-public:
-    TTxUpdateGroupLatencies(THashSet<TGroupId> ids, TBlobStorageController *controller)
-        : TBase(controller)
-        , Ids(std::move(ids))
-    {}
-
-    TTxType GetTxType() const override { return NBlobStorageController::TXTYPE_UPDATE_GROUP_LATENCIES; }
-
-    bool Execute(TTransactionContext& txc, const TActorContext&) override {
-        NIceDb::TNiceDb db(txc.DB);
-        for (const TGroupId groupId : Ids) {
-            TGroupInfo *groupInfo = Self->FindGroup(groupId);
-            if (!groupInfo) {
-                continue;
-            }
-            TGroupLatencyStats& stats = groupInfo->LatencyStats;
-
-#define UPDATE_CELL(VALUE, COLUMN) \
-            if (const auto& x = stats.VALUE) { \
-                db.Table<Schema::GroupLatencies>().Key(groupId.GetRawId()).Update(NIceDb::TUpdate<Schema::GroupLatencies::COLUMN>(x->MicroSeconds())); \
-            } else { \
-                db.Table<Schema::GroupLatencies>().Key(groupId.GetRawId()).Update(NIceDb::TNull<Schema::GroupLatencies::COLUMN>()); \
-            }
-
-            UPDATE_CELL(PutTabletLog, PutTabletLogLatencyUs);
-            UPDATE_CELL(PutUserData, PutUserDataLatencyUs);
-            UPDATE_CELL(GetFast, GetFastLatencyUs);
-
-            Self->SysViewChangedGroups.insert(groupId);
-        }
-        return true;
-    }
-
-    void Complete(const TActorContext&) override
-    {}
-};
+namespace NKikimr::NBsController {
 
 void TBlobStorageController::Handle(TEvControllerCommitGroupLatencies::TPtr& ev) {
-    THashSet<TGroupId> ids;
-
     auto& updates = ev->Get()->Updates;
-    if (updates.size() <= GroupMap.size() / 2) {
-        for (auto& [key, value] : updates) {
-            if (TGroupInfo *group = FindGroup(key)) {
-                group->LatencyStats = std::move(value);
-                ids.insert(key);
-            }
+    for (auto& [key, value] : updates) {
+        if (TGroupInfo *group = FindGroup(key)) {
+            group->LatencyStats = std::move(value);
+            SysViewChangedGroups.insert(key);
         }
-    } else {
-        auto updateIt = updates.begin();
-        auto groupIt = GroupMap.begin();
-        while (updateIt != updates.end() && groupIt != GroupMap.end()) {
-            if (updateIt->first < groupIt->first) {
-                ++updateIt;
-            } else if (groupIt->first < updateIt->first) {
-                ++groupIt;
-            } else {
-                groupIt->second->LatencyStats = std::move(updateIt->second);
-                ids.insert(groupIt->first);
-                ++groupIt;
-                ++updateIt;
-            }
-        }
-    }
-
-    if (ids) {
-        Execute(new TTxUpdateGroupLatencies(std::move(ids), this));
     }
 }
 
-}
-}
+} // NKikimr::NBsController

--- a/ydb/core/protos/blobstorage_disk.proto
+++ b/ydb/core/protos/blobstorage_disk.proto
@@ -79,8 +79,8 @@ message TPDiskMetrics {
     optional uint64 TotalSize = 3;
     optional uint64 MaxReadThroughput = 4; // bytes per second
     optional uint64 MaxWriteThroughput = 5; // bytes per second
-    optional uint64 NonRealTimeMs = 6; // ms per second of non-realtime, [0..1000]
-    optional uint64 SlowDeviceMs = 7; // ms per second of slow device, [0..1000]
+    //optional uint64 NonRealTimeMs = 6; // ms per second of non-realtime, [0..1000]
+    //optional uint64 SlowDeviceMs = 7; // ms per second of slow device, [0..1000]
     optional uint32 MaxIOPS = 8; // number of IOPS this device can carry out
 
     // maximum expected slot size; if set, then it is guaranteed that EnforcedDynamicSlotSize bytes of space are


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce amount of stats written by BSC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes BSC write only required metrics to the local database, suppressing big stream of data.
