### PR TITLE
Fix Coverity 106812: assign cookie without std::move from const ref

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -224,7 +224,7 @@ TConclusionStatus TJsonPathAccessorTrie::Insert(TJsonPathBuf jsonPath, std::shar
     AFL_VERIFY(!currentNode->Accessor);
 
     currentNode->Accessor = std::move(accessor);
-    currentNode->Cookie = std::move(cookie);
+    currentNode->Cookie = cookie;
 
     return TConclusionStatus::Success();
 }


### PR DESCRIPTION
Coverity CID 106812 (CLOUD-254986): `TJsonPathAccessorTrie::Insert` took `cookie` as `const std::optional<ui64>&` but used `std::move(cookie)` before `return`, which does not perform a move from `const` and is reported as use-after-move on the reference parameter.

Assign `currentNode->Cookie = cookie` instead.