### PR TITLE
DqHashCombineExportTypeInfo pragma to support auto-analysis of benchmark suite plans

### DIFF
--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole.cpp
@@ -207,6 +207,7 @@ public:
     TKqpPeepholeNewOperatorTransformer(TTypeAnnotationContext& ctx, TKikimrConfiguration::TPtr config)
         : TOptimizeTransformerBase(&ctx, NYql::NLog::EComponent::ProviderKqp, {})
         , DqHashOperatorsUseBlocks(config->GetDqHashOperatorsUseBlocks())
+        , DqHashCombineExportTypeInfo(config->GetDqHashCombineExportTypeInfo())
     {
 #define HNDL(name) "KqpPeepholeNewOperator-"#name, Hndl(&TKqpPeepholeNewOperatorTransformer::name)
         if (config->GetUseDqHashCombine()) {
@@ -219,19 +220,20 @@ public:
     }
 
     TMaybeNode<TExprBase> RewriteWideCombinerToDqHashCombiner(TExprBase node, TExprContext& ctx) {
-        TExprBase output = DqPeepholeRewriteWideCombinerToDqHashCombiner(node, ctx, DqHashOperatorsUseBlocks);
+        TExprBase output = DqPeepholeRewriteWideCombinerToDqHashCombiner(node, ctx, DqHashOperatorsUseBlocks, DqHashCombineExportTypeInfo);
         DumpAppliedRule(__func__, node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 
     TMaybeNode<TExprBase> RewriteWideCombinerToDqHashAggregator(TExprBase node, TExprContext& ctx) {
-        TExprBase output = DqPeepholeRewriteWideCombinerToDqHashAggregator(node, ctx, DqHashOperatorsUseBlocks);
+        TExprBase output = DqPeepholeRewriteWideCombinerToDqHashAggregator(node, ctx, DqHashOperatorsUseBlocks, DqHashCombineExportTypeInfo);
         DumpAppliedRule(__func__, node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 
 private:
     bool DqHashOperatorsUseBlocks;
+    bool DqHashCombineExportTypeInfo;
 };
 
 class TKqpPeepholeBlockPackUnpackTransformer : public TOptimizeTransformerBase {

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -105,6 +105,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, UseDqHashCombine);
     REGISTER_SETTING(*this, UseDqHashAggregate);
     REGISTER_SETTING(*this, DqHashOperatorsUseBlocks);
+    REGISTER_SETTING(*this, DqHashCombineExportTypeInfo);
 
     REGISTER_SETTING(*this, OptUseFinalizeByKey);
     REGISTER_SETTING(*this, CostBasedOptimizationLevel);
@@ -294,6 +295,10 @@ NYql::EBackportCompatibleFeaturesMode TKikimrConfiguration::GetYqlBackportMode()
 
 bool TKikimrConfiguration::GetUseDqHashAggregate() const {
     return UseDqHashAggregate.Get().GetOrElse(TTableServiceConfig::GetEnableDqHashAggregateByDefault());
+}
+
+bool TKikimrConfiguration::GetDqHashCombineExportTypeInfo() const {
+    return GetFlagValue(DqHashCombineExportTypeInfo.Get());
 }
 
 bool TKikimrConfiguration::GetDqHashOperatorsUseBlocks() const {

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -69,6 +69,7 @@ public:
     NCommon::TConfSetting<bool, Static> UseDqHashCombine;
     NCommon::TConfSetting<bool, Static> UseDqHashAggregate;
     NCommon::TConfSetting<bool, Static> DqHashOperatorsUseBlocks;
+    NCommon::TConfSetting<bool, Static> DqHashCombineExportTypeInfo;
 
     NCommon::TConfSetting<TString, Static> OptOverrideStatistics;
     NCommon::TConfSetting<NKikimr::NKqp::TOptimizerHints, Static> OptimizerHints;
@@ -212,6 +213,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool GetUseDqHashCombine() const;
     bool GetUseDqHashAggregate() const;
     bool GetDqHashOperatorsUseBlocks() const;
+    bool GetDqHashCombineExportTypeInfo() const;
     bool GetUseBlockHashJoin() const;
 };
 

--- a/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
@@ -1079,8 +1079,13 @@ TExprBase DqPeepholeRewriteBlockHashJoin(const TExprBase& node, TExprContext& ct
     return TExprBase(result);
 }
 
-NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, TExprContext& ctx, const bool rewritingFinalAggregator, const bool useBlocks)
-{
+NNodes::TExprBase DqPeepholeRewriteWideCombiner(
+    const NNodes::TExprBase& node,
+    TExprContext& ctx,
+    const bool rewritingFinalAggregator,
+    const bool useBlocks,
+    const bool exportTypeInfo
+) {
     if (!node.Maybe<TCoWideCombiner>()) {
         return node;
     }
@@ -1122,10 +1127,33 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, T
         outputIsFlow = *outputKind;
     }
 
+    auto expandTypeAnnFromNode = [&](const NNodes::TExprBase& src) -> TExprNode::TPtr {
+        if (const TTypeAnnotationNode* typeAnn; src.Ptr() && (typeAnn = src.Ptr()->GetTypeAnn())) {
+            return ExpandType(node.Pos(), *typeAnn, ctx);
+        } else {
+            return ctx.NewList(node.Pos(), {});
+        }
+    };
+
+    auto exportTypeAnnotations = [&](TDqPhyHashCombine& dest, const NNodes::TExprBase& input) -> void {
+        if (!exportTypeInfo) {
+            return;
+        }
+
+        auto children = dest.Ptr()->ChildrenList();
+        TExprNode::TListType typeInfos;
+        typeInfos.push_back(expandTypeAnnFromNode(input));
+        typeInfos.push_back(expandTypeAnnFromNode(wideCombiner.KeyExtractor()));
+        typeInfos.push_back(expandTypeAnnFromNode(wideCombiner.InitHandler()));
+        typeInfos.push_back(expandTypeAnnFromNode(dest));
+        children.push_back(ctx.NewList(node.Pos(), std::move(typeInfos)));
+        dest.Ptr()->ChangeChildrenInplace(std::move(children));
+    };
+
     bool inputIsBlocks = false;
 
     if (simpleReplace) {
-        return Build<TDqPhyHashCombine>(ctx, node.Pos())
+        auto dqPhyCombine = Build<TDqPhyHashCombine>(ctx, node.Pos())
             .Input(wideCombiner.Input())
             .MemLimit(wideCombiner.MemLimit())
             .KeyExtractor(copyLambda(wideCombiner.KeyExtractor()))
@@ -1133,6 +1161,8 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, T
             .UpdateHandler(copyLambda(wideCombiner.UpdateHandler()))
             .FinishHandler(copyLambda(wideCombiner.FinishHandler()))
         .Done();
+        exportTypeAnnotations(dqPhyCombine, wideCombiner.Input());
+        return dqPhyCombine;
     }
 
     while (input->IsCallable()) {
@@ -1166,6 +1196,8 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, T
         .UpdateHandler(copyLambda(wideCombiner.UpdateHandler()))
         .FinishHandler(copyLambda(wideCombiner.FinishHandler()))
     .Done();
+
+    exportTypeAnnotations(dqPhyCombine, wrappedInput);
 
     auto dqPhyCombinePtr = dqPhyCombine.Ptr();
 
@@ -1205,18 +1237,18 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner(const NNodes::TExprBase& node, T
     return NNodes::TExprBase(dqPhyCombinePtr);
 }
 
-NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashAggregator(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks) {
+NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashAggregator(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks, const bool exportTypeInfo) {
     if (!node.Maybe<TCoWideCombiner>()) {
         return node;
     }
-    return DqPeepholeRewriteWideCombiner(node, ctx, true, useBlocks);
+    return DqPeepholeRewriteWideCombiner(node, ctx, true, useBlocks, exportTypeInfo);
 }
 
-NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashCombiner(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks) {
+NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashCombiner(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks, const bool exportTypeInfo) {
     if (!node.Maybe<TCoWideCombiner>()) {
         return node;
     }
-    return DqPeepholeRewriteWideCombiner(node, ctx, false, useBlocks);
+    return DqPeepholeRewriteWideCombiner(node, ctx, false, useBlocks, exportTypeInfo);
 } // namespace NYql::NDq
 
 }

--- a/ydb/library/yql/dq/opt/dq_opt_peephole.h
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.h
@@ -17,7 +17,7 @@ NNodes::TExprBase DqPeepholeRewriteReplicate(const NNodes::TExprBase& node, TExp
 NNodes::TExprBase DqPeepholeRewritePureJoin(const NNodes::TExprBase& node, TExprContext& ctx);
 NNodes::TExprBase DqPeepholeDropUnusedInputs(const NNodes::TExprBase& node, TExprContext& ctx);
 NNodes::TExprBase DqPeepholeRewriteLength(const NNodes::TExprBase& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx);
-NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashCombiner(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks);
-NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashAggregator(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks);
+NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashCombiner(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks, const bool exportTypeInfo);
+NNodes::TExprBase DqPeepholeRewriteWideCombinerToDqHashAggregator(const NNodes::TExprBase& node, TExprContext& ctx, const bool useBlocks, const bool exportTypeInfo);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -1274,7 +1274,7 @@ TStatus AnnotateDqBlockHashJoinCore(const TExprNode::TPtr& node, TExprContext& c
 }
 
 TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
-    if (!EnsureArgsCount(*input, 6, ctx)) {
+    if (!EnsureMinArgsCount(*input, 6, ctx)) {
         return TStatus::Error;
     }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Support for `pragma DqHashCombineExportTypeInfo = "true"` (false by default); when enabled, exports input/key/state/final types as an extra 4-tuple argument to DqPhyHashCombine in the AST.