### PR TITLE
Discard per Task ResourceManager State

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -21,7 +21,7 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     {}
 
     ~TMemoryQuotaManager() override {
-        ResourceManager->FreeResources(Tx, TaskId, NRm::TKqpResourcesRequest{
+        ResourceManager->FreeResources(*Tx, TaskId, NRm::TKqpResourcesRequest{
             .ExecutionUnits = 1,
             .Memory = Limit - Guarantee,
             .ExternalMemory = Guarantee,
@@ -29,7 +29,7 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     }
 
     bool AllocateExtraQuota(ui64 extraSize) override {
-        auto result = ResourceManager->AllocateResources(Tx, TaskId,
+        auto result = ResourceManager->AllocateResources(*Tx, TaskId,
             NRm::TKqpResourcesRequest{.Memory = extraSize});
 
         if (!result) {
@@ -46,7 +46,7 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     }
 
     void FreeExtraQuota(ui64 extraSize) override {
-        ResourceManager->FreeResources(Tx, TaskId, NRm::TKqpResourcesRequest{.Memory = extraSize});
+        ResourceManager->FreeResources(*Tx, TaskId, NRm::TKqpResourcesRequest{.Memory = extraSize});
     }
 
     bool IsReasonableToUseSpilling() const override {
@@ -154,7 +154,7 @@ public:
         };
 
         auto rmResult = ResourceManager_->AllocateResources(
-            args.TxInfo, args.Task->GetId(), resourcesRequest);
+            *args.TxInfo, args.Task->GetId(), resourcesRequest);
 
         if (!rmResult) {
             return NRm::TKqpRMAllocateResult{rmResult};

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -12,27 +12,31 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
 
     TMemoryQuotaManager(std::shared_ptr<NRm::IKqpResourceManager> resourceManager
         , TIntrusivePtr<NRm::TTxState> tx
-        , TIntrusivePtr<NRm::TTaskState> task
+        , ui64 taskId
         , ui64 limit)
     : NYql::NDq::TGuaranteeQuotaManager(limit, limit)
     , ResourceManager(std::move(resourceManager))
     , Tx(std::move(tx))
-    , Task(std::move(task))
+    , TaskId(taskId)
     {}
 
     ~TMemoryQuotaManager() override {
-        ResourceManager->FreeResources(Tx, Task);
+        ResourceManager->FreeResources(Tx, TaskId, NRm::TKqpResourcesRequest{
+            .ExecutionUnits = 1,
+            .Memory = Limit - Guarantee,
+            .ExternalMemory = Guarantee,
+        });
     }
 
     bool AllocateExtraQuota(ui64 extraSize) override {
-        auto result = ResourceManager->AllocateResources(Tx, Task,
+        auto result = ResourceManager->AllocateResources(Tx, TaskId,
             NRm::TKqpResourcesRequest{.Memory = extraSize});
 
         if (!result) {
             AFL_WARN(NKikimrServices::KQP_COMPUTE)
                 ("problem", "cannot_allocate_memory")
                 ("tx_id", Tx->TxId)
-                ("task_id", Task->TaskId)
+                ("task_id", TaskId)
                 ("memory", extraSize);
 
             return false;
@@ -42,29 +46,20 @@ struct TMemoryQuotaManager : public NYql::NDq::TGuaranteeQuotaManager {
     }
 
     void FreeExtraQuota(ui64 extraSize) override {
-        NRm::TKqpResourcesRequest request = NRm::TKqpResourcesRequest{.Memory = extraSize};
-        ResourceManager->FreeResources(Tx, Task, Task->FitRequest(request));
+        ResourceManager->FreeResources(Tx, TaskId, NRm::TKqpResourcesRequest{.Memory = extraSize});
     }
 
     bool IsReasonableToUseSpilling() const override {
-        return Task->IsReasonableToStartSpilling();
+        return Tx->IsReasonableToStartSpilling();
     }
 
     TString MemoryConsumptionDetails() const override {
         return Tx->ToString();
     }
 
-    void TerminateHandler(bool success, const NYql::TIssues& issues) {
-        AFL_DEBUG(NKikimrServices::KQP_COMPUTE)
-            ("problem", "finish_compute_actor")
-            ("tx_id", Tx->TxId)("task_id", Task->TaskId)("success", success)("message", issues.ToOneLineString());
-        Success = success;
-    }
-
     std::shared_ptr<NRm::IKqpResourceManager> ResourceManager;
     TIntrusivePtr<NRm::TTxState> Tx;
-    TIntrusivePtr<NRm::TTaskState> Task;
-    bool Success = true;
+    ui64 TaskId;
     ui64 ReasonableSpillingTreshold = 0;
 };
 
@@ -158,10 +153,8 @@ public:
             .IsSchedulable = args.Query && !args.TxInfo->PoolId.empty() && args.TxInfo->PoolId != NResourcePool::DEFAULT_POOL_ID,
         };
 
-        TIntrusivePtr<NRm::TTaskState> task = MakeIntrusive<NRm::TTaskState>(args.Task->GetId(), args.TxInfo->CreatedAt);
-
         auto rmResult = ResourceManager_->AllocateResources(
-            args.TxInfo, task, resourcesRequest);
+            args.TxInfo, args.Task->GetId(), resourcesRequest);
 
         if (!rmResult) {
             return NRm::TKqpRMAllocateResult{rmResult};
@@ -187,7 +180,7 @@ public:
         memoryLimits.MemoryQuotaManager = std::make_shared<TMemoryQuotaManager>(
             ResourceManager_,
             std::move(args.TxInfo),
-            std::move(task),
+            args.Task->GetId(),
             memoryLimits.MkqlLightProgramMemoryLimit);
 
         NYql::NDq::TComputeRuntimeSettings runtimeSettings;
@@ -209,12 +202,11 @@ public:
             runtimeSettings.RlPath = args.RlPath;
         }
 
-        NYql::NDq::IMemoryQuotaManager::TWeakPtr memoryQuotaManager = memoryLimits.MemoryQuotaManager;
-        runtimeSettings.TerminateHandler = [memoryQuotaManager, state=args.State, txId=args.TxId, executerId=args.ExecuterId, taskId=args.Task->GetId()]
+        runtimeSettings.TerminateHandler = [state=args.State, txId=args.TxId, executerId=args.ExecuterId, taskId=args.Task->GetId()]
             (bool success, const NYql::TIssues& issues) {
-                if (auto manager = memoryQuotaManager.lock()) {
-                    static_cast<TMemoryQuotaManager*>(manager.get())->TerminateHandler(success, issues);
-                }
+                AFL_DEBUG(NKikimrServices::KQP_COMPUTE)
+                    ("problem", "finish_compute_actor")
+                    ("tx_id", txId)("task_id", taskId)("success", success)("message", issues.ToOneLineString());
                 if (state) {
                     state->OnTaskFinished(txId, executerId, taskId, success);
                 }

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -123,12 +123,6 @@ TKqpPlanner::TKqpPlanner(TKqpPlanner::TArgs&& args)
     }
 }
 
-TKqpPlanner::~TKqpPlanner() {
-    if (TxInfo) {
-        ResourceManager_->FinishTx(TxInfo);
-    }
-}
-
 // ResourcesSnapshot, ResourceEstimations
 
 void TKqpPlanner::LogMemoryStatistics(const TLogFunc& logFunc) {
@@ -498,7 +492,7 @@ TString TKqpPlanner::ExecuteDataComputeTask(ui64 taskId, ui32 computeTasksSize) 
         }
 
         TxInfo = MakeIntrusive<NRm::TTxState>(
-            TxId, TInstant::Now(), ResourceManager_->GetCounters(),
+            ResourceManager_, TxId, TInstant::Now(), ResourceManager_->GetCounters(),
             UserRequestContext->PoolId, memoryPoolPercent, Database, CaFactory_->GetVerboseMemoryLimitException());
     }
 

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -123,6 +123,12 @@ TKqpPlanner::TKqpPlanner(TKqpPlanner::TArgs&& args)
     }
 }
 
+TKqpPlanner::~TKqpPlanner() {
+    if (TxInfo) {
+        ResourceManager_->FinishTx(TxInfo);
+    }
+}
+
 // ResourcesSnapshot, ResourceEstimations
 
 void TKqpPlanner::LogMemoryStatistics(const TLogFunc& logFunc) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -492,8 +492,8 @@ TString TKqpPlanner::ExecuteDataComputeTask(ui64 taskId, ui32 computeTasksSize) 
         }
 
         TxInfo = MakeIntrusive<NRm::TTxState>(
-            ResourceManager_, TxId, TInstant::Now(), ResourceManager_->GetCounters(),
-            UserRequestContext->PoolId, memoryPoolPercent, Database, CaFactory_->GetVerboseMemoryLimitException());
+            ResourceManager_, TxId, TInstant::Now(), UserRequestContext->PoolId, memoryPoolPercent, Database,
+            CaFactory_->GetVerboseMemoryLimitException());
     }
 
     if (ArrayBufferMinFillPercentage) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.h
+++ b/ydb/core/kqp/executer_actor/kqp_planner.h
@@ -72,6 +72,7 @@ public:
     };
 
     TKqpPlanner(TKqpPlanner::TArgs&& args);
+    ~TKqpPlanner();
     bool SendStartKqpTasksRequest(ui32 requestId, const TActorId& target, bool isShutdown = false);
     std::unique_ptr<IEventHandle> PlanExecution();
     std::unique_ptr<IEventHandle> AssignTasksToNodes();

--- a/ydb/core/kqp/executer_actor/kqp_planner.h
+++ b/ydb/core/kqp/executer_actor/kqp_planner.h
@@ -72,7 +72,6 @@ public:
     };
 
     TKqpPlanner(TKqpPlanner::TArgs&& args);
-    ~TKqpPlanner();
     bool SendStartKqpTasksRequest(ui32 requestId, const TActorId& target, bool isShutdown = false);
     std::unique_ptr<IEventHandle> PlanExecution();
     std::unique_ptr<IEventHandle> AssignTasksToNodes();

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -156,7 +156,7 @@ public:
         }
 
         if (!TxInfo) {
-            TxInfo = MakeIntrusive<NRm::TTxState>(ResourceManager_, txId, TInstant::Now(), ResourceManager_->GetCounters(),
+            TxInfo = MakeIntrusive<NRm::TTxState>(ResourceManager_, txId, TInstant::Now(),
                 poolId, msg.GetMemoryPoolPercent(),
                 msg.GetDatabase(),  CaFactory_->GetVerboseMemoryLimitException());
         }

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -32,6 +32,12 @@ public:
     {
     }
 
+    ~TKqpQueryManager() {
+        if (TxInfo) {
+            ResourceManager_->FinishTx(TxInfo);
+        }
+    }
+
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NActors::TEvents::TEvPoison, HandlePoison);
@@ -155,10 +161,11 @@ public:
             rlPath.ConstructInPlace(runtimeSettings.GetRlPath());
         }
 
