### PR TITLE
Add HTTP/2 support to the HTTP proxy

### DIFF
--- a/ydb/library/actors/http/http2.cpp
+++ b/ydb/library/actors/http/http2.cpp
@@ -1,0 +1,891 @@
+#include "http2.h"
+
+#include <util/string/builder.h>
+
+namespace NHttp::NHttp2 {
+
+// ============== TSession ==============
+
+TSession::TSession(ERole role, TSessionCallbacks callbacks)
+    : Role(role)
+    , Callbacks(std::move(callbacks))
+{
+    if (Role == ERole::Server) {
+        FrameParseState = EFrameParseState::WaitingPreface;
+        NextLocalStreamId = 2; // server uses even stream IDs
+    } else {
+        FrameParseState = EFrameParseState::ReadingHeader;
+        NextLocalStreamId = 1; // client uses odd stream IDs
+    }
+}
+
+void TSession::Initialize() {
+    if (Initialized) return;
+    Initialized = true;
+
+    if (Role == ERole::Client) {
+        // Client sends connection preface (magic + SETTINGS)
+        QueueOutput(TString(CONNECTION_PREFACE));
+    }
+    // Both sides send initial SETTINGS
+    SendSettings();
+    if (Callbacks.OnSend) {
+        Callbacks.OnSend(FlushOutputBuffer());
+    }
+}
+
+void TSession::QueueOutput(TString data) {
+    OutputBuffer.append(data);
+}
+
+void TSession::QueueOutput(const char* data, size_t len) {
+    OutputBuffer.append(data, len);
+}
+
+TString TSession::FlushOutputBuffer() {
+    TString result;
+    result.swap(OutputBuffer);
+    return result;
+}
+
+void TSession::SendSettings() {
+    TVector<TSettingsEntry> entries;
+    entries.push_back({ESettingsId::MAX_CONCURRENT_STREAMS, LocalSettings.MaxConcurrentStreams});
+    entries.push_back({ESettingsId::INITIAL_WINDOW_SIZE, LocalSettings.InitialWindowSize});
+    entries.push_back({ESettingsId::MAX_FRAME_SIZE, LocalSettings.MaxFrameSize});
+    entries.push_back({ESettingsId::ENABLE_PUSH, 0}); // disable server push
+    QueueOutput(TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, entries));
+}
+
+void TSession::SendSettingsAck() {
+    QueueOutput(TFrameBuilder::BuildSettingsAck());
+}
+
+void TSession::SendWindowUpdate(uint32_t streamId, uint32_t increment) {
+    if (increment > 0) {
+        QueueOutput(TFrameBuilder::BuildWindowUpdate(streamId, increment));
+    }
+}
+
+void TSession::SendRstStream(uint32_t streamId, EErrorCode errorCode) {
+    QueueOutput(TFrameBuilder::BuildRstStream(streamId, errorCode));
+}
+
+TStream& TSession::GetOrCreateStream(uint32_t streamId) {
+    auto [it, inserted] = Streams.try_emplace(streamId);
+    if (inserted) {
+        it->second.StreamId = streamId;
+        it->second.State = EStreamState::Open;
+        it->second.SendWindowSize = PeerSettings.InitialWindowSize;
+        it->second.RecvWindowSize = LocalSettings.InitialWindowSize;
+    }
+    return it->second;
+}
+
+TStream* TSession::FindStream(uint32_t streamId) {
+    auto it = Streams.find(streamId);
+    if (it == Streams.end()) return nullptr;
+    return &it->second;
+}
+
+size_t TSession::Feed(const char* data, size_t len) {
+    size_t consumed = 0;
+
+    while (consumed < len) {
+        switch (FrameParseState) {
+            case EFrameParseState::WaitingPreface: {
+                // Server waits for "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" (24 bytes)
+                while (consumed < len && PrefaceBytesMatched < CONNECTION_PREFACE.size()) {
+                    if (data[consumed] == CONNECTION_PREFACE[PrefaceBytesMatched]) {
+                        PrefaceBytesMatched++;
+                        consumed++;
+                    } else {
+                        if (Callbacks.OnError) {
+                            Callbacks.OnError("Invalid HTTP/2 connection preface");
+                        }
+                        return consumed;
+                    }
+                }
+                if (PrefaceBytesMatched == CONNECTION_PREFACE.size()) {
+                    PrefaceReceived = true;
+                    FrameParseState = EFrameParseState::ReadingHeader;
+                    FrameBuffer.clear();
+                }
+                break;
+            }
+
+            case EFrameParseState::ReadingHeader: {
+                size_t need = FRAME_HEADER_SIZE - FrameBuffer.size();
+                size_t avail = len - consumed;
+                size_t take = std::min(need, avail);
+                FrameBuffer.append(data + consumed, take);
+                consumed += take;
+
+                if (FrameBuffer.size() == FRAME_HEADER_SIZE) {
+                    CurrentFrameHeader.Parse(FrameBuffer.data());
+                    FrameBuffer.clear();
+
+                    if (CurrentFrameHeader.Length > PeerSettings.MaxFrameSize) {
+                        // For unrecognized frame types, we still need to respect FRAME_SIZE_ERROR
+                        ConnectionError(EErrorCode::FRAME_SIZE_ERROR, "Frame too large");
+                        return consumed;
+                    }
+
+                    if (CurrentFrameHeader.Length == 0) {
+                        ProcessFrame(CurrentFrameHeader, {});
+                        FrameParseState = EFrameParseState::ReadingHeader;
+                    } else {
+                        FrameParseState = EFrameParseState::ReadingPayload;
+                    }
+                }
+                break;
+            }
+
+            case EFrameParseState::ReadingPayload: {
+                size_t need = CurrentFrameHeader.Length - FrameBuffer.size();
+                size_t avail = len - consumed;
+                size_t take = std::min(need, avail);
+                FrameBuffer.append(data + consumed, take);
+                consumed += take;
+
+                if (FrameBuffer.size() == CurrentFrameHeader.Length) {
+                    ProcessFrame(CurrentFrameHeader, FrameBuffer);
+                    FrameBuffer.clear();
+                    FrameParseState = EFrameParseState::ReadingHeader;
+                }
+                break;
+            }
+        }
+    }
+
+    // Flush accumulated output
+    if (HasPendingOutput() && Callbacks.OnSend) {
+        Callbacks.OnSend(FlushOutputBuffer());
+    }
+
+    return consumed;
+}
+
+void TSession::ProcessFrame(const TFrameHeader& header, TStringBuf payload) {
+    // If waiting for CONTINUATION, only CONTINUATION for the same stream is acceptable
+    if (ExpectingContinuationStream != 0) {
+        if (header.Type != EFrameType::CONTINUATION || header.StreamId != ExpectingContinuationStream) {
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR, "Expected CONTINUATION frame");
+        }
+    }
+
+    switch (header.Type) {
+        case EFrameType::DATA:
+            ProcessDataFrame(header, payload);
+            break;
+        case EFrameType::HEADERS:
+            ProcessHeadersFrame(header, payload);
+            break;
+        case EFrameType::PRIORITY:
+            ProcessPriorityFrame(header, payload);
+            break;
+        case EFrameType::RST_STREAM:
+            ProcessRstStreamFrame(header, payload);
+            break;
+        case EFrameType::SETTINGS:
+            ProcessSettingsFrame(header, payload);
+            break;
+        case EFrameType::PUSH_PROMISE:
+            // We don't support server push, send PROTOCOL_ERROR
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR, "PUSH_PROMISE not supported");
+        case EFrameType::PING:
+            ProcessPingFrame(header, payload);
+            break;
+        case EFrameType::GOAWAY:
+            ProcessGoawayFrame(header, payload);
+            break;
+        case EFrameType::WINDOW_UPDATE:
+            ProcessWindowUpdateFrame(header, payload);
+            break;
+        case EFrameType::CONTINUATION:
+            ProcessContinuationFrame(header, payload);
+            break;
+        default:
+            // Unknown frame types MUST be ignored (RFC 7540 Section 4.1)
+            break;
+    }
+}
+
+void TSession::ProcessDataFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId == 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "DATA frame on stream 0");
+    }
+
+    TStream* stream = FindStream(header.StreamId);
+    if (!stream) {
+        // Stream might have been closed/reset - ignore or send error
+        return;
+    }
+
+    TStringBuf data = payload;
+    // Handle PADDED flag
+    if (header.HasFlag(NFrameFlag::PADDED)) {
+        if (data.empty()) {
+            return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+        }
+        uint8_t padLen = static_cast<uint8_t>(data[0]);
+        data.Skip(1);
+        if (padLen >= data.size()) {
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR);
+        }
+        data.Chop(padLen);
+    }
+
+    stream->Body.append(data);
+
+    // Update flow control
+    RecvWindowSize -= static_cast<int32_t>(payload.size());
+    stream->RecvWindowSize -= static_cast<int32_t>(payload.size());
+
+    // Send WINDOW_UPDATE if window is getting low
+    if (RecvWindowSize < static_cast<int32_t>(DEFAULT_INITIAL_WINDOW_SIZE / 2)) {
+        uint32_t increment = DEFAULT_INITIAL_WINDOW_SIZE - RecvWindowSize;
+        SendWindowUpdate(0, increment);
+        RecvWindowSize += increment;
+    }
+    if (stream->RecvWindowSize < static_cast<int32_t>(DEFAULT_INITIAL_WINDOW_SIZE / 2)) {
+        uint32_t increment = DEFAULT_INITIAL_WINDOW_SIZE - stream->RecvWindowSize;
+        SendWindowUpdate(header.StreamId, increment);
+        stream->RecvWindowSize += increment;
+    }
+
+    if (header.HasFlag(NFrameFlag::END_STREAM)) {
+        stream->EndStream = true;
+        if (stream->State == EStreamState::Open) {
+            stream->State = EStreamState::HalfClosedRemote;
+        } else if (stream->State == EStreamState::HalfClosedLocal) {
+            stream->State = EStreamState::Closed;
+        }
+
+        if (Role == ERole::Server && stream->HeadersComplete) {
+            if (Callbacks.OnRequest) {
+                Callbacks.OnRequest(header.StreamId, *stream);
+            }
+        } else if (Role == ERole::Client && stream->HeadersComplete) {
+            if (Callbacks.OnResponse) {
+                Callbacks.OnResponse(header.StreamId, *stream);
+            }
+        }
+        if (stream->State == EStreamState::Closed) {
+            Streams.erase(header.StreamId);
+        }
+    }
+}
+
+void TSession::ProcessHeadersFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId == 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "HEADERS frame on stream 0");
+    }
+
+    TStringBuf data = payload;
+
+    // Handle PADDED flag
+    uint8_t padLen = 0;
+    if (header.HasFlag(NFrameFlag::PADDED)) {
+        if (data.empty()) {
+            return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+        }
+        padLen = static_cast<uint8_t>(data[0]);
+        data.Skip(1);
+    }
+
+    // Handle PRIORITY flag
+    if (header.HasFlag(NFrameFlag::PRIORITY)) {
+        if (data.size() < 5) {
+            return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+        }
+        // Skip priority fields (stream dependency + weight)
+        data.Skip(5);
+    }
+
+    if (padLen > 0) {
+        if (padLen >= data.size()) {
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR);
+        }
+        data.Chop(padLen);
+    }
+
+    // Track stream
+    bool isNewStream = (Role == ERole::Server && (header.StreamId & 1) != 0 && header.StreamId > LastPeerStreamId);
+    if (isNewStream) {
+        LastPeerStreamId = header.StreamId;
+    }
+
+    TStream& stream = GetOrCreateStream(header.StreamId);
+    stream.HeaderBlockFragment.append(data);
+
+    bool endHeaders = header.HasFlag(NFrameFlag::END_HEADERS);
+    bool endStream = header.HasFlag(NFrameFlag::END_STREAM);
+
+    if (endHeaders) {
+        CompleteHeaderBlock(header.StreamId, stream, endStream);
+    } else {
+        // Need CONTINUATION frames
+        ExpectingContinuationStream = header.StreamId;
+        stream.EndStream = endStream; // remember for when headers complete
+    }
+}
+
+void TSession::ProcessPriorityFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId == 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "PRIORITY frame on stream 0");
+    }
+    if (payload.size() != 5) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+    }
+    // We ignore priority information
+}
+
+void TSession::ProcessRstStreamFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId == 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "RST_STREAM on stream 0");
+    }
+    if (payload.size() != 4) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+    }
+
+    CloseStream(header.StreamId);
+}
+
+void TSession::ProcessSettingsFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId != 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "SETTINGS on non-zero stream");
+    }
+
+    if (header.HasFlag(NFrameFlag::ACK)) {
+        if (payload.size() != 0) {
+            return ConnectionError(EErrorCode::FRAME_SIZE_ERROR, "SETTINGS ACK with payload");
+        }
+        SettingsAckPending = false;
+        if (!PrefaceReceived && Role == ERole::Client) {
+            PrefaceReceived = true;
+        }
+        return;
+    }
+
+    if (payload.size() % 6 != 0) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR, "SETTINGS payload not multiple of 6");
+    }
+
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(payload.data());
+    for (size_t i = 0; i < payload.size(); i += 6) {
+        uint16_t id = (static_cast<uint16_t>(p[i]) << 8) | p[i + 1];
+        uint32_t val = (static_cast<uint32_t>(p[i + 2]) << 24)
+                     | (static_cast<uint32_t>(p[i + 3]) << 16)
+                     | (static_cast<uint32_t>(p[i + 4]) << 8)
+                     | p[i + 5];
+
+        // Save old value before applying (needed for window size delta calculation)
+        uint32_t oldInitialWindowSize = PeerSettings.InitialWindowSize;
+
+        if (!PeerSettings.Apply(static_cast<ESettingsId>(id), val)) {
+            if (static_cast<ESettingsId>(id) == ESettingsId::INITIAL_WINDOW_SIZE) {
+                return ConnectionError(EErrorCode::FLOW_CONTROL_ERROR);
+            }
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR);
+        }
+
+        // Handle initial window size change (update all existing streams)
+        if (static_cast<ESettingsId>(id) == ESettingsId::INITIAL_WINDOW_SIZE) {
+            int32_t delta = static_cast<int32_t>(val) - static_cast<int32_t>(oldInitialWindowSize);
+            for (auto& [sid, s] : Streams) {
+                s.SendWindowSize += delta;
+            }
+        }
+
+        // Update encoder table size if header table size changed
+        if (static_cast<ESettingsId>(id) == ESettingsId::HEADER_TABLE_SIZE) {
+            Encoder.SetMaxTableSize(val);
+        }
+    }
+
+    // Always ACK settings
+    SendSettingsAck();
+
+    if (!PrefaceReceived && Role == ERole::Server) {
+        PrefaceReceived = true;
+    }
+}
+
+void TSession::ProcessPingFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId != 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "PING on non-zero stream");
+    }
+    if (payload.size() != 8) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR, "PING payload not 8 bytes");
+    }
+    if (header.HasFlag(NFrameFlag::ACK)) {
+        return; // PING response, ignore
+    }
+    // Echo back with ACK
+    QueueOutput(TFrameBuilder::BuildPing(NFrameFlag::ACK, payload.data()));
+}
+
+void TSession::ProcessGoawayFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (header.StreamId != 0) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "GOAWAY on non-zero stream");
+    }
+    if (payload.size() < 8) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+    }
+
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(payload.data());
+    uint32_t lastStreamId = (static_cast<uint32_t>(p[0]) << 24)
+                          | (static_cast<uint32_t>(p[1]) << 16)
+                          | (static_cast<uint32_t>(p[2]) << 8)
+                          | p[3];
+    lastStreamId &= 0x7FFFFFFF;
+
+    uint32_t errorCode = (static_cast<uint32_t>(p[4]) << 24)
+                       | (static_cast<uint32_t>(p[5]) << 16)
+                       | (static_cast<uint32_t>(p[6]) << 8)
+                       | p[7];
+
+    GoawayReceived = true;
+
+    if (Callbacks.OnGoaway) {
+        Callbacks.OnGoaway(lastStreamId, static_cast<EErrorCode>(errorCode));
+    }
+}
+
+void TSession::ProcessWindowUpdateFrame(const TFrameHeader& header, TStringBuf payload) {
+    if (payload.size() != 4) {
+        return ConnectionError(EErrorCode::FRAME_SIZE_ERROR);
+    }
+
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(payload.data());
+    uint32_t increment = (static_cast<uint32_t>(p[0]) << 24)
+                       | (static_cast<uint32_t>(p[1]) << 16)
+                       | (static_cast<uint32_t>(p[2]) << 8)
+                       | p[3];
+    increment &= 0x7FFFFFFF;
+
+    if (increment == 0) {
+        if (header.StreamId == 0) {
+            return ConnectionError(EErrorCode::PROTOCOL_ERROR, "Zero WINDOW_UPDATE increment");
+        } else {
+            SendRstStream(header.StreamId, EErrorCode::PROTOCOL_ERROR);
+            return;
+        }
+    }
+
+    if (header.StreamId == 0) {
+        int64_t newSize = static_cast<int64_t>(SendWindowSize) + increment;
+        if (newSize > static_cast<int64_t>(MAX_WINDOW_SIZE)) {
+            return ConnectionError(EErrorCode::FLOW_CONTROL_ERROR);
+        }
+        SendWindowSize = static_cast<int32_t>(newSize);
+    } else {
+        TStream* stream = FindStream(header.StreamId);
+        if (stream) {
+            int64_t newSize = static_cast<int64_t>(stream->SendWindowSize) + increment;
+            if (newSize > static_cast<int64_t>(MAX_WINDOW_SIZE)) {
+                SendRstStream(header.StreamId, EErrorCode::FLOW_CONTROL_ERROR);
+                CloseStream(header.StreamId);
+            } else {
+                stream->SendWindowSize = static_cast<int32_t>(newSize);
+            }
+        }
+    }
+}
+
+void TSession::ProcessContinuationFrame(const TFrameHeader& header, TStringBuf payload) {
+    TStream* stream = FindStream(header.StreamId);
+    if (!stream) {
+        return ConnectionError(EErrorCode::PROTOCOL_ERROR, "CONTINUATION for unknown stream");
+    }
+
+    stream->HeaderBlockFragment.append(payload);
+
+    if (header.HasFlag(NFrameFlag::END_HEADERS)) {
+        ExpectingContinuationStream = 0;
+        CompleteHeaderBlock(header.StreamId, *stream, stream->EndStream);
+    }
+}
+
+void TSession::CompleteHeaderBlock(uint32_t streamId, TStream& stream, bool endStream) {
+    // Decode the accumulated header block
+    TVector<std::pair<TString, TString>> headers;
+    if (!Decoder.Decode(stream.HeaderBlockFragment, headers)) {
+        return ConnectionError(EErrorCode::COMPRESSION_ERROR, "HPACK decode failure");
+    }
+    stream.HeaderBlockFragment.clear();
+    stream.HeadersComplete = true;
+
+    // Separate pseudo-headers from regular headers
+    for (auto& [name, value] : headers) {
+        if (name == ":method") {
+            stream.Method = std::move(value);
+        } else if (name == ":path") {
+            stream.Path = std::move(value);
+        } else if (name == ":scheme") {
+            stream.Scheme = std::move(value);
+        } else if (name == ":authority") {
+            stream.Authority = std::move(value);
+        } else if (name == ":status") {
+            stream.Status = std::move(value);
+        } else {
+            stream.Headers.emplace_back(std::move(name), std::move(value));
+        }
+    }
+
+    if (endStream) {
+        stream.EndStream = true;
+        if (stream.State == EStreamState::Open) {
+            stream.State = EStreamState::HalfClosedRemote;
+        } else if (stream.State == EStreamState::HalfClosedLocal) {
+            stream.State = EStreamState::Closed;
+        }
+    }
+
+    // If END_STREAM was set on HEADERS (no body), deliver immediately
+    if (endStream) {
+        if (Role == ERole::Server && Callbacks.OnRequest) {
+            Callbacks.OnRequest(streamId, stream);
+        } else if (Role == ERole::Client && Callbacks.OnResponse) {
+            Callbacks.OnResponse(streamId, stream);
+        }
+        if (stream.State == EStreamState::Closed) {
+            Streams.erase(streamId);
+        }
+    }
+    // If not endStream, we wait for DATA frames to deliver the body
+}
+
+void TSession::CloseStream(uint32_t streamId, EErrorCode) {
+    auto it = Streams.find(streamId);
+    if (it != Streams.end()) {
+        it->second.State = EStreamState::Closed;
+        Streams.erase(it);
+    }
+}
+
+void TSession::ConnectionError(EErrorCode errorCode, TStringBuf message) {
+    SendGoaway(errorCode, message);
+    if (Callbacks.OnError) {
+        TString errorMsg = TStringBuilder() << "HTTP/2 connection error: " << static_cast<uint32_t>(errorCode);
+        if (!message.empty()) {
+            errorMsg += ": ";
+            errorMsg += message;
+        }
+        Callbacks.OnError(errorMsg);
+    }
+}
+
+void TSession::SendResponse(uint32_t streamId, TStringBuf status,
+                             const TVector<std::pair<TString, TString>>& headers, TStringBuf body, bool endStream) {
+    TStream* stream = FindStream(streamId);
+    if (!stream) return;
+
+    // Build pseudo-headers + regular headers
+    TVector<std::pair<TString, TString>> allHeaders;
+    allHeaders.emplace_back(":status", TString(status));
+    allHeaders.insert(allHeaders.end(), headers.begin(), headers.end());
+
+    TString headerBlock = Encoder.Encode(allHeaders);
+
+    bool hasBody = !body.empty();
+    uint8_t headerFlags = NFrameFlag::END_HEADERS;
+    if (!hasBody && endStream) {
+        headerFlags |= NFrameFlag::END_STREAM;
+    }
+
+    // Split header block into frames if needed
+    size_t maxPayload = PeerSettings.MaxFrameSize;
+    if (headerBlock.size() <= maxPayload) {
+        QueueOutput(TFrameBuilder::BuildHeaders(streamId, headerFlags, headerBlock));
+    } else {
+        // END_STREAM goes on the HEADERS frame (per RFC 7540 §6.2, §6.10)
+        uint8_t firstFlags = (!hasBody && endStream) ? NFrameFlag::END_STREAM : NFrameFlag::NONE;
+        QueueOutput(TFrameBuilder::BuildHeaders(streamId, firstFlags, TStringBuf(headerBlock).Head(maxPayload)));
+        size_t offset = maxPayload;
+        while (offset < headerBlock.size()) {
+            size_t chunkSize = std::min(maxPayload, headerBlock.size() - offset);
+            uint8_t contFlags = (offset + chunkSize >= headerBlock.size()) ? NFrameFlag::END_HEADERS : NFrameFlag::NONE;
+            QueueOutput(TFrameBuilder::BuildContinuation(streamId, contFlags,
+                TStringBuf(headerBlock).SubStr(offset, chunkSize)));
+            offset += chunkSize;
+        }
+    }
+
+    // Send body as DATA frames
+    if (hasBody) {
+        size_t offset = 0;
+        while (offset < body.size()) {
+            size_t chunkSize = std::min(maxPayload, body.size() - offset);
+            bool isLast = (offset + chunkSize >= body.size());
+            uint8_t dataFlags = (isLast && endStream) ? NFrameFlag::END_STREAM : NFrameFlag::NONE;
+            QueueOutput(TFrameBuilder::BuildData(streamId, dataFlags, body.SubStr(offset, chunkSize)));
+            offset += chunkSize;
+        }
+    }
+
+    // Update stream state
+    if (endStream) {
+        if (stream->State == EStreamState::HalfClosedRemote) {
+            stream->State = EStreamState::Closed;
+            Streams.erase(streamId);
+        } else if (stream->State == EStreamState::Open) {
+            stream->State = EStreamState::HalfClosedLocal;
+        }
+    }
+
+    // Flush
+    if (HasPendingOutput() && Callbacks.OnSend) {
+        Callbacks.OnSend(FlushOutputBuffer());
+    }
+}
+
+uint32_t TSession::SendRequest(TStringBuf method, TStringBuf path, TStringBuf authority, TStringBuf scheme,
+                                const TVector<std::pair<TString, TString>>& headers, TStringBuf body) {
+    uint32_t streamId = NextLocalStreamId;
+    NextLocalStreamId += 2;
+
+    TStream& stream = GetOrCreateStream(streamId);
+
+    TVector<std::pair<TString, TString>> allHeaders;
+    allHeaders.emplace_back(":method", TString(method));
+    allHeaders.emplace_back(":path", TString(path));
+    allHeaders.emplace_back(":scheme", TString(scheme));
+    allHeaders.emplace_back(":authority", TString(authority));
+    allHeaders.insert(allHeaders.end(), headers.begin(), headers.end());
+
+    TString headerBlock = Encoder.Encode(allHeaders);
+
+    bool hasBody = !body.empty();
+    uint8_t headerFlags = NFrameFlag::END_HEADERS;
+    if (!hasBody) {
+        headerFlags |= NFrameFlag::END_STREAM;
+    }
+
+    size_t maxPayload = PeerSettings.MaxFrameSize;
+    if (headerBlock.size() <= maxPayload) {
+        QueueOutput(TFrameBuilder::BuildHeaders(streamId, headerFlags, headerBlock));
+    } else {
+        // END_STREAM goes on the HEADERS frame (per RFC 7540 §6.2, §6.10)
+        uint8_t firstFlags = !hasBody ? NFrameFlag::END_STREAM : NFrameFlag::NONE;
+        QueueOutput(TFrameBuilder::BuildHeaders(streamId, firstFlags, TStringBuf(headerBlock).Head(maxPayload)));
+        size_t offset = maxPayload;
+        while (offset < headerBlock.size()) {
+            size_t chunkSize = std::min(maxPayload, headerBlock.size() - offset);
+            uint8_t contFlags = (offset + chunkSize >= headerBlock.size()) ? NFrameFlag::END_HEADERS : NFrameFlag::NONE;
+            QueueOutput(TFrameBuilder::BuildContinuation(streamId, contFlags,
+                TStringBuf(headerBlock).SubStr(offset, chunkSize)));
+            offset += chunkSize;
+        }
+    }
+
+    if (hasBody) {
+        size_t offset = 0;
+        while (offset < body.size()) {
+            size_t chunkSize = std::min(maxPayload, body.size() - offset);
+            uint8_t dataFlags = (offset + chunkSize >= body.size()) ? NFrameFlag::END_STREAM : NFrameFlag::NONE;
+            QueueOutput(TFrameBuilder::BuildData(streamId, dataFlags, body.SubStr(offset, chunkSize)));
+            offset += chunkSize;
+        }
+    }
+
+    if (!hasBody) {
+        stream.State = EStreamState::HalfClosedLocal;
+    }
+
+    if (HasPendingOutput() && Callbacks.OnSend) {
+        Callbacks.OnSend(FlushOutputBuffer());
+    }
+
+    return streamId;
+}
+
+void TSession::RegisterUpgradeStream(TStringBuf path, TStringBuf authority) {
+    const uint32_t streamId = 1;
+    TStream& stream = GetOrCreateStream(streamId);
+    stream.Path = TString(path);
+    stream.Authority = TString(authority);
+    // Client already sent the request as HTTP/1.1
+    // Server already received the request as HTTP/1.1
+    stream.State = (Role == ERole::Client) ? EStreamState::HalfClosedLocal : EStreamState::HalfClosedRemote;
+    if (NextLocalStreamId <= streamId) {
+        NextLocalStreamId = streamId + 2;
+    }
+}
+
+void TSession::SendGoaway(EErrorCode errorCode, TStringBuf debugData) {
+    if (GoawaySent) return;
+    GoawaySent = true;
+    QueueOutput(TFrameBuilder::BuildGoaway(LastPeerStreamId, errorCode, debugData));
+    if (HasPendingOutput() && Callbacks.OnSend) {
+        Callbacks.OnSend(FlushOutputBuffer());
+    }
+}
+
+// ============== Conversion Helpers ==============
+
+static bool ContainsCrLf(TStringBuf s) {
+    return s.Contains('\r') || s.Contains('\n');
+}
+
+THttpIncomingRequestPtr StreamToIncomingRequest(
+    const TStream& stream,
+    std::shared_ptr<THttpEndpointInfo> endpoint,
+    THttpConfig::SocketAddressType address) {
+
+    // Build an HTTP/1.1-style request string for THttpIncomingRequest to parse
+    TStringBuilder req;
+    req << stream.Method << " " << stream.Path << " HTTP/2.0\r\n";
+    if (!stream.Authority.empty()) {
+        req << "Host: " << stream.Authority << "\r\n";
+    }
+    for (const auto& [name, value] : stream.Headers) {
+        if (!ContainsCrLf(name) && !ContainsCrLf(value)) {
+            req << name << ": " << value << "\r\n";
+        }
+    }
+    if (!stream.Body.empty()) {
+        req << "Content-Length: " << stream.Body.size() << "\r\n";
+    }
+    req << "\r\n";
+    req << stream.Body;
+
+    TString reqStr = req;
+    THttpIncomingRequestPtr request = new THttpIncomingRequest(reqStr, std::move(endpoint), address);
+    return request;
+}
+
+void OutgoingResponseToStream(
+    const THttpOutgoingResponsePtr& response,
+    TString& status,
+    TVector<std::pair<TString, TString>>& headers,
+    TString& body) {
+
+    status = TString(response->Status);
+
+    // Parse headers from the response
+    // response->Body is always uncompressed (THttpOutgoingResponse::SetBody stores uncompressed copy).
+    // If content-encoding was set, we need to re-compress the body for HTTP/2.
+    TString contentEncoding;
+    THeaders parsedHeaders(response->Headers);
+    for (const auto& [name, value] : parsedHeaders.Headers) {
+        TString lowerName = TString(name);
+        lowerName.to_lower();
+        // Skip HTTP/1.1-specific headers
+        if (lowerName == "connection" || lowerName == "transfer-encoding" || lowerName == "keep-alive") {
+            continue;
+        }
+        // Remember content-encoding but skip content-length (will be recalculated after compression)
+        if (lowerName == "content-encoding") {
+            contentEncoding = TString(value);
+            headers.emplace_back(lowerName, TString(value));
+            continue;
+        }
+        if (lowerName == "content-length") {
+            continue; // will be set below after potential compression
+        }
+        headers.emplace_back(lowerName, TString(value));
+    }
+
+    // Add known headers that might not be in the generic headers map
+    if (!response->ContentType.empty()) {
+        bool found = false;
+        for (const auto& [name, _] : headers) {
+            if (TEqNoCase()(name, "content-type")) { found = true; break; }
+        }
+        if (!found) {
+            headers.emplace_back("content-type", TString(response->ContentType));
+        }
+    }
+
+    // Re-compress body if content-encoding was set
+    if (!contentEncoding.empty() && response->Body) {
+        TCompressContext compressor;
+        compressor.InitCompress(contentEncoding);
+        body = compressor.Compress(response->Body, true);
+    } else {
+        body = TString(response->Body);
+    }
+
+    // Set content-length
+    if (!body.empty()) {
+        headers.emplace_back("content-length", ToString(body.size()));
+    }
+}
+
+void OutgoingRequestToStream(
+    const THttpOutgoingRequestPtr& request,
+    TString& method,
+    TString& path,
+    TString& authority,
+    TString& scheme,
+    TVector<std::pair<TString, TString>>& headers,
+    TString& body) {
+
+    method = TString(request->Method);
+    path = TString(request->URL);
+    authority = TString(request->Host);
+    scheme = request->Secure ? "https" : "http";
+
+    THeaders parsedHeaders(request->Headers);
+    for (const auto& [name, value] : parsedHeaders.Headers) {
+        TString lowerName = TString(name);
+        lowerName.to_lower();
+        if (lowerName == "host" || lowerName == "connection" || lowerName == "transfer-encoding") {
+            continue;
+        }
+        headers.emplace_back(lowerName, TString(value));
+    }
+
+    body = TString(request->Body);
+}
+
+THttpIncomingResponsePtr StreamToIncomingResponse(
+    const TStream& stream,
+    THttpOutgoingRequestPtr request) {
+
+    TStringBuilder resp;
+    resp << "HTTP/2.0 " << stream.Status << " ";
+    // HTTP/2 doesn't have a reason phrase, use a placeholder
+    int statusCode = 0;
+    TryFromString(stream.Status, statusCode);
+    switch (statusCode) {
+        case 200: resp << "OK"; break;
+        case 201: resp << "Created"; break;
+        case 204: resp << "No Content"; break;
+        case 301: resp << "Moved Permanently"; break;
+        case 302: resp << "Found"; break;
+        case 304: resp << "Not Modified"; break;
+        case 400: resp << "Bad Request"; break;
+        case 401: resp << "Unauthorized"; break;
+        case 403: resp << "Forbidden"; break;
+        case 404: resp << "Not Found"; break;
+        case 500: resp << "Internal Server Error"; break;
+        case 502: resp << "Bad Gateway"; break;
+        case 503: resp << "Service Unavailable"; break;
+        case 504: resp << "Gateway Timeout"; break;
+        default: resp << "Unknown"; break;
+    }
+    resp << "\r\n";
+
+    for (const auto& [name, value] : stream.Headers) {
+        if (!ContainsCrLf(name) && !ContainsCrLf(value)) {
+            resp << name << ": " << value << "\r\n";
+        }
+    }
+    if (!stream.Body.empty()) {
+        resp << "Content-Length: " << stream.Body.size() << "\r\n";
+    }
+    resp << "\r\n";
+    resp << stream.Body;
+
+    TString respStr = resp;
+    THttpIncomingResponsePtr response = new THttpIncomingResponse(std::move(request));
+    response->EnsureEnoughSpaceAvailable(respStr.size());
+    std::memcpy(response->Pos(), respStr.data(), respStr.size());
+    response->Advance(respStr.size());
+    return response;
+}
+
+} // namespace NHttp::NHttp2

