### PR TITLE
Fix Coverity 108444: Histogram::AddData must not forward-move Args in a loop

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
+++ b/ydb/library/yql/dq/comp_nodes/hash_join_utils/histogram.h
@@ -19,7 +19,7 @@ public:
     Histogram() = default;
 
     template <typename F, typename... Args>
-    void AddData(const TTupleLayout* layout, const ui8* data, ui32 nTuples, F HashMapper, Args&&... args) {
+    void AddData(const TTupleLayout* layout, const ui8* data, ui32 nTuples, F HashMapper, const Args&... args) {
         const auto layoutTotalRowSize = layout->TotalRowSize;
 
         for (ui32 i = 0; i < nTuples; i += 1 /*step*/) {
@@ -38,7 +38,7 @@ public:
                 overflowSize += size;
             }
 
-            auto key = HashMapper(hash, std::forward<Args>(args)...);
+            auto key = HashMapper(hash, args...);
             TuplesCountStatistics_[key]++;
             TuplesSizeStatistics_[key] += layoutTotalRowSize;
             OverflowSizeStatistics_[key] += overflowSize;


### PR DESCRIPTION
Coverity CID 108444 (CLOUD-257266): `AddData` iterated tuples and called `HashMapper(hash, std::forward<Args>(args)...)` with `Args&&...`, so rvalue pack members were moved on the first iteration and used again later (use-after-move).

Take extra arguments as `const Args&...` and invoke `HashMapper(hash, args...)` so every iteration sees the same values.