### PR TITLE
enable bloom indexes by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -256,8 +256,8 @@ message TFeatureFlags {
     optional bool EnableConditionalEraseResponseBatching = 229 [default = false];
     optional bool EnablePDiskDataEncryption = 230 [default = true];
     optional bool EnableForcedCompactions = 231 [default = false];
-    optional bool EnableLocalBloomFilterIndex = 232 [default = false];
-    optional bool EnableLocalBloomNgramFilterIndex = 233 [default = false];
+    optional bool EnableLocalBloomFilterIndex = 232 [default = true];
+    optional bool EnableLocalBloomNgramFilterIndex = 233 [default = true];
     optional bool EnableSetDropDefaultValue = 234 [ default = false];
     optional bool EnableStreamingQueriesPqSinkDeduplication = 235 [default = false];
     optional bool EnableBlobIdInSectorChecksum = 236 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enable bloom and bloom ngram skip indexes by default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
