### PR TITLE
Fix Coverity 113581: use counters response size before std::move

### DIFF
--- a/ydb/core/grpc_services/rpc_cluster_state.cpp
+++ b/ydb/core/grpc_services/rpc_cluster_state.cpp
@@ -344,8 +344,8 @@ public:
     void Handle(NKikimr::NCountersInfo::TEvCountersInfoResponse::TPtr& ev) {
         ui32 idx = ev.Get()->Cookie;
         auto& response = ev->Get()->Record.GetResponse();
-        Counters[idx].push_back(std::make_pair(std::move(response), TInstant::Now()));
         CountersSize += response.size();
+        Counters[idx].push_back(std::make_pair(std::move(response), TInstant::Now()));
         if (CountersSize > MaxCountersSize) {
             ReplyAndPassAway();
         }


### PR DESCRIPTION
Coverity CID 113581 (CLOUD-259377): `TEvCountersInfoResponse` handler appended `std::move(response)` and then called `response.size()` for `CountersSize`.

Add to `CountersSize` before moving `response` into the stored pair.