### PR TITLE
Process requests in anonymous mode if errors happen in TicketParser and anonymous mode is allowed

### DIFF
--- a/ydb/core/http_proxy/auth_actors.cpp
+++ b/ydb/core/http_proxy/auth_actors.cpp
@@ -123,10 +123,15 @@ namespace NKikimr::NHttpProxy {
         }
 
         void HandleTicketParser(const TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const TActorContext& ctx) {
+            NACLib::TUserToken userToken = NACLibProto::TUserToken();
             if (ev->Get()->HasError()) {
-                return ReplyWithError(ctx, ev->Get()->Error.Retryable ? NYdb::EStatus::UNAVAILABLE : NYdb::EStatus::UNAUTHORIZED, TString{ev->Get()->Error.Message});
+                if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+                    return ReplyWithError(ctx, ev->Get()->Error.Retryable ? NYdb::EStatus::UNAVAILABLE : NYdb::EStatus::UNAUTHORIZED, TString{ev->Get()->Error.Message});
+                }
+            } else {
+                userToken = *ev->Get()->Token;
             }
-            ctx.Send(Sender, new TEvServerlessProxy::TEvToken(ev->Get()->Token->GetUserSID(), "", ev->Get()->SerializedToken, {"", DatabaseId, DatabasePath, CloudId, FolderId}));
+            ctx.Send(Sender, new TEvServerlessProxy::TEvToken(userToken.GetUserSID(), "", userToken.GetSerializedToken(), {"", DatabaseId, DatabasePath, CloudId, FolderId}));
 
             LOG_SP_DEBUG_S(ctx, NKikimrServices::HTTP_PROXY, "Authorized successfully");
 

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -198,13 +198,15 @@ void TKafkaSaslAuthActor::HandleLoginResult(TEvSasl::TEvSaslScramFinalServerResp
 
 void TKafkaSaslAuthActor::Handle(NKikimr::TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const NActors::TActorContext& ctx) {
     if (ev->Get()->HasError()) {
-        if (Context->SaslMechanism == "SCRAM-SHA-256") {
-            AuthResponse = NLogin::NSasl::BuildErrorMsg(NLogin::NSasl::EScramServerError::OtherError);
-        }
+        if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+            if (Context->SaslMechanism == "SCRAM-SHA-256") {
+                AuthResponse = NLogin::NSasl::BuildErrorMsg(NLogin::NSasl::EScramServerError::OtherError);
+            }
 
-        SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, Ydb::StatusIds::UNAUTHORIZED,
-                            "", TString{ev->Get()->Error.Message}, ctx);
-        return;
+            SendResponseAndDie(EKafkaErrors::SASL_AUTHENTICATION_FAILED, Ydb::StatusIds::UNAUTHORIZED,
+                                "", TString{ev->Get()->Error.Message}, ctx);
+            return;
+        }
     }
 
     UserToken = ev->Get()->Token;

--- a/ydb/core/local_pgwire/local_pgwire_auth_actor.cpp
+++ b/ydb/core/local_pgwire/local_pgwire_auth_actor.cpp
@@ -71,8 +71,10 @@ public:
 
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev) {
         if (ev->Get()->HasError()) {
-            SendResponseAndDie(ev->Get()->Error.Message);
-            return;
+            if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+                SendResponseAndDie(ev->Get()->Error.Message);
+                return;
+            }
         }
 
         SerializedToken = ev->Get()->SerializedToken;