--- a/ydb/library/actors/http/http2.h
+++ b/ydb/library/actors/http/http2.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include "http.h"
+#include "http2_frames.h"
+#include "http2_hpack.h"
+
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+#include <deque>
+#include <functional>
+
+namespace NHttp::NHttp2 {
+
+// HTTP/2 stream
+struct TStream {
+    uint32_t StreamId = 0;
+    EStreamState State = EStreamState::Idle;
+
+    // Accumulated header block fragments (HEADERS + CONTINUATION)
+    TString HeaderBlockFragment;
+    bool HeadersComplete = false;
+
+    // Request data (server-side)
+    TString Method;
+    TString Path;
+    TString Scheme;
+    TString Authority;
+    TVector<std::pair<TString, TString>> Headers;
+    TString Body;
+    bool EndStream = false; // received END_STREAM
+
+    // Response data (client-side)
+    TString Status;
+
+    // Flow control
+    int32_t SendWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
+    int32_t RecvWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
+};
+
+// Callback interface for session events
+struct TSessionCallbacks {
+    // Server-side: called when a complete request is received
+    std::function<void(uint32_t streamId, TStream& stream)> OnRequest;
+    // Client-side: called when a complete response is received
+    std::function<void(uint32_t streamId, TStream& stream)> OnResponse;
+    // Called when data needs to be sent on the wire
+    std::function<void(TString data)> OnSend;
+    // Called on error
+    std::function<void(TString error)> OnError;
+    // Called when GOAWAY is received
+    std::function<void(uint32_t lastStreamId, EErrorCode errorCode)> OnGoaway;
+};
+
+// HTTP/2 session state machine
+// Handles framing, HPACK, stream management, flow control
+class TSession {
+public:
+    enum class ERole {
+        Server,
+        Client,
+    };
+
+    TSession(ERole role, TSessionCallbacks callbacks);
+
+    // Feed raw bytes from the wire. Returns number of bytes consumed.
+    size_t Feed(const char* data, size_t len);
+
+    // For server: send response on a stream
+    // If endStream is false, the stream remains open for subsequent DATA frames (streaming)
+    void SendResponse(uint32_t streamId, TStringBuf status, const TVector<std::pair<TString, TString>>& headers, TStringBuf body, bool endStream = true);
+
+    // For client: send request
+    uint32_t SendRequest(TStringBuf method, TStringBuf path, TStringBuf authority, TStringBuf scheme,
+                         const TVector<std::pair<TString, TString>>& headers, TStringBuf body);
+
+    // For client: register stream 1 for HTTP/1.1 upgrade (RFC 7540 §3.2)
+    // The request was already sent as HTTP/1.1; this just creates the stream
+    // so we can receive the response on it via HTTP/2.
+    void RegisterUpgradeStream(TStringBuf path, TStringBuf authority);
+
+    // Send GOAWAY and close
+    void SendGoaway(EErrorCode errorCode = EErrorCode::NO_ERROR, TStringBuf debugData = {});
+
+    // Returns true if session has been initialized (preface received/sent)
+    bool IsReady() const { return PrefaceReceived; }
+    bool IsGoaway() const { return GoawaySent || GoawayReceived; }
+
+    // Initialize the connection (send preface + initial SETTINGS)
+    void Initialize();
+
+    // Get pending outgoing data (batched write optimization)
+    TString FlushOutputBuffer();
+    bool HasPendingOutput() const { return !OutputBuffer.empty(); }
+
+private:
+    ERole Role;
+    TSessionCallbacks Callbacks;
+
+    // Connection state
+    bool Initialized = false;
+    bool PrefaceReceived = false;
+    bool GoawaySent = false;
+    bool GoawayReceived = false;
+    size_t PrefaceBytesMatched = 0; // for server: tracking client preface
+
+    // Settings
+    TSettings LocalSettings;     // our settings (sent to peer)
+    TSettings PeerSettings;      // peer's settings (received from peer)
+    bool SettingsAckPending = false;
+
+    // HPACK
+    THPackEncoder Encoder;
+    THPackDecoder Decoder;
+
+    // Streams
+    THashMap<uint32_t, TStream> Streams;
+    uint32_t LastPeerStreamId = 0;   // highest stream ID from peer
+    uint32_t NextLocalStreamId = 0;  // next stream ID we'll use
+
+    // Connection-level flow control
+    int32_t SendWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
+    int32_t RecvWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
+
+    // Frame parsing state
+    enum class EFrameParseState {
+        WaitingPreface,  // server: waiting for client connection preface
+        ReadingHeader,
+        ReadingPayload,
+    };
+    EFrameParseState FrameParseState;
+    TString FrameBuffer; // accumulates partial frame data
+    TFrameHeader CurrentFrameHeader;
+
+    // For CONTINUATION frames
+    uint32_t ExpectingContinuationStream = 0; // non-zero if we're waiting for CONTINUATION
+
+    // Output buffer
+    TString OutputBuffer;
+
+    // Internal methods
+    void QueueOutput(TString data);
+    void QueueOutput(const char* data, size_t len);
+
+    void SendSettings();
+    void SendSettingsAck();
+    void SendWindowUpdate(uint32_t streamId, uint32_t increment);
+    void SendRstStream(uint32_t streamId, EErrorCode errorCode);
+
+    TStream& GetOrCreateStream(uint32_t streamId);
+    TStream* FindStream(uint32_t streamId);
+
+    // Frame processing
+    void ProcessFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessDataFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessHeadersFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessPriorityFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessRstStreamFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessSettingsFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessPingFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessGoawayFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessWindowUpdateFrame(const TFrameHeader& header, TStringBuf payload);
+    void ProcessContinuationFrame(const TFrameHeader& header, TStringBuf payload);
+
+    void CompleteHeaderBlock(uint32_t streamId, TStream& stream, bool endStream);
+    void CloseStream(uint32_t streamId, EErrorCode errorCode = EErrorCode::NO_ERROR);
+
+    void ConnectionError(EErrorCode errorCode, TStringBuf message = {});
+};
+
+// Helper: Convert HTTP/2 stream to THttpIncomingRequest
+THttpIncomingRequestPtr StreamToIncomingRequest(
+    const TStream& stream,
+    std::shared_ptr<THttpEndpointInfo> endpoint,
+    THttpConfig::SocketAddressType address);
+
+// Helper: Convert THttpOutgoingResponse to HTTP/2 headers + body
+void OutgoingResponseToStream(
+    const THttpOutgoingResponsePtr& response,
+    TString& status,
+    TVector<std::pair<TString, TString>>& headers,
+    TString& body);
+
+// Helper: Convert THttpOutgoingRequest to HTTP/2 headers + body
+void OutgoingRequestToStream(
+    const THttpOutgoingRequestPtr& request,
+    TString& method,
+    TString& path,
+    TString& authority,
+    TString& scheme,
+    TVector<std::pair<TString, TString>>& headers,
+    TString& body);
+
+// Helper: Convert HTTP/2 stream to THttpIncomingResponse
+THttpIncomingResponsePtr StreamToIncomingResponse(
+    const TStream& stream,
+    THttpOutgoingRequestPtr request);
+
+} // namespace NHttp::NHttp2

--- a/ydb/library/actors/http/http2_frames.h
+++ b/ydb/library/actors/http/http2_frames.h
@@ -1,0 +1,358 @@
+#pragma once
+
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/system/byteorder.h>
+
+#include <cstdint>
+#include <cstring>
+
+namespace NHttp::NHttp2 {
+
+// HTTP/2 Connection Preface (RFC 7540 Section 3.5)
+inline constexpr TStringBuf CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+// Frame header size is always 9 bytes (RFC 7540 Section 4.1)
+inline constexpr size_t FRAME_HEADER_SIZE = 9;
+
+// Default limits
+inline constexpr uint32_t DEFAULT_HEADER_TABLE_SIZE = 4096;
+inline constexpr uint32_t DEFAULT_MAX_CONCURRENT_STREAMS = 100;
+inline constexpr uint32_t DEFAULT_INITIAL_WINDOW_SIZE = 65535;
+inline constexpr uint32_t DEFAULT_MAX_FRAME_SIZE = 16384;
+inline constexpr uint32_t DEFAULT_MAX_HEADER_LIST_SIZE = 8192;
+inline constexpr uint32_t MAX_WINDOW_SIZE = 0x7FFFFFFF;
+inline constexpr uint32_t MAX_MAX_FRAME_SIZE = 16777215; // 2^24-1
+
+// Frame types (RFC 7540 Section 6)
+enum class EFrameType : uint8_t {
+    DATA          = 0x0,
+    HEADERS       = 0x1,
+    PRIORITY      = 0x2,
+    RST_STREAM    = 0x3,
+    SETTINGS      = 0x4,
+    PUSH_PROMISE  = 0x5,
+    PING          = 0x6,
+    GOAWAY        = 0x7,
+    WINDOW_UPDATE = 0x8,
+    CONTINUATION  = 0x9,
+};
+
+// Frame flags
+namespace NFrameFlag {
+    inline constexpr uint8_t NONE         = 0x0;
+    // DATA & HEADERS
+    inline constexpr uint8_t END_STREAM   = 0x1;
+    // HEADERS & CONTINUATION
+    inline constexpr uint8_t END_HEADERS  = 0x4;
+    // DATA
+    inline constexpr uint8_t PADDED       = 0x8;
+    // HEADERS
+    inline constexpr uint8_t PRIORITY     = 0x20;
+    // SETTINGS & PING
+    inline constexpr uint8_t ACK          = 0x1;
+}
+
+// Settings identifiers (RFC 7540 Section 6.5.2)
+enum class ESettingsId : uint16_t {
+    HEADER_TABLE_SIZE      = 0x1,
+    ENABLE_PUSH            = 0x2,
+    MAX_CONCURRENT_STREAMS = 0x3,
+    INITIAL_WINDOW_SIZE    = 0x4,
+    MAX_FRAME_SIZE         = 0x5,
+    MAX_HEADER_LIST_SIZE   = 0x6,
+};
+
+// Error codes (RFC 7540 Section 7)
+enum class EErrorCode : uint32_t {
+    NO_ERROR            = 0x0,
+    PROTOCOL_ERROR      = 0x1,
+    INTERNAL_ERROR      = 0x2,
+    FLOW_CONTROL_ERROR  = 0x3,
+    SETTINGS_TIMEOUT    = 0x4,
+    STREAM_CLOSED       = 0x5,
+    FRAME_SIZE_ERROR    = 0x6,
+    REFUSED_STREAM      = 0x7,
+    CANCEL              = 0x8,
+    COMPRESSION_ERROR   = 0x9,
+    CONNECT_ERROR       = 0xa,
+    ENHANCE_YOUR_CALM   = 0xb,
+    INADEQUATE_SECURITY = 0xc,
+    HTTP_1_1_REQUIRED   = 0xd,
+};
+
+// Stream states (RFC 7540 Section 5.1)
+enum class EStreamState {
+    Idle,
+    ReservedLocal,
+    ReservedRemote,
+    Open,
+    HalfClosedLocal,
+    HalfClosedRemote,
+    Closed,
+};
+
+// Parsed frame header
+struct TFrameHeader {
+    uint32_t Length = 0;     // 24 bits
+    EFrameType Type = EFrameType::DATA;
+    uint8_t Flags = 0;
+    uint32_t StreamId = 0;   // 31 bits (R bit ignored)
+
+    bool HasFlag(uint8_t flag) const {
+        return (Flags & flag) != 0;
+    }
+
+    // Parse from 9-byte buffer
+    bool Parse(const char* data) {
+        Length = (static_cast<uint8_t>(data[0]) << 16)
+               | (static_cast<uint8_t>(data[1]) << 8)
+               | static_cast<uint8_t>(data[2]);
+        Type = static_cast<EFrameType>(data[3]);
+        Flags = static_cast<uint8_t>(data[4]);
+        StreamId = (static_cast<uint8_t>(data[5]) << 24)
+                 | (static_cast<uint8_t>(data[6]) << 16)
+                 | (static_cast<uint8_t>(data[7]) << 8)
+                 | static_cast<uint8_t>(data[8]);
+        StreamId &= 0x7FFFFFFF; // clear R bit
+        return true;
+    }
+
+    // Serialize to 9-byte buffer
+    void Serialize(char* out) const {
+        out[0] = static_cast<char>((Length >> 16) & 0xFF);
+        out[1] = static_cast<char>((Length >> 8) & 0xFF);
+        out[2] = static_cast<char>(Length & 0xFF);
+        out[3] = static_cast<char>(Type);
+        out[4] = static_cast<char>(Flags);
+        out[5] = static_cast<char>((StreamId >> 24) & 0x7F);
+        out[6] = static_cast<char>((StreamId >> 16) & 0xFF);
+        out[7] = static_cast<char>((StreamId >> 8) & 0xFF);
+        out[8] = static_cast<char>(StreamId & 0xFF);
+    }
+};
+
+// Settings entry
+struct TSettingsEntry {
+    ESettingsId Id;
+    uint32_t Value;
+};
+
+// Connection settings
+struct TSettings {
+    uint32_t HeaderTableSize = DEFAULT_HEADER_TABLE_SIZE;
+    bool EnablePush = true;
+    uint32_t MaxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
+    uint32_t InitialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
+    uint32_t MaxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+    uint32_t MaxHeaderListSize = DEFAULT_MAX_HEADER_LIST_SIZE;
+
+    bool Apply(ESettingsId id, uint32_t value) {
+        switch (id) {
+            case ESettingsId::HEADER_TABLE_SIZE:
+                HeaderTableSize = value;
+                return true;
+            case ESettingsId::ENABLE_PUSH:
+                if (value > 1) return false;
+                EnablePush = (value == 1);
+                return true;
+            case ESettingsId::MAX_CONCURRENT_STREAMS:
+                MaxConcurrentStreams = value;
+                return true;
+            case ESettingsId::INITIAL_WINDOW_SIZE:
+                if (value > MAX_WINDOW_SIZE) return false;
+                InitialWindowSize = value;
+                return true;
+            case ESettingsId::MAX_FRAME_SIZE:
+                if (value < DEFAULT_MAX_FRAME_SIZE || value > MAX_MAX_FRAME_SIZE) return false;
+                MaxFrameSize = value;
+                return true;
+            case ESettingsId::MAX_HEADER_LIST_SIZE:
+                MaxHeaderListSize = value;
+                return true;
+        }
+        // Unknown settings MUST be ignored (RFC 7540 Section 6.5.2)
+        return true;
+    }
+};
+
+// Helper to build frames
+class TFrameBuilder {
+public:
+    // Build a SETTINGS frame
+    static TString BuildSettings(uint32_t streamId, uint8_t flags, const TVector<TSettingsEntry>& entries) {
+        TString result;
+        size_t payloadSize = entries.size() * 6;
+        result.resize(FRAME_HEADER_SIZE + payloadSize);
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = payloadSize;
+        hdr.Type = EFrameType::SETTINGS;
+        hdr.Flags = flags;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        char* payload = out + FRAME_HEADER_SIZE;
+        for (const auto& entry : entries) {
+            uint16_t id = static_cast<uint16_t>(entry.Id);
+            payload[0] = static_cast<char>((id >> 8) & 0xFF);
+            payload[1] = static_cast<char>(id & 0xFF);
+            payload[2] = static_cast<char>((entry.Value >> 24) & 0xFF);
+            payload[3] = static_cast<char>((entry.Value >> 16) & 0xFF);
+            payload[4] = static_cast<char>((entry.Value >> 8) & 0xFF);
+            payload[5] = static_cast<char>(entry.Value & 0xFF);
+            payload += 6;
+        }
+        return result;
+    }
+
+    static TString BuildSettingsAck() {
+        return BuildSettings(0, NFrameFlag::ACK, {});
+    }
+
+    // Build a HEADERS frame (header block fragment)
+    static TString BuildHeaders(uint32_t streamId, uint8_t flags, TStringBuf headerBlock) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + headerBlock.size());
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = headerBlock.size();
+        hdr.Type = EFrameType::HEADERS;
+        hdr.Flags = flags;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        std::memcpy(out + FRAME_HEADER_SIZE, headerBlock.data(), headerBlock.size());
+        return result;
+    }
+
+    // Build a DATA frame
+    static TString BuildData(uint32_t streamId, uint8_t flags, TStringBuf data) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + data.size());
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = data.size();
+        hdr.Type = EFrameType::DATA;
+        hdr.Flags = flags;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        std::memcpy(out + FRAME_HEADER_SIZE, data.data(), data.size());
+        return result;
+    }
+
+    // Build a WINDOW_UPDATE frame
+    static TString BuildWindowUpdate(uint32_t streamId, uint32_t increment) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + 4);
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = 4;
+        hdr.Type = EFrameType::WINDOW_UPDATE;
+        hdr.Flags = NFrameFlag::NONE;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        char* payload = out + FRAME_HEADER_SIZE;
+        payload[0] = static_cast<char>((increment >> 24) & 0x7F);
+        payload[1] = static_cast<char>((increment >> 16) & 0xFF);
+        payload[2] = static_cast<char>((increment >> 8) & 0xFF);
+        payload[3] = static_cast<char>(increment & 0xFF);
+        return result;
+    }
+
+    // Build a RST_STREAM frame
+    static TString BuildRstStream(uint32_t streamId, EErrorCode errorCode) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + 4);
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = 4;
+        hdr.Type = EFrameType::RST_STREAM;
+        hdr.Flags = NFrameFlag::NONE;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        uint32_t code = static_cast<uint32_t>(errorCode);
+        char* payload = out + FRAME_HEADER_SIZE;
+        payload[0] = static_cast<char>((code >> 24) & 0xFF);
+        payload[1] = static_cast<char>((code >> 16) & 0xFF);
+        payload[2] = static_cast<char>((code >> 8) & 0xFF);
+        payload[3] = static_cast<char>(code & 0xFF);
+        return result;
+    }
+
+    // Build a GOAWAY frame
+    static TString BuildGoaway(uint32_t lastStreamId, EErrorCode errorCode, TStringBuf debugData = {}) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + 8 + debugData.size());
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = 8 + debugData.size();
+        hdr.Type = EFrameType::GOAWAY;
+        hdr.Flags = NFrameFlag::NONE;
+        hdr.StreamId = 0;
+        hdr.Serialize(out);
+
+        char* payload = out + FRAME_HEADER_SIZE;
+        payload[0] = static_cast<char>((lastStreamId >> 24) & 0x7F);
+        payload[1] = static_cast<char>((lastStreamId >> 16) & 0xFF);
+        payload[2] = static_cast<char>((lastStreamId >> 8) & 0xFF);
+        payload[3] = static_cast<char>(lastStreamId & 0xFF);
+
+        uint32_t code = static_cast<uint32_t>(errorCode);
+        payload[4] = static_cast<char>((code >> 24) & 0xFF);
+        payload[5] = static_cast<char>((code >> 16) & 0xFF);
+        payload[6] = static_cast<char>((code >> 8) & 0xFF);
+        payload[7] = static_cast<char>(code & 0xFF);
+
+        if (!debugData.empty()) {
+            std::memcpy(payload + 8, debugData.data(), debugData.size());
+        }
+        return result;
+    }
+
+    // Build a PING frame
+    static TString BuildPing(uint8_t flags, const char opaqueData[8]) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + 8);
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = 8;
+        hdr.Type = EFrameType::PING;
+        hdr.Flags = flags;
+        hdr.StreamId = 0;
+        hdr.Serialize(out);
+
+        std::memcpy(out + FRAME_HEADER_SIZE, opaqueData, 8);
+        return result;
+    }
+
+    // Build a CONTINUATION frame
+    static TString BuildContinuation(uint32_t streamId, uint8_t flags, TStringBuf headerBlock) {
+        TString result;
+        result.resize(FRAME_HEADER_SIZE + headerBlock.size());
+        char* out = result.Detach();
+
+        TFrameHeader hdr;
+        hdr.Length = headerBlock.size();
+        hdr.Type = EFrameType::CONTINUATION;
+        hdr.Flags = flags;
+        hdr.StreamId = streamId;
+        hdr.Serialize(out);
+
+        std::memcpy(out + FRAME_HEADER_SIZE, headerBlock.data(), headerBlock.size());
+        return result;
+    }
+};
+
+} // namespace NHttp::NHttp2

