### PR TITLE
Fix condition for triggering issue creation workflow

### DIFF
--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -29,7 +29,7 @@ jobs:
     if: |
       ((github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'update-muted-ya')) ||
+      startsWith(github.event.pull_request.head.ref || github.head_ref, 'update-muted-ya')) ||
       github.event_name == 'workflow_dispatch')
 
     steps:


### PR DESCRIPTION
Проблема, иногда ` github.event.pull_request.base_ref` пустой, зато `github.head_ref` содержит ветку откуда пр был создан в base

<img width="735" height="174" alt="image" src="https://github.com/user-attachments/assets/4221abcb-e83a-495a-9fe4-deb31cc43cf3" />


Вот пример аналогичного фикса https://stackoverflow.com/questions/76322053/get-the-head-ref-branch-name-in-github-actions-when-pr-is-merged-to-main-branch

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
