### PR TITLE
Fix Coverity 106419: avoid use-after-move when attaching generic splits

### DIFF
--- a/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_list_splits.cpp
@@ -321,7 +321,7 @@ IGraphTransformer::TStatus TGenericListSplitTransformer::DoApplyAsyncChanges(TEx
 
         Y_ENSURE(!result->Splits.empty());
 
-        if (auto issue = State_->AttachSplitsToTable(tableAddress, selectKey, result->Splits); issue) {
+        if (auto issue = State_->AttachSplitsToTable(tableAddress, selectKey, std::move(result->Splits)); issue) {
             ctx.AddError(*issue);
             return TStatus::Error;
         }

--- a/ydb/library/yql/providers/generic/provider/yql_generic_state.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_state.cpp
@@ -53,9 +53,10 @@ namespace NYql {
         return SelectSplits.contains(key);
     }
 
-    void TGenericState::TTableMeta::AttachSplitsForSelect(const TSelectKey& key, std::vector<NYql::NConnector::NApi::TSplit>& splits) {
+    void TGenericState::TTableMeta::AttachSplitsForSelect(
+        const TSelectKey& key, std::vector<NYql::NConnector::NApi::TSplit>&& splits) {
         Y_ENSURE(splits.size());
-        Y_ENSURE(SelectSplits.emplace(key, std::move(splits)).second);
+        Y_ENSURE(SelectSplits.try_emplace(key, std::move(splits)).second);
     }
 
     const std::vector<NYql::NConnector::NApi::TSplit>& TGenericState::TTableMeta::GetSplitsForSelect(
@@ -94,14 +95,14 @@ namespace NYql {
 
     std::optional<TIssue> TGenericState::AttachSplitsToTable(const TTableAddress& tableAddress,
                                                              const TSelectKey& key,
-                                                             std::vector<NYql::NConnector::NApi::TSplit>& splits) {
+                                                             std::vector<NYql::NConnector::NApi::TSplit>&& splits) {
         auto result = Tables_.FindPtr(tableAddress);
 
         if (!result) {
             return {TIssue(TStringBuilder() << "no metadata for table " << tableAddress.ToString())};
         }
 
-        result->AttachSplitsForSelect(key, splits);
+        result->AttachSplitsForSelect(key, std::move(splits));
         return std::nullopt;
     }
 

--- a/ydb/library/yql/providers/generic/provider/yql_generic_state.h
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_state.h
@@ -84,7 +84,7 @@ namespace NYql {
             bool HasSplitsForSelect(const TSelectKey& key) const;
 
             void AttachSplitsForSelect(const TSelectKey& key,
-                                       std::vector<NYql::NConnector::NApi::TSplit>& splits);
+                                       std::vector<NYql::NConnector::NApi::TSplit>&& splits);
 
             const std::vector<NYql::NConnector::NApi::TSplit>& GetSplitsForSelect(const TSelectKey& key) const;
         };
@@ -114,7 +114,7 @@ namespace NYql {
         void AddTable(const TTableAddress& tableAddress, TTableMeta&& tableMeta);
         std::optional<TIssue> AttachSplitsToTable(const TTableAddress& tableAddress,
                                                   const TSelectKey& key,
-                                                  std::vector<NYql::NConnector::NApi::TSplit>& splits);
+                                                  std::vector<NYql::NConnector::NApi::TSplit>&& splits);
         TGetTableResult GetTable(const TTableAddress& tableAddress) const;
 
         TTypeAnnotationContext* Types;


### PR DESCRIPTION
Coverity CID 106419 (CLOUD-249393): `emplace(key, std::move(splits))` could leave the caller vector moved-from when insert does not happen.

- Use `try_emplace` so `splits` are only consumed on successful insert.
- Pass split vectors by rvalue reference in `AttachSplitsForSelect` and `AttachSplitsToTable`; the call site uses `std::move(result->Splits)`.