-        TIntrusivePtr<NRm::TTxState> txInfo = MakeIntrusive<NRm::TTxState>(
-            txId, TInstant::Now(), ResourceManager_->GetCounters(),
-            poolId, msg.GetMemoryPoolPercent(),
-            msg.GetDatabase(),  CaFactory_->GetVerboseMemoryLimitException());
+        if (!TxInfo) {
+            TxInfo = MakeIntrusive<NRm::TTxState>(txId, TInstant::Now(), ResourceManager_->GetCounters(),
+                poolId, msg.GetMemoryPoolPercent(),
+                msg.GetDatabase(),  CaFactory_->GetVerboseMemoryLimitException());
+        }
 
         auto reportStatsSettings = ReportStatsSettingsFromProto(runtimeSettings);
 
@@ -173,7 +180,7 @@ public:
                 .LockNodeId = lockNodeId,
                 .LockMode = lockMode,
                 .Task = &dqTask,
-                .TxInfo = txInfo,
+                .TxInfo = TxInfo,
                 .ReportStatsSettings = reportStatsSettings,
                 .TraceId = NWilson::TTraceId(ev->TraceId),
                 .Arena = ev->Get()->Arena,
@@ -323,6 +330,7 @@ public:
 private:
     TIntrusivePtr<TKqpCounters> Counters_;
     std::shared_ptr<TNodeState> State_;
+    TIntrusivePtr<NRm::TTxState> TxInfo;
     std::shared_ptr<NRm::IKqpResourceManager> ResourceManager_;
     std::shared_ptr<NComputeActor::IKqpNodeComputeActorFactory> CaFactory_;
     TActorId ExecuterId;

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -32,12 +32,6 @@ public:
     {
     }
 
