### PR TITLE
Fix Coverity 106565: use VDiskLogPrefix after move in TChain ctor

### DIFF
--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
@@ -155,7 +155,7 @@ namespace NKikimr {
         public:
             TChain(TString vdiskLogPrefix, ui32 slotsInChunk, ui32 slotSize, TControlWrapper chunksSoftLocking)
                 : VDiskLogPrefix(std::move(vdiskLogPrefix))
-                , ConstMask(BuildConstMask(vdiskLogPrefix, slotsInChunk))
+                , ConstMask(BuildConstMask(VDiskLogPrefix, slotsInChunk))
                 , ChunksSoftLocking(chunksSoftLocking)
                 , SlotsInChunk(slotsInChunk)
                 , SlotSize(slotSize)


### PR DESCRIPTION
Coverity CID 106565 (CLOUD-252157): `TChain` ctor moved `vdiskLogPrefix` into `VDiskLogPrefix`, then passed the parameter to `BuildConstMask` (use-after-move).

Use `VDiskLogPrefix` for `BuildConstMask`; it is initialized earlier in the member-init list (declaration order matches).