### PR TITLE
Add test for dstool cluster balance

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -654,7 +654,7 @@ def do(args):
 
     iteration_number = 1
     while True:
-        if args.max_iterations and iteration_number > args.max_iterations:
+        if args.max_iterations > 0 and iteration_number > args.max_iterations:
             break
         common.print_if_not_quiet(args, f"\nStart balancing iteration {iteration_number}", file=sys.stdout)
         if groups_info.unhealthy_groups:

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -4,9 +4,8 @@ import sys
 import random
 from collections import defaultdict, Counter
 
-description = '''Balance VDisks across PDisks in a storage pool.
-
-This tool ivokes ReassignGroupDisk BSC command. It can operate in several modes:
+description = '''Balance VDisks across PDisks in a storage pool by invoking ReassignGroupDisk BSC command.
+It can operate in several modes:
 
 1. Overpopulated PDisk mode (--only-from-overpopulated-pdisks):
    Moves VDisks from PDisks that exceed their expected slot count to less populated PDisks.

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -4,7 +4,22 @@ import sys
 import random
 from collections import defaultdict, Counter
 
-description = 'Move vdisks out from overpopulated pdisks.'
+description = '''Balance VDisks across PDisks in a storage pool.
+
+This tool ivokes ReassignGroupDisk BSC command. It can operate in several modes:
+
+1. Overpopulated PDisk mode (--only-from-overpopulated-pdisks):
+   Moves VDisks from PDisks that exceed their expected slot count to less populated PDisks.
+
+2. Slot-based balancing (--sort-by=slots, default):
+   Redistributes VDisks to equalize slot usage across PDisks.
+
+3. Space-based balancing (--sort-by=space_ratio):
+   Redistributes VDisks based on available free space ratios.
+
+Use --storage-pool to limit balancing to a specific storage pool, or --group-ids to target
+specific groups. The tool runs iteratively until balance is achieved or no more moves are possible.
+'''
 
 
 class Constants:
@@ -37,6 +52,7 @@ def add_options(p):
     p.add_argument('--with-attention-to-replication', action='store_true', help='Take into account replicating vdisks picking node and pdisk with less amount of them')
     p.add_argument('--waiting-time', type=int, default=Constants.WAITING_TIME, help='Time to wait when there are no vdisks to reassign')
     p.add_argument('--time-between-reassignings', type=int, default=Constants.TIME_BERWEEN_REASSIGNINGS, help='Time to wait between reassignings')
+    p.add_argument('--max-iterations', type=int, default=0, help='Maximum number of balancing iterations (0 = unlimited)')
     common.add_basic_format_options(p)
 
 
@@ -639,6 +655,8 @@ def do(args):
 
     iteration_number = 1
     while True:
+        if args.max_iterations and iteration_number > args.max_iterations:
+            break
         common.print_if_not_quiet(args, f"\nStart balancing iteration {iteration_number}", file=sys.stdout)
         if groups_info.unhealthy_groups:
             common.print_if_verbose(args, f'Skipping vdisks from unhealthy groups: {groups_info.unhealthy_groups}', file=sys.stdout)

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -10,6 +10,15 @@
             "uri": "file://test_canonical_requests.Test.test_capacity_metrics/results.txt.1"
         }
     ],
