### PR TITLE
Use secure proto printer when needed

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -2,6 +2,7 @@
 #include "node_warden_impl.h"
 #include <ydb/core/mind/dynamic_nameserver.h>
 #include <ydb/core/protos/bridge.pb.h>
+#include <ydb/library/protobuf_printer/security_printer.h>
 #include <ydb/library/yaml_config/yaml_config_helpers.h>
 #include <ydb/library/yaml_config/yaml_config.h>
 #include <library/cpp/streams/zstd/zstd.h>
@@ -591,7 +592,7 @@ namespace NKikimr::NStorage {
             bridgeInfo->SelfNodePile = &bridgeInfo->Piles[it->second.GetPileIndex()];
         }
 
-        Y_VERIFY_S(bridgeInfo->SelfNodePile, "SelfNodeId# " << SelfNode.NodeId() << " Config# " << SingleLineProto(config));
+        Y_VERIFY_S(bridgeInfo->SelfNodePile, "SelfNodeId# " << SelfNode.NodeId() << " Config# " << NKikimr::SecureDebugString(config));
 
         Y_ABORT_UNLESS(config.HasClusterState());
         const NKikimrBridge::TClusterState& state = config.GetClusterState();

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -2,6 +2,8 @@
 #include "distconf_quorum.h"
 #include "distconf_invoke.h"
 
+#include <ydb/library/protobuf_printer/security_printer.h>
+
 namespace NKikimr::NStorage {
 
     void TDistributedConfigKeeper::UpdateQuorums() {
@@ -718,8 +720,8 @@ namespace NKikimr::NStorage {
                 configToPropose->SetGeneration(propositionBase->GetGeneration() + 1);
             } else {
                 Y_VERIFY_S(propositionBase->GetGeneration() < configToPropose->GetGeneration(),
-                    "PropositionBase# " << SingleLineProto(*propositionBase)
-                    << " ConfigToPropose# " << SingleLineProto(*configToPropose));
+                    "PropositionBase# " << NKikimr::SecureDebugString(*propositionBase)
+                    << " ConfigToPropose# " << NKikimr::SecureDebugString(*configToPropose));
             }
 
             configToPropose->MutablePrevConfig()->CopyFrom(*propositionBase);
@@ -744,8 +746,8 @@ namespace NKikimr::NStorage {
             }
             if (auto error = ValidateConfigUpdate(*propositionBase, *configToPropose)) {
                 return TStringBuilder() << "incorrect config proposed: " << *error
-                    << " Base# " << SingleLineProto(*propositionBase)
-                    << " Proposed# " << SingleLineProto(*configToPropose);
+                    << " Base# " << NKikimr::SecureDebugString(*propositionBase)
+                    << " Proposed# " << NKikimr::SecureDebugString(*configToPropose);
             }
         } else if (auto error = ValidateConfig(*configToPropose)) {
             return TStringBuilder() << "incorrect config proposed: " << *error;

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -62,6 +62,7 @@ PEERDIR(
     ydb/core/blobstorage/vdisk
     ydb/core/control/lib
     ydb/library/pdisk_io
+    ydb/library/protobuf_printer
     ydb/library/yaml_config
 )
 

--- a/ydb/core/grpc_services/grpc_helper.h
+++ b/ydb/core/grpc_services/grpc_helper.h
@@ -35,7 +35,9 @@ inline TCreateLimiterCB CreateLimiterCb(TIntrusivePtr<TInFlightLimiterRegistry> 
     return TCreateLimiterCB(limiterRegistry);
 }
 
-template <typename TIn, typename TOut, typename TService, typename TInProtoPrinter=google::protobuf::TextFormat::Printer, typename TOutProtoPrinter=google::protobuf::TextFormat::Printer>
+template <typename TIn, typename TOut, typename TService,
+    typename TInProtoPrinter = ::NKikimr::TSecurityTextFormatPrinter<TIn>,
+    typename TOutProtoPrinter = ::NKikimr::TSecurityTextFormatPrinter<TOut>>
 using TGRpcRequest = NYdbGrpc::TGRpcRequest<TIn, TOut, TService, TInProtoPrinter, TOutProtoPrinter>;
 
 } // namespace NGRpcService

