### PR TITLE
Support false_positive_probability for DataShard prefix bloom filter indexes

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1,6 +1,7 @@
 #include "kqp_host_impl.h"
 
 #include <ydb/core/formats/arrow/accessor/common/const.h>
+#include <ydb/core/tablet_flat/bloom_filter_defaults.h>
 #include <ydb/core/formats/arrow/serializer/parsing.h>
 #include <ydb/core/formats/arrow/serializer/utils.h>
 #include <ydb/core/grpc_services/table_settings.h>
@@ -1001,7 +1002,7 @@ public:
                 if (!metadata->Indexes.empty() || !sequences.empty()) {
                     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
                     tableDesc = schemeTx.MutableCreateIndexedTable()->MutableTableDescription();
-                    TSet<ui32> bloomPrefixes;
+                    TMap<ui32, double> bloomPrefixes;
                     for (auto&& index : metadata->Indexes) {
                         const bool isLocalBloom = (index.Type == TIndexDescription::EType::LocalBloomFilter ||
                                     index.Type == TIndexDescription::EType::LocalBloomNgramFilter);
@@ -1017,8 +1018,22 @@ public:
                                 continue; // handled by OLAP path below
                             }
 
-                            // Row-store LocalBloomFilter: collect prefix lengths for de-duplication
-                            bloomPrefixes.insert(static_cast<ui32>(index.KeyColumns.size()));
+                            // Row-store LocalBloomFilter: collect prefix lengths + FPP
+                            {
+                                ui32 prefix = static_cast<ui32>(index.KeyColumns.size());
+                                double fpp = NTable::DefaultBloomFilterFpp;
+                                if (auto* desc = std::get_if<TIndexDescription::TLocalBloomFilterDescription>(&index.SpecializedIndexDescription)) {
+                                    if (desc->FalsePositiveProbability) {
+                                        fpp = *desc->FalsePositiveProbability;
+                                        if (fpp <= 0.0 || fpp >= 1.0) {
+                                            tablePromise.SetValue(ResultFromError<TGenericResult>(
+                                                "false_positive_probability must be in range (0, 1)"));
+                                            return;
+                                        }
+                                    }
+                                }
+                                bloomPrefixes[prefix] = fpp;
+                            }
                             continue;
                         }
 
@@ -1052,8 +1067,10 @@ public:
                                 break;
                         }
                     }
-                    for (ui32 prefix : bloomPrefixes) {
-                        tableDesc->MutablePartitionConfig()->AddByKeyFilterPrefixes(prefix);
+                    for (const auto& [prefix, fpp] : bloomPrefixes) {
+                        auto* entry = tableDesc->MutablePartitionConfig()->AddByKeyFilterPrefixes();
+                        entry->SetPrefixLength(prefix);
+                        entry->SetFalsePositiveProbability(fpp);
                     }
                     if (!FillCreateTableColumnDesc(*tableDesc, pathPair.second, metadata, columnError)) {
                         tablePromise.SetValue(ResultFromError<TGenericResult>(columnError));

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1617,8 +1617,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
         }
 
         // KEY_BLOOM_FILTER = DISABLED disables all bloom filters on the table
@@ -1638,7 +1638,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
         }
 
         execScheme(R"(
@@ -1649,8 +1649,23 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
+        }
+
+        // ALTER TABLE ADD INDEX with custom false_positive_probability
+        execScheme(R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T`
+            ADD INDEX idx_bloom3 LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0.05);
+        )");
+        {
+            auto cfg = getPartitionConfig();
+            // prefix 1 already existed, FPP should be updated to 0.05
+            UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_DOUBLES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetFalsePositiveProbability(), 0.05, 1e-9);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
         }
 
         // KEY_BLOOM_FILTER = DISABLED clears all bloom filters including ByKeyFilterPrefixes
@@ -1683,6 +1698,21 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) COVER (Value);
+        )");
+        // false_positive_probability must be in (0, 1)
+        auto expectBadRequest = [&](const TString& q) {
+            auto result = session.ExecuteSchemeQuery(q).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        };
+        expectBadRequest(R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T`
+            ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0);
+        )");
+        expectBadRequest(R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T`
+            ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=1);
         )");
     }
 

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -208,7 +208,13 @@ message TPartitionConfig {
     repeated NKikimrHive.TFollowerGroup FollowerGroups = 23;
     reserved 24; // EMvccState MvccState = 24; no longer used
     optional uint64 KeepSnapshotTimeout = 25; // milliseconds
-    repeated uint32 ByKeyFilterPrefixes = 26; // Build per-part bloom filters on PK prefixes of these lengths (number of leading key columns)
+    reserved 26; // deprecated -> ByKeyFilterPrefixes
+    repeated TByKeyFilterPrefix ByKeyFilterPrefixes = 27; // Bloom filters on PK prefixes
+}
+
+message TByKeyFilterPrefix {
+    optional uint32 PrefixLength = 1;           // Number of leading key columns
+    optional double FalsePositiveProbability = 2; // Bloom filter FPP (default 0.0001 when absent)
 }
 
 message TSplitBoundary {

--- a/ydb/core/protos/scheme_log.proto
+++ b/ydb/core/protos/scheme_log.proto
@@ -1,4 +1,5 @@
 import "ydb/core/protos/compaction.proto";
+import "ydb/core/protos/flat_scheme_op.proto";
 import "ydb/core/scheme/protos/type_info.proto";
 
 package NTabletFlatScheme;
@@ -64,7 +65,8 @@ message TAlterRecord {
     optional bytes Default = 10;    // Serialized default value for cell
     optional bool NotNull = 24 [default = false];
     optional bool IsSensitive = 28 [default = false];
-    repeated uint32 ByKeyFilterPrefixes = 29; // Prefix bloom filter column counts (number of leading PK columns)
+    reserved 29; // deprecated -> ByKeyFilterPrefixes
+    repeated NKikimrSchemeOp.TByKeyFilterPrefix ByKeyFilterPrefixes = 30; // Bloom filters on PK prefixes
 
     optional uint64 ExecutorCacheSize = 100;
     optional NKikimrCompaction.TCompactionPolicy CompactionPolicy = 101;

--- a/ydb/core/sys_view/ut_show_create.cpp
+++ b/ydb/core/sys_view/ut_show_create.cpp
@@ -2442,6 +2442,26 @@ Y_UNIT_TEST(TableDataShardLocalBloomFilterIndex) {
             );
         )"
     );
+
+    // Custom false_positive_probability — should appear in SHOW CREATE output
+    checker.CheckShowCreateTable(
+        R"(
+            CREATE TABLE test_show_create (
+                Key1 Uint64 NOT NULL,
+                Value String,
+                PRIMARY KEY (Key1),
+                INDEX idx_bloom LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0.05)
+            );
+        )", "test_show_create",
+        R"(
+            CREATE TABLE `test_show_create` (
+                `Key1` Uint64 NOT NULL,
+                `Value` String,
+                INDEX `idx_bloom_1` LOCAL USING bloom_filter ON (`Key1`) WITH (false_positive_probability=0.05),
+                PRIMARY KEY (`Key1`)
+            );
+        )"
+    );
 }
 
 }

--- a/ydb/core/tablet_flat/bloom_filter_defaults.h
+++ b/ydb/core/tablet_flat/bloom_filter_defaults.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace NKikimr::NTable {
+
+// Default false positive probability for bloom filters when not explicitly specified
+inline constexpr double DefaultBloomFilterFpp = 0.0001;
+
+} // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -2,6 +2,7 @@
 #include "util_fmt_abort.h"
 
 #include <ydb/core/base/localdb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 
 namespace NKikimr {
@@ -149,16 +150,17 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
 
         if (delta.HasByKeyFilter()) {
             // Legacy: convert ByKeyFilter bool to a prefix entry for full key
+            using TPrefix = TScheme::TTableInfo::TByKeyFilterPrefix;
             ui32 keyCount = tableInfo.KeyColumns.size();
-            TVector<ui32> prefixes = tableInfo.ByKeyFilterPrefixes;
+            auto prefixes = tableInfo.ByKeyFilterPrefixes;
             if (delta.GetByKeyFilter()) {
-                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), keyCount);
-                if (it == prefixes.end() || *it != keyCount) {
-                    prefixes.insert(it, keyCount);
+                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), TPrefix{keyCount, 0});
+                if (it == prefixes.end() || it->PrefixLength != keyCount) {
+                    prefixes.insert(it, TPrefix{keyCount, DefaultBloomFilterFpp});
                 }
             } else {
-                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), keyCount);
-                if (it != prefixes.end() && *it == keyCount) {
+                auto it = std::lower_bound(prefixes.begin(), prefixes.end(), TPrefix{keyCount, 0});
+                if (it != prefixes.end() && it->PrefixLength == keyCount) {
                     prefixes.erase(it);
                 }
             }
@@ -166,17 +168,22 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
         }
 
         if (delta.ByKeyFilterPrefixesSize() > 0) {
+            using TPrefix = TScheme::TTableInfo::TByKeyFilterPrefix;
             ui32 keyCount = tableInfo.KeyColumns.size();
-            TVector<ui32> prefixes;
-            for (auto p : delta.GetByKeyFilterPrefixes()) {
-                if (p > 0) {
-                    Y_ENSURE(p <= keyCount,
-                        "Bloom filter prefix " << p << " exceeds key column count " << keyCount);
-                    prefixes.push_back(p);
+            TMap<ui32, double> prefixMap;
+            for (const auto& p : delta.GetByKeyFilterPrefixes()) {
+                ui32 len = p.GetPrefixLength();
+                if (len > 0) {
+                    Y_ENSURE(len <= keyCount,
+                        "Bloom filter prefix " << len << " exceeds key column count " << keyCount);
+                    double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : DefaultBloomFilterFpp;
+                    prefixMap[len] = fpp;
                 }
             }
-            SortUnique(prefixes);
-            // A single 0 entry means "clear all", resulting in empty vector
+            TVector<TPrefix> prefixes;
+            for (const auto& [len, fpp] : prefixMap) {
+                prefixes.push_back(TPrefix{len, fpp});
+            }
             changes |= ChangeTableSetting(table, tableInfo.ByKeyFilterPrefixes, prefixes);
         }
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -1,5 +1,6 @@
 #include "flat_dbase_scheme.h"
 
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/scheme/protos/type_info.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 
@@ -73,11 +74,12 @@ TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
 
         // For backward compatibility: if full-key bloom filter is enabled,
         // also set legacy ByKeyFilter=true so older versions understand it
-        bool hasFullKeyBloom = std::find(
+        ui32 keyCount = itTable.second.KeyColumns.size();
+        bool hasFullKeyBloom = std::any_of(
             itTable.second.ByKeyFilterPrefixes.begin(),
             itTable.second.ByKeyFilterPrefixes.end(),
-            itTable.second.KeyColumns.size()
-        ) != itTable.second.ByKeyFilterPrefixes.end();
+            [keyCount](const auto& p) { return p.PrefixLength == keyCount; }
+        );
 
         if (hasFullKeyBloom) {
             delta.SetByKeyFilter(table, true);
@@ -363,18 +365,21 @@ TAlter& TAlter::SetByKeyFilter(ui32 tableId, bool enabled)
     return ApplyLastRecord();
 }
 
-TAlter& TAlter::SetByKeyFilterPrefixes(ui32 tableId, const TVector<ui32>& prefixes)
+TAlter& TAlter::SetByKeyFilterPrefixes(ui32 tableId, const TVector<TScheme::TTableInfo::TByKeyFilterPrefix>& prefixes)
 {
     TAlterRecord &delta = *Log.AddDelta();
     delta.SetDeltaType(TAlterRecord::SetTable);
     delta.SetTableId(tableId);
     if (prefixes.empty()) {
-        // Sentinel: a single 0 entry means "clear all prefix bloom filters"
-        delta.AddByKeyFilterPrefixes(0);
+        // Sentinel: a single entry with PrefixLength=0 means "clear all prefix bloom filters"
+        auto* entry = delta.AddByKeyFilterPrefixes();
+        entry->SetPrefixLength(0);
     } else {
-        for (ui32 p : prefixes) {
-            Y_ENSURE(p > 0, "Prefix length must be positive");
-            delta.AddByKeyFilterPrefixes(p);
+        for (const auto& p : prefixes) {
+            Y_ENSURE(p.PrefixLength > 0, "Prefix length must be positive");
+            auto* entry = delta.AddByKeyFilterPrefixes();
+            entry->SetPrefixLength(p.PrefixLength);
+            entry->SetFalsePositiveProbability(p.FalsePositiveProbability);
         }
     }
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "bloom_filter_defaults.h"
 #include "flat_table_column.h"
 #include "flat_page_iface.h"
 #include "util_basics.h"
@@ -83,7 +84,14 @@ public:
 
         TIntrusiveConstPtr<TCompactionPolicy> CompactionPolicy;
         bool ColdBorrow = false;
-        TVector<ui32> ByKeyFilterPrefixes; // Prefix column counts for bloom filters (full-key = keyColumnCount entry)
+        struct TByKeyFilterPrefix {
+            ui32 PrefixLength = 0;
+            double FalsePositiveProbability = DefaultBloomFilterFpp;
+
+            bool operator==(const TByKeyFilterPrefix&) const = default;
+            auto operator<=>(const TByKeyFilterPrefix&) const = default;
+        };
+        TVector<TByKeyFilterPrefix> ByKeyFilterPrefixes;
         bool EraseCacheEnabled = false;
         ui32 EraseCacheMinRows = 0; // 0 means use default
         ui32 EraseCacheMaxBytes = 0; // 0 means use default
@@ -249,7 +257,7 @@ public:
     TAlter& SetExecutorResourceProfile(const TString &name);
     TAlter& SetCompactionPolicy(ui32 tableId, const TCompactionPolicy& newPolicy);
     TAlter& SetByKeyFilter(ui32 tableId, bool enabled);
-    TAlter& SetByKeyFilterPrefixes(ui32 tableId, const TVector<ui32>& prefixes);
+    TAlter& SetByKeyFilterPrefixes(ui32 tableId, const TVector<TScheme::TTableInfo::TByKeyFilterPrefix>& prefixes);
     TAlter& SetColdBorrow(ui32 tableId, bool enabled);
     TAlter& SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 maxBytes);
     TAlter& SetRewrite();

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "flat_executor.h"
 #include "flat_executor_bootlogic.h"
 #include "flat_executor_txloglogic.h"
@@ -680,7 +682,7 @@ void TExecutor::TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPa
         return;
     }
     TTransactionWaitPad& transaction = *it->second;
-    
+
     if (pageCollection) {
         auto &pinnedCollection = transaction.Seat->Pinned[pageCollection->Id];
         for (auto& loaded : loadedPages) {
@@ -760,7 +762,7 @@ void TExecutor::AddPageCollection(const TIntrusivePtr<TPrivatePageCache::TPageCo
 {
     auto syncPages = PrivatePageCache->AddPageCollection(pageCollection);
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(pageCollection->PageCollection, pageCollection->GetCacheMode()));
-   
+
     if (syncPages) {
         Send(MakeSharedPageCacheId(), new NSharedCache::TEvSync(std::move(syncPages)));
     }
@@ -4018,7 +4020,7 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
                 Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY].Set(stats.StickyBytes);
                 Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY].Set(stats.TryKeepInMemoryBytes);
             }
-            
+
             Counters->Simple()[TExecutorCounters::CACHE_TOTAL_USED].Set(TransactionPagesMemory);
 
             const auto &memory = Memory->Stats();
@@ -4825,12 +4827,21 @@ bool TExecutor::HasSchemaChanges(const NTable::TPartView& partView, const NTable
     }
 
     { // Check bloom filters
-        TVector<ui32> partPrefixes;
-        for (const auto& [prefixLen, bloom] : partView->ByKeyPrefixes) {
-            if (bloom) partPrefixes.push_back(prefixLen);
-        }
-        if (partPrefixes != tableInfo.ByKeyFilterPrefixes) {
+        if (partView->ByKeyPrefixes.size() != tableInfo.ByKeyFilterPrefixes.size()) {
             return true;
+        }
+        for (size_t i = 0; i < tableInfo.ByKeyFilterPrefixes.size(); ++i) {
+            const auto& [prefixLen, bloom] = partView->ByKeyPrefixes[i];
+            const auto& expected = tableInfo.ByKeyFilterPrefixes[i];
+            if (!bloom || prefixLen != expected.PrefixLength) {
+                return true;
+            }
+            // Detect FalsePositiveProbability changes: hashes = ceil(-log2(fpp))
+            ui16 expectedHashes = static_cast<ui16>(std::min<ui64>(
+                Max<ui16>(), static_cast<ui64>(std::ceil(-std::log2(expected.FalsePositiveProbability)))));
+            if (bloom->Stats().Hashes != expectedHashes) {
+                return true;
+            }
         }
     }
 
@@ -4902,7 +4913,9 @@ ui64 TExecutor::BeginCompaction(THolder<NTable::TCompactionParams> params)
     comp->Layout.WriteFlatIndex = AppData()->FeatureFlags.GetEnableLocalDBFlatIndex();
     comp->Writer.StickyFlatIndex = !comp->Layout.WriteBTreeIndex;
     comp->Layout.MaxRows = snapshot->Subset->MaxRows();
-    comp->Layout.ByKeyFilterPrefixes = tableInfo->ByKeyFilterPrefixes;
+    for (const auto& p : tableInfo->ByKeyFilterPrefixes) {
+        comp->Layout.ByKeyFilterPrefixes.push_back({p.PrefixLength, p.FalsePositiveProbability});
+    }
     comp->Layout.UnderlayMask = comp->Params->UnderlayMask.Get();
     comp->Layout.SplitKeys = comp->Params->SplitKeys.Get();
     comp->Layout.MinRowVersion = snapshot->Subset->MinRowVersion();

--- a/ydb/core/tablet_flat/flat_page_conf.h
+++ b/ydb/core/tablet_flat/flat_page_conf.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "bloom_filter_defaults.h"
 #include "flat_page_iface.h"
 #include "flat_row_eggs.h"
 
@@ -88,7 +89,11 @@ namespace NPage {
         ui32 MaxLargeBlob = 8 * 1024 * 1024 - 8; /* Maximum large blob size */
         ui32 LargeEdge = Max<ui32>();   /* External blob edge size      */
         ui32 SmallEdge = Max<ui32>();   /* Outer blobs edge bytes limit */
-        TVector<ui32> ByKeyFilterPrefixes; /* Bloom filters on PK prefixes of these lengths */
+        struct TByKeyFilterPrefix {
+            ui32 PrefixLength = 0;
+            double FalsePositiveProbability = DefaultBloomFilterFpp;
+        };
+        TVector<TByKeyFilterPrefix> ByKeyFilterPrefixes;
         ui64 MaxRows = 0;               /* Used to set up bloom filter size */
         ui64 SliceSize = Max<ui64>();   /* Data size for slice creation */
         ui64 MainPageCollectionEdge = Max<ui64>();

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -63,13 +63,15 @@ namespace NTable {
                 Histories.emplace_back(scheme, conf, tags, NPage::TGroupId(group, true));
             }
 
-            for (ui32 prefixLen : conf.ByKeyFilterPrefixes) {
+            for (const auto& bloomPrefix : conf.ByKeyFilterPrefixes) {
+                ui32 prefixLen = bloomPrefix.PrefixLength;
+                double fpp = bloomPrefix.FalsePositiveProbability;
                 Y_ENSURE(prefixLen > 0 && prefixLen <= Scheme->Groups[0].ColsKeyData.size(),
                     "Bloom filter prefix " << prefixLen << " exceeds key column count " << Scheme->Groups[0].ColsKeyData.size());
                 if (MainPageCollectionEdge || SmallPageCollectionEdge || !conf.MaxRows) {
-                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TQueue>(0.0001));
+                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TQueue>(fpp));
                 } else {
-                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TWriter>(conf.MaxRows, 0.0001));
+                    ByKeyPrefixes.emplace_back(prefixLen, MakeHolder<NBloom::TWriter>(conf.MaxRows, fpp));
                 }
             }
 

--- a/ydb/core/tablet_flat/test/libs/table/test_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dbase.h
@@ -295,7 +295,9 @@ namespace NTest {
 
             NPage::TConf conf{ last, 8291, family->Large };
 
-            conf.ByKeyFilterPrefixes = Base->GetScheme().GetTableInfo(table)->ByKeyFilterPrefixes;
+            for (const auto& p : Base->GetScheme().GetTableInfo(table)->ByKeyFilterPrefixes) {
+                conf.ByKeyFilterPrefixes.push_back(NPage::TConf::TByKeyFilterPrefix{p.PrefixLength, p.FalsePositiveProbability});
+            }
             conf.MaxRows = subset->MaxRows();
             conf.MinRowVersion = subset->MinRowVersion();
             conf.SmallEdge = family->Small;

--- a/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
+++ b/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
@@ -148,7 +148,9 @@ public:
         conf.SmallEdge = family->Small;
         conf.LargeEdge = family->Large;
         conf.MaxRows = subset->MaxRows();
-        conf.ByKeyFilterPrefixes = scheme.GetTableInfo(params->Table)->ByKeyFilterPrefixes;
+        for (const auto& p : scheme.GetTableInfo(params->Table)->ByKeyFilterPrefixes) {
+            conf.ByKeyFilterPrefixes.push_back(NPage::TConf::TByKeyFilterPrefix{p.PrefixLength, p.FalsePositiveProbability});
+        }
 
         // Don't care about moving blobs by reference
         TAutoPtr<IPages> env = new TTestEnv;

--- a/ydb/core/tablet_flat/ut/ut_bloom.cpp
+++ b/ydb/core/tablet_flat/ut/ut_bloom.cpp
@@ -12,6 +12,7 @@ namespace NTable {
 
 Y_UNIT_TEST_SUITE(Bloom) {
     using namespace NTest;
+    using TBloomPrefix = TScheme::TTableInfo::TByKeyFilterPrefix;
 
     static const NTest::TMass Mass0(new NTest::TModelS3Hash, 24000, 42, 0.5);
 
@@ -191,7 +192,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
 
         /*_ 20: Make next part Pw with enabled by key bloom filter */
 
-        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}}));
         me.To(21).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1, false);
         me.To(22).Select(1).Has(ru1, ru2, rw1, rw2, rw3).NoKey(no1, no2, no3);
 
@@ -279,7 +280,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
 
         /*_ 10: Enable prefix bloom on first PK column only */
 
-        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {1}));
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{1}}));
         me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
         me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noSame, noDiff1, noDiff2);
 
@@ -357,7 +358,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
 
         /* Enable prefix bloom on 1 column and full-key bloom (prefix=3) */
         me.To(11).Begin()
-            .Apply(*TAlter().SetByKeyFilterPrefixes(1, {1, 3}));
+            .Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{1}, TBloomPrefix{3}}));
         me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
         me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noSamePrefix, noDiffPrefix);
 
@@ -404,7 +405,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         /* Different 1st column — rejected by bloom-on-2 (longest) */
         const auto noDiff = *me.SchemedCookRow(1).Col("aab", 100_u64, "x1");
 
-        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2, 1})); /* deliberately reversed */
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}, TBloomPrefix{1}})); /* deliberately reversed */
         me.To(12).Put(1, rw1, rw2, rw3).Commit().Snap(1).Compact(1);
         me.To(13).Select(1).Has(rw1, rw2, rw3).NoKey(noPassesFirst, noDiff);
 
@@ -494,7 +495,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         const auto no1 = *me.SchemedCookRow(1).Col("ba1_p9lw", 53543_u64);
 
         /* Enable bloom, write data, compact */
-        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}}));
         me.To(21).Put(1, rw1, rw2).Commit().Snap(1).Compact(1);
 
         /* Bloom filters before restart */
@@ -544,7 +545,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         const auto no1 = *me.SchemedCookRow(1).Col("ba1_p9lw", 53543_u64);
 
         /* Enable bloom, write data, compact */
-        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2}));
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}}));
         me.To(21).Put(1, rw1, rw2).Commit().Snap(1).Compact(1);
 
         /* Bloom filters initially */
@@ -603,7 +604,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
         me.To(10).Begin().Apply(*MakeAlter()).Commit();
 
         /* Enable full-key (2-column) bloom filter using new API */
-        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2})).Commit();
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}})).Commit();
 
         /* GetSnapshot() must include both legacy ByKeyFilter and new ByKeyFilterPrefixes */
         {
@@ -637,17 +638,74 @@ Y_UNIT_TEST_SUITE(Bloom) {
         me.To(10).Begin().Apply(*MakeAlter()).Commit();
 
         // prefix=1 (first key column): valid
-        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {1})).Commit();
+        me.To(11).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{1}})).Commit();
 
         // prefix=2 (full key): valid
-        me.To(12).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {2})).Commit();
+        me.To(12).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2}})).Commit();
 
         // prefix=3: exceeds key column count — must be rejected
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            me.Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {3})),
+            me.Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{3}})),
             yexception,
             "exceeds key column count"
         );
+    }
+
+    Y_UNIT_TEST(FalsePositiveProbability)
+    {
+        /* Verify that FPP setting affects bloom filter parameters.
+           For n items, optimal bloom filter uses:
+             bits = ceil(-1.44 * log2(fpp) * n), rounded up to 64
+             hashes = ceil(-log2(fpp))
+           With 100 rows:
+             fpp=0.5:   bits=ceil(1.44*100)=144→192,  hashes=1
+             fpp=0.001: bits=ceil(14.3*100)=1430→1472, hashes=10 */
+        TDbExec me;
+        me.To(10).Begin().Apply(*MakeAlter()).Commit();
+
+        // Enable bloom with high FPP (0.5)
+        me.To(20).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2, 0.5}})).Commit();
+
+        // Insert 100 rows
+        me.To(21).Begin();
+        for (ui32 i = 0; i < 100; ++i) {
+            me.Put(1, *me.SchemedCookRow(1).Col(Sprintf("key_%03u", i), ui64(i)));
+        }
+        me.Commit().Snap(1).Compact(1, true);
+
+        NPage::TBloom::TStats statsHighFpp;
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 1);
+            statsHighFpp = subset->Flatten[0]->ByKeyPrefixes[0].second->Stats();
+        }
+
+        // Switch to low FPP (0.001)
+        me.To(30).Begin().Apply(*TAlter().SetByKeyFilterPrefixes(1, {TBloomPrefix{2, 0.001}})).Commit();
+
+        // Insert same rows again for new compaction
+        me.To(31).Begin();
+        for (ui32 i = 0; i < 100; ++i) {
+            me.Put(1, *me.SchemedCookRow(1).Col(Sprintf("key_%03u", i), ui64(i)));
+        }
+        me.Commit().Snap(1).Compact(1, true);
+
+        NPage::TBloom::TStats statsLowFpp;
+        {
+            auto subset = me->Subset(1, TEpoch::Max(), { }, { });
+            UNIT_ASSERT(subset->Flatten.size() == 1);
+            UNIT_ASSERT(subset->Flatten[0]->ByKeyPrefixes.size() == 1);
+            statsLowFpp = subset->Flatten[0]->ByKeyPrefixes[0].second->Stats();
+        }
+
+        // hashes = ceil(-log2(fpp)): fpp=0.5 → 1, fpp=0.001 → 10
+        UNIT_ASSERT_VALUES_EQUAL(statsHighFpp.Hashes, 1);
+        UNIT_ASSERT_VALUES_EQUAL(statsLowFpp.Hashes, 10);
+
+        // bits: fpp=0.5 → 192, fpp=0.001 → 1472
+        UNIT_ASSERT_VALUES_EQUAL(statsHighFpp.Items, 192);
+        UNIT_ASSERT_VALUES_EQUAL(statsLowFpp.Items, 1472);
     }
 
     Y_UNIT_TEST(Stairs)
@@ -671,7 +729,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
             alter.AddColumn(1, name, col, ETypes::String, false, false);
             alter.AddColumnToKey(1, col);
             if (col > 10) {
-                alter.SetByKeyFilterPrefixes(1, {col}); /* enable bloom on full key */
+                alter.SetByKeyFilterPrefixes(1, {TBloomPrefix{col}}); /* enable bloom on full key */
             } else {
                 alter.SetByKeyFilterPrefixes(1, {}); /* no bloom for first 8 parts */
             }

--- a/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         initialConf.CutIndexKeys = false;
         initialConf.SmallEdge = 19;
         initialConf.LargeEdge = 29;
-        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
+        initialConf.ByKeyFilterPrefixes = {NPage::TConf::TByKeyFilterPrefix{2}}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = mass.Saved.Size();
 
         RunMainEdgeTest(mass.Model->Scheme, mass.Saved, initialConf, false, 2);
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         initialConf.CutIndexKeys = false;
         initialConf.SmallEdge = 19;
         initialConf.LargeEdge = 29;
-        initialConf.ByKeyFilterPrefixes = {2}; /* full-key bloom for 2-column PK */
+        initialConf.ByKeyFilterPrefixes = {NPage::TConf::TByKeyFilterPrefix{2}}; /* full-key bloom for 2-column PK */
         initialConf.MaxRows = mass.Saved.Size();
 
         auto initial =
@@ -196,7 +196,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
+        initialConf.ByKeyFilterPrefixes = {NPage::TConf::TByKeyFilterPrefix{1}}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
 
         RunMainEdgeTest(lay.RowScheme(), rows, initialConf);
@@ -227,7 +227,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
+        initialConf.ByKeyFilterPrefixes = {NPage::TConf::TByKeyFilterPrefix{1}}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.SmallEdge = 13;
 
@@ -259,7 +259,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         auto initialConf = NPage::TConf{ false, 2044 };
         // precise size estimation doesn't work with cut keys
         initialConf.CutIndexKeys = false;
-        initialConf.ByKeyFilterPrefixes = {1}; /* full-key bloom for 1-column PK */
+        initialConf.ByKeyFilterPrefixes = {NPage::TConf::TByKeyFilterPrefix{1}}; /* full-key bloom for 1-column PK */
         initialConf.MaxRows = rows.Size();
         initialConf.LargeEdge = 13;
 

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -483,18 +483,23 @@ void TUserTable::DoApplyCreate(
     }
 
     {
+        using TPrefix = NTable::TScheme::TTableInfo::TByKeyFilterPrefix;
         // Unify EnableFilterByKey and ByKeyFilterPrefixes into a single prefix list
-        TVector<ui32> prefixes;
-        for (auto p : partConfig.GetByKeyFilterPrefixes()) {
-            if (p > 0) {
-                prefixes.push_back(p);
+        TMap<ui32, double> prefixMap;
+        for (const auto& p : partConfig.GetByKeyFilterPrefixes()) {
+            if (p.GetPrefixLength() > 0) {
+                double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
         if (partConfig.HasEnableFilterByKey() && partConfig.GetEnableFilterByKey()) {
-            prefixes.push_back(KeyColumnIds.size());
+            prefixMap.emplace(KeyColumnIds.size(), NTable::DefaultBloomFilterFpp);
         }
-        SortUnique(prefixes);
-        if (!prefixes.empty()) {
+        if (!prefixMap.empty()) {
+            TVector<TPrefix> prefixes;
+            for (const auto& [len, fpp] : prefixMap) {
+                prefixes.push_back(TPrefix{len, fpp});
+            }
             alter.SetByKeyFilterPrefixes(tid, prefixes);
         }
     }
@@ -629,12 +634,15 @@ void TUserTable::ApplyAlter(
     }
 
     if (configDelta.HasEnableFilterByKey() || configDelta.ByKeyFilterPrefixesSize() > 0) {
+        using TPrefix = NTable::TScheme::TTableInfo::TByKeyFilterPrefix;
         // Rebuild unified prefix list from current config + delta
-        TVector<ui32> prefixes;
+        // Use a map to track FPP per prefix length
+        TMap<ui32, double> prefixMap;
         // Start with existing prefixes from current config
-        for (auto p : config.GetByKeyFilterPrefixes()) {
-            if (p > 0) {
-                prefixes.push_back(p);
+        for (const auto& p : config.GetByKeyFilterPrefixes()) {
+            if (p.GetPrefixLength() > 0) {
+                double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
         ui32 keyCount = KeyColumnIds.size();
@@ -642,32 +650,34 @@ void TUserTable::ApplyAlter(
         if (configDelta.HasEnableFilterByKey()) {
             config.SetEnableFilterByKey(configDelta.GetEnableFilterByKey());
             if (configDelta.GetEnableFilterByKey()) {
-                prefixes.push_back(keyCount);
+                prefixMap.emplace(keyCount, NTable::DefaultBloomFilterFpp);
             } else {
-                // Remove full-key entry
-                prefixes.erase(std::remove(prefixes.begin(), prefixes.end(), keyCount), prefixes.end());
+                prefixMap.erase(keyCount);
             }
         }
 
         if (configDelta.ByKeyFilterPrefixesSize() > 0) {
             // Delta replaces the explicit prefix list
-            prefixes.clear();
-            for (auto p : configDelta.GetByKeyFilterPrefixes()) {
-                if (p > 0) {
-                    prefixes.push_back(p);
+            prefixMap.clear();
+            for (const auto& p : configDelta.GetByKeyFilterPrefixes()) {
+                if (p.GetPrefixLength() > 0) {
+                    double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                    prefixMap[p.GetPrefixLength()] = fpp;
                 }
             }
             // Re-add full-key entry if EnableFilterByKey is enabled
             if (config.GetEnableFilterByKey()) {
-                prefixes.push_back(keyCount);
+                prefixMap.emplace(keyCount, NTable::DefaultBloomFilterFpp);
             }
         }
 
-        SortUnique(prefixes);
-
         config.ClearByKeyFilterPrefixes();
-        for (auto p : prefixes) {
-            config.AddByKeyFilterPrefixes(p);
+        TVector<TPrefix> prefixes;
+        for (const auto& [len, fpp] : prefixMap) {
+            auto* entry = config.AddByKeyFilterPrefixes();
+            entry->SetPrefixLength(len);
+            entry->SetFalsePositiveProbability(fpp);
+            prefixes.push_back(TPrefix{len, fpp});
         }
         for (ui32 tid : tids) {
             alter.SetByKeyFilterPrefixes(tid, prefixes);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -6,6 +6,7 @@
 
 #include <ydb/core/backup/regexp/regexp.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/tablet_flat/bloom_filter_defaults.h>
 #include <ydb/core/base/channel_profiles.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/base/tx_processing.h>
@@ -1077,21 +1078,25 @@ bool TPartitionConfigMerger::ApplyChanges(
     }
 
     if (changes.ByKeyFilterPrefixesSize() > 0) {
-        TVector<ui32> prefixes;
-        for (auto p : result.GetByKeyFilterPrefixes()) {
-            if (p > 0) {
-                prefixes.push_back(p);
+        // Merge existing + new prefixes, keyed by PrefixLength (new FPP wins on conflict)
+        TMap<ui32, double> prefixMap;
+        for (const auto& p : result.GetByKeyFilterPrefixes()) {
+            if (p.GetPrefixLength() > 0) {
+                double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
-        for (auto p : changes.GetByKeyFilterPrefixes()) {
-            if (p > 0) {
-                prefixes.push_back(p);
+        for (const auto& p : changes.GetByKeyFilterPrefixes()) {
+            if (p.GetPrefixLength() > 0) {
+                double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
-        SortUnique(prefixes);
         result.ClearByKeyFilterPrefixes();
-        for (auto p : prefixes) {
-            result.AddByKeyFilterPrefixes(p);
+        for (const auto& [len, fpp] : prefixMap) {
+            auto* entry = result.AddByKeyFilterPrefixes();
+            entry->SetPrefixLength(len);
+            entry->SetFalsePositiveProbability(fpp);
         }
     }
 

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -6789,29 +6789,30 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         TestAlterTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
             PartitionConfig {
-                ByKeyFilterPrefixes: 1
+                ByKeyFilterPrefixes { PrefixLength: 1 }
             }
         )");
         env.TestWaitNotification(runtime, txId);
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
         }
 
-        // Add another prefix — should accumulate [1, 2]
+        // Add another prefix with custom FPP — should accumulate [1, 2]
         TestAlterTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
             PartitionConfig {
-                ByKeyFilterPrefixes: 2
+                ByKeyFilterPrefixes { PrefixLength: 2 FalsePositiveProbability: 0.05 }
             }
         )");
         env.TestWaitNotification(runtime, txId);
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
+            UNIT_ASSERT_DOUBLES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.05, 1e-9);
         }
 
         // Disable KEY_BLOOM_FILTER — should clear all prefixes
@@ -6840,7 +6841,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
                 .GetPathDescription().GetTable().GetPartitionConfig();
         };
 
-        // Create table with bloom filter prefix from the start
+        // Create table with bloom filter prefix and custom FPP from the start
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
             Columns { Name: "Key1" Type: "Uint64"}
@@ -6848,29 +6849,30 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
             Columns { Name: "Value" Type: "Utf8"}
             KeyColumnNames: ["Key1", "Key2"]
             PartitionConfig {
-                ByKeyFilterPrefixes: 1
+                ByKeyFilterPrefixes { PrefixLength: 1 FalsePositiveProbability: 0.02 }
             }
         )");
         env.TestWaitNotification(runtime, txId);
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_DOUBLES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetFalsePositiveProbability(), 0.02, 1e-9);
         }
 
         // Alter to add second prefix — should accumulate [1, 2]
         TestAlterTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
             PartitionConfig {
-                ByKeyFilterPrefixes: 2
+                ByKeyFilterPrefixes { PrefixLength: 2 }
             }
         )");
         env.TestWaitNotification(runtime, txId);
         {
             auto cfg = getPartitionConfig();
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0), 1);
-            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
         }
 
         // Disable — should clear all

--- a/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
@@ -254,31 +254,53 @@ ColumnFamilies {
         return TPartitionConfigMerger::ApplyChanges(result, src, changes, columns, nullptr, false, errDescr);
     }
 
+    void AddBloomPrefix(NKikimrSchemeOp::TPartitionConfig& config, ui32 prefixLen, double fpp = NKikimr::NTable::DefaultBloomFilterFpp) {
+        auto* entry = config.AddByKeyFilterPrefixes();
+        entry->SetPrefixLength(prefixLen);
+        entry->SetFalsePositiveProbability(fpp);
+    }
+
     Y_UNIT_TEST(BloomFilterPrefixMerge) {
         // Existing [3, 1], delta adds [1, 2] -> result should be [1, 2, 3] (merged, sorted, deduped)
         NKikimrSchemeOp::TPartitionConfig src;
-        src.AddByKeyFilterPrefixes(3);
-        src.AddByKeyFilterPrefixes(1);
+        AddBloomPrefix(src, 3);
+        AddBloomPrefix(src, 1);
 
         NKikimrSchemeOp::TPartitionConfig changes;
-        changes.AddByKeyFilterPrefixes(1);
-        changes.AddByKeyFilterPrefixes(2);
+        AddBloomPrefix(changes, 1);
+        AddBloomPrefix(changes, 2);
 
         NKikimrSchemeOp::TPartitionConfig result;
         TString errDescr;
         UNIT_ASSERT(ApplyBloomChanges(result, src, changes, errDescr));
         UNIT_ASSERT_VALUES_EQUAL(result.ByKeyFilterPrefixesSize(), 3);
-        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(0), 1);
-        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(1), 2);
-        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(2), 3);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(2).GetPrefixLength(), 3);
+    }
+
+    Y_UNIT_TEST(BloomFilterPrefixMergeFpp) {
+        // New FPP wins on conflict: existing prefix 1 with fpp=0.01, delta adds prefix 1 with fpp=0.05
+        NKikimrSchemeOp::TPartitionConfig src;
+        AddBloomPrefix(src, 1, 0.01);
+
+        NKikimrSchemeOp::TPartitionConfig changes;
+        AddBloomPrefix(changes, 1, 0.05);
+
+        NKikimrSchemeOp::TPartitionConfig result;
+        TString errDescr;
+        UNIT_ASSERT(ApplyBloomChanges(result, src, changes, errDescr));
+        UNIT_ASSERT_VALUES_EQUAL(result.ByKeyFilterPrefixesSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+        UNIT_ASSERT_DOUBLES_EQUAL(result.GetByKeyFilterPrefixes(0).GetFalsePositiveProbability(), 0.05, 1e-9);
     }
 
     Y_UNIT_TEST(BloomFilterDisableClearsPrefixes) {
         // Existing config has prefixes [1, 2], delta disables EnableFilterByKey -> prefixes cleared
         NKikimrSchemeOp::TPartitionConfig src;
         src.SetEnableFilterByKey(true);
-        src.AddByKeyFilterPrefixes(1);
-        src.AddByKeyFilterPrefixes(2);
+        AddBloomPrefix(src, 1);
+        AddBloomPrefix(src, 2);
 
         NKikimrSchemeOp::TPartitionConfig changes;
         changes.SetEnableFilterByKey(false);
@@ -296,7 +318,7 @@ ColumnFamilies {
 
         NKikimrSchemeOp::TPartitionConfig changes;
         changes.SetEnableFilterByKey(false);
-        changes.AddByKeyFilterPrefixes(1);
+        AddBloomPrefix(changes, 1);
 
         NKikimrSchemeOp::TPartitionConfig result;
         TString errDescr;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1726,7 +1726,7 @@ namespace NSchemeShardUT_Private {
                 // Check if full-key bloom is enabled
                 // Full-key bloom is represented as a prefix entry with length = key column count
                 for (ui32 j = 0; j < d.ByKeyFilterPrefixesSize(); ++j) {
-                    if (d.GetByKeyFilterPrefixes(j) == keyColumnCount && keyColumnCount > 0) {
+                    if (d.GetByKeyFilterPrefixes(j).GetPrefixLength() == keyColumnCount && keyColumnCount > 0) {
                         return true;
                     }
                 }

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -4,6 +4,7 @@
 #include "ydb_convert.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/tablet_flat/bloom_filter_defaults.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/tx/columnshard/engines/storage/indexes/helper/index_defaults.h>
@@ -229,7 +230,8 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
     tableDesc->SetName(pathPair.second);
 
     // Deduplicate prefix lengths: multiple bloom indexes with the same column count collapse into one.
-    TSet<ui32> bloomPrefixes;
+    // When duplicated, the last FPP wins.
+    TMap<ui32, double> bloomPrefixes;
     for (const auto& index : req->add_indexes()) {
         if (index.type_case() != Ydb::Table::TableIndex::kLocalBloomFilterIndex) {
             continue;
@@ -239,11 +241,23 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
             error = "Bloom filter index must specify at least one column";
             return false;
         }
-        bloomPrefixes.insert(static_cast<ui32>(index.index_columns_size()));
+        ui32 prefixLen = static_cast<ui32>(index.index_columns_size());
+        double fpp = NTable::DefaultBloomFilterFpp;
+        if (index.local_bloom_filter_index().has_false_positive_probability()) {
+            fpp = index.local_bloom_filter_index().false_positive_probability();
+            if (fpp <= 0.0 || fpp >= 1.0) {
+                code = Ydb::StatusIds::BAD_REQUEST;
+                error = "false_positive_probability must be in range (0, 1)";
+                return false;
+            }
+        }
+        bloomPrefixes[prefixLen] = fpp;
     }
 
-    for (ui32 prefix : bloomPrefixes) {
-        tableDesc->MutablePartitionConfig()->AddByKeyFilterPrefixes(prefix);
+    for (const auto& [prefix, fpp] : bloomPrefixes) {
+        auto* entry = tableDesc->MutablePartitionConfig()->AddByKeyFilterPrefixes();
+        entry->SetPrefixLength(prefix);
+        entry->SetFalsePositiveProbability(fpp);
     }
 
     return true;
@@ -1521,11 +1535,12 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
     }
 
     // Synthesize LocalBloomFilter index entries for DataShard tables.
-    // ByKeyFilterPrefixes stores prefix lengths (not index names), so names are generated
+    // ByKeyFilterPrefixes stores prefix lengths + FPP. Names are generated
     // as "idx_bloom_<prefixLen>".
     if (in.HasPartitionConfig() && in.GetPartitionConfig().ByKeyFilterPrefixesSize() > 0) {
         const auto& pkCols = in.GetKeyColumnNames();
-        for (auto prefix : in.GetPartitionConfig().GetByKeyFilterPrefixes()) {
+        for (const auto& bloomPrefix : in.GetPartitionConfig().GetByKeyFilterPrefixes()) {
+            ui32 prefix = bloomPrefix.GetPrefixLength();
             if (prefix == 0 || static_cast<int>(prefix) > pkCols.size()) {
                 continue;
             }
@@ -1534,7 +1549,11 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
             for (ui32 i = 0; i < prefix; ++i) {
                 index->add_index_columns(pkCols[i]);
             }
-            index->mutable_local_bloom_filter_index();
+            auto* bloomFilter = index->mutable_local_bloom_filter_index();
+            if (bloomPrefix.HasFalsePositiveProbability() &&
+                bloomPrefix.GetFalsePositiveProbability() != NTable::DefaultBloomFilterFpp) {
+                bloomFilter->set_false_positive_probability(bloomPrefix.GetFalsePositiveProbability());
+            }
             if constexpr (std::is_same<TYdbProto, Ydb::Table::DescribeTableResult>::value) {
                 index->set_status(Ydb::Table::TableIndexDescription::STATUS_READY);
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Replace `repeated uint32 ByKeyFilterPrefixes` with `repeated TByKeyFilterPrefix`
message containing `PrefixLength` and `FalsePositiveProbability`. 
The FPP value
now flows from CREATE/ALTER TABLE through SchemeShard, DataShard, and tablet
flat layer to the bloom filter writer, instead of being hardcoded to 0.0001.
Old proto fields are reserved (no backward compatibility needed since
ByKeyFilterPrefixes has not reached a stable release yet).

Previous PRs: https://github.com/ydb-platform/ydb/pull/36833 https://github.com/ydb-platform/ydb/pull/35155

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