+    "test_canonical_requests.Test.test_cluster_balance": [
+        {
+            "uri": "file://test_canonical_requests.Test.test_cluster_balance/results.txt"
+        },
+        null,
+        {
+            "uri": "file://test_canonical_requests.Test.test_cluster_balance/results.txt.0"
+        }
+    ],
     "test_canonical_requests.Test.test_cluster_get_set": [
         {
             "uri": "file://test_canonical_requests.Test.test_cluster_get_set/results.txt"

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
@@ -1,0 +1,120 @@
+dstool -e <endpoint> --mon-port <mon_port> --verbose cluster balance --storage-pool=test-pool --max-iterations=1 --only-from-overpopulated-pdisks
+Exit Status: 0
+===== stdout =====
+
+Start balancing iteration 1
+Number of used slots -> number pdisks: 0=>1 2=>1
+
+===== stderr =====
+success
+
+===== grpc_calls =====
+
+===== http_calls =====
+GET viewer/json/vdiskinfo?... (mocked)
+
+===== mock_base_config =====
+
+TBaseConfig {
+PDisk {
+  NodeId: 1
+  PDiskId: 1001
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 0
+  }
+}
+PDisk {
+  NodeId: 1
+  PDiskId: 1002
+  PDiskConfig {
+    ExpectedSlotCount: 4
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 4
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 4
+    SlotSizeInUnits: 0
+  }
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  GroupId: 2147483649
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  GroupId: 2147483650
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+Group {
+  GroupId: 2147483649
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Group {
+  GroupId: 2147483650
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Node {
+  NodeId: 1
+  HostKey {
+    Fqdn: "localhost"
+    IcPort: 19001
+  }
+}
+}
+
+DefineStoragePool {
+BoxId: 1
+StoragePoolId: 1
+Name: "test-pool"
+ErasureSpecies: "none"
+Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
@@ -1,0 +1,147 @@
+dstool -e <endpoint> --mon-port <mon_port> --verbose cluster balance --storage-pool=test-pool --max-iterations=1 --only-from-overpopulated-pdisks
+Exit Status: 0
+===== stdout =====
+
+Start balancing iteration 1
+Number of used slots -> number pdisks: 0=>1 9=>1
+Found 2 candidate vslots, 1 groups to reassign
+Checking to relocate vdisk from vslot (1, 1001, 1001) on pdisk (1, 1001) with slot usage 9
+Relocated vdisk from pdisk [1:1001] to pdisk [1:1002] with slot usages (9 -> 0)
+
+===== stderr =====
+INFO: using random hosts
+INFO: using random hosts
+
+===== grpc_calls =====
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483650
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483650
+      GroupGeneration: 1
+    }
+  }
+}
+
+===== http_calls =====
+GET viewer/json/vdiskinfo?... (mocked)
+GET viewer/json/vdiskinfo?... (mocked)
+
+===== mock_base_config =====
+
+TBaseConfig {
+PDisk {
+  NodeId: 1
+  PDiskId: 1001
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 0
+  }
+}
+PDisk {
+  NodeId: 1
+  PDiskId: 1002
+  PDiskConfig {
+    ExpectedSlotCount: 4
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 4
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 4
+    SlotSizeInUnits: 0
+  }
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  GroupId: 2147483649
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  GroupId: 2147483650
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+Group {
+  GroupId: 2147483649
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 8
+}
+Group {
+  GroupId: 2147483650
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Node {
+  NodeId: 1
+  HostKey {
+    Fqdn: "localhost"
+    IcPort: 19001
+  }
+}
+}
+
+DefineStoragePool {
+BoxId: 1
+StoragePoolId: 1
+Name: "test-pool"
+ErasureSpecies: "none"
+Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_essential/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_essential/results.txt
@@ -57,11 +57,9 @@ dstool
 │  └─ list                              List nodes
 ├─ cluster
 │  ├─ balance                           Balance VDisks across PDisks in a 
-│  │                                    storage pool.
-│  │                                    
-│  │                                    This tool ivokes ReassignGroupDisk BSC 
-│  │                                    command. It can operate in several 
-│  │                                    modes:
+│  │                                    storage pool by invoking 
+│  │                                    ReassignGroupDisk BSC command.
+│  │                                    It can operate in several modes:
 │  │                                    
 │  │                                    1. Overpopulated PDisk mode (--only-
 │  │                                    from-overpopulated-pdisks):

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_essential/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_essential/results.txt
@@ -56,8 +56,35 @@ dstool
 ├─ node
 │  └─ list                              List nodes
 ├─ cluster
-│  ├─ balance                           Move vdisks out from overpopulated 
-│  │                                    pdisks.
+│  ├─ balance                           Balance VDisks across PDisks in a 
+│  │                                    storage pool.
+│  │                                    
+│  │                                    This tool ivokes ReassignGroupDisk BSC 
+│  │                                    command. It can operate in several 
+│  │                                    modes:
+│  │                                    
+│  │                                    1. Overpopulated PDisk mode (--only-
+│  │                                    from-overpopulated-pdisks):
+│  │                                       Moves VDisks from PDisks that exceed 
+│  │                                    their expected slot count to less 
+│  │                                    populated PDisks.
+│  │                                    
+│  │                                    2. Slot-based balancing (--sort-
+│  │                                    by=slots, default):
+│  │                                       Redistributes VDisks to equalize slot
+│  │                                     usage across PDisks.
+│  │                                    
+│  │                                    3. Space-based balancing (--sort-
+│  │                                    by=space_ratio):
+│  │                                       Redistributes VDisks based on 
+│  │                                    available free space ratios.
+│  │                                    
+│  │                                    Use --storage-pool to limit balancing to
+│  │                                     a specific storage pool, or --group-ids
+│  │                                     to target
+│  │                                    specific groups. The tool runs 
+│  │                                    iteratively until balance is achieved or
+│  │                                     no more moves are possible.
 │  ├─ get                               Get cluster wide settings
 │  ├─ set                               Set cluster wide settings
 │  ├─ workload

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
@@ -2,3 +2,30 @@ dstool -e <endpoint> --mon-port <mon_port> group take-snapshot --group-ids=0 --o
 Exit Status: 0
 ===== stderr =====
 WARNING: endpoint for http requests is not specified, grpc endpoints will be used instead with conversion to http. You can specify additional endpoints with "http" or "https" protocol.
+
+===== http_calls =====
+GET viewer/json/sysinfo?enums=1&merge=0&node_id=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt
@@ -21,11 +21,3 @@ GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
 GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
 GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
 GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
-GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_group_take_snapshot/results.txt.1
@@ -1,2 +1,19 @@
 dstool -e <endpoint> --mon-port <mon_port> group take-snapshot --group-ids=0 --output=group0_2.bin
 Exit Status: 0
+===== http_calls =====
+GET viewer/json/sysinfo?enums=1&merge=0&node_id=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID
+GET vdisk_stream?pdiskId=1&vdiskSlotId=0&sessionId=SESSION_ID

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pdisk_check_leaked_slots/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pdisk_check_leaked_slots/results.txt.1
@@ -21,3 +21,6 @@ Exit Status: 0
 │ [8:1]          │                │ localhost │ SectorMap:1:64 │ ROT  │ ACTIVE │ DECOMMIT_NONE  │ NO_REQUEST        │ 1              │ 0           │
 │ [8:1000]       │                │ localhost │ SectorMap:2:4  │ ROT  │ ACTIVE │ DECOMMIT_NONE  │ NO_REQUEST        │ 1              │ 0           │
 └────────────────┴────────────────┴───────────┴────────────────┴──────┴────────┴────────────────┴───────────────────┴────────────────┴─────────────┘
+
+===== http_calls =====
+GET viewer/json/pdiskinfo?enums=1&merge=0&node_id=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
@@ -18,6 +18,8 @@ Exit Status: 0
   }
 ]
 ===== mock_base_config =====
+
+TBaseConfig {
 PDisk {
   NodeId: 1
   PDiskId: 1001
@@ -25,6 +27,9 @@ PDisk {
     ExpectedSlotCount: 16
     SlotSizeInUnits: 0
   }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 16
   PDiskMetrics {
     EnforcedDynamicSlotSize: 200000000000
     SlotCount: 16
@@ -63,10 +68,12 @@ Node {
     IcPort: 19001
   }
 }
+}
 
-===== DefineStoragePool =====
+DefineStoragePool {
 BoxId: 1
 StoragePoolId: 1
 Name: "test-pool"
 ErasureSpecies: "none"
 Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
@@ -18,6 +18,8 @@ Exit Status: 0
   }
 ]
 ===== mock_base_config =====
+
+TBaseConfig {
 PDisk {
   NodeId: 1
   PDiskId: 1001
@@ -25,6 +27,9 @@ PDisk {
     ExpectedSlotCount: 16
     SlotSizeInUnits: 2
   }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 16
   PDiskMetrics {
     EnforcedDynamicSlotSize: 400000000000
     SlotCount: 16
@@ -63,10 +68,12 @@ Node {
     IcPort: 19001
   }
 }
+}
 
-===== DefineStoragePool =====
+DefineStoragePool {
 BoxId: 1
 StoragePoolId: 1
 Name: "test-pool"
 ErasureSpecies: "none"
 Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
@@ -18,6 +18,8 @@ Exit Status: 0
   }
 ]
 ===== mock_base_config =====
+
+TBaseConfig {
 PDisk {
   NodeId: 1
   PDiskId: 1001
@@ -25,6 +27,9 @@ PDisk {
     ExpectedSlotCount: 16
     SlotSizeInUnits: 2
   }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 16
   PDiskMetrics {
     EnforcedDynamicSlotSize: 400000000000
     SlotCount: 16
@@ -64,10 +69,12 @@ Node {
     IcPort: 19001
   }
 }
+}
 
-===== DefineStoragePool =====
+DefineStoragePool {
 BoxId: 1
 StoragePoolId: 1
 Name: "test-pool"
 ErasureSpecies: "none"
 Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/conftest.py
+++ b/ydb/tests/functional/dstool/conftest.py
@@ -1,4 +1,7 @@
 import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
+import ydb.core.protos.blobstorage_base3_pb2 as kikimr_bsbase3
+import ydb.core.protos.msgbus_pb2 as kikimr_msgbus
+from ydb.tests.library.common.msgbus_types import MessageBusStatus
 
 # XXX: setting of pytest_plugins should work if specified directly in test modules
 # but somehow it does not
@@ -21,11 +24,16 @@ class BaseConfigBuilder:
         node.HostKey.IcPort = ic_port
         return self
 
-    def add_pdisk(self, node_id=1, pdisk_id=1, expected_slot_count=0, slot_size_in_units=0, enforced_dynamic_slot_size=0):
+    def add_pdisk(self, node_id=1, pdisk_id=1, expected_slot_count=0, slot_size_in_units=0, enforced_dynamic_slot_size=0,
+                  box_id=1, pdisk_type=kikimr_bsbase3.EPDiskType.ROT, drive_status=kikimr_bsconfig.EDriveStatus.ACTIVE):
         pdisk = self._base_config.PDisk.add()
         pdisk.NodeId = node_id
         pdisk.PDiskId = pdisk_id
         pdisk.NumStaticSlots = 0
+        pdisk.BoxId = box_id
+        pdisk.Type = pdisk_type
+        pdisk.DriveStatus = drive_status
+        pdisk.ExpectedSlotCount = expected_slot_count
         pdisk.PDiskConfig.ExpectedSlotCount = expected_slot_count
         pdisk.PDiskConfig.SlotSizeInUnits = slot_size_in_units
         pdisk.PDiskMetrics.SlotCount = expected_slot_count
@@ -111,3 +119,82 @@ class BaseConfigBuilder:
 
     def build(self):
         return dict(BaseConfig=self._base_config, StoragePools=self._storage_pools)
+
+
+class FakeReassignGroupDiskHandler:
+    """Build a fake BlobStorageConfig response for ReassignGroupDisk.
+
+    Mimics BSC behavior from ydb/core/mind/bscontroller/config_cmd.cpp
+    (TConfigState::ExecuteStep + WrapCommand + Finish):
+    - When group_id is in pending_reassigns: returns success with ReassignedItem
+    - Otherwise returns failure with
+      kReassignNotViable, same as TExReassignNotViable in
+      ydb/core/mind/bscontroller/config_fit_groups.cpp
+    """
+
+    def __init__(self, pending_reassigns, base_config):
+        self.pending_reassigns = pending_reassigns
+        self.base_config = base_config
+
+    @staticmethod
+    def find_source_vslot(cmd, base_config):
+        for vslot in base_config['BaseConfig'].VSlot:
+            if (vslot.GroupId == cmd.GroupId
+                    and vslot.FailRealmIdx == cmd.FailRealmIdx
+                    and vslot.FailDomainIdx == cmd.FailDomainIdx
+                    and vslot.VDiskIdx == cmd.VDiskIdx):
+                return vslot
+        return None
+
+    def should_handle(self, bs_request):
+        return all(cmd.HasField('ReassignGroupDisk') for cmd in bs_request.Request.Command)
+
+    def handle(self, func, *params):
+        assert func == 'BlobStorageConfig'
+        bs_request = params[0]
+
+        is_rollback = bs_request.Request.Rollback
+        all_commands_ok = True
+
+        config_response = kikimr_bsconfig.TConfigResponse()
+
+        for command in bs_request.Request.Command:
+            status = config_response.Status.add()
+
+            assert command.HasField('ReassignGroupDisk')
+            cmd = command.ReassignGroupDisk
+            target_vslot = self.pending_reassigns.get(cmd.GroupId)
+
+            if target_vslot is None:
+                status.Success = False
+                status.FailReason = kikimr_bsconfig.TConfigResponse.TStatus.kReassignNotViable
+                all_commands_ok = False
+                continue
+
+            status.Success = True
+            source_vslot = self.find_source_vslot(cmd, self.base_config)
+            item = status.ReassignedItem.add()
+            if source_vslot is not None:
+                item.From.NodeId = source_vslot.VSlotId.NodeId
+                item.From.PDiskId = source_vslot.VSlotId.PDiskId
+                item.From.VSlotId = source_vslot.VSlotId.VSlotId
+            item.To.NodeId = target_vslot[0]
+            item.To.PDiskId = target_vslot[1]
+            item.To.VSlotId = target_vslot[2]
+
+            if not is_rollback:
+                del self.pending_reassigns[cmd.GroupId]
+
+        if is_rollback and all_commands_ok:
+            config_response.Success = False
+            config_response.ErrorDescription = 'fake transaction rollback'
+            config_response.RollbackSuccess = True
+        elif all_commands_ok:
+            config_response.Success = True
+        else:
+            config_response.Success = False
+
+        response = kikimr_msgbus.TResponse()
+        response.Status = MessageBusStatus.MSTATUS_OK
+        response.BlobStorageConfigResponse.CopyFrom(config_response)
+        return response

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -496,7 +496,7 @@ class Test(TestBase):
             # No overpopulated pdisks yet, no reassignments are necessary
             _trace_cluster_balance('--only-from-overpopulated-pdisks'),
 
-            # Change GroupSizeInUnits. The pdsik becomes overpopulated
+            # Change GroupSizeInUnits. The pdisk becomes overpopulated
             # ReassignGroupDisk should be invoked
             builder.update_group(group_id=0x80000001, group_size_in_units=8) and None,
             _trace_cluster_balance('--only-from-overpopulated-pdisks', pending_reassigns={0x80000002: (1, 1002, 1000)}),

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -188,6 +188,7 @@ class TestBase:
 
             response = original_http_fetch(path, params, *args, **kwargs)
 
+            params = dict(params)
             if 'sessionId' in params:
                 params['sessionId'] = 'SESSION_ID'
             query_string = urllib.parse.urlencode(params, doseq=True)

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -7,6 +7,7 @@ import pytest
 import yatest
 import yaml
 import urllib.parse
+import random
 
 from io import StringIO
 from unittest.mock import patch
@@ -113,6 +114,7 @@ class TestBase:
 
     def _trace(self, *args, with_grpc_calls=False, with_response=False, canonize_columns=None,
                mock_base_config=None, allow_http_fetch=False, fake_grpc_handler=None):
+        random.seed(42)
         common.cache.clear()
         common.name_cache.clear()
         results = []

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -2,9 +2,11 @@
 import sys
 import os
 import logging
+import contextlib
 import pytest
 import yatest
 import yaml
+import urllib.parse
 
 from io import StringIO
 from unittest.mock import patch
@@ -22,7 +24,7 @@ from ydb.tests.library.clients.kikimr_dynconfig_client import DynConfigClient
 from ydb.core.protos.whiteboard_disk_states_pb2 import EVDiskState
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 import ydb.public.api.protos.draft.ydb_dynamic_config_pb2 as dynconfig
-from .conftest import BaseConfigBuilder
+from .conftest import BaseConfigBuilder, FakeReassignGroupDiskHandler
 
 logger = logging.getLogger(__name__)
 C_4GB = 4 * 2**30
@@ -110,7 +112,7 @@ class TestBase:
             assert vslot.VDiskMetrics.State == EVDiskState.OK
 
     def _trace(self, *args, with_grpc_calls=False, with_response=False, canonize_columns=None,
-               mock_base_config=None):
+               mock_base_config=None, allow_http_fetch=False, fake_grpc_handler=None):
         common.cache.clear()
         common.name_cache.clear()
         results = []
@@ -118,10 +120,16 @@ class TestBase:
         args = ['-e', self.endpoint, '--mon-port', self.mon_port, *args]
 
         grpc_calls = []
+        http_calls = []
         original_invoke_grpc = common.invoke_grpc
 
         def mock_invoke_grpc(func, *params, **kwargs):
-            response = original_invoke_grpc(func, *params, **kwargs)
+            response = None
+            if mock_base_config is None:
+                response = original_invoke_grpc(func, *params, **kwargs)
+            elif fake_grpc_handler is not None:
+                response = fake_grpc_handler.handle(func, *params)
+
             grpc_calls.append(f'=== Invoke {func} ===')
             for param in params:
                 self._canonize_request(param.Request)
@@ -144,21 +152,67 @@ class TestBase:
             self._canonize_table_output(rows, canonize_columns=canonize_columns)
             return original_table_dump(table_self, rows, args)
 
-        if mock_base_config is not None:
-            invoke_grpc_patch = patch.object(common, 'fetch_base_config_and_storage_pools', return_value=mock_base_config)
-        else:
-            invoke_grpc_patch = patch.object(common, 'invoke_grpc', side_effect=mock_invoke_grpc)
+        def mock_fetch_json_info(entity, nodes=None, enums=1):
+            if not allow_http_fetch:
+                raise RuntimeError('Mock: HTTP fetch is forbidden')
 
+            if entity == 'vdiskinfo':
+                # Build synthetic vdisk info from mock base config VSlots
+                http_calls.append('GET viewer/json/vdiskinfo?... (mocked)')
+                res = {}
+                for vslot in mock_base_config['BaseConfig'].VSlot:
+                    key = (vslot.VSlotId.NodeId, vslot.VSlotId.PDiskId, vslot.VSlotId.VSlotId)
+                    res[key] = {
+                        'NodeId': vslot.VSlotId.NodeId,
+                        'PDiskId': vslot.VSlotId.PDiskId,
+                        'VDiskSlotId': vslot.VSlotId.VSlotId,
+                        'Replicated': True,
+                        'VDiskState': 'OK',
+                        'VDiskId': {
+                            'GroupID': vslot.GroupId,
+                            'GroupGeneration': vslot.GroupGeneration,
+                            'Ring': vslot.FailRealmIdx,
+                            'Domain': vslot.FailDomainIdx,
+                            'VDisk': vslot.VDiskIdx,
+                        },
+                    }
+                return res
+            raise RuntimeError('Mock: fetch_json_info(%r) is not supported' % entity)
+
+        original_http_fetch = common.fetch
+
+        def mock_http_fetch(path, params={}, *args, **kwargs):
+            method = kwargs.get('method') or 'GET'
+
+            if not allow_http_fetch:
+                raise RuntimeError(f'Mock: HTTP fetch is forbidden: {method} {path}')
+
+            response = original_http_fetch(path, params, *args, **kwargs)
+
+            if 'sessionId' in params:
+                params['sessionId'] = 'SESSION_ID'
+            query_string = urllib.parse.urlencode(params, doseq=True)
+            http_calls.append(f'{method} {path}?{query_string}')
+
+            return response
+
+        patches = contextlib.ExitStack()
+        if mock_base_config is not None:
+            patches.enter_context(patch.object(common, 'fetch_base_config_and_storage_pools', return_value=mock_base_config))
+            patches.enter_context(patch.object(common, 'fetch_json_info', side_effect=mock_fetch_json_info))
         exit_status = 0
         captured_stdout = StringIO()
         captured_stderr = StringIO()
-        with invoke_grpc_patch, \
-             patch.object(sys, 'exit', side_effect=mock_exit), \
-             patch.object(sys, 'argv', ['dstool']), \
-             patch('sys.stdout', captured_stdout), \
-             patch('sys.stderr', captured_stderr), \
-             patch('shutil.get_terminal_size', side_effect=mock_get_terminal_size), \
-             patch.object(table.TableOutput, 'dump', mock_table_dump):
+        patches.enter_context(patch.object(common, 'invoke_grpc', side_effect=mock_invoke_grpc))
+        patches.enter_context(patch.object(common, 'fetch', side_effect=mock_http_fetch))
+        patches.enter_context(patch.object(sys, 'exit', side_effect=mock_exit))
+        patches.enter_context(patch.object(sys, 'argv', ['dstool']))
+        patches.enter_context(patch('sys.stdout', captured_stdout))
+        patches.enter_context(patch('sys.stderr', captured_stderr))
+        patches.enter_context(patch('shutil.get_terminal_size', side_effect=mock_get_terminal_size))
+        patches.enter_context(patch.object(table.TableOutput, 'dump', mock_table_dump))
+
+        with patches:
             try:
                 dstool_main(args)
             except SystemExit as e:
@@ -174,16 +228,16 @@ class TestBase:
             results.extend(['===== stderr =====', captured_stderr])
         if with_grpc_calls:
             results.extend(['===== grpc_calls =====', '\n'.join(grpc_calls)])
+        if allow_http_fetch:
+            http_calls.append('')
+            results.extend(['===== http_calls =====', '\n'.join(http_calls)])
         if mock_base_config is not None:
-            results.extend([
-                '===== mock_base_config =====',
-                text_format.MessageToString(mock_base_config['BaseConfig'], as_one_line=False),
-            ])
+            results.extend(['===== mock_base_config ====='])
+            base_config_text = text_format.MessageToString(mock_base_config['BaseConfig'], as_one_line=False)
+            results.extend(['', 'TBaseConfig {', base_config_text.strip(), '}'])
             for sp in mock_base_config['StoragePools']:
-                results.extend([
-                    '===== DefineStoragePool =====',
-                    text_format.MessageToString(sp, as_one_line=False),
-                ])
+                sp_text = text_format.MessageToString(sp, as_one_line=False)
+                results.extend(['', 'DefineStoragePool {', sp_text.strip(), '}'])
         return self._canonical_file('results.txt', '\n'.join(results))
 
 
@@ -243,10 +297,10 @@ class Test(TestBase):
             assert vslot.VDiskMetrics.State == EVDiskState.PDiskError
 
         return [
-            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_1.bin'),
+            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_1.bin', allow_http_fetch=True),
             self._trace('pdisk', 'stop', '--node-id=1', '--pdisk-id=1'),
             retry_assertions(check_vdisk_state_error, timeout_seconds=20),
-            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_2.bin'),
+            self._trace('group', 'take-snapshot', '--group-ids=0', '--output=group0_2.bin', allow_http_fetch=True),
         ]
 
     def test_capacity_metrics(self):
@@ -383,7 +437,7 @@ class Test(TestBase):
         return [
             self._trace(*vdisk_evict_cmd, '--vdisk-ids', '[82000000:_:0:0:0]', with_grpc_calls=True),
             self._trace(*vdisk_evict_cmd, '--vdisk-ids', '[82000000:_:0:1:0]', '--suppress-donor-mode', with_grpc_calls=True),
-            self._trace('--quiet', 'pdisk', 'list', '--check-leaked-slots'),
+            self._trace('--quiet', 'pdisk', 'list', '--check-leaked-slots', allow_http_fetch=True),
         ]
 
     def test_pool_estimated_usage(self):
@@ -414,4 +468,37 @@ class Test(TestBase):
             # Change GroupSizeInUnits = 4
             builder.update_group(group_id=0x80000001, group_size_in_units=4) and None,
             _trace_pool_list(),
+        ]
+
+    def test_cluster_balance(self):
+        builder = (
+            BaseConfigBuilder()
+            .add_node(node_id=1)
+            .add_pdisk(node_id=1, pdisk_id=1001, expected_slot_count=8)
+            .add_pdisk(node_id=1, pdisk_id=1002, expected_slot_count=4)
+            .add_group(group_id=0x80000001, vslot_ids=[(1, 1001, 1000)], group_size_in_units=1)
+            .add_group(group_id=0x80000002, vslot_ids=[(1, 1001, 1001)], group_size_in_units=1)
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1000, group_id=0x80000001, group_generation=1)
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1001, group_id=0x80000002, group_generation=1)
+            .add_storage_pool(name='test-pool', erasure_species='none', kind='hdd')
+        )
+
+        def _trace_cluster_balance(*args, pending_reassigns=None):
+            base_config = builder.build()
+            if pending_reassigns is None:
+                pending_reassigns = {}
+            fake_grpc_handler = FakeReassignGroupDiskHandler(pending_reassigns, base_config)
+            return self._trace('--verbose', 'cluster', 'balance', '--storage-pool=test-pool', '--max-iterations=1', *args,
+                               with_grpc_calls=True, allow_http_fetch=True,
+                               mock_base_config=base_config,
+                               fake_grpc_handler=fake_grpc_handler)
+
+        return [
+            # No overpopulated pdisks yet, no reassignments are necessary
+            _trace_cluster_balance('--only-from-overpopulated-pdisks'),
+
+            # Change GroupSizeInUnits. The pdsik becomes overpopulated
+            # ReassignGroupDisk should be invoked
+            builder.update_group(group_id=0x80000001, group_size_in_units=8) and None,
+            _trace_cluster_balance('--only-from-overpopulated-pdisks', pending_reassigns={0x80000002: (1, 1002, 1000)}),
         ]

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -124,11 +124,10 @@ class TestBase:
         original_invoke_grpc = common.invoke_grpc
 
         def mock_invoke_grpc(func, *params, **kwargs):
-            response = None
-            if mock_base_config is None:
-                response = original_invoke_grpc(func, *params, **kwargs)
-            elif fake_grpc_handler is not None:
+            if fake_grpc_handler is not None:
                 response = fake_grpc_handler.handle(func, *params)
+            else:
+                response = original_invoke_grpc(func, *params, **kwargs)
 
             grpc_calls.append(f'=== Invoke {func} ===')
             for param in params:


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Add a test for `dstool cluster balance`
- Mock ReassignGroupDisk grpc commands handling
- Improve BaseConfigBuilder itself and its canonization format
- Improve `dstool cluster balance --help`
- Add option `dstool cluster balance --max-iterations`, mostly for testing purposes
- Only allow whitelisted dstool commands to use http fetch in tests and canonize those requests
- Suppress random in the test to make it deterministic and to reduce flakiness 