-    ~TKqpQueryManager() {
-        if (TxInfo) {
-            ResourceManager_->FinishTx(TxInfo);
-        }
-    }
-
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NActors::TEvents::TEvPoison, HandlePoison);
@@ -162,7 +156,7 @@ public:
         }
 
         if (!TxInfo) {
-            TxInfo = MakeIntrusive<NRm::TTxState>(txId, TInstant::Now(), ResourceManager_->GetCounters(),
+            TxInfo = MakeIntrusive<NRm::TTxState>(ResourceManager_, txId, TInstant::Now(), ResourceManager_->GetCounters(),
                 poolId, msg.GetMemoryPoolPercent(),
                 msg.GetDatabase(),  CaFactory_->GetVerboseMemoryLimitException());
         }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -376,8 +376,10 @@ public:
         auto released = tx.Released(resources);
         Y_ABORT_UNLESS(released);
 
-        if (reduceResourceBrokerTask) {
-            bool reduced = ResourceBroker->ReduceTaskResourcesInstant(tx.TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
+        if (resources.Memory && reduceResourceBrokerTask) {
+            auto currentRbTaskId = tx.TxResourceBrokerTaskId.load();
+            Y_DEBUG_ABORT_UNLESS(currentRbTaskId);
+            bool reduced = ResourceBroker->ReduceTaskResourcesInstant(currentRbTaskId, {0, resources.Memory}, SelfId);
             Y_DEBUG_ABORT_UNLESS(reduced);
         }
 

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -341,14 +341,12 @@ public:
             return result;
         }
 
-        with_lock(tx->Lock) {
-            tx->Allocated(resources);
-            if (!tx->TxResourceBrokerTaskId) {
-                tx->TxResourceBrokerTaskId = rbTaskId;
-            } else {
-                bool merged = ResourceBroker->MergeTasksInstant(tx->TxResourceBrokerTaskId, rbTaskId, SelfId);
-                Y_ABORT_UNLESS(merged);
-            }
+        tx->Allocated(resources);
+
+        ui64 currentRbTaskId = 0;
+        if (!tx->TxResourceBrokerTaskId.compare_exchange_strong(currentRbTaskId, rbTaskId)) {
+            bool merged = ResourceBroker->MergeTasksInstant(currentRbTaskId, rbTaskId, SelfId);
+            Y_ABORT_UNLESS(merged);
         }
 
         LOG_AS_D("TxId: " << txId << ", taskId: " << taskId << ". Allocated " << resources.ToString());
@@ -356,24 +354,14 @@ public:
         return result;
     }
 
-    void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
+    void FreeResourcesImpl(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources, bool reduceResourceBrokerTask) {
 
-        with_lock(tx->Lock) {
-            auto released = tx->Released(resources);
-            Y_ABORT_UNLESS(released);
+        auto released = tx->Released(resources);
+        Y_ABORT_UNLESS(released);
 
-            if (tx->TxResourceBrokerTaskId) {
-                if (tx->TxScanQueryMemory.load() == 0) {
-                    bool finished = ResourceBroker->FinishTaskInstant(
-                        TEvResourceBroker::TEvFinishTask(tx->TxResourceBrokerTaskId), SelfId);
-                    Y_DEBUG_ABORT_UNLESS(finished);
-                    tx->TxResourceBrokerTaskId = 0;
-                } else {
-                    bool reduced = ResourceBroker->ReduceTaskResourcesInstant(
-                        tx->TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
-                    Y_DEBUG_ABORT_UNLESS(reduced);
-                }
-            }
+        if (reduceResourceBrokerTask) {
+            bool reduced = ResourceBroker->ReduceTaskResourcesInstant(tx->TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
+            Y_DEBUG_ABORT_UNLESS(reduced);
         }
 
         if (resources.ExecutionUnits) {
@@ -406,6 +394,18 @@ public:
             << "ExecutionUnits: " << resources.ExecutionUnits << ".");
 
         FireResourcesPublishing();
+    }
+
+    void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
+        FreeResourcesImpl(tx, taskId, resources, true);
+    }
+
+    void FinishTx(TIntrusivePtr<TTxState>& tx) override {
+        if (auto currentRbTaskId = tx->TxResourceBrokerTaskId.exchange(0); currentRbTaskId) {
+            bool finished = ResourceBroker->FinishTaskInstant(TEvResourceBroker::TEvFinishTask(currentRbTaskId), SelfId);
+            Y_DEBUG_ABORT_UNLESS(finished);
+        }
+        FreeResourcesImpl(tx, 0, tx->FreeResourcesRequest(), false);
     }
 
     TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const override {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -46,6 +46,11 @@ using namespace NResourceBroker;
 #define LOG_AS_W(stream) LOG_AS_SAFE(LOG_WARN_S(*ActorSystem, NKikimrServices::KQP_RESOURCE_MANAGER, stream))
 #define LOG_AS_N(stream) LOG_AS_SAFE(LOG_NOTICE_S(*ActorSystem, NKikimrServices::KQP_RESOURCE_MANAGER, stream))
 
+TTxState::~TTxState() {
+    ResourceManager->FinishTx(this);
+    delete TxMaxAllocationBacktrace.load();
+}
+
 namespace {
 
 static constexpr double MYEPS = 1e-9;
@@ -354,7 +359,7 @@ public:
         return result;
     }
 
-    void FreeResourcesImpl(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources, bool reduceResourceBrokerTask) {
+    void FreeResourcesImpl(TTxState* tx, ui64 taskId, const TKqpResourcesRequest& resources, bool reduceResourceBrokerTask) {
 
         auto released = tx->Released(resources);
         Y_ABORT_UNLESS(released);
@@ -397,10 +402,10 @@ public:
     }
 
     void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
-        FreeResourcesImpl(tx, taskId, resources, true);
+        FreeResourcesImpl(tx.Get(), taskId, resources, true);
     }
 
-    void FinishTx(TIntrusivePtr<TTxState>& tx) override {
+    void FinishTx(TTxState* tx) override {
         if (auto currentRbTaskId = tx->TxResourceBrokerTaskId.exchange(0); currentRbTaskId) {
             bool finished = ResourceBroker->FinishTaskInstant(TEvResourceBroker::TEvFinishTask(currentRbTaskId), SelfId);
             Y_DEBUG_ABORT_UNLESS(finished);

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -46,8 +46,20 @@ using namespace NResourceBroker;
 #define LOG_AS_W(stream) LOG_AS_SAFE(LOG_WARN_S(*ActorSystem, NKikimrServices::KQP_RESOURCE_MANAGER, stream))
 #define LOG_AS_N(stream) LOG_AS_SAFE(LOG_NOTICE_S(*ActorSystem, NKikimrServices::KQP_RESOURCE_MANAGER, stream))
 
+TTxState::TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
+    const TString& database, bool collectBacktrace)
+    : ResourceManager(resourceManager)
+    , Counters(resourceManager->GetCounters())
+    , TxId(txId)
+    , CreatedAt(now)
+    , PoolId(poolId)
+    , MemoryPoolPercent(memoryPoolPercent)
+    , Database(database)
+    , CollectBacktrace(collectBacktrace)
+{}
+
 TTxState::~TTxState() {
-    ResourceManager->FinishTx(this);
+    ResourceManager->FinishTx(*this);
     delete TxMaxAllocationBacktrace.load();
 }
 
@@ -229,9 +241,9 @@ public:
         }
     }
 
-    TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override
+    TKqpRMAllocateResult AllocateResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) override
     {
-        const ui64 txId = tx->TxId;
+        const ui64 txId = tx.TxId;
 
         TKqpRMAllocateResult result;
         if (resources.ExecutionUnits) {
@@ -248,7 +260,7 @@ public:
         }
 
         if (Y_UNLIKELY(resources.Memory == 0)) {
-            tx->Allocated(resources);
+            tx.Allocated(resources);
             return result;
         }
 
@@ -276,17 +288,17 @@ public:
             }
 
             hasScanQueryMemory = TotalMemoryResource->AcquireIfAvailable(resources.Memory);
-            if (!tx->TotalMemoryCookie) {
-                tx->TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
+            if (!tx.TotalMemoryCookie) {
+                tx.TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
             }
 
-            if (hasScanQueryMemory && !tx->PoolId.empty() && tx->MemoryPoolPercent > 0) {
-                auto [it, success] = MemoryNamedPools.emplace(tx->MakePoolId(), nullptr);
+            if (hasScanQueryMemory && !tx.PoolId.empty() && tx.MemoryPoolPercent > 0) {
+                auto [it, success] = MemoryNamedPools.emplace(tx.MakePoolId(), nullptr);
 
                 if (success) {
-                    it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), tx->MemoryPoolPercent, SpillingPercent.load());
+                    it->second = MakeIntrusive<TMemoryResource>(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
                 } else {
-                    it->second->SetNewLimit(TotalMemoryResource->GetLimit(), tx->MemoryPoolPercent, SpillingPercent.load());
+                    it->second->SetNewLimit(TotalMemoryResource->GetLimit(), tx.MemoryPoolPercent, SpillingPercent.load());
                 }
 
                 auto& poolMemory = it->second;
@@ -295,18 +307,18 @@ public:
                     TotalMemoryResource->Release(resources.Memory);
                 }
 
-                if (!tx->PoolMemoryCookie) {
-                    tx->PoolMemoryCookie = poolMemory->GetSpillingCookie();
+                if (!tx.PoolMemoryCookie) {
+                    tx.PoolMemoryCookie = poolMemory->GetSpillingCookie();
                 }
             }
         }
 
         if (!hasScanQueryMemory) {
             Counters->RmNotEnoughMemory->Inc();
-            tx->AckFailedMemoryAlloc(resources.Memory);
+            tx.AckFailedMemoryAlloc(resources.Memory);
             TStringBuilder reason;
             reason << "TxId: " << txId << ", taskId: " << taskId << ". Not enough memory for query, requested: " << resources.Memory
-                << ". " << tx->ToString();
+                << ". " << tx.ToString();
             result.SetError(NKikimrKqp::TEvStartKqpTasksResponse::NOT_ENOUGH_MEMORY, reason);
             return result;
         }
@@ -317,11 +329,11 @@ public:
         Y_DEFER {
             if (!result) {
                 Counters->RmNotEnoughMemory->Inc();
-                tx->AckFailedMemoryAlloc(resources.Memory);
+                tx.AckFailedMemoryAlloc(resources.Memory);
                 with_lock (Lock) {
                     TotalMemoryResource->Release(resources.Memory);
-                    if (!tx->PoolId.empty()) {
-                        auto it = MemoryNamedPools.find(tx->MakePoolId());
+                    if (!tx.PoolId.empty()) {
+                        auto it = MemoryNamedPools.find(tx.MakePoolId());
                         if (it != MemoryNamedPools.end()) {
                             it->second->Release(resources.Memory);
                             if (it->second->GetUsed() == 0) {
@@ -340,16 +352,16 @@ public:
         if (!allocated) {
             TStringBuilder reason;
             reason << "TxId: " << txId << ", taskId: " << taskId << ". Not enough memory for query, requested: " << resources.Memory
-                << ". " << tx->ToString();
+                << ". " << tx.ToString();
             LOG_AS_N(reason);
             result.SetError(NKikimrKqp::TEvStartKqpTasksResponse::NOT_ENOUGH_MEMORY, reason);
             return result;
         }
 
-        tx->Allocated(resources);
+        tx.Allocated(resources);
 
         ui64 currentRbTaskId = 0;
-        if (!tx->TxResourceBrokerTaskId.compare_exchange_strong(currentRbTaskId, rbTaskId)) {
+        if (!tx.TxResourceBrokerTaskId.compare_exchange_strong(currentRbTaskId, rbTaskId)) {
             bool merged = ResourceBroker->MergeTasksInstant(currentRbTaskId, rbTaskId, SelfId);
             Y_ABORT_UNLESS(merged);
         }
@@ -359,13 +371,13 @@ public:
         return result;
     }
 
-    void FreeResourcesImpl(TTxState* tx, ui64 taskId, const TKqpResourcesRequest& resources, bool reduceResourceBrokerTask) {
+    void FreeResourcesImpl(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources, bool reduceResourceBrokerTask) {
 
-        auto released = tx->Released(resources);
+        auto released = tx.Released(resources);
         Y_ABORT_UNLESS(released);
 
         if (reduceResourceBrokerTask) {
-            bool reduced = ResourceBroker->ReduceTaskResourcesInstant(tx->TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
+            bool reduced = ResourceBroker->ReduceTaskResourcesInstant(tx.TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
             Y_DEBUG_ABORT_UNLESS(reduced);
         }
 
@@ -379,8 +391,8 @@ public:
         if (resources.Memory > 0) {
             with_lock (Lock) {
                 TotalMemoryResource->Release(resources.Memory);
-                if (!tx->PoolId.empty()) {
-                    auto it = MemoryNamedPools.find(tx->MakePoolId());
+                if (!tx.PoolId.empty()) {
+                    auto it = MemoryNamedPools.find(tx.MakePoolId());
                     if (it != MemoryNamedPools.end()) {
                         it->second->Release(resources.Memory);
 
@@ -392,7 +404,7 @@ public:
             }
         }
 
-        LOG_AS_D("TxId: " << tx->TxId << ", taskId: " << taskId
+        LOG_AS_D("TxId: " << tx.TxId << ", taskId: " << taskId
             << ". Released resources, "
             << "Memory: " << resources.Memory << ", "
             << "Free Tier: " << resources.ExternalMemory << ", "
@@ -401,16 +413,16 @@ public:
         FireResourcesPublishing();
     }
 
-    void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
-        FreeResourcesImpl(tx.Get(), taskId, resources, true);
+    void FreeResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
+        FreeResourcesImpl(tx, taskId, resources, true);
     }
 
-    void FinishTx(TTxState* tx) override {
-        if (auto currentRbTaskId = tx->TxResourceBrokerTaskId.exchange(0); currentRbTaskId) {
+    void FinishTx(TTxState& tx) override {
+        if (auto currentRbTaskId = tx.TxResourceBrokerTaskId.exchange(0); currentRbTaskId) {
             bool finished = ResourceBroker->FinishTaskInstant(TEvResourceBroker::TEvFinishTask(currentRbTaskId), SelfId);
             Y_DEBUG_ABORT_UNLESS(finished);
         }
-        FreeResourcesImpl(tx, 0, tx->FreeResourcesRequest(), false);
+        FreeResourcesImpl(tx, 0, tx.FreeResourcesRequest(), false);
     }
 
     TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const override {

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -380,7 +380,7 @@ public:
             ExecutionUnitsResource.fetch_add(resources.ExecutionUnits);
         }
 
-        i64 prev = ExternalDataQueryMemory.fetch_sub(resources.ExternalMemory);
+        auto prev = ExternalDataQueryMemory.fetch_sub(resources.ExternalMemory);
         Y_DEBUG_ABORT_UNLESS(prev >= resources.ExternalMemory);
 
         if (resources.Memory > 0) {
@@ -540,7 +540,7 @@ public:
     std::atomic<i32> ExecutionUnitsLimit;
     std::atomic<double> SpillingPercent;
     TIntrusivePtr<TMemoryResource> TotalMemoryResource;
-    std::atomic<i64> ExternalDataQueryMemory = 0;
+    std::atomic<ui64> ExternalDataQueryMemory = 0;
     std::atomic<ui64> MaxNonParallelTopStageExecutionLimit = 1;
     std::atomic<ui64> MaxNonParallelTasksExecutionLimit = 8;
     std::atomic<bool> PreferLocalDatacenterExecution = true;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.cpp
@@ -224,10 +224,9 @@ public:
         }
     }
 
-    TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task, const TKqpResourcesRequest& resources) override
+    TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override
     {
         const ui64 txId = tx->TxId;
-        const ui64 taskId = task->TaskId;
 
         TKqpRMAllocateResult result;
         if (resources.ExecutionUnits) {
@@ -244,7 +243,7 @@ public:
         }
 
         if (Y_UNLIKELY(resources.Memory == 0)) {
-            tx->Allocated(task, resources);
+            tx->Allocated(resources);
             return result;
         }
 
@@ -272,7 +271,9 @@ public:
             }
 
             hasScanQueryMemory = TotalMemoryResource->AcquireIfAvailable(resources.Memory);
-            task->TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
+            if (!tx->TotalMemoryCookie) {
+                tx->TotalMemoryCookie = TotalMemoryResource->GetSpillingCookie();
+            }
 
             if (hasScanQueryMemory && !tx->PoolId.empty() && tx->MemoryPoolPercent > 0) {
                 auto [it, success] = MemoryNamedPools.emplace(tx->MakePoolId(), nullptr);
@@ -289,7 +290,9 @@ public:
                     TotalMemoryResource->Release(resources.Memory);
                 }
 
-                task->PoolMemoryCookie = poolMemory->GetSpillingCookie();
+                if (!tx->PoolMemoryCookie) {
+                    tx->PoolMemoryCookie = poolMemory->GetSpillingCookie();
+                }
             }
         }
 
@@ -338,12 +341,14 @@ public:
             return result;
         }
 
-        tx->Allocated(task, resources);
-        if (!task->ResourceBrokerTaskId) {
-            task->ResourceBrokerTaskId = rbTaskId;
-        } else {
-            bool merged = ResourceBroker->MergeTasksInstant(task->ResourceBrokerTaskId, rbTaskId, SelfId);
-            Y_ABORT_UNLESS(merged);
+        with_lock(tx->Lock) {
+            tx->Allocated(resources);
+            if (!tx->TxResourceBrokerTaskId) {
+                tx->TxResourceBrokerTaskId = rbTaskId;
+            } else {
+                bool merged = ResourceBroker->MergeTasksInstant(tx->TxResourceBrokerTaskId, rbTaskId, SelfId);
+                Y_ABORT_UNLESS(merged);
+            }
         }
 
         LOG_AS_D("TxId: " << txId << ", taskId: " << taskId << ". Allocated " << resources.ToString());
@@ -351,33 +356,32 @@ public:
         return result;
     }
 
-    void FreeResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task) override {
-        FreeResources(tx, task, task->FreeResourcesRequest());
-    }
+    void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) override {
 
-    void FreeResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task, const TKqpResourcesRequest& resources) override {
+        with_lock(tx->Lock) {
+            auto released = tx->Released(resources);
+            Y_ABORT_UNLESS(released);
+
+            if (tx->TxResourceBrokerTaskId) {
+                if (tx->TxScanQueryMemory.load() == 0) {
+                    bool finished = ResourceBroker->FinishTaskInstant(
+                        TEvResourceBroker::TEvFinishTask(tx->TxResourceBrokerTaskId), SelfId);
+                    Y_DEBUG_ABORT_UNLESS(finished);
+                    tx->TxResourceBrokerTaskId = 0;
+                } else {
+                    bool reduced = ResourceBroker->ReduceTaskResourcesInstant(
+                        tx->TxResourceBrokerTaskId, {0, resources.Memory}, SelfId);
+                    Y_DEBUG_ABORT_UNLESS(reduced);
+                }
+            }
+        }
+
         if (resources.ExecutionUnits) {
             ExecutionUnitsResource.fetch_add(resources.ExecutionUnits);
         }
 
-        Y_ABORT_UNLESS(resources.Memory <= task->ScanQueryMemory);
-
-        if (resources.Memory > 0 && task->ResourceBrokerTaskId) {
-            if (resources.Memory == task->ScanQueryMemory) {
-                bool finished = ResourceBroker->FinishTaskInstant(
-                    TEvResourceBroker::TEvFinishTask(task->ResourceBrokerTaskId), SelfId);
-                Y_DEBUG_ABORT_UNLESS(finished);
-                task->ResourceBrokerTaskId = 0;
-            } else {
-                bool reduced = ResourceBroker->ReduceTaskResourcesInstant(
-                    task->ResourceBrokerTaskId, {0, resources.Memory}, SelfId);
-                Y_DEBUG_ABORT_UNLESS(reduced);
-            }
-        }
-
-        tx->Released(task, resources);
         i64 prev = ExternalDataQueryMemory.fetch_sub(resources.ExternalMemory);
-        Y_DEBUG_ABORT_UNLESS(prev >= 0);
+        Y_DEBUG_ABORT_UNLESS(prev >= resources.ExternalMemory);
 
         if (resources.Memory > 0) {
             with_lock (Lock) {
@@ -395,7 +399,7 @@ public:
             }
         }
 
-        LOG_AS_D("TxId: " << tx->TxId << ", taskId: " << task->TaskId
+        LOG_AS_D("TxId: " << tx->TxId << ", taskId: " << taskId
             << ". Released resources, "
             << "Memory: " << resources.Memory << ", "
             << "Free Tier: " << resources.ExternalMemory << ", "

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -175,20 +175,23 @@ public:
             Counters->RmExtraMemFree->Inc();
         }
 
+        auto prevExternalMemory = TxExternalDataQueryMemory.fetch_sub(resources.ExternalMemory);
+        if (prevExternalMemory < resources.ExternalMemory) {
+            return false;
+        }
         Counters->RmExternalMemory->Sub(resources.ExternalMemory);
-        if (TxExternalDataQueryMemory.fetch_sub(resources.ExternalMemory) < resources.ExternalMemory) {
+
+        auto prevMemory = TxScanQueryMemory.fetch_sub(resources.Memory);
+        if (prevMemory < resources.Memory) {
             return false;
         }
-
         Counters->RmMemory->Sub(resources.Memory);
-        if (TxScanQueryMemory.fetch_sub(resources.Memory) < resources.Memory) {
-            return false;
-        }
 
-        Counters->RmComputeActors->Sub(resources.ExecutionUnits);
-        if (TxExecutionUnits.fetch_sub(resources.ExecutionUnits) < resources.ExecutionUnits) {
+        auto prevExecutionUnits = TxExecutionUnits.fetch_sub(resources.ExecutionUnits);
+        if (prevExecutionUnits < resources.ExecutionUnits) {
             return false;
         }
+        Counters->RmComputeActors->Sub(resources.ExecutionUnits);
 
         return true;
     }

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -55,14 +55,13 @@ public:
     const double MemoryPoolPercent;
     const TString Database;
     const bool CollectBacktrace;
-    TMutex Lock;
     TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
     TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
 
     std::atomic<ui64> TxScanQueryMemory = 0;
     std::atomic<ui64> TxExternalDataQueryMemory = 0;
     std::atomic<ui32> TxExecutionUnits = 0;
-    ui64 TxResourceBrokerTaskId = 0;
+    std::atomic<ui64> TxResourceBrokerTaskId = 0;
     std::atomic<ui64> TxMaxAllocationSize = 0;
 
     // TODO(ilezhankin): it's better to use std::atomic<std::shared_ptr<>> which is not supported at the moment.
@@ -290,6 +289,7 @@ public:
     virtual void EstimateTaskResources(TTaskResourceEstimation& result, const ui32 tasksCount) = 0;
 
     virtual void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
+    virtual void FinishTx(TIntrusivePtr<TTxState>& tx) = 0;
     virtual void RequestClusterResourcesInfo(TOnResourcesSnapshotCallback&& callback) = 0;
 
     virtual TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const = 0;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -40,57 +40,9 @@ struct TKqpResourcesRequest {
     }
 };
 
-class TTxState;
-
 class TMemoryResourceCookie : public TAtomicRefCount<TMemoryResourceCookie> {
 public:
     std::atomic<bool> SpillingPercentReached{false};
-};
-
-class TTaskState : public TAtomicRefCount<TTaskState> {
-    friend TTxState;
-
-public:
-    const ui64 TaskId = 0;
-    const TInstant CreatedAt;
-    ui64 ScanQueryMemory = 0;
-    ui64 ExternalDataQueryMemory = 0;
-    ui64 ResourceBrokerTaskId = 0;
-    ui32 ExecutionUnits = 0;
-    TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
-    TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
-
-public:
-
-    // compute actor wants to release some memory.
-    // we distribute that memory across granted resources
-    TKqpResourcesRequest FitRequest(TKqpResourcesRequest& resources) {
-        ui64 releaseScanQueryMemory = std::min(ScanQueryMemory, resources.Memory);
-        ui64 leftToRelease = resources.Memory - releaseScanQueryMemory;
-        ui64 releaseExternalDataQueryMemory = std::min(ExternalDataQueryMemory, resources.ExternalMemory + leftToRelease);
-
-        resources.Memory = releaseScanQueryMemory;
-        resources.ExternalMemory = releaseExternalDataQueryMemory;
-        return resources;
-    }
-
-    bool IsReasonableToStartSpilling() {
-        return (PoolMemoryCookie && PoolMemoryCookie->SpillingPercentReached.load())
-            || (TotalMemoryCookie && TotalMemoryCookie->SpillingPercentReached.load());
-    }
-
-    TKqpResourcesRequest FreeResourcesRequest() const {
-        return TKqpResourcesRequest{
-            .ExecutionUnits=ExecutionUnits,
-            .Memory=ScanQueryMemory,
-            .ExternalMemory=ExternalDataQueryMemory};
-    }
-
-    explicit TTaskState(ui64 taskId, TInstant createdAt)
-        : TaskId(taskId)
-        , CreatedAt(createdAt)
-    {
-    }
 };
 
 class TTxState : public TAtomicRefCount<TTxState> {
@@ -103,11 +55,14 @@ public:
     const double MemoryPoolPercent;
     const TString Database;
     const bool CollectBacktrace;
+    TMutex Lock;
+    TIntrusivePtr<TMemoryResourceCookie> TotalMemoryCookie;
+    TIntrusivePtr<TMemoryResourceCookie> PoolMemoryCookie;
 
-private:
     std::atomic<ui64> TxScanQueryMemory = 0;
     std::atomic<ui64> TxExternalDataQueryMemory = 0;
     std::atomic<ui32> TxExecutionUnits = 0;
+    ui64 TxResourceBrokerTaskId = 0;
     std::atomic<ui64> TxMaxAllocationSize = 0;
 
     // TODO(ilezhankin): it's better to use std::atomic<std::shared_ptr<>> which is not supported at the moment.
@@ -138,6 +93,18 @@ public:
 
     std::pair<TString, TString> MakePoolId() const {
         return std::make_pair(Database, PoolId);
+    }
+
+    bool IsReasonableToStartSpilling() {
+        return (PoolMemoryCookie && PoolMemoryCookie->SpillingPercentReached.load())
+            || (TotalMemoryCookie && TotalMemoryCookie->SpillingPercentReached.load());
+    }
+
+    TKqpResourcesRequest FreeResourcesRequest() const {
+        return TKqpResourcesRequest{
+            .ExecutionUnits=TxExecutionUnits.load(),
+            .Memory=TxScanQueryMemory.load(),
+            .ExternalMemory=TxExternalDataQueryMemory.load()};
     }
 
     TString ToString() const {
@@ -201,7 +168,7 @@ public:
         }
     }
 
-    void Released(TIntrusivePtr<TTaskState>& taskState, const TKqpResourcesRequest& resources) {
+    bool Released(const TKqpResourcesRequest& resources) {
         if (resources.ExecutionUnits) {
             Counters->RmOnCompleteFree->Inc();
         } else {
@@ -209,30 +176,38 @@ public:
         }
 
         Counters->RmExternalMemory->Sub(resources.ExternalMemory);
-        TxExternalDataQueryMemory.fetch_sub(resources.ExternalMemory);
-        taskState->ExternalDataQueryMemory -= resources.ExternalMemory;
+        if (TxExternalDataQueryMemory.fetch_sub(resources.ExternalMemory) < resources.ExternalMemory) {
+            return false;
+        }
 
-        TxScanQueryMemory.fetch_sub(resources.Memory);
-        taskState->ScanQueryMemory -= resources.Memory;
         Counters->RmMemory->Sub(resources.Memory);
+        if (TxScanQueryMemory.fetch_sub(resources.Memory) < resources.Memory) {
+            return false;
+        }
 
-        TxExecutionUnits.fetch_sub(resources.ExecutionUnits);
-        taskState->ExecutionUnits -= resources.ExecutionUnits;
         Counters->RmComputeActors->Sub(resources.ExecutionUnits);
+        if (TxExecutionUnits.fetch_sub(resources.ExecutionUnits) < resources.ExecutionUnits) {
+            return false;
+        }
+
+        return true;
     }
 
-    void Allocated(TIntrusivePtr<TTaskState>& taskState, const TKqpResourcesRequest& resources) {
+    void Allocated(const TKqpResourcesRequest& resources) {
+
+        TxExecutionUnits.fetch_add(resources.ExecutionUnits);
+        Counters->RmComputeActors->Add(resources.ExecutionUnits);
+
+        TxScanQueryMemory.fetch_add(resources.Memory);
+        Counters->RmMemory->Add(resources.Memory);
+
+        TxExternalDataQueryMemory.fetch_add(resources.ExternalMemory);
+        Counters->RmExternalMemory->Add(resources.ExternalMemory);
+
         if (resources.ExecutionUnits > 0) {
             Counters->RmOnStartAllocs->Inc();
         }
 
-        Counters->RmExternalMemory->Add(resources.ExternalMemory);
-        TxExternalDataQueryMemory.fetch_add(resources.ExternalMemory);
-        taskState->ExternalDataQueryMemory += resources.ExternalMemory;
-
-        TxScanQueryMemory.fetch_add(resources.Memory);
-        taskState->ScanQueryMemory += resources.Memory;
-        Counters->RmMemory->Add(resources.Memory);
         if (resources.Memory) {
             Counters->RmExtraMemAllocs->Inc();
         }
@@ -255,10 +230,6 @@ public:
                 delete newBacktrace;
             }
         }
-
-        TxExecutionUnits.fetch_add(resources.ExecutionUnits);
-        taskState->ExecutionUnits += resources.ExecutionUnits;
-        Counters->RmComputeActors->Add(resources.ExecutionUnits);
     }
 };
 
@@ -267,7 +238,6 @@ struct TKqpRMAllocateResult {
     bool Success = true;
     NKikimrKqp::TEvStartKqpTasksResponse::ENotStartedTaskReason Status = NKikimrKqp::TEvStartKqpTasksResponse::INTERNAL_ERROR;
     TString FailReason;
-    TIntrusivePtr<TTaskState> TaskInfo;
     TIntrusivePtr<TTxState> TxInfo;
 
     NKikimrKqp::TEvStartKqpTasksResponse::ENotStartedTaskReason GetStatus() const {
@@ -310,14 +280,13 @@ public:
 
     virtual const TIntrusivePtr<TKqpCounters>& GetCounters() const = 0;
 
-    virtual TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task, const TKqpResourcesRequest& resources) = 0;
+    virtual TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
 
     virtual TPlannerPlacingOptions GetPlacingOptions() = 0;
     virtual TTaskResourceEstimation EstimateTaskResources(const NYql::NDqProto::TDqTask& task, const ui32 tasksCount) = 0;
     virtual void EstimateTaskResources(TTaskResourceEstimation& result, const ui32 tasksCount) = 0;
 
-    virtual void FreeResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task, const TKqpResourcesRequest& resources) = 0;
-    virtual void FreeResources(TIntrusivePtr<TTxState>& tx, TIntrusivePtr<TTaskState>& task) = 0;
+    virtual void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
     virtual void RequestClusterResourcesInfo(TOnResourcesSnapshotCallback&& callback) = 0;
 
     virtual TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const = 0;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -45,9 +45,12 @@ public:
     std::atomic<bool> SpillingPercentReached{false};
 };
 
+class IKqpResourceManager;
+
 class TTxState : public TAtomicRefCount<TTxState> {
 
 public:
+    std::shared_ptr<IKqpResourceManager> ResourceManager;
     const ui64 TxId;
     const TInstant CreatedAt;
     TIntrusivePtr<TKqpCounters> Counters;
@@ -75,9 +78,10 @@ public:
     std::atomic<bool> HasFailedAllocationBacktrace = false;
 
 public:
-    explicit TTxState(ui64 txId, TInstant now, TIntrusivePtr<TKqpCounters> counters, const TString& poolId, const double memoryPoolPercent,
+    explicit TTxState(std::shared_ptr<IKqpResourceManager> resourceManager, ui64 txId, TInstant now, TIntrusivePtr<TKqpCounters> counters, const TString& poolId, const double memoryPoolPercent,
         const TString& database, bool collectBacktrace)
-        : TxId(txId)
+        : ResourceManager(resourceManager)
+        , TxId(txId)
         , CreatedAt(now)
         , Counters(std::move(counters))
         , PoolId(poolId)
@@ -86,9 +90,7 @@ public:
         , CollectBacktrace(collectBacktrace)
     {}
 
-    ~TTxState() {
-        delete TxMaxAllocationBacktrace.load();
-    }
+    ~TTxState();
 
     std::pair<TString, TString> MakePoolId() const {
         return std::make_pair(Database, PoolId);
@@ -289,7 +291,7 @@ public:
     virtual void EstimateTaskResources(TTaskResourceEstimation& result, const ui32 tasksCount) = 0;
 
     virtual void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
-    virtual void FinishTx(TIntrusivePtr<TTxState>& tx) = 0;
+    virtual void FinishTx(TTxState* tx) = 0;
     virtual void RequestClusterResourcesInfo(TOnResourcesSnapshotCallback&& callback) = 0;
 
     virtual TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const = 0;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -32,7 +32,6 @@ struct TKqpResourcesRequest {
     ui64 ExecutionUnits = 0;
     ui64 Memory = 0;
     ui64 ExternalMemory = 0;
-    bool ReleaseAllResources = false;
 
     TString ToString() const {
         return TStringBuilder() << "TKqpResourcesRequest{ ExecutionUnits: " << ExecutionUnits << ", Memory: " << Memory
@@ -51,9 +50,9 @@ class TTxState : public TAtomicRefCount<TTxState> {
 
 public:
     std::shared_ptr<IKqpResourceManager> ResourceManager;
+    TIntrusivePtr<TKqpCounters> Counters;
     const ui64 TxId;
     const TInstant CreatedAt;
-    TIntrusivePtr<TKqpCounters> Counters;
     const TString PoolId;
     const double MemoryPoolPercent;
     const TString Database;
@@ -78,18 +77,8 @@ public:
     std::atomic<bool> HasFailedAllocationBacktrace = false;
 
 public:
-    explicit TTxState(std::shared_ptr<IKqpResourceManager> resourceManager, ui64 txId, TInstant now, TIntrusivePtr<TKqpCounters> counters, const TString& poolId, const double memoryPoolPercent,
-        const TString& database, bool collectBacktrace)
-        : ResourceManager(resourceManager)
-        , TxId(txId)
-        , CreatedAt(now)
-        , Counters(std::move(counters))
-        , PoolId(poolId)
-        , MemoryPoolPercent(memoryPoolPercent)
-        , Database(database)
-        , CollectBacktrace(collectBacktrace)
-    {}
-
+    TTxState(std::shared_ptr<IKqpResourceManager>& resourceManager, ui64 txId, TInstant now, const TString& poolId, const double memoryPoolPercent,
+        const TString& database, bool collectBacktrace);
     ~TTxState();
 
     std::pair<TString, TString> MakePoolId() const {
@@ -283,14 +272,14 @@ public:
 
     virtual const TIntrusivePtr<TKqpCounters>& GetCounters() const = 0;
 
-    virtual TKqpRMAllocateResult AllocateResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
+    virtual TKqpRMAllocateResult AllocateResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
 
     virtual TPlannerPlacingOptions GetPlacingOptions() = 0;
     virtual TTaskResourceEstimation EstimateTaskResources(const NYql::NDqProto::TDqTask& task, const ui32 tasksCount) = 0;
     virtual void EstimateTaskResources(TTaskResourceEstimation& result, const ui32 tasksCount) = 0;
 
-    virtual void FreeResources(TIntrusivePtr<TTxState>& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
-    virtual void FinishTx(TTxState* tx) = 0;
+    virtual void FreeResources(TTxState& tx, ui64 taskId, const TKqpResourcesRequest& resources) = 0;
+    virtual void FinishTx(TTxState& tx) = 0;
     virtual void RequestClusterResourcesInfo(TOnResourcesSnapshotCallback&& callback) = 0;
 
     virtual TVector<NKikimrKqp::TKqpNodeResources> GetClusterResources() const = 0;

--- a/ydb/core/kqp/rm_service/kqp_rm_service.h
+++ b/ydb/core/kqp/rm_service/kqp_rm_service.h
@@ -242,7 +242,6 @@ struct TKqpRMAllocateResult {
     bool Success = true;
     NKikimrKqp::TEvStartKqpTasksResponse::ENotStartedTaskReason Status = NKikimrKqp::TEvStartKqpTasksResponse::INTERNAL_ERROR;
     TString FailReason;
-    TIntrusivePtr<TTxState> TxInfo;
 
     NKikimrKqp::TEvStartKqpTasksResponse::ENotStartedTaskReason GetStatus() const {
         return Status;

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -194,7 +194,7 @@ public:
     }
 
     TIntrusivePtr<NRm::TTxState> MakeTx(ui64 txId, std::shared_ptr<NRm::IKqpResourceManager> rm) {
-        return MakeIntrusive<NRm::TTxState>(txId, TInstant::Now(), rm->GetCounters(), "", (double)100, "", false);
+        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), rm->GetCounters(), "", (double)100, "", false);
     }
 
     void AssertResourceManagerStats(
@@ -317,19 +317,22 @@ void KqpRm::SingleTask() {
     UNIT_ASSERT_VALUES_EQUAL(1000, stats.Memory);
 
     NRm::TKqpResourcesRequest request{.ExecutionUnits = 1, .Memory = 100};
-    auto tx = MakeTx(1, rm);
-    auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, request);
-    UNIT_ASSERT(allocated);
+    {
+        auto tx = MakeTx(1, rm);
+        auto task = 2;
 
-    AssertResourceManagerStats(rm, 900, 99);
-    AssertResourceBrokerSensors(0, 100, 0, 0, 1);
+        bool allocated = rm->AllocateResources(tx, task, request);
+        UNIT_ASSERT(allocated);
 
-    rm->FreeResources(tx, task, request);
-    AssertResourceManagerStats(rm, 1000, 100);
-    AssertResourceBrokerSensors(0, 0, 0, 0, 1);
-    rm->FinishTx(tx);
+        AssertResourceManagerStats(rm, 900, 99);
+        AssertResourceBrokerSensors(0, 100, 0, 0, 1);
+
+        rm->FreeResources(tx, task, request);
+        AssertResourceManagerStats(rm, 1000, 100);
+        AssertResourceBrokerSensors(0, 0, 0, 0, 1);
+    }
+
     AssertResourceBrokerSensors(0, 0, 0, 1, 0);
 }
 
@@ -341,18 +344,17 @@ void KqpRm::ManyTasks() {
 
     NRm::TKqpResourcesRequest request{.ExecutionUnits = 1, .Memory = 100};
 
-    auto tx = MakeTx(1, rm);
+    {
+        auto tx = MakeTx(1, rm);
+        for (ui32 i = 1; i < 10; ++i) {
+            auto task = i;
+            bool allocated = rm->AllocateResources(tx, task, request);
+            UNIT_ASSERT(allocated);
 
-    for (ui32 i = 1; i < 10; ++i) {
-        auto task = i;
-        bool allocated = rm->AllocateResources(tx, task, request);
-        UNIT_ASSERT(allocated);
-
-        AssertResourceManagerStats(rm, 1000 - 100 * i, 100 - i);
-        AssertResourceBrokerSensors(0, 100 * i, 0, i - 1, 1);
+            AssertResourceManagerStats(rm, 1000 - 100 * i, 100 - i);
+            AssertResourceBrokerSensors(0, 100 * i, 0, i - 1, 1);
+        }
     }
-
-    rm->FinishTx(tx);
 
     AssertResourceManagerStats(rm, 1000, 100);
     AssertResourceBrokerSensors(0, 0, 0, 9, 0);
@@ -420,33 +422,32 @@ void KqpRm::Snapshot() {
 
     NRm::TKqpResourcesRequest request{.ExecutionUnits = 10, .Memory = 100};
 
-    auto tx1 = MakeTx(1, rm);
-    auto tx2 = MakeTx(2, rm);
+    {
+        auto tx1 = MakeTx(1, rm);
+        auto tx2 = MakeTx(2, rm);
 
-    auto task2 = 2;
-    auto task1 = 1;
+        auto task2 = 2;
+        auto task1 = 1;
 
-    bool allocated = rm->AllocateResources(tx1, task2, request);
-    UNIT_ASSERT(allocated);
+        bool allocated = rm->AllocateResources(tx1, task2, request);
+        UNIT_ASSERT(allocated);
 
-    allocated &= rm->AllocateResources(tx2, task1, request);
-    UNIT_ASSERT(allocated);
+        allocated &= rm->AllocateResources(tx2, task1, request);
+        UNIT_ASSERT(allocated);
 
-    AssertResourceManagerStats(rm, 800, 80);
-    AssertResourceBrokerSensors(0, 200, 0, 0, 2);
+        AssertResourceManagerStats(rm, 800, 80);
+        AssertResourceBrokerSensors(0, 200, 0, 0, 2);
 
-    Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
-    CheckSnapshot(0, {{800, 80}, {1000, 100}}, rm);
+        CheckSnapshot(0, {{800, 80}, {1000, 100}}, rm);
 
-    rm->FreeResources(tx1, task2, request);
-    rm->FreeResources(tx2, task1, request);
+        rm->FreeResources(tx1, task2, request);
+        rm->FreeResources(tx2, task1, request);
 
-    AssertResourceManagerStats(rm, 1000, 100);
-    AssertResourceBrokerSensors(0, 0, 0, 0, 2);
-
-    rm->FinishTx(tx1);
-    rm->FinishTx(tx2);
+        AssertResourceManagerStats(rm, 1000, 100);
+        AssertResourceBrokerSensors(0, 0, 0, 0, 2);
+    }
 
     AssertResourceBrokerSensors(0, 0, 0, 2, 0);
 
@@ -488,46 +489,46 @@ void KqpRm::ConcurrentTasks() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    auto tx = MakeTx(1, rm);
+    {
+        auto tx = MakeTx(1, rm);
 
-    std::array<TMuxEvent, 10> events;
-    NPar::LocalExecutor().RunAdditionalThreads(10);
-    std::atomic<ui64> failedAllocations = 0;
+        std::array<TMuxEvent, 10> events;
+        NPar::LocalExecutor().RunAdditionalThreads(10);
+        std::atomic<ui64> failedAllocations = 0;
 
-    for (auto i = 0u; i < 10u; i++) {
-        NPar::LocalExecutor().Exec([&](int taskId) mutable {
-            auto count = 0u;
-            for (auto n = 0u; n < 20u; n++) {
-                for (auto j = 0u; j < 20u; j++) {
-                    if (!rm->AllocateResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u})) {
-                        failedAllocations++;
-                        Sleep(TDuration::MilliSeconds(j * 10));
-                        break;
+        for (auto i = 0u; i < 10u; i++) {
+            NPar::LocalExecutor().Exec([&](int taskId) mutable {
+                auto count = 0u;
+                for (auto n = 0u; n < 20u; n++) {
+                    for (auto j = 0u; j < 20u; j++) {
+                        if (!rm->AllocateResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u})) {
+                            failedAllocations++;
+                            Sleep(TDuration::MilliSeconds(j * 10));
+                            break;
+                        }
+                        count += j;
                     }
-                    count += j;
-                }
-                for (auto j = 20u; j > 0u; j--) {
-                    if (count < j) {
-                        break;
+                    for (auto j = 20u; j > 0u; j--) {
+                        if (count < j) {
+                            break;
+                        }
+                        rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u});
+                        count -= j;
                     }
-                    rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u});
-                    count -= j;
                 }
-            }
-            rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = count, .Memory = count * 10u});
-            events[taskId - 1].Signal();
-        }, i + 1, NPar::TLocalExecutor::MED_PRIORITY);
+                rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = count, .Memory = count * 10u});
+                events[taskId - 1].Signal();
+            }, i + 1, NPar::TLocalExecutor::MED_PRIORITY);
+        }
+
+        for (auto i = 0; i < 10; i++) {
+            events[i].WaitI();
+        }
+
+        UNIT_ASSERT_GT(failedAllocations.load(), 0);
+        AssertResourceManagerStats(rm, 1000, 100);
+        AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 1);
     }
-
-    for (auto i = 0; i < 10; i++) {
-        events[i].WaitI();
-    }
-
-    UNIT_ASSERT_GT(failedAllocations.load(), 0);
-    AssertResourceManagerStats(rm, 1000, 100);
-    AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 1);
-
-    rm->FinishTx(tx);
 
     AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 0);
 }

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -191,20 +191,11 @@ public:
         return MakeIntrusive<NRm::TTxState>(txId, TInstant::Now(), rm->GetCounters(), "", (double)100, "", false);
     }
 
-    TIntrusivePtr<NRm::TTaskState> MakeTask(ui64 taskId, TIntrusivePtr<NRm::TTxState> tx) {
-        return MakeIntrusive<NRm::TTaskState>(taskId, tx->CreatedAt);
-    }
-
     void AssertResourceManagerStats(
             std::shared_ptr<NRm::IKqpResourceManager> rm, ui64 scanQueryMemory, ui32 executionUnits) {
         Y_UNUSED(executionUnits);
         auto stats = rm->GetLocalResources();
         UNIT_ASSERT_VALUES_EQUAL(scanQueryMemory, stats.Memory);
-        // UNIT_ASSERT_VALUES_EQUAL(executionUnits, stats.ExecutionUnits);
-    }
-
-    void AssertResourceManagerStatsExecutionUnits( std::shared_ptr<NRm::IKqpResourceManager> rm, ui32 executionUnits) {
-        auto stats = rm->GetLocalResources();
         UNIT_ASSERT_VALUES_EQUAL(executionUnits, stats.ExecutionUnits);
     }
 
@@ -317,18 +308,17 @@ void KqpRm::SingleTask() {
     auto stats = rm->GetLocalResources();
     UNIT_ASSERT_VALUES_EQUAL(1000, stats.Memory);
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
-    auto tx1 = MakeTx(1, rm);
-    auto task2 = MakeTask(2, tx1);
+    NRm::TKqpResourcesRequest request{.ExecutionUnits = 1, .Memory = 100};
+    auto tx = MakeTx(1, rm);
+    auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx1, task2, request);
+    bool allocated = rm->AllocateResources(tx, task, request);
     UNIT_ASSERT(allocated);
 
-    AssertResourceManagerStats(rm, 900, 90);
+    AssertResourceManagerStats(rm, 900, 99);
     AssertResourceBrokerSensors(0, 100, 0, 0, 1);
 
-    rm->FreeResources(tx1, task2);
+    rm->FreeResources(tx, task, request);
     AssertResourceManagerStats(rm, 1000, 100);
     AssertResourceBrokerSensors(0, 0, 0, 1, 0);
 }
@@ -339,40 +329,22 @@ void KqpRm::ManyTasks() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
+    NRm::TKqpResourcesRequest request{.ExecutionUnits = 1, .Memory = 100};
 
-    auto tx1 = MakeTx(1, rm);
-    TIntrusivePtr<NRm::TTaskState> task1;
+    auto tx = MakeTx(1, rm);
 
     for (ui32 i = 1; i < 10; ++i) {
-        auto task = MakeTask(i, tx1);
-        if (!task1) {
-            task1 = task;
-        }
-
-        bool allocated = rm->AllocateResources(tx1, task, request);
+        auto task = i;
+        bool allocated = rm->AllocateResources(tx, task, request);
         UNIT_ASSERT(allocated);
 
-        AssertResourceManagerStats(rm, 1000 - 100 * i, 100 - 10 * i);
-        AssertResourceBrokerSensors(0, 100 * i, 0, 0, i);
+        AssertResourceManagerStats(rm, 1000 - 100 * i, 100 - i);
+        AssertResourceBrokerSensors(0, 100 * i, 0, i - 1, 1);
     }
 
-/*
-    // invalid taskId
-    rm->FreeResources(1, 0);
-    AssertResourceManagerStats(rm, 100, 10);
-    AssertResourceBrokerSensors(0, 900, 0, 0, 9);
-
-    // invalid txId
-    rm->FreeResources(10, 1);
-    AssertResourceManagerStats(rm, 100, 10);
-    AssertResourceBrokerSensors(0, 900, 0, 0, 9);
-*/
-
-    rm->FreeResources(tx1, task1);
-    AssertResourceManagerStats(rm, 200, 20);
-    AssertResourceBrokerSensors(0, 800, 0, 1, 8);
+    rm->FreeResources(tx, 0, NRm::TKqpResourcesRequest{.ExecutionUnits = 9, .Memory = 900});
+    AssertResourceManagerStats(rm, 1000, 100);
+    AssertResourceBrokerSensors(0, 0, 0, 9, 0);
 }
 
 void KqpRm::NotEnoughMemory() {
@@ -381,13 +353,10 @@ void KqpRm::NotEnoughMemory() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 10'000;
-
     auto tx = MakeTx(1, rm);
-    auto task = MakeTask(2, tx);
+    auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, request);
+    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 10'000});
     UNIT_ASSERT(!allocated);
 
     AssertResourceManagerStats(rm, 1000, 100);
@@ -400,14 +369,10 @@ void KqpRm::NotEnoughExecutionUnits() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
-    request.ExecutionUnits = 1000;
-
     auto tx = MakeTx(1, rm);
-    auto task = MakeTask(2, tx);
+    auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, request);
+    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1000, .Memory = 100});
     UNIT_ASSERT(!allocated);
 
     AssertResourceManagerStats(rm, 1000, 100);
@@ -423,20 +388,16 @@ void KqpRm::ResourceBrokerNotEnoughResources() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 1'000;
-
     auto tx = MakeTx(1, rm);
-    auto task = MakeTask(2, tx);
+    auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, request);
+    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1'000});
     UNIT_ASSERT(allocated);
 
-    request.Memory = 100'000;
-    allocated = rm->AllocateResources(tx, task, request);
+    allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 100'000});
     UNIT_ASSERT(!allocated);
 
-    AssertResourceManagerStats(rm, config.GetQueryMemoryLimit() - 1000, 90);
+    AssertResourceManagerStats(rm, config.GetQueryMemoryLimit() - 1000, 99);
     AssertResourceBrokerSensors(0, 1000, 0, 0, 1);
 }
 
@@ -446,14 +407,13 @@ void KqpRm::Snapshot() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
-    request.ExecutionUnits = 10;
+    NRm::TKqpResourcesRequest request{.ExecutionUnits = 10, .Memory = 100};
+
     auto tx1 = MakeTx(1, rm);
     auto tx2 = MakeTx(2, rm);
 
-    auto task2 = MakeTask(2, tx1);
-    auto task1 = MakeTask(1, tx2);
+    auto task2 = 2;
+    auto task1 = 1;
 
     bool allocated = rm->AllocateResources(tx1, task2, request);
     UNIT_ASSERT(allocated);
@@ -468,8 +428,8 @@ void KqpRm::Snapshot() {
 
     CheckSnapshot(0, {{800, 80}, {1000, 100}}, rm);
 
-    rm->FreeResources(tx1, task2);
-    rm->FreeResources(tx2, task1);
+    rm->FreeResources(tx1, task2, request);
+    rm->FreeResources(tx2, task1, request);
 
     AssertResourceManagerStats(rm, 1000, 100);
     AssertResourceBrokerSensors(0, 0, 0, 2, 0);
@@ -489,12 +449,10 @@ void KqpRm::Reduce() {
 
     auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
     auto tx = MakeTx(1, rm);
-    auto task = MakeTask(1, tx);
+    auto task = 1;
 
-    bool allocated = rm->AllocateResources(tx, task, request);
+    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 100});
     UNIT_ASSERT(allocated);
 
     AssertResourceManagerStats(rm, 1000 - 100, 100 - 10);
@@ -503,20 +461,8 @@ void KqpRm::Reduce() {
     NRm::TKqpResourcesRequest reduceRequest;
     reduceRequest.Memory = 70;
 
-/*
-    // invalid taskId
-    rm->FreeResources(1, 0);
-    AssertResourceManagerStats(rm, 1000 - 100, 100 - 10);
-    AssertResourceBrokerSensors(0, 100, 0, 0, 1);
-
-    // invalid txId
-    rm->FreeResources(10, 1);
-    AssertResourceManagerStats(rm, 1000 - 100, 100 - 10);
-    AssertResourceBrokerSensors(0, 100, 0, 0, 1);
-*/
-
-    rm->FreeResources(tx, task, reduceRequest);
-    AssertResourceManagerStats(rm, 1000 - 30, 100 - 7);
+    rm->FreeResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 7, .Memory = 70});
+    AssertResourceManagerStats(rm, 1000 - 100 + 70, 100 - 10 + 7);
     AssertResourceBrokerSensors(0, 30, 0, 0, 1);
 }
 
@@ -532,19 +478,17 @@ void KqpRm::SnapshotSharing() {
     CheckSnapshot(0, {{1000, 100}, {1000, 100}}, rm_first);
     CheckSnapshot(1, {{1000, 100}, {1000, 100}}, rm_second);
 
-    NRm::TKqpResourcesRequest request;
-    request.Memory = 100;
-    request.ExecutionUnits = 10;
+    NRm::TKqpResourcesRequest request{.ExecutionUnits = 10, .Memory = 100};
 
     auto tx1Rm1 = MakeTx(1, rm_first);
     auto tx2Rm1 = MakeTx(2, rm_first);
-    auto task1Rm1 = MakeTask(1, tx1Rm1);
-    auto task2Rm1 = MakeTask(1, tx2Rm1);
+    auto task1Rm1 = 1;
+    auto task2Rm1 = 2;
 
     auto tx1Rm2 = MakeTx(1, rm_second);
     auto tx2Rm2 = MakeTx(2, rm_second);
-    auto task1Rm2 = MakeTask(1, tx1Rm2);
-    auto task2Rm2 = MakeTask(2, tx2Rm2);
+    auto task1Rm2 = 1;
+    auto task2Rm2 = 2;
 
     {
         bool allocated = rm_first->AllocateResources(tx1Rm1, task1Rm1, request);
@@ -571,8 +515,8 @@ void KqpRm::SnapshotSharing() {
     }
 
     {
-        rm_first->FreeResources(tx1Rm1, task1Rm1);
-        rm_first->FreeResources(tx2Rm1, task2Rm1);
+        rm_first->FreeResources(tx1Rm1, task1Rm1, request);
+        rm_first->FreeResources(tx2Rm1, task2Rm1, request);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
@@ -580,8 +524,8 @@ void KqpRm::SnapshotSharing() {
     }
 
     {
-        rm_second->FreeResources(tx1Rm2, task1Rm2);
-        rm_second->FreeResources(tx2Rm2, task2Rm2);
+        rm_second->FreeResources(tx1Rm2, task1Rm2, request);
+        rm_second->FreeResources(tx2Rm2, task2Rm2, request);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -328,6 +328,8 @@ void KqpRm::SingleTask() {
 
     rm->FreeResources(tx, task, request);
     AssertResourceManagerStats(rm, 1000, 100);
+    AssertResourceBrokerSensors(0, 0, 0, 0, 1);
+    rm->FinishTx(tx);
     AssertResourceBrokerSensors(0, 0, 0, 1, 0);
 }
 
@@ -350,7 +352,8 @@ void KqpRm::ManyTasks() {
         AssertResourceBrokerSensors(0, 100 * i, 0, i - 1, 1);
     }
 
-    rm->FreeResources(tx, 0, NRm::TKqpResourcesRequest{.ExecutionUnits = 9, .Memory = 900});
+    rm->FinishTx(tx);
+
     AssertResourceManagerStats(rm, 1000, 100);
     AssertResourceBrokerSensors(0, 0, 0, 9, 0);
 }
@@ -440,6 +443,11 @@ void KqpRm::Snapshot() {
     rm->FreeResources(tx2, task1, request);
 
     AssertResourceManagerStats(rm, 1000, 100);
+    AssertResourceBrokerSensors(0, 0, 0, 0, 2);
+
+    rm->FinishTx(tx1);
+    rm->FinishTx(tx2);
+
     AssertResourceBrokerSensors(0, 0, 0, 2, 0);
 
     Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
@@ -517,6 +525,10 @@ void KqpRm::ConcurrentTasks() {
 
     UNIT_ASSERT_GT(failedAllocations.load(), 0);
     AssertResourceManagerStats(rm, 1000, 100);
+    AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 1);
+
+    rm->FinishTx(tx);
+
     AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 0);
 }
 

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -194,7 +194,7 @@ public:
     }
 
     TIntrusivePtr<NRm::TTxState> MakeTx(ui64 txId, std::shared_ptr<NRm::IKqpResourceManager> rm) {
-        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), rm->GetCounters(), "", (double)100, "", false);
+        return MakeIntrusive<NRm::TTxState>(rm, txId, TInstant::Now(), "", (double)100, "", false);
     }
 
     void AssertResourceManagerStats(
@@ -322,13 +322,13 @@ void KqpRm::SingleTask() {
         auto tx = MakeTx(1, rm);
         auto task = 2;
 
-        bool allocated = rm->AllocateResources(tx, task, request);
+        bool allocated = rm->AllocateResources(*tx, task, request);
         UNIT_ASSERT(allocated);
 
         AssertResourceManagerStats(rm, 900, 99);
         AssertResourceBrokerSensors(0, 100, 0, 0, 1);
 
-        rm->FreeResources(tx, task, request);
+        rm->FreeResources(*tx, task, request);
         AssertResourceManagerStats(rm, 1000, 100);
         AssertResourceBrokerSensors(0, 0, 0, 0, 1);
     }
@@ -348,7 +348,7 @@ void KqpRm::ManyTasks() {
         auto tx = MakeTx(1, rm);
         for (ui32 i = 1; i < 10; ++i) {
             auto task = i;
-            bool allocated = rm->AllocateResources(tx, task, request);
+            bool allocated = rm->AllocateResources(*tx, task, request);
             UNIT_ASSERT(allocated);
 
             AssertResourceManagerStats(rm, 1000 - 100 * i, 100 - i);
@@ -369,7 +369,7 @@ void KqpRm::NotEnoughMemory() {
     auto tx = MakeTx(1, rm);
     auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 10'000});
+    bool allocated = rm->AllocateResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 10'000});
     UNIT_ASSERT(!allocated);
 
     AssertResourceManagerStats(rm, 1000, 100);
@@ -385,7 +385,7 @@ void KqpRm::NotEnoughExecutionUnits() {
     auto tx = MakeTx(1, rm);
     auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1000, .Memory = 100});
+    bool allocated = rm->AllocateResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1000, .Memory = 100});
     UNIT_ASSERT(!allocated);
 
     AssertResourceManagerStats(rm, 1000, 100);
@@ -404,10 +404,10 @@ void KqpRm::ResourceBrokerNotEnoughResources() {
     auto tx = MakeTx(1, rm);
     auto task = 2;
 
-    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1'000});
+    bool allocated = rm->AllocateResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 1'000});
     UNIT_ASSERT(allocated);
 
-    allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 100'000});
+    allocated = rm->AllocateResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 1, .Memory = 100'000});
     UNIT_ASSERT(!allocated);
 
     AssertResourceManagerStats(rm, config.GetQueryMemoryLimit() - 1000, 99);
@@ -429,10 +429,10 @@ void KqpRm::Snapshot() {
         auto task2 = 2;
         auto task1 = 1;
 
-        bool allocated = rm->AllocateResources(tx1, task2, request);
+        bool allocated = rm->AllocateResources(*tx1, task2, request);
         UNIT_ASSERT(allocated);
 
-        allocated &= rm->AllocateResources(tx2, task1, request);
+        allocated &= rm->AllocateResources(*tx2, task1, request);
         UNIT_ASSERT(allocated);
 
         AssertResourceManagerStats(rm, 800, 80);
@@ -442,8 +442,8 @@ void KqpRm::Snapshot() {
 
         CheckSnapshot(0, {{800, 80}, {1000, 100}}, rm);
 
-        rm->FreeResources(tx1, task2, request);
-        rm->FreeResources(tx2, task1, request);
+        rm->FreeResources(*tx1, task2, request);
+        rm->FreeResources(*tx2, task1, request);
 
         AssertResourceManagerStats(rm, 1000, 100);
         AssertResourceBrokerSensors(0, 0, 0, 0, 2);
@@ -469,7 +469,7 @@ void KqpRm::Reduce() {
     auto tx = MakeTx(1, rm);
     auto task = 1;
 
-    bool allocated = rm->AllocateResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 100});
+    bool allocated = rm->AllocateResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 10, .Memory = 100});
     UNIT_ASSERT(allocated);
 
     AssertResourceManagerStats(rm, 1000 - 100, 100 - 10);
@@ -478,7 +478,7 @@ void KqpRm::Reduce() {
     NRm::TKqpResourcesRequest reduceRequest;
     reduceRequest.Memory = 70;
 
-    rm->FreeResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 7, .Memory = 70});
+    rm->FreeResources(*tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 7, .Memory = 70});
     AssertResourceManagerStats(rm, 1000 - 100 + 70, 100 - 10 + 7);
     AssertResourceBrokerSensors(0, 30, 0, 0, 1);
 }
