### PR TITLE
Fix Coverity 119948: remove std::move from const-ref parameter key

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session.cpp
@@ -1968,7 +1968,7 @@ bool TSimpleBlockingKeyedWriteSession::Write(const std::string& key, TWriteMessa
     }
 
     auto seqNo = message.SeqNo_;
-    Writer->Write(std::move(*continuationToken), std::move(key), std::move(message), tx);
+    Writer->Write(std::move(*continuationToken), key, std::move(message), tx);
     return WaitForAck(seqNo, blockTimeout);
 }
 


### PR DESCRIPTION
Fix Coverity defect 119948: Using a moved object in write_session.cpp