### PR TITLE
kqp: skip logging queries with secrets in kqp_log_query

### DIFF
--- a/ydb/core/kqp/common/ut/kqp_is_query_allowed_to_log_ut.cpp
+++ b/ydb/core/kqp/common/ut/kqp_is_query_allowed_to_log_ut.cpp
@@ -54,6 +54,28 @@ Y_UNIT_TEST_SUITE(IsQueryAllowedToLogTest) {
         UNIT_ASSERT(!IsQueryAllowedToLog("CREATE USER foo; ALTER USER bar PASSWORD 'x'"));
     }
 
+    Y_UNIT_TEST(CreateSecretIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE SECRET name WITH (value = 'test_value')"));
+    }
+
+    Y_UNIT_TEST(AlterSecretIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("ALTER SECRET name WITH (value = 'test_value')"));
+    }
+
+    Y_UNIT_TEST(CreateObjectTypeSecretIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE OBJECT name (TYPE SECRET) WITH value = \"secretvalue\""));
+    }
+
+    Y_UNIT_TEST(UpsertObjectTypeSecretIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("UPSERT OBJECT name (TYPE SECRET) WITH value = \"secretvalue\""));
+    }
+
+    Y_UNIT_TEST(SecretCaseInsensitive) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("create secret name WITH (value = 'val')"));
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE SECRET name WITH (value = 'val')"));
+        UNIT_ASSERT(!IsQueryAllowedToLog("Create Secret name WITH (value = 'val')"));
+    }
+
 } // Y_UNIT_TEST_SUITE
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/ut/kqp_is_query_allowed_to_log_ut.cpp
+++ b/ydb/core/kqp/common/ut/kqp_is_query_allowed_to_log_ut.cpp
@@ -1,0 +1,59 @@
+#include <ydb/core/kqp/session_actor/kqp_worker_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp {
+
+Y_UNIT_TEST_SUITE(IsQueryAllowedToLogTest) {
+
+    Y_UNIT_TEST(RegularSelectIsAllowed) {
+        UNIT_ASSERT(IsQueryAllowedToLog("SELECT 1"));
+    }
+
+    Y_UNIT_TEST(RegularInsertIsAllowed) {
+        UNIT_ASSERT(IsQueryAllowedToLog("INSERT INTO t (a) VALUES (1)"));
+    }
+
+    Y_UNIT_TEST(CreateUserWithPasswordIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE USER foo PASSWORD 'secret123'"));
+    }
+
+    Y_UNIT_TEST(AlterUserWithPasswordIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("ALTER USER foo WITH PASSWORD 'newsecret'"));
+    }
+
+    Y_UNIT_TEST(CaseInsensitive) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("create user foo password 'secret'"));
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE USER foo PASSWORD 'secret'"));
+        UNIT_ASSERT(!IsQueryAllowedToLog("Create User foo Password 'secret'"));
+    }
+
+    Y_UNIT_TEST(UserWithoutPasswordIsAllowed) {
+        UNIT_ASSERT(IsQueryAllowedToLog("CREATE USER foo"));
+    }
+
+    Y_UNIT_TEST(PasswordWithoutUserIsAllowed) {
+        UNIT_ASSERT(IsQueryAllowedToLog("SELECT password FROM t"));
+    }
+
+    Y_UNIT_TEST(EmptyStringIsAllowed) {
+        UNIT_ASSERT(IsQueryAllowedToLog(""));
+    }
+
+    Y_UNIT_TEST(EncryptedPasswordIsNotAllowed) {
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE USER foo ENCRYPTED PASSWORD 'secret'"));
+    }
+
+    Y_UNIT_TEST(UserBeforePasswordRequired) {
+        // "password" before "user" should be allowed (the function searches password after user)
+        UNIT_ASSERT(IsQueryAllowedToLog("SELECT password FROM user_table"));
+    }
+
+    Y_UNIT_TEST(UserAndPasswordInDifferentStatements) {
+        // user appears first, then password later — not allowed
+        UNIT_ASSERT(!IsQueryAllowedToLog("CREATE USER foo; ALTER USER bar PASSWORD 'x'"));
+    }
+
+} // Y_UNIT_TEST_SUITE
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/ut/ya.make
+++ b/ydb/core/kqp/common/ut/ya.make
@@ -5,6 +5,7 @@ FORK_SUBTESTS()
 SIZE(SMALL)
 
 SRCS(
+    kqp_is_query_allowed_to_log_ut.cpp
     kqp_tli_ut.cpp
 )
 