--- a/ydb/library/actors/http/http2_hpack.cpp
+++ b/ydb/library/actors/http/http2_hpack.cpp
@@ -1,0 +1,711 @@
+#include "http2_hpack.h"
+
+#include <util/generic/yexception.h>
+
+namespace NHttp::NHttp2 {
+
+// Static table entry
+struct THPackEntry {
+    TStringBuf Name;
+    TStringBuf Value;
+};
+
+// RFC 7541 Appendix A - Static Table
+static constexpr THPackEntry STATIC_TABLE[] = {
+    {"",                          ""},             // index 0 (unused, 1-based)
+    {":authority",                ""},             // 1
+    {":method",                   "GET"},          // 2
+    {":method",                   "POST"},         // 3
+    {":path",                     "/"},            // 4
+    {":path",                     "/index.html"},  // 5
+    {":scheme",                   "http"},         // 6
+    {":scheme",                   "https"},        // 7
+    {":status",                   "200"},          // 8
+    {":status",                   "204"},          // 9
+    {":status",                   "206"},          // 10
+    {":status",                   "304"},          // 11
+    {":status",                   "400"},          // 12
+    {":status",                   "404"},          // 13
+    {":status",                   "500"},          // 14
+    {"accept-charset",            ""},             // 15
+    {"accept-encoding",           "gzip, deflate"},// 16
+    {"accept-language",           ""},             // 17
+    {"accept-ranges",             ""},             // 18
+    {"accept",                    ""},             // 19
+    {"access-control-allow-origin",""},            // 20
+    {"age",                       ""},             // 21
+    {"allow",                     ""},             // 22
+    {"authorization",             ""},             // 23
+    {"cache-control",             ""},             // 24
+    {"content-disposition",       ""},             // 25
+    {"content-encoding",          ""},             // 26
+    {"content-language",          ""},             // 27
+    {"content-length",            ""},             // 28
+    {"content-location",          ""},             // 29
+    {"content-range",             ""},             // 30
+    {"content-type",              ""},             // 31
+    {"cookie",                    ""},             // 32
+    {"date",                      ""},             // 33
+    {"etag",                      ""},             // 34
+    {"expect",                    ""},             // 35
+    {"expires",                   ""},             // 36
+    {"from",                      ""},             // 37
+    {"host",                      ""},             // 38
+    {"if-match",                  ""},             // 39
+    {"if-modified-since",         ""},             // 40
+    {"if-none-match",             ""},             // 41
+    {"if-range",                  ""},             // 42
+    {"if-unmodified-since",       ""},             // 43
+    {"last-modified",             ""},             // 44
+    {"link",                      ""},             // 45
+    {"location",                  ""},             // 46
+    {"max-forwards",              ""},             // 47
+    {"proxy-authenticate",        ""},             // 48
+    {"proxy-authorization",       ""},             // 49
+    {"range",                     ""},             // 50
+    {"referer",                   ""},             // 51
+    {"refresh",                   ""},             // 52
+    {"retry-after",               ""},             // 53
+    {"server",                    ""},             // 54
+    {"set-cookie",                ""},             // 55
+    {"strict-transport-security", ""},             // 56
+    {"transfer-encoding",         ""},             // 57
+    {"user-agent",                ""},             // 58
+    {"vary",                      ""},             // 59
+    {"via",                       ""},             // 60
+    {"www-authenticate",          ""},             // 61
+};
+
+static constexpr size_t STATIC_TABLE_SIZE = 61; // entries 1..61
+
+// Huffman code table (RFC 7541 Appendix B)
+struct THuffmanCode {
+    uint32_t Code;
+    uint8_t BitLen;
+};
+
+// RFC 7541 Appendix B - Huffman Code
+static constexpr THuffmanCode HUFFMAN_TABLE[257] = {
+    {0x1ff8,     13}, // (  0)
+    {0x7fffd8,   23}, // (  1)
+    {0xfffffe2,  28}, // (  2)
+    {0xfffffe3,  28}, // (  3)
+    {0xfffffe4,  28}, // (  4)
+    {0xfffffe5,  28}, // (  5)
+    {0xfffffe6,  28}, // (  6)
+    {0xfffffe7,  28}, // (  7)
+    {0xfffffe8,  28}, // (  8)
+    {0xffffea,   24}, // (  9)
+    {0x3ffffffc, 30}, // ( 10)
+    {0xfffffe9,  28}, // ( 11)
+    {0xfffffea,  28}, // ( 12)
+    {0x3ffffffd, 30}, // ( 13)
+    {0xfffffeb,  28}, // ( 14)
+    {0xfffffec,  28}, // ( 15)
+    {0xfffffed,  28}, // ( 16)
+    {0xfffffee,  28}, // ( 17)
+    {0xfffffef,  28}, // ( 18)
+    {0xffffff0,  28}, // ( 19)
+    {0xffffff1,  28}, // ( 20)
+    {0xffffff2,  28}, // ( 21)
+    {0x3ffffffe, 30}, // ( 22)
+    {0xffffff3,  28}, // ( 23)
+    {0xffffff4,  28}, // ( 24)
+    {0xffffff5,  28}, // ( 25)
+    {0xffffff6,  28}, // ( 26)
+    {0xffffff7,  28}, // ( 27)
+    {0xffffff8,  28}, // ( 28)
+    {0xffffff9,  28}, // ( 29)
+    {0xffffffa,  28}, // ( 30)
+    {0xffffffb,  28}, // ( 31)
+    {0x14,        6}, // ' ' ( 32)
+    {0x3f8,      10}, // '!' ( 33)
+    {0x3f9,      10}, // '"' ( 34)
+    {0xffa,      12}, // '#' ( 35)
+    {0x1ff9,     13}, // '$' ( 36)
+    {0x15,        6}, // '%' ( 37)
+    {0xf8,        8}, // '&' ( 38)
+    {0x7fa,      11}, // '\'' ( 39)
+    {0x3fa,      10}, // '(' ( 40)
+    {0x3fb,      10}, // ')' ( 41)
+    {0xf9,        8}, // '*' ( 42)
+    {0x7fb,      11}, // '+' ( 43)
+    {0xfa,        8}, // ',' ( 44)
+    {0x16,        6}, // '-' ( 45)
+    {0x17,        6}, // '.' ( 46)
+    {0x18,        6}, // '/' ( 47)
+    {0x0,         5}, // '0' ( 48)
+    {0x1,         5}, // '1' ( 49)
+    {0x2,         5}, // '2' ( 50)
+    {0x19,        6}, // '3' ( 51)
+    {0x1a,        6}, // '4' ( 52)
+    {0x1b,        6}, // '5' ( 53)
+    {0x1c,        6}, // '6' ( 54)
+    {0x1d,        6}, // '7' ( 55)
+    {0x1e,        6}, // '8' ( 56)
+    {0x1f,        6}, // '9' ( 57)
+    {0x5c,        7}, // ':' ( 58)
+    {0xfb,        8}, // ';' ( 59)
+    {0x7ffc,     15}, // '<' ( 60)
+    {0x20,        6}, // '=' ( 61)
+    {0xffb,      12}, // '>' ( 62)
+    {0x3fc,      10}, // '?' ( 63)
+    {0x1ffa,     13}, // '@' ( 64)
+    {0x21,        6}, // 'A' ( 65)
+    {0x5d,        7}, // 'B' ( 66)
+    {0x5e,        7}, // 'C' ( 67)
+    {0x5f,        7}, // 'D' ( 68)
+    {0x60,        7}, // 'E' ( 69)
+    {0x61,        7}, // 'F' ( 70)
+    {0x62,        7}, // 'G' ( 71)
+    {0x63,        7}, // 'H' ( 72)
+    {0x64,        7}, // 'I' ( 73)
+    {0x65,        7}, // 'J' ( 74)
+    {0x66,        7}, // 'K' ( 75)
+    {0x67,        7}, // 'L' ( 76)
+    {0x68,        7}, // 'M' ( 77)
+    {0x69,        7}, // 'N' ( 78)
+    {0x6a,        7}, // 'O' ( 79)
+    {0x6b,        7}, // 'P' ( 80)
+    {0x6c,        7}, // 'Q' ( 81)
+    {0x6d,        7}, // 'R' ( 82)
+    {0x6e,        7}, // 'S' ( 83)
+    {0x6f,        7}, // 'T' ( 84)
+    {0x70,        7}, // 'U' ( 85)
+    {0x71,        7}, // 'V' ( 86)
+    {0x72,        7}, // 'W' ( 87)
+    {0xfc,        8}, // 'X' ( 88)
+    {0x73,        7}, // 'Y' ( 89)
+    {0xfd,        8}, // 'Z' ( 90)
+    {0x1ffb,     13}, // '[' ( 91)
+    {0x7fff0,    19}, // '\' ( 92)
+    {0x1ffc,     13}, // ']' ( 93)
+    {0x3ffc,     14}, // '^' ( 94)
+    {0x22,        6}, // '_' ( 95)
+    {0x7ffd,     15}, // '`' ( 96)
+    {0x3,         5}, // 'a' ( 97)
+    {0x23,        6}, // 'b' ( 98)
+    {0x4,         5}, // 'c' ( 99)
+    {0x24,        6}, // 'd' (100)
+    {0x5,         5}, // 'e' (101)
+    {0x25,        6}, // 'f' (102)
+    {0x26,        6}, // 'g' (103)
+    {0x27,        6}, // 'h' (104)
+    {0x6,         5}, // 'i' (105)
+    {0x74,        7}, // 'j' (106)
+    {0x75,        7}, // 'k' (107)
+    {0x28,        6}, // 'l' (108)
+    {0x29,        6}, // 'm' (109)
+    {0x2a,        6}, // 'n' (110)
+    {0x7,         5}, // 'o' (111)
+    {0x2b,        6}, // 'p' (112)
+    {0x76,        7}, // 'q' (113)
+    {0x2c,        6}, // 'r' (114)
+    {0x8,         5}, // 's' (115)
+    {0x9,         5}, // 't' (116)
+    {0x2d,        6}, // 'u' (117)
+    {0x77,        7}, // 'v' (118)
+    {0x78,        7}, // 'w' (119)
+    {0x79,        7}, // 'x' (120)
+    {0x7a,        7}, // 'y' (121)
+    {0x7b,        7}, // 'z' (122)
+    {0x7fffe,    19}, // '{' (123)
+    {0x7fc,      11}, // '|' (124)
+    {0x3ffd,     14}, // '}' (125)
+    {0x1ffd,     13}, // '~' (126)
+    {0xffffffc,  28}, // (127)
+    {0xfffe6,    20}, // (128)
+    {0x3fffd2,   22}, // (129)
+    {0xfffe7,    20}, // (130)
+    {0xfffe8,    20}, // (131)
+    {0x3fffd3,   22}, // (132)
+    {0x3fffd4,   22}, // (133)
+    {0x3fffd5,   22}, // (134)
+    {0x7fffd9,   23}, // (135)
+    {0x3fffd6,   22}, // (136)
+    {0x7fffda,   23}, // (137)
+    {0x7fffdb,   23}, // (138)
+    {0x7fffdc,   23}, // (139)
+    {0x7fffdd,   23}, // (140)
+    {0x7fffde,   23}, // (141)
+    {0xffffeb,   24}, // (142)
+    {0x7fffdf,   23}, // (143)
+    {0xffffec,   24}, // (144)
+    {0xffffed,   24}, // (145)
+    {0x3fffd7,   22}, // (146)
+    {0x7fffe0,   23}, // (147)
+    {0xffffee,   24}, // (148)
+    {0x7fffe1,   23}, // (149)
+    {0x7fffe2,   23}, // (150)
+    {0x7fffe3,   23}, // (151)
+    {0x7fffe4,   23}, // (152)
+    {0x1fffdc,   21}, // (153)
+    {0x3fffd8,   22}, // (154)
+    {0x7fffe5,   23}, // (155)
+    {0x3fffd9,   22}, // (156)
+    {0x7fffe6,   23}, // (157)
+    {0x7fffe7,   23}, // (158)
+    {0xffffef,   24}, // (159)
+    {0x3fffda,   22}, // (160)
+    {0x1fffdd,   21}, // (161)
+    {0xfffe9,    20}, // (162)
+    {0x3fffdb,   22}, // (163)
+    {0x3fffdc,   22}, // (164)
+    {0x7fffe8,   23}, // (165)
+    {0x7fffe9,   23}, // (166)
+    {0x1fffde,   21}, // (167)
+    {0x7fffea,   23}, // (168)
+    {0x3fffdd,   22}, // (169)
+    {0x3fffde,   22}, // (170)
+    {0xfffff0,   24}, // (171)
+    {0x1fffdf,   21}, // (172)
+    {0x3fffdf,   22}, // (173)
+    {0x7fffeb,   23}, // (174)
+    {0x7fffec,   23}, // (175)
+    {0x1fffe0,   21}, // (176)
+    {0x1fffe1,   21}, // (177)
+    {0x3fffe0,   22}, // (178)
+    {0x1fffe2,   21}, // (179)
+    {0x7fffed,   23}, // (180)
+    {0x3fffe1,   22}, // (181)
+    {0x7fffee,   23}, // (182)
+    {0x7fffef,   23}, // (183)
+    {0xfffea,    20}, // (184)
+    {0x3fffe2,   22}, // (185)
+    {0x3fffe3,   22}, // (186)
+    {0x3fffe4,   22}, // (187)
+    {0x7ffff0,   23}, // (188)
+    {0x3fffe5,   22}, // (189)
+    {0x3fffe6,   22}, // (190)
+    {0x7ffff1,   23}, // (191)
+    {0x3ffffe0,  26}, // (192)
+    {0x3ffffe1,  26}, // (193)
+    {0xfffeb,    20}, // (194)
+    {0x7fff1,    19}, // (195)
+    {0x3fffe7,   22}, // (196)
+    {0x7ffff2,   23}, // (197)
+    {0x3fffe8,   22}, // (198)
+    {0x1ffffec,  25}, // (199)
+    {0x3ffffe2,  26}, // (200)
+    {0x3ffffe3,  26}, // (201)
+    {0x3ffffe4,  26}, // (202)
+    {0x7ffffde,  27}, // (203)
+    {0x7ffffdf,  27}, // (204)
+    {0x3ffffe5,  26}, // (205)
+    {0xfffff1,   24}, // (206)
+    {0x1ffffed,  25}, // (207)
+    {0x7fff2,    19}, // (208)
+    {0x1fffe3,   21}, // (209)
+    {0x3ffffe6,  26}, // (210)
+    {0x7ffffe0,  27}, // (211)
+    {0x7ffffe1,  27}, // (212)
+    {0x3ffffe7,  26}, // (213)
+    {0x7ffffe2,  27}, // (214)
+    {0xfffff2,   24}, // (215)
+    {0x1fffe4,   21}, // (216)
+    {0x1fffe5,   21}, // (217)
+    {0x3ffffe8,  26}, // (218)
+    {0x3ffffe9,  26}, // (219)
+    {0xffffffd,  28}, // (220)
+    {0x7ffffe3,  27}, // (221)
+    {0x7ffffe4,  27}, // (222)
+    {0x7ffffe5,  27}, // (223)
+    {0xfffec,    20}, // (224)
+    {0xfffff3,   24}, // (225)
+    {0xfffed,    20}, // (226)
+    {0x1fffe6,   21}, // (227)
+    {0x3fffe9,   22}, // (228)
+    {0x1fffe7,   21}, // (229)
+    {0x1fffe8,   21}, // (230)
+    {0x7ffff3,   23}, // (231)
+    {0x3fffea,   22}, // (232)
+    {0x3fffeb,   22}, // (233)
+    {0x1ffffee,  25}, // (234)
+    {0x1ffffef,  25}, // (235)
+    {0xfffff4,   24}, // (236)
+    {0xfffff5,   24}, // (237)
+    {0x3ffffea,  26}, // (238)
+    {0x7ffff4,   23}, // (239)
+    {0x3ffffeb,  26}, // (240)
+    {0x7ffffe6,  27}, // (241)
+    {0x3ffffec,  26}, // (242)
+    {0x3ffffed,  26}, // (243)
+    {0x7ffffe7,  27}, // (244)
+    {0x7ffffe8,  27}, // (245)
+    {0x7ffffe9,  27}, // (246)
+    {0x7ffffea,  27}, // (247)
+    {0x7ffffeb,  27}, // (248)
+    {0xffffffe,  28}, // (249)
+    {0x7ffffec,  27}, // (250)
+    {0x7ffffed,  27}, // (251)
+    {0x7ffffee,  27}, // (252)
+    {0x7ffffef,  27}, // (253)
+    {0x7fffff0,  27}, // (254)
+    {0x3ffffee,  26}, // (255)
+    {0x3fffffff, 30}, // EOS (256)
+};
+
+// ============== THuffmanDecoder ==============
+
+THuffmanDecoder::THuffmanDecoder() {
+    // Build binary trie from Huffman table
+    Nodes.reserve(1024);
+    AllocNode(); // root = 0
+    for (int sym = 0; sym < 257; ++sym) {
+        const auto& hc = HUFFMAN_TABLE[sym];
+        int32_t node = 0;
+        for (int bit = hc.BitLen - 1; bit >= 0; --bit) {
+            int child = (hc.Code >> bit) & 1;
+            if (Nodes[node].Children[child] < 0) {
+                Nodes[node].Children[child] = AllocNode();
+            }
+            node = Nodes[node].Children[child];
+        }
+        Nodes[node].Symbol = static_cast<int16_t>(sym);
+    }
+}
+
+int32_t THuffmanDecoder::AllocNode() {
+    Nodes.emplace_back();
+    return static_cast<int32_t>(Nodes.size() - 1);
+}
+
+bool THuffmanDecoder::Decode(const uint8_t* data, size_t len, TString& out) const {
+    out.clear();
+    int32_t node = 0;
+    int bitsLeft = 0; // track padding bits
+
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t byte = data[i];
+        for (int bit = 7; bit >= 0; --bit) {
+            int child = (byte >> bit) & 1;
+            if (Nodes[node].Children[child] < 0) {
+                return false; // invalid encoding
+            }
+            node = Nodes[node].Children[child];
+            if (Nodes[node].Symbol >= 0) {
+                if (Nodes[node].Symbol == 256) {
+                    return false; // EOS in the middle of data is an error
+                }
+                out.push_back(static_cast<char>(Nodes[node].Symbol));
+                node = 0;
+                bitsLeft = 0;
+            } else {
+                bitsLeft++;
+            }
+        }
+    }
+    // Remaining bits must be padding (all 1s) and <= 7 bits
+    if (bitsLeft > 7) {
+        return false;
+    }
+    // Per RFC 7541 §5.2: padding must be the most-significant bits of EOS (all 1s)
+    if (bitsLeft > 0 && len > 0) {
+        uint8_t lastByte = data[len - 1];
+        uint8_t mask = static_cast<uint8_t>((1 << bitsLeft) - 1);
+        if ((lastByte & mask) != mask) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ============== THPackDynamicTable ==============
+
+THPackDynamicTable::THPackDynamicTable(uint32_t maxSize)
+    : MaxSize(maxSize)
+{}
+
+void THPackDynamicTable::Add(TString name, TString value) {
+    size_t entrySize = name.size() + value.size() + 32;
+    // Evict entries if needed to make room
+    while (CurrentSize + entrySize > MaxSize && !Entries.empty()) {
+        CurrentSize -= Entries.back().EntrySize();
+        Entries.pop_back();
+    }
+    if (entrySize <= MaxSize) {
+        Entries.push_front({std::move(name), std::move(value)});
+        CurrentSize += entrySize;
+    }
+    // If entrySize > MaxSize, the entry is not added (table is emptied)
+}
+
+bool THPackDynamicTable::Get(size_t index, TStringBuf& name, TStringBuf& value) const {
+    if (index < 1 || index > Entries.size()) {
+        return false;
+    }
+    const auto& entry = Entries[index - 1];
+    name = entry.Name;
+    value = entry.Value;
+    return true;
+}
+
+void THPackDynamicTable::SetMaxSize(uint32_t maxSize) {
+    MaxSize = maxSize;
+    Evict();
+}
+
+void THPackDynamicTable::Evict() {
+    while (CurrentSize > MaxSize && !Entries.empty()) {
+        CurrentSize -= Entries.back().EntrySize();
+        Entries.pop_back();
+    }
+}
+
+// ============== THPackEncoder ==============
+
+THPackEncoder::THPackEncoder(uint32_t maxTableSize)
+    : DynTable(maxTableSize)
+    , PendingMaxSize(maxTableSize)
+{}
+
+std::pair<size_t, bool> THPackEncoder::FindHeader(TStringBuf name, TStringBuf value) const {
+    size_t nameMatch = 0;
+
+    // Search static table
+    for (size_t i = 1; i <= STATIC_TABLE_SIZE; ++i) {
+        if (STATIC_TABLE[i].Name == name) {
+            if (STATIC_TABLE[i].Value == value) {
+                return {i, false}; // exact match
+            }
+            if (nameMatch == 0) {
+                nameMatch = i;
+            }
+        }
+    }
+
+    // Search dynamic table
+    for (size_t i = 0; i < DynTable.Size(); ++i) {
+        TStringBuf dName, dValue;
+        DynTable.Get(i + 1, dName, dValue);
+        if (dName == name) {
+            if (dValue == value) {
+                return {STATIC_TABLE_SIZE + i + 1, false}; // exact match
+            }
+            if (nameMatch == 0) {
+                nameMatch = STATIC_TABLE_SIZE + i + 1;
+            }
+        }
+    }
+
+    return {nameMatch, nameMatch > 0}; // nameOnly=true if we found only a name match
+}
+
+void THPackEncoder::EncodeInteger(TString& out, uint32_t value, uint8_t prefix, uint8_t pattern) {
+    uint8_t maxPrefix = (1 << prefix) - 1;
+    if (value < maxPrefix) {
+        out.push_back(static_cast<char>(pattern | value));
+    } else {
+        out.push_back(static_cast<char>(pattern | maxPrefix));
+        value -= maxPrefix;
+        while (value >= 128) {
+            out.push_back(static_cast<char>((value & 0x7F) | 0x80));
+            value >>= 7;
+        }
+        out.push_back(static_cast<char>(value));
+    }
+}
+
+TString THPackEncoder::HuffmanEncode(TStringBuf str) {
+    TString result;
+    uint64_t buffer = 0;
+    int bufBits = 0;
+
+    for (uint8_t ch : str) {
+        const auto& hc = HUFFMAN_TABLE[ch];
+        buffer = (buffer << hc.BitLen) | hc.Code;
+        bufBits += hc.BitLen;
+        while (bufBits >= 8) {
+            bufBits -= 8;
+            result.push_back(static_cast<char>((buffer >> bufBits) & 0xFF));
+        }
+    }
+    // Pad with EOS prefix bits (all 1s)
+    if (bufBits > 0) {
+        buffer = (buffer << (8 - bufBits)) | ((1 << (8 - bufBits)) - 1);
+        result.push_back(static_cast<char>(buffer & 0xFF));
+    }
+    return result;
+}
+
+void THPackEncoder::EncodeString(TString& out, TStringBuf str, bool huffman) {
+    if (huffman) {
+        TString encoded = HuffmanEncode(str);
+        EncodeInteger(out, encoded.size(), 7, 0x80); // H=1
+        out.append(encoded);
+    } else {
+        EncodeInteger(out, str.size(), 7, 0x00); // H=0
+        out.append(str);
+    }
+}
+
+TString THPackEncoder::Encode(const TVector<std::pair<TString, TString>>& headers) {
+    TString result;
+
+    // Emit dynamic table size update if changed
+    if (TableSizeChanged) {
+        EncodeInteger(result, PendingMaxSize, 5, 0x20);
+        TableSizeChanged = false;
+    }
+
+    for (const auto& [name, value] : headers) {
+        auto [index, nameOnly] = FindHeader(name, value);
+
+        if (index > 0 && !nameOnly) {
+            // Indexed Header Field (RFC 7541 Section 6.1)
+            EncodeInteger(result, index, 7, 0x80);
+        } else if (index > 0) {
+            // Literal Header Field with Incremental Indexing - Indexed Name (RFC 7541 Section 6.2.1)
+            EncodeInteger(result, index, 6, 0x40);
+            EncodeString(result, value);
+            DynTable.Add(TString(name), TString(value));
+        } else {
+            // Literal Header Field with Incremental Indexing - New Name (RFC 7541 Section 6.2.1)
+            result.push_back(static_cast<char>(0x40));
+            EncodeString(result, name);
+            EncodeString(result, value);
+            DynTable.Add(TString(name), TString(value));
+        }
+    }
+    return result;
+}
+
+void THPackEncoder::SetMaxTableSize(uint32_t maxSize) {
+    DynTable.SetMaxSize(maxSize);
+    PendingMaxSize = maxSize;
+    TableSizeChanged = true;
+}
+
+// ============== THPackDecoder ==============
+
+THPackDecoder::THPackDecoder(uint32_t maxTableSize)
+    : DynTable(maxTableSize)
+{}
+
+bool THPackDecoder::DecodeInteger(const uint8_t*& pos, const uint8_t* end, uint8_t prefix, uint32_t& value) {
+    if (pos >= end) return false;
+    uint8_t maxPrefix = (1 << prefix) - 1;
+    value = *pos & maxPrefix;
+    pos++;
+
+    if (value < maxPrefix) {
+        return true;
+    }
+
+    uint32_t m = 0;
+    while (pos < end) {
+        uint8_t b = *pos;
+        pos++;
+        if (m >= 28) return false; // overflow protection
+        value += static_cast<uint32_t>(b & 0x7F) << m;
+        m += 7;
+        if ((b & 0x80) == 0) {
+            return true;
+        }
+    }
+    return false; // incomplete
+}
+
+bool THPackDecoder::DecodeString(const uint8_t*& pos, const uint8_t* end, TString& out) {
+    if (pos >= end) return false;
+    bool huffman = (*pos & 0x80) != 0;
+
+    uint32_t length;
+    if (!DecodeInteger(pos, end, 7, length)) return false;
+    if (pos + length > end) return false;
+
+    if (huffman) {
+        if (!HuffDecoder.Decode(pos, length, out)) return false;
+    } else {
+        out.assign(reinterpret_cast<const char*>(pos), length);
+    }
+    pos += length;
+    return true;
+}
+
+bool THPackDecoder::LookupIndex(size_t index, TString& name, TString& value) const {
+    if (index <= STATIC_TABLE_SIZE) {
+        if (index < 1) return false;
+        name = TString(STATIC_TABLE[index].Name);
+        value = TString(STATIC_TABLE[index].Value);
+        return true;
+    }
+    size_t dynIndex = index - STATIC_TABLE_SIZE;
+    TStringBuf n, v;
+    if (!DynTable.Get(dynIndex, n, v)) return false;
+    name = TString(n);
+    value = TString(v);
+    return true;
+}
+
+bool THPackDecoder::LookupIndexName(size_t index, TString& name) const {
+    if (index <= STATIC_TABLE_SIZE) {
+        if (index < 1) return false;
+        name = TString(STATIC_TABLE[index].Name);
+        return true;
+    }
+    size_t dynIndex = index - STATIC_TABLE_SIZE;
+    TStringBuf n, v;
+    if (!DynTable.Get(dynIndex, n, v)) return false;
+    name = TString(n);
+    return true;
+}
+
+bool THPackDecoder::Decode(TStringBuf data, TVector<std::pair<TString, TString>>& headers) {
+    const uint8_t* pos = reinterpret_cast<const uint8_t*>(data.data());
+    const uint8_t* end = pos + data.size();
+
+    while (pos < end) {
+        uint8_t byte = *pos;
+
+        if (byte & 0x80) {
+            // Indexed Header Field (Section 6.1)
+            uint32_t index;
+            if (!DecodeInteger(pos, end, 7, index)) return false;
+            if (index == 0) return false;
+            TString name, value;
+            if (!LookupIndex(index, name, value)) return false;
+            headers.emplace_back(std::move(name), std::move(value));
+        } else if (byte & 0x40) {
+            // Literal Header Field with Incremental Indexing (Section 6.2.1)
+            uint32_t index;
+            if (!DecodeInteger(pos, end, 6, index)) return false;
+            TString name, value;
+            if (index > 0) {
+                if (!LookupIndexName(index, name)) return false;
+            } else {
+                if (!DecodeString(pos, end, name)) return false;
+            }
+            if (!DecodeString(pos, end, value)) return false;
+            DynTable.Add(TString(name), TString(value));
+            headers.emplace_back(std::move(name), std::move(value));
+        } else if (byte & 0x20) {
+            // Dynamic Table Size Update (Section 6.3)
+            uint32_t maxSize;
+            if (!DecodeInteger(pos, end, 5, maxSize)) return false;
+            DynTable.SetMaxSize(maxSize);
+        } else {
+            // Literal Header Field without Indexing (Section 6.2.2) or
+            // Literal Header Field Never Indexed (Section 6.2.3)
+            uint8_t prefix = 4; // Both "without indexing" (6.2.2) and "never indexed" (6.2.3) use 4-bit prefix
+            uint32_t index;
+            if (!DecodeInteger(pos, end, prefix, index)) return false;
+            TString name, value;
+            if (index > 0) {
+                if (!LookupIndexName(index, name)) return false;
+            } else {
+                if (!DecodeString(pos, end, name)) return false;
+            }
+            if (!DecodeString(pos, end, value)) return false;
+            // These are not added to the dynamic table
+            headers.emplace_back(std::move(name), std::move(value));
+        }
+    }
+    return true;
+}
+
+void THPackDecoder::SetMaxTableSize(uint32_t maxSize) {
+    DynTable.SetMaxSize(maxSize);
+}
+
+} // namespace NHttp::NHttp2

--- a/ydb/library/actors/http/http2_hpack.h
+++ b/ydb/library/actors/http/http2_hpack.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "http2_frames.h"
+
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/deque.h>
+
+#include <cstdint>
+#include <utility>
+
+namespace NHttp::NHttp2 {
+
+// HPACK: Header Compression for HTTP/2 (RFC 7541)
+
+// Huffman decoder node for trie-based decoding
+class THuffmanDecoder {
+public:
+    THuffmanDecoder();
+    // Decode Huffman-encoded data. Returns false on error.
+    bool Decode(const uint8_t* data, size_t len, TString& out) const;
+
+private:
+    // Binary trie for fast decoding
+    // Each node has two children (0 and 1)
+    // If Symbol >= 0, it's a leaf node
+    struct TNode {
+        int32_t Children[2] = {-1, -1};
+        int16_t Symbol = -1; // -1 = not a leaf
+    };
+    TVector<TNode> Nodes;
+    int32_t AllocNode();
+};
+
+// HPACK dynamic table (RFC 7541 Section 2.3.2)
+class THPackDynamicTable {
+public:
+    explicit THPackDynamicTable(uint32_t maxSize = DEFAULT_HEADER_TABLE_SIZE);
+
+    void Add(TString name, TString value);
+    bool Get(size_t index, TStringBuf& name, TStringBuf& value) const; // 1-based index into dynamic table
+    size_t Size() const { return Entries.size(); }
+    size_t TableSize() const { return CurrentSize; } // in bytes (per HPACK rules)
+    void SetMaxSize(uint32_t maxSize);
+
+private:
+    struct TDynEntry {
+        TString Name;
+        TString Value;
+        size_t EntrySize() const { return Name.size() + Value.size() + 32; } // RFC 7541 Section 4.1
+    };
+
+    TDeque<TDynEntry> Entries; // front = most recently added
+    uint32_t MaxSize;
+    size_t CurrentSize = 0;
+
+    void Evict();
+};
+
+// HPACK Encoder
+class THPackEncoder {
+public:
+    explicit THPackEncoder(uint32_t maxTableSize = DEFAULT_HEADER_TABLE_SIZE);
+
+    // Encode a list of headers into an HPACK block
+    TString Encode(const TVector<std::pair<TString, TString>>& headers);
+
+    void SetMaxTableSize(uint32_t maxSize);
+
+    static void EncodeInteger(TString& out, uint32_t value, uint8_t prefix, uint8_t pattern);
+    static void EncodeString(TString& out, TStringBuf str, bool huffman = false);
+    static TString HuffmanEncode(TStringBuf str);
+
+private:
+    THPackDynamicTable DynTable;
+    bool TableSizeChanged = false;
+    uint32_t PendingMaxSize = DEFAULT_HEADER_TABLE_SIZE;
+
+    // Find header in static or dynamic table
+    // Returns: {index, nameOnly} where index=0 means not found
+    std::pair<size_t, bool> FindHeader(TStringBuf name, TStringBuf value) const;
+};
+
+// HPACK Decoder
+class THPackDecoder {
+public:
+    explicit THPackDecoder(uint32_t maxTableSize = DEFAULT_HEADER_TABLE_SIZE);
+
+    // Decode an HPACK block into a list of headers
+    // Returns false on decode error
+    bool Decode(TStringBuf data, TVector<std::pair<TString, TString>>& headers);
+
+    void SetMaxTableSize(uint32_t maxSize);
+
+    bool DecodeInteger(const uint8_t*& pos, const uint8_t* end, uint8_t prefix, uint32_t& value);
+    bool DecodeString(const uint8_t*& pos, const uint8_t* end, TString& out);
+    bool LookupIndex(size_t index, TString& name, TString& value) const;
+    bool LookupIndexName(size_t index, TString& name) const;
+
+private:
+    THPackDynamicTable DynTable;
+    THuffmanDecoder HuffDecoder;
+};
+
+} // namespace NHttp::NHttp2

--- a/ydb/library/actors/http/http2_ut.cpp
+++ b/ydb/library/actors/http/http2_ut.cpp
@@ -1,0 +1,3396 @@
+#include "http2_frames.h"
+#include "http2_hpack.h"
+#include "http2.h"
+#include "http_proxy.h"
+
+#include <ydb/library/actors/testlib/test_runtime.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/testing/unittest/tests_data.h>
+
+#include <thread>
+#include <atomic>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+using namespace NHttp::NHttp2;
+
+namespace {
+
+template <typename HttpType>
+void EatWholeString(TIntrusivePtr<HttpType>& request, const TString& data) {
+    request->EnsureEnoughSpaceAvailable(data.size());
+    auto size = std::min(request->Avail(), data.size());
+    memcpy(request->Pos(), data.data(), size);
+    request->Advance(size);
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(Http2Frames) {
+    Y_UNIT_TEST(FrameHeaderParseSerializeRoundtrip) {
+        TFrameHeader hdr;
+        hdr.Length = 0x123456 & 0xFFFFFF; // 24-bit
+        hdr.Type = EFrameType::HEADERS;
+        hdr.Flags = NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM;
+        hdr.StreamId = 7;
+
+        char buf[FRAME_HEADER_SIZE];
+        hdr.Serialize(buf);
+
+        TFrameHeader parsed;
+        parsed.Parse(buf);
+
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Length, hdr.Length);
+        UNIT_ASSERT_EQUAL(parsed.Type, EFrameType::HEADERS);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Flags, hdr.Flags);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.StreamId, 7u);
+    }
+
+    Y_UNIT_TEST(FrameHeaderRBitCleared) {
+        // R bit (highest bit of stream ID) should be masked off
+        char buf[FRAME_HEADER_SIZE] = {};
+        buf[5] = static_cast<char>(0xFF); // set R bit + high bits
+        buf[6] = static_cast<char>(0xFF);
+        buf[7] = static_cast<char>(0xFF);
+        buf[8] = static_cast<char>(0xFF);
+
+        TFrameHeader hdr;
+        hdr.Parse(buf);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 0x7FFFFFFFu);
+    }
+
+    Y_UNIT_TEST(FrameHeaderZeroValues) {
+        TFrameHeader hdr;
+        hdr.Length = 0;
+        hdr.Type = EFrameType::DATA;
+        hdr.Flags = 0;
+        hdr.StreamId = 0;
+
+        char buf[FRAME_HEADER_SIZE];
+        hdr.Serialize(buf);
+
+        TFrameHeader parsed;
+        parsed.Parse(buf);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Length, 0u);
+        UNIT_ASSERT_EQUAL(parsed.Type, EFrameType::DATA);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Flags, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.StreamId, 0u);
+    }
+
+    Y_UNIT_TEST(FrameHeaderMaxValues) {
+        TFrameHeader hdr;
+        hdr.Length = 0xFFFFFF; // max 24-bit
+        hdr.Type = EFrameType::CONTINUATION;
+        hdr.Flags = 0xFF;
+        hdr.StreamId = 0x7FFFFFFF; // max 31-bit
+
+        char buf[FRAME_HEADER_SIZE];
+        hdr.Serialize(buf);
+
+        TFrameHeader parsed;
+        parsed.Parse(buf);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Length, 0xFFFFFFu);
+        UNIT_ASSERT_EQUAL(parsed.Type, EFrameType::CONTINUATION);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.Flags, 0xFFu);
+        UNIT_ASSERT_VALUES_EQUAL(parsed.StreamId, 0x7FFFFFFFu);
+    }
+
+    Y_UNIT_TEST(HasFlag) {
+        TFrameHeader hdr;
+        hdr.Flags = NFrameFlag::END_STREAM | NFrameFlag::END_HEADERS;
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_STREAM));
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_HEADERS));
+        UNIT_ASSERT(!hdr.HasFlag(NFrameFlag::PADDED));
+        UNIT_ASSERT(!hdr.HasFlag(NFrameFlag::PRIORITY));
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2Settings) {
+    Y_UNIT_TEST(DefaultValues) {
+        TSettings s;
+        UNIT_ASSERT_VALUES_EQUAL(s.HeaderTableSize, DEFAULT_HEADER_TABLE_SIZE);
+        UNIT_ASSERT(s.EnablePush);
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxConcurrentStreams, DEFAULT_MAX_CONCURRENT_STREAMS);
+        UNIT_ASSERT_VALUES_EQUAL(s.InitialWindowSize, DEFAULT_INITIAL_WINDOW_SIZE);
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxFrameSize, DEFAULT_MAX_FRAME_SIZE);
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxHeaderListSize, DEFAULT_MAX_HEADER_LIST_SIZE);
+    }
+
+    Y_UNIT_TEST(ApplyValidSettings) {
+        TSettings s;
+        UNIT_ASSERT(s.Apply(ESettingsId::HEADER_TABLE_SIZE, 8192));
+        UNIT_ASSERT_VALUES_EQUAL(s.HeaderTableSize, 8192u);
+
+        UNIT_ASSERT(s.Apply(ESettingsId::ENABLE_PUSH, 0));
+        UNIT_ASSERT(!s.EnablePush);
+        UNIT_ASSERT(s.Apply(ESettingsId::ENABLE_PUSH, 1));
+        UNIT_ASSERT(s.EnablePush);
+
+        UNIT_ASSERT(s.Apply(ESettingsId::MAX_CONCURRENT_STREAMS, 200));
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxConcurrentStreams, 200u);
+
+        UNIT_ASSERT(s.Apply(ESettingsId::INITIAL_WINDOW_SIZE, 32768));
+        UNIT_ASSERT_VALUES_EQUAL(s.InitialWindowSize, 32768u);
+
+        UNIT_ASSERT(s.Apply(ESettingsId::MAX_FRAME_SIZE, 32768));
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxFrameSize, 32768u);
+
+        UNIT_ASSERT(s.Apply(ESettingsId::MAX_HEADER_LIST_SIZE, 16384));
+        UNIT_ASSERT_VALUES_EQUAL(s.MaxHeaderListSize, 16384u);
+    }
+
+    Y_UNIT_TEST(ApplyInvalidSettings) {
+        TSettings s;
+        // ENABLE_PUSH > 1 is invalid
+        UNIT_ASSERT(!s.Apply(ESettingsId::ENABLE_PUSH, 2));
+
+        // INITIAL_WINDOW_SIZE > MAX_WINDOW_SIZE is invalid
+        UNIT_ASSERT(!s.Apply(ESettingsId::INITIAL_WINDOW_SIZE, MAX_WINDOW_SIZE + 1));
+
+        // MAX_FRAME_SIZE < DEFAULT_MAX_FRAME_SIZE is invalid
+        UNIT_ASSERT(!s.Apply(ESettingsId::MAX_FRAME_SIZE, DEFAULT_MAX_FRAME_SIZE - 1));
+        // MAX_FRAME_SIZE > MAX_MAX_FRAME_SIZE is invalid
+        UNIT_ASSERT(!s.Apply(ESettingsId::MAX_FRAME_SIZE, MAX_MAX_FRAME_SIZE + 1));
+    }
+
+    Y_UNIT_TEST(UnknownSettingsIgnored) {
+        TSettings s;
+        // Unknown settings must be ignored (return true)
+        UNIT_ASSERT(s.Apply(static_cast<ESettingsId>(0xFF), 42));
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2FrameBuilder) {
+    Y_UNIT_TEST(BuildSettingsAck) {
+        TString frame = TFrameBuilder::BuildSettingsAck();
+        UNIT_ASSERT_VALUES_EQUAL(frame.size(), FRAME_HEADER_SIZE);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 0u);
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::SETTINGS);
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::ACK));
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 0u);
+    }
+
+    Y_UNIT_TEST(BuildSettings) {
+        TVector<TSettingsEntry> entries = {
+            {ESettingsId::MAX_CONCURRENT_STREAMS, 128},
+            {ESettingsId::INITIAL_WINDOW_SIZE, 32768},
+        };
+        TString frame = TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, entries);
+        UNIT_ASSERT_VALUES_EQUAL(frame.size(), FRAME_HEADER_SIZE + 12);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 12u);
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::SETTINGS);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Flags, NFrameFlag::NONE);
+
+        // Parse first entry
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(frame.data() + FRAME_HEADER_SIZE);
+        uint16_t id1 = (p[0] << 8) | p[1];
+        uint32_t val1 = (p[2] << 24) | (p[3] << 16) | (p[4] << 8) | p[5];
+        UNIT_ASSERT_VALUES_EQUAL(id1, static_cast<uint16_t>(ESettingsId::MAX_CONCURRENT_STREAMS));
+        UNIT_ASSERT_VALUES_EQUAL(val1, 128u);
+
+        // Parse second entry
+        uint16_t id2 = (p[6] << 8) | p[7];
+        uint32_t val2 = (p[8] << 24) | (p[9] << 16) | (p[10] << 8) | p[11];
+        UNIT_ASSERT_VALUES_EQUAL(id2, static_cast<uint16_t>(ESettingsId::INITIAL_WINDOW_SIZE));
+        UNIT_ASSERT_VALUES_EQUAL(val2, 32768u);
+    }
+
+    Y_UNIT_TEST(BuildHeaders) {
+        TString headerBlock = "test-header-block";
+        TString frame = TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, headerBlock);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, headerBlock.size());
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::HEADERS);
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_HEADERS));
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_STREAM));
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 1u);
+
+        TStringBuf payload(frame.data() + FRAME_HEADER_SIZE, hdr.Length);
+        UNIT_ASSERT_VALUES_EQUAL(payload, headerBlock);
+    }
+
+    Y_UNIT_TEST(BuildData) {
+        TString data = "Hello, HTTP/2!";
+        TString frame = TFrameBuilder::BuildData(3, NFrameFlag::END_STREAM, data);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, data.size());
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::DATA);
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_STREAM));
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 3u);
+
+        TStringBuf payload(frame.data() + FRAME_HEADER_SIZE, hdr.Length);
+        UNIT_ASSERT_VALUES_EQUAL(payload, data);
+    }
+
+    Y_UNIT_TEST(BuildWindowUpdate) {
+        TString frame = TFrameBuilder::BuildWindowUpdate(5, 65535);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 4u);
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::WINDOW_UPDATE);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 5u);
+
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(frame.data() + FRAME_HEADER_SIZE);
+        uint32_t increment = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+        increment &= 0x7FFFFFFF;
+        UNIT_ASSERT_VALUES_EQUAL(increment, 65535u);
+    }
+
+    Y_UNIT_TEST(BuildRstStream) {
+        TString frame = TFrameBuilder::BuildRstStream(1, EErrorCode::CANCEL);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 4u);
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::RST_STREAM);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 1u);
+
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(frame.data() + FRAME_HEADER_SIZE);
+        uint32_t errorCode = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+        UNIT_ASSERT_VALUES_EQUAL(errorCode, static_cast<uint32_t>(EErrorCode::CANCEL));
+    }
+
+    Y_UNIT_TEST(BuildGoaway) {
+        TString debug = "test error";
+        TString frame = TFrameBuilder::BuildGoaway(3, EErrorCode::NO_ERROR, debug);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 8 + debug.size());
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::GOAWAY);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 0u);
+
+        const uint8_t* p = reinterpret_cast<const uint8_t*>(frame.data() + FRAME_HEADER_SIZE);
+        uint32_t lastStreamId = ((p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3]) & 0x7FFFFFFF;
+        UNIT_ASSERT_VALUES_EQUAL(lastStreamId, 3u);
+        uint32_t errorCode = (p[4] << 24) | (p[5] << 16) | (p[6] << 8) | p[7];
+        UNIT_ASSERT_VALUES_EQUAL(errorCode, static_cast<uint32_t>(EErrorCode::NO_ERROR));
+
+        TStringBuf debugPayload(frame.data() + FRAME_HEADER_SIZE + 8, debug.size());
+        UNIT_ASSERT_VALUES_EQUAL(debugPayload, debug);
+    }
+
+    Y_UNIT_TEST(BuildGoawayNoDebug) {
+        TString frame = TFrameBuilder::BuildGoaway(0, EErrorCode::PROTOCOL_ERROR);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 8u);
+    }
+
+    Y_UNIT_TEST(BuildPing) {
+        char opaqueData[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        TString frame = TFrameBuilder::BuildPing(NFrameFlag::NONE, opaqueData);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, 8u);
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::PING);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Flags, NFrameFlag::NONE);
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 0u);
+
+        UNIT_ASSERT(std::memcmp(frame.data() + FRAME_HEADER_SIZE, opaqueData, 8) == 0);
+    }
+
+    Y_UNIT_TEST(BuildPingAck) {
+        char opaqueData[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        TString frame = TFrameBuilder::BuildPing(NFrameFlag::ACK, opaqueData);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::ACK));
+    }
+
+    Y_UNIT_TEST(BuildContinuation) {
+        TString headerBlock = "continuation-data";
+        TString frame = TFrameBuilder::BuildContinuation(1, NFrameFlag::END_HEADERS, headerBlock);
+
+        TFrameHeader hdr;
+        hdr.Parse(frame.data());
+        UNIT_ASSERT_VALUES_EQUAL(hdr.Length, headerBlock.size());
+        UNIT_ASSERT_EQUAL(hdr.Type, EFrameType::CONTINUATION);
+        UNIT_ASSERT(hdr.HasFlag(NFrameFlag::END_HEADERS));
+        UNIT_ASSERT_VALUES_EQUAL(hdr.StreamId, 1u);
+
+        TStringBuf payload(frame.data() + FRAME_HEADER_SIZE, hdr.Length);
+        UNIT_ASSERT_VALUES_EQUAL(payload, headerBlock);
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2Hpack) {
+    Y_UNIT_TEST(HuffmanEncodeDecodeRoundtrip) {
+        // Test Huffman through the encoder/decoder roundtrip
+        // Encode headers with values that will use Huffman coding
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-test", "www.example.com"},
+            {"x-path", "/index.html"},
+            {"x-custom", "custom-value"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        UNIT_ASSERT(!encoded.empty());
+
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), headers.size());
+
+        for (size_t i = 0; i < headers.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].first, headers[i].first);
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].second, headers[i].second);
+        }
+    }
+
+    Y_UNIT_TEST(HuffmanEncodeDecodeEmpty) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-empty", ""},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].second, "");
+    }
+
+    Y_UNIT_TEST(HuffmanEncodeDecodeNumbers) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {":status", "200"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].second, "200");
+    }
+
+    Y_UNIT_TEST(DynamicTableAddAndGet) {
+        THPackDynamicTable table(4096);
+        table.Add("custom-header", "custom-value");
+
+        TStringBuf name, value;
+        UNIT_ASSERT(table.Get(1, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "custom-header");
+        UNIT_ASSERT_VALUES_EQUAL(value, "custom-value");
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 1u);
+    }
+
+    Y_UNIT_TEST(DynamicTableFIFO) {
+        THPackDynamicTable table(4096);
+        table.Add("header-1", "value-1");
+        table.Add("header-2", "value-2");
+
+        // Most recently added is index 1
+        TStringBuf name, value;
+        UNIT_ASSERT(table.Get(1, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "header-2");
+
+        UNIT_ASSERT(table.Get(2, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "header-1");
+    }
+
+    Y_UNIT_TEST(DynamicTableEviction) {
+        // Each entry has 32 bytes overhead + name.size() + value.size()
+        // "a" + "b" + 32 = 34 bytes. Set max to allow only 1 entry.
+        THPackDynamicTable table(34);
+        table.Add("a", "b"); // 34 bytes
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 1u);
+
+        table.Add("c", "d"); // evicts first, adds new
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 1u);
+
+        TStringBuf name, value;
+        UNIT_ASSERT(table.Get(1, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "c");
+    }
+
+    Y_UNIT_TEST(DynamicTableOversizeEntry) {
+        // Entry larger than max table size should empty the table and not be added
+        THPackDynamicTable table(33); // too small for any entry (32 overhead + at least 1 byte)
+        table.Add("a", "b"); // 34 bytes > 33, not added
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 0u);
+    }
+
+    Y_UNIT_TEST(DynamicTableSetMaxSize) {
+        THPackDynamicTable table(4096);
+        table.Add("header-1", "value-1"); // 32 + 8 + 7 = 47
+        table.Add("header-2", "value-2"); // 47
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 2u);
+
+        // Shrink to fit only 1 entry
+        table.SetMaxSize(50);
+        UNIT_ASSERT_VALUES_EQUAL(table.Size(), 1u);
+
+        TStringBuf name, value;
+        UNIT_ASSERT(table.Get(1, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "header-2"); // most recent survives
+    }
+
+    Y_UNIT_TEST(DynamicTableOutOfBounds) {
+        THPackDynamicTable table(4096);
+        table.Add("a", "b");
+
+        TStringBuf name, value;
+        UNIT_ASSERT(!table.Get(0, name, value)); // 0 is invalid (1-based)
+        UNIT_ASSERT(!table.Get(2, name, value)); // only 1 entry
+    }
+
+    Y_UNIT_TEST(EncoderDecoderRoundtripSimple) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+            {":path", "/"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+            {"accept", "text/html"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        UNIT_ASSERT(!encoded.empty());
+
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), headers.size());
+
+        for (size_t i = 0; i < headers.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].first, headers[i].first);
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].second, headers[i].second);
+        }
+    }
+
+    Y_UNIT_TEST(EncoderDecoderRoundtripCustomHeaders) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {":status", "200"},
+            {"content-type", "application/json"},
+            {"x-custom-header", "custom-value"},
+            {"x-request-id", "12345-abcde"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), headers.size());
+
+        for (size_t i = 0; i < headers.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].first, headers[i].first);
+            UNIT_ASSERT_VALUES_EQUAL(decoded[i].second, headers[i].second);
+        }
+    }
+
+    Y_UNIT_TEST(EncoderDecoderMultipleEncodes) {
+        // Verify dynamic table state evolves correctly across multiple encodes
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers1 = {
+            {":method", "GET"},
+            {":path", "/api/v1"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+        };
+
+        TString encoded1 = encoder.Encode(headers1);
+        TVector<std::pair<TString, TString>> decoded1;
+        UNIT_ASSERT(decoder.Decode(encoded1, decoded1));
+        UNIT_ASSERT_VALUES_EQUAL(decoded1.size(), headers1.size());
+
+        // Second request with same authority (should reference dynamic table)
+        TVector<std::pair<TString, TString>> headers2 = {
+            {":method", "POST"},
+            {":path", "/api/v2"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+            {"content-type", "application/json"},
+        };
+
+        TString encoded2 = encoder.Encode(headers2);
+        TVector<std::pair<TString, TString>> decoded2;
+        UNIT_ASSERT(decoder.Decode(encoded2, decoded2));
+        UNIT_ASSERT_VALUES_EQUAL(decoded2.size(), headers2.size());
+
+        for (size_t i = 0; i < headers2.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(decoded2[i].first, headers2[i].first);
+            UNIT_ASSERT_VALUES_EQUAL(decoded2[i].second, headers2[i].second);
+        }
+
+        // Second encode should be smaller due to dynamic table references
+        UNIT_ASSERT_LE(encoded2.size(), encoded1.size() + 30); // approximate; custom header adds overhead
+    }
+
+    Y_UNIT_TEST(EncoderDecoderEmptyValue) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {":status", "204"},
+            {"x-empty", ""},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(decoded[1].first, "x-empty");
+        UNIT_ASSERT_VALUES_EQUAL(decoded[1].second, "");
+    }
+
+    Y_UNIT_TEST(EncoderUsesStaticTableForKnownHeaders) {
+        THPackEncoder encoder;
+
+        // ":method GET" is static table entry 2 - should encode as single byte
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+        };
+        TString encoded = encoder.Encode(headers);
+        // Indexed representation: single byte 0x82 (1_0000010)
+        UNIT_ASSERT_VALUES_EQUAL(encoded.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<uint8_t>(encoded[0]), 0x82u);
+    }
+
+    Y_UNIT_TEST(DecoderRejectsInvalidIndex) {
+        THPackDecoder decoder;
+        // Indexed header with index 0 is invalid
+        TString data;
+        data.push_back(static_cast<char>(0x80)); // index 0 with indexed flag
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(!decoder.Decode(data, decoded));
+    }
+
+    Y_UNIT_TEST(EncoderSetMaxTableSize) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        encoder.SetMaxTableSize(0); // no dynamic table
+        decoder.SetMaxTableSize(0);
+
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+            {":path", "/test"},
+            {"x-custom", "value"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), headers.size());
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2Session) {
+    // Helper to connect a client and server session together
+    struct TSessionPair {
+        TString ServerRecvBuf;
+        TString ClientRecvBuf;
+        TString ServerError;
+        TString ClientError;
+
+        struct TReceivedRequest {
+            uint32_t StreamId;
+            TString Method;
+            TString Path;
+            TString Authority;
+            TString Body;
+            TVector<std::pair<TString, TString>> Headers;
+        };
+
+        struct TReceivedResponse {
+            uint32_t StreamId;
+            TString Status;
+            TString Body;
+            TVector<std::pair<TString, TString>> Headers;
+        };
+
+        TVector<TReceivedRequest> ServerRequests;
+        TVector<TReceivedResponse> ClientResponses;
+        bool ServerGotGoaway = false;
+        bool ClientGotGoaway = false;
+
+        std::unique_ptr<TSession> Server;
+        std::unique_ptr<TSession> Client;
+
+        TSessionPair() {
+            TSessionCallbacks serverCb;
+            serverCb.OnRequest = [this](uint32_t streamId, TStream& stream) {
+                TReceivedRequest req;
+                req.StreamId = streamId;
+                req.Method = stream.Method;
+                req.Path = stream.Path;
+                req.Authority = stream.Authority;
+                req.Body = stream.Body;
+                req.Headers = stream.Headers;
+                ServerRequests.push_back(std::move(req));
+            };
+            serverCb.OnSend = [this](TString data) {
+                ClientRecvBuf.append(data);
+            };
+            serverCb.OnError = [this](TString error) {
+                ServerError = error;
+            };
+            serverCb.OnGoaway = [this](uint32_t, EErrorCode) {
+                ServerGotGoaway = true;
+            };
+
+            TSessionCallbacks clientCb;
+            clientCb.OnResponse = [this](uint32_t streamId, TStream& stream) {
+                TReceivedResponse resp;
+                resp.StreamId = streamId;
+                resp.Status = stream.Status;
+                resp.Body = stream.Body;
+                resp.Headers = stream.Headers;
+                ClientResponses.push_back(std::move(resp));
+            };
+            clientCb.OnSend = [this](TString data) {
+                ServerRecvBuf.append(data);
+            };
+            clientCb.OnError = [this](TString error) {
+                ClientError = error;
+            };
+            clientCb.OnGoaway = [this](uint32_t, EErrorCode) {
+                ClientGotGoaway = true;
+            };
+
+            Server = std::make_unique<TSession>(TSession::ERole::Server, std::move(serverCb));
+            Client = std::make_unique<TSession>(TSession::ERole::Client, std::move(clientCb));
+        }
+
+        void Initialize() {
+            Client->Initialize();
+            Server->Initialize();
+            // Exchange init data
+            Pump();
+        }
+
+        // Pump data between client and server until no more pending data
+        void Pump() {
+            for (int i = 0; i < 10; ++i) { // limit iterations to prevent infinite loop
+                bool progress = false;
+                if (!ServerRecvBuf.empty()) {
+                    TString data;
+                    data.swap(ServerRecvBuf);
+                    Server->Feed(data.data(), data.size());
+                    progress = true;
+                }
+                if (!ClientRecvBuf.empty()) {
+                    TString data;
+                    data.swap(ClientRecvBuf);
+                    Client->Feed(data.data(), data.size());
+                    progress = true;
+                }
+                if (!progress) break;
+            }
+        }
+    };
+
+    Y_UNIT_TEST(Handshake) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        UNIT_ASSERT(pair.Server->IsReady());
+        UNIT_ASSERT(pair.Client->IsReady());
+        UNIT_ASSERT(pair.ServerError.empty());
+        UNIT_ASSERT(pair.ClientError.empty());
+    }
+
+    Y_UNIT_TEST(SimpleGetRequest) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Client sends GET request
+        uint32_t streamId = pair.Client->SendRequest("GET", "/test", "example.com", "https", {}, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].StreamId, streamId);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Method, "GET");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Path, "/test");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Authority, "example.com");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Body, "");
+    }
+
+    Y_UNIT_TEST(SimplePostRequest) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        TString body = "Hello, World!";
+        uint32_t streamId = pair.Client->SendRequest("POST", "/submit", "example.com", "https",
+            {{"content-type", "text/plain"}}, body);
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].StreamId, streamId);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Method, "POST");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Path, "/submit");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Body, body);
+    }
+
+    Y_UNIT_TEST(RequestResponse) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t streamId = pair.Client->SendRequest("GET", "/api", "example.com", "https", {}, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+
+        // Server sends response
+        TVector<std::pair<TString, TString>> respHeaders = {
+            {"content-type", "application/json"},
+        };
+        TString respBody = R"({"status":"ok"})";
+        pair.Server->SendResponse(streamId, "200", respHeaders, respBody);
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].StreamId, streamId);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Status, "200");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Body, respBody);
+
+        // Check response headers contain content-type
+        bool foundContentType = false;
+        for (const auto& [name, value] : pair.ClientResponses[0].Headers) {
+            if (name == "content-type") {
+                UNIT_ASSERT_VALUES_EQUAL(value, "application/json");
+                foundContentType = true;
+            }
+        }
+        UNIT_ASSERT(foundContentType);
+    }
+
+    Y_UNIT_TEST(EmptyBodyResponse) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t streamId = pair.Client->SendRequest("GET", "/empty", "example.com", "https", {}, "");
+        pair.Pump();
+
+        pair.Server->SendResponse(streamId, "204", {}, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Status, "204");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Body, "");
+    }
+
+    Y_UNIT_TEST(MultipleConcurrentStreams) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t stream1 = pair.Client->SendRequest("GET", "/path1", "example.com", "https", {}, "");
+        uint32_t stream2 = pair.Client->SendRequest("GET", "/path2", "example.com", "https", {}, "");
+        uint32_t stream3 = pair.Client->SendRequest("POST", "/path3", "example.com", "https",
+            {{"content-type", "text/plain"}}, "body3");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 3u);
+
+        // Stream IDs should be odd and increasing (client-initiated)
+        UNIT_ASSERT_VALUES_EQUAL(stream1, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(stream2, 3u);
+        UNIT_ASSERT_VALUES_EQUAL(stream3, 5u);
+
+        // Verify each request
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Path, "/path1");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[1].Path, "/path2");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[2].Path, "/path3");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[2].Body, "body3");
+
+        // Respond to all in different order
+        pair.Server->SendResponse(stream2, "200", {}, "resp2");
+        pair.Server->SendResponse(stream3, "201", {}, "resp3");
+        pair.Server->SendResponse(stream1, "200", {}, "resp1");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 3u);
+        // Responses arrive in the order sent by server
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].StreamId, stream2);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Body, "resp2");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[1].StreamId, stream3);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[1].Body, "resp3");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[2].StreamId, stream1);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[2].Body, "resp1");
+    }
+
+    Y_UNIT_TEST(PingPong) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Client sends PING
+        char pingData[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        TString pingFrame = TFrameBuilder::BuildPing(NFrameFlag::NONE, pingData);
+
+        // Feed ping to server
+        pair.ServerRecvBuf.append(pingFrame);
+        pair.Pump();
+
+        // Server should have sent PING ACK back (it's in ClientRecvBuf which was already pumped)
+        // No errors
+        UNIT_ASSERT(pair.ServerError.empty());
+        UNIT_ASSERT(pair.ClientError.empty());
+    }
+
+    Y_UNIT_TEST(Goaway) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR, "shutting down");
+        pair.Pump();
+
+        UNIT_ASSERT(pair.Client->IsGoaway());
+        UNIT_ASSERT(pair.ServerGotGoaway);
+    }
+
+    Y_UNIT_TEST(ServerGoaway) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        pair.Server->SendGoaway(EErrorCode::NO_ERROR);
+        pair.Pump();
+
+        UNIT_ASSERT(pair.Server->IsGoaway());
+        UNIT_ASSERT(pair.ClientGotGoaway);
+    }
+
+    Y_UNIT_TEST(GoawayDoubleCallNoop) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR);
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR); // should be noop
+        pair.Pump();
+
+        UNIT_ASSERT(pair.Client->IsGoaway());
+    }
+
+    Y_UNIT_TEST(InvalidPreface) {
+        TSessionCallbacks cb;
+        TString error;
+        cb.OnError = [&error](TString e) { error = e; };
+        cb.OnSend = [](TString) {};
+
+        TSession server(TSession::ERole::Server, std::move(cb));
+        server.Initialize();
+
+        // Feed invalid preface
+        TString badPreface = "GET / HTTP/1.1\r\n\r\n";
+        server.Feed(badPreface.data(), badPreface.size());
+
+        UNIT_ASSERT(!error.empty());
+    }
+
+    Y_UNIT_TEST(IncrementalFeed) {
+        // Verify that feeding data byte-by-byte works
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t streamId = pair.Client->SendRequest("GET", "/incremental", "example.com", "https", {}, "");
+        // Don't use Pump - manually feed byte by byte to server
+        TString data;
+        data.swap(pair.ServerRecvBuf);
+        for (size_t i = 0; i < data.size(); ++i) {
+            pair.Server->Feed(data.data() + i, 1);
+        }
+        // Also feed server responses to client
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Path, "/incremental");
+        Y_UNUSED(streamId);
+    }
+
+    Y_UNIT_TEST(LargeBody) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Send a body larger than default frame size (16384 bytes)
+        TString largeBody(32000, 'X');
+        uint32_t streamId = pair.Client->SendRequest("POST", "/large", "example.com", "https",
+            {{"content-type", "application/octet-stream"}}, largeBody);
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Body.size(), largeBody.size());
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Body, largeBody);
+
+        // Server responds with large body
+        TString largeResp(32000, 'Y');
+        pair.Server->SendResponse(streamId, "200", {}, largeResp);
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Body, largeResp);
+    }
+
+    Y_UNIT_TEST(ManyHeaders) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        TVector<std::pair<TString, TString>> headers;
+        for (int i = 0; i < 50; ++i) {
+            headers.emplace_back("x-header-" + ToString(i), "value-" + ToString(i));
+        }
+
+        pair.Client->SendRequest("GET", "/headers", "example.com", "https", headers, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        // All custom headers should be present
+        UNIT_ASSERT_GE(pair.ServerRequests[0].Headers.size(), 50u);
+    }
+
+    Y_UNIT_TEST(ClientStreamIdsOdd) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        for (int i = 0; i < 5; ++i) {
+            uint32_t streamId = pair.Client->SendRequest("GET", "/", "example.com", "https", {}, "");
+            UNIT_ASSERT(streamId % 2 == 1); // client streams are odd
+        }
+    }
+
+    Y_UNIT_TEST(WindowUpdateOnLargeBody) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Send enough data to trigger WINDOW_UPDATE
+        TString body(50000, 'Z');
+        pair.Client->SendRequest("POST", "/big", "example.com", "https", {}, body);
+        pair.Pump();
+
+        // Should have received the full body
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Body.size(), 50000u);
+        UNIT_ASSERT(pair.ServerError.empty());
+    }
+
+    Y_UNIT_TEST(SettingsExchange) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Both sides should be ready after settings exchange
+        UNIT_ASSERT(pair.Server->IsReady());
+        UNIT_ASSERT(pair.Client->IsReady());
+
+        // Should be able to exchange requests after settings
+        pair.Client->SendRequest("GET", "/after-settings", "example.com", "https", {}, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+    }
+
+    Y_UNIT_TEST(RequestWithCustomHeaders) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        TVector<std::pair<TString, TString>> customHeaders = {
+            {"authorization", "Bearer token123"},
+            {"accept", "application/json"},
+            {"x-request-id", "req-001"},
+        };
+
+        pair.Client->SendRequest("GET", "/api/data", "api.example.com", "https", customHeaders, "");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests.size(), 1u);
+        const auto& req = pair.ServerRequests[0];
+        UNIT_ASSERT_VALUES_EQUAL(req.Authority, "api.example.com");
+
+        // Verify custom headers are present
+        THashMap<TString, TString> headerMap;
+        for (const auto& [name, value] : req.Headers) {
+            headerMap[name] = value;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["authorization"], "Bearer token123");
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["accept"], "application/json");
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["x-request-id"], "req-001");
+    }
+
+    Y_UNIT_TEST(ResponseWithMultipleHeaders) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t streamId = pair.Client->SendRequest("GET", "/multi-header", "example.com", "https", {}, "");
+        pair.Pump();
+
+        TVector<std::pair<TString, TString>> respHeaders = {
+            {"content-type", "text/html"},
+            {"cache-control", "no-cache"},
+            {"x-powered-by", "ydb"},
+            {"set-cookie", "session=abc123"},
+        };
+
+        pair.Server->SendResponse(streamId, "200", respHeaders, "<html></html>");
+        pair.Pump();
+
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 1u);
+        THashMap<TString, TString> headerMap;
+        for (const auto& [name, value] : pair.ClientResponses[0].Headers) {
+            headerMap[name] = value;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["content-type"], "text/html");
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["cache-control"], "no-cache");
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["x-powered-by"], "ydb");
+        UNIT_ASSERT_VALUES_EQUAL(headerMap["set-cookie"], "session=abc123");
+    }
+
+    Y_UNIT_TEST(RstStreamOnConnection) {
+        TSessionPair pair;
+        pair.Initialize();
+
+        // Directly feed RST_STREAM for stream 0 (should be protocol error)
+        TString rstFrame = TFrameBuilder::BuildRstStream(0, EErrorCode::CANCEL);
+        pair.ServerRecvBuf.append(rstFrame);
+        pair.Pump();
+
+        // Server should report error (RST_STREAM on stream 0 is protocol error)
+        UNIT_ASSERT(!pair.ServerError.empty());
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2ConversionHelpers) {
+    Y_UNIT_TEST(StreamToIncomingRequestBasic) {
+        TStream stream;
+        stream.Method = "GET";
+        stream.Path = "/test";
+        stream.Scheme = "https";
+        stream.Authority = "example.com";
+        stream.Headers = {{"accept", "text/html"}};
+        stream.Body = "";
+
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpConfig::SocketAddressType address;
+        auto request = StreamToIncomingRequest(stream, endpoint, address);
+        UNIT_ASSERT(request);
+        UNIT_ASSERT_VALUES_EQUAL(request->Method, "GET");
+        UNIT_ASSERT_VALUES_EQUAL(request->URL, "/test");
+    }
+
+    Y_UNIT_TEST(StreamToIncomingRequestWithBody) {
+        TStream stream;
+        stream.Method = "POST";
+        stream.Path = "/submit";
+        stream.Scheme = "https";
+        stream.Authority = "example.com";
+        stream.Headers = {{"content-type", "application/json"}};
+        stream.Body = R"({"key":"value"})";
+
+        auto endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpConfig::SocketAddressType address;
+        auto request = StreamToIncomingRequest(stream, endpoint, address);
+        UNIT_ASSERT(request);
+        UNIT_ASSERT_VALUES_EQUAL(request->Method, "POST");
+        UNIT_ASSERT_VALUES_EQUAL(request->Body, R"({"key":"value"})");
+    }
+
+    Y_UNIT_TEST(OutgoingResponseToStreamBasic) {
+        NHttp::THttpIncomingRequestPtr inReq = new NHttp::THttpIncomingRequest();
+        EatWholeString(inReq, "GET /test HTTP/1.1\r\nHost: test\r\n\r\n");
+
+        NHttp::THttpOutgoingResponsePtr response = inReq->CreateResponseOK("hello", "text/plain");
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(status, "200");
+        UNIT_ASSERT_VALUES_EQUAL(body, "hello");
+
+        bool foundContentType = false;
+        for (const auto& [name, value] : headers) {
+            if (name == "content-type" || name == "Content-Type") {
+                foundContentType = true;
+            }
+        }
+        UNIT_ASSERT(foundContentType);
+    }
+
+    Y_UNIT_TEST(OutgoingResponseSkipsConnectionHeaders) {
+        NHttp::THttpIncomingRequestPtr inReq = new NHttp::THttpIncomingRequest();
+        EatWholeString(inReq, "GET /test HTTP/1.1\r\nHost: test\r\n\r\n");
+
+        NHttp::THttpOutgoingResponsePtr response = inReq->CreateResponseOK("ok", "text/plain");
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        // connection, transfer-encoding, keep-alive should be filtered
+        for (const auto& [name, _] : headers) {
+            TString lowerName = name;
+            lowerName.to_lower();
+            UNIT_ASSERT_UNEQUAL(lowerName, "connection");
+            UNIT_ASSERT_UNEQUAL(lowerName, "transfer-encoding");
+            UNIT_ASSERT_UNEQUAL(lowerName, "keep-alive");
+        }
+    }
+
+    Y_UNIT_TEST(OutgoingRequestToStreamBasic) {
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/api");
+
+        TString method, path, authority, scheme;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingRequestToStream(request, method, path, authority, scheme, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(method, "GET");
+        UNIT_ASSERT_VALUES_EQUAL(path, "/api");
+        UNIT_ASSERT_VALUES_EQUAL(authority, "example.com");
+        UNIT_ASSERT_VALUES_EQUAL(scheme, "http");
+    }
+
+    Y_UNIT_TEST(StreamToIncomingResponseBasic) {
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/test");
+
+        TStream stream;
+        stream.Status = "200";
+        stream.Headers = {
+            {"content-type", "text/plain"},
+            {"x-custom", "value"},
+        };
+        stream.Body = "response body";
+
+        auto response = StreamToIncomingResponse(stream, request);
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_VALUES_EQUAL(response->Status, "200");
+        UNIT_ASSERT_VALUES_EQUAL(response->Body, "response body");
+    }
+
+    Y_UNIT_TEST(StreamToIncomingResponseEmptyBody) {
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/empty");
+
+        TStream stream;
+        stream.Status = "204";
+        stream.Headers = {};
+        stream.Body = "";
+
+        auto response = StreamToIncomingResponse(stream, request);
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_VALUES_EQUAL(response->Status, "204");
+    }
+
+    Y_UNIT_TEST(StreamToIncomingResponseVariousStatusCodes) {
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/");
+
+        // Test a few status codes for proper reason phrase mapping
+        for (TString statusCode : {"200", "404", "500", "302"}) {
+            TStream stream;
+            stream.Status = statusCode;
+            stream.Headers = {};
+            stream.Body = "";
+
+            auto response = StreamToIncomingResponse(stream, request);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_VALUES_EQUAL(response->Status, statusCode);
+        }
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2Integration) {
+    Y_UNIT_TEST(Http2ClearTextUpgrade) {
+        // Test h2c (HTTP/2 over cleartext TCP) protocol detection.
+        // Simulates what curl --http2-prior-knowledge does:
+        // connect via plain TCP and send HTTP/2 connection preface.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        THolder<NHttp::TEvHttpProxy::TEvAddListeningPort> add = MakeHolder<NHttp::TEvHttpProxy::TEvAddListeningPort>(port);
+        add->AllowHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, actorSystem.AllocateEdgeActor(), add.Release()), 0, true);
+        actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvConfirmListen>(handle);
+
+        NActors::TActorId serverId = actorSystem.AllocateEdgeActor();
+        actorSystem.Send(new NActors::IEventHandle(proxyId, serverId, new NHttp::TEvHttpProxy::TEvRegisterHandler("/h2test", serverId)), 0, true);
+
+        TString clientError;
+        TString clientResponseStatus;
+        TString clientResponseBody;
+        std::atomic<bool> clientDone{false};
+
+        std::thread clientThread([port, &clientError, &clientResponseStatus, &clientResponseBody, &clientDone]() {
+            // Connect a raw TCP socket and speak HTTP/2 directly
+            int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+            if (fd < 0) {
+                clientError = "socket() failed";
+                clientDone = true;
+                return;
+            }
+            struct sockaddr_in6 addr = {};
+            addr.sin6_family = AF_INET6;
+            addr.sin6_port = htons(port);
+            addr.sin6_addr = in6addr_loopback;
+            if (::connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+                clientError = "connect() failed";
+                ::close(fd);
+                clientDone = true;
+                return;
+            }
+
+            // Use TSession as HTTP/2 client
+            TString outputData;
+            TString responseStatus;
+            TString responseBody;
+            bool gotResponse = false;
+
+            NHttp::NHttp2::TSessionCallbacks callbacks;
+            callbacks.OnResponse = [&](uint32_t /*streamId*/, NHttp::NHttp2::TStream& stream) {
+                responseStatus = stream.Status;
+                responseBody = stream.Body;
+                gotResponse = true;
+            };
+            callbacks.OnSend = [&](TString data) {
+                outputData.append(data);
+            };
+            callbacks.OnError = [&](TString error) {
+                clientError = error;
+            };
+
+            NHttp::NHttp2::TSession session(NHttp::NHttp2::TSession::ERole::Client, std::move(callbacks));
+            session.Initialize();
+
+            // Send a request
+            TVector<std::pair<TString, TString>> headers;
+            session.SendRequest("GET", "/h2test", "localhost", "http", headers, "");
+
+            // Flush all pending output (connection preface + SETTINGS + HEADERS)
+            if (!outputData.empty()) {
+                const char* buf = outputData.data();
+                size_t remaining = outputData.size();
+                while (remaining > 0) {
+                    ssize_t sent = ::send(fd, buf, remaining, 0);
+                    if (sent <= 0) {
+                        clientError = "send() failed";
+                        ::close(fd);
+                        clientDone = true;
+                        return;
+                    }
+                    buf += sent;
+                    remaining -= sent;
+                }
+                outputData.clear();
+            }
+
+            // Read responses until we have what we need (with timeout)
+            auto deadline = TInstant::Now() + TDuration::Seconds(5);
+            char readBuf[16384];
+            while (!gotResponse && TInstant::Now() < deadline) {
+                struct timeval tv;
+                tv.tv_sec = 1;
+                tv.tv_usec = 0;
+                setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+                ssize_t n = ::recv(fd, readBuf, sizeof(readBuf), 0);
+                if (n > 0) {
+                    session.Feed(readBuf, static_cast<size_t>(n));
+                    // Send any pending data (e.g. SETTINGS ACK, WINDOW_UPDATE)
+                    if (!outputData.empty()) {
+                        const char* buf2 = outputData.data();
+                        size_t rem = outputData.size();
+                        while (rem > 0) {
+                            ssize_t sent = ::send(fd, buf2, rem, 0);
+                            if (sent <= 0) break;
+                            buf2 += sent;
+                            rem -= sent;
+                        }
+                        outputData.clear();
+                    }
+                } else if (n == 0) {
+                    break; // connection closed
+                } else {
+                    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                        continue;
+                    }
+                    break;
+                }
+            }
+
+            if (gotResponse) {
+                clientResponseStatus = responseStatus;
+                clientResponseBody = responseBody;
+            } else if (clientError.empty()) {
+                clientError = "timed out waiting for HTTP/2 response";
+            }
+
+            ::close(fd);
+            clientDone = true;
+        });
+
+        // Server side: grab the incoming request delivered through the actor system
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_EQUAL(request->Request->URL, "/h2test");
+        UNIT_ASSERT_EQUAL(request->Request->Method, "GET");
+
+        // Send response back
+        NHttp::THttpOutgoingResponsePtr httpResponse = request->Request->CreateResponseOK("h2 works", "text/plain");
+        actorSystem.Send(new NActors::IEventHandle(handle->Sender, serverId, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse)), 0, true);
+
+        clientThread.join();
+
+        UNIT_ASSERT_C(clientError.empty(), "Client error: " + clientError);
+        UNIT_ASSERT_EQUAL(clientResponseStatus, "200");
+        UNIT_ASSERT_EQUAL(clientResponseBody, "h2 works");
+    }
+
+    Y_UNIT_TEST(Http2UpgradeFrom101) {
+        // Test HTTP/1.1 -> h2c upgrade via 101 Switching Protocols (RFC 7540 §3.2).
+        // Simulates what curl --http2 does:
+        // send HTTP/1.1 request with Upgrade: h2c, expect 101, then switch to HTTP/2.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        THolder<NHttp::TEvHttpProxy::TEvAddListeningPort> add = MakeHolder<NHttp::TEvHttpProxy::TEvAddListeningPort>(port);
+        add->AllowHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, actorSystem.AllocateEdgeActor(), add.Release()), 0, true);
+        actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvConfirmListen>(handle);
+
+        NActors::TActorId serverId = actorSystem.AllocateEdgeActor();
+        actorSystem.Send(new NActors::IEventHandle(proxyId, serverId, new NHttp::TEvHttpProxy::TEvRegisterHandler("/h2upgrade", serverId)), 0, true);
+
+        TString clientError;
+        TString clientResponseStatus;
+        TString clientResponseBody;
+        std::atomic<bool> clientDone{false};
+
+        std::thread clientThread([port, &clientError, &clientResponseStatus, &clientResponseBody, &clientDone]() {
+            int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+            if (fd < 0) {
+                clientError = "socket() failed";
+                clientDone = true;
+                return;
+            }
+            struct sockaddr_in6 addr = {};
+            addr.sin6_family = AF_INET6;
+            addr.sin6_port = htons(port);
+            addr.sin6_addr = in6addr_loopback;
+            if (::connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+                clientError = "connect() failed";
+                ::close(fd);
+                clientDone = true;
+                return;
+            }
+
+            // Step 1: Send HTTP/1.1 request with Upgrade: h2c
+            TString httpRequest =
+                "GET /h2upgrade HTTP/1.1\r\n"
+                "Host: localhost\r\n"
+                "Connection: Upgrade, HTTP2-Settings\r\n"
+                "Upgrade: h2c\r\n"
+                "HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA\r\n"
+                "\r\n";
+            {
+                const char* buf = httpRequest.data();
+                size_t remaining = httpRequest.size();
+                while (remaining > 0) {
+                    ssize_t sent = ::send(fd, buf, remaining, 0);
+                    if (sent <= 0) {
+                        clientError = "send() failed for HTTP/1.1 request";
+                        ::close(fd);
+                        clientDone = true;
+                        return;
+                    }
+                    buf += sent;
+                    remaining -= sent;
+                }
+            }
+
+            // Step 2: Read 101 Switching Protocols response
+            TString responseBuffer;
+            {
+                auto deadline = TInstant::Now() + TDuration::Seconds(5);
+                char readBuf[4096];
+                while (TInstant::Now() < deadline) {
+                    struct timeval tv;
+                    tv.tv_sec = 1;
+                    tv.tv_usec = 0;
+                    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+                    ssize_t n = ::recv(fd, readBuf, sizeof(readBuf), 0);
+                    if (n > 0) {
+                        responseBuffer.append(readBuf, n);
+                        if (responseBuffer.Contains("\r\n\r\n")) {
+                            break;
+                        }
+                    } else if (n == 0) {
+                        clientError = "connection closed before 101";
+                        ::close(fd);
+                        clientDone = true;
+                        return;
+                    } else {
+                        if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
+                        clientError = "recv() failed waiting for 101";
+                        ::close(fd);
+                        clientDone = true;
+                        return;
+                    }
+                }
+                if (!responseBuffer.StartsWith("HTTP/1.1 101")) {
+                    clientError = "expected 101, got: " + responseBuffer;
+                    ::close(fd);
+                    clientDone = true;
+                    return;
+                }
+            }
+
+            // Step 3: Switch to HTTP/2 — send client connection preface + SETTINGS
+            TString outputData;
+            TString responseStatus;
+            TString responseBody;
+            bool gotResponse = false;
+
+            NHttp::NHttp2::TSessionCallbacks callbacks;
+            callbacks.OnResponse = [&](uint32_t /*streamId*/, NHttp::NHttp2::TStream& stream) {
+                responseStatus = stream.Status;
+                responseBody = stream.Body;
+                gotResponse = true;
+            };
+            callbacks.OnSend = [&](TString data) {
+                outputData.append(data);
+            };
+            callbacks.OnError = [&](TString error) {
+                clientError = error;
+            };
+
+            NHttp::NHttp2::TSession session(NHttp::NHttp2::TSession::ERole::Client, std::move(callbacks));
+            session.Initialize();
+
+            // The original request was already sent as HTTP/1.1, so stream 1 is
+            // reserved for the upgrade response — we don't send a new HEADERS frame
+            // for it. Just register that we expect a response on stream 1.
+            session.RegisterUpgradeStream("/h2upgrade", "localhost");
+
+            // Flush client preface + SETTINGS
+            if (!outputData.empty()) {
+                const char* buf = outputData.data();
+                size_t remaining = outputData.size();
+                while (remaining > 0) {
+                    ssize_t sent = ::send(fd, buf, remaining, 0);
+                    if (sent <= 0) {
+                        clientError = "send() failed for h2 preface";
+                        ::close(fd);
+                        clientDone = true;
+                        return;
+                    }
+                    buf += sent;
+                    remaining -= sent;
+                }
+                outputData.clear();
+            }
+
+            // Step 4: Read HTTP/2 frames (server SETTINGS + response on stream 1)
+            auto deadline = TInstant::Now() + TDuration::Seconds(5);
+            char readBuf[16384];
+            while (!gotResponse && TInstant::Now() < deadline) {
+                struct timeval tv;
+                tv.tv_sec = 1;
+                tv.tv_usec = 0;
+                setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+                ssize_t n = ::recv(fd, readBuf, sizeof(readBuf), 0);
+                if (n > 0) {
+                    session.Feed(readBuf, static_cast<size_t>(n));
+                    if (!outputData.empty()) {
+                        const char* buf2 = outputData.data();
+                        size_t rem = outputData.size();
+                        while (rem > 0) {
+                            ssize_t sent = ::send(fd, buf2, rem, 0);
+                            if (sent <= 0) break;
+                            buf2 += sent;
+                            rem -= sent;
+                        }
+                        outputData.clear();
+                    }
+                } else if (n == 0) {
+                    break;
+                } else {
+                    if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
+                    break;
+                }
+            }
+
+            if (gotResponse) {
+                clientResponseStatus = responseStatus;
+                clientResponseBody = responseBody;
+            } else if (clientError.empty()) {
+                clientError = "timed out waiting for HTTP/2 response";
+            }
+
+            ::close(fd);
+            clientDone = true;
+        });
+
+        // Server side: grab the incoming request delivered through the actor system
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_EQUAL(request->Request->URL, "/h2upgrade");
+        UNIT_ASSERT_EQUAL(request->Request->Method, "GET");
+
+        // Send response back — this should be delivered as HTTP/2 stream 1
+        NHttp::THttpOutgoingResponsePtr httpResponse = request->Request->CreateResponseOK("upgrade works", "text/plain");
+        actorSystem.Send(new NActors::IEventHandle(handle->Sender, serverId, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse)), 0, true);
+
+        clientThread.join();
+
+        UNIT_ASSERT_C(clientError.empty(), "Client error: " + clientError);
+        UNIT_ASSERT_EQUAL(clientResponseStatus, "200");
+        UNIT_ASSERT_EQUAL(clientResponseBody, "upgrade works");
+    }
+}
+
+Y_UNIT_TEST_SUITE(Http2Compression) {
+
+    NHttp::THttpIncomingRequestPtr MakeRequestWithAcceptEncoding(TStringBuf acceptEncoding, const std::vector<TString>& compressTypes = {"text/plain"}) {
+        auto endpoint = std::make_shared<NHttp::TPrivateEndpointInfo>(compressTypes);
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest(
+            std::shared_ptr<NHttp::THttpEndpointInfo>(endpoint, static_cast<NHttp::THttpEndpointInfo*>(endpoint.get())),
+            NHttp::THttpConfig::SocketAddressType());
+        TString raw = TStringBuilder()
+            << "GET /test HTTP/1.1\r\n"
+            << "Host: test\r\n"
+            << "Accept-Encoding: " << acceptEncoding << "\r\n"
+            << "\r\n";
+        EatWholeString(request, raw);
+        return request;
+    }
+
+    Y_UNIT_TEST(DeflateCompressedResponseRoundtrip) {
+        auto request = MakeRequestWithAcceptEncoding("deflate");
+        TString originalBody = "hello world, this is a test body for compression";
+
+        auto response = request->CreateResponseOK(originalBody, "text/plain");
+        // Response should have compression enabled
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->ContentEncoding), "deflate");
+        // response->Body stores uncompressed data
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Body), originalBody);
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(status, "200");
+
+        // Body should be compressed (different from original)
+        UNIT_ASSERT(body != originalBody);
+        UNIT_ASSERT(!body.empty());
+
+        // content-encoding header should be present
+        bool foundEncoding = false;
+        TString encodingValue;
+        for (const auto& [name, value] : headers) {
+            if (name == "content-encoding") {
+                foundEncoding = true;
+                encodingValue = value;
+            }
+        }
+        UNIT_ASSERT(foundEncoding);
+        UNIT_ASSERT_VALUES_EQUAL(encodingValue, "deflate");
+
+        // content-length should match compressed body size
+        bool foundLength = false;
+        for (const auto& [name, value] : headers) {
+            if (name == "content-length") {
+                foundLength = true;
+                UNIT_ASSERT_VALUES_EQUAL(value, ToString(body.size()));
+            }
+        }
+        UNIT_ASSERT(foundLength);
+
+        // Decompress and verify roundtrip
+        NHttp::TCompressContext decompressor;
+        decompressor.InitDecompress("deflate");
+        TString decompressed = decompressor.Decompress(body);
+        UNIT_ASSERT_VALUES_EQUAL(decompressed, originalBody);
+    }
+
+    Y_UNIT_TEST(GzipCompressedResponseRoundtrip) {
+        auto request = MakeRequestWithAcceptEncoding("gzip");
+        TString originalBody = "hello world, this is a test body for gzip compression";
+
+        auto response = request->CreateResponseOK(originalBody, "text/plain");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->ContentEncoding), "gzip");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Body), originalBody);
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(status, "200");
+        UNIT_ASSERT(body != originalBody);
+
+        bool foundEncoding = false;
+        for (const auto& [name, value] : headers) {
+            if (name == "content-encoding") {
+                foundEncoding = true;
+                UNIT_ASSERT_VALUES_EQUAL(value, "gzip");
+            }
+        }
+        UNIT_ASSERT(foundEncoding);
+
+        NHttp::TCompressContext decompressor;
+        decompressor.InitDecompress("gzip");
+        TString decompressed = decompressor.Decompress(body);
+        UNIT_ASSERT_VALUES_EQUAL(decompressed, originalBody);
+    }
+
+    Y_UNIT_TEST(NoCompressionWhenNotRequested) {
+        // Request without Accept-Encoding — no compression
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest();
+        EatWholeString(request, TString("GET /test HTTP/1.1\r\nHost: test\r\n\r\n"));
+
+        auto response = request->CreateResponseOK("hello", "text/plain");
+        UNIT_ASSERT(response->ContentEncoding.empty());
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        // Body should be uncompressed
+        UNIT_ASSERT_VALUES_EQUAL(body, "hello");
+
+        // No content-encoding header
+        for (const auto& [name, _] : headers) {
+            UNIT_ASSERT_UNEQUAL(name, "content-encoding");
+        }
+    }
+
+    Y_UNIT_TEST(NoCompressionWhenContentTypeNotInList) {
+        // Accept-Encoding present but content type not in CompressContentTypes
+        auto request = MakeRequestWithAcceptEncoding("deflate", {"application/json"});
+        auto response = request->CreateResponseOK("plain text body", "text/plain");
+
+        // text/plain is not in compress list, so no encoding
+        UNIT_ASSERT(response->ContentEncoding.empty());
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(body, "plain text body");
+        for (const auto& [name, _] : headers) {
+            UNIT_ASSERT_UNEQUAL(name, "content-encoding");
+        }
+    }
+
+    Y_UNIT_TEST(EmptyBodyNotCompressed) {
+        auto request = MakeRequestWithAcceptEncoding("deflate");
+        auto response = request->CreateResponse("204", "No Content");
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        UNIT_ASSERT_VALUES_EQUAL(status, "204");
+        UNIT_ASSERT(body.empty());
+    }
+
+    Y_UNIT_TEST(CompressedResponseViaCreateResponseString) {
+        // This tests the path where an upstream HTTP/1.1 response is forwarded as HTTP/2
+        auto request = MakeRequestWithAcceptEncoding("deflate");
+
+        TString upstreamBody = "upstream response body that should be compressed for HTTP/2";
+        TString rawUpstreamResponse = TStringBuilder()
+            << "HTTP/1.1 200 OK\r\n"
+            << "Content-Type: text/plain\r\n"
+            << "Content-Length: " << upstreamBody.size() << "\r\n"
+            << "\r\n"
+            << upstreamBody;
+
+        auto response = request->CreateResponseString(rawUpstreamResponse);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Status), "200");
+        // Body should be uncompressed in response->Body
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Body), upstreamBody);
+
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        OutgoingResponseToStream(response, status, headers, body);
+
+        // Should be compressed for HTTP/2
+        UNIT_ASSERT(body != upstreamBody);
+
+        NHttp::TCompressContext decompressor;
+        decompressor.InitDecompress("deflate");
+        TString decompressed = decompressor.Decompress(body);
+        UNIT_ASSERT_VALUES_EQUAL(decompressed, upstreamBody);
+    }
+}
+
+// ============== Helper: Build a raw frame of arbitrary type ==============
+namespace {
+
+TString BuildRawFrame(EFrameType type, uint8_t flags, uint32_t streamId, TStringBuf payload) {
+    TString result;
+    result.resize(FRAME_HEADER_SIZE + payload.size());
+    char* out = result.Detach();
+    TFrameHeader hdr;
+    hdr.Length = payload.size();
+    hdr.Type = type;
+    hdr.Flags = flags;
+    hdr.StreamId = streamId;
+    hdr.Serialize(out);
+    if (!payload.empty()) {
+        std::memcpy(out + FRAME_HEADER_SIZE, payload.data(), payload.size());
+    }
+    return result;
+}
+
+// Helper: create an initialized server session for raw frame injection
+struct TRawServerSession {
+    std::unique_ptr<TSession> Session;
+    TString OutputBuf;
+    TString Error;
+    bool GotGoaway = false;
+
+    struct TReceivedRequest {
+        uint32_t StreamId;
+        TString Method;
+        TString Path;
+        TString Body;
+        TVector<std::pair<TString, TString>> Headers;
+    };
+    TVector<TReceivedRequest> Requests;
+
+    TRawServerSession() {
+        TSessionCallbacks cb;
+        cb.OnSend = [this](TString data) { OutputBuf.append(data); };
+        cb.OnError = [this](TString e) { Error = e; };
+        cb.OnRequest = [this](uint32_t streamId, TStream& stream) {
+            TReceivedRequest req;
+            req.StreamId = streamId;
+            req.Method = stream.Method;
+            req.Path = stream.Path;
+            req.Body = stream.Body;
+            req.Headers = stream.Headers;
+            Requests.push_back(std::move(req));
+        };
+        cb.OnGoaway = [this](uint32_t, EErrorCode) { GotGoaway = true; };
+
+        Session = std::make_unique<TSession>(TSession::ERole::Server, std::move(cb));
+        Session->Initialize();
+
+        // Feed connection preface from "client"
+        Session->Feed(CONNECTION_PREFACE.data(), CONNECTION_PREFACE.size());
+
+        // Feed client SETTINGS (empty)
+        TString settings = TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, {});
+        Session->Feed(settings.data(), settings.size());
+
+        // Feed SETTINGS ACK for server's settings
+        TString settingsAck = TFrameBuilder::BuildSettingsAck();
+        Session->Feed(settingsAck.data(), settingsAck.size());
+
+        OutputBuf.clear();
+        Error.clear();
+    }
+
+    void Feed(const TString& data) {
+        Session->Feed(data.data(), data.size());
+    }
+};
+
+} // anonymous namespace
+
+// ============== Huffman Codec Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2HuffmanCodec) {
+    Y_UNIT_TEST(HuffmanEncodeDecodeRoundtrip) {
+        THuffmanDecoder decoder;
+        TString original = "www.example.com";
+        TString encoded = THPackEncoder::HuffmanEncode(original);
+        UNIT_ASSERT(!encoded.empty());
+        UNIT_ASSERT_LT(encoded.size(), original.size()); // Huffman should compress
+
+        TString decoded;
+        UNIT_ASSERT(decoder.Decode(
+            reinterpret_cast<const uint8_t*>(encoded.data()), encoded.size(), decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded, original);
+    }
+
+    Y_UNIT_TEST(HuffmanEncodeDecodeVariousStrings) {
+        THuffmanDecoder decoder;
+        TVector<TString> testStrings = {
+            "",
+            "a",
+            "Hello, World!",
+            "/index.html",
+            "application/json",
+            "text/html; charset=utf-8",
+            "0123456789",
+            "AAAAAAAAAA",
+            TString(200, 'x'),
+        };
+
+        for (const auto& original : testStrings) {
+            TString encoded = THPackEncoder::HuffmanEncode(original);
+            TString decoded;
+            UNIT_ASSERT_C(decoder.Decode(
+                reinterpret_cast<const uint8_t*>(encoded.data()), encoded.size(), decoded),
+                "Failed to decode Huffman for: " + original);
+            UNIT_ASSERT_VALUES_EQUAL(decoded, original);
+        }
+    }
+
+    Y_UNIT_TEST(HuffmanDecodeInvalidData) {
+        THuffmanDecoder decoder;
+        // Invalid Huffman data (random bytes that end in the middle of a symbol)
+        uint8_t badData[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+        TString out;
+        // May or may not fail depending on exact bit pattern, but shouldn't crash
+        decoder.Decode(badData, sizeof(badData), out);
+    }
+
+    Y_UNIT_TEST(EncodeStringWithHuffman) {
+        THPackEncoder encoder;
+        TString result;
+        encoder.EncodeString(result, "www.example.com", true);
+        UNIT_ASSERT(!result.empty());
+        // First byte should have H bit set (0x80)
+        UNIT_ASSERT((static_cast<uint8_t>(result[0]) & 0x80) != 0);
+    }
+
+    Y_UNIT_TEST(EncodeStringWithoutHuffman) {
+        THPackEncoder encoder;
+        TString result;
+        encoder.EncodeString(result, "test", false);
+        UNIT_ASSERT(!result.empty());
+        // First byte should NOT have H bit set
+        UNIT_ASSERT((static_cast<uint8_t>(result[0]) & 0x80) == 0);
+    }
+
+    Y_UNIT_TEST(EncodeDecodeStringHuffmanRoundtrip) {
+        // Encode a string with huffman, then decode it using THPackDecoder's DecodeString
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        // Build a header block with huffman-encoded string using literal-with-indexing
+        // We'll just use Encode() which internally calls EncodeString
+        // Instead, let's test the full roundtrip through encoder/decoder with huffman
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-test-header", "this-is-a-huffman-encoded-value"},
+        };
+
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].first, "x-test-header");
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].second, "this-is-a-huffman-encoded-value");
+    }
+
+    Y_UNIT_TEST(HuffmanEmptyString) {
+        THuffmanDecoder decoder;
+        TString encoded = THPackEncoder::HuffmanEncode("");
+        UNIT_ASSERT(encoded.empty());
+        TString decoded;
+        UNIT_ASSERT(decoder.Decode(
+            reinterpret_cast<const uint8_t*>(encoded.data()), encoded.size(), decoded));
+        UNIT_ASSERT(decoded.empty());
+    }
+
+    Y_UNIT_TEST(HuffmanAllPrintableAscii) {
+        // Test encoding/decoding all printable ASCII byte values
+        THuffmanDecoder decoder;
+        TString original;
+        for (int i = 32; i < 127; ++i) {
+            original.push_back(static_cast<char>(i));
+        }
+        TString encoded = THPackEncoder::HuffmanEncode(original);
+        TString decoded;
+        UNIT_ASSERT(decoder.Decode(
+            reinterpret_cast<const uint8_t*>(encoded.data()), encoded.size(), decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded, original);
+    }
+}
+
+// ============== HPACK Advanced Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2HpackAdvanced) {
+    Y_UNIT_TEST(EncodeIntegerMultiByte) {
+        THPackEncoder encoder;
+        // Value that requires multi-byte encoding (value >= maxPrefix)
+        // With 5-bit prefix, maxPrefix = 31. So value=300 needs multi-byte
+        TString result;
+        encoder.EncodeInteger(result, 300, 5, 0x00);
+        UNIT_ASSERT_GT(result.size(), 1u);
+        // First byte should have all 5 prefix bits set (31)
+        UNIT_ASSERT_VALUES_EQUAL(static_cast<uint8_t>(result[0]) & 0x1F, 0x1Fu);
+    }
+
+    Y_UNIT_TEST(EncodeDecodeIntegerRoundtrip) {
+        // Test encode/decode roundtrip for various integer sizes
+        THPackEncoder encoder;
+        TVector<uint32_t> values = {0, 1, 30, 31, 127, 128, 255, 256, 1000, 16384, 65535, 100000};
+
+        for (uint8_t prefix = 4; prefix <= 7; ++prefix) {
+            for (uint32_t val : values) {
+                TString encoded;
+                encoder.EncodeInteger(encoded, val, prefix, 0x00);
+
+                // Decode
+                const uint8_t* pos = reinterpret_cast<const uint8_t*>(encoded.data());
+                const uint8_t* end = pos + encoded.size();
+                uint32_t decoded;
+                THPackDecoder decoder;
+                UNIT_ASSERT_C(decoder.DecodeInteger(pos, end, prefix, decoded),
+                    "Failed for val=" + ToString(val) + " prefix=" + ToString(prefix));
+                UNIT_ASSERT_VALUES_EQUAL_C(decoded, val,
+                    "Mismatch for val=" + ToString(val) + " prefix=" + ToString(prefix));
+                UNIT_ASSERT_VALUES_EQUAL(pos, end); // all consumed
+            }
+        }
+    }
+
+    Y_UNIT_TEST(DecodeIntegerEmpty) {
+        THPackDecoder decoder;
+        const uint8_t* pos = nullptr;
+        const uint8_t* end = nullptr;
+        uint32_t value;
+        UNIT_ASSERT(!decoder.DecodeInteger(pos, end, 7, value));
+    }
+
+    Y_UNIT_TEST(DecodeIntegerTruncated) {
+        THPackDecoder decoder;
+        // Multi-byte integer with continuation bit set but no more bytes
+        uint8_t data[] = {0x7F, 0x80}; // prefix=7: value=127+... but continuation bit set and no next byte
+        const uint8_t* pos = data;
+        const uint8_t* end = data + sizeof(data);
+        uint32_t value;
+        UNIT_ASSERT(!decoder.DecodeInteger(pos, end, 7, value));
+    }
+
+    Y_UNIT_TEST(DecodeStringEmpty) {
+        THPackDecoder decoder;
+        const uint8_t* pos = nullptr;
+        const uint8_t* end = nullptr;
+        TString out;
+        UNIT_ASSERT(!decoder.DecodeString(pos, end, out));
+    }
+
+    Y_UNIT_TEST(DecodeStringHuffman) {
+        // Build a huffman-encoded string and decode it
+        TString original = "custom-value";
+        TString huffEncoded = THPackEncoder::HuffmanEncode(original);
+
+        // Build the string representation: H=1 bit + length + data
+        TString strData;
+        THPackEncoder encoder;
+        encoder.EncodeString(strData, original, true);
+
+        THPackDecoder decoder;
+        const uint8_t* pos = reinterpret_cast<const uint8_t*>(strData.data());
+        const uint8_t* end = pos + strData.size();
+        TString decoded;
+        UNIT_ASSERT(decoder.DecodeString(pos, end, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded, original);
+    }
+
+    Y_UNIT_TEST(LookupIndexStaticTable) {
+        THPackDecoder decoder;
+        TString name, value;
+        // Static table index 2 = :method GET
+        UNIT_ASSERT(decoder.LookupIndex(2, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, ":method");
+        UNIT_ASSERT_VALUES_EQUAL(value, "GET");
+    }
+
+    Y_UNIT_TEST(LookupIndexInvalid) {
+        THPackDecoder decoder;
+        TString name, value;
+        // Index 0 is invalid
+        UNIT_ASSERT(!decoder.LookupIndex(0, name, value));
+        // Very large index (beyond static + dynamic)
+        UNIT_ASSERT(!decoder.LookupIndex(1000, name, value));
+    }
+
+    Y_UNIT_TEST(LookupIndexDynamicTable) {
+        // Add entries to dynamic table through decoding, then look them up
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-custom", "myvalue"},
+        };
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+
+        // Now the dynamic table should have "x-custom: myvalue" at dynamic index 1
+        // which is static table size (61) + 1
+        TString name, value;
+        UNIT_ASSERT(decoder.LookupIndex(62, name, value));
+        UNIT_ASSERT_VALUES_EQUAL(name, "x-custom");
+        UNIT_ASSERT_VALUES_EQUAL(value, "myvalue");
+    }
+
+    Y_UNIT_TEST(LookupIndexNameInvalid) {
+        THPackDecoder decoder;
+        TString name;
+        UNIT_ASSERT(!decoder.LookupIndexName(0, name));
+        UNIT_ASSERT(!decoder.LookupIndexName(1000, name));
+    }
+
+    Y_UNIT_TEST(LookupIndexNameDynamicTable) {
+        THPackEncoder encoder;
+        THPackDecoder decoder;
+
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-my-header", "value1"},
+        };
+        TString encoded = encoder.Encode(headers);
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(encoded, decoded));
+
+        TString name;
+        UNIT_ASSERT(decoder.LookupIndexName(62, name));
+        UNIT_ASSERT_VALUES_EQUAL(name, "x-my-header");
+    }
+
+    Y_UNIT_TEST(DynamicTableSizeUpdateInDecode) {
+        // Test §6.3: Dynamic Table Size Update issued inside a header block
+        THPackDecoder decoder;
+
+        // Build raw HPACK block: dynamic table size update to 0, then a literal header
+        TString data;
+        // §6.3: 001xxxxx pattern, 5-bit prefix
+        // Size 0: 0x20 (001_00000)
+        data.push_back(0x20);
+        // Then a literal-without-indexing: 0000xxxx with new name
+        // index=0, new name "a", value "b"
+        data.push_back(0x00); // literal without indexing, index=0
+        data.push_back(0x01); // name length=1
+        data.push_back('a');
+        data.push_back(0x01); // value length=1
+        data.push_back('b');
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(decoder.Decode(data, headers));
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].first, "a");
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].second, "b");
+    }
+
+    Y_UNIT_TEST(LiteralWithoutIndexing) {
+        // §6.2.2: 0000xxxx pattern
+        THPackDecoder decoder;
+
+        TString data;
+        // Literal without indexing, new name
+        data.push_back(0x00); // pattern 0000, index=0
+        data.push_back(0x06); // name length=6
+        data.append("x-test");
+        data.push_back(0x05); // value length=5
+        data.append("hello");
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(decoder.Decode(data, headers));
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].first, "x-test");
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].second, "hello");
+    }
+
+    Y_UNIT_TEST(LiteralNeverIndexed) {
+        // §6.2.3: 0001xxxx pattern
+        THPackDecoder decoder;
+
+        TString data;
+        // Literal never indexed, new name
+        data.push_back(0x10); // pattern 0001, index=0
+        data.push_back(0x09); // name length=9
+        data.append("sensitive");
+        data.push_back(0x06); // value length=6
+        data.append("secret");
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(decoder.Decode(data, headers));
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].first, "sensitive");
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].second, "secret");
+    }
+
+    Y_UNIT_TEST(LiteralWithIndexingByIndex) {
+        // §6.2.1 with index>0: references a name from the table
+        THPackDecoder decoder;
+
+        TString data;
+        // Literal with incremental indexing, referencing static table entry
+        // :path (index 4 in static table) = 01_000100 = 0x44
+        data.push_back(0x44);
+        data.push_back(0x0A); // value length=10
+        data.append("/api/items");
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(decoder.Decode(data, headers));
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].first, ":path");
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].second, "/api/items");
+    }
+
+    Y_UNIT_TEST(LiteralWithoutIndexingByIndex) {
+        // §6.2.2 with index>0: references a name from the table
+        THPackDecoder decoder;
+
+        TString data;
+        // :authority is static index 1. Without indexing: 0000_0001 = 0x01
+        data.push_back(0x01);
+        data.push_back(0x0B); // value length=11
+        data.append("example.com");
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(decoder.Decode(data, headers));
+        UNIT_ASSERT_VALUES_EQUAL(headers.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].first, ":authority");
+        UNIT_ASSERT_VALUES_EQUAL(headers[0].second, "example.com");
+    }
+
+    Y_UNIT_TEST(FindHeaderDynamicTableExactMatch) {
+        THPackEncoder encoder;
+
+        // Encode a custom header - it gets added to the dynamic table
+        TVector<std::pair<TString, TString>> headers = {
+            {"x-custom-key", "custom-val"},
+        };
+        TString firstEncoded = encoder.Encode(headers);
+
+        // Encode again - should find exact match in dynamic table (indexed representation)
+        TString secondEncoded = encoder.Encode(headers);
+        // Second encoding should be shorter (indexed reference)
+        UNIT_ASSERT_LE(secondEncoded.size(), firstEncoded.size());
+
+        // Verify roundtrip
+        THPackDecoder decoder;
+        TVector<std::pair<TString, TString>> decoded;
+        UNIT_ASSERT(decoder.Decode(firstEncoded, decoded));
+        decoded.clear();
+        UNIT_ASSERT(decoder.Decode(secondEncoded, decoded));
+        UNIT_ASSERT_VALUES_EQUAL(decoded.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].first, "x-custom-key");
+        UNIT_ASSERT_VALUES_EQUAL(decoded[0].second, "custom-val");
+    }
+
+    Y_UNIT_TEST(DecoderRejectsTruncatedLiteral) {
+        THPackDecoder decoder;
+        // Literal with indexing, new name, but data is truncated
+        TString data;
+        data.push_back(0x40); // literal with indexing, index=0
+        data.push_back(0x05); // name length=5
+        data.append("abc"); // only 3 bytes, expected 5
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(!decoder.Decode(data, headers));
+    }
+
+    Y_UNIT_TEST(DecoderRejectsInvalidIndexedLookup) {
+        THPackDecoder decoder;
+        // Indexed header with very large index (beyond static table + empty dynamic table)
+        TString data;
+        // Indexed: 1_xxxxxxx. Index = 100 which is beyond static table (61 entries)
+        // 7-bit prefix: maxPrefix = 127. 100 < 127, so single byte: 0x80 | 100 = 0xE4
+        data.push_back(static_cast<char>(0x80 | 100));
+
+        TVector<std::pair<TString, TString>> headers;
+        UNIT_ASSERT(!decoder.Decode(data, headers));
+    }
+}
+
+// ============== CONTINUATION Frame Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2ContinuationFrames) {
+    // Helper struct for session pair in this suite
+    struct TSessionPair {
+        TString ServerRecvBuf;
+        TString ClientRecvBuf;
+        TString ServerError;
+        TString ClientError;
+
+        struct TReceivedRequest {
+            uint32_t StreamId;
+            TString Method;
+            TString Path;
+            TVector<std::pair<TString, TString>> Headers;
+        };
+
+        struct TReceivedResponse {
+            uint32_t StreamId;
+            TString Status;
+            TString Body;
+            TVector<std::pair<TString, TString>> Headers;
+        };
+
+        TVector<TReceivedRequest> ServerRequests;
+        TVector<TReceivedResponse> ClientResponses;
+
+        std::unique_ptr<TSession> Server;
+        std::unique_ptr<TSession> Client;
+
+        TSessionPair() {
+            TSessionCallbacks serverCb;
+            serverCb.OnRequest = [this](uint32_t streamId, TStream& stream) {
+                TReceivedRequest req;
+                req.StreamId = streamId;
+                req.Method = stream.Method;
+                req.Path = stream.Path;
+                req.Headers = stream.Headers;
+                ServerRequests.push_back(std::move(req));
+            };
+            serverCb.OnSend = [this](TString data) { ClientRecvBuf.append(data); };
+            serverCb.OnError = [this](TString e) { ServerError = e; };
+            serverCb.OnGoaway = [](uint32_t, EErrorCode) {};
+
+            TSessionCallbacks clientCb;
+            clientCb.OnResponse = [this](uint32_t streamId, TStream& stream) {
+                TReceivedResponse resp;
+                resp.StreamId = streamId;
+                resp.Status = stream.Status;
+                resp.Body = stream.Body;
+                resp.Headers = stream.Headers;
+                ClientResponses.push_back(std::move(resp));
+            };
+            clientCb.OnSend = [this](TString data) { ServerRecvBuf.append(data); };
+            clientCb.OnError = [this](TString e) { ClientError = e; };
+            clientCb.OnGoaway = [](uint32_t, EErrorCode) {};
+
+            Server = std::make_unique<TSession>(TSession::ERole::Server, std::move(serverCb));
+            Client = std::make_unique<TSession>(TSession::ERole::Client, std::move(clientCb));
+        }
+
+        void Initialize() {
+            Client->Initialize();
+            Server->Initialize();
+            Pump();
+        }
+
+        void Pump() {
+            for (int i = 0; i < 10; ++i) {
+                bool progress = false;
+                if (!ServerRecvBuf.empty()) {
+                    TString data;
+                    data.swap(ServerRecvBuf);
+                    Server->Feed(data.data(), data.size());
+                    progress = true;
+                }
+                if (!ClientRecvBuf.empty()) {
+                    TString data;
+                    data.swap(ClientRecvBuf);
+                    Client->Feed(data.data(), data.size());
+                    progress = true;
+                }
+                if (!progress) break;
+            }
+        }
+    };
+
+    Y_UNIT_TEST(ReceiveContinuation) {
+        // Send HEADERS without END_HEADERS, then CONTINUATION with END_HEADERS
+        TRawServerSession srv;
+
+        // Encode a simple request
+        THPackEncoder encoder;
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+            {":path", "/continuation-test"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+        };
+        TString headerBlock = encoder.Encode(headers);
+
+        // Split header block in half
+        size_t half = headerBlock.size() / 2;
+        TStringBuf firstPart(headerBlock.data(), half);
+        TStringBuf secondPart(headerBlock.data() + half, headerBlock.size() - half);
+
+        // HEADERS without END_HEADERS, with END_STREAM (no body)
+        uint8_t headersFlags = NFrameFlag::END_STREAM; // no END_HEADERS
+        TString headersFrame = TFrameBuilder::BuildHeaders(1, headersFlags, firstPart);
+        srv.Feed(headersFrame);
+
+        // Should not have received request yet (waiting for CONTINUATION)
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 0u);
+        UNIT_ASSERT(srv.Error.empty());
+
+        // CONTINUATION with END_HEADERS
+        TString contFrame = TFrameBuilder::BuildContinuation(1, NFrameFlag::END_HEADERS, secondPart);
+        srv.Feed(contFrame);
+
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Path, "/continuation-test");
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Method, "GET");
+    }
+
+    Y_UNIT_TEST(ReceiveMultipleContinuations) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "POST"},
+            {":path", "/multi-cont"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+            {"x-header-1", "value-1"},
+            {"x-header-2", "value-2"},
+            {"x-header-3", "value-3"},
+        };
+        TString headerBlock = encoder.Encode(headers);
+
+        // Split into 3 parts
+        size_t partSize = headerBlock.size() / 3;
+        TStringBuf part1(headerBlock.data(), partSize);
+        TStringBuf part2(headerBlock.data() + partSize, partSize);
+        TStringBuf part3(headerBlock.data() + 2 * partSize, headerBlock.size() - 2 * partSize);
+
+        // HEADERS without END_HEADERS
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_STREAM, part1));
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 0u);
+
+        // CONTINUATION without END_HEADERS
+        srv.Feed(TFrameBuilder::BuildContinuation(1, NFrameFlag::NONE, part2));
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 0u);
+
+        // CONTINUATION with END_HEADERS
+        srv.Feed(TFrameBuilder::BuildContinuation(1, NFrameFlag::END_HEADERS, part3));
+
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Path, "/multi-cont");
+    }
+
+    Y_UNIT_TEST(NonContinuationWhileExpecting) {
+        // Send HEADERS without END_HEADERS, then a DATA frame -> PROTOCOL_ERROR
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+            {":path", "/"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+        };
+        TString headerBlock = encoder.Encode(headers);
+
+        // HEADERS without END_HEADERS
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::NONE, headerBlock));
+        UNIT_ASSERT(srv.Error.empty());
+
+        // Send DATA instead of CONTINUATION -> error
+        srv.Feed(TFrameBuilder::BuildData(1, NFrameFlag::END_STREAM, "body"));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("CONTINUATION"));
+    }
+
+    Y_UNIT_TEST(ContinuationForWrongStream) {
+        // Send HEADERS without END_HEADERS for stream 1, then CONTINUATION for stream 3
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TVector<std::pair<TString, TString>> headers = {
+            {":method", "GET"},
+            {":path", "/"},
+            {":scheme", "https"},
+            {":authority", "example.com"},
+        };
+        TString headerBlock = encoder.Encode(headers);
+
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::NONE, headerBlock));
+        // CONTINUATION for wrong stream
+        srv.Feed(TFrameBuilder::BuildContinuation(3, NFrameFlag::END_HEADERS, ""));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(ContinuationForUnknownStream) {
+        // CONTINUATION frame for a stream that doesn't exist
+        TRawServerSession srv;
+
+        srv.Feed(TFrameBuilder::BuildContinuation(99, NFrameFlag::END_HEADERS, ""));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(SendResponseWithContinuation) {
+        // Force CONTINUATION by sending very large headers that exceed MaxFrameSize.
+        // We use a session pair and verify the response arrives correctly.
+        // Since default MaxFrameSize is 16384, we need headers > 16KB.
+        TSessionPair pair;
+        pair.Initialize();
+
+        uint32_t streamId = pair.Client->SendRequest("GET", "/large-headers", "example.com", "https", {}, "");
+        pair.Pump();
+
+        // Build response with enough headers to exceed 16384 bytes
+        TVector<std::pair<TString, TString>> respHeaders;
+        for (int i = 0; i < 500; ++i) {
+            respHeaders.emplace_back("x-large-header-" + ToString(i), TString(30, 'A' + (i % 26)));
+        }
+
+        pair.Server->SendResponse(streamId, "200", respHeaders, "ok");
+        pair.Pump();
+
+        UNIT_ASSERT_C(pair.ClientError.empty(), pair.ClientError);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Status, "200");
+        UNIT_ASSERT_VALUES_EQUAL(pair.ClientResponses[0].Body, "ok");
+    }
+
+    Y_UNIT_TEST(SendRequestWithContinuation) {
+        // Force CONTINUATION on client side with large headers
+        TSessionPair pair;
+        pair.Initialize();
+
+        TVector<std::pair<TString, TString>> reqHeaders;
+        for (int i = 0; i < 500; ++i) {
+            reqHeaders.emplace_back("x-large-req-" + ToString(i), TString(30, 'a' + (i % 26)));
+        }
+
+        pair.Client->SendRequest("GET", "/", "example.com", "https", reqHeaders, "");
+
+        // Need extra pump iterations for large data
+        for (int i = 0; i < 20; ++i) {
+            bool progress = false;
+            if (!pair.ServerRecvBuf.empty()) {
+                TString data;
+                data.swap(pair.ServerRecvBuf);
+                pair.Server->Feed(data.data(), data.size());
+                progress = true;
+            }
+            if (!pair.ClientRecvBuf.empty()) {
+                TString data;
+                data.swap(pair.ClientRecvBuf);
+                pair.Client->Feed(data.data(), data.size());
+                progress = true;
+            }
+            if (!progress) break;
+        }
+
+        UNIT_ASSERT_C(pair.ServerError.empty(), "Server error: " + pair.ServerError);
+        UNIT_ASSERT_C(pair.ClientError.empty(), "Client error: " + pair.ClientError);
+        UNIT_ASSERT_VALUES_EQUAL_C(pair.ServerRequests.size(), 1u,
+            "Server got " + ToString(pair.ServerRequests.size()) + " requests, ServerError=" + pair.ServerError);
+        UNIT_ASSERT_VALUES_EQUAL(pair.ServerRequests[0].Path, "/");
+    }
+}
+
+// ============== Error Handling Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2ErrorHandling) {
+    Y_UNIT_TEST(DataFrameOnStream0) {
+        TRawServerSession srv;
+        srv.Feed(TFrameBuilder::BuildData(0, NFrameFlag::NONE, "payload"));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("DATA"));
+    }
+
+    Y_UNIT_TEST(DataFrameOnUnknownStream) {
+        TRawServerSession srv;
+        // DATA on stream 99 which doesn't exist - should be silently ignored
+        srv.Feed(TFrameBuilder::BuildData(99, NFrameFlag::END_STREAM, "data"));
+        UNIT_ASSERT(srv.Error.empty()); // Not an error, just ignored
+    }
+
+    Y_UNIT_TEST(HeadersFrameOnStream0) {
+        TRawServerSession srv;
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({{":method", "GET"}, {":path", "/"}});
+        srv.Feed(TFrameBuilder::BuildHeaders(0, NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, headerBlock));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("HEADERS"));
+    }
+
+    Y_UNIT_TEST(PriorityFrameOnStream0) {
+        TRawServerSession srv;
+        // PRIORITY frame needs exactly 5 bytes of payload
+        TString payload(5, '\0');
+        srv.Feed(BuildRawFrame(EFrameType::PRIORITY, NFrameFlag::NONE, 0, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("PRIORITY"));
+    }
+
+    Y_UNIT_TEST(PriorityFrameWrongSize) {
+        TRawServerSession srv;
+        TString payload(3, '\0'); // wrong size, should be 5
+        srv.Feed(BuildRawFrame(EFrameType::PRIORITY, NFrameFlag::NONE, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PriorityFrameValid) {
+        TRawServerSession srv;
+        TString payload(5, '\0'); // correct size
+        srv.Feed(BuildRawFrame(EFrameType::PRIORITY, NFrameFlag::NONE, 1, payload));
+        UNIT_ASSERT(srv.Error.empty()); // ignored but no error
+    }
+
+    Y_UNIT_TEST(RstStreamOnStream0) {
+        TRawServerSession srv;
+        srv.Feed(TFrameBuilder::BuildRstStream(0, EErrorCode::CANCEL));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(RstStreamWrongSize) {
+        TRawServerSession srv;
+        // RST_STREAM should be exactly 4 bytes
+        TString payload(8, '\0');
+        srv.Feed(BuildRawFrame(EFrameType::RST_STREAM, NFrameFlag::NONE, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(RstStreamClosesStream) {
+        TRawServerSession srv;
+
+        // First create a stream by sending HEADERS
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "GET"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, headerBlock));
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+
+        // Now send RST_STREAM for stream 1
+        srv.Feed(TFrameBuilder::BuildRstStream(1, EErrorCode::CANCEL));
+        UNIT_ASSERT(srv.Error.empty()); // Not a connection error
+    }
+
+    Y_UNIT_TEST(SettingsOnNonZeroStream) {
+        TRawServerSession srv;
+        srv.Feed(TFrameBuilder::BuildSettings(1, NFrameFlag::NONE, {}));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("SETTINGS"));
+    }
+
+    Y_UNIT_TEST(SettingsAckWithPayload) {
+        TRawServerSession srv;
+        // Build SETTINGS ACK with non-empty payload
+        TVector<TSettingsEntry> entries = {{ESettingsId::MAX_CONCURRENT_STREAMS, 100}};
+        srv.Feed(TFrameBuilder::BuildSettings(0, NFrameFlag::ACK, entries));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("SETTINGS ACK"));
+    }
+
+    Y_UNIT_TEST(SettingsBadPayloadSize) {
+        TRawServerSession srv;
+        // Payload size not multiple of 6
+        TString payload(7, '\0');
+        srv.Feed(BuildRawFrame(EFrameType::SETTINGS, NFrameFlag::NONE, 0, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("multiple of 6"));
+    }
+
+    Y_UNIT_TEST(SettingsInvalidInitialWindowSize) {
+        TRawServerSession srv;
+        // INITIAL_WINDOW_SIZE (0x3) with value > MAX_WINDOW_SIZE (0x7FFFFFFF)
+        TVector<TSettingsEntry> entries = {{ESettingsId::INITIAL_WINDOW_SIZE, 0x80000000u}};
+        srv.Feed(TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, entries));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(SettingsHeaderTableSizeUpdate) {
+        TRawServerSession srv;
+        // Change HEADER_TABLE_SIZE
+        TVector<TSettingsEntry> entries = {{ESettingsId::HEADER_TABLE_SIZE, 2048}};
+        srv.Feed(TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, entries));
+        UNIT_ASSERT(srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(SettingsInitialWindowSizeAdjustsStreams) {
+        TRawServerSession srv;
+
+        // Create a stream first
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "POST"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+
+        // Now change INITIAL_WINDOW_SIZE - should adjust existing stream
+        TVector<TSettingsEntry> entries = {{ESettingsId::INITIAL_WINDOW_SIZE, 32768}};
+        srv.Feed(TFrameBuilder::BuildSettings(0, NFrameFlag::NONE, entries));
+        UNIT_ASSERT(srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PingOnNonZeroStream) {
+        TRawServerSession srv;
+        char data[8] = {};
+        // Build PING on non-zero stream
+        srv.Feed(BuildRawFrame(EFrameType::PING, NFrameFlag::NONE, 1, TStringBuf(data, 8)));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("PING"));
+    }
+
+    Y_UNIT_TEST(PingWrongSize) {
+        TRawServerSession srv;
+        char data[4] = {};
+        srv.Feed(BuildRawFrame(EFrameType::PING, NFrameFlag::NONE, 0, TStringBuf(data, 4)));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("PING"));
+    }
+
+    Y_UNIT_TEST(PingAckIgnored) {
+        TRawServerSession srv;
+        char data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        srv.Feed(BuildRawFrame(EFrameType::PING, NFrameFlag::ACK, 0, TStringBuf(data, 8)));
+        UNIT_ASSERT(srv.Error.empty()); // ACK should be silently ignored
+    }
+
+    Y_UNIT_TEST(GoawayOnNonZeroStream) {
+        TRawServerSession srv;
+        // Build GOAWAY on non-zero stream (normally BuildGoaway uses stream 0)
+        TString goawayPayload(8, '\0'); // minimum GOAWAY payload: 4 bytes last-stream-id + 4 bytes error code
+        srv.Feed(BuildRawFrame(EFrameType::GOAWAY, NFrameFlag::NONE, 1, goawayPayload));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("GOAWAY"));
+    }
+
+    Y_UNIT_TEST(GoawayTooSmall) {
+        TRawServerSession srv;
+        TString payload(4, '\0'); // only 4 bytes, needs at least 8
+        srv.Feed(BuildRawFrame(EFrameType::GOAWAY, NFrameFlag::NONE, 0, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(GoawayValid) {
+        TRawServerSession srv;
+        srv.Feed(TFrameBuilder::BuildGoaway(0, EErrorCode::NO_ERROR));
+        UNIT_ASSERT(srv.Error.empty());
+        UNIT_ASSERT(srv.GotGoaway);
+    }
+
+    Y_UNIT_TEST(WindowUpdateWrongSize) {
+        TRawServerSession srv;
+        TString payload(8, '\0'); // should be exactly 4
+        srv.Feed(BuildRawFrame(EFrameType::WINDOW_UPDATE, NFrameFlag::NONE, 0, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(WindowUpdateZeroIncrementConnection) {
+        TRawServerSession srv;
+        srv.Feed(TFrameBuilder::BuildWindowUpdate(0, 0));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("WINDOW_UPDATE") || srv.Error.Contains("Zero"));
+    }
+
+    Y_UNIT_TEST(WindowUpdateZeroIncrementStream) {
+        TRawServerSession srv;
+
+        // Create stream 1 first
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "GET"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // Zero increment on stream 1 → RST_STREAM (not connection error)
+        srv.Feed(TFrameBuilder::BuildWindowUpdate(1, 0));
+        // This sends RST_STREAM, not a connection error
+        UNIT_ASSERT(srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(WindowUpdateOverflowConnection) {
+        TRawServerSession srv;
+        // Send a WINDOW_UPDATE that would overflow the connection window
+        srv.Feed(TFrameBuilder::BuildWindowUpdate(0, MAX_WINDOW_SIZE));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(WindowUpdateOverflowStream) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "GET"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // Overflow stream window
+        srv.Feed(TFrameBuilder::BuildWindowUpdate(1, MAX_WINDOW_SIZE));
+        // This should send RST_STREAM + close the stream
+        UNIT_ASSERT(srv.Error.empty()); // Stream-level, not connection error
+    }
+
+    Y_UNIT_TEST(PushPromiseRejected) {
+        TRawServerSession srv;
+        TString payload(4, '\0'); // minimal PUSH_PROMISE payload
+        srv.Feed(BuildRawFrame(EFrameType::PUSH_PROMISE, NFrameFlag::NONE, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(HpackDecodeFailure) {
+        TRawServerSession srv;
+        // Feed HEADERS with garbage header block → COMPRESSION_ERROR
+        TString garbage = "\xFF\xFF\xFF\xFF";
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, garbage));
+        UNIT_ASSERT(!srv.Error.empty());
+        UNIT_ASSERT(srv.Error.Contains("COMPRESSION") || srv.Error.Contains("HPACK"));
+    }
+
+    Y_UNIT_TEST(UnknownFrameTypeIgnored) {
+        TRawServerSession srv;
+        // Unknown frame type (0xFF) should be ignored per RFC 7540 Section 4.1
+        TString payload = "whatever";
+        srv.Feed(BuildRawFrame(static_cast<EFrameType>(0xFF), NFrameFlag::NONE, 0, payload));
+        UNIT_ASSERT(srv.Error.empty());
+    }
+}
+
+// ============== Padded Frame Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2PaddedFrames) {
+    Y_UNIT_TEST(PaddedDataFrame) {
+        TRawServerSession srv;
+
+        // First, create stream 1 with headers
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "POST"}, {":path", "/padded"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // Build PADDED DATA frame manually
+        // Payload: [pad_length=3] [actual_data="hello"] [padding="\0\0\0"]
+        TString payload;
+        payload.push_back(3); // pad length
+        payload.append("hello");
+        payload.append(TString(3, '\0')); // padding
+
+        srv.Feed(BuildRawFrame(EFrameType::DATA, NFrameFlag::PADDED | NFrameFlag::END_STREAM, 1, payload));
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Body, "hello");
+    }
+
+    Y_UNIT_TEST(PaddedDataFrameEmptyPayload) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "POST"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // PADDED DATA with empty payload → error (needs at least 1 byte for pad length)
+        srv.Feed(BuildRawFrame(EFrameType::DATA, NFrameFlag::PADDED, 1, ""));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PaddedDataFramePadOverflow) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "POST"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // Pad length exceeds payload: [pad_length=10] [only 3 bytes of data]
+        TString payload;
+        payload.push_back(10); // pad length = 10
+        payload.append("abc"); // only 3 bytes after pad length
+        srv.Feed(BuildRawFrame(EFrameType::DATA, NFrameFlag::PADDED | NFrameFlag::END_STREAM, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PaddedHeadersFrame) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "GET"}, {":path", "/padded-headers"}, {":scheme", "https"}, {":authority", "host"},
+        });
+
+        // Build PADDED HEADERS: [pad_length=2] [header_block] [padding="\0\0"]
+        TString payload;
+        payload.push_back(2); // pad length
+        payload.append(headerBlock);
+        payload.append(TString(2, '\0')); // padding
+
+        srv.Feed(BuildRawFrame(EFrameType::HEADERS,
+            NFrameFlag::PADDED | NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, 1, payload));
+
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Path, "/padded-headers");
+    }
+
+    Y_UNIT_TEST(PaddedHeadersWithPriority) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "GET"}, {":path", "/padded-prio"}, {":scheme", "https"}, {":authority", "host"},
+        });
+
+        // Build PADDED+PRIORITY HEADERS:
+        // [pad_length=1] [stream_dep(4 bytes)] [weight(1 byte)] [header_block] [padding]
+        TString payload;
+        payload.push_back(1); // pad length
+        // Stream dependency (4 bytes): 0
+        payload.append(TString(4, '\0'));
+        // Weight (1 byte): 15
+        payload.push_back(15);
+        payload.append(headerBlock);
+        payload.append(TString(1, '\0')); // padding
+
+        srv.Feed(BuildRawFrame(EFrameType::HEADERS,
+            NFrameFlag::PADDED | NFrameFlag::PRIORITY | NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM,
+            1, payload));
+
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Path, "/padded-prio");
+    }
+
+    Y_UNIT_TEST(PaddedHeadersEmptyPayload) {
+        TRawServerSession srv;
+        // PADDED HEADERS with empty payload → FRAME_SIZE_ERROR
+        srv.Feed(BuildRawFrame(EFrameType::HEADERS,
+            NFrameFlag::PADDED | NFrameFlag::END_HEADERS, 1, ""));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PaddedHeadersPadOverflow) {
+        TRawServerSession srv;
+
+        // Pad length exceeds available header block space
+        TString payload;
+        payload.push_back(100); // pad length = 100
+        payload.append("abc"); // only 3 bytes
+        srv.Feed(BuildRawFrame(EFrameType::HEADERS,
+            NFrameFlag::PADDED | NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(HeadersWithPriorityTooSmall) {
+        TRawServerSession srv;
+        // PRIORITY flag requires 5 extra bytes. Payload is too small.
+        TString payload(3, '\0');
+        srv.Feed(BuildRawFrame(EFrameType::HEADERS,
+            NFrameFlag::PRIORITY | NFrameFlag::END_HEADERS | NFrameFlag::END_STREAM, 1, payload));
+        UNIT_ASSERT(!srv.Error.empty());
+    }
+
+    Y_UNIT_TEST(PaddedDataFrameZeroPadding) {
+        TRawServerSession srv;
+
+        THPackEncoder encoder;
+        TString headerBlock = encoder.Encode({
+            {":method", "POST"}, {":path", "/"}, {":scheme", "https"}, {":authority", "host"},
+        });
+        srv.Feed(TFrameBuilder::BuildHeaders(1, NFrameFlag::END_HEADERS, headerBlock));
+        srv.Error.clear();
+
+        // PADDED with pad_length=0 (valid, just the pad_length byte)
+        TString payload;
+        payload.push_back(0); // pad length = 0
+        payload.append("data");
+        srv.Feed(BuildRawFrame(EFrameType::DATA, NFrameFlag::PADDED | NFrameFlag::END_STREAM, 1, payload));
+        UNIT_ASSERT_C(srv.Error.empty(), srv.Error);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(srv.Requests[0].Body, "data");
+    }
+}
+
+// ============== Status Code Mapping Tests ==============
+
+Y_UNIT_TEST_SUITE(Http2StatusCodeMapping) {
+    Y_UNIT_TEST(AllStatusCodes) {
+        // Test all status code → reason phrase mappings in StreamToIncomingResponse
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/");
+
+        struct StatusTest {
+            TString Code;
+            TString ExpectedPhrase;
+        };
+        TVector<StatusTest> tests = {
+            {"200", "OK"},
+            {"201", "Created"},
+            {"204", "No Content"},
+            {"301", "Moved Permanently"},
+            {"302", "Found"},
+            {"304", "Not Modified"},
+            {"400", "Bad Request"},
+            {"401", "Unauthorized"},
+            {"403", "Forbidden"},
+            {"404", "Not Found"},
+            {"500", "Internal Server Error"},
+            {"502", "Bad Gateway"},
+            {"503", "Service Unavailable"},
+            {"504", "Gateway Timeout"},
+            {"418", "Unknown"}, // not in the switch
+        };
+
+        for (const auto& test : tests) {
+            TStream stream;
+            stream.Status = test.Code;
+            stream.Headers = {{"content-type", "text/plain"}};
+            stream.Body = "body";
+
+            auto response = StreamToIncomingResponse(stream, request);
+            UNIT_ASSERT(response);
+            UNIT_ASSERT_VALUES_EQUAL_C(TString(response->Status), test.Code,
+                "Status mismatch for " + test.Code);
+            UNIT_ASSERT_C(TString(response->Message).Contains(test.ExpectedPhrase),
+                "Expected phrase '" + test.ExpectedPhrase + "' for " + test.Code +
+                " but got '" + TString(response->Message) + "'");
+        }
+    }
+
+    Y_UNIT_TEST(StreamToIncomingResponseWithBody) {
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet("http://example.com/");
+
+        TStream stream;
+        stream.Status = "200";
+        stream.Headers = {{"content-type", "application/json"}};
+        stream.Body = R"({"key":"value"})";
+
+        auto response = StreamToIncomingResponse(stream, request);
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Status), "200");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Body), stream.Body);
+    }
+}
+
+// Helper: run a raw HTTP/2 server on the given port.
+// Accepts one TCP connection, performs HTTP/2 handshake, receives requests,
+// calls requestHandler for each, then closes.
+// requestHandler returns {status, headers, body} for each request.
+struct TH2ServerRequest {
+    TString Method;
+    TString Path;
+    TString Authority;
+    TString Body;
+};
+
+struct TH2ServerResponse {
+    TString Status;
+    TVector<std::pair<TString, TString>> Headers;
+    TString Body;
+};
+
+static void RunH2Server(
+    TIpPort port,
+    std::function<TH2ServerResponse(const TH2ServerRequest&)> requestHandler,
+    TString& serverError,
+    std::atomic<bool>& serverReady,
+    std::atomic<bool>& serverDone,
+    int expectedRequests = 1)
+{
+    int listenFd = ::socket(AF_INET6, SOCK_STREAM, 0);
+    if (listenFd < 0) {
+        serverError = "socket() failed";
+        serverReady = true;
+        serverDone = true;
+        return;
+    }
+    int one = 1;
+    ::setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct sockaddr_in6 addr = {};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port);
+    addr.sin6_addr = in6addr_loopback;
+    if (::bind(listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        serverError = TStringBuilder() << "bind() failed: " << strerror(errno);
+        ::close(listenFd);
+        serverReady = true;
+        serverDone = true;
+        return;
+    }
+    if (::listen(listenFd, 1) < 0) {
+        serverError = "listen() failed";
+        ::close(listenFd);
+        serverReady = true;
+        serverDone = true;
+        return;
+    }
+    serverReady = true;
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    ::setsockopt(listenFd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    int fd = ::accept(listenFd, nullptr, nullptr);
+    ::close(listenFd);
+    if (fd < 0) {
+        serverError = "accept() timed out";
+        serverDone = true;
+        return;
+    }
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    // Set up HTTP/2 server session.
+    // We need to capture a pointer to the session from inside the OnRequest callback,
+    // so we use a raw pointer that is set after construction.
+    TString outputData;
+    int responsesCount = 0;
+    NHttp::NHttp2::TSession* sessionPtr = nullptr;
+
+    NHttp::NHttp2::TSessionCallbacks callbacks;
+    callbacks.OnRequest = [&](uint32_t streamId, NHttp::NHttp2::TStream& stream) {
+        TH2ServerRequest req;
+        req.Method = stream.Method;
+        req.Path = stream.Path;
+        req.Authority = stream.Authority;
+        req.Body = stream.Body;
+
+        TH2ServerResponse resp = requestHandler(req);
+        sessionPtr->SendResponse(streamId, resp.Status, resp.Headers, resp.Body);
+        responsesCount++;
+    };
+    callbacks.OnSend = [&](TString data) {
+        outputData.append(data);
+    };
+    callbacks.OnError = [&](TString error) {
+        serverError = "H2 server error: " + error;
+    };
+
+    NHttp::NHttp2::TSession session(NHttp::NHttp2::TSession::ERole::Server, std::move(callbacks));
+    sessionPtr = &session;
+    session.Initialize();
+
+    // Flush server preface (SETTINGS frame is queued during Initialize)
+    // — actually for server role, no preface is sent until client preface arrives.
+    // But the OnSend callback fires with SETTINGS during Initialize.
+    if (!outputData.empty()) {
+        const char* buf = outputData.data();
+        size_t remaining = outputData.size();
+        while (remaining > 0) {
+            ssize_t sent = ::send(fd, buf, remaining, 0);
+            if (sent <= 0) { serverError = "send() failed"; ::close(fd); serverDone = true; return; }
+            buf += sent;
+            remaining -= sent;
+        }
+        outputData.clear();
+    }
+
+    // Read/write loop
+    auto deadline = TInstant::Now() + TDuration::Seconds(5);
+    char readBuf[16384];
+    while (responsesCount < expectedRequests && TInstant::Now() < deadline && serverError.empty()) {
+        ssize_t n = ::recv(fd, readBuf, sizeof(readBuf), 0);
+        if (n > 0) {
+            session.Feed(readBuf, static_cast<size_t>(n));
+
+            // Flush any pending output
+            if (!outputData.empty()) {
+                const char* buf = outputData.data();
+                size_t remaining = outputData.size();
+                while (remaining > 0) {
+                    ssize_t sent = ::send(fd, buf, remaining, 0);
+                    if (sent <= 0) break;
+                    buf += sent;
+                    remaining -= sent;
+                }
+                outputData.clear();
+            }
+        } else if (n == 0) {
+            break;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
+            break;
+        }
+    }
+
+    ::close(fd);
+    serverDone = true;
+}
+
+Y_UNIT_TEST_SUITE(Http2OutgoingIntegration) {
+
+    Y_UNIT_TEST(OutgoingH2cPriorKnowledge) {
+        // Test outgoing HTTP/2 over cleartext TCP (h2c prior-knowledge).
+        // Actor system sends TEvHttpOutgoingRequest with UseHttp2=true.
+        // A raw HTTP/2 server thread accepts the connection and responds.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        TString serverError;
+        std::atomic<bool> serverReady{false};
+        std::atomic<bool> serverDone{false};
+
+        std::thread serverThread([port, &serverError, &serverReady, &serverDone]() {
+            RunH2Server(port, [](const TH2ServerRequest& req) -> TH2ServerResponse {
+                UNIT_ASSERT_VALUES_EQUAL(req.Method, "GET");
+                UNIT_ASSERT_VALUES_EQUAL(req.Path, "/h2out");
+                return {"200", {{"content-type", "text/plain"}}, "h2c-response"};
+            }, serverError, serverReady, serverDone);
+        });
+
+        // Wait for server to be ready
+        while (!serverReady) {
+            Sleep(TDuration::MilliSeconds(1));
+        }
+        UNIT_ASSERT_C(serverError.empty(), "Server error: " + serverError);
+
+        // Send outgoing HTTP/2 request through actor system
+        NActors::TActorId clientId = actorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestGet("http://[::1]:" + ToString(port) + "/h2out");
+        auto* event = new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest);
+        event->UseHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, clientId, event), 0, true);
+
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+
+        UNIT_ASSERT_C(response->Error.empty(), "Response error: " + response->Error);
+        UNIT_ASSERT(response->Response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Status), "200");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Body), "h2c-response");
+
+        serverThread.join();
+        UNIT_ASSERT_C(serverError.empty(), "Server error after join: " + serverError);
+    }
+
+    Y_UNIT_TEST(OutgoingH2cWithBody) {
+        // Test outgoing HTTP/2 POST with request body.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        TString serverError;
+        std::atomic<bool> serverReady{false};
+        std::atomic<bool> serverDone{false};
+
+        TString capturedBody;
+        std::thread serverThread([port, &serverError, &serverReady, &serverDone, &capturedBody]() {
+            RunH2Server(port, [&capturedBody](const TH2ServerRequest& req) -> TH2ServerResponse {
+                UNIT_ASSERT_VALUES_EQUAL(req.Method, "POST");
+                UNIT_ASSERT_VALUES_EQUAL(req.Path, "/h2post");
+                capturedBody = req.Body;
+                return {"201", {{"content-type", "text/plain"}}, "created"};
+            }, serverError, serverReady, serverDone);
+        });
+
+        while (!serverReady) {
+            Sleep(TDuration::MilliSeconds(1));
+        }
+        UNIT_ASSERT_C(serverError.empty(), "Server error: " + serverError);
+
+        NActors::TActorId clientId = actorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestPost("http://[::1]:" + ToString(port) + "/h2post", "text/plain", "hello-h2-body");
+        auto* event = new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest);
+        event->UseHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, clientId, event), 0, true);
+
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+
+        UNIT_ASSERT_C(response->Error.empty(), "Response error: " + response->Error);
+        UNIT_ASSERT(response->Response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Status), "201");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Body), "created");
+        UNIT_ASSERT_VALUES_EQUAL(capturedBody, "hello-h2-body");
+
+        serverThread.join();
+        UNIT_ASSERT_C(serverError.empty(), "Server error after join: " + serverError);
+    }
+
+    Y_UNIT_TEST(OutgoingH2cWithLargeResponseBody) {
+        // Test outgoing HTTP/2 request receiving a large response body.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        TString serverError;
+        std::atomic<bool> serverReady{false};
+        std::atomic<bool> serverDone{false};
+
+        TString largeBody(32768, 'X'); // 32KB response
+        std::thread serverThread([port, &serverError, &serverReady, &serverDone, &largeBody]() {
+            RunH2Server(port, [&largeBody](const TH2ServerRequest& /*req*/) -> TH2ServerResponse {
+                return {"200", {{"content-type", "application/octet-stream"}}, largeBody};
+            }, serverError, serverReady, serverDone);
+        });
+
+        while (!serverReady) {
+            Sleep(TDuration::MilliSeconds(1));
+        }
+        UNIT_ASSERT_C(serverError.empty(), "Server error: " + serverError);
+
+        NActors::TActorId clientId = actorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestGet("http://[::1]:" + ToString(port) + "/large");
+        auto* event = new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest);
+        event->UseHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, clientId, event), 0, true);
+
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+
+        UNIT_ASSERT_C(response->Error.empty(), "Response error: " + response->Error);
+        UNIT_ASSERT(response->Response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Status), "200");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Body), largeBody);
+
+        serverThread.join();
+        UNIT_ASSERT_C(serverError.empty(), "Server error after join: " + serverError);
+    }
+
+    Y_UNIT_TEST(OutgoingH2cEndToEndThroughActorSystem) {
+        // End-to-end test: outgoing request with UseHttp2=true goes through
+        // the actor system to an HTTP/2-enabled actor-system server.
+        // Both client and server are actors — verifies the full round-trip.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        // Start a server with AllowHttp2 = true
+        THolder<NHttp::TEvHttpProxy::TEvAddListeningPort> add = MakeHolder<NHttp::TEvHttpProxy::TEvAddListeningPort>(port);
+        add->AllowHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, actorSystem.AllocateEdgeActor(), add.Release()), 0, true);
+        actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvConfirmListen>(handle);
+
+        NActors::TActorId serverId = actorSystem.AllocateEdgeActor();
+        actorSystem.Send(new NActors::IEventHandle(proxyId, serverId, new NHttp::TEvHttpProxy::TEvRegisterHandler("/e2e", serverId)), 0, true);
+
+        // Send outgoing HTTP/2 request through the same proxy
+        NActors::TActorId clientId = actorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestGet("http://[::1]:" + ToString(port) + "/e2e");
+        auto* event = new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest);
+        event->UseHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, clientId, event), 0, true);
+
+        // Grab incoming request on server side
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(TString(request->Request->URL), "/e2e");
+        UNIT_ASSERT_VALUES_EQUAL(TString(request->Request->Method), "GET");
+
+        // Send response
+        NHttp::THttpOutgoingResponsePtr httpResponse = request->Request->CreateResponseOK("e2e-ok", "text/plain");
+        actorSystem.Send(new NActors::IEventHandle(handle->Sender, serverId, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse)), 0, true);
+
+        // Grab response on client side
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+        UNIT_ASSERT_C(response->Error.empty(), "Response error: " + response->Error);
+        UNIT_ASSERT(response->Response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Status), "200");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Body), "e2e-ok");
+    }
+
+    Y_UNIT_TEST(OutgoingH1FallbackWhenHttp2NotRequested) {
+        // Verify that when UseHttp2 is NOT set, the outgoing request uses HTTP/1.1
+        // even if the server supports HTTP/2.
+        NActors::TTestActorRuntimeBase actorSystem(1, true);
+        TPortManager portManager;
+        TIpPort port = portManager.GetTcpPort();
+        TAutoPtr<NActors::IEventHandle> handle;
+        actorSystem.Initialize();
+#ifndef NDEBUG
+        actorSystem.SetLogPriority(NActorsServices::HTTP, NActors::NLog::PRI_DEBUG);
+#endif
+
+        NActors::IActor* proxy = NHttp::CreateHttpProxy();
+        NActors::TActorId proxyId = actorSystem.Register(proxy);
+
+        // Server with AllowHttp2 = true (supports both)
+        THolder<NHttp::TEvHttpProxy::TEvAddListeningPort> add = MakeHolder<NHttp::TEvHttpProxy::TEvAddListeningPort>(port);
+        add->AllowHttp2 = true;
+        actorSystem.Send(new NActors::IEventHandle(proxyId, actorSystem.AllocateEdgeActor(), add.Release()), 0, true);
+        actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvConfirmListen>(handle);
+
+        NActors::TActorId serverId = actorSystem.AllocateEdgeActor();
+        actorSystem.Send(new NActors::IEventHandle(proxyId, serverId, new NHttp::TEvHttpProxy::TEvRegisterHandler("/h1fall", serverId)), 0, true);
+
+        // Send outgoing request WITHOUT UseHttp2 — should use HTTP/1.1
+        NActors::TActorId clientId = actorSystem.AllocateEdgeActor();
+        NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestGet("http://[::1]:" + ToString(port) + "/h1fall");
+        auto* event = new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest);
+        // UseHttp2 defaults to false
+        actorSystem.Send(new NActors::IEventHandle(proxyId, clientId, event), 0, true);
+
+        // Grab incoming request on server side (should arrive as HTTP/1.1)
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest* request = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingRequest>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(TString(request->Request->URL), "/h1fall");
+        UNIT_ASSERT_VALUES_EQUAL(TString(request->Request->Method), "GET");
+
+        // Respond
+        NHttp::THttpOutgoingResponsePtr httpResponse = request->Request->CreateResponseOK("h1-ok", "text/plain");
+        actorSystem.Send(new NActors::IEventHandle(handle->Sender, serverId, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse)), 0, true);
+
+        NHttp::TEvHttpProxy::TEvHttpIncomingResponse* response = actorSystem.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpIncomingResponse>(handle);
+        UNIT_ASSERT_C(response->Error.empty(), "Response error: " + response->Error);
+        UNIT_ASSERT(response->Response);
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Status), "200");
+        UNIT_ASSERT_VALUES_EQUAL(TString(response->Response->Body), "h1-ok");
+    }
+}

