### PR TITLE
Fix Coverity 120587: use-after-move of acks object

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
@@ -301,7 +301,8 @@ private:
             } while ((maybeMsg = EventsMsgQ.Pop(false)));
 
             fo.Flush();
-            EventsQ.Push(std::move(acks), 1 + acks.Acks.size());
+            auto acksSize = acks.Acks.size();
+            EventsQ.Push(std::move(acks), 1 + acksSize);
             EventsQ.Push(TWriteSessionEvent::TReadyToAcceptEvent(IssueContinuationToken()), 1);
 
             if (EventsQ.IsStopped()) {


### PR DESCRIPTION
Fix Coverity defect 120587: Using a moved object in yql_pq_file_topic_client.cpp