### PR TITLE
Introduce detailed VDisk replication status

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_mongroups.h
@@ -322,6 +322,7 @@ public:                                                                         
                 COUNTER_INIT_IF_EXTENDED(ReplNodeRequestThrottledMicroseconds, false);
                 COUNTER_INIT_IF_EXTENDED(ReplNodeResponseThrottledMicroseconds, false);
                 COUNTER_INIT_IF_EXTENDED(ReplPDiskReadThrottledMicroseconds, false);
+                COUNTER_INIT(ReplIsHoldingToken, false);
             }
 
             COUNTER_DEF(SyncerVSyncMessagesSent);
@@ -351,6 +352,7 @@ public:                                                                         
             COUNTER_DEF(ReplNodeRequestThrottledMicroseconds);
             COUNTER_DEF(ReplNodeResponseThrottledMicroseconds);
             COUNTER_DEF(ReplPDiskReadThrottledMicroseconds);
+            COUNTER_DEF(ReplIsHoldingToken);
         };
 
         ///////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.cpp
@@ -290,6 +290,7 @@ namespace NKikimr {
             ReplCtx->MonGroup.ReplWorkUnitsDone() = 0;
             ReplCtx->MonGroup.ReplItemsRemaining() = 0;
             ReplCtx->MonGroup.ReplItemsDone() = 0;
+            ReplCtx->MonGroup.ReplIsHoldingToken() = false;
             Y_VERIFY_S(NextMinHugeBlobInBytes, ReplCtx->VCtx->VDiskLogPrefix);
             ReplCtx->MinHugeBlobInBytes = NextMinHugeBlobInBytes;
             UnrecoveredNonphantomBlobs = false;
@@ -336,6 +337,7 @@ namespace NKikimr {
             Y_VERIFY_S(RequestedReplicationToken, ReplCtx->VCtx->VDiskLogPrefix);
             RequestedReplicationToken = false;
             HoldingReplicationToken = true;
+            ReplCtx->MonGroup.ReplIsHoldingToken() = true;
 
             // switch to replication state
             Transition(AwaitToken, Replication);
@@ -479,6 +481,7 @@ namespace NKikimr {
                     Y_DEBUG_ABORT_UNLESS(!RequestedReplicationToken);
                     Y_DEBUG_ABORT_UNLESS(HoldingReplicationToken);
                     HoldingReplicationToken = false;
+                    ReplCtx->MonGroup.ReplIsHoldingToken() = false;
                 }
                 ResetReplProgressTimer(true);
 
@@ -502,6 +505,7 @@ namespace NKikimr {
                     ReplCtx->MonGroup.ReplWorkUnitsDone() = 0;
                     ReplCtx->MonGroup.ReplItemsRemaining() = 0;
                     ReplCtx->MonGroup.ReplItemsDone() = 0;
+                    ReplCtx->MonGroup.ReplIsHoldingToken() = false;
                     TActivationContext::Send(new IEventHandle(TEvBlobStorage::EvReplDone, 0, ReplCtx->SkeletonId,
                         SelfId(), nullptr, 0));
                 }

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -1172,9 +1172,20 @@ namespace NKikimr {
                                IntQueueHugePutsBackground.get()}) {
                 light = Max(light, queue->GetCumulativeLight());
             }
+            NKikimrWhiteboard::TVDiskDetailedReplicationStatus::E replicationStatus =
+                    NKikimrWhiteboard::TVDiskDetailedReplicationStatus::Replicated;
+            if (!replicated) {
+                if (!ReplMonGroup.ReplIsHoldingToken()) {
+                    replicationStatus = NKikimrWhiteboard::TVDiskDetailedReplicationStatus::WaitingForToken;
+                } else if (!unreplicatedNonPhantoms && unreplicatedPhantoms) {
+                    replicationStatus = NKikimrWhiteboard::TVDiskDetailedReplicationStatus::PhantomsOnly;
+                } else {
+                    replicationStatus = NKikimrWhiteboard::TVDiskDetailedReplicationStatus::InProgress;
+                }
+            }
             // send a message to Whiteboard
             auto ev = std::make_unique<NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate>(state, outOfSpaceFlags,
-                replicated, unreplicatedPhantoms, unreplicatedNonPhantoms, unsyncedVDisks, light, HasUnreadableBlobs);
+                replicated, unreplicatedPhantoms, unreplicatedNonPhantoms, replicationStatus, unsyncedVDisks, light, HasUnreadableBlobs);
             if (ReplMonGroup.ReplUnreplicatedVDisks()) {
                 const i64 a = ReplMonGroup.ReplWorkUnitsDone();
                 const i64 b = ReplMonGroup.ReplWorkUnitsRemaining();

--- a/ydb/core/node_whiteboard/node_whiteboard.h
+++ b/ydb/core/node_whiteboard/node_whiteboard.h
@@ -227,6 +227,7 @@ struct TEvWhiteboard {
                                      bool replicated,
                                      bool unreplicatedPhantoms,
                                      bool unreplicatedNonPhantoms,
+                                     NKikimrWhiteboard::TVDiskDetailedReplicationStatus::E detailedReplicationStatus,
                                      ui64 unsyncedVDisks,
                                      NKikimrWhiteboard::EFlag frontQueuesLigth,
                                      bool hasUnreadableBlobs) {
@@ -235,6 +236,7 @@ struct TEvWhiteboard {
             Record.SetReplicated(replicated);
             Record.SetUnreplicatedPhantoms(unreplicatedPhantoms);
             Record.SetUnreplicatedNonPhantoms(unreplicatedNonPhantoms);
+            Record.SetDetailedReplicationStatus(detailedReplicationStatus);
             Record.SetUnsyncedVDisks(unsyncedVDisks);
             Record.SetFrontQueues(frontQueuesLigth);
             Record.SetHasUnreadableBlobs(hasUnreadableBlobs);

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -220,7 +220,7 @@ message TVDiskStateInfo {
     // The same for the non-phantom-like blobs.
     optional bool UnreplicatedNonPhantoms = 21 [default = false,  (DefaultField) = true];
     // Detailed replication status.
-    optional TVDiskDetailedReplicationStatus.E DetailedReplicationStatus = 37 [(DefaultField) = true];
+    optional TVDiskDetailedReplicationStatus.E DetailedReplicationStatus = 37;
     // Replication progress (0 to 1). Only for replication, not blob scrubbing.
     optional float ReplicationProgress = 30 [(DefaultField) = true];
     // Replication ETA.

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -184,6 +184,15 @@ message TVDiskSatisfactionRank {
     optional TRank LevelRank = 2;
 }
 
+message TVDiskDetailedReplicationStatus {
+    enum E {
+        Replicated = 0;         // Disk is fully replicated, no replication needed
+        WaitingForToken = 1;    // Replication is waiting for a token from the broker
+        InProgress = 2;         // Replication is in progress, data is being transferred to VDisk
+        PhantomsOnly = 3;       // Replication cannot finish due to phantom blobs
+    }
+}
+
 message TVDiskStateInfo {
     optional NKikimrBlobStorage.TVDiskID VDiskId = 1 [(DefaultField) = true];
     optional uint64 CreateTime = 2;
@@ -210,6 +219,8 @@ message TVDiskStateInfo {
     optional bool UnreplicatedPhantoms = 20 [default = false, (DefaultField) = true];
     // The same for the non-phantom-like blobs.
     optional bool UnreplicatedNonPhantoms = 21 [default = false,  (DefaultField) = true];
+    // Detailed replication status.
+    optional TVDiskDetailedReplicationStatus.E DetailedReplicationStatus = 37 [(DefaultField) = true];
     // Replication progress (0 to 1). Only for replication, not blob scrubbing.
     optional float ReplicationProgress = 30 [(DefaultField) = true];
     // Replication ETA.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce detailed VDisk replication status. This allows to distinguish situations when replication is actively processing data, when it is waiting for token and when it can't finish due to phantoms.

### Changelog category <!-- remove all except one -->

* Improvement