### PR TITLE
Fix Coverity 106814: drop std::move from const TIssues& in cancel script actor

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -3227,7 +3227,7 @@ private:
 
         if (const auto delay = RetryState->GetNextRetryDelay()) {
             KQP_PROXY_LOG_W("Schedule retry for error: " << issues.ToOneLineString() << " in " << *delay);
-            Issues.AddIssues(std::move(issues));
+            Issues.AddIssues(issues);
             Schedule(*delay, new TEvents::TEvWakeup());
             WaitRetry = true;
             return true;
@@ -3241,7 +3241,7 @@ private:
     }
 
     void Reply(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
-        Issues.AddIssues(std::move(issues));
+        Issues.AddIssues(issues);
 
         if (status == Ydb::StatusIds::SUCCESS) {
             KQP_PROXY_LOG_D("Reply success, issues: " << Issues.ToOneLineString());


### PR DESCRIPTION
Coverity CID 106814 (CLOUD-254986): `TCancelScriptExecutionOperationActor::ScheduleRetry` and `Reply` take `issues` as `const NYql::TIssues&`, but `Issues.AddIssues(std::move(issues))` does not move from `const` and is flagged as use-after-move before `return`.

Use `AddIssues(issues)` in both places.