### PR TITLE
support cloud auth for CREATE EXTERNAL DATA SOURCE (yql part)

### DIFF
--- a/yql/essentials/providers/common/structured_token/ut/yql_token_builder_ut.cpp
+++ b/yql/essentials/providers/common/structured_token/ut/yql_token_builder_ut.cpp
@@ -12,6 +12,7 @@ Y_UNIT_TEST(Empty) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
 }
 
@@ -24,6 +25,7 @@ Y_UNIT_TEST(ServiceAccountId) {
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
     UNIT_ASSERT(!p.IsNoAuth());
+    UNIT_ASSERT(!p.HasIamAuth());
     TString id, sign;
     UNIT_ASSERT(p.GetServiceAccountIdAuth(id, sign));
     UNIT_ASSERT_VALUES_EQUAL(id, "my_sa_id");
@@ -38,6 +40,7 @@ Y_UNIT_TEST(ServiceAccountIdWithSecret) {
     UNIT_ASSERT(p.HasServiceAccountIdAuth());
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
     TString id, sign, reference;
     UNIT_ASSERT(p.GetServiceAccountIdAuth(id, sign, reference));
@@ -62,6 +65,7 @@ Y_UNIT_TEST(BasicAuth) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
     TString login, password;
     UNIT_ASSERT(p.GetBasicAuth(login, password));
@@ -77,6 +81,7 @@ Y_UNIT_TEST(BasicAuthWithSecret) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
     TString login, password, reference;
     UNIT_ASSERT(p.GetBasicAuth(login, password, reference));
@@ -103,6 +108,7 @@ Y_UNIT_TEST(TokenAuthWithSecret) {
     UNIT_ASSERT(p.HasIAMToken());
     UNIT_ASSERT(!p.HasTransientToken());
     UNIT_ASSERT(!p.IsNoAuth());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(p.GetIAMToken() == "my_token");
     TSet<TString> references;
     p.ListReferences(references);
@@ -123,6 +129,7 @@ Y_UNIT_TEST(IAMToken) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
     TString token = p.GetIAMToken();
     UNIT_ASSERT_VALUES_EQUAL(token, "my_token");
@@ -137,6 +144,7 @@ Y_UNIT_TEST(TransientToken) {
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
     UNIT_ASSERT(p.HasTransientToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
     TSet<TString> references;
     p.ListReferences(references);
@@ -156,6 +164,7 @@ Y_UNIT_TEST(NoAuth) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(!p.HasBasicAuth());
     UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(p.IsNoAuth());
 }
 
@@ -168,6 +177,7 @@ Y_UNIT_TEST(BasicAuthAndToken) {
     UNIT_ASSERT(!p.HasServiceAccountIdAuth());
     UNIT_ASSERT(p.HasBasicAuth());
     UNIT_ASSERT(p.HasIAMToken());
+    UNIT_ASSERT(!p.HasIamAuth());
     UNIT_ASSERT(!p.IsNoAuth());
 
     TString login, password;
@@ -177,6 +187,22 @@ Y_UNIT_TEST(BasicAuthAndToken) {
 
     TString token = p.GetIAMToken();
     UNIT_ASSERT_VALUES_EQUAL(token, "my_token");
+}
+
+Y_UNIT_TEST(IamAuth) {
+    TStructuredTokenBuilder b;
+    b.SetIamAuth("my_sa_id", "my_resource");
+    UNIT_ASSERT_VALUES_EQUAL(R"({"iam_resource_id":"my_resource","iam_sa_id":"my_sa_id"})", b.ToJson());
+    const TStructuredTokenParser p = CreateStructuredTokenParser(b.ToJson());
+    UNIT_ASSERT(!p.HasServiceAccountIdAuth());
+    UNIT_ASSERT(!p.HasBasicAuth());
+    UNIT_ASSERT(!p.HasIAMToken());
+    UNIT_ASSERT(!p.IsNoAuth());
+    UNIT_ASSERT(p.HasIamAuth());
+    TString id, res;
+    UNIT_ASSERT(p.GetIamAuth(id, res));
+    UNIT_ASSERT_VALUES_EQUAL(id, "my_sa_id");
+    UNIT_ASSERT_VALUES_EQUAL(res, "my_resource");
 }
 
 Y_UNIT_TEST(ComposeForBasicAuth) {
@@ -203,6 +229,18 @@ Y_UNIT_TEST(ComposeForTransientTokenAuth) {
 
     TString json2 = ComposeStructuredTokenJsonForTransientTokenAuth("");
     UNIT_ASSERT_VALUES_EQUAL(json2, R"({"no_auth":""})");
+}
+
+Y_UNIT_TEST(ComposeForIamAuth) {
+    TStructuredTokenBuilder b;
+    TString json1 = ComposeStructuredTokenJsonForIamAuth("my_sa_id", "my_resource");
+    UNIT_ASSERT_VALUES_EQUAL(json1, R"({"iam_resource_id":"my_resource","iam_sa_id":"my_sa_id"})");
+
+    TString json2 = ComposeStructuredTokenJsonForIamAuth("my_sa_id", "");
+    UNIT_ASSERT_VALUES_EQUAL(json2, R"({"no_auth":""})");
+
+    TString json3 = ComposeStructuredTokenJsonForIamAuth("", "my_resource");
+    UNIT_ASSERT_VALUES_EQUAL(json3, R"({"no_auth":""})");
 }
 
 } // Y_UNIT_TEST_SUITE(TokenBuilderTest)

--- a/yql/essentials/providers/common/structured_token/yql_token_builder.cpp
+++ b/yql/essentials/providers/common/structured_token/yql_token_builder.cpp
@@ -34,6 +34,12 @@ TStructuredTokenBuilder& TStructuredTokenBuilder::SetBasicAuthWithSecret(const T
     return *this;
 }
 
+TStructuredTokenBuilder& TStructuredTokenBuilder::SetIamAuth(const TString& serviceAccountId, const TString& resourceId) {
+    Data_.SetField("iam_sa_id", serviceAccountId);
+    Data_.SetField("iam_resource_id", resourceId);
+    return *this;
+}
+
 TStructuredTokenBuilder& TStructuredTokenBuilder::SetTokenAuthWithSecret(const TString& tokenReference, const TString& token) {
     Data_.SetField("token_ref", tokenReference);
     Data_.SetField("token", token);
@@ -147,6 +153,16 @@ bool TStructuredTokenParser::IsNoAuth() const {
     return Data_.HasField("no_auth");
 }
 
+bool TStructuredTokenParser::GetIamAuth(TString& serviceAccountId, TString& resourceId) const {
+    serviceAccountId = Data_.GetField("iam_sa_id");
+    resourceId = Data_.GetField("iam_resource_id");
+    return true;
+}
+
+bool TStructuredTokenParser::HasIamAuth() const {
+    return Data_.HasField("iam_sa_id") && Data_.HasField("iam_resource_id");
+}
+
 void TStructuredTokenParser::ListReferences(TSet<TString>& references) const {
     if (Data_.HasField("basic_password_ref")) {
         references.insert(Data_.GetField("basic_password_ref"));
@@ -238,6 +254,18 @@ TString ComposeStructuredTokenJsonForTransientTokenAuth(const TString& transient
 
     if (transientToken) {
         result.SetTransientTokenAuth(transientToken);
+        return result.ToJson();
+    }
+
+    result.SetNoAuth();
+    return result.ToJson();
+}
+
+TString ComposeStructuredTokenJsonForIamAuth(const TString& serviceAccountId, const TString& resourceId) {
+    TStructuredTokenBuilder result;
+
+    if (serviceAccountId && resourceId) {
+        result.SetIamAuth(serviceAccountId, resourceId);
         return result.ToJson();
     }
 

--- a/yql/essentials/providers/common/structured_token/yql_token_builder.h
+++ b/yql/essentials/providers/common/structured_token/yql_token_builder.h
@@ -19,6 +19,7 @@ public:
     TStructuredTokenBuilder& SetTokenAuthWithSecret(const TString& tokenReference, const TString& token);
     TStructuredTokenBuilder& SetTransientTokenAuth(const TString& transientToken);
     TStructuredTokenBuilder& SetIAMToken(const TString& token);
+    TStructuredTokenBuilder& SetIamAuth(const TString& serviceAccountId, const TString& resourceId);
     TStructuredTokenBuilder& SetNoAuth();
     TStructuredTokenBuilder& ReplaceReferences(const std::map<TString, TString>& secrets);
     TStructuredTokenBuilder& RemoveSecrets();
@@ -38,6 +39,8 @@ public:
     bool HasBasicAuth() const;
     bool GetBasicAuth(TString& login, TString& password) const;
     bool GetBasicAuth(TString& login, TString& password, TString& passwordReference) const;
+    bool GetIamAuth(TString& serviceAccountId, TString& resourceId) const;
+    bool HasIamAuth() const;
     bool HasIAMToken() const;
     bool HasTransientToken() const;
     TString GetIAMToken() const;
@@ -58,5 +61,6 @@ TString ComposeStructuredTokenJsonForBasicAuth(const TString& login, const TStri
 TString ComposeStructuredTokenJsonForBasicAuthWithSecret(const TString& login, const TString& passwordSecretName, const TString& password);
 TString ComposeStructuredTokenJsonForTokenAuthWithSecret(const TString& tokenSecretName, const TString& token);
 TString ComposeStructuredTokenJsonForTransientTokenAuth(const TString& transientToken);
+TString ComposeStructuredTokenJsonForIamAuth(const TString& serviceAccountId, const TString& resourceId);
 
 } // namespace NYql

--- a/yql/essentials/sql/v1/secret_settings.cpp
+++ b/yql/essentials/sql/v1/secret_settings.cpp
@@ -162,6 +162,11 @@ bool ValidateExternalDataSourceAuthMethod(const std::map<TString, TDeferredAtom>
                               TSecretSettingsNames("service_account_secret"),
                               TSecretSettingsNames("password_secret"),
                           })},
+        {"IAM", TExternalDataSourceAuthFields(
+                    {"service_account_id"},
+                    {
+                        TSecretSettingsNames("initial_token_secret"),
+                    })},
         {"TOKEN", TExternalDataSourceAuthFields(
                       {},
                       {

--- a/yql/essentials/sql/v1/secret_settings.h
+++ b/yql/essentials/sql/v1/secret_settings.h
@@ -26,6 +26,7 @@ static const TVector<TSecretSettingsNames> EDS_SECRETS_SETTINGS = {
     TSecretSettingsNames("service_account_secret"),
     TSecretSettingsNames("aws_access_key_id_secret"),
     TSecretSettingsNames("aws_secret_access_key_secret"),
+    TSecretSettingsNames("initial_token_secret"),
 };
 
 static const TVector<TSecretSettingsNames> REPLICATION_AND_TRANSFER_SECRETS_SETTINGS = {


### PR DESCRIPTION
structured token will require service_account_id and resource_id and AUTH_METHOD=IAM will require SERVICE_ACCOUNT_ID and INITIAL_TOKEN_SECRET[_NAME|_PATH]

Initial token is used on EDS creation for resolving resource_id/cloud_id and verifying database access, then service_account_id and resource_id will be used for delegated token issue

(about same as used for async replication)
commit_hash:3eec95e2dea61654a1939bd92549222f752d9654

(cherry picked from commit 64946a27145a742708a8ad1d705142e35ba66c49)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