--- a/ydb/core/kqp/session_actor/kqp_log_query.cpp
+++ b/ydb/core/kqp/session_actor/kqp_log_query.cpp
@@ -1,4 +1,5 @@
 #include "kqp_log_query.h"
+#include "kqp_worker_common.h"
 
 #include <ydb/core/kqp/common/events/query.h>
 #include <ydb/core/kqp/session_actor/kqp_query_state.h>
@@ -82,6 +83,10 @@ TLogQuery TLogQuery::Started(const TKqpQueryState& state) {
 
         auto query = state.ExtractQueryText();
 
+        if (!IsQueryAllowedToLog(query)) {
+            return;
+        }
+
         WriteJsonChunks(
             poolId,
             GetRequestId(state),
@@ -106,6 +111,10 @@ TLogQuery TLogQuery::Completed(const TKqpQueryState& state,
             : TString{};
 
         auto queryText = state.ExtractQueryText();
+
+        if (!IsQueryAllowedToLog(queryText)) {
+            return;
+        }
 
         NYql::TIssues issues;
         TStringBuf poolId;

--- a/ydb/core/kqp/session_actor/kqp_worker_common.h
+++ b/ydb/core/kqp/session_actor/kqp_worker_common.h
@@ -66,14 +66,26 @@ inline bool IsExecuteAction(const NKikimrKqp::EQueryAction& action) {
 inline bool IsQueryAllowedToLog(const TString& text) {
     static const TString user = "user";
     static const TString password = "password";
-    auto itUser = std::search(text.begin(), text.end(), user.begin(), user.end(),
-        [](const char a, const char b) -> bool { return std::tolower(a) == b; });
-    if (itUser == text.end()) {
-        return true;
+    static const TString secret = "secret";
+
+    auto caseInsensitiveSearch = [](auto begin, auto end, const TString& keyword) {
+        return std::search(begin, end, keyword.begin(), keyword.end(),
+            [](const char a, const char b) -> bool { return std::tolower(a) == b; });
+    };
+
+    auto itUser = caseInsensitiveSearch(text.begin(), text.end(), user);
+    if (itUser != text.end()) {
+        auto itPassword = caseInsensitiveSearch(itUser, text.end(), password);
+        if (itPassword != text.end()) {
+            return false;
+        }
     }
-    auto itPassword = std::search(itUser, text.end(), password.begin(), password.end(),
-        [](const char a, const char b) -> bool { return std::tolower(a) == b; });
-    return itPassword == text.end();
+
+    if (caseInsensitiveSearch(text.begin(), text.end(), secret) != text.end()) {
+        return false;
+    }
+
+    return true;
 }
 
 inline TIntrusivePtr<NYql::TKikimrConfiguration> CreateConfig(const TKqpSettings::TConstPtr& kqpSettings,


### PR DESCRIPTION
## Summary
- Reuse `IsQueryAllowedToLog()` in `kqp_log_query.cpp` to prevent logging SQL queries containing user passwords (e.g. `CREATE USER ... PASSWORD`) in the JSON request logger
- Extend `IsQueryAllowedToLog()` to also block logging of queries containing secrets (`CREATE SECRET`, `ALTER SECRET`, `CREATE/UPSERT OBJECT (TYPE SECRET)`)
- Add unit tests for `IsQueryAllowedToLog()` covering regular queries, password queries, secret queries, case sensitivity, edge cases

Follow-up to #36008

## Test plan
- [x] Unit tests pass: `./ya make -tA ydb/core/kqp/common/ut` (23/23 GOOD)
- [x] Build passes: `./ya make ydb/core/kqp/session_actor`