### PR TITLE
Fix AddBlobsFromBody key index for FindPos with multiple blobs

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -431,10 +431,6 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
     AFL_ENSURE(end <= blobs.size());
 
     for (ui32 blobIdx = begin; blobIdx < end; ++blobIdx) {
-        if (blobIdx != begin && needStop && cnt < Count && !(LastOffset && Offset >= LastOffset)) {
-            needStop = false;
-        }
-
         AFL_ENSURE(Blobs[blobIdx].Offset == blobs[blobIdx].Offset)("l", Blobs[blobIdx].Offset)("r", blobs[blobIdx].Offset);
         AFL_ENSURE(Blobs[blobIdx].Count == blobs[blobIdx].Count)("l", Blobs[blobIdx].Count)("r", blobs[blobIdx].Count);
 
@@ -519,7 +515,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
                 if (res.IsLastPart()) {
                     PartNo = 0;
                     ++Offset;
-                    if (LastOffset && Offset >= LastOffset) {
+                    if (ReachedLastOffset()) {
                         needStop = true;
                         break;
                     }
@@ -661,7 +657,7 @@ TReadAnswer TReadInfo::FormAnswer(
             if (updateUsage(writeBlob)) {
                 break;
             }
-            if (LastOffset && Offset >= LastOffset) {
+            if (ReachedLastOffset()) {
                 break;
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -420,7 +420,7 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
                                                 const ui64 endOffset,
                                                 const ui64 sizeLag,
                                                 const TActorId& tablet,
-                                                ui64 realReadOffset,
+                                                const ui64 realReadOffset,
                                                 NKikimrClient::TCmdReadResult* readResult,
                                                 THolder<TEvPQ::TEvProxyResponse>& answer,
                                                 bool& needStop,
@@ -439,13 +439,12 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
         AFL_ENSURE(Blobs[blobIdx].Count == blobs[blobIdx].Count)("l", Blobs[blobIdx].Count)("r", blobs[blobIdx].Count);
 
         ui64 offset = blobs[blobIdx].Offset;
-        ui32 count = blobs[blobIdx].Count;
-        ui16 partNo = blobs[blobIdx].PartNo;
-        ui16 internalPartsCount = blobs[blobIdx].InternalPartsCount;
+        const ui32 count = blobs[blobIdx].Count;
+        const ui16 partNo = blobs[blobIdx].PartNo;
 
         if (blobs[blobIdx].Empty()) { // this is ok. Means that someone requested too much data or retention race
             PQ_LOG_D("Not full answer here!");
-            ui64 answerSize = answer->Response->ByteSize();
+            const ui64 answerSize = answer->Response->ByteSize();
             if (userInfo && Destination != 0) {
                 userInfo->ReadDone(ctx, ctx.Now(), answerSize, cnt, ClientDC,
                         tablet, IsExternalRead, endOffset);
@@ -469,42 +468,41 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
         AFL_ENSURE(blobs[blobIdx].RawValue.size() <= blobs[blobIdx].Size)("value for offset", offset)("count", count)
             ("size must be",  blobs[blobIdx].Size)("got", blobs[blobIdx].RawValue.size());
 
-        auto blobBatches = blobs[blobIdx].GetBatches();
+        const auto blobBatches = blobs[blobIdx].GetBatches();
         if (offset > Offset || (offset == Offset && partNo > PartNo)) { // got gap
             Offset = offset;
             PartNo = partNo;
         }
         AFL_ENSURE(offset <= Offset);
         AFL_ENSURE(offset < Offset || partNo <= PartNo);
-        auto key = TKey::ForBody(TKeyPrefix::TypeData, TPartitionId(0), offset, partNo, count, internalPartsCount);
-        ui64 firstHeaderOffset = blobBatches->front().GetOffset();
+        const ui64 firstHeaderOffset = blobBatches->front().GetOffset();
 
-        for (auto& batch : *blobBatches) {
+        for (const auto& batch : *blobBatches) {
             if (needStop) {
                 break;
             }
 
-            auto& header = batch.Header;
-            ui64 trueOffset = blobs[blobIdx].Key.GetOffset() + (header.GetOffset() - firstHeaderOffset);
+            const auto& header = batch.Header;
+            const ui64 trueOffset = blobs[blobIdx].Key.GetOffset() + (header.GetOffset() - firstHeaderOffset);
 
             ui32 batchStartIdx = 0;
             if (trueOffset > Offset || (trueOffset == Offset && header.GetPartNo() >= PartNo)) {
                 batchStartIdx = 0;
             } else {
-                ui64 trueSearchOffset = Offset - blobs[blobIdx].Key.GetOffset() + firstHeaderOffset;
+                const ui64 trueSearchOffset = Offset - blobs[blobIdx].Key.GetOffset() + firstHeaderOffset;
                 batchStartIdx = batch.FindPos(trueSearchOffset, PartNo);
             }
             offset += header.GetCount();
 
-            if (batchStartIdx == Max<ui32>()) // this batch does not contain data to read, skip it
+            if (batchStartIdx == Max<ui32>()) { // this batch does not contain data to read, skip it
                 continue;
-
+            }
 
             PQ_LOG_D("FormAnswer processing batch offset " << (offset - header.GetCount()) <<  " totakecount " << count << " count " << header.GetCount()
                     << " size " << header.GetPayloadSize() << " from batchStartIdx " << batchStartIdx << " cbcount " << batch.Blobs.size());
 
             for (size_t i = batchStartIdx; i < batch.Blobs.size(); ++i) {
-                TClientBlob &res = batch.Blobs[i];
+                const TClientBlob &res = batch.Blobs[i];
                 VERIFY_RESULT_BLOB(res, i);
 
                 AFL_ENSURE(PartNo == res.GetPartNo())("batchStartIdx", batchStartIdx)("i", i)("Offset", Offset)("PartNo", PartNo)("offset", offset)("partNo", res.GetPartNo());

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -430,16 +430,20 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
     AFL_ENSURE(begin <= end);
     AFL_ENSURE(end <= blobs.size());
 
-    for (ui32 pos = begin; pos < end; ++pos) {
-        AFL_ENSURE(Blobs[pos].Offset == blobs[pos].Offset)("l", Blobs[pos].Offset)("r", blobs[pos].Offset);
-        AFL_ENSURE(Blobs[pos].Count == blobs[pos].Count)("l", Blobs[pos].Count)("r", blobs[pos].Count);
+    for (ui32 blobIdx = begin; blobIdx < end; ++blobIdx) {
+        if (blobIdx != begin && needStop && cnt < Count && !(LastOffset && Offset >= LastOffset)) {
+            needStop = false;
+        }
 
-        ui64 offset = blobs[pos].Offset;
-        ui32 count = blobs[pos].Count;
-        ui16 partNo = blobs[pos].PartNo;
-        ui16 internalPartsCount = blobs[pos].InternalPartsCount;
+        AFL_ENSURE(Blobs[blobIdx].Offset == blobs[blobIdx].Offset)("l", Blobs[blobIdx].Offset)("r", blobs[blobIdx].Offset);
+        AFL_ENSURE(Blobs[blobIdx].Count == blobs[blobIdx].Count)("l", Blobs[blobIdx].Count)("r", blobs[blobIdx].Count);
 
-        if (blobs[pos].Empty()) { // this is ok. Means that someone requested too much data or retention race
+        ui64 offset = blobs[blobIdx].Offset;
+        ui32 count = blobs[blobIdx].Count;
+        ui16 partNo = blobs[blobIdx].PartNo;
+        ui16 internalPartsCount = blobs[blobIdx].InternalPartsCount;
+
+        if (blobs[blobIdx].Empty()) { // this is ok. Means that someone requested too much data or retention race
             PQ_LOG_D("Not full answer here!");
             ui64 answerSize = answer->Response->ByteSize();
             if (userInfo && Destination != 0) {
@@ -462,10 +466,10 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
             };
         }
 
-        AFL_ENSURE(blobs[pos].RawValue.size() <= blobs[pos].Size)("value for offset", offset)("count", count)
-            ("size must be",  blobs[pos].Size)("got", blobs[pos].RawValue.size());
+        AFL_ENSURE(blobs[blobIdx].RawValue.size() <= blobs[blobIdx].Size)("value for offset", offset)("count", count)
+            ("size must be",  blobs[blobIdx].Size)("got", blobs[blobIdx].RawValue.size());
 
-        auto blobBatches = blobs[pos].GetBatches();
+        auto blobBatches = blobs[blobIdx].GetBatches();
         if (offset > Offset || (offset == Offset && partNo > PartNo)) { // got gap
             Offset = offset;
             PartNo = partNo;
@@ -481,29 +485,29 @@ TMaybe<TReadAnswer> TReadInfo::AddBlobsFromBody(const TVector<NPQ::TRequestedBlo
             }
 
             auto& header = batch.Header;
-            ui64 trueOffset = blobs[pos].Key.GetOffset() + (header.GetOffset() - firstHeaderOffset);
+            ui64 trueOffset = blobs[blobIdx].Key.GetOffset() + (header.GetOffset() - firstHeaderOffset);
 
-            ui32 pos = 0;
-            if (trueOffset > Offset || trueOffset == Offset && header.GetPartNo() >= PartNo) {
-                pos = 0;
+            ui32 batchStartIdx = 0;
+            if (trueOffset > Offset || (trueOffset == Offset && header.GetPartNo() >= PartNo)) {
+                batchStartIdx = 0;
             } else {
-                ui64 trueSearchOffset = Offset - blobs[pos].Key.GetOffset() + firstHeaderOffset;
-                pos = batch.FindPos(trueSearchOffset, PartNo);
+                ui64 trueSearchOffset = Offset - blobs[blobIdx].Key.GetOffset() + firstHeaderOffset;
+                batchStartIdx = batch.FindPos(trueSearchOffset, PartNo);
             }
             offset += header.GetCount();
 
-            if (pos == Max<ui32>()) // this batch does not contain data to read, skip it
+            if (batchStartIdx == Max<ui32>()) // this batch does not contain data to read, skip it
                 continue;
 
 
             PQ_LOG_D("FormAnswer processing batch offset " << (offset - header.GetCount()) <<  " totakecount " << count << " count " << header.GetCount()
-                    << " size " << header.GetPayloadSize() << " from pos " << pos << " cbcount " << batch.Blobs.size());
+                    << " size " << header.GetPayloadSize() << " from batchStartIdx " << batchStartIdx << " cbcount " << batch.Blobs.size());
 
-            for (size_t i = pos; i < batch.Blobs.size(); ++i) {
+            for (size_t i = batchStartIdx; i < batch.Blobs.size(); ++i) {
                 TClientBlob &res = batch.Blobs[i];
                 VERIFY_RESULT_BLOB(res, i);
 
-                AFL_ENSURE(PartNo == res.GetPartNo())("pos", pos)("i", i)("Offset", Offset)("PartNo", PartNo)("offset", offset)("partNo", res.GetPartNo());
+                AFL_ENSURE(PartNo == res.GetPartNo())("batchStartIdx", batchStartIdx)("i", i)("Offset", Offset)("PartNo", PartNo)("offset", offset)("partNo", res.GetPartNo());
 
                 if (userInfo) {
                     userInfo->AddTimestampToCache(

--- a/ydb/core/persqueue/pqtablet/partition/subscriber.h
+++ b/ydb/core/persqueue/pqtablet/partition/subscriber.h
@@ -88,6 +88,10 @@ struct TReadInfo {
         , IsInternal(isInternal)
     {}
 
+    bool ReachedLastOffset() const {
+        return LastOffset != 0 && Offset >= LastOffset;
+    }
+
     TReadAnswer FormAnswer(
         const TActorContext& ctx,
         const TEvPQ::TEvBlobResponse& response,

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/pqtablet/partition/partition.h>
@@ -4042,6 +4043,63 @@ TString SerializePackedBatchForReadBodyTest(TBatch batch) {
     return raw;
 }
 
+TRequestedBlob MakeRequestedBlobForRead(
+    ui64 offset,
+    ui16 partNo,
+    ui32 count,
+    ui16 internalPartsCount,
+    TString payload,
+    const TKey& key)
+{
+    const ui32 sz = static_cast<ui32>(payload.size());
+    return {
+        offset,
+        partNo,
+        count,
+        internalPartsCount,
+        sz,
+        std::move(payload),
+        key,
+        TInstant::Now().Seconds()
+    };
+}
+
+constexpr ui32 kAddBlobsFromBodyDefaultMsgLimit = 100;
+constexpr ui32 kAddBlobsFromBodyDefaultByteLimit = static_cast<ui32>(1_MB);
+
+constexpr ui64 kAddBlobsFromBodyProbeEndOffset = 100;
+constexpr ui64 kAddBlobsFromBodyProbeSizeLag = 1_MB;
+constexpr ui64 kAddBlobsFromBodyProbeReadOffset10 = 10;
+constexpr ui64 kAddBlobsFromBodyProbeReadOffset12 = 12;
+constexpr ui64 kAddBlobsFromBodyProbeReadOffset20 = 20;
+
+TReadInfo MakeReadInfoForAddBlobsFromBodyTest(
+    const TActorId& edge,
+    ui64 readOffset,
+    ui64 lastOffset = 0,
+    ui16 partNo = 0,
+    ui64 messageCountLimit = kAddBlobsFromBodyDefaultMsgLimit,
+    ui32 byteSizeLimit = kAddBlobsFromBodyDefaultByteLimit,
+    ui64 readTimestampMs = 0)
+{
+    return {
+        TString("user"),
+        TString("dc"),
+        readOffset,
+        lastOffset,
+        partNo,
+        messageCountLimit,
+        byteSizeLimit,
+        ui64{0},
+        readTimestampMs,
+        TDuration::Zero(),
+        false,
+        edge,
+        false,
+        edge
+    };
+}
+
 class TAddBlobsFromBodyReadTestActor : public TActorBootstrapped<TAddBlobsFromBodyReadTestActor> {
 public:
     TAddBlobsFromBodyReadTestActor(TActorId edge, std::function<void(const TActorContext&)> body)
@@ -4062,6 +4120,12 @@ private:
 
 }
 
+// Regression: in the FindPos branch, trueSearchOffset must use blobs[blobIdx].Key, not blobs[0].Key.
+// Two non-overlapping body blobs: [10..12] then [13..17] (five messages in blob1). After blob0 the reader
+// is at 13. Correct Key.GetOffset()==13 → all five rows are read (8 results total). If the bug used
+// Key from blob0 (GetOffset()==10), trueSearchOffset becomes 13-10+13=16, FindPos(16,0) skips the first
+// three rows of blob1: the client loses messages at offsets 13, 14, 15 and only gets 16 and 17
+// (5 vs 8 results). Multipart ++PartNo is covered elsewhere (e.g. AddBlobsFromBodyGotGap).
 Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
     UNIT_ASSERT(Ctx.Defined());
 
@@ -4071,60 +4135,30 @@ Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
     dq0.push_back(MakeSinglePartBodyReadBlob(1, 'a'));
     dq0.push_back(MakeSinglePartBodyReadBlob(2, 'b'));
     dq0.push_back(MakeSinglePartBodyReadBlob(3, 'b'));
+    TString raw0 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(10, std::move(dq0)));
 
     const TKey key0 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 10, 0, 3, 0);
-    TString raw0 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(10, std::move(dq0)));
-    TRequestedBlob blob0(10,
-                         0,
-                         3,
-                         0,
-                         raw0.size(),
-                         raw0,
-                         key0,
-                         TInstant::Now().Seconds());
+    TRequestedBlob blob0 = MakeRequestedBlobForRead(10, 0, 3, 0, std::move(raw0), key0);
 
     std::deque<TClientBlob> dq1;
     dq1.push_back(MakeSinglePartBodyReadBlob(4, 'c'));
-    dq1.push_back(MakeMultipartBodyReadBlob(5, 0, 2, 20, 'd'));
-    dq1.push_back(MakeMultipartBodyReadBlob(5, 1, 2, 20, 'e'));
+    dq1.push_back(MakeSinglePartBodyReadBlob(5, 'd'));
+    dq1.push_back(MakeSinglePartBodyReadBlob(6, 'e'));
+    dq1.push_back(MakeSinglePartBodyReadBlob(7, 'f'));
+    dq1.push_back(MakeSinglePartBodyReadBlob(8, 'g'));
+    TString raw1 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(13, std::move(dq1)));
 
-    const TKey key1 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 12, 0, 2, 1);
-    TString raw1 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(12, std::move(dq1)));
-    TRequestedBlob blob1(12,
-                         0,
-                         2,
-                         1,
-                         raw1.size(),
-                         raw1,
-                         key1,
-                         TInstant::Now().Seconds());
+    const TKey key1 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 13, 0, 5, 0);
+    TRequestedBlob blob1 = MakeRequestedBlobForRead(13, 0, 5, 0, std::move(raw1), key1);
 
     TVector<TRequestedBlob> blobs;
     blobs.push_back(std::move(blob0));
     blobs.push_back(std::move(blob1));
 
     auto probe = [&](const TActorContext& ctx) {
-        constexpr ui32 kReadMaxMessages = 100;
-        constexpr ui32 kReadMaxBytes = static_cast<ui32>(1_MB);
-
-        TReadInfo info(TString("user"),
-                       TString("dc"),
-                       ui64{10},
-                       ui64{0},
-                       ui16{0},
-                       ui64{kReadMaxMessages},
-                       kReadMaxBytes,
-                       ui64{0},
-                       ui64{0},
-                       TDuration::Zero(),
-                       false,
-                       Ctx->Edge,
-                       false,
-                       Ctx->Edge);
+        TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset10);
         info.Blobs = blobs;
         info.CompactedBlobsCount = 2;
-        info.Count = kReadMaxMessages;
-        info.Size = kReadMaxBytes;
 
         auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
         NKikimrClient::TResponse& res = *answer->Response;
@@ -4134,17 +4168,16 @@ Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
         ui32 cnt = 0;
         ui32 size = 0;
         ui32 lastBlobSize = 0;
-        const ui64 realReadOffset = 10;
 
         TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
                                                           0,
                                                           2,
                                                           nullptr,
-                                                          10,
-                                                          100,
-                                                          1_MB,
+                                                          kAddBlobsFromBodyProbeReadOffset10,
+                                                          kAddBlobsFromBodyProbeEndOffset,
+                                                          kAddBlobsFromBodyProbeSizeLag,
                                                           Ctx->Edge,
-                                                          realReadOffset,
+                                                          kAddBlobsFromBodyProbeReadOffset10,
                                                           readResult,
                                                           answer,
                                                           needStop,
@@ -4154,12 +4187,419 @@ Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
                                                           ctx);
 
         UNIT_ASSERT(!early.Defined());
-        UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 5u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 8u);
+        for (ui32 i = 0; i < 8; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(i).GetOffset(), 10u + i);
+        }
+    };
+
+    Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
+}
+
+// Empty TRequestedBlob body (retention / requested range past data): AddBlobsFromBody logs
+// "Not full answer here!", fills read result metadata and returns TReadAnswer early.
+Y_UNIT_TEST_F(AddBlobsFromBodyStopsOnEmptyBlob, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    const TPartitionId partitionId(1);
+
+    std::deque<TClientBlob> dq0;
+    dq0.push_back(MakeSinglePartBodyReadBlob(1, 'z'));
+    TString raw0 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(10, std::move(dq0)));
+
+    const TKey key0 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 10, 0, 1, 0);
+    TRequestedBlob blob0 = MakeRequestedBlobForRead(10, 0, 1, 0, std::move(raw0), key0);
+
+    // Key must not use Count==0 and InternalPartsCount==0 together; body is still empty (Empty()).
+    const TKey key1 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 11, 0, 1, 0);
+    TRequestedBlob blob1 = MakeRequestedBlobForRead(11, 0, 0, 0, TString(), key1);
+
+    TVector<TRequestedBlob> blobs;
+    blobs.push_back(std::move(blob0));
+    blobs.push_back(std::move(blob1));
+
+    auto probe = [&](const TActorContext& ctx) {
+        const ui32 consumedBytes = MakeSinglePartBodyReadBlob(1, 'z').GetSerializedSize();
+
+        TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset10);
+        info.Blobs = blobs;
+        info.CompactedBlobsCount = 2;
+
+        auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+        NKikimrClient::TResponse& res = *answer->Response;
+        auto* readResult = res.MutablePartitionResponse()->MutableCmdReadResult();
+
+        bool needStop = false;
+        ui32 cnt = 0;
+        ui32 size = 0;
+        ui32 lastBlobSize = 0;
+
+        TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                          0,
+                                                          2,
+                                                          nullptr,
+                                                          kAddBlobsFromBodyProbeReadOffset10,
+                                                          kAddBlobsFromBodyProbeEndOffset,
+                                                          kAddBlobsFromBodyProbeSizeLag,
+                                                          Ctx->Edge,
+                                                          kAddBlobsFromBodyProbeReadOffset10,
+                                                          readResult,
+                                                          answer,
+                                                          needStop,
+                                                          cnt,
+                                                          size,
+                                                          lastBlobSize,
+                                                          ctx);
+
+        UNIT_ASSERT(early.Defined());
+        UNIT_ASSERT(early->Event.Get() != nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
         UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(0).GetOffset(), 10u);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(1).GetOffset(), 11u);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(2).GetOffset(), 12u);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(3).GetOffset(), 13u);
-        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(4).GetOffset(), 13u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetLastOffset(), i64{10});
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetStartOffset(), kAddBlobsFromBodyProbeReadOffset10);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetEndOffset(), kAddBlobsFromBodyProbeEndOffset);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetSizeLag(), kAddBlobsFromBodyProbeSizeLag - consumedBytes);
+        UNIT_ASSERT_VALUES_EQUAL(info.RealReadOffset, kAddBlobsFromBodyProbeReadOffset10);
+        UNIT_ASSERT_VALUES_EQUAL(info.LastOffset, 10u);
+        UNIT_ASSERT_VALUES_EQUAL(info.Offset, 11u);
+    };
+
+    Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
+}
+
+// Covers "got gap": jump read cursor to blobs[blobIdx].Offset / PartNo when BS returns a hole.
+Y_UNIT_TEST_F(AddBlobsFromBodyGotGap, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    const TPartitionId partitionId(1);
+
+    auto probe = [&](const TActorContext& ctx) {
+        // Gap in partition offsets: reader at 10, first data in response starts at 12.
+        {
+            std::deque<TClientBlob> dq;
+            dq.push_back(MakeSinglePartBodyReadBlob(1, 'g'));
+            TString raw = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(12, std::move(dq)));
+
+            const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 12, 0, 1, 0);
+            TRequestedBlob blob = MakeRequestedBlobForRead(12, 0, 1, 0, std::move(raw), key);
+
+            TVector<TRequestedBlob> blobs;
+            blobs.push_back(std::move(blob));
+
+            TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset10);
+            info.Blobs = blobs;
+            info.CompactedBlobsCount = 1;
+
+            auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+            NKikimrClient::TResponse& res = *answer->Response;
+            auto* readResult = res.MutablePartitionResponse()->MutableCmdReadResult();
+
+            bool needStop = false;
+            ui32 cnt = 0;
+            ui32 size = 0;
+            ui32 lastBlobSize = 0;
+
+            TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                              0,
+                                                              1,
+                                                              nullptr,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              kAddBlobsFromBodyProbeEndOffset,
+                                                              kAddBlobsFromBodyProbeSizeLag,
+                                                              Ctx->Edge,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              readResult,
+                                                              answer,
+                                                              needStop,
+                                                              cnt,
+                                                              size,
+                                                              lastBlobSize,
+                                                              ctx);
+
+            UNIT_ASSERT(!early.Defined());
+            UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(0).GetOffset(), 12u);
+            UNIT_ASSERT_VALUES_EQUAL(info.Offset, 13u);
+            UNIT_ASSERT_VALUES_EQUAL(info.PartNo, 0u);
+        }
+
+        // Same partition offset, higher PartNo: reader expects part 0, blob carries part 1+.
+        {
+            std::deque<TClientBlob> dq;
+            dq.push_back(MakeMultipartBodyReadBlob(2, 1, 2, 16, 'h'));
+            TString raw = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(12, std::move(dq)));
+
+            const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 12, 1, 1, 0);
+            TRequestedBlob blob = MakeRequestedBlobForRead(12, 1, 1, 0, std::move(raw), key);
+
+            TVector<TRequestedBlob> blobs;
+            blobs.push_back(std::move(blob));
+
+            TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset12);
+            info.Blobs = blobs;
+            info.CompactedBlobsCount = 1;
+
+            auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+            NKikimrClient::TResponse& res = *answer->Response;
+            auto* readResult = res.MutablePartitionResponse()->MutableCmdReadResult();
+
+            bool needStop = false;
+            ui32 cnt = 0;
+            ui32 size = 0;
+            ui32 lastBlobSize = 0;
+
+            TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                              0,
+                                                              1,
+                                                              nullptr,
+                                                              kAddBlobsFromBodyProbeReadOffset12,
+                                                              kAddBlobsFromBodyProbeEndOffset,
+                                                              kAddBlobsFromBodyProbeSizeLag,
+                                                              Ctx->Edge,
+                                                              kAddBlobsFromBodyProbeReadOffset12,
+                                                              readResult,
+                                                              answer,
+                                                              needStop,
+                                                              cnt,
+                                                              size,
+                                                              lastBlobSize,
+                                                              ctx);
+
+            UNIT_ASSERT(!early.Defined());
+            UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(0).GetOffset(), 12u);
+            UNIT_ASSERT_VALUES_EQUAL(info.Offset, 13u);
+            UNIT_ASSERT_VALUES_EQUAL(info.PartNo, 0u);
+        }
+    };
+
+    Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
+}
+
+// Reader is past this blob's data: FindPos returns Max → "this batch does not contain data to read, skip it".
+Y_UNIT_TEST_F(AddBlobsFromBodySkipsBatchWhenReaderAhead, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    const TPartitionId partitionId(1);
+
+    std::deque<TClientBlob> dq;
+    dq.push_back(MakeSinglePartBodyReadBlob(1, 'p'));
+    dq.push_back(MakeSinglePartBodyReadBlob(2, 'q'));
+    dq.push_back(MakeSinglePartBodyReadBlob(3, 'r'));
+    TString raw = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(12, std::move(dq)));
+
+    const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 12, 0, 3, 0);
+    TRequestedBlob blob = MakeRequestedBlobForRead(12, 0, 3, 0, std::move(raw), key);
+
+    TVector<TRequestedBlob> blobs;
+    blobs.push_back(std::move(blob));
+
+    auto probe = [&](const TActorContext& ctx) {
+        TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset20);
+        info.Blobs = blobs;
+        info.CompactedBlobsCount = 1;
+
+        auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+        NKikimrClient::TResponse& res = *answer->Response;
+        auto* readResult = res.MutablePartitionResponse()->MutableCmdReadResult();
+
+        bool needStop = false;
+        ui32 cnt = 0;
+        ui32 size = 0;
+        ui32 lastBlobSize = 0;
+
+        TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                          0,
+                                                          1,
+                                                          nullptr,
+                                                          kAddBlobsFromBodyProbeReadOffset20,
+                                                          kAddBlobsFromBodyProbeEndOffset,
+                                                          kAddBlobsFromBodyProbeSizeLag,
+                                                          Ctx->Edge,
+                                                          kAddBlobsFromBodyProbeReadOffset20,
+                                                          readResult,
+                                                          answer,
+                                                          needStop,
+                                                          cnt,
+                                                          size,
+                                                          lastBlobSize,
+                                                          ctx);
+
+        UNIT_ASSERT(!early.Defined());
+        UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 0u);
+        UNIT_ASSERT_VALUES_EQUAL(info.Offset, kAddBlobsFromBodyProbeReadOffset20);
+        UNIT_ASSERT_VALUES_EQUAL(info.PartNo, 0u);
+    };
+
+    Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
+}
+
+// Covers: (1) `if (res.IsLastPart())` then + inner `if (ReachedLastOffset())`;
+// (2) UpdateUsage last-part branch with inner `if (messageSkippingBehaviour)` true vs false.
+Y_UNIT_TEST_F(AddBlobsFromBodyLastOffsetAndUpdateUsageSkips, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    const TPartitionId partitionId(1);
+
+    auto probe = [&](const TActorContext& ctx) {
+        auto makeOneBlob10 = [&]() {
+            std::deque<TClientBlob> dq;
+            dq.push_back(MakeSinglePartBodyReadBlob(1, 'u'));
+            TString raw = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(10, std::move(dq)));
+            const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 10, 0, 1, 0);
+            TVector<TRequestedBlob> blobs;
+            blobs.push_back(MakeRequestedBlobForRead(10, 0, 1, 0, std::move(raw), key));
+            return blobs;
+        };
+
+        // LastOffset bound: after finishing one message, Offset reaches TReadInfo::LastOffset → needStop
+        // before UpdateUsage on that row.
+        {
+            TVector<TRequestedBlob> blobs = makeOneBlob10();
+            constexpr ui64 kLastOff = 11;
+            TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset10, kLastOff);
+            info.Blobs = blobs;
+            info.CompactedBlobsCount = 1;
+
+            auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+            auto* readResult = answer->Response->MutablePartitionResponse()->MutableCmdReadResult();
+            bool needStop = false;
+            ui32 cnt = 0;
+            ui32 size = 0;
+            ui32 lastBlobSize = 0;
+
+            TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                              0,
+                                                              1,
+                                                              nullptr,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              kAddBlobsFromBodyProbeEndOffset,
+                                                              kAddBlobsFromBodyProbeSizeLag,
+                                                              Ctx->Edge,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              readResult,
+                                                              answer,
+                                                              needStop,
+                                                              cnt,
+                                                              size,
+                                                              lastBlobSize,
+                                                              ctx);
+
+            UNIT_ASSERT(!early.Defined());
+            UNIT_ASSERT(needStop);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(info.Offset, kLastOff);
+        }
+
+        // UpdateUsage: messageSkippingBehaviour true (FCC + ReadTimestampMs > write ts) → cnt not charged.
+        Ctx->Runtime->GetAppData(0).FeatureFlags.SetEnableSkipMessagesWithObsoleteTimestamp(false);
+        Ctx->Runtime->GetAppData(0).PQConfig.SetTopicsAreFirstClassCitizen(true);
+        NKikimr::AppData(ctx)->PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+        {
+            TVector<TRequestedBlob> blobs = makeOneBlob10();
+            TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge,
+                                                                 kAddBlobsFromBodyProbeReadOffset10,
+                                                                 0,
+                                                                 0,
+                                                                 1,
+                                                                 kAddBlobsFromBodyDefaultByteLimit,
+                                                                 1'000'000);
+            info.Blobs = blobs;
+            info.CompactedBlobsCount = 1;
+
+            auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+            auto* readResult = answer->Response->MutablePartitionResponse()->MutableCmdReadResult();
+            bool needStop = false;
+            ui32 cnt = 0;
+            ui32 size = 0;
+            ui32 lastBlobSize = 0;
+
+            TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                              0,
+                                                              1,
+                                                              nullptr,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              kAddBlobsFromBodyProbeEndOffset,
+                                                              kAddBlobsFromBodyProbeSizeLag,
+                                                              Ctx->Edge,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              readResult,
+                                                              answer,
+                                                              needStop,
+                                                              cnt,
+                                                              size,
+                                                              lastBlobSize,
+                                                              ctx);
+
+            UNIT_ASSERT(!early.Defined());
+            UNIT_ASSERT(!needStop);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
+        }
+
+        // UpdateUsage: no timestamp skip → cnt reaches Count → needStop from UpdateUsage.
+        Ctx->Runtime->GetAppData(0).FeatureFlags.SetEnableSkipMessagesWithObsoleteTimestamp(false);
+        Ctx->Runtime->GetAppData(0).PQConfig.SetTopicsAreFirstClassCitizen(false);
+        NKikimr::AppData(ctx)->PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+        {
+            TVector<TRequestedBlob> blobs = makeOneBlob10();
+            TReadInfo info = MakeReadInfoForAddBlobsFromBodyTest(Ctx->Edge, kAddBlobsFromBodyProbeReadOffset10, 0, 0, 1);
+            info.Blobs = blobs;
+            info.CompactedBlobsCount = 1;
+
+            auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+            auto* readResult = answer->Response->MutablePartitionResponse()->MutableCmdReadResult();
+            bool needStop = false;
+            ui32 cnt = 0;
+            ui32 size = 0;
+            ui32 lastBlobSize = 0;
+
+            TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                              0,
+                                                              1,
+                                                              nullptr,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              kAddBlobsFromBodyProbeEndOffset,
+                                                              kAddBlobsFromBodyProbeSizeLag,
+                                                              Ctx->Edge,
+                                                              kAddBlobsFromBodyProbeReadOffset10,
+                                                              readResult,
+                                                              answer,
+                                                              needStop,
+                                                              cnt,
+                                                              size,
+                                                              lastBlobSize,
+                                                              ctx);
+
+            UNIT_ASSERT(!early.Defined());
+            UNIT_ASSERT(needStop);
+            UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 1u);
+        }
     };
 
     Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -16,8 +16,6 @@
 #include <ydb/library/actors/core/event.h>
 #include <library/cpp/testing/unittest/registar.h>
 