--- a/ydb/library/actors/http/http_proxy.h
+++ b/ydb/library/actors/http/http_proxy.h
@@ -80,6 +80,7 @@ struct TEvHttpProxy {
         ui32 MaxRequestsPerSecond = 0;
         ui32 MaxRecycledRequestsCount = DEFAULT_MAX_RECYCLED_REQUESTS_COUNT;
         TDuration InactivityTimeout = TDuration::Minutes(2);
+        bool AllowHttp2 = false; // enable HTTP/2 support on this port
 
         TEvAddListeningPort() = default;
 
@@ -126,6 +127,7 @@ struct TEvHttpProxy {
         THttpOutgoingRequestPtr Request;
         TDuration Timeout;
         bool AllowConnectionReuse = false;
+        bool UseHttp2 = false;
         std::vector<TString> StreamContentTypes;
 
         TEvHttpOutgoingRequest(THttpOutgoingRequestPtr request)
@@ -183,7 +185,7 @@ struct TEvHttpProxy {
             , Response(std::move(response))
         {}
     };
-    
+
     struct TEvHttpOutgoingResponse : NActors::TEventLocal<TEvHttpOutgoingResponse, EvHttpOutgoingResponse> {
         THttpOutgoingResponsePtr Response;
         ui64 ProgressNotificationBytes = 0;
@@ -342,6 +344,7 @@ struct TPrivateEndpointInfo : THttpEndpointInfo {
     TSslHelpers::TSslHolder<SSL_CTX> SecureContext;
     TRateLimiter RateLimiter;
     TDuration InactivityTimeout;
+    bool AllowHttp2 = false;
 
     TPrivateEndpointInfo(const std::vector<TString>& compressContentTypes)
         : THttpEndpointInfo(compressContentTypes)

--- a/ydb/library/actors/http/http_proxy_acceptor.cpp
+++ b/ydb/library/actors/http/http_proxy_acceptor.cpp
@@ -59,6 +59,7 @@ protected:
         Endpoint->Proxy = Owner;
         Endpoint->WorkerName = event->Get()->WorkerName;
         Endpoint->Secure = event->Get()->Secure;
+        Endpoint->AllowHttp2 = event->Get()->AllowHttp2;
         Endpoint->RateLimiter.Limit = event->Get()->MaxRequestsPerSecond;
         Endpoint->RateLimiter.Period = TDuration::Seconds(1);
         Endpoint->InactivityTimeout = event->Get()->InactivityTimeout;
@@ -72,6 +73,10 @@ protected:
             if (Endpoint->SecureContext == nullptr) {
                 err = -1;
                 ALOG_WARN(HttpLog, "Failed to construct server security context");
+            }
+            // Enable ALPN for HTTP/2 negotiation on secure endpoints
+            if (Endpoint->SecureContext && Endpoint->AllowHttp2) {
+                TSslHelpers::EnableAlpn(Endpoint->SecureContext.Get());
             }
         }
         if (err == 0) {

--- a/ydb/library/actors/http/http_proxy_incoming.cpp
+++ b/ydb/library/actors/http/http_proxy_incoming.cpp
@@ -1,6 +1,8 @@
 #include "http_proxy.h"
 #include "http_proxy_sock_impl.h"
 #include "http_proxy_ssl.h"
+#include "http2.h"
+#include "http2_frames.h"
 
 #include <openssl/x509.h>
 #include <openssl/pem.h>
@@ -44,6 +46,24 @@ public:
     TResponseState CurrentResponse;
     TDeque<THttpIncomingRequestPtr> RecycledRequests;
 
+    // HTTP/2 state (allocated on demand when protocol is detected as HTTP/2)
+    struct THttp2State {
+        std::unique_ptr<NHttp2::TSession> Session;
+
+        struct TStreamState {
+            THttpIncomingRequestPtr Request;
+            uint32_t StreamId = 0;
+        };
+        THashMap<uint32_t, TStreamState> StreamStates;
+        TVector<TEvHttpProxy::TEvSubscribeForCancel::TPtr> CancelSubscribers;
+
+        TString OutputBuffer;
+        size_t OutputOffset = 0;
+        size_t PendingWriteSize = 0; // for SSL_write retry with same length
+        bool Error = false;
+    };
+    std::unique_ptr<THttp2State> H2;
+
     THPTimer InactivityTimer;
     TEvPollerReady* InactivityEvent = nullptr;
 
@@ -51,6 +71,10 @@ public:
     TEvHttpProxy::TEvSubscribeForCancel::TPtr CancelSubscriber;
 
     TString MTlsClientCertificate;
+
+    // Protocol detection buffer (used only during StateDetecting for h2c)
+    char DetectionBuffer[24]; // NHttp2::CONNECTION_PREFACE.size()
+    size_t DetectionSize = 0;
 
     TIncomingConnectionActor(
             std::shared_ptr<TPrivateEndpointInfo> endpoint,
@@ -93,6 +117,17 @@ public:
         if (CancelSubscriber) {
             Send(CancelSubscriber->Sender, new TEvHttpProxy::TEvRequestCancelled(), 0, CancelSubscriber->Cookie);
         }
+        if (H2) {
+            if (H2->Session && !H2->Error) {
+                H2->Session->SendGoaway();
+                FlushHttp2Output(); // best-effort, may fail silently
+            }
+            for (auto& subscriber : H2->CancelSubscribers) {
+                Send(subscriber->Sender, new TEvHttpProxy::TEvRequestCancelled(), 0, subscriber->Cookie);
+            }
+            H2->CancelSubscribers.clear();
+            H2->StreamStates.clear();
+        }
         Send(Endpoint->Owner, new TEvHttpProxy::TEvHttpIncomingConnectionClosed(SelfId(), std::move(RecycledRequests)));
         TSocketImpl::Shutdown();
         TBase::PassAway();
@@ -124,6 +159,22 @@ protected:
             break;
         }
         ExtractClientCertificate();
+        // Check for HTTP/2 via ALPN negotiation after TLS handshake
+        if constexpr (std::is_same_v<TSocketImpl, TSecureSocketImpl>) {
+            if (Endpoint->AllowHttp2 && this->GetAlpnProtocol() == "h2") {
+                ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") ALPN negotiated h2, switching to HTTP/2");
+                SwitchToHttp2();
+                return;
+            }
+        }
+        // For plain connections with HTTP/2 enabled, detect h2c preface
+        if constexpr (std::is_same_v<TSocketImpl, TPlainSocketImpl>) {
+            if (Endpoint->AllowHttp2) {
+                Become(&TIncomingConnectionActor::StateDetecting);
+                TryDetectProtocol();
+                return;
+            }
+        }
         Become(&TIncomingConnectionActor::StateConnected);
         Send(SelfId(), new TEvPollerReady(nullptr, true, true));
     }
@@ -143,6 +194,393 @@ protected:
                 } // else: client did not provide certificate; that's OK
             }
         }
