### PR TITLE
Fix Coverity 120624: use-after-move of *msg object

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
@@ -610,7 +610,8 @@ void TICStorageTransportActor::HandleListPersistentBuffer(
         msg->RequestId
     );
 
-    ListPersistentBufferEventsByRequestId.emplace(msg->RequestId, std::move(*msg));
+    auto requestId = msg->RequestId;
+    ListPersistentBufferEventsByRequestId.emplace(requestId, std::move(*msg));
 }
 
 void TICStorageTransportActor::HandleListPersistentBufferResult(


### PR DESCRIPTION
Fix Coverity defect 120624: Using a moved object in ic_storage_transport.cpp