### PR TITLE
Adjust CA start quota limit with RM resource allocation

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -188,17 +188,12 @@ public:
                 ("input_channels_count", inputChannelsCount);
         }
 
-        auto& taskOpts = args.Task->GetProgram().GetSettings();
-        auto limit = taskOpts.GetHasMapJoin() || taskOpts.GetHasStateAggregation()
-            ? memoryLimits.MkqlHeavyProgramMemoryLimit
-            : memoryLimits.MkqlLightProgramMemoryLimit;
-
         memoryLimits.MemoryQuotaManager = std::make_shared<TMemoryQuotaManager>(
             ResourceManager_,
             args.MemoryPool,
             std::move(args.TxInfo),
             std::move(task),
-            limit);
+            memoryLimits.MkqlLightProgramMemoryLimit);
 
         NYql::NDq::TComputeRuntimeSettings runtimeSettings;
 


### PR DESCRIPTION
Before start, for each CA a MkqlLightProgramMemoryLimit of memory is booked in RM

CA should use the same value as own limit for correct memory accounting. If it is really "heavy" and needs more memory - it will ask for RM later