### PR TITLE
Increase IC whiteboard update interval (1sec -> 5sec). NBYDB-2121

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -14,6 +14,8 @@
 #include <tuple>
 
 namespace NActors {
+    static constexpr TDuration WhiteboardUpdatePeriod = TDuration::Seconds(5);
+
     LWTRACE_USING(ACTORLIB_PROVIDER);
 
     template<typename T>
@@ -1250,7 +1252,7 @@ namespace NActors {
         }
 
         if (connected && reschedule) {
-            Schedule(TDuration::Seconds(1), new TEvents::TEvWakeup);
+            Schedule(WhiteboardUpdatePeriod, new TEvents::TEvWakeup);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

in case of huge cluster (10k nodes) 1 second causes some additional overhead.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