+    }
+
+    void TryDetectProtocol() {
+        for (;;) {
+            size_t toRead = sizeof(DetectionBuffer) - DetectionSize;
+            bool read = false, write = false;
+            ssize_t res = TSocketImpl::Recv(DetectionBuffer + DetectionSize, toRead, read, write);
+            if (res > 0) {
+                InactivityTimer.Reset();
+                DetectionSize += static_cast<size_t>(res);
+                if (DetectionSize >= 3) {
+                    TStringBuf peek(DetectionBuffer, DetectionSize);
+                    if (peek.StartsWith(NHttp2::CONNECTION_PREFACE.Head(DetectionSize))) {
+                        if (DetectionSize >= NHttp2::CONNECTION_PREFACE.size()) {
+                            // Full preface matched -> HTTP/2
+                            SwitchToHttp2();
+                            // Feed the already-read preface to the session
+                            H2->Session->Feed(DetectionBuffer, DetectionSize);
+                            return;
+                        }
+                        // Partial match, need more data
+                        if (PollerToken) {
+                            if (!read && !write) {
+                                read = true;
+                            }
+                            if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                                continue;
+                            }
+                        }
+                        return;
+                    }
+                    // Not HTTP/2 preface -> HTTP/1.1
+                    SwitchToHttp1();
+                    return;
+                }
+                // Less than 3 bytes, need more
+                if (PollerToken) {
+                    if (!read && !write) {
+                        read = true;
+                    }
+                    if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                        continue;
+                    }
+                }
+                return;
+            } else if (-res == EAGAIN || -res == EWOULDBLOCK) {
+                if (PollerToken) {
+                    if (!read && !write) {
+                        read = true;
+                    }
+                    if (PollerToken->RequestReadNotificationAfterWouldBlock()) {
+                        continue;
+                    }
+                }
+                return;
+            } else if (-res == EINTR) {
+                continue;
+            } else {
+                PassAway();
+                return;
+            }
+        }
+    }
+
+    void SwitchToHttp1() {
+        // Feed detection bytes into CurrentRequest before switching to HTTP/1.1
+        if (RecycleRequests && !RecycledRequests.empty()) {
+            CurrentRequest = std::move(RecycledRequests.front());
+            RecycledRequests.pop_front();
+            CurrentRequest->Address = Address;
+            CurrentRequest->Endpoint = Endpoint;
+            CurrentRequest->MTlsClientCertificate = MTlsClientCertificate;
+        } else {
+            CurrentRequest = new THttpIncomingRequest(Endpoint, Address, MTlsClientCertificate);
+        }
+        CurrentRequest->EnsureEnoughSpaceAvailable();
+        std::memcpy(CurrentRequest->Pos(), DetectionBuffer, DetectionSize);
+        CurrentRequest->Advance(DetectionSize);
+        Become(&TIncomingConnectionActor::StateConnected);
+        Send(SelfId(), new TEvPollerReady(nullptr, true, true));
+    }
+
+    void SwitchToHttp2() {
+        ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") switching to HTTP/2");
+        InitHttp2Session();
+        Become(&TIncomingConnectionActor::StateConnectedHttp2);
+        Send(SelfId(), new TEvPollerReady(nullptr, true, true));
+    }
+
+    // RFC 7540 §3.2: HTTP/1.1 Upgrade to h2c
+    // Returns true if upgrade was initiated (caller should return immediately)
+    bool TryUpgradeToHttp2(THttpIncomingRequestPtr& request) {
+        if constexpr (!std::is_same_v<TSocketImpl, TPlainSocketImpl>) {
+            return false; // h2c upgrade only on plain connections
+        }
+        if (!Endpoint->AllowHttp2) {
+            return false;
+        }
+        THeaders headers(request->Headers);
+        TStringBuf upgrade = headers.Get("Upgrade");
+        if (upgrade != "h2c") {
+            return false;
+        }
+
+        ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/1.1 -> h2c upgrade");
+
+        // Clean up HTTP/1.1 request pipeline state
+        THttpIncomingRequestPtr savedRequest = request;
+        Requests.pop_back(); // remove the request we just pushed
+        CurrentRequest = nullptr;
+
+        // Initialize HTTP/2 session (generates SETTINGS in H2->OutputBuffer)
+        InitHttp2Session();
+
+        // Prepend 101 Switching Protocols before the SETTINGS frame
+        static const TString response101 =
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Connection: Upgrade\r\n"
+            "Upgrade: h2c\r\n"
+            "\r\n";
+        H2->OutputBuffer.insert(H2->OutputBuffer.begin(), response101.begin(), response101.end());
+
+        if (!FlushHttp2Output()) { // send 101 + server connection preface (SETTINGS)
+            PassAway();
+            return true;
+        }
+
+        // Deliver the original request as HTTP/2 stream 1 (per RFC 7540 §3.2)
+        // Stream 1 is implicitly half-closed (remote) since the request is complete
+        const uint32_t upgradeStreamId = 1;
+        H2->Session->RegisterUpgradeStream(savedRequest->URL, savedRequest->Host);
+        typename THttp2State::TStreamState state;
+        state.Request = savedRequest;
+        state.StreamId = upgradeStreamId;
+        H2->StreamStates[upgradeStreamId] = std::move(state);
+
+        ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 stream " << upgradeStreamId << " -> (" << savedRequest->Method << " " << savedRequest->URL << ") (upgrade)");
+        Send(Endpoint->Proxy, new TEvHttpProxy::TEvHttpIncomingRequest(savedRequest));
+
+        Become(&TIncomingConnectionActor::StateConnectedHttp2);
+        Send(SelfId(), new TEvPollerReady(nullptr, true, true));
+        return true;
+    }
+
+    void InitHttp2Session() {
+        H2 = std::make_unique<THttp2State>();
+        NHttp2::TSessionCallbacks callbacks;
+        callbacks.OnRequest = [this](uint32_t streamId, NHttp2::TStream& stream) {
+            OnHttp2Request(streamId, stream);
+        };
+        callbacks.OnSend = [this](TString data) {
+            H2->OutputBuffer.append(data);
+        };
+        callbacks.OnError = [this](TString error) {
+            ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 error: " << error);
+            H2->Error = true;
+        };
+        callbacks.OnGoaway = [this](uint32_t lastStreamId, NHttp2::EErrorCode errorCode) {
+            ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") GOAWAY received, lastStreamId=" << lastStreamId << " error=" << static_cast<uint32_t>(errorCode));
+        };
+        H2->Session = std::make_unique<NHttp2::TSession>(NHttp2::TSession::ERole::Server, std::move(callbacks));
+        H2->Session->Initialize();
+    }
+
+    void OnHttp2Request(uint32_t streamId, NHttp2::TStream& stream) {
+        THttpIncomingRequestPtr request = NHttp2::StreamToIncomingRequest(stream, Endpoint, Address);
+        request->MTlsClientCertificate = MTlsClientCertificate;
+
+        typename THttp2State::TStreamState state;
+        state.Request = request;
+        state.StreamId = streamId;
+        H2->StreamStates[streamId] = std::move(state);
+
+        if (Endpoint->RateLimiter.Check(TActivationContext::Now())) {
+            ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 stream " << streamId << " -> (" << request->Method << " " << request->URL << ")");
+            Send(Endpoint->Proxy, new TEvHttpProxy::TEvHttpIncomingRequest(request));
+        } else {
+            auto response = request->CreateResponseTooManyRequests();
+            SendHttp2Response(streamId, response);
+            H2->StreamStates.erase(streamId);
+        }
+    }
+
+    void SendHttp2Response(uint32_t streamId, THttpOutgoingResponsePtr response, bool endStream = true) {
+        TString status;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        NHttp2::OutgoingResponseToStream(response, status, headers, body);
+        H2->Session->SendResponse(streamId, status, headers, body, endStream);
+    }
+
+    static constexpr size_t READ_BUFFER_SIZE = 64 * 1024;
+
+    void ReadHttp2Input() {
+        char readBuffer[READ_BUFFER_SIZE];
+        for (;;) {
+            bool read = false, write = false;
+            ssize_t res = TSocketImpl::Recv(readBuffer, READ_BUFFER_SIZE, read, write);
+            if (res > 0) {
+                InactivityTimer.Reset();
+                H2->Session->Feed(readBuffer, static_cast<size_t>(res));
+                if (H2->Error) {
+                    FlushHttp2Output();
+                    return PassAway();
+                }
+                if (!FlushHttp2Output()) {
+                    return PassAway();
+                }
+            } else if (-res == EAGAIN || -res == EWOULDBLOCK) {
+                if (PollerToken) {
+                    if (!read && !write) {
+                        read = true;
+                    }
+                    if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                        continue;
+                    }
+                }
+                break;
+            } else if (-res == EINTR) {
+                continue;
+            } else if (!res) {
+                ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 connection closed");
+                return PassAway();
+            } else {
+                ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 connection closed - error in Receive: " << strerror(-res));
+                return PassAway();
+            }
+        }
+    }
+
+    bool FlushHttp2Output() {
+        while (H2->OutputOffset < H2->OutputBuffer.size()) {
+            size_t size = H2->PendingWriteSize ? H2->PendingWriteSize : (H2->OutputBuffer.size() - H2->OutputOffset);
+            bool read = false, write = false;
+            ssize_t res = TSocketImpl::Send(H2->OutputBuffer.data() + H2->OutputOffset, size, read, write);
+            if (res > 0) {
+                InactivityTimer.Reset();
+                H2->OutputOffset += res;
+                H2->PendingWriteSize = 0;
+            } else if (-res == EINTR) {
+                continue;
+            } else if (-res == EAGAIN || -res == EWOULDBLOCK) {
+                if (PollerToken) {
+                    if (!read && !write) {
+                        write = true;
+                    }
+                    if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                        continue;
+                    }
+                }
+                break;
+            } else {
+                ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 connection closed - error in FlushOutput: " << strerror(-res));
+                H2->Error = true;
+                return false;
+            }
+        }
+        if (H2->OutputOffset == H2->OutputBuffer.size()) {
+            H2->OutputBuffer.clear();
+            H2->OutputOffset = 0;
+        } else if (H2->OutputOffset > 0) {
+            H2->OutputBuffer = H2->OutputBuffer.substr(H2->OutputOffset);
+            H2->OutputOffset = 0;
+        }
+        return true;
+    }
+
+    void HandleDetecting(TEvPollerReady::TPtr& event) {
+        if (event->Get() == InactivityEvent) {
+            const TDuration passed = TDuration::Seconds(std::abs(InactivityTimer.Passed()));
+            if (passed >= Endpoint->InactivityTimeout) {
+                ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") connection closed by inactivity timeout during detection");
+                return PassAway();
+            } else {
+                Schedule(Endpoint->InactivityTimeout - passed, InactivityEvent = new TEvPollerReady(nullptr, false, false));
+            }
+            return;
+        }
+        TryDetectProtocol();
+    }
+
+    void HandleDetecting(TEvPollerRegisterResult::TPtr& ev) {
+        PollerToken = std::move(ev->Get()->PollerToken);
+        TryDetectProtocol();
+    }
+
+    void HandleHttp2(TEvPollerReady::TPtr& event) {
+        if (event->Get()->Read) {
+            ReadHttp2Input();
+        }
+        if (event->Get() == InactivityEvent) {
+            const TDuration passed = TDuration::Seconds(std::abs(InactivityTimer.Passed()));
+            if (passed >= Endpoint->InactivityTimeout) {
+                ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 connection closed by inactivity timeout");
+                if (H2 && H2->Session) {
+                    H2->Session->SendGoaway();
+                }
+                FlushHttp2Output(); // best-effort
+                return PassAway();
+            } else {
+                Schedule(Endpoint->InactivityTimeout - passed, InactivityEvent = new TEvPollerReady(nullptr, false, false));
+            }
+        }
+        if (event->Get()->Write) {
+            if (!FlushHttp2Output()) {
+                return PassAway();
+            }
+        }
+    }
+
+    void HandleHttp2(TEvPollerRegisterResult::TPtr& ev) {
+        PollerToken = std::move(ev->Get()->PollerToken);
+        PollerToken->Request(true, true);
+    }
+
+    void HandleHttp2(TEvHttpProxy::TEvHttpOutgoingResponse::TPtr& event) {
+        auto response = event->Get()->Response;
+        THttpIncomingRequestPtr request = response->GetRequest();
+
+        uint32_t streamId = 0;
+        for (auto& [sid, state] : H2->StreamStates) {
+            if (state.Request == request) {
+                streamId = sid;
+                break;
+            }
+        }
+
+        if (streamId == 0) {
+            ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 response for unknown request");
+            return;
+        }
+
+        ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 stream " << streamId
+            << " <- (" << response->Status << " " << response->Message << ")");
+
+        THolder<TEvHttpProxy::TEvReportSensors> sensors(BuildIncomingRequestSensors(request, response));
+        Send(Endpoint->Owner, sensors.Release());
+
+        bool endStream = response->IsDone();
+        SendHttp2Response(streamId, response, endStream);
+        if (!FlushHttp2Output()) {
+            return PassAway();
+        }
+
+        if (endStream) {
+            H2->StreamStates.erase(streamId);
+        }
+    }
+
+    void HandleHttp2(TEvHttpProxy::TEvHttpOutgoingDataChunk::TPtr& event) {
+        if (event->Get()->Error) {
+            ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 DataChunk error: " << event->Get()->Error);
+            return PassAway();
+        }
+
+        auto dataChunk = event->Get()->DataChunk;
+        THttpIncomingRequestPtr request = dataChunk->GetRequest();
+
+        uint32_t streamId = 0;
+        for (auto& [sid, state] : H2->StreamStates) {
+            if (state.Request == request) {
+                streamId = sid;
+                break;
+            }
+        }
+
+        if (streamId == 0) {
+            ALOG_ERROR(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") HTTP/2 data chunk for unknown stream");
+            return;
+        }
+
+        uint8_t flags = dataChunk->IsEndOfData() ? NHttp2::NFrameFlag::END_STREAM : NHttp2::NFrameFlag::NONE;
+        TStringBuf data(dataChunk->Data(), dataChunk->Size());
+        if (!data.empty() || dataChunk->IsEndOfData()) {
+            H2->OutputBuffer.append(NHttp2::TFrameBuilder::BuildData(streamId, flags, data));
+            if (!FlushHttp2Output()) {
+                return PassAway();
+            }
+        }
+
+        if (dataChunk->IsEndOfData()) {
+            H2->StreamStates.erase(streamId);
+        }
+    }
+
+    void HandleHttp2(TEvHttpProxy::TEvSubscribeForCancel::TPtr& event) {
+        H2->CancelSubscribers.push_back(std::move(event));
     }
 
     void HandleAccepting(TEvPollerRegisterResult::TPtr& ev) {
@@ -193,6 +631,9 @@ protected:
                         Requests.emplace_back(CurrentRequest);
                         CurrentRequest->Timer.Reset();
                         if (CurrentRequest->IsReady()) {
+                            if (TryUpgradeToHttp2(CurrentRequest)) {
+                                return;
+                            }
                             if (Endpoint->RateLimiter.Check(TActivationContext::Now())) {
                                 ALOG_DEBUG(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") -> (" << GetRequestDebugText() << ")");
                                 ALOG_TRACE(HttpLog, "(#" << TSocketImpl::GetRawSocket() << "," << Address << ") Request:\n" << CurrentRequest->GetObfuscatedData());
@@ -470,6 +911,23 @@ protected:
             hFunc(TEvHttpProxy::TEvHttpOutgoingDataChunk, HandleConnected);
             hFunc(TEvHttpProxy::TEvSubscribeForCancel, HandleConnected);
             hFunc(TEvPollerRegisterResult, HandleConnected);
+        }
+    }
+
+    STATEFN(StateDetecting) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvPollerReady, HandleDetecting);
+            hFunc(TEvPollerRegisterResult, HandleDetecting);
+        }
+    }
+
+    STATEFN(StateConnectedHttp2) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvPollerReady, HandleHttp2);
+            hFunc(TEvHttpProxy::TEvHttpOutgoingResponse, HandleHttp2);
+            hFunc(TEvHttpProxy::TEvHttpOutgoingDataChunk, HandleHttp2);
+            hFunc(TEvHttpProxy::TEvSubscribeForCancel, HandleHttp2);
+            hFunc(TEvPollerRegisterResult, HandleHttp2);
         }
     }
 };

