### PR TITLE
Fix Coverity 113585: avoid use-after-move in TOutputDescriptor::PushDataChunk

### DIFF
--- a/ydb/library/yql/dq/runtime/dq_channel_service.cpp
+++ b/ydb/library/yql/dq/runtime/dq_channel_service.cpp
@@ -370,6 +370,8 @@ void TOutputDescriptor::PushDataChunk(TDataChunk&& data, TNodeState* nodeState, 
         PushStats.Resume();
     }
 
+    const ui64 chunkBytes = data.Bytes;
+
     std::lock_guard lock(FlowControlMutex);
 
     if (FinishPushed.load()) {
@@ -416,7 +418,7 @@ void TOutputDescriptor::PushDataChunk(TDataChunk&& data, TNodeState* nodeState, 
     }
 
     (*OutputBufferChunks)++;
-    *OutputBufferBytes += data.Bytes;
+    *OutputBufferBytes += chunkBytes;
 
     if (!spilled) {
         nodeState->PushDataChunk(std::move(data), self);


### PR DESCRIPTION
Coverity CID 113585 (CLOUD-259377): on the spill path `DataToBuffer(std::move(data))` consumed `data`, but `*OutputBufferBytes += data.Bytes` still ran afterward.

Capture `chunkBytes` before any move and add that to `OutputBufferBytes`.