### PR TITLE
Fix YdbLogStore.AlterLogTable: Use GetAppConfig for server initialization

### DIFF
--- a/ydb/services/ydb/ydb_logstore_ut.cpp
+++ b/ydb/services/ydb/ydb_logstore_ut.cpp
@@ -421,8 +421,7 @@ Y_UNIT_TEST_SUITE(YdbLogStore) {
     }
 
     Y_UNIT_TEST(AlterLogTable) {
-        NKikimrConfig::TAppConfig appConfig;
-        TKikimrWithGrpcAndRootSchema server(appConfig);
+        TKikimrWithGrpcAndRootSchema server(GetAppConfig());
         EnableDebugLogs(server);
 
         auto connection = ConnectToServer(server);


### PR DESCRIPTION
#### `YdbLogStore.AlterLogTable` — падение

`CreateLogStore` возвращал `PRECONDITION_FAILED`: «Column stores are not supported», потому что тест поднимал кластер с **пустым** `TAppConfig` без `EnableColumnStore`. Остальные тесты в файле используют `GetAppConfig()` с `SetEnableColumnStore(true)`; проверка в `create_store.cpp`.

**Исправление:** `TKikimrWithGrpcAndRootSchema server(GetAppConfig());` , как в других тестах


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
