### PR TITLE
Disable change data collection (CDC) for IsBuildInProgress columns

### DIFF
--- a/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
@@ -2,11 +2,15 @@
 
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/operation/operation.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+
+#include <library/cpp/json/json_reader.h>
 
 namespace NKikimr::NKqp {
 
 using namespace NYdb;
 using namespace NYdb::NQuery;
+using namespace NYdb::NTopic;
 
 Y_UNIT_TEST_SUITE(KqpConstraints) {
     Y_UNIT_TEST(SerialTypeNegative1) {
@@ -2911,6 +2915,129 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
             auto result = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unsupported type of literal: CurrentUtcTimestamp");
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableAddColumnDefaultWithChangefeed) {
+        TKikimrRunner kikimr(TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetEnableAddColumsWithDefaults(true));
+
+        auto db = kikimr.GetQueryClient();
+
+        {
+            const auto query = R"(
+                CREATE TABLE `/Root/TestCdcDefaultColumn` (
+                    Key Int32,
+                    Value String,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const auto query = R"(
+                ALTER TABLE `/Root/TestCdcDefaultColumn` ADD CHANGEFEED `feed` WITH (
+                    MODE = 'UPDATES', FORMAT = 'JSON'
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const auto query = R"(
+                ALTER TOPIC `/Root/TestCdcDefaultColumn/feed` ADD CONSUMER `test_consumer`;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const auto query = R"(
+                UPSERT INTO `/Root/TestCdcDefaultColumn` (Key, Value)
+                VALUES (1, "One"), (2, "Two"), (3, "Three");
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const auto query = R"(
+                ALTER TABLE `/Root/TestCdcDefaultColumn`
+                ADD COLUMN DefaultColumn Int32 NOT NULL DEFAULT 42;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            const auto query = R"(
+                UPSERT INTO `/Root/TestCdcDefaultColumn` (Key, Value)
+                VALUES (4, "Four"), (5, "Five");
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        TTopicClient topicClient(kikimr.GetDriver());
+
+        TReadSessionSettings readSettings;
+        readSettings.ConsumerName("test_consumer");
+        TTopicReadSettings topicReadSettings;
+        topicReadSettings.Path("/Root/TestCdcDefaultColumn/feed");
+        readSettings.AppendTopics(topicReadSettings);
+
+        auto readSession = topicClient.CreateReadSession(readSettings);
+
+        {
+            auto event = readSession->GetEvent(/* block = */ true, /* maxEventsCount = */ 1);
+            UNIT_ASSERT(event);
+            auto* startEvent = std::get_if<NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event);
+            UNIT_ASSERT(startEvent);
+            startEvent->Confirm();
+        }
+
+        const size_t expectedMessages = 5;
+
+        std::vector<TString> messages;
+        while (messages.size() < expectedMessages) {
+            TInstant deadline = TInstant::Now() + TDuration::Seconds(2);
+            TDuration remain = TDuration::Seconds(2);
+
+            while (TInstant::Now() < deadline) {
+                if (!readSession->WaitEvent().Wait(remain)) {
+                    break;
+                }
+
+                for (auto& ev : readSession->GetEvents(false)) {
+                    if (auto* e = std::get_if<NTopic::TReadSessionEvent::TDataReceivedEvent>(&ev)) {
+                        for (auto& m : e->GetMessages()) {
+                            messages.emplace_back(m.GetData());
+                        }
+                        e->Commit();
+                    }
+                }
+
+                remain = deadline - TInstant::Now();
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(messages.size(), expectedMessages);
+
+        for (size_t i = 0; i < messages.size(); ++i) {
+            NJson::TJsonValue json;
+            NJson::ReadJsonTree(messages[i], &json);
+
+            auto key = json["key"][0].GetInteger();
+            if (key >= 4) {
+                UNIT_ASSERT_C(json["update"].Has("DefaultColumn"), "DefaultColumn should be present");
+                UNIT_ASSERT_VALUES_EQUAL(json["update"]["DefaultColumn"].GetInteger(), 42);
+            } else {
+                UNIT_ASSERT_C(!json["update"].Has("DefaultColumn"), "DefaultColumn should not be present");
+            }
         }
     }
 }

--- a/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_constraints_ut.cpp
@@ -3029,7 +3029,8 @@ Y_UNIT_TEST_SUITE(KqpConstraints) {
 
         for (size_t i = 0; i < messages.size(); ++i) {
             NJson::TJsonValue json;
-            NJson::ReadJsonTree(messages[i], &json);
+            const bool parsed = NJson::ReadJsonTree(messages[i], &json);
+            UNIT_ASSERT_C(parsed, TStringBuilder() << "Failed to parse changefeed message as JSON: " << messages[i]);
 
             auto key = json["key"][0].GetInteger();
             if (key >= 4) {

--- a/ydb/core/kqp/ut/scheme/ya.make
+++ b/ydb/core/kqp/ut/scheme/ya.make
@@ -29,6 +29,7 @@ PEERDIR(
     ydb/core/tx/columnshard/hooks/testing
     ydb/public/sdk/cpp/src/client/arrow
     ydb/public/sdk/cpp/src/client/draft
+    ydb/public/sdk/cpp/src/client/topic
     yql/essentials/sql/pg
     yql/essentials/parser/pg_wrapper
 )

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -983,6 +983,7 @@ message TEvUploadRowsRequest {
     optional bool UpsertIfExists = 8 [ default = false ];
     optional uint64 SchemaVersion = 9;
     optional string UserSID = 10;
+    optional bool DisableChangeCollection = 11 [ default = false ];
 }
 
 message TEvUploadRowsResponse {

--- a/ydb/core/transfer/row_table.cpp
+++ b/ydb/core/transfer/row_table.cpp
@@ -88,7 +88,7 @@ IActor* TTableUploader<TData>::CreateUploaderInternal(
     const TString& database, const TString& tablePath,
     const std::shared_ptr<TData>& data, ui64 cookie)
 {
-    return NTxProxy::CreateUploadRowsInternal(SelfId(), database, tablePath, Scheme->Types, data, NTxProxy::EUploadRowsMode::Normal, false, false, cookie, DefaultBackoff);
+    return NTxProxy::CreateUploadRowsInternal(SelfId(), database, tablePath, Scheme->Types, data, NTxProxy::EUploadRowsMode::Normal, false, false, false, cookie, DefaultBackoff);
 }
 
 }

--- a/ydb/core/tx/datashard/build_index/secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/secondary_index.cpp
@@ -129,6 +129,8 @@ protected:
     TUploadMonStats Stats = TUploadMonStats("tablets", "build_index_upload");
     TUploadStatus UploadStatus;
 
+    const bool DisableChangeCollection;
+
     TBuildScanUpload(ui64 buildIndexId,
                      const TString& databaseName,
                      const TString& target,
@@ -137,7 +139,8 @@ protected:
                      const TActorId& progressActorId,
                      const TSerializedTableRange& range,
                      const TUserTable& tableInfo,
-                     const TIndexBuildScanSettings& scanSettings)
+                     const TIndexBuildScanSettings& scanSettings,
+                     bool disableChangeCollection)
         : TBase(&TThis::StateWork)
         , ScanSettings(scanSettings)
         , BuildIndexId(buildIndexId)
@@ -149,7 +152,8 @@ protected:
         , KeyColumnIds(tableInfo.KeyColumnIds)
         , KeyTypes(tableInfo.KeyColumnTypes)
         , TableRange(tableInfo.Range)
-        , RequestedRange(range) {
+        , RequestedRange(range)
+        , DisableChangeCollection(disableChangeCollection) {
     }
 
     template <typename TAddRow>
@@ -405,7 +409,8 @@ private:
             WriteBuf.GetRowsData(),
             UploadMode,
             true /*writeToPrivateTable*/,
-            true /*writeToIndexImplTable*/);
+            true /*writeToIndexImplTable*/,
+            DisableChangeCollection);
 
         Uploader = this->Register(actor, TMailboxType::HTSwap, AppData()->BatchPoolId);
     }
@@ -426,7 +431,7 @@ public:
                     TProtoColumnsCRef targetDataColumns,
                     const TUserTable& tableInfo,
                     const TIndexBuildScanSettings& scanSettings)
-        : TBuildScanUpload(buildIndexId, databaseName, target, seqNo, dataShardId, progressActorId, range, tableInfo, scanSettings)
+        : TBuildScanUpload(buildIndexId, databaseName, target, seqNo, dataShardId, progressActorId, range, tableInfo, scanSettings, false)
         , TargetDataColumnPos(targetIndexColumns.size()) {
         ScanTags = BuildTags(tableInfo, targetIndexColumns, targetDataColumns);
         UploadColumnsTypes = BuildTypes(tableInfo, targetIndexColumns, targetDataColumns);
@@ -460,7 +465,7 @@ public:
                       const NKikimrIndexBuilder::TColumnBuildSettings& columnBuildSettings,
                       const TUserTable& tableInfo,
                       const TIndexBuildScanSettings& scanSettings)
-        : TBuildScanUpload(buildIndexId, databaseName, target, seqNo, dataShardId, progressActorId, range, tableInfo, scanSettings) {
+        : TBuildScanUpload(buildIndexId, databaseName, target, seqNo, dataShardId, progressActorId, range, tableInfo, scanSettings, true) {
         Y_ENSURE(columnBuildSettings.columnSize() > 0);
         UploadColumnsTypes = BuildTypes(tableInfo, columnBuildSettings);
         UploadMode = NTxProxy::EUploadRowsMode::UpsertIfExists;

--- a/ydb/core/tx/datashard/datashard_direct_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_upload.cpp
@@ -4,7 +4,7 @@ namespace NKikimr {
 namespace NDataShard {
 
 TDirectTxUpload::TDirectTxUpload(TEvDataShard::TEvUploadRowsRequest::TPtr& ev)
-    : TCommonUploadOps(ev, true, true)
+    : TCommonUploadOps(ev, true, !ev->Get()->Record.GetDisableChangeCollection())
 {
 }
 

--- a/ydb/core/tx/datashard/datashard_ut_upload_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_upload_rows.cpp
@@ -45,7 +45,7 @@ static void DoStartUploadTestRows(
         rows->emplace_back(serializedKey, serializedValue);
     }
 
-    auto actor = NTxProxy::CreateUploadRowsInternal(sender, database, tableName, types, rows, NTxProxy::EUploadRowsMode::Normal, false, false, 0, backoff);
+    auto actor = NTxProxy::CreateUploadRowsInternal(sender, database, tableName, types, rows, NTxProxy::EUploadRowsMode::Normal, false, false, false, 0, backoff);
     runtime.Register(actor);
 }
 

--- a/ydb/core/tx/tx_proxy/upload_rows.cpp
+++ b/ydb/core/tx/tx_proxy/upload_rows.cpp
@@ -18,6 +18,7 @@ public:
         EUploadRowsMode mode,
         bool writeToPrivateTable,
         bool writeToIndexImplTable,
+        bool disableChangeCollection,
         ui64 cookie,
         TBackoff backoff)
         : TUploadRowsBase(std::move(rows), userSID)
@@ -29,6 +30,7 @@ public:
     {
         AllowWriteToPrivateTable = writeToPrivateTable;
         AllowWriteToIndexImplTable = writeToIndexImplTable;
+        DisableChangeCollection = disableChangeCollection;
 
         switch (mode) {
             case EUploadRowsMode::Normal:
@@ -106,6 +108,7 @@ IActor* CreateUploadRowsInternal(const TActorId& sender,
     EUploadRowsMode mode,
     bool writeToPrivateTable,
     bool writeToIndexImplTable,
+    bool disableChangeCollection,
     ui64 cookie,
     TBackoff backoff)
 {
@@ -118,6 +121,7 @@ IActor* CreateUploadRowsInternal(const TActorId& sender,
         mode,
         writeToPrivateTable,
         writeToIndexImplTable,
+        disableChangeCollection,
         cookie,
         backoff);
 }

--- a/ydb/core/tx/tx_proxy/upload_rows.h
+++ b/ydb/core/tx/tx_proxy/upload_rows.h
@@ -30,6 +30,7 @@ IActor* CreateUploadRowsInternal(const TActorId& sender,
                                  EUploadRowsMode mode = EUploadRowsMode::Normal,
                                  bool writeToPrivateTable = false,
                                  bool writeToIndexImplTable = false,
+                                 bool disableChangeCollection = false,
                                  ui64 cookie = 0,
                                  TBackoff backoff = TBackoff(0));
 } // namespace NTxProxy

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -185,6 +185,7 @@ protected:
     bool WriteToTableShadow = false;
     bool AllowWriteToPrivateTable = false;
     bool AllowWriteToIndexImplTable = false;
+    bool DisableChangeCollection = false;
     bool DiskQuotaExceeded = false;
     bool UpsertIfExists = false;
 
@@ -1187,6 +1188,9 @@ private:
                 }
                 if (UpsertIfExists) {
                     ev->Record.SetUpsertIfExists(true);
+                }
+                if (DisableChangeCollection) {
+                    ev->Record.SetDisableChangeCollection(true);
                 }
                 // Copy protobuf settings without rows
                 retryState->Headers = ev->Record;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Disable change data collection for `DEFAULT` columns if they are under build operations (`ADD COLUMN DEFAULT`), in `TBuildColumnsScan`.

Closes #36069

...

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