--- a/ydb/library/actors/http/http_proxy_outgoing.cpp
+++ b/ydb/library/actors/http/http_proxy_outgoing.cpp
@@ -1,5 +1,8 @@
 #include "http_proxy.h"
 #include "http_proxy_sock_impl.h"
+#include "http2.h"
+
+#include <type_traits>
 
 namespace NHttp {
 
@@ -22,6 +25,7 @@ public:
     TInstant LastActivity;
     TDuration ConnectionTimeout = CONNECTION_TIMEOUT;
     bool AllowConnectionReuse = false;
+    bool UseHttp2 = false;
     NActors::TPollerToken::TPtr PollerToken;
 
     enum class EStreamState {
@@ -30,6 +34,26 @@ public:
         Approved,
     } StreamState = EStreamState::Unknown;
     std::vector<TString> StreamContentTypes;
+
+    // HTTP/2 state (allocated on demand when HTTP/2 mode is activated)
+    struct THttp2State {
+        std::unique_ptr<NHttp2::TSession> Session;
+
+        struct TPendingRequest {
+            THttpOutgoingRequestPtr Request;
+            TActorId RequestOwner;
+            uint32_t StreamId;
+        };
+        THashMap<uint32_t, TPendingRequest> PendingRequests;
+
+        TString OutputBuffer;
+        size_t OutputOffset = 0;
+        size_t PendingWriteSize = 0; // for SSL_write retry with same length
+        bool Error = false;
+
+        TDeque<TEvHttpProxy::TEvHttpOutgoingRequest::TPtr> RequestQueue;
+    };
+    std::unique_ptr<THttp2State> H2;
 
     TOutgoingConnectionActor(const TActorId& owner, TEvHttpProxy::TEvHttpOutgoingRequest::TPtr& event)
         : Owner(owner)
@@ -49,6 +73,20 @@ public:
 
     void PassAway() override {
         if (IsAlive()) {
+            if (H2) {
+                if (H2->Session && !H2->Error) {
+                    H2->Session->SendGoaway();
+                    FlushH2Output(); // best-effort, may fail silently
+                }
+                for (auto& [streamId, pending] : H2->PendingRequests) {
+                    Send(pending.RequestOwner, new TEvHttpProxy::TEvHttpIncomingResponse(pending.Request, nullptr, "Connection closed"));
+                }
+                H2->PendingRequests.clear();
+                for (auto& event : H2->RequestQueue) {
+                    Send(event->Sender, new TEvHttpProxy::TEvHttpIncomingResponse(event->Get()->Request, nullptr, "Connection closed"));
+                }
+                H2->RequestQueue.clear();
+            }
             Send(Owner, new TEvHttpProxy::TEvHttpOutgoingConnectionClosed(SelfId(), Destination));
             TSocketImpl::Shutdown(); // to avoid errors when connection already closed
             TBase::PassAway();
@@ -170,6 +208,7 @@ protected:
             ConnectionTimeout = event->Get()->Timeout;
         }
         AllowConnectionReuse = event->Get()->AllowConnectionReuse;
+        UseHttp2 = event->Get()->UseHttp2;
         StreamContentTypes = event->Get()->StreamContentTypes;
         StreamState = EStreamState::Unknown;
     }
@@ -306,9 +345,22 @@ protected:
         Send(NActors::MakePollerActorId(), new NActors::TEvPollerRegister(TSocketImpl::Socket, SelfId(), SelfId()));
     }
 
