### PR TITLE
Add --stats option to benchmark workloads

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `--compact` option to `ydb workload tpcc import` command.
 * When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
+* Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).
 * Added support for the new compaction operation in the `ydb operation` subcommands.
 
 ## 2.29.0 ##

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).
 
 ## 2.30.0 ##
 
@@ -7,7 +8,6 @@
 * Added `--compact` option to `ydb workload tpcc import` command.
 * When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
-* Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).
 * Added support for the new compaction operation in the `ydb operation` subcommands.
 
 ## 2.29.0 ##

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
@@ -337,7 +337,7 @@ TMaybe<TQueryBenchmarkResult> SetTimeoutSettings(NQuery::TExecuteQuerySettings& 
 
 TQueryBenchmarkResult ExecuteImpl(const TString& query, TStringBuf expected, NQuery::TQueryClient& client, const TQueryBenchmarkSettings& benchmarkSettings, bool explainOnly) {
     NQuery::TExecuteQuerySettings settings;
-    settings.StatsMode(benchmarkSettings.StatsMode.value_or(NQuery::EStatsMode::Profile));
+    settings.StatsMode(benchmarkSettings.StatsMode);
     settings.ExecMode(explainOnly ? NQuery::EExecMode::Explain : NQuery::EExecMode::Execute);
     if (benchmarkSettings.WithProgress) {
         settings.StatsCollectPeriod(std::chrono::milliseconds(3000));

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.cpp
@@ -80,7 +80,7 @@ TTestInfo::TTestInfo(std::vector<TTiming>&& timings)
         Min = std::min(Min, timing.Server);
         totalServer += timing.Server.MillisecondsFloat();
 
-        TDuration rtt = timing.Total - timing.Server; 
+        TDuration rtt = timing.Total - timing.Server;
         RttMax = std::max(RttMax, rtt);
         RttMin = std::min(RttMin, rtt);
         totalRtt += rtt.MillisecondsFloat();
@@ -337,7 +337,7 @@ TMaybe<TQueryBenchmarkResult> SetTimeoutSettings(NQuery::TExecuteQuerySettings& 
 
 TQueryBenchmarkResult ExecuteImpl(const TString& query, TStringBuf expected, NQuery::TQueryClient& client, const TQueryBenchmarkSettings& benchmarkSettings, bool explainOnly) {
     NQuery::TExecuteQuerySettings settings;
-    settings.StatsMode(NQuery::EStatsMode::Full);
+    settings.StatsMode(benchmarkSettings.StatsMode.value_or(NQuery::EStatsMode::Profile));
     settings.ExecMode(explainOnly ? NQuery::EExecMode::Explain : NQuery::EExecMode::Execute);
     if (benchmarkSettings.WithProgress) {
         settings.StatsCollectPeriod(std::chrono::milliseconds(3000));

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
@@ -110,7 +110,7 @@ struct TQueryBenchmarkSettings {
     std::optional<TString> PlanFileName;
     bool WithProgress = false;
     ETxMode TxMode = ETxMode::SerializableRW;
-    std::optional<NQuery::EStatsMode> StatsMode;
+    NQuery::EStatsMode StatsMode = NQuery::EStatsMode::Full;
     NYdb::NRetry::TRetryOperationSettings RetrySettings;
     // Maximum number of rows to store per result index.
     // Used both for CompareWithExpected and for output.

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
@@ -110,6 +110,7 @@ struct TQueryBenchmarkSettings {
     std::optional<TString> PlanFileName;
     bool WithProgress = false;
     ETxMode TxMode = ETxMode::SerializableRW;
+    std::optional<NQuery::EStatsMode> StatsMode;
     NYdb::NRetry::TRetryOperationSettings RetrySettings;
     // Maximum number of rows to store per result index.
     // Used both for CompareWithExpected and for output.

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -5,6 +5,7 @@
 #include <ydb/public/lib/ydb_cli/common/plan2svg.h>
 #include <ydb/public/lib/ydb_cli/common/pretty_table.h>
 #include <ydb/public/lib/ydb_cli/common/duration.h>
+#include <ydb/public/lib/ydb_cli/common/query_stats.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -106,7 +107,10 @@ void TWorkloadCommandBenchmark::Config(TConfig& config) {
         .StoreResult(&Threads).DefaultValue(Threads).RequiredArgument("COUNT");
 
     config.Opts->AddLongOption("tx-mode", TStringBuilder() << "Transaction mode (" << GetEnumAllNames<BenchmarkUtils::ETxMode>() << ")")
-        .RequiredArgument("STRING").StoreResult(&TxMode).DefaultValue(TxMode);
+        .RequiredArgument("VAL").StoreResult(&TxMode).DefaultValue(TxMode);
+
+    config.Opts->AddLongOption("stats", "Collect statistics mode [full, profile]")
+        .RequiredArgument("VAL").StoreResult(&CollectStatsMode);
 }
 
 TString TWorkloadCommandBenchmark::PatchQuery(const TStringBuf& original) const {
@@ -658,6 +662,12 @@ BenchmarkUtils::TQueryBenchmarkSettings TWorkloadCommandBenchmark::GetBenchmarkS
     if (requestDeadline < result.Deadline.Deadline) {
         result.Deadline.Deadline = requestDeadline;
         result.Deadline.Name = "Request";
+    }
+    if (CollectStatsMode) {
+        result.StatsMode = ParseQueryStatsModeOrThrow(CollectStatsMode, NQuery::EStatsMode::None);
+        if (result.StatsMode < NQuery::EStatsMode::Full) {
+            throw TMisuseException() << "Stats collection mode can't be less than [full] in benchmark mode";
+        }
     }
     return result;
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -109,8 +109,13 @@ void TWorkloadCommandBenchmark::Config(TConfig& config) {
     config.Opts->AddLongOption("tx-mode", TStringBuilder() << "Transaction mode (" << GetEnumAllNames<BenchmarkUtils::ETxMode>() << ")")
         .RequiredArgument("VAL").StoreResult(&TxMode).DefaultValue(TxMode);
 
-    config.Opts->AddLongOption("stats", "Collect statistics mode [full, profile]")
-        .RequiredArgument("VAL").StoreResult(&CollectStatsMode);
+    config.Opts->AddLongOption("stats", TStringBuilder() << "Collect statistics mode (full, profile)")
+        .RequiredArgument("VAL").Handler([&](const TStringBuf option) {
+            StatsMode = ParseQueryStatsModeOrThrow(TString(option), StatsMode);
+            if (StatsMode < NQuery::EStatsMode::Full) {
+                throw TMisuseException() << "Stats collection mode can't be less than [full] in benchmark mode";
+            }
+        });
 }
 
 TString TWorkloadCommandBenchmark::PatchQuery(const TStringBuf& original) const {
@@ -653,6 +658,7 @@ BenchmarkUtils::TQueryBenchmarkSettings TWorkloadCommandBenchmark::GetBenchmarkS
     BenchmarkUtils::TQueryBenchmarkSettings result;
     result.WithProgress = withProgress;
     result.TxMode = TxMode;
+    result.StatsMode = StatsMode;
     result.RetrySettings = RetrySettings;
     if (GlobalDeadline != TInstant::Max()) {
         result.Deadline.Deadline = GlobalDeadline;
@@ -662,12 +668,6 @@ BenchmarkUtils::TQueryBenchmarkSettings TWorkloadCommandBenchmark::GetBenchmarkS
     if (requestDeadline < result.Deadline.Deadline) {
         result.Deadline.Deadline = requestDeadline;
         result.Deadline.Name = "Request";
-    }
-    if (CollectStatsMode) {
-        result.StatsMode = ParseQueryStatsModeOrThrow(CollectStatsMode, NQuery::EStatsMode::None);
-        if (result.StatsMode < NQuery::EStatsMode::Full) {
-            throw TMisuseException() << "Stats collection mode can't be less than [full] in benchmark mode";
-        }
     }
     return result;
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -109,12 +109,16 @@ void TWorkloadCommandBenchmark::Config(TConfig& config) {
     config.Opts->AddLongOption("tx-mode", TStringBuilder() << "Transaction mode (" << GetEnumAllNames<BenchmarkUtils::ETxMode>() << ")")
         .RequiredArgument("VAL").StoreResult(&TxMode).DefaultValue(TxMode);
 
-    config.Opts->AddLongOption("stats", TStringBuilder() << "Collect statistics mode (full, profile)")
+    config.Opts->AddLongOption("stats", TStringBuilder() << "Collect statistics mode")
         .RequiredArgument("VAL").Handler([&](const TStringBuf option) {
             StatsMode = ParseQueryStatsModeOrThrow(TString(option), StatsMode);
             if (StatsMode < NQuery::EStatsMode::Full) {
                 throw TMisuseException() << "Stats collection mode can't be less than [full] in benchmark mode";
             }
+        })
+        .ChoicesWithCompletion({
+            {"full", "Full"},
+            {"profile", "Profile"},
         });
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -31,7 +31,7 @@ private:
     class TIterationExecution;
     TString OutFilePath;
     ETxMode TxMode = ETxMode::SerializableRW;
-    TString CollectStatsMode;
+    NQuery::EStatsMode StatsMode = NQuery::EStatsMode::Full;
     ui32 IterationsCount;
     TString JsonReportFileName;
     TString CsvReportFileName;

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -31,6 +31,7 @@ private:
     class TIterationExecution;
     TString OutFilePath;
     ETxMode TxMode = ETxMode::SerializableRW;
+    TString CollectStatsMode;
     ui32 IterationsCount;
     TString JsonReportFileName;
     TString CsvReportFileName;

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -1,4 +1,6 @@
 #include "ydb_workload.h"
+
+#include <ydb/public/lib/ydb_cli/common/query_stats.h>
 #include "ydb_workload_import.h"
 #include "ydb_workload_tpcc.h"
 #include "ydb_workload_testshard.h"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).

### Changelog category <!-- remove all except one -->

* User Interface

### Description for reviewers <!-- (optional) description for those who read this PR -->

User can now override StatsMode for TWorkloadCommandBenchmark workloads. It can't be less than Full though, so only Full and Profile options are actually available.