### PR TITLE
Fix connect database permission check for anonymous user

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -683,6 +683,10 @@ private:
             return {false, std::nullopt};
         }
 
+
+        // An empty token at this point means that anonymous access is allowed by the system configuration,
+        // as the EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement flags have already been
+        // validated earlier in the request processing pipeline.
         if (!TBase::GetParsedToken()) {
             LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
                         "Skip check permission connect db, anonymous requests allowed"

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -683,15 +683,13 @@ private:
             return {false, std::nullopt};
         }
 
-        if (!TBase::GetSecurityToken()) {
-            if (!TBase::IsTokenRequired()) {
-                LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
-                            "Skip check permission connect db, token is not required, there is no token provided"
-                            << ", database: " << CheckedDatabaseName_
-                            << ", user: " << TBase::GetUserSID()
-                            << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
-                return {false, std::nullopt};
-            }
+        if (!TBase::GetParsedToken()) {
+            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
+                        "Skip check permission connect db, anonymous requests allowed"
+                        << ", database: " << CheckedDatabaseName_
+                        << ", user: " << TBase::GetUserSID()
+                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+            return {false, std::nullopt};
         }
 
         if (!SecurityObject_) {

--- a/ydb/core/mon/ut_utils/ut_utils.cpp
+++ b/ydb/core/mon/ut_utils/ut_utils.cpp
@@ -11,6 +11,7 @@ const TString TEST_MON_PATH = "test_mon";
 const TString TEST_RESPONSE = "Test actor";
 const TString AUTHORIZATION_HEADER = "Authorization";
 const TString VALID_TOKEN = "Bearer token";
+const TString ROOT_TOKEN = "root@builtin";
 const TVector<TString> DEFAULT_TICKET_PARSER_GROUPS = {"group_name"};
 
 void TTestActorPage::Bootstrap() {
@@ -68,6 +69,10 @@ void TFakeTicketParserActor::Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& e
     LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER, "Ticket parser: got TEvAuthorizeTicket event: " << ev->Get()->Ticket << " " << ev->Get()->Database << " " << ev->Get()->Entries.size());
     ++AuthorizeTicketRequests;
 
+    if (ev->Get()->Ticket == ROOT_TOKEN) {
+        return Success(ev);
+    }
+
     if (ev->Get()->Database != "/Root") {
         Fail(ev, TStringBuilder() << "Incorrect database " << ev->Get()->Database);
         return;
@@ -122,8 +127,12 @@ void TFakeTicketParserActor::Fail(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev,
 void TFakeTicketParserActor::Success(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
     ++AuthorizeTicketSuccesses;
     NACLib::TUserToken::TUserTokenInitFields args;
-    args.UserSID = "username";
-    args.GroupSIDs = GroupSIDs;
+    if (ev->Get()->Ticket == ROOT_TOKEN) {
+        args.UserSID = ROOT_TOKEN;
+    } else {
+        args.UserSID = "username";
+        args.GroupSIDs = GroupSIDs;
+    }
     TIntrusivePtr<NACLib::TUserToken> userToken = MakeIntrusive<NACLib::TUserToken>(args);
     userToken->SaveSerializationInfo();
     LOG_INFO_S(*TlsActivationContext, NKikimrServices::TICKET_PARSER,

--- a/ydb/core/mon/ut_utils/ut_utils.h
+++ b/ydb/core/mon/ut_utils/ut_utils.h
@@ -15,6 +15,7 @@ extern const TString TEST_MON_PATH;
 extern const TString TEST_RESPONSE;
 extern const TString AUTHORIZATION_HEADER;
 extern const TString VALID_TOKEN;
+extern const TString ROOT_TOKEN;
 extern const TVector<TString> DEFAULT_TICKET_PARSER_GROUPS;
 
 class TTestActorPage : public TActorBootstrapped<TTestActorPage> {

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -841,7 +841,6 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     entry.Path = SplitPath(path);
     entry.RedirectRequired = false;
     entry.ShowPrivatePath = true;
-    entry.SyncVersion = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
     request->ResultSet.emplace_back(entry);
     auto tokenObj = GetRequest().GetUserTokenObject();

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -841,6 +841,7 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     entry.Path = SplitPath(path);
     entry.RedirectRequired = false;
     entry.ShowPrivatePath = true;
+    entry.SyncVersion = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
     request->ResultSet.emplace_back(entry);
     auto tokenObj = GetRequest().GetUserTokenObject();

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1747,9 +1747,10 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
 
         TString consumerName = "consumer1";
-        NYdb::TDriver ydbDriver{driverCfg};
 
         driverCfg.SetAuthToken(ROOT_TOKEN);
+        NYdb::TDriver ydbDriver{driverCfg};
+
         auto topicClient = NYdb::NTopic::TTopicClient(ydbDriver);
 
         auto res = topicClient.CreateTopic(topicPath, NYdb::NTopic::TCreateTopicSettings()

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -485,10 +485,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         return NJson::ReadJsonTree(&responseStream, /* throwOnError = */ true);
     }
 
-    void GrantConnect(TClient& client) {
+    void CreateUser(TClient& client) {
         client.CreateUser("/Root", "username", "password");
-        client.GrantConnect("username");
-        client.Grant("/", "Root", "username", NACLib::EAccessRights::DescribeSchema);
         const auto alterAttrsStatus = client.AlterUserAttributes("/", "Root", {
             { "folder_id", "test_folder_id" },
             { "database_id", "test_database_id" },
@@ -496,7 +494,14 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_EQUAL(alterAttrsStatus, NMsgBusProxy::MSTATUS_OK);
     }
 
+    void GrantConnect(TClient& client) {
+        client.GrantConnect("username");
+        const auto grantStatus = client.Grant("/", "Root", "username", NACLib::EAccessRights::DescribeSchema);
+        UNIT_ASSERT_EQUAL(grantStatus, NMsgBusProxy::MSTATUS_OK);
+    }
+
     void GrantRead(TClient& client) {
+        CreateUser(client);
         GrantConnect(client);
         client.Grant("/", "Root", "username", NACLib::EAccessRights::GenericRead);
     }
@@ -1724,10 +1729,16 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 .SetDomainName("Root")
                 .SetMonitoringPortOffset(monPort, true);
         settings.CreateTicketParser = CreateFakeTicketParser;
+        auto& securityConfig = *settings.AppConfig->MutableDomainsConfig()->MutableSecurityConfig();
+        securityConfig.SetEnforceUserTokenCheckRequirement(true);
+        securityConfig.AddAdministrationAllowedSIDs(ROOT_TOKEN);
+        securityConfig.AddViewerAllowedSIDs("username");
+
         auto grpcSettings = NYdbGrpc::TServerOptions().SetHost("[::1]").SetPort(grpcPort);
         TServer server{settings};
         server.EnableGRpc(grpcSettings);
         auto pqClient = MakeHolder<NKikimr::NPersQueueTests::TFlatMsgBusPQClient>(settings, grpcPort);
+        pqClient->SetSecurityToken(ROOT_TOKEN);
         pqClient->InitRoot();
         pqClient->InitSourceIds();
         NYdb::TDriverConfig driverCfg;
@@ -1738,7 +1749,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TString consumerName = "consumer1";
         NYdb::TDriver ydbDriver{driverCfg};
 
-        driverCfg.SetAuthToken("root@builtin");
+        driverCfg.SetAuthToken(ROOT_TOKEN);
         auto topicClient = NYdb::NTopic::TTopicClient(ydbDriver);
 
         auto res = topicClient.CreateTopic(topicPath, NYdb::NTopic::TCreateTopicSettings()
@@ -1765,34 +1776,38 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TKeepAliveHttpClient httpClient("localhost", monPort);
         NKikimr::NViewerTests::WaitForHttpReady(httpClient);
 
-        // checking that user with correct token but no rights cannot commit to the topic
-        auto postReturnCode1 = PostOffsetCommit(httpClient, "root@builtin");
-        UNIT_ASSERT_EQUAL(postReturnCode1, HTTP_FORBIDDEN);
-
         TClient client(settings);
-        client.InitRootScheme();
+        client.SetSecurityToken(ROOT_TOKEN);
+        CreateUser(client);
+
+        // checking that user with correct token but no connect right cannot commit to the topic
+        auto postReturnCode1 = PostOffsetCommit(httpClient, VALID_TOKEN);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode1, HTTP_FORBIDDEN);
+
         GrantConnect(client);
+        Sleep(TDuration::MilliSeconds(200));
 
         // client without required AccessRights can't commit offsets
         auto postReturnCode2 = PostOffsetCommit(httpClient, VALID_TOKEN);
-        Cerr << postReturnCode2 << Endl;
-        UNIT_ASSERT_EQUAL(postReturnCode2, HTTP_FORBIDDEN);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode2, HTTP_FORBIDDEN);
 
 
         client.Grant("/", "Root", "username", NACLib::EAccessRights::SelectRow);
+        Sleep(TDuration::MilliSeconds(200));
+
         // checking that user with rights and correct token can commit successfully
         auto postReturnCode3 = PostOffsetCommit(httpClient, VALID_TOKEN);
-        UNIT_ASSERT_EQUAL(postReturnCode3, HTTP_OK);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode3, HTTP_OK);
 
 
         // checking that user with invalid token cannot commit
         TString invalid_token = "abracadabra";
         auto postReturnCode4 = PostOffsetCommit(httpClient, invalid_token);
-        UNIT_ASSERT_EQUAL(postReturnCode4, HTTP_FORBIDDEN);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode4, HTTP_FORBIDDEN);
 
         // checking that commiting with consumer without read rule is forbidden
         auto postReturnCode5 = PostOffsetCommit(httpClient, VALID_TOKEN, "/Root", "/Root/topic1", "consumer2", 0, 55000);
-        UNIT_ASSERT_EQUAL(postReturnCode5, HTTP_BAD_REQUEST);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode5, HTTP_BAD_REQUEST);
 
         auto describeTopicResult = topicClient.DescribeTopic(topicPath).GetValueSync();
         UNIT_ASSERT(describeTopicResult.IsSuccess());
@@ -1807,10 +1822,10 @@ Y_UNIT_TEST_SUITE(Viewer) {
         // now messages are deleted because of retention
         // check that if we commit offset less than start offset in strict mode, start offset is committed
         auto postReturnCode6 = PostOffsetCommit(httpClient, VALID_TOKEN, "/Root", "/Root/topic1", "consumer1", 0, 1000);
-        UNIT_ASSERT_EQUAL(postReturnCode6, HTTP_OK);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode6, HTTP_OK);
         // check that offset commit works correctly if start offset is non-zero and offset is greater that start offset
         auto postReturnCode7 = PostOffsetCommit(httpClient, VALID_TOKEN, "/Root", "/Root/topic1", "consumer1", 0, 15000);
-        UNIT_ASSERT_EQUAL(postReturnCode7, HTTP_OK);
+        UNIT_ASSERT_VALUES_EQUAL(postReturnCode7, HTTP_OK);
 
     }
 
@@ -1974,6 +1989,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         runtime.SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
         TClient client1(settings);
         client1.InitRootScheme();
+        CreateUser(client1);
         GrantConnect(client1);
         TKeepAliveHttpClient httpClient("localhost", monPort);
         TString consumerName = "consumer1";
@@ -2058,6 +2074,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         runtime.SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
         TClient client1(settings);
         client1.InitRootScheme();
+        CreateUser(client1);
         GrantConnect(client1);
         TKeepAliveHttpClient httpClient("localhost", monPort);
         TString consumerName = "consumer1";

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -274,7 +274,7 @@ Y_UNIT_TEST_SUITE(TGRpcClientLowTest) {
         if (enforceUserTokenCheckRequirement) {
             UNIT_ASSERT_EQUAL(reqResultWithInvalidToken, std::make_pair(Ydb::StatusIds::STATUS_CODE_UNSPECIFIED, grpc::StatusCode::UNAUTHENTICATED));
         } else {
-            UNIT_ASSERT_EQUAL(reqResultWithInvalidToken, std::make_pair(Ydb::StatusIds::UNAUTHORIZED, grpc::StatusCode::OK));
+            UNIT_ASSERT_EQUAL(reqResultWithInvalidToken, std::make_pair(Ydb::StatusIds::SUCCESS, grpc::StatusCode::OK));
         }
 
         UNIT_ASSERT_EQUAL(MakeTestRequest(clientConfig, "/blabla", "invalid token"), std::make_pair(Ydb::StatusIds::STATUS_CODE_UNSPECIFIED, grpc::StatusCode::UNAUTHENTICATED));


### PR DESCRIPTION
If a user sends invalid token and EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement are disabled then all requests become anonymous and system doesn't have to check all permissions including connect database&