### PR TITLE
disable file's storing of tablet info

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -229,7 +229,9 @@ void TPartitionActor::StateInit(TAutoPtr<NActors::IEventHandle>& ev)
 
 bool TPartitionActor::HaveStoredTabletInfo()
 {
-    return NFs::Exists(GetDDiskConnectionsFilePath(TabletID()));
+    // TODO FIX this after implementation tabltet's local database - NBS-7078
+    return false;
+    // return NFs::Exists(GetDDiskConnectionsFilePath(TabletID()));
 }
 
 TVector<IDirectBlockGroupPtr> TPartitionActor::CreateDirectBlockGroups(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Выключаем проверку наличия сохраненных соединений для nbs2  partition_direct таблетки. 
Проверка-хранение были реализованы через файл. В нижеупомянутом тикете будет осуществлен перевод из файла в локальную базу - тогда проверка и починится тоже.
https://st.yandex-team.ru/NBS-7078

Цель выключения: фикс тестов IO, падающих в определенных условиях **_локального_** запуска.
