### PR TITLE
[NEW RBO] Use canonical statistic names

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -104,8 +104,8 @@ void TOpEmptySource::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) 
     Y_UNUSED(planProps);
     Y_ENSURE(Props.Metadata.has_value());
     Props.Statistics = TRBOStatistics();
-    Props.Statistics->RecordsCount = 1;
-    Props.Statistics->DataSize = 1;
+    Props.Statistics->ERows = 1;
+    Props.Statistics->EBytes = 1;
     Props.Cost = 0;
 }
 
@@ -175,8 +175,8 @@ void TOpRead::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
     const auto& tableData = ctx.KqpCtx.Tables->ExistingTable(ctx.KqpCtx.Cluster, path.Value());
 
     Props.Statistics = TRBOStatistics();
-    Props.Statistics->RecordsCount = tableData.Metadata->RecordsCount;
-    Props.Statistics->DataSize = tableData.Metadata->DataSize;
+    Props.Statistics->ERows = tableData.Metadata->RecordsCount;
+    Props.Statistics->EBytes = tableData.Metadata->DataSize;
     Props.Cost = 0;
 }
 
@@ -198,7 +198,7 @@ void TOpFilter::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
     double selectivity = TPredicateSelectivityComputer(inputStats).Compute(lambda.Body());
 
     double filterSelectivity = selectivity * Props.Statistics->Selectivity;
-    Props.Statistics->DataSize = filterSelectivity * Props.Statistics->DataSize;
+    Props.Statistics->EBytes = filterSelectivity * Props.Statistics->EBytes;
     Props.Statistics->Selectivity = filterSelectivity;
 }
 
@@ -275,14 +275,14 @@ void TOpMap::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
 
     const auto inputColumnsCount = GetInput()->Props.Metadata->ColumnsCount;
     if (Props.Metadata->ColumnsCount != inputColumnsCount) {
-        double inputDataSize = Props.Statistics->DataSize;
+        double inputDataSize = Props.Statistics->EBytes;
         if (inputColumnsCount!=0) {
-            Props.Statistics->DataSize = inputDataSize * Props.Metadata->ColumnsCount / (double)inputColumnsCount;
+            Props.Statistics->EBytes = inputDataSize * Props.Metadata->ColumnsCount / (double)inputColumnsCount;
         }
         // Input may have 0 columns (e.g. EmptySource), in such case the data size depends on the number of records
         // and the number of columns in the output. We just assume each column contains 8 bytes
         else {
-            Props.Statistics->DataSize = Props.Statistics->RecordsCount * Props.Metadata->ColumnsCount * 8;
+            Props.Statistics->EBytes = Props.Statistics->ERows * Props.Metadata->ColumnsCount * 8;
         }
     }
 }
@@ -328,8 +328,8 @@ void TOpAggregate::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
 
     const auto inputColumnsCount = GetInput()->Props.Metadata->ColumnsCount;
     if (Props.Metadata->ColumnsCount != inputColumnsCount) {
-        double inputDataSize = Props.Statistics->DataSize;
-        Props.Statistics->DataSize = inputDataSize * Props.Metadata->ColumnsCount / (double)inputColumnsCount;
+        double inputDataSize = Props.Statistics->EBytes;
+        Props.Statistics->EBytes = inputDataSize * Props.Metadata->ColumnsCount / (double)inputColumnsCount;
     }
 }
 
@@ -435,8 +435,8 @@ void TOpJoin::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
         false,
         FindCardHint(unionOfAliases, *hints.BytesHints));
 
-    Props.Statistics->DataSize = CBOStats.ByteSize;
-    Props.Statistics->RecordsCount = CBOStats.Nrows;
+    Props.Statistics->EBytes = CBOStats.ByteSize;
+    Props.Statistics->ERows = CBOStats.Nrows;
     Props.Statistics->Selectivity = CBOStats.Selectivity;
 
     if (Props.JoinAlgo.has_value()) {
@@ -465,8 +465,8 @@ void TOpUnionAll::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
     }
 
     Props.Statistics = TRBOStatistics();
-    Props.Statistics->DataSize = GetLeftInput()->Props.Statistics->DataSize + GetRightInput()->Props.Statistics->DataSize;
-    Props.Statistics->RecordsCount = GetLeftInput()->Props.Statistics->RecordsCount + GetRightInput()->Props.Statistics->RecordsCount;
+    Props.Statistics->EBytes = GetLeftInput()->Props.Statistics->EBytes + GetRightInput()->Props.Statistics->EBytes;
+    Props.Statistics->ERows = GetLeftInput()->Props.Statistics->ERows + GetRightInput()->Props.Statistics->ERows;
 
     if (GetLeftInput()->Props.Cost.has_value() && GetRightInput()->Props.Cost.has_value()) {
         Props.Cost = *GetLeftInput()->Props.Cost + *GetRightInput()->Props.Cost;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
@@ -72,9 +72,9 @@ TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps& props, bool with
     const double cost = props.Cost.has_value() ? *props.Cost : 0.0;
 
     return TOptimizerStatistics(props.Metadata->Type, 
-        withStatsAndCosts ? props.Statistics->DataSize : 0.0,
+        withStatsAndCosts ? props.Statistics->EBytes : 0.0,
         props.Metadata->ColumnsCount,
-        withStatsAndCosts ? props.Statistics->DataSize : 0.0,
+        withStatsAndCosts ? props.Statistics->EBytes : 0.0,
         withStatsAndCosts ? cost : 0.0,
         TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(
             new TOptimizerStatistics::TKeyColumns(keyColumnNames)));
@@ -145,7 +145,7 @@ TString TRBOMetadata::ToString(ui32 printOptions) {
 
 TString TRBOStatistics::ToString(ui32 printOptions) {
     Y_UNUSED(printOptions);
-    return TStringBuilder() << "N records: " << RecordsCount << ", Size: " << DataSize << ", Selectivity: " << Selectivity; 
+    return TStringBuilder() << "N records: " << ERows << ", Size: " << EBytes << ", Selectivity: " << Selectivity;
 }
 
 }

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.h
@@ -93,8 +93,8 @@ public:
 
 class TRBOStatistics {
 public:
-    double RecordsCount = 0;
-    double DataSize = 0;
+    double ERows = 0;
+    double EBytes = 0;
     double Selectivity = 1.0;
 
     TString ToString(ui32 printOptions);


### PR DESCRIPTION
Replace `RecordsCount` and `DataSize` with a more commonly used and clear `ERows` (estimated rows) and `EBytes` (estimated bytes). Also makes it clearer that we don't know the exact counts, only estimates.