--- a/ydb/library/grpc/actor_client/grpc_service_client.h
+++ b/ydb/library/grpc/actor_client/grpc_service_client.h
@@ -2,6 +2,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/protobuf_printer/security_printer.h>
 #include <library/cpp/digest/crc32c/crc32c.h>
 #include <ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h>
 #include <ydb/library/services/services.pb.h>
@@ -44,7 +45,7 @@ class TGrpcServiceClient  {
     template <typename TProtoMessageType>
     static TString Trim(const TProtoMessageType& message) {
         TStringBuilder log;
-        log << message.GetDescriptor()->name() << " { " << Trim(message.ShortDebugString()) << " }";
+        log << message.GetDescriptor()->name() << " { " << Trim(NKikimr::SecureDebugString(message)) << " }";
         return log;
     }
 

--- a/ydb/library/grpc/actor_client/ya.make
+++ b/ydb/library/grpc/actor_client/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/library/actors/core
     ydb/core/util
     library/cpp/digest/crc32c
+    ydb/library/protobuf_printer
     ydb/public/sdk/cpp/src/library/grpc/client
     ydb/library/services
 

--- a/ydb/library/protobuf_printer/protobuf_printer_ut.cpp
+++ b/ydb/library/protobuf_printer/protobuf_printer_ut.cpp
@@ -91,6 +91,34 @@ Y_UNIT_TEST_SUITE(SecurityPrinterTest) {
             UNIT_ASSERT_STRINGS_EQUAL(s, "name: \"name1\" login: \"***\" types { login: \"***\" } types { name: \"name3\" } ");
         }
     }
+
+    Y_UNIT_TEST(SecureDebugStringViaMessageRefSingleLine) {
+        NTestProto::TConnectionContent m;
+        m.set_name("name1");
+        m.mutable_setting()->mutable_connection2()->set_login("login1");
+        m.mutable_setting()->mutable_connection2()->set_password("pswd");
+        const google::protobuf::Message& ref = m;
+        const TString s = SecureDebugString(ref);
+        UNIT_ASSERT_STRINGS_EQUAL(s, "name: \"name1\" setting { connection2 { login: \"***\" password: \"***\" } } ");
+    }
+
+    Y_UNIT_TEST(SecureDebugStringMultilineViaMessageRef) {
+        NTestProto::TConnectionContent m;
+        m.set_name("name1");
+        m.mutable_setting()->mutable_connection2()->set_login("login1");
+        m.mutable_setting()->mutable_connection2()->set_password("pswd");
+        const google::protobuf::Message& ref = m;
+        const TString s = SecureDebugStringMultiline(ref);
+        const TString expected =
+            "name: \"name1\"\n"
+            "setting {\n"
+            "  connection2 {\n"
+            "    login: \"***\"\n"
+            "    password: \"***\"\n"
+            "  }\n"
+            "}\n";
+        UNIT_ASSERT_STRINGS_EQUAL(s, expected);
+    }
 }
 
 Y_UNIT_TEST_SUITE(FieldSizePrinterTest) {

--- a/ydb/library/protobuf_printer/security_printer.cpp
+++ b/ydb/library/protobuf_printer/security_printer.cpp
@@ -1,0 +1,25 @@
+#include "security_printer.h"
+
+namespace NKikimr {
+
+namespace {
+
+TString SecureDebugStringMessageImpl(const google::protobuf::Message& message, bool singleLine) {
+    TString result;
+    TSecurityTextFormatPrinterBase printer(message.GetDescriptor());
+    printer.SetSingleLineMode(singleLine);
+    printer.PrintToString(message, &result);
+    return result;
+}
+
+} // namespace
+
+TString SecureDebugString(const google::protobuf::Message& message) {
+    return SecureDebugStringMessageImpl(message, true);
+}
+
+TString SecureDebugStringMultiline(const google::protobuf::Message& message) {
+    return SecureDebugStringMessageImpl(message, false);
+}
+
+} // namespace NKikimr

--- a/ydb/library/protobuf_printer/security_printer.h
+++ b/ydb/library/protobuf_printer/security_printer.h
@@ -48,6 +48,9 @@ public:
     {}
 };
 
