### PR TITLE
Fix Coverity 106747: drop useless std::move on const TCurlInitConfig

### DIFF
--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
@@ -350,7 +350,7 @@ public:
               offset,
               sizeLimit,
               data.size(),
-              std::move(config),
+              config,
               std::move(dnsCache),
               std::move(data))
         , Input(Data)
@@ -387,7 +387,7 @@ public:
             sizeLimit,
             std::move(callback),
             std::move(retryState),
-            std::move(config),
+            config,
             std::move(dnsCache));
     }
 
@@ -485,7 +485,7 @@ public:
         size_t threshold,
         const TCurlInitConfig& config = TCurlInitConfig(),
         TDNSGateway<>::TDNSConstCurlListPtr dnsCache = nullptr)
-        : TEasyCurl(counter, downloadedBytes, uploadededBytes, url, std::move(headers), EMethod::GET, offset, sizeLimit, 0ULL, std::move(config), std::move(dnsCache))
+        : TEasyCurl(counter, downloadedBytes, uploadededBytes, url, std::move(headers), EMethod::GET, offset, sizeLimit, 0ULL, config, std::move(dnsCache))
         , OnStart(std::move(onStart))
         , OnNewData(std::move(onNewData))
         , OnFinish(std::move(onFinish))
@@ -512,7 +512,7 @@ public:
         const TCurlInitConfig& config = TCurlInitConfig(),
         TDNSGateway<>::TDNSConstCurlListPtr dnsCache = nullptr)
     {
-        return std::make_shared<TEasyCurlStream>(counter, downloadedBytes, uploadededBytes, std::move(url), std::move(headers), offset, sizeLimit, std::move(onStart), std::move(onNewData), std::move(onFinish), inflightCounter, handle, threshold, std::move(config), std::move(dnsCache));
+        return std::make_shared<TEasyCurlStream>(counter, downloadedBytes, uploadededBytes, std::move(url), std::move(headers), offset, sizeLimit, std::move(onStart), std::move(onNewData), std::move(onFinish), inflightCounter, handle, threshold, config, std::move(dnsCache));
     }
 
     enum class EAction : i8 {


### PR DESCRIPTION
Coverity CID 106747 (CLOUD-253676): `std::move` on a `const TCurlInitConfig&` parameter does not enable move (it yields `const TCurlInitConfig&&` and still copies into `TEasyCurl`), and triggers a bogus use-after-move on the reference parameter.

Pass `config` by lvalue in `TEasyCurlBuffer` / `TEasyCurlStream` constructors and `Make` helpers.