@@ -501,7 +501,7 @@ void KqpRm::ConcurrentTasks() {
                 auto count = 0u;
                 for (auto n = 0u; n < 20u; n++) {
                     for (auto j = 0u; j < 20u; j++) {
-                        if (!rm->AllocateResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u})) {
+                        if (!rm->AllocateResources(*tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u})) {
                             failedAllocations++;
                             Sleep(TDuration::MilliSeconds(j * 10));
                             break;
@@ -512,11 +512,11 @@ void KqpRm::ConcurrentTasks() {
                         if (count < j) {
                             break;
                         }
-                        rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u});
+                        rm->FreeResources(*tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u});
                         count -= j;
                     }
                 }
-                rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = count, .Memory = count * 10u});
+                rm->FreeResources(*tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = count, .Memory = count * 10u});
                 events[taskId - 1].Signal();
             }, i + 1, NPar::TLocalExecutor::MED_PRIORITY);
         }
@@ -558,10 +558,10 @@ void KqpRm::SnapshotSharing() {
     auto task2Rm2 = 2;
 
     {
-        bool allocated = rm_first->AllocateResources(tx1Rm1, task1Rm1, request);
+        bool allocated = rm_first->AllocateResources(*tx1Rm1, task1Rm1, request);
         UNIT_ASSERT(allocated);
 
-        allocated &= rm_first->AllocateResources(tx2Rm1, task2Rm1, request);
+        allocated &= rm_first->AllocateResources(*tx2Rm1, task2Rm1, request);
         UNIT_ASSERT(allocated);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
@@ -570,10 +570,10 @@ void KqpRm::SnapshotSharing() {
     }
 
     {
-        bool allocated = rm_second->AllocateResources(tx1Rm2, task1Rm2, request);
+        bool allocated = rm_second->AllocateResources(*tx1Rm2, task1Rm2, request);
         UNIT_ASSERT(allocated);
 
-        allocated &= rm_second->AllocateResources(tx2Rm2, task2Rm2, request);
+        allocated &= rm_second->AllocateResources(*tx2Rm2, task2Rm2, request);
         UNIT_ASSERT(allocated);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
@@ -582,8 +582,8 @@ void KqpRm::SnapshotSharing() {
     }
 
     {
-        rm_first->FreeResources(tx1Rm1, task1Rm1, request);
-        rm_first->FreeResources(tx2Rm1, task2Rm1, request);
+        rm_first->FreeResources(*tx1Rm1, task1Rm1, request);
+        rm_first->FreeResources(*tx2Rm1, task2Rm1, request);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 
@@ -591,8 +591,8 @@ void KqpRm::SnapshotSharing() {
     }
 
     {
-        rm_second->FreeResources(tx1Rm2, task1Rm2, request);
-        rm_second->FreeResources(tx2Rm2, task2Rm2, request);
+        rm_second->FreeResources(*tx1Rm2, task1Rm2, request);
+        rm_second->FreeResources(*tx2Rm2, task2Rm2, request);
 
         Runtime->DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
 

--- a/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
+++ b/ydb/core/kqp/rm_service/kqp_rm_ut.cpp
@@ -10,6 +10,8 @@
 #include <ydb/library/actors/interconnect/interconnect_impl.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/local_executor/local_executor.h>
+#include <library/cpp/threading/mux_event/mux_event.h>
 
 #ifndef NDEBUG
 const bool DETAILED_LOG = false;
@@ -171,19 +173,23 @@ public:
         WaitForBootstrap();
     }
 
-    void AssertResourceBrokerSensors(i64 cpu, i64 mem, i64 enqueued, i64 finished, i64 infly) {
+    void AssertResourceBrokerSensors(i64 cpu, i64 mem, i64 enqueued, std::optional<i64> finished, i64 infly) {
         auto q = Counters->GetSubgroup("queue", "queue_kqp_resource_manager");
         UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("CPUConsumption")->Val(), cpu);
         UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("MemoryConsumption")->Val(), mem);
         UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("EnqueuedTasks")->Val(), enqueued);
-        UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("FinishedTasks")->Val(), finished);
+        if (finished) {
+            UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("FinishedTasks")->Val(), *finished);
+        }
         UNIT_ASSERT_VALUES_EQUAL(q->GetCounter("InFlyTasks")->Val(), infly);
 
         auto t = Counters->GetSubgroup("task", "kqp_query");
         UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("CPUConsumption")->Val(), cpu);
         UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("MemoryConsumption")->Val(), mem);
         UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("EnqueuedTasks")->Val(), enqueued);
