### PR TITLE
Fix Coverity 106823: no std::move from const TIssues& in cancel script actor

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -3227,7 +3227,7 @@ private:
 
         if (const auto delay = RetryState->GetNextRetryDelay()) {
             KQP_PROXY_LOG_W("Schedule retry for error: " << issues.ToOneLineString() << " in " << *delay);
-            Issues.AddIssues(std::move(issues));
+            Issues.AddIssues(issues);
             Schedule(*delay, new TEvents::TEvWakeup());
             WaitRetry = true;
             return true;
@@ -3241,7 +3241,7 @@ private:
     }
 
     void Reply(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
-        Issues.AddIssues(std::move(issues));
+        Issues.AddIssues(issues);
 
         if (status == Ydb::StatusIds::SUCCESS) {
             KQP_PROXY_LOG_D("Reply success, issues: " << Issues.ToOneLineString());


### PR DESCRIPTION
Coverity CID 106823 (CLOUD-254986): `Reply` used `Issues.AddIssues(std::move(issues))` while `issues` is `const NYql::TIssues&`, which does not move and is reported as use-after-move when the function ends.

Also fix the same pattern in `ScheduleRetry` (same actor, same defect class).

Tracker CLOUD-254986 lists multiple Coverity items; this PR targets CID 106823.