+    int DoConnect(bool& read, bool& write) {
+        if constexpr (std::is_same_v<TSocketImpl, TSecureSocketImpl>) {
+            if (UseHttp2) {
+                if (!TSocketImpl::Ssl) {
+                    TSocketImpl::InitClientSslWithAlpn();
+                }
+                ERR_clear_error();
+                return TSocketImpl::ProcessSslResult(SSL_connect(TSocketImpl::Ssl.Get()), read, write);
+            }
+        }
+        return TSocketImpl::OnConnect(read, write);
+    }
+
     void OnConnect() {
         bool read = false, write = false;
-        if (int res = TSocketImpl::OnConnect(read, write); res != 1) {
+        if (int res = DoConnect(read, write); res != 1) {
             if (-res == EAGAIN) {
                 if (PollerToken) {
                     PollerToken->Request(read, write);
@@ -318,11 +370,182 @@ protected:
                 return ReplyErrorAndPassAway(strerror(-res));
             }
         }
+
+        bool useH2 = UseHttp2;
+        if constexpr (std::is_same_v<TSocketImpl, TSecureSocketImpl>) {
+            TStringBuf alpn = TSocketImpl::GetAlpnProtocol();
+            useH2 = (alpn == "h2"); // For TLS, ALPN negotiation is authoritative
+        }
+
+        if (useH2) {
+            ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 outgoing connection opened");
+            SwitchToHttp2();
+            return;
+        }
+
         ALOG_DEBUG(HttpLog, GetSocketName() << "outgoing connection opened");
         TBase::Become(&TOutgoingConnectionActor::StateConnected);
         ALOG_DEBUG(HttpLog, GetSocketName() << "<- (" << GetRequestDebugText() << ")");
         ALOG_TRACE(HttpLog, GetSocketName() << "Request:\n" << Request->GetObfuscatedData());
         Send(SelfId(), new NActors::TEvPollerReady(nullptr, true, true));
+    }
+
+    void SwitchToHttp2() {
+        if (!H2) {
+            H2 = std::make_unique<THttp2State>();
+        }
+        InitHttp2Session();
+        if (!FlushH2Output()) { // send connection preface + SETTINGS
+            PassAway();
+            return;
+        }
+
+        // Move the initial request to HTTP/2 flow
+        if (Request) {
+            SendH2Request(std::move(Request), RequestOwner);
+            Request = nullptr;
+            RequestOwner = {};
+        }
+
+        TBase::Become(&TOutgoingConnectionActor::StateConnectedHttp2);
+        Send(SelfId(), new NActors::TEvPollerReady(nullptr, true, true));
+    }
+
+    void InitHttp2Session() {
+        NHttp2::TSessionCallbacks callbacks;
+        callbacks.OnResponse = [this](uint32_t streamId, NHttp2::TStream& stream) {
+            OnHttp2Response(streamId, stream);
+        };
+        callbacks.OnSend = [this](TString data) {
+            H2->OutputBuffer.append(data);
+        };
+        callbacks.OnError = [this](TString error) {
+            ALOG_ERROR(HttpLog, GetSocketName() << "HTTP/2 error: " << error);
+            H2->Error = true;
+        };
+        callbacks.OnGoaway = [this](uint32_t lastStreamId, NHttp2::EErrorCode errorCode) {
+            ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 GOAWAY received, lastStreamId=" << lastStreamId << " error=" << static_cast<uint32_t>(errorCode));
+        };
+
+        H2->Session = std::make_unique<NHttp2::TSession>(NHttp2::TSession::ERole::Client, std::move(callbacks));
+        H2->Session->Initialize();
+    }
+
+    void OnHttp2Response(uint32_t streamId, NHttp2::TStream& stream) {
+        auto it = H2->PendingRequests.find(streamId);
+        if (it == H2->PendingRequests.end()) {
+            ALOG_ERROR(HttpLog, GetSocketName() << "HTTP/2 response for unknown stream " << streamId);
+            return;
+        }
+
+        auto& pending = it->second;
+
+        THttpIncomingResponsePtr response = NHttp2::StreamToIncomingResponse(stream, pending.Request);
+
+        ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 stream " << streamId << " -> (" << response->Status << " " << response->Message << ")");
+        Send(pending.RequestOwner, new TEvHttpProxy::TEvHttpIncomingResponse(pending.Request, response));
+
+        THolder<TEvHttpProxy::TEvReportSensors> sensors(BuildOutgoingRequestSensors(pending.Request, response));
+        Send(Owner, sensors.Release());
+
+        H2->PendingRequests.erase(it);
+    }
+
+    void SendH2Request(THttpOutgoingRequestPtr request, TActorId requestOwner) {
+        TString method, path, authority, scheme;
+        TVector<std::pair<TString, TString>> headers;
+        TString body;
+        NHttp2::OutgoingRequestToStream(request, method, path, authority, scheme, headers, body);
+
+        uint32_t streamId = H2->Session->SendRequest(method, path, authority, scheme, headers, body);
+
+        ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 stream " << streamId << " <- (" << request->Method << " " << request->URL << ")");
+
+        typename THttp2State::TPendingRequest pending;
+        pending.Request = request;
+        pending.RequestOwner = requestOwner;
+        pending.StreamId = streamId;
+        H2->PendingRequests[streamId] = std::move(pending);
+    }
+
+    static constexpr size_t READ_BUFFER_SIZE = 64 * 1024;
+
+    void ReadH2Input() {
+        char readBuffer[READ_BUFFER_SIZE];
+        while (IsAlive()) {
+            bool read = false, write = false;
+            ssize_t res = TSocketImpl::Recv(readBuffer, READ_BUFFER_SIZE, read, write);
+            if (res > 0) {
+                LastActivity = NActors::TActivationContext::Now();
+                H2->Session->Feed(readBuffer, static_cast<size_t>(res));
+                if (H2->Error) {
+                    PassAway();
+                    return;
+                }
+                if (!FlushH2Output()) {
+                    PassAway();
+                    return;
+                }
+            } else if (-res == EINTR) {
+                continue;
+            } else if (-res == EAGAIN || -res == EWOULDBLOCK) {
+                if (PollerToken) {
+                    if (!read && !write) {
+                        read = true;
+                    }
+                    if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                        continue;
+                    }
+                }
+                return;
+            } else {
+                if (res == 0) {
+                    ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 connection closed by peer");
+                } else {
+                    ALOG_ERROR(HttpLog, GetSocketName() << "HTTP/2 error in Receive: " << strerror(-res));
+                }
+                PassAway();
+                return;
+            }
+        }
+    }
+
+    bool FlushH2Output() {
+        while (H2->OutputOffset < H2->OutputBuffer.size()) {
+            size_t size = H2->PendingWriteSize ? H2->PendingWriteSize : (H2->OutputBuffer.size() - H2->OutputOffset);
+            bool read = false, write = false;
+            ssize_t res = TSocketImpl::Send(H2->OutputBuffer.data() + H2->OutputOffset, size, read, write);
+            if (res > 0) {
+                LastActivity = NActors::TActivationContext::Now();
+                H2->OutputOffset += res;
+                H2->PendingWriteSize = 0;
+            } else if (-res == EINTR) {
+                continue;
+            } else if (-res == EAGAIN || -res == EWOULDBLOCK) {
+                H2->PendingWriteSize = size;
+                if (PollerToken) {
+                    if (!read && !write) {
+                        write = true;
+                    }
+                    if (PollerToken->RequestNotificationAfterWouldBlock(read, write)) {
+                        continue;
+                    }
+                }
+                break;
+            } else {
+                ALOG_ERROR(HttpLog, GetSocketName() << "HTTP/2 error in FlushOutput: " << strerror(-res));
+                H2->Error = true;
+                return false;
+            }
+        }
+        if (H2->OutputOffset == H2->OutputBuffer.size()) {
+            H2->OutputBuffer.clear();
+            H2->OutputOffset = 0;
+        } else if (H2->OutputOffset > 0) {
+            H2->OutputBuffer = H2->OutputBuffer.substr(H2->OutputOffset);
+            H2->OutputOffset = 0;
+        }
+        return true;
     }
 
     static int GetPort(SocketAddressType address) {
@@ -424,7 +647,14 @@ protected:
     void HandleTimeout() {
         TDuration inactivityTime = NActors::TActivationContext::Now() - LastActivity;
         if (inactivityTime >= ConnectionTimeout) {
-            if (RequestOwner) {
+            if (H2) {
+                if (!H2->PendingRequests.empty()) {
+                    ALOG_ERROR(HttpLog, GetSocketName() << "HTTP/2 connection timed out");
+                } else {
+                    ALOG_DEBUG(HttpLog, GetSocketName() << "HTTP/2 connection closed due to inactivity");
+                }
+                PassAway();
+            } else if (RequestOwner) {
                 FailConnection("Connection timed out");
             } else {
                 ALOG_DEBUG(HttpLog, GetSocketName() << "connection closed due to inactivity");
@@ -462,6 +692,36 @@ protected:
     STATEFN(StateFailed) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvHttpProxy::TEvHttpOutgoingRequest, HandleFailed);
+        }
+    }
+
+    void HandleConnectedHttp2(NActors::TEvPollerReady::TPtr& event) {
+        LastActivity = NActors::TActivationContext::Now();
+        if (event->Get()->Write) {
+            if (!FlushH2Output()) {
+                PassAway();
+                return;
+            }
+        }
+        if (event->Get()->Read) {
+            ReadH2Input();
+        }
+    }
+
+    void HandleConnectedHttp2(TEvHttpProxy::TEvHttpOutgoingRequest::TPtr& event) {
+        LastActivity = NActors::TActivationContext::Now();
+        SendH2Request(std::move(event->Get()->Request), event->Sender);
+        if (!FlushH2Output()) {
+            PassAway();
+        }
+    }
+
+    STATEFN(StateConnectedHttp2) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NActors::TEvPollerReady, HandleConnectedHttp2);
+            cFunc(NActors::TEvents::TEvWakeup::EventType, HandleTimeout);
+            hFunc(TEvHttpProxy::TEvHttpOutgoingRequest, HandleConnectedHttp2);
+            cFunc(NActors::TEvents::TEvPoison::EventType, PassAway);
         }
     }
 };

