### PR TITLE
Fix Coverity 120570: Pq read actor settings use-after-move

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -1073,6 +1073,10 @@ std::pair<IDqComputeActorAsyncInput*, IActor*> CreateDqPqReadActor(
     const TString& tokenName = settings.GetToken().GetName();
     const TString token = secureParams.Value(tokenName, TString());
     const bool addBearerToToken = settings.GetAddBearerToToken();
+    const auto configuredReadBufferBytes = settings.GetReadSessionBufferBytes();
+    const i64 effectiveReadBufferBytes = configuredReadBufferBytes
+        ? static_cast<i64>(configuredReadBufferBytes)
+        : bufferSize;
 
     TDqPqReadActor* actor = new TDqPqReadActor(
         inputIndex,
@@ -1087,7 +1091,7 @@ std::pair<IDqComputeActorAsyncInput*, IActor*> CreateDqPqReadActor(
         CreateCredentialsProviderFactoryForStructuredToken(credentialsFactory, token, addBearerToToken),
         computeActorId,
         counters,
-        settings.GetReadSessionBufferBytes() ? settings.GetReadSessionBufferBytes() : bufferSize,
+        effectiveReadBufferBytes,
         pqGateway,
         topicPartitionsCount,
         enableStreamingQueriesCounters,


### PR DESCRIPTION
## Problem
Coverity CID 120570: in `CreateDqPqReadActor`, `settings` was moved into `TDqPqReadActor` while another argument still called `settings.GetReadSessionBufferBytes()` in the same constructor call (undefined / analyzer-reported use-after-move).

## Change
Read configured read buffer bytes (and derive `effectiveReadBufferBytes`) **before** `std::move(settings)`, pass the computed `i64` into the actor ctor.

Made-with: Cursor

Made with [Cursor](https://cursor.com)