### PR TITLE
Fix Coverity 106585: avoid use-after-move in PreProcessImmediateTx

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -3567,7 +3567,7 @@ TPartition::EProcessResult TPartition::PreProcessImmediateTx(TTransaction& t,
         consumers.push_back(user);
     }
     affectedSourceIdsAndConsumers.ReadConsumers = std::move(consumers);
-    affectedSourceIdsAndConsumers.WriteKeysSize += consumers.size();
+    affectedSourceIdsAndConsumers.WriteKeysSize += affectedSourceIdsAndConsumers.ReadConsumers.size();
     return EProcessResult::Continue;
 }
 


### PR DESCRIPTION
Coverity CID 106585: `consumers` was moved into `ReadConsumers`, then `consumers.size()` was used for `WriteKeysSize`.

Use `ReadConsumers.size()` after the move. Tracker: CLOUD-252157.