### PR TITLE
Fix Coverity 106704: freeaddrinfo on getaddrinfo error in dnsresolver

### DIFF
--- a/ydb/library/actors/dnsresolver/dnsresolver.cpp
+++ b/ydb/library/actors/dnsresolver/dnsresolver.cpp
@@ -544,17 +544,18 @@ namespace NDnsResolver {
             name = AddTrailingDot(std::move(name), Options.AddTrailingDot);
             auto result = std::make_unique<TEvDns::TEvGetHostByNameResult>();
 
-            struct addrinfo hints, *res;
+            struct addrinfo hints, *res = nullptr;
             memset(&hints, 0, sizeof(hints));
             hints.ai_family = family;
             hints.ai_socktype = Options.ForceTcp ? SOCK_STREAM : SOCK_DGRAM;
+
+            Y_DEFER { freeaddrinfo(res); };
 
             result->Status = getaddrinfo(name.c_str(), nullptr, &hints, &res);
             if (result->Status != 0) {
                 result->ErrorText = gai_strerror(result->Status);
                 return result;
             }
-            Y_DEFER { freeaddrinfo(res); };
 
             for (auto *node = res; node; node = node->ai_next) {
                 switch (node->ai_family) {


### PR DESCRIPTION
Coverity CID 106704 (CLOUD-252157): on `getaddrinfo` failure the code returned without calling `freeaddrinfo` on `res`.

- Initialize `res` to `nullptr`.
- Move `Y_DEFER { freeaddrinfo(res); }` before `getaddrinfo` so cleanup runs on every return; `freeaddrinfo(nullptr)` is allowed by POSIX.