### PR TITLE
Fix losing ydb_session_id in cookies in redirected requests (viewer tests)

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -92,7 +92,7 @@
                     }
                 ],
                 "name": "TestAsyncReplication",
-                "owner": "root@builtin",
+                "owner": "root",
                 "type": "REPLICATION"
             }
         }
@@ -182,7 +182,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "table1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TABLE"
                 },
                 {
@@ -191,7 +191,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "topic1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TOPIC"
                 }
             ],
@@ -321,7 +321,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "table1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TABLE"
                 },
                 {
@@ -330,7 +330,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "test_dir",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "DIRECTORY"
                 },
                 {
@@ -339,7 +339,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "topic1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TOPIC"
                 }
             ],
@@ -469,7 +469,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "table1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TABLE"
                 },
                 {
@@ -478,7 +478,7 @@
                         "tx_id": "not-zero-number-text"
                     },
                     "name": "topic1",
-                    "owner": "root@builtin",
+                    "owner": "root",
                     "type": "TOPIC"
                 }
             ],
@@ -734,15 +734,10 @@
         "storage_nodes_database": {
             "FieldsAvailable": "0000010000000110011000000110100000011",
             "FieldsRequired": "0000000000000000000000000000000000011",
-            "FoundNodes": "1",
+            "FoundNodes": "0",
             "MaximumDisksPerNode": "1",
             "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "NodeId": 1
-                }
-            ],
-            "TotalNodes": "1"
+            "TotalNodes": "0"
         },
         "storage_nodes_monitoring": {
             "FieldsAvailable": "0000010000000110011000000110100000011",
@@ -1708,7 +1703,7 @@
                     }
                 ],
                 "name": "TestTransfer",
-                "owner": "root@builtin",
+                "owner": "root",
                 "type": "TRANSFER"
             },
             "source_path": "TestTransferSourceTopic",
