### PR TITLE
Fix PossibleMaxLimit without harmonizer

### DIFF
--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -555,6 +555,10 @@ namespace NActors {
     }
 
     void TBasicExecutorPool::GetExecutorPoolState(TExecutorPoolState &poolState) const {
+        poolState.CurrentLimit = GetThreadCount();
+        poolState.MaxLimit = GetMaxThreadCount();
+        poolState.MinLimit = GetDefaultThreadCount();
+
         if (Harmonizer) {
             TPoolHarmonizerStats stats = Harmonizer->GetPoolStats(PoolId);
             poolState.ElapsedCpu = stats.AvgElapsedCpu;
@@ -566,9 +570,6 @@ namespace NActors {
         } else {
             poolState.PossibleMaxLimit = poolState.MaxLimit;
         }
-        poolState.CurrentLimit = GetThreadCount();
-        poolState.MaxLimit = GetMaxThreadCount();
-        poolState.MinLimit = GetDefaultThreadCount();
     }
 
     void TBasicExecutorPool::Prepare(TActorSystem* actorSystem, NSchedulerQueue::TReader** scheduleReaders, ui32* scheduleSz) {

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -557,7 +557,7 @@ namespace NActors {
     void TBasicExecutorPool::GetExecutorPoolState(TExecutorPoolState &poolState) const {
         poolState.CurrentLimit = GetThreadCount();
         poolState.MaxLimit = GetMaxThreadCount();
-        poolState.MinLimit = GetDefaultThreadCount();
+        poolState.MinLimit = GetMinThreadCount();
 
         if (Harmonizer) {
             TPoolHarmonizerStats stats = Harmonizer->GetPoolStats(PoolId);

--- a/ydb/library/actors/core/ut/executor_pool_basic_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pool_basic_ut.cpp
@@ -302,7 +302,7 @@ Y_UNIT_TEST_SUITE(BasicExecutorPool) {
         UNIT_ASSERT_VALUES_EQUAL(stats[0].MailboxPushedOutBySoftPreemption, 0);
     }
 
-    Y_UNIT_TEST(GetExecutorPoolStateWithoutHarmonizerUsesMaxLimitForPossibleMaxLimit) {
+    Y_UNIT_TEST(GetExecutorPoolStateWithoutHarmonizerUsesMinAndMaxLimits) {
         TBasicExecutorPoolConfig config;
         config.Threads = 4;
         config.MinThreadCount = 1;
@@ -318,7 +318,7 @@ Y_UNIT_TEST_SUITE(BasicExecutorPool) {
         executorPool.GetExecutorPoolState(state);
 
         UNIT_ASSERT_VALUES_EQUAL(state.CurrentLimit, executorPool.GetThreadCount());
-        UNIT_ASSERT_VALUES_EQUAL(state.MinLimit, executorPool.GetDefaultThreadCount());
+        UNIT_ASSERT_VALUES_EQUAL(state.MinLimit, executorPool.GetMinThreadCount());
         UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, executorPool.GetMaxThreadCount());
         UNIT_ASSERT_VALUES_EQUAL(state.PossibleMaxLimit, state.MaxLimit);
     }

--- a/ydb/library/actors/core/ut/executor_pool_basic_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pool_basic_ut.cpp
@@ -301,6 +301,27 @@ Y_UNIT_TEST_SUITE(BasicExecutorPool) {
         UNIT_ASSERT(stats[0].MailboxPushedOutByTime + stats[0].MailboxPushedOutByEventCount >= 2 * msgCount / TBasicExecutorPoolConfig::DEFAULT_EVENTS_PER_MAILBOX);
         UNIT_ASSERT_VALUES_EQUAL(stats[0].MailboxPushedOutBySoftPreemption, 0);
     }
+
+    Y_UNIT_TEST(GetExecutorPoolStateWithoutHarmonizerUsesMaxLimitForPossibleMaxLimit) {
+        TBasicExecutorPoolConfig config;
+        config.Threads = 4;
+        config.MinThreadCount = 1;
+        config.DefaultThreadCount = 2;
+        config.MaxThreadCount = 4;
+
+        TBasicExecutorPool executorPool(config, nullptr, nullptr);
+
+        TExecutorPoolState state;
+        state.PossibleMaxLimit = -1;
+        state.MaxLimit = -1;
+
+        executorPool.GetExecutorPoolState(state);
+
+        UNIT_ASSERT_VALUES_EQUAL(state.CurrentLimit, executorPool.GetThreadCount());
+        UNIT_ASSERT_VALUES_EQUAL(state.MinLimit, executorPool.GetDefaultThreadCount());
+        UNIT_ASSERT_VALUES_EQUAL(state.MaxLimit, executorPool.GetMaxThreadCount());
+        UNIT_ASSERT_VALUES_EQUAL(state.PossibleMaxLimit, state.MaxLimit);
+    }
 }
 
 Y_UNIT_TEST_SUITE(ChangingThreadsCountInBasicExecutorPool) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix GetExecutorPoolState: now the Current/Max/Min limit is set before calculating PossibleMaxLimit, so without a harmonizer, PossibleMaxLimit no longer takes an uninitialized value. Now `MinLimit` reflects `GetMinThreadCount()` rather than `GetDefaultThreadCount()'.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