--- a/ydb/library/actors/http/http_proxy_sock_impl.h
+++ b/ydb/library/actors/http/http_proxy_sock_impl.h
@@ -176,6 +176,23 @@ struct TSecureSocketImpl : TPlainSocketImpl, TSslHelpers {
         BIO_set_nbio(Bio.Get(), 1);
         Ctx = CreateClientContext();
         Ssl = ConstructSsl(Ctx.Get(), Bio.Get());
+        SSL_set_mode(Ssl.Get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+        if (!Host.empty()) {
+            TVector<TString> items;
+            Split(Host, ":", items);
+            SSL_set_tlsext_host_name(Ssl.Get(), items[0].c_str());
+        }
+        SSL_set_connect_state(Ssl.Get());
+    }
+
+    void InitClientSslWithAlpn() {
+        Bio.Reset(BIO_new(IoMethod()));
+        BIO_set_data(Bio.Get(), this);
+        BIO_set_nbio(Bio.Get(), 1);
+        Ctx = CreateClientContext();
+        TSslHelpers::SetClientAlpn(Ctx.Get());
+        Ssl = ConstructSsl(Ctx.Get(), Bio.Get());
+        SSL_set_mode(Ssl.Get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
         if (!Host.empty()) {
             TVector<TString> items;
             Split(Host, ":", items);
@@ -189,6 +206,7 @@ struct TSecureSocketImpl : TPlainSocketImpl, TSslHelpers {
         BIO_set_data(Bio.Get(), this);
         BIO_set_nbio(Bio.Get(), 1);
         Ssl = ConstructSsl(ctx, Bio.Get());
+        SSL_set_mode(Ssl.Get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
         SSL_set_accept_state(Ssl.Get());
     }
 
@@ -233,11 +251,33 @@ struct TSecureSocketImpl : TPlainSocketImpl, TSslHelpers {
     }
 
     int OnAccept(std::shared_ptr<TPrivateEndpointInfo> endpoint, bool& read, bool& write) {
+        if (Ssl && SSL_is_init_finished(Ssl.Get())) {
+            return 1; // SSL handshake already completed (adopted from another actor)
+        }
         if (!Ssl) {
             InitServerSsl(endpoint->SecureContext.Get());
         }
         ERR_clear_error();
         return ProcessSslResult(SSL_accept(Ssl.Get()), read, write);
+    }
+
+    // Take ownership of an already-established SSL connection (post-handshake)
+    void AdoptSsl(TSslHolder<BIO> bio, TSslHolder<SSL> ssl) {
+        Bio = std::move(bio);
+        Ssl = std::move(ssl);
+        BIO_set_data(Bio.Get(), this); // Update BIO data pointer to this instance
+    }
+
+    // Get the ALPN-negotiated protocol (returns empty string if none)
+    TStringBuf GetAlpnProtocol() const {
+        if (!Ssl) return {};
+        const unsigned char* proto = nullptr;
+        unsigned int protoLen = 0;
+        SSL_get0_alpn_selected(Ssl.Get(), &proto, &protoLen);
+        if (proto && protoLen > 0) {
+            return TStringBuf(reinterpret_cast<const char*>(proto), protoLen);
+        }
+        return {};
     }
 };
 

--- a/ydb/library/actors/http/http_proxy_ssl.h
+++ b/ydb/library/actors/http/http_proxy_ssl.h
@@ -149,6 +149,40 @@ struct TSslHelpers {
 
         return ssl;
     }
+
+    // ALPN callback for HTTP/2 negotiation (server-side)
+    // Advertises both "h2" and "http/1.1", prefers "h2"
+    static int AlpnSelectCallback(SSL*, const unsigned char** out, unsigned char* outlen,
+                                   const unsigned char* in, unsigned int inlen, void*) {
+        // Try to select "h2" first, then "http/1.1"
+        static const unsigned char h2[] = { 2, 'h', '2' };
+        static const unsigned char h1[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+
+        if (SSL_select_next_proto(const_cast<unsigned char**>(out), outlen,
+                                   h2, sizeof(h2), in, inlen) == OPENSSL_NPN_NEGOTIATED) {
+            return SSL_TLSEXT_ERR_OK;
+        }
+        if (SSL_select_next_proto(const_cast<unsigned char**>(out), outlen,
+                                   h1, sizeof(h1), in, inlen) == OPENSSL_NPN_NEGOTIATED) {
+            return SSL_TLSEXT_ERR_OK;
+        }
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    // Enable ALPN on a server SSL context for HTTP/2 support
+    static void EnableAlpn(SSL_CTX* ctx) {
+        SSL_CTX_set_alpn_select_cb(ctx, AlpnSelectCallback, nullptr);
+    }
+
+    // Set ALPN protocols for client SSL context (advertise h2 and http/1.1)
+    static void SetClientAlpn(SSL_CTX* ctx) {
+        // Wire format: length-prefixed protocol names
+        static const unsigned char protos[] = {
+            2, 'h', '2',
+            8, 'h', 't', 't', 'p', '/', '1', '.', '1'
+        };
+        SSL_CTX_set_alpn_protos(ctx, protos, sizeof(protos));
+    }
 };
 
 }

--- a/ydb/library/actors/http/ut/ya.make
+++ b/ydb/library/actors/http/ut/ya.make
@@ -16,6 +16,7 @@ IF (NOT OS_WINDOWS)
 SRCS(
     http_cache_ut.cpp
     http_ut.cpp
+    http2_ut.cpp
     tls_client_connection.cpp
 )
 ELSE()

--- a/ydb/library/actors/http/ya.make
+++ b/ydb/library/actors/http/ya.make
@@ -17,6 +17,11 @@ SRCS(
     http_static.h
     http.cpp
     http.h
+    http2_frames.h
+    http2_hpack.h
+    http2_hpack.cpp
+    http2.h
+    http2.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
- Introduced HTTP/2 support in the HTTP proxy by adding necessary structures and methods for handling HTTP/2 connections.
- Enhanced the TEvHttpProxy structure to include flags for enabling HTTP/2 and managing connection states.
- Implemented ALPN negotiation for HTTP/2 in secure connections and added support for h2c upgrades in plain connections.
- Updated the connection handling logic to switch between HTTP/1.1 and HTTP/2 based on protocol detection.
- Added unit tests for HTTP/2 functionality to ensure proper behavior and regression coverage.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
