### PR TITLE
Fix Coverity 120589: use-after-move of inflightItem object

### DIFF
--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -1994,7 +1994,8 @@ public:
             auto evRead = reader->GetReadRequest(inflightItem.ReadId, inflightItem.Points);
             YQL_ENSURE(evRead);
             ReadsState.SendEvRead(shardId, evRead, TReadInfo{.ReadKind = readKind, .Cookie = cookie, .ShardId = shardId});
-            Enqueue(inflightItem.ReadId, std::move(inflightItem));
+            auto readId = inflightItem.ReadId;
+            Enqueue(readId, std::move(inflightItem));
         }
 
         return prefixSize;


### PR DESCRIPTION
Fix Coverity defect 120589: Using a moved object in kqp_full_text_source.cpp