### PR TITLE
Fix Coverity 113575: no std::move from const TCoMember& in dq_opt_stat

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_stat.h
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.h
@@ -74,11 +74,11 @@ public:
         };
 
         void AddEquality(const NNodes::TCoMember& member) {
-            Data.emplace_back(std::move(member), TColumnStatisticsUsedMember::EEquality);
+            Data.emplace_back(member, TColumnStatisticsUsedMember::EEquality);
         }
 
         void AddInequality(const NNodes::TCoMember& member) {
-            Data.emplace_back(std::move(member), TColumnStatisticsUsedMember::EInequality);
+            Data.emplace_back(member, TColumnStatisticsUsedMember::EInequality);
         }
 
         TVector<TColumnStatisticsUsedMember> Data{};


### PR DESCRIPTION
Coverity CID 113575 (CLOUD-259377): `AddEquality` / `AddInequality` took `const NNodes::TCoMember&` but used `std::move(member)` in `emplace_back`, which does not move from `const` and is reported as use-after-move.

Pass `member` by lvalue; `TColumnStatisticsUsedMember` still constructs from `TCoMember` by value.