### PR TITLE
remove ussless check

### DIFF
--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
@@ -110,7 +110,7 @@ TConclusionStatus TBloomIndexMeta::DoCheckModificationCompatibility(const IIndex
         return TConclusionStatus::Fail(
             "cannot read meta as appropriate class: " + GetClassName() + ". Meta said that class name is " + newMeta.GetClassName());
     }
-    AFL_VERIFY(FalsePositiveProbability < 1 && FalsePositiveProbability >= 0.01);
+
     return TBase::CheckSameColumnsForModification(newMeta);
 }
 
@@ -153,7 +153,6 @@ void TBloomIndexMeta::Initialize() {
     std::vector<std::shared_ptr<arrow::Field>> fields = { std::make_shared<arrow::Field>(
         "", arrow::TypeTraits<arrow::BooleanType>::type_singleton()) };
     ResultSchema = std::make_shared<arrow::Schema>(fields);
-    AFL_VERIFY(FalsePositiveProbability < 1 && FalsePositiveProbability >= 0.01);
     HashesCount = -1 * std::log(FalsePositiveProbability) / std::log(2);
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

У нас теперь есть проверка в constructor.cpp, поэтому эта проверка не валидная

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
