### PR TITLE
Engineerng: fix compat tests

### DIFF
--- a/ydb/tests/compatibility/test_fulltext_index.py
+++ b/ydb/tests/compatibility/test_fulltext_index.py
@@ -22,7 +22,7 @@ class TestFulltextIndex(RollingUpgradeAndDowngradeFixture):
     def create_table(self, table_name):
         query = f"""
             CREATE TABLE {table_name} (
-                key Int64 NOT NULL,
+                key Uint64 NOT NULL,
                 text String NOT NULL,
                 PRIMARY KEY (key)
             )

--- a/ydb/tests/compatibility/test_topic.py
+++ b/ydb/tests/compatibility/test_topic.py
@@ -36,6 +36,9 @@ class Workload:
 
         if topic_writer is not None:
             write_loop(topic_writer)
+            # Long-lived writer: write() only enqueues; without flush, partition stats
+            # lag behind message_count until close(). Short-lived `with writer` flushes on exit.
+            topic_writer.flush()
         else:
             with self.driver.topic_client.writer(self.topic_name, producer_id="producer-id") as writer:
                 write_loop(writer)


### PR DESCRIPTION
# Compatibility tests: что поправили

## `ydb/tests/compatibility/test_topic.py`

**Проблема:** в `test_write_and_read_with_long_live_producer` после записи в топик локальный `message_count` не совпадал с `partition_end` из `describe_topic` (например, 996 vs 972).

**Причина:** `TopicWriter.write()` только ставит сообщения в очередь и не ждёт ack. У короткоживущего writer при выходе из `with` вызывается `close(flush=True)` — буфер сбрасывается. У долгоживущего writer между записью и чтением flush не выполнялся, часть сообщений ещё не была видна в статистике партиции.

**Исправление:** после цикла записи при переданном `topic_writer` вызывается `topic_writer.flush()`.

---

## `ydb/tests/compatibility/test_fulltext_index.py`

**Проблема:** `ALTER TABLE … ADD INDEX … GLOBAL USING fulltext_*` падал с `ydb.issues.BadRequest`: fulltext-индекс требует PK типа `Uint64`, а в DDL было `key Int64`.

**Исправление:** в `CREATE TABLE` тип ключа заменён на `Uint64` (значения ключей в тесте неотрицательные, с типом совместимы).


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
