### PR TITLE
Suppress Coverity leak warning in async bridge

### DIFF
--- a/ydb/library/actors/async/async.cpp
+++ b/ydb/library/actors/async/async.cpp
@@ -73,6 +73,9 @@ namespace NActors::NDetail {
 
     std::coroutine_handle<> MakeBridgeCoroutine(IActor& actor, TActorRunnableItem& item) {
         TBridgeCoroutine* c = new TBridgeCoroutine(actor, item);
+        // coverity[leaked_storage]
+        // Ownership of c is transferred to the returned coroutine handle and is
+        // released via TBridgeCoroutine::OnDestroy/DoRun.
         return c->ToCoroutineHandle();
     }
 
@@ -159,6 +162,9 @@ namespace NActors::NDetail {
         IActor& actor, TActorRunnableItem& item1, TActorRunnableItem& item2)
     {
         TBridgeCoroutines* c = new TBridgeCoroutines(actor, item1, item2);
+        // coverity[leaked_storage]
+        // Ownership of c is transferred to the returned coroutine handles and is
+        // released when either handle is resumed or destroyed.
         return c->ToCoroutineHandles();
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Suppress a false positive Coverity resource leak warning in the async actor bridge by documenting ownership transfer from the heap-allocated bridge object to the returned coroutine handle(s) and adding targeted coverity[leaked_storage] annotations.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