-        UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("FinishedTasks")->Val(), finished);
+        if (finished) {
+            UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("FinishedTasks")->Val(), *finished);
+        }
         UNIT_ASSERT_VALUES_EQUAL(t->GetCounter("InFlyTasks")->Val(), infly);
     }
 
@@ -271,6 +277,7 @@ public:
         UNIT_TEST(ResourceBrokerNotEnoughResources);
         UNIT_TEST(SingleSnapshotByExchanger);
         UNIT_TEST(Reduce);
+        UNIT_TEST(ConcurrentTasks);
         UNIT_TEST(SnapshotSharingByExchanger);
         UNIT_TEST(NodesMembershipByExchanger);
         UNIT_TEST(DisonnectNodes);
@@ -284,6 +291,7 @@ public:
     void Snapshot();
     void SingleSnapshotByExchanger();
     void Reduce();
+    void ConcurrentTasks();
     void SnapshotSharing();
     void SnapshotSharingByExchanger();
     void NodesMembership();
@@ -464,6 +472,52 @@ void KqpRm::Reduce() {
     rm->FreeResources(tx, task, NRm::TKqpResourcesRequest{.ExecutionUnits = 7, .Memory = 70});
     AssertResourceManagerStats(rm, 1000 - 100 + 70, 100 - 10 + 7);
     AssertResourceBrokerSensors(0, 30, 0, 0, 1);
+}
+
+void KqpRm::ConcurrentTasks() {
+    StartRms();
+    NKikimr::TActorSystemStub stub;
+
+    auto rm = GetKqpResourceManager(ResourceManagers.front().NodeId());
+
+    auto tx = MakeTx(1, rm);
+
+    std::array<TMuxEvent, 10> events;
+    NPar::LocalExecutor().RunAdditionalThreads(10);
+    std::atomic<ui64> failedAllocations = 0;
+
+    for (auto i = 0u; i < 10u; i++) {
+        NPar::LocalExecutor().Exec([&](int taskId) mutable {
+            auto count = 0u;
+            for (auto n = 0u; n < 20u; n++) {
+                for (auto j = 0u; j < 20u; j++) {
+                    if (!rm->AllocateResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u})) {
+                        failedAllocations++;
+                        Sleep(TDuration::MilliSeconds(j * 10));
+                        break;
+                    }
+                    count += j;
+                }
+                for (auto j = 20u; j > 0u; j--) {
+                    if (count < j) {
+                        break;
+                    }
+                    rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = j, .Memory = j * 10u});
+                    count -= j;
+                }
+            }
+            rm->FreeResources(tx, taskId, NRm::TKqpResourcesRequest{.ExecutionUnits = count, .Memory = count * 10u});
+            events[taskId - 1].Signal();
+        }, i + 1, NPar::TLocalExecutor::MED_PRIORITY);
+    }
+
+    for (auto i = 0; i < 10; i++) {
+        events[i].WaitI();
+    }
+
+    UNIT_ASSERT_GT(failedAllocations.load(), 0);
+    AssertResourceManagerStats(rm, 1000, 100);
+    AssertResourceBrokerSensors(0, 0, 0, std::nullopt, 0);
 }
 
 void KqpRm::SnapshotSharing() {

--- a/ydb/core/kqp/rm_service/ut/ya.make
+++ b/ydb/core/kqp/rm_service/ut/ya.make
@@ -9,6 +9,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/threading/local_executor
     ydb/core/kqp/ut/common
     yql/essentials/sql/pg_dummy
 )


### PR DESCRIPTION
To allow more flexible and efficient memory management

Old call sequence

1. Each tasks asks RM to Allocate/Free resourcs (Memory)
2. These calls are made from AS event handler, so they are serialized and no additional sync primitives (per task) is required
3. Each tasks also allocates "tasks" in ResourceBroker (so N tasks consume N slots in Scheduler Queue)

New (these PR) call sequence

1. All tasks of the graph share single (large) quota, managed by RM in TxState
2. They may call RM simultaneously
3. But these N tasks use common "task" in RB in consume only 1 slot in Scheduler Queue
4. RB task is started with very 1st allocation and finished from ~TxState for serialization reasons

Current state is transitional. Intention is to provide single memory manager for the graph which will deal with all tasks memory requests. It enables various complex scenario, for example

- tasks may agree on the start, who is potentially needed a lot of memory for processing, and change memory allocation policy (f.e. from greedy to fair share)
- tasks may communicate in runtime to redistribute already allocated memory
- and it's good point for integration with WM

So, target call sequence (future PRs) is:

1. Task never calls RM directly. Instead it calls special memory manager for this query (using the same API)
2. This memory manager batches and clears (does netting) requests, reducing number of RM calls by the order pf magnitude