@@ -3763,13 +3758,13 @@
             "read": false
         },
         "/Root/dedicated_db": {
-            "read": true
+            "read": false
         },
         "/Root/serverless_db": {
-            "read": true
+            "read": false
         },
         "/Root/shared_db": {
-            "read": true
+            "read": false
         },
         "no-database": {
             "read": false
@@ -4146,7 +4141,7 @@
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
                         "Name": "table1",
-                        "Owner": "root@builtin",
+                        "Owner": "root",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
                         "PathState": 3,
@@ -4268,7 +4263,7 @@
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
                         "Name": "table1",
-                        "Owner": "root@builtin",
+                        "Owner": "root",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
                         "PathState": 3,
@@ -4402,7 +4397,7 @@
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
                         "Name": "table1",
-                        "Owner": "root@builtin",
+                        "Owner": "root",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
                         "PathState": 3,

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -70,25 +70,42 @@ class TestViewer(object):
         return requests.post("http://localhost:%s/login" % cls.cluster.nodes[1].mon_port, json=request)
 
     @classmethod
+    def _split_cookies_from_headers(cls, headers):
+        if not headers or 'Cookie' not in headers:
+            return headers, {}
+        headers = dict(headers)
+        cookie_str = headers.pop('Cookie')
+        cookies = {}
+        for part in cookie_str.split(';'):
+            part = part.strip()
+            if '=' in part:
+                name, value = part.split('=', 1)
+                cookies[name.strip()] = value.strip()
+        return headers, cookies
+
+    @classmethod
     def call_viewer_api_get(cls, url, headers=None):
         if headers is None:
             headers = cls.default_headers
+        headers, cookies = cls._split_cookies_from_headers(headers)
         port = cls.cluster.nodes[1].mon_port
-        return requests.get("http://localhost:%s%s" % (port, url), headers=headers)
+        return requests.get("http://localhost:%s%s" % (port, url), headers=headers, cookies=cookies)
 
     @classmethod
     def call_viewer_api_post(cls, url, body=None, headers=None):
         if headers is None:
             headers = cls.default_headers
+        headers, cookies = cls._split_cookies_from_headers(headers)
         port = cls.cluster.nodes[1].mon_port
-        return requests.post("http://localhost:%s%s" % (port, url), json=body, headers=headers)
+        return requests.post("http://localhost:%s%s" % (port, url), json=body, headers=headers, cookies=cookies)
 
     @classmethod
     def call_viewer_api_delete(cls, url, headers=None):
         if headers is None:
             headers = cls.default_headers
+        headers, cookies = cls._split_cookies_from_headers(headers)
         port = cls.cluster.nodes[1].mon_port
-        return requests.delete("http://localhost:%s%s" % (port, url), headers=headers)
+        return requests.delete("http://localhost:%s%s" % (port, url), headers=headers, cookies=cookies)
 
     @classmethod
     def get_result(cls, result):
@@ -178,6 +195,13 @@ class TestViewer(object):
         return cls.call_viewer_delete(url, params)
 
     @classmethod
+    def _make_request(cls, method, url, headers=None, **kwargs):
+        if headers is None:
+            headers = cls.default_headers
+        headers, cookies = cls._split_cookies_from_headers(headers)
+        return method(url, headers=headers, cookies=cookies, **kwargs)
+
+    @classmethod
     def wait_for_cluster_ready(cls):
         wait_time = 0
         max_wait_time = 300
@@ -187,10 +211,10 @@ class TestViewer(object):
                 while True:
                     try:
                         print("Waiting for node %s to be ready" % node_id)
-                        result_counter = cls.get_result(requests.get("http://localhost:%s/viewer/simple_counter?max_counter=1&period=1" % node.mon_port, headers=cls.default_headers))
+                        result_counter = cls.get_result(cls._make_request(requests.get, "http://localhost:%s/viewer/simple_counter?max_counter=1&period=1" % node.mon_port))
                         if result_counter['status_code'] != 200:
                             break
-                        result = cls.get_result(requests.get("http://localhost:%s/viewer/sysinfo?node_id=." % node.mon_port, headers=cls.default_headers))
+                        result = cls.get_result(cls._make_request(requests.get, "http://localhost:%s/viewer/sysinfo?node_id=." % node.mon_port))
                         if 'status_code' in result and result.status_code != 200:
                             break
                         if 'SystemStateInfo' not in result or len(result['SystemStateInfo']) == 0:
@@ -266,16 +290,18 @@ class TestViewer(object):
                 all_good = False
                 print("Waiting for database %s to be ready" % database)
                 while True:
-                    result = cls.get_result(requests.get(
+                    result = cls.get_result(cls._make_request(
+                        requests.get,
                         "http://localhost:%s/viewer/tenantinfo?database=%s" %
-                        (cls.cluster.nodes[1].mon_port, database), headers=cls.default_headers))  # force connect between nodes
+                        (cls.cluster.nodes[1].mon_port, database)))  # force connect between nodes
                     if 'status_code' in result and result['status_code'] != 200:
                         break
                     if 'CoresUsed' not in result['TenantInfo'][0]:
                         break
-                    result = cls.get_result(requests.get(
+                    result = cls.get_result(cls._make_request(
+                        requests.get,
                         "http://localhost:%s/viewer/healthcheck?database=%s" %
-                        (cls.cluster.nodes[1].mon_port, database), headers=cls.default_headers))  # force connect between nodes
+                        (cls.cluster.nodes[1].mon_port, database)))  # force connect between nodes
                     if 'status_code' in result and result['status_code'] != 200:
                         break
                     if result['self_check_result'] != 'GOOD':
@@ -301,16 +327,18 @@ class TestViewer(object):
                         bad += 1
                 if bad > 0:
                     break
-                result = cls.get_result(requests.get(
+                result = cls.get_result(cls._make_request(
+                    requests.get,
                     "http://localhost:%s/storage/groups?fields_required=all" %
-                    (cls.cluster.nodes[1].mon_port), headers=cls.default_headers))  # force connect between nodes
+                    (cls.cluster.nodes[1].mon_port)))  # force connect between nodes
                 if 'status_code' in result and result['status_code'] != 200:
                     break
                 if len(result['StorageGroups']) < 5:
                     break
-                result = cls.get_result(requests.get(
+                result = cls.get_result(cls._make_request(
+                    requests.get,
                     "http://localhost:%s/viewer/cluster" %
-                    (cls.cluster.nodes[1].mon_port), headers=cls.default_headers))  # force connect between nodes
+                    (cls.cluster.nodes[1].mon_port)))  # force connect between nodes
                 if 'status_code' in result and result['status_code'] != 200:
                     break
                 if 'StorageTotal' not in result or result['StorageTotal'] == 0:
@@ -1319,7 +1347,8 @@ class TestViewer(object):
         # Make raw HTTP request to get multipart response
         port = cls.cluster.nodes[1].mon_port
         headers = {'Accept': 'multipart/x-mixed-replace'}
-        response = requests.get("http://localhost:%s%s?%s" % (port, path, urlencode(params)), headers=headers)
+        response = cls._make_request(requests.get, "http://localhost:%s%s?%s" % (port, path, urlencode(params)),
+                                     headers={**cls.default_headers, **headers})
 
         if response.status_code != 200:
             return {"status_code": response.status_code, "text": response.text}


### PR DESCRIPTION
Redirected requests in viewer tests were made by anonymous users due to losing cookies.
