### PR TITLE
Fix Coverity 113889: default-init TBasicExecutorPool thread fields before ctor body

### DIFF
--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -166,13 +166,13 @@ namespace NActors {
         std::atomic<float> SharedCpuQuota = 0.0;
         TMutex ChangeThreadsLock;
 
-        float MinThreadCount;
-        i16 MinFullThreadCount;
-        float MaxThreadCount;
-        i16 MaxFullThreadCount;
-        float DefaultThreadCount;
-        i16 DefaultFullThreadCount;
-        IHarmonizer *Harmonizer;
+        float MinThreadCount = 0.0;
+        i16 MinFullThreadCount = 0;
+        float MaxThreadCount = 0.0;
+        i16 MaxFullThreadCount = 0;
+        float DefaultThreadCount = 0.0;
+        i16 DefaultFullThreadCount = 0;
+        IHarmonizer *Harmonizer = nullptr;
         ui64 SoftProcessingDurationTs = 0;
         bool HasOwnSharedThread = false;
         ui16 MaxLocalQueueSize = 0;


### PR DESCRIPTION
Coverity CID 113889 (CLOUD-262762): `TBasicExecutorPool` ctor could read `DefaultThreadCount` in the `AllThreadsAreShared` branch before the float thread counters were assigned (they are only set near the end of the ctor from the `*FullThreadCount` fields).

Add in-class default initializers for `MinThreadCount`, `MaxThreadCount`, `DefaultThreadCount`, the matching `*FullThreadCount` fields, and `Harmonizer` so all uses in the ctor body see defined values (init list still overrides the `*FullThreadCount` / `Harmonizer` members as before).