### PR TITLE
Fix typo in Kubernetes deployment documentation

### DIFF
--- a/ydb/docs/ru/core/devops/deployment-options/kubernetes/initial-deployment.md
+++ b/ydb/docs/ru/core/devops/deployment-options/kubernetes/initial-deployment.md
@@ -1,6 +1,6 @@
 # Начало работы с {{ ydb-short-name }} в {{ k8s }}
 
-Развертывание {{ ydb-short-name }} в {{ k8s }} — это простой способ установки и эксплуатации {{ ydb-short-name }} кластера. С {{ k8s }} вы можете использовать универсальный подход к управлению приложением в любом облачном провайдере. Это руководство содержит инструкции для развертывания {{ ydb-short-name }} в [AWS EKS](https://aws.amazon.com/ru/eks/) or [{{ managed-k8s-full-name}}](https://cloud.yandex.ru/services/managed-kubernetes).
+Развертывание {{ ydb-short-name }} в {{ k8s }} — это простой способ установки и эксплуатации {{ ydb-short-name }} кластера. С {{ k8s }} вы можете использовать универсальный подход к управлению приложением в любом облачном провайдере. Это руководство содержит инструкции для развертывания {{ ydb-short-name }} в [AWS EKS](https://aws.amazon.com/ru/eks/) или [{{ managed-k8s-full-name}}](https://cloud.yandex.ru/services/managed-kubernetes).
 
 ## Пререквизиты
 


### PR DESCRIPTION
Corrected a typo in the deployment options documentation regarding the conjunction used in the Russian language.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->
* Documentation (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
