### PR TITLE
Fix Coverity 120576: static initialization order fiasco in whiteboard merger registrators

### DIFF
--- a/ydb/core/viewer/viewer_bsgroupinfo.cpp
+++ b/ydb/core/viewer/viewer_bsgroupinfo.cpp
@@ -1,9 +1,3 @@
 #include "viewer_bsgroupinfo.h"
 
-namespace NKikimr::NViewer {
-
-const TWhiteboardMergerBase::TRegistrator TWhiteboardInfo<NKikimrWhiteboard::TEvBSGroupStateResponse>::Registrator({
-    {NKikimrWhiteboard::TBSGroupStateInfo::descriptor()->FindFieldByName("Latency"), &TWhiteboardMergerBase::ProtoMaximizeEnumField}
-});
-
-} // namespace NKikimr::NViewer
+// TWhiteboardInfo<TEvBSGroupStateResponse>::Registrator is defined in wb_merge.cpp (initialization order vs FieldMerger).

--- a/ydb/core/viewer/viewer_nodeinfo.cpp
+++ b/ydb/core/viewer/viewer_nodeinfo.cpp
@@ -1,10 +1,3 @@
 #include "viewer_nodeinfo.h"
 
-namespace NKikimr::NViewer {
-
-const TWhiteboardMergerBase::TRegistrator TWhiteboardInfo<NKikimrWhiteboard::TEvNodeStateResponse>::Registrator({
-    {NKikimrWhiteboard::TNodeStateInfo::descriptor()->FindFieldByName("ConnectStatus"), &TWhiteboardMergerBase::ProtoMaximizeEnumField},
-    {NKikimrWhiteboard::TNodeStateInfo::descriptor()->FindFieldByName("Connected"), &TWhiteboardMergerBase::ProtoMaximizeBoolField}
-});
-
-} // namespace NKikimr::NViewer
+// TWhiteboardInfo<TEvNodeStateResponse>::Registrator is defined in wb_merge.cpp (initialization order vs FieldMerger).

--- a/ydb/core/viewer/wb_merge.cpp
+++ b/ydb/core/viewer/wb_merge.cpp
@@ -1,5 +1,8 @@
 #include "wb_merge.h"
 
+#include "viewer_bsgroupinfo.h"
+#include "viewer_nodeinfo.h"
+
 #include <util/system/rwlock.h>
 
 namespace NKikimr::NViewer {
@@ -225,5 +228,15 @@ void TWhiteboardMergerBase::ProtoMerge(google::protobuf::Message& protoTo, const
         }
     }
 }
+
+// Registrator globals are defined in this TU so they initialize after FieldMerger above (Coverity 120576).
+const TWhiteboardMergerBase::TRegistrator TWhiteboardInfo<NKikimrWhiteboard::TEvBSGroupStateResponse>::Registrator({
+    {NKikimrWhiteboard::TBSGroupStateInfo::descriptor()->FindFieldByName("Latency"), &TWhiteboardMergerBase::ProtoMaximizeEnumField}
+});
+
+const TWhiteboardMergerBase::TRegistrator TWhiteboardInfo<NKikimrWhiteboard::TEvNodeStateResponse>::Registrator({
+    {NKikimrWhiteboard::TNodeStateInfo::descriptor()->FindFieldByName("ConnectStatus"), &TWhiteboardMergerBase::ProtoMaximizeEnumField},
+    {NKikimrWhiteboard::TNodeStateInfo::descriptor()->FindFieldByName("Connected"), &TWhiteboardMergerBase::ProtoMaximizeBoolField}
+});
 
 } // namespace NKikimr::NViewer


### PR DESCRIPTION
Fix Coverity defect 120576: global object used before initialization.