--- a/ydb/core/ymq/actor/action.h
+++ b/ydb/core/ymq/actor/action.h
@@ -783,10 +783,14 @@ private:
     void HandleTicketParserResponse(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev) {
         const TEvTicketParser::TEvAuthorizeTicketResult& result(*ev->Get());
         if (result.HasError()) {
-            RLOG_SQS_ERROR("Got ticket parser error: " << result.Error << ". " << Action_ << " was rejected");
-            MakeError(MutableErrorDesc(), NErrors::ACCESS_DENIED);
-            SendReplyAndDie();
-            return;
+            if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+                RLOG_SQS_ERROR("Got ticket parser error: " << result.Error << ". " << Action_ << " was rejected");
+                MakeError(MutableErrorDesc(), NErrors::ACCESS_DENIED);
+                SendReplyAndDie();
+                return;
+            }
+
+            UserToken_ = nullptr;
         } else {
             UserToken_ = ev->Get()->Token;
             Y_ABORT_UNLESS(UserToken_);
@@ -799,18 +803,20 @@ private:
         --SecurityCheckRequestsToWaitFor_;
 
         if (SecurityCheckRequestsToWaitFor_ == 0) {
-            const TString& actionName = ToString(Action_);
-            const ui32 requiredAccess = GetActionRequiredAccess(actionName);
-            UserSID_ = UserToken_->GetUserSID();
-            if (requiredAccess != 0 && SecurityObject_ && !SecurityObject_->CheckAccess(requiredAccess, *UserToken_)) {
-                if (Action_ == EAction::ModifyPermissions) {
-                    // do not spam for other actions
-                    RLOG_SQS_WARN("User " << UserSID_ << " tried to modify ACL for " << GetActionACLSourcePath() << ". Access denied");
+            if (UserToken_) {
+                const TString& actionName = ToString(Action_);
+                const ui32 requiredAccess = GetActionRequiredAccess(actionName);
+                UserSID_ = UserToken_->GetUserSID();
+                if (requiredAccess != 0 && SecurityObject_ && !SecurityObject_->CheckAccess(requiredAccess, *UserToken_)) {
+                    if (Action_ == EAction::ModifyPermissions) {
+                        // do not spam for other actions
+                        RLOG_SQS_WARN("User " << UserSID_ << " tried to modify ACL for " << GetActionACLSourcePath() << ". Access denied");
+                    }
+                    MakeError(MutableErrorDesc(), NErrors::ACCESS_DENIED, Sprintf("%s on %s was denied for %s due to missing permission %s.",
+                            actionName.c_str(), SanitizeNodePath(GetActionACLSourcePath()).c_str(), UserSID_.c_str(), GetActionMatchingACE(actionName).c_str()));
+                    SendReplyAndDie();
+                    return;
                 }
-                MakeError(MutableErrorDesc(), NErrors::ACCESS_DENIED, Sprintf("%s on %s was denied for %s due to missing permission %s.",
-                          actionName.c_str(), SanitizeNodePath(GetActionACLSourcePath()).c_str(), UserSID_.c_str(), GetActionMatchingACE(actionName).c_str()));
-                SendReplyAndDie();
-                return;
             }
 
             DoGetQuotaAndProcess();

--- a/ydb/core/ymq/actor/auth_multi_factory.cpp
+++ b/ydb/core/ymq/actor/auth_multi_factory.cpp
@@ -253,18 +253,22 @@ void TBaseCloudAuthRequestProxy::ProcessAuthorizationResult(const TEvTicketParse
     if (result.HasError()) {
         if (CanRetry() && result.Error.Retryable) {
             ScheduleAuthorizationRetry();
+            return;
         } else {
-            RLOG_SQS_INFO("Authorize failed. Error: " << result.Error.ToString());
-            SetError(
-                result.Error.Retryable ? NErrors::SERVICE_UNAVAILABLE : NErrors::ACCESS_DENIED,
-                "IAM authorization error."
-            );
-            SendReplyAndDie();
+            if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+                RLOG_SQS_INFO("Authorize failed. Error: " << result.Error.ToString());
+                SetError(
+                    result.Error.Retryable ? NErrors::SERVICE_UNAVAILABLE : NErrors::ACCESS_DENIED,
+                    "IAM authorization error."
+                );
+                SendReplyAndDie();
+                return;
+            }
         }
-        return;
+    } else {
+        UserSID_ = result.Token->GetUserSID();
     }
 
-    UserSID_ = result.Token->GetUserSID();
     MaskedToken_ = NKikimr::MaskIAMTicket(IamToken_);
 
     // Of course, in practice the accounts that come in aren’t always of the "service_account" type.

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -815,8 +815,10 @@ void TReadSessionActor::Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& 
                             << (!ev->Get()->HasError() ? ev->Get()->Token->GetUserSID() : ""));
 
     if (ev->Get()->HasError()) {
-        CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
-        return;
+        if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+            CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
+            return;
+        }
     }
     Token = ev->Get()->Token;
     CreateInitAndAuthActor(ctx);

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_write_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_write_actor.cpp
@@ -405,10 +405,6 @@ void TWriteSessionActor::Handle(TEvDescribeTopicsResponse::TPtr& ev, const TActo
         LOG_WARN_S(ctx, NKikimrServices::PQ_WRITE_PROXY, "session without AuthInfo : " << DiscoveryConverter->GetPrintableString()
                                                          << " sourceId " << SourceId << " from " << PeerName);
         SessionsWithoutAuth.Inc();
-        if (AppData(ctx)->EnforceUserTokenRequirement || AppData(ctx)->PQConfig.GetRequireCredentialsInNewProtocol()) {
-            CloseSession("Unauthenticated access is forbidden, please provide credentials", NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
-            return;
-        }
         if (FirstACLCheck) {
             FirstACLCheck = false;
             DiscoverPartition(ctx);
@@ -454,8 +450,10 @@ void TWriteSessionActor::Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr&
                             << (!ev->Get()->HasError() ? ev->Get()->Token->GetUserSID() : ""));
 
     if (ev->Get()->HasError()) {
-        CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
-        return;
+        if (AppData()->EnforceUserTokenRequirement || AppData()->EnforceUserTokenCheckRequirement) {
+            CloseSession(TStringBuilder() << "Ticket parsing error: " << ev->Get()->Error, NPersQueue::NErrorCode::ACCESS_DENIED, ctx);
+            return;
+        }
     }
     Token = ev->Get()->Token;
 

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -46,6 +46,7 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(KikimrSqsTest
             fl.write("root@builtin")
 
         config_generator.yaml_config['sqs_config']['auth_config'] = {'oauth_token': {'token_file': temp_token_file}}
+        config_generator.yaml_config['domains_config']['security_config']['enforce_user_token_check_requirement'] = True
         return config_generator
 
     def _before_test_start(self):


### PR DESCRIPTION
Errors in TicketParser must no result in forbidding request processing if EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement settings are disabled. In this case the request have to be processed in anonymous mode.