-#include <deque>
-
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>
 #include <util/generic/ptr.h>
@@ -25,6 +23,9 @@
 #include <util/system/types.h>
 
 #include "make_config.h"
+
+#include <deque>
+#include <functional>
 
 template<>
 void Out<NKikimrPQ::TEvProposeTransactionResult_EStatus>(IOutputStream& out, NKikimrPQ::TEvProposeTransactionResult_EStatus v) {
@@ -4001,7 +4002,6 @@ Y_UNIT_TEST_F(GetPartitionWriteInfoWithoutSrcIdInfo, TPartitionFixture) {
 
 namespace {
 
-// обычное сообщение
 TClientBlob MakeSinglePartBodyReadBlob(ui64 seqNo, char fill) {
     TString data(24, fill);
     const ui32 sz = data.size();
@@ -4018,7 +4018,6 @@ TClientBlob MakeSinglePartBodyReadBlob(ui64 seqNo, char fill) {
     };
 }
 
-// часть большого сообщения. номер partNo, всего totalParts частей
 TClientBlob MakeMultipartBodyReadBlob(ui64 seqNo, ui16 partNo, ui16 totalParts, ui32 bytesPerPart, char fill) {
     const ui32 totalSize = bytesPerPart * totalParts;
     TString data(bytesPerPart, fill);
@@ -4043,7 +4042,6 @@ TString SerializePackedBatchForReadBodyTest(TBatch batch) {
     return raw;
 }
 
-// актор помогает вызвать функцию внутри акторной системы. функции PersQueue ожидают ссылку на AppData в TLS
 class TAddBlobsFromBodyReadTestActor : public TActorBootstrapped<TAddBlobsFromBodyReadTestActor> {
 public:
     TAddBlobsFromBodyReadTestActor(TActorId edge, std::function<void(const TActorContext&)> body)
@@ -4106,8 +4104,6 @@ Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
     blobs.push_back(std::move(blob1));
 
     auto probe = [&](const TActorContext& ctx) {
-        Y_UNUSED(ctx);
-
         constexpr ui32 kReadMaxMessages = 100;
         constexpr ui32 kReadMaxBytes = static_cast<ui32>(1_MB);
 
@@ -4159,6 +4155,11 @@ Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
 
         UNIT_ASSERT(!early.Defined());
         UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 5u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(0).GetOffset(), 10u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(1).GetOffset(), 11u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(2).GetOffset(), 12u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(3).GetOffset(), 13u);
+        UNIT_ASSERT_VALUES_EQUAL(readResult->GetResult(4).GetOffset(), 13u);
     };
 
     Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -11,9 +11,12 @@
 #include <ydb/public/lib/base/msgbus_status.h>
 #include <ydb/core/jaeger_tracing/sampling_throttling_configurator.h>
 
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/event.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <deque>
 
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>
@@ -3994,6 +3997,177 @@ Y_UNIT_TEST_F(GetPartitionWriteInfoWithoutSrcIdInfo, TPartitionFixture) {
 
         UNIT_ASSERT(event->BodyKeys.begin()->Key.ToString().StartsWith("D0000100001_"));
     }
+}
+
+namespace {
+
+// обычное сообщение
+TClientBlob MakeSinglePartBodyReadBlob(ui64 seqNo, char fill) {
+    TString data(24, fill);
+    const ui32 sz = data.size();
+    return {
+        TString("src"),
+        seqNo,
+        std::move(data),
+        TMaybe<TPartData>(),
+        TInstant::MilliSeconds(1),
+        TInstant::MilliSeconds(1),
+        sz,
+        TString(),
+        TString()
+    };
+}
+
+// часть большого сообщения. номер partNo, всего totalParts частей
+TClientBlob MakeMultipartBodyReadBlob(ui64 seqNo, ui16 partNo, ui16 totalParts, ui32 bytesPerPart, char fill) {
+    const ui32 totalSize = bytesPerPart * totalParts;
+    TString data(bytesPerPart, fill);
+    TMaybe<TPartData> partData = TPartData(partNo, totalParts, totalSize);
+    return {
+        TString("src"),
+        seqNo,
+        std::move(data),
+        std::move(partData),
+        TInstant::MilliSeconds(1),
+        TInstant::MilliSeconds(1),
+        bytesPerPart,
+        TString(),
+        TString()
+    };
+}
+
+TString SerializePackedBatchForReadBodyTest(TBatch batch) {
+    batch.Pack();
+    TString raw;
+    batch.SerializeTo(raw);
+    return raw;
+}
+
+// актор помогает вызвать функцию внутри акторной системы. функции PersQueue ожидают ссылку на AppData в TLS
+class TAddBlobsFromBodyReadTestActor : public TActorBootstrapped<TAddBlobsFromBodyReadTestActor> {
+public:
+    TAddBlobsFromBodyReadTestActor(TActorId edge, std::function<void(const TActorContext&)> body)
+        : Edge(edge)
+        , Body(std::move(body))
+    {}
+
+    void Bootstrap(const TActorContext& ctx) {
+        Body(ctx);
+        Send(Edge, new NActors::TEvents::TEvWakeup());
+        PassAway();
+    }
+
+private:
+    TActorId Edge;
+    std::function<void(const TActorContext&)> Body;
+};
+
+}
+
+Y_UNIT_TEST_F(AddBlobsFromBodyUsesKeyOfCurrentBlob, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+
+    const TPartitionId partitionId(1);
+
+    std::deque<TClientBlob> dq0;
+    dq0.push_back(MakeSinglePartBodyReadBlob(1, 'a'));
+    dq0.push_back(MakeSinglePartBodyReadBlob(2, 'b'));
+    dq0.push_back(MakeSinglePartBodyReadBlob(3, 'b'));
+
+    const TKey key0 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 10, 0, 3, 0);
+    TString raw0 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(10, std::move(dq0)));
+    TRequestedBlob blob0(10,
+                         0,
+                         3,
+                         0,
+                         raw0.size(),
+                         raw0,
+                         key0,
+                         TInstant::Now().Seconds());
+
+    std::deque<TClientBlob> dq1;
+    dq1.push_back(MakeSinglePartBodyReadBlob(4, 'c'));
+    dq1.push_back(MakeMultipartBodyReadBlob(5, 0, 2, 20, 'd'));
+    dq1.push_back(MakeMultipartBodyReadBlob(5, 1, 2, 20, 'e'));
+
+    const TKey key1 = TKey::ForBody(TKeyPrefix::TypeData, partitionId, 12, 0, 2, 1);
+    TString raw1 = SerializePackedBatchForReadBodyTest(TBatch::FromBlobs(12, std::move(dq1)));
+    TRequestedBlob blob1(12,
+                         0,
+                         2,
+                         1,
+                         raw1.size(),
+                         raw1,
+                         key1,
+                         TInstant::Now().Seconds());
+
+    TVector<TRequestedBlob> blobs;
+    blobs.push_back(std::move(blob0));
+    blobs.push_back(std::move(blob1));
+
+    auto probe = [&](const TActorContext& ctx) {
+        Y_UNUSED(ctx);
+
+        constexpr ui32 kReadMaxMessages = 100;
+        constexpr ui32 kReadMaxBytes = static_cast<ui32>(1_MB);
+
+        TReadInfo info(TString("user"),
+                       TString("dc"),
+                       ui64{10},
+                       ui64{0},
+                       ui16{0},
+                       ui64{kReadMaxMessages},
+                       kReadMaxBytes,
+                       ui64{0},
+                       ui64{0},
+                       TDuration::Zero(),
+                       false,
+                       Ctx->Edge,
+                       false,
+                       Ctx->Edge);
+        info.Blobs = blobs;
+        info.CompactedBlobsCount = 2;
+        info.Count = kReadMaxMessages;
+        info.Size = kReadMaxBytes;
+
+        auto answer = MakeHolder<TEvPQ::TEvProxyResponse>(0, false);
+        NKikimrClient::TResponse& res = *answer->Response;
+        auto* readResult = res.MutablePartitionResponse()->MutableCmdReadResult();
+
+        bool needStop = false;
+        ui32 cnt = 0;
+        ui32 size = 0;
+        ui32 lastBlobSize = 0;
+        const ui64 realReadOffset = 10;
+
+        TMaybe<TReadAnswer> early = info.AddBlobsFromBody(blobs,
+                                                          0,
+                                                          2,
+                                                          nullptr,
+                                                          10,
+                                                          100,
+                                                          1_MB,
+                                                          Ctx->Edge,
+                                                          realReadOffset,
+                                                          readResult,
+                                                          answer,
+                                                          needStop,
+                                                          cnt,
+                                                          size,
+                                                          lastBlobSize,
+                                                          ctx);
+
+        UNIT_ASSERT(!early.Defined());
+        UNIT_ASSERT_VALUES_EQUAL(readResult->ResultSize(), 5u);
+    };
+
+    Ctx->Runtime->Register(new TAddBlobsFromBodyReadTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
 }
 
 } // End of suite


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #37558

В `TReadInfo::AddBlobsFromBody` есть ветка с `FindPos`. При разборе нескольких блобов в одном ответе в этой ветке для смещения внутри батча использовался первый блоб (blobs[0]), а не текущий (blobs[i]).

В результате батч пропускался и часть сообщений не попадала в результат.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