+TString SecureDebugString(const google::protobuf::Message& message);
+TString SecureDebugStringMultiline(const google::protobuf::Message& message);
+
 template <typename TMsg>
 inline TString SecureDebugString(const TMsg& message) {
     TString result;

--- a/ydb/library/protobuf_printer/ya.make
+++ b/ydb/library/protobuf_printer/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     hide_field_printer.cpp
+    security_printer.cpp
     size_printer.cpp
     stream_helper.cpp
     token_field_printer.cpp

--- a/ydb/tests/functional/blobstorage/test_security_token_not_in_logs.py
+++ b/ydb/tests/functional/blobstorage/test_security_token_not_in_logs.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time
+import uuid
+
+import grpc
+import pytest
+
+from ydb.core.protos import grpc_pb2_grpc, msgbus_pb2
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.util import LogLevels
+
+BLOB_STORAGE_CONFIG_MARKER = 'NKikimrClient.TGRpcServer/BlobStorageConfig'
+
+
+@pytest.fixture(scope='module')
+def cluster(tmp_path_factory):
+    work_dir = tmp_path_factory.mktemp('kikimr_grpc_log')
+    config = KikimrConfigGenerator(
+        additional_log_configs={'GRPC_SERVER': LogLevels.DEBUG},
+        use_log_files=True,
+        output_path=str(work_dir),
+    )
+    cluster = KiKiMR(configurator=config)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
+def test_blob_storage_config_security_token_not_logged_plaintext(cluster):
+    # We need minimally filled request to trigger initial logging
+    req = msgbus_pb2.TBlobStorageConfigRequest()
+    req.SecurityToken = 'YDB_SENSITIVE_LEAK_' + uuid.uuid4().hex
+
+    node = cluster.nodes[1]
+    log_path = node.ydbd_log_file_path
+    assert log_path, 'use_log_files must set ydbd log path'
+    target = '{}:{}'.format(node.host, node.grpc_port)
+    with grpc.insecure_channel(target) as channel:
+        stub = grpc_pb2_grpc.TGRpcServerStub(channel)
+        stub.BlobStorageConfig(req, timeout=60)
+
+    deadline = time.time() + 30.0
+    found = False
+    while time.time() < deadline:
+        with open(log_path, 'rb') as f:
+            combined = f.read().decode('utf-8', errors='replace')
+        if BLOB_STORAGE_CONFIG_MARKER in combined and 'SecurityToken' in combined:
+            found = True
+            assert req.SecurityToken not in combined, 'SecurityToken plaintext leaked into ydbd log'
+            break
+        time.sleep(0.2)
+
+    assert found, 'Expected log line was not found in GRPC_SERVER request log'

--- a/ydb/tests/functional/blobstorage/ya.make
+++ b/ydb/tests/functional/blobstorage/ya.make
@@ -2,6 +2,7 @@ PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 TEST_SRCS(
+    test_security_token_not_in_logs.py
     test_pdisk_format_info.py
     test_pdisk_slot_size_in_units.py
     test_replication.py

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -161,6 +161,11 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
         return self.__working_dir
 
     @property
+    def ydbd_log_file_path(self):
+        """Absolute path passed to ydbd --log-file-name when use_log_files is set; otherwise None."""
+        return self.__log_file_name
+
+    @property
     def binary_path(self):
         return self.__binary_path
 


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
У нас есть Ydb.sensitive разметка. Печать SecureDebugString её уважает и маскирует.
Чиним то, что где-то мог выводиться SecurityToken в дебажные логи. Сейчас будет логироваться так
```
2026-04-09T13:51:13.633079Z :GRPC_SERVER DEBUG: logger.cpp:36: [0x30ddf1e9ee00] received request Name# NKikimrClient.TGRpcServer/BlobStorageConfig ok# true data# Domain: 1 Request { Command { QueryBaseConfig { } } Rollback: true } SecurityToken: "***"  peer# ipv4:127.0.0.1:53928
```

Так же прошёлся по местам печати и подозрительные места поменял.