### PR TITLE
blobstorage: value-initialize TDiskFormat (Coverity 119929)

### DIFF
--- a/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
+++ b/ydb/core/blobstorage/ddisk/ut/ddisk_actor_ut.cpp
@@ -141,7 +141,7 @@ public:
             BlockSize,
             "");
 
-        NPDisk::TDiskFormat format;
+        NPDisk::TDiskFormat format = {};
         format.Clear(false);
         initReply->DiskFormat = NPDisk::TDiskFormatPtr(new NPDisk::TDiskFormat(format), +[](NPDisk::TDiskFormat* ptr) {
             delete ptr;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1803,7 +1803,7 @@ void TPDisk::WriteDiskFormat(ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 user
         std::optional<TRcBuf> metadata, bool plainDataChunks, std::optional<bool> forceRandomizeMagic) {
     TGuard<TMutex> guard(StateMutex);
     // Prepare format record
-    alignas(16) TDiskFormat format;
+    alignas(16) TDiskFormat format = {};
     format.Clear(Cfg->EnableFormatAndMetadataEncryption);
     format.SetPlainDataChunks(plainDataChunks);
     format.DiskSize = diskSizeBytes;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -145,7 +145,7 @@ public:
     TNonceSet ForceLogNonceDiff;
 
     // Static state
-    alignas(16) TDiskFormat Format;
+    alignas(16) TDiskFormat Format = {};
     ui64 ExpectedDiskGuid;
     TPDiskCategory PDiskCategory;
     TNonceJumpLogPageHeader2 LastNonceJumpLogPageHeader2;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -164,7 +164,7 @@ bool ReadPDiskFormatInfo(const TString &path, const NPDisk::TMainKey &mainKey, T
         NPDisk::TPDiskStreamCypher cypher(true);
         cypher.SetKey(key);
         bool isOk = false;
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         for (ui32 recordIdx = 0; recordIdx < NPDisk::ReplicationFactor; ++recordIdx) {
             ui64 recordSectorOffset = recordIdx * NPDisk::FormatSectorSize;
             ui8 *formatSector = formatRaw->Data() + recordSectorOffset;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_pdisk_config.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_pdisk_config.cpp
@@ -56,7 +56,7 @@ Y_UNIT_TEST_SUITE(TPDiskConfig) {
         TIntrusivePtr<TPDiskConfig> cfg = new TPDiskConfig(0, 0, TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
         cfg->FeatureFlags.SetEnablePDiskLogForSmallDisks(true);
 
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         format.DiskSize = 4ull << 30;
 
         NPDisk::TKeeperParams params;
@@ -71,7 +71,7 @@ Y_UNIT_TEST_SUITE(TPDiskConfig) {
         TIntrusivePtr<TPDiskConfig> cfg = new TPDiskConfig(0, 0, TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
         cfg->FeatureFlags.SetEnablePDiskLogForSmallDisks(true);
 
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         format.DiskSize = 100ull << 30;
 
         NPDisk::TKeeperParams params;
@@ -86,7 +86,7 @@ Y_UNIT_TEST_SUITE(TPDiskConfig) {
         TIntrusivePtr<TPDiskConfig> cfg = new TPDiskConfig(0, 0, TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
         cfg->FeatureFlags.SetEnablePDiskLogForSmallDisks(true);
 
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         format.DiskSize = 1000ull << 30;
 
         NPDisk::TKeeperParams params;
@@ -101,7 +101,7 @@ Y_UNIT_TEST_SUITE(TPDiskConfig) {
         TIntrusivePtr<TPDiskConfig> cfg = new TPDiskConfig(0, 0, TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
         cfg->FeatureFlags.SetEnablePDiskLogForSmallDisks(false);
 
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         format.DiskSize = 100ull << 30;
 
         NPDisk::TKeeperParams params;
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(TPDiskConfig) {
         TIntrusivePtr<TPDiskConfig> cfg = new TPDiskConfig(0, 0, TPDiskCategory(NPDisk::DEVICE_TYPE_ROT, 0).GetRaw());
         cfg->FeatureFlags.SetEnablePDiskLogForSmallDisks(false);
 
-        alignas(16) NPDisk::TDiskFormat format;
+        alignas(16) NPDisk::TDiskFormat format = {};
         format.DiskSize = 100ull << 30;
 
         NPDisk::TKeeperParams params;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
@@ -165,7 +165,7 @@ YARD_UNIT_TEST(TestChunkReadRandomOffset) {
     {
         TTestContext tc(true);
         constexpr ui32 sectorPayload = 4064;
-        NPDisk::TDiskFormat format;
+        NPDisk::TDiskFormat format = {};
         format.Clear(true);
         UNIT_ASSERT(sectorPayload == format.SectorPayloadSize());
         constexpr ui32 sizeWithHalfOfBlockSize = sectorPayload * 512 - sectorPayload / 2;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_ut.cpp
@@ -266,7 +266,7 @@ Y_UNIT_TEST_SUITE(TPDiskUtil) {
 
 void TestOffset(ui64 offset, ui64 size, ui64 expectedFirstSector, ui64 expectedLastSector,
         ui64 expectedSectorOffset) {
-    TDiskFormat format;
+    TDiskFormat format = {};
     format.Clear(true);
     format.SectorSize = 4096;
     format.FormatFlags &= ~EFormatFlags::FormatFlagErasureEncodeUserChunks;
@@ -286,7 +286,7 @@ void TestOffset(ui64 offset, ui64 size, ui64 expectedFirstSector, ui64 expectedL
 }
 
     Y_UNIT_TEST(OffsetParsingCorrectness) {
-        TDiskFormat format;
+        TDiskFormat format = {};
         format.Clear(true);
         format.SectorSize = 4096;
         const ui64 sectorPayload = format.SectorPayloadSize();
@@ -310,7 +310,7 @@ void TestOffset(ui64 offset, ui64 size, ui64 expectedFirstSector, ui64 expectedL
 
 void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui64 expectedPayloadSize,
         ui64 expectedPayloadOffset) {
-    TDiskFormat format;
+    TDiskFormat format = {};
     format.Clear(true);
     format.SectorSize = 4096;
     format.FormatFlags &= ~EFormatFlags::FormatFlagErasureEncodeUserChunks;
@@ -326,7 +326,7 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
 }
 
     Y_UNIT_TEST(PayloadParsingTest) {
-        TDiskFormat format;
+        TDiskFormat format = {};
         format.Clear(true);
         format.SectorSize = 4096;
         const ui64 sectorPayload = format.SectorPayloadSize();
@@ -346,7 +346,7 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
 
     Y_UNIT_TEST(SectorRestorator) {
         const bool enableSectorEncryption = true;
-        TDiskFormat format;
+        TDiskFormat format = {};
         format.Clear(enableSectorEncryption);
         TSectorsWithData sectors(format.SectorSize, LogErasureDataParts + 1);
         constexpr ui64 magic = 0x123951924;
@@ -373,7 +373,7 @@ void TestPayloadOffset(ui64 firstSector, ui64 lastSector, ui64 currentSector, ui
 
     Y_UNIT_TEST(SectorRestoratorOldNewHash) {
         const bool enableSectorEncryption = true;
-        TDiskFormat format;
+        TDiskFormat format = {};
         format.Clear(enableSectorEncryption);
         TSectorsWithData sectors(format.SectorSize, 3);
         const ui64 magic = 0x123951924;

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -512,7 +512,7 @@ public:
                 owner->OwnerRound, 0u, GetStatusFlags(), std::move(ownedChunks), NPDisk::DEVICE_TYPE_NVME, false,
                 Impl.AppendBlockSize, TString());
             res->StartingPoints = owner->StartingPoints;
-            NPDisk::TDiskFormat format;
+            NPDisk::TDiskFormat format = {};
             format.Clear(false);
             res->DiskFormat = NPDisk::TDiskFormatPtr(new NPDisk::TDiskFormat(format), +[](NPDisk::TDiskFormat* ptr) {
                 delete ptr;


### PR DESCRIPTION
## Problem
Coverity 119929: use of uninitialized value in `TDiskFormat::UpgradeFrom` when called from `blobstorage_pdisk_tools.cpp`. `UpgradeFrom` calls `Clear(IsEncryptFormat())`, which reads `FormatFlags` before `memcpy` overwrites the object.

## Change
Value-initialize every default-constructed `TDiskFormat` in `ydb/core/blobstorage` with `= {}` (including `TPDisk::Format` and test/mock code).

Made with [Cursor](https://cursor.com)