### PR TITLE
Add support for KQP Compute Scheduler into datashard reading

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -780,9 +780,15 @@ void TKqpTasksGraph::BuildStreamLookupChannels(const TStageInfo& stageInfo, ui32
 {
     YQL_ENSURE(stageInfo.Tasks.size() == inputStageInfo.Tasks.size());
 
-    NKikimrKqp::TKqpStreamLookupSettings* settings = GetMeta().Allocate<NKikimrKqp::TKqpStreamLookupSettings>();
+    auto* settings = GetMeta().Allocate<NKikimrKqp::TKqpStreamLookupSettings>();
 
     settings->SetDatabase(GetMeta().Database);
+
+    const auto& poolId = GetMeta().UserRequestContext->PoolId;
+    if (!poolId.empty() && poolId != NResourcePool::DEFAULT_POOL_ID) {
+        settings->SetPoolId(poolId);
+    }
+
     settings->MutableTable()->CopyFrom(streamLookup.GetTable());
 
     const auto& tableInfo = stageInfo.Meta.TableConstInfo;
@@ -859,6 +865,12 @@ void TKqpTasksGraph::BuildVectorResolveChannels(const TStageInfo& stageInfo, ui3
     const auto& levelTableInfo = stageInfo.Meta.IndexMetas.back().TableConstInfo;
 
     settings->SetDatabase(GetMeta().Database);
+
+    const auto& poolId = GetMeta().UserRequestContext->PoolId;
+    if (!poolId.empty() && poolId != NResourcePool::DEFAULT_POOL_ID) {
+        settings->SetPoolId(poolId);
+    }
+
     auto* levelMeta = settings->MutableLevelTable();
     const auto& kqpMeta = vectorResolve.GetLevelTable();
     levelMeta->SetTablePath(kqpMeta.GetPath());
@@ -1593,6 +1605,7 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
         if (settings.Is<NKikimrKqp::TKqpStreamLookupSettings>()) {
             auto* transformSettings = meta.StreamLookupSettings = GetMeta().Allocate<NKikimrKqp::TKqpStreamLookupSettings>();
             YQL_ENSURE(settings.UnpackTo(transformSettings), "Failed to parse stream lookup settings");
+            // TODO: should we setup Database and PoolId for settings?
             transformSettings->ClearSnapshot();
             transformSettings->ClearLockTxId();
             transformSettings->ClearLockNodeId();
@@ -1602,6 +1615,7 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
         } else if (settings.Is<NKikimrTxDataShard::TKqpVectorResolveSettings>()) {
             auto* transformSettings = meta.VectorResolveSettings = GetMeta().Allocate<NKikimrTxDataShard::TKqpVectorResolveSettings>();
             YQL_ENSURE(settings.UnpackTo(transformSettings), "Failed to parse vector resolve settings");
+            // TODO: should we setup Database and PoolId for settings?
             transformSettings->ClearSnapshot();
             transformSettings->ClearLockTxId();
             transformSettings->ClearLockNodeId();
@@ -1737,10 +1751,12 @@ void TKqpTasksGraph::RestoreTasksGraphInfo(const TVector<NKikimrKqp::TKqpNodeRes
                         if (settings.Is<NKikimrTxDataShard::TKqpReadRangesSourceSettings>()) {
                             auto* sourceSettings = newInput.Meta.SourceSettings = GetMeta().Allocate<NKikimrTxDataShard::TKqpReadRangesSourceSettings>();
                             YQL_ENSURE(settings.UnpackTo(sourceSettings), "Failed to parse source settings");
+                            // TODO: should we setup Database and PoolId for settings?
                             FillScanTaskLockTxId(*sourceSettings);
                             sourceSettings->ClearSnapshot();
                         } else if (settings.Is<NKikimrKqp::TKqpFullTextSourceSettings>()) {
                             auto* sourceSettings = newInput.Meta.FullTextSourceSettings = GetMeta().Allocate<NKikimrKqp::TKqpFullTextSourceSettings>();
+                            // TODO: should we setup Database and PoolId for settings?
                             YQL_ENSURE(settings.UnpackTo(sourceSettings), "Failed to parse full text source settings");
                             sourceSettings->ClearSnapshot();
                         } else if (settings.Is<NKikimrKqp::TKqpSysViewSourceSettings>()) {
@@ -2420,6 +2436,12 @@ void TKqpTasksGraph::BuildFullTextScanTasksFromSource(TStageInfo& stageInfo, TQu
 
     settings->SetIndex(fullTextSource.GetIndex());
     settings->SetDatabase(GetMeta().Database);
+
+    const auto& poolId = GetMeta().UserRequestContext->PoolId;
+    if (!poolId.empty() && poolId != NResourcePool::DEFAULT_POOL_ID) {
+        settings->SetPoolId(poolId);
+    }
+
     settings->MutableTable()->CopyFrom(fullTextSource.GetTable());
     settings->SetIndexType(fullTextSource.GetIndexType());
     settings->MutableIndexDescription()->CopyFrom(fullTextSource.GetIndexDescription());
@@ -2679,6 +2701,11 @@ TMaybe<size_t> TKqpTasksGraph::BuildScanTasksFromSource(TStageInfo& stageInfo, b
         NKikimrTxDataShard::TKqpReadRangesSourceSettings* settings = input.Meta.SourceSettings;
         settings->SetDatabase(GetMeta().Database);
         FillTableMeta(stageInfo, settings->MutableTable());
+
+        const auto& poolId = GetMeta().UserRequestContext->PoolId;
+        if (!poolId.empty() && poolId != NResourcePool::DEFAULT_POOL_ID) {
+            settings->SetPoolId(poolId);
+        }
 
         settings->SetIsTableImmutable(source.GetIsTableImmutable());
         settings->SetIsolationLevel(GetMeta().RequestIsolationLevel);

--- a/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
@@ -476,7 +476,8 @@ public:
             case Ydb::StatusIds::OVERLOADED: {
                 CA_LOG_D("OVERLOADED was received from tablet: " << shardId << "."
                     << getIssues().ToOneLineString());
-                if (!RetryTableRead(record.GetReadId(), false)) {
+                const bool isThrottled = record.HasThrottled() && record.GetThrottled();
+                if (!RetryTableRead(record.GetReadId(), false, isThrottled)) {
                     return RuntimeError(
                         NYql::NDqProto::StatusIds::OVERLOADED,
                         NYql::TIssuesIds::KIKIMR_OVERLOADED,
@@ -613,14 +614,14 @@ public:
         }
     }
 
-    bool RetryTableRead(const ui64 failedReadId, bool allowInstantRetry) {
+    bool RetryTableRead(const ui64 failedReadId, bool allowInstantRetry, bool isThrottled = false) {
         auto& failedRead = ReadIdToState.at(failedReadId);
         auto& lookupState = CookieToLookupState.at(failedRead.LookupCookie);
         CA_LOG_D("Retry reading of table: " << lookupState.Worker->GetTablePath() << ", failedReadId: " << failedReadId
             << ", shardId: " << failedRead.ShardId);
         failedRead.Blocked = true;
 
-        if (failedRead.RetryAttempts >= MaxShardRetries()) {
+        if (!isThrottled && failedRead.RetryAttempts >= MaxShardRetries()) {
             return false;
         }
 

--- a/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
@@ -153,6 +153,7 @@ public:
         TLookupSettings settings {
             .TablePath = Settings.TablePath,
             .TableId = Settings.TableId,
+            .PoolId = Settings.PoolId,
 
             .AllowNullKeysPrefixSize = 0,
             .KeepRowsOrder = false,

--- a/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.cpp
@@ -153,6 +153,7 @@ public:
         TLookupSettings settings {
             .TablePath = Settings.TablePath,
             .TableId = Settings.TableId,
+            .Database = Settings.Database,
             .PoolId = Settings.PoolId,
 
             .AllowNullKeysPrefixSize = 0,

--- a/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.h
+++ b/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.h
@@ -74,6 +74,7 @@ struct TKqpBufferTableLookupSettings {
 
     NWilson::TTraceId ParentTraceId;
 
+    TString Database;
     TString PoolId;
 };
 

--- a/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.h
+++ b/ydb/core/kqp/runtime/kqp_buffer_lookup_actor.h
@@ -73,6 +73,8 @@ struct TKqpBufferTableLookupSettings {
     TIntrusivePtr<TKqpCounters> Counters;
 
     NWilson::TTraceId ParentTraceId;
+
+    TString PoolId;
 };
 
 std::pair<IKqpBufferTableLookup*, NActors::IActor*> CreateKqpBufferTableLookup(TKqpBufferTableLookupSettings&& settings);

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -141,6 +141,7 @@ class TTableReader : public TAtomicRefCount<T> {
     TString TablePath;
     IKqpGateway::TKqpSnapshot Snapshot;
     TString LogPrefix;
+    TString Database;
     TString PoolId;
 
     ui64 ReadRows = 0;
@@ -159,6 +160,7 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
@@ -168,6 +170,7 @@ public:
         , TablePath(tablePath)
         , Snapshot(snapshot)
         , LogPrefix(logPrefix)
+        , Database(database)
         , PoolId(poolId)
         , KeyColumnTypes(keyColumnTypes)
         , ResultColumnTypes(resultColumnTypes)
@@ -270,6 +273,7 @@ public:
         record.SetResultFormat(UseArrowFormat ? NKikimrDataEvents::FORMAT_ARROW : NKikimrDataEvents::FORMAT_CELLVEC);
 
         if (!PoolId.empty()) {
+            record.SetDatabaseId(Database);
             record.SetPoolId(PoolId);
         }
 
@@ -607,12 +611,13 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds,
         i32 frequencyColumnIndex)
-        : TTableReader(counters, tableId, tablePath,  snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath,  snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , FrequencyColumnIndex(frequencyColumnIndex)
     {}
 
@@ -673,7 +678,8 @@ public:
         }
 
         TIntrusivePtr<TIndexTableImplReader> reader = MakeIntrusive<TIndexTableImplReader>(
-            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+            settings->GetDatabase(),settings->GetPoolId(),
             keyColumnTypes, resultColumnTypes, resultColumnIds, freqColumnIndex);
         reader->SetUseArrowFormat(useArrowFormat);
         return reader;
@@ -1213,11 +1219,12 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , IndexType(indexType)
     {}
 
@@ -1275,7 +1282,8 @@ public:
 
         auto reader = MakeIntrusive<TDocsTableReader>(
             settings->GetIndexType(), counters,
-            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+                settings->GetDatabase(), settings->GetPoolId(),
                 keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
         reader->SetUseArrowFormat(useArrowFormat);
         return reader;
@@ -1308,11 +1316,12 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , IndexType(indexType)
     {}
 
@@ -1374,7 +1383,8 @@ public:
 
         return MakeIntrusive<TStatsTableReader>(
             settings->GetIndexType(), counters,
-            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+                settings->GetDatabase(), settings->GetPoolId(),
                 keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
     }
 
@@ -1433,11 +1443,12 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
     {}
 
     static TIntrusivePtr<TDictTableReader> FromSettings(
@@ -1482,7 +1493,8 @@ public:
         resultKeyColumnIds.push_back(freqColumnIndex);
 
         return MakeIntrusive<TDictTableReader>(
-            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+            settings->GetDatabase(), settings->GetPoolId(),
             keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
     }
 
@@ -1543,6 +1555,7 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& database,
         const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
@@ -1550,7 +1563,7 @@ public:
         const TVector<std::pair<i32, NScheme::TTypeInfo>>& resultCellIndices,
         bool mainTableCovered,
         bool withRelevance)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, database, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , WithRelevance(withRelevance)
         , ResultCellIndices(resultCellIndices)
         , MainTableCovered(mainTableCovered)
@@ -1606,8 +1619,8 @@ public:
         withRelevance = withRelevance && settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance;
 
         return MakeIntrusive<TMainTableReader>(counters, FromProto(settings->GetTable()), settings->GetTable().GetPath(),
-            snapshot, logPrefix, settings->GetPoolId(), keyColumnTypes, resultColumnTypes, resultColumnIds, resultCellIndices,
-            mainTableCovered, withRelevance);
+            snapshot, logPrefix, settings->GetDatabase(), settings->GetPoolId(), keyColumnTypes, resultColumnTypes, resultColumnIds,
+            resultCellIndices, mainTableCovered, withRelevance);
     }
 
     bool GetWithRelevance() {

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -3115,9 +3115,11 @@ public:
         }
     }
 
-    void ScheduleReadRetry(ui64 readId, ui64 shardId, bool allowInstantRetry, NYql::NDqProto::StatusIds::StatusCode errorStatus) {
+    void ScheduleReadRetry(ui64 readId, ui64 shardId, bool allowInstantRetry, NYql::NDqProto::StatusIds::StatusCode errorStatus,
+        bool isThrottled = false)
+    {
         auto maxRetries = MaxShardRetries();
-        if (ReadsState.CheckShardRetriesExeeded(shardId, maxRetries)) {
+        if (!isThrottled && ReadsState.CheckShardRetriesExeeded(shardId, maxRetries)) {
             RuntimeError(TStringBuilder() << "Max retries (" << maxRetries << ") exceeded for read " << readId
                 << " on shard " << shardId, errorStatus);
             return;
@@ -3145,7 +3147,8 @@ public:
 
         switch (statusCode) {
             case Ydb::StatusIds::OVERLOADED: {
-                ScheduleReadRetry(readId, shardId, false, NYql::NDqProto::StatusIds::OVERLOADED);
+                const bool isThrottled = record.HasThrottled() && record.GetThrottled();
+                ScheduleReadRetry(readId, shardId, false, NYql::NDqProto::StatusIds::OVERLOADED, isThrottled);
                 return;
             }
             case Ydb::StatusIds::INTERNAL_ERROR: {

--- a/ydb/core/kqp/runtime/kqp_full_text_source.cpp
+++ b/ydb/core/kqp/runtime/kqp_full_text_source.cpp
@@ -141,6 +141,7 @@ class TTableReader : public TAtomicRefCount<T> {
     TString TablePath;
     IKqpGateway::TKqpSnapshot Snapshot;
     TString LogPrefix;
+    TString PoolId;
 
     ui64 ReadRows = 0;
     ui64 ReadBytes = 0;
@@ -158,6 +159,7 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
@@ -166,6 +168,7 @@ public:
         , TablePath(tablePath)
         , Snapshot(snapshot)
         , LogPrefix(logPrefix)
+        , PoolId(poolId)
         , KeyColumnTypes(keyColumnTypes)
         , ResultColumnTypes(resultColumnTypes)
         , ResultColumnIds(resultColumnIds)
@@ -265,6 +268,10 @@ public:
         record.SetMaxRows(MaxRowsDefaultQuota);
         record.SetMaxBytes(MaxBytesDefaultQuota);
         record.SetResultFormat(UseArrowFormat ? NKikimrDataEvents::FORMAT_ARROW : NKikimrDataEvents::FORMAT_CELLVEC);
+
+        if (!PoolId.empty()) {
+            record.SetPoolId(PoolId);
+        }
 
         return request;
     }
@@ -600,11 +607,12 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds,
         i32 frequencyColumnIndex)
-        : TTableReader(counters, tableId, tablePath,  snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath,  snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , FrequencyColumnIndex(frequencyColumnIndex)
     {}
 
@@ -665,7 +673,7 @@ public:
         }
 
         TIntrusivePtr<TIndexTableImplReader> reader = MakeIntrusive<TIndexTableImplReader>(
-            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
             keyColumnTypes, resultColumnTypes, resultColumnIds, freqColumnIndex);
         reader->SetUseArrowFormat(useArrowFormat);
         return reader;
@@ -1205,10 +1213,11 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , IndexType(indexType)
     {}
 
@@ -1266,7 +1275,8 @@ public:
 
         auto reader = MakeIntrusive<TDocsTableReader>(
             settings->GetIndexType(), counters,
-            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
+            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+                keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
         reader->SetUseArrowFormat(useArrowFormat);
         return reader;
     }
@@ -1298,10 +1308,11 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , IndexType(indexType)
     {}
 
@@ -1363,7 +1374,8 @@ public:
 
         return MakeIntrusive<TStatsTableReader>(
             settings->GetIndexType(), counters,
-            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
+            FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
+                keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
     }
 
     ui64 GetDocCount(const TConstArrayRef<TCell>& row) const {
@@ -1421,10 +1433,11 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
     {}
 
     static TIntrusivePtr<TDictTableReader> FromSettings(
@@ -1468,7 +1481,8 @@ public:
         resultKeyColumnTypes.push_back(freqColumnType);
         resultKeyColumnIds.push_back(freqColumnIndex);
 
-        return MakeIntrusive<TDictTableReader>(counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix,
+        return MakeIntrusive<TDictTableReader>(
+            counters, FromProto(info.GetTable()), info.GetTable().GetPath(), snapshot, logPrefix, settings->GetPoolId(),
             keyColumnTypes, resultKeyColumnTypes, resultKeyColumnIds);
     }
 
@@ -1529,13 +1543,14 @@ public:
         const TString& tablePath,
         const IKqpGateway::TKqpSnapshot& snapshot,
         const TString& logPrefix,
+        const TString& poolId,
         const TVector<NScheme::TTypeInfo>& keyColumnTypes,
         const TVector<NScheme::TTypeInfo>& resultColumnTypes,
         const TVector<i32>& resultColumnIds,
         const TVector<std::pair<i32, NScheme::TTypeInfo>>& resultCellIndices,
         bool mainTableCovered,
         bool withRelevance)
-        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds)
+        : TTableReader(counters, tableId, tablePath, snapshot, logPrefix, poolId, keyColumnTypes, resultColumnTypes, resultColumnIds)
         , WithRelevance(withRelevance)
         , ResultCellIndices(resultCellIndices)
         , MainTableCovered(mainTableCovered)
@@ -1591,7 +1606,7 @@ public:
         withRelevance = withRelevance && settings->GetIndexType() == NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance;
 
         return MakeIntrusive<TMainTableReader>(counters, FromProto(settings->GetTable()), settings->GetTable().GetPath(),
-            snapshot, logPrefix, keyColumnTypes, resultColumnTypes, resultColumnIds, resultCellIndices,
+            snapshot, logPrefix, settings->GetPoolId(), keyColumnTypes, resultColumnTypes, resultColumnIds, resultCellIndices,
             mainTableCovered, withRelevance);
     }
 

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -892,6 +892,10 @@ public:
             *record.MutableVectorTopK() = Settings->GetVectorTopK();
         }
 
+        if (Settings->HasPoolId()) {
+            record.SetPoolId(Settings->GetPoolId());
+        }
+
         CA_LOG_D(TStringBuilder() << "Send EvRead to shardId: " << state->TabletId << ", tablePath: " << Settings->GetTable().GetTablePath()
             << ", ranges: " << DebugPrintRanges(KeyColumnTypes, ev->Ranges, *AppData()->TypeRegistry)
             << ", limit: " << limit

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -895,6 +895,7 @@ public:
         }
 
         if (Settings->HasPoolId()) {
+            record.SetDatabaseId(Settings->GetDatabase());
             record.SetPoolId(Settings->GetPoolId());
         }
 

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -752,26 +752,28 @@ public:
         return state->RetryAttempt + 1 > MaxShardRetries();
     }
 
-    void RetryRead(ui64 id, bool allowInstantRetry = true) {
+    void RetryRead(ui64 id, bool allowInstantRetry = true, bool throttled = false) {
         if (!Reads[id] || Reads[id].Finished) {
             return;
         }
 
-        auto state = Reads[id].Shard;
+        auto* state = Reads[id].Shard;
 
-        if (CheckTotalRetriesExeeded()) {
-            return RuntimeError(TStringBuilder() << "Table '" << Settings->GetTable().GetTablePath() << "' retry limit exceeded",
-                NDqProto::StatusIds::UNAVAILABLE);
-        }
-        ++TotalRetries;
+        if (!throttled) {
+            if (CheckTotalRetriesExeeded()) {
+                return RuntimeError(TStringBuilder() << "Table '" << Settings->GetTable().GetTablePath() << "' retry limit exceeded",
+                    NDqProto::StatusIds::UNAVAILABLE);
+            }
+            ++TotalRetries;
 
-        if (CheckShardRetriesExeeded(id)) {
-            ResetRead(id);
-            return ResolveShard(state);
+            if (CheckShardRetriesExeeded(id)) {
+                ResetRead(id);
+                return ResolveShard(state);
+            }
         }
         ++state->RetryAttempt;
 
-        auto delay = CalcDelay(state->RetryAttempt, allowInstantRetry); // TODO: account potential quota shortage
+        auto delay = CalcDelay(state->RetryAttempt, allowInstantRetry && !throttled); // TODO: account potential quota shortage
         if (delay == TDuration::Zero()) {
             return DoRetryRead(id);
         }
@@ -1028,12 +1030,13 @@ public:
                 break;
             }
             case Ydb::StatusIds::OVERLOADED: {
-                if (CheckTotalRetriesExeeded() || CheckShardRetriesExeeded(id)) {
+                const bool isThrottled = record.HasThrottled() && record.GetThrottled();
+                if (!isThrottled && (CheckTotalRetriesExeeded() || CheckShardRetriesExeeded(id))) {
                     return replyError(
                         TStringBuilder() << "Table '" << Settings->GetTable().GetTablePath() << "' retry limit exceeded.",
                         NYql::NDqProto::StatusIds::OVERLOADED);
                 }
-                return RetryRead(id, false);
+                return RetryRead(id, false, isThrottled);
             }
             case Ydb::StatusIds::INTERNAL_ERROR: {
                 if (CheckTotalRetriesExeeded() || CheckShardRetriesExeeded(id)) {

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -771,7 +771,7 @@ public:
         }
         ++state->RetryAttempt;
 
-        auto delay = CalcDelay(state->RetryAttempt, allowInstantRetry);
+        auto delay = CalcDelay(state->RetryAttempt, allowInstantRetry); // TODO: account potential quota shortage
         if (delay == TDuration::Zero()) {
             return DoRetryRead(id);
         }

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -525,7 +525,8 @@ private:
                 return ResolveTableShards();
             }
             case Ydb::StatusIds::OVERLOADED: {
-                if (CheckTotalRetriesExeeded() || Reads.CheckShardRetriesExeeded(read)) {
+                const bool isThrottled = record.HasThrottled() && record.GetThrottled();
+                if (!isThrottled && (CheckTotalRetriesExeeded() || Reads.CheckShardRetriesExeeded(read))) {
                     return replyError(
                         TStringBuilder() << "Table '" << StreamLookupWorker->GetTablePath() << "' retry limit exceeded.",
                         NYql::NDqProto::StatusIds::OVERLOADED);
@@ -533,7 +534,7 @@ private:
                 CA_LOG_D("OVERLOADED was received from tablet: " << read.ShardId << "."
                     << getIssues().ToOneLineString());
                 read.SetBlocked();
-                return RetryTableRead(read, /*allowInstantRetry = */false);
+                return RetryTableRead(read, /*allowInstantRetry = */false, isThrottled);
             }
             case Ydb::StatusIds::INTERNAL_ERROR: {
                 if (CheckTotalRetriesExeeded() || Reads.CheckShardRetriesExeeded(read)) {
@@ -795,20 +796,22 @@ private:
         return limit && TotalRetryAttempts + 1 > *limit;
     }
 
-    void RetryTableRead(TReadState& failedRead, bool allowInstantRetry = true) {
+    void RetryTableRead(TReadState& failedRead, bool allowInstantRetry = true, bool isThrottled = false) {
         CA_LOG_D("Retry reading of table: " << StreamLookupWorker->GetTablePath() << ", readId: " << failedRead.Id
             << ", shardId: " << failedRead.ShardId);
 
-        if (CheckTotalRetriesExeeded()) {
-            return RuntimeError(TStringBuilder() << "Table '" << StreamLookupWorker->GetTablePath() << "' retry limit exceeded",
-                NYql::NDqProto::StatusIds::UNAVAILABLE);
-        }
-        ++TotalRetryAttempts;
+        if (!isThrottled) {
+            if (CheckTotalRetriesExeeded()) {
+                return RuntimeError(TStringBuilder() << "Table '" << StreamLookupWorker->GetTablePath() << "' retry limit exceeded",
+                    NYql::NDqProto::StatusIds::UNAVAILABLE);
+            }
+            ++TotalRetryAttempts;
 
-        if (Reads.CheckShardRetriesExeeded(failedRead)) {
-            StreamLookupWorker->ResetRowsProcessing(failedRead.Id);
-            Reads.erase(failedRead);
-            return ResolveTableShards();
+            if (Reads.CheckShardRetriesExeeded(failedRead)) {
+                StreamLookupWorker->ResetRowsProcessing(failedRead.Id);
+                Reads.erase(failedRead);
+                return ResolveTableShards();
+            }
         }
 
         auto delay = Reads.CalcDelayForShard(failedRead, allowInstantRetry);

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -456,6 +456,7 @@ private:
         }
 
         if (!Settings.PoolId.empty()) {
+            record.SetDatabaseId(Settings.Database);
             record.SetPoolId(Settings.PoolId);
         }
 
@@ -1146,6 +1147,7 @@ private:
         }
 
         if (!Settings.PoolId.empty()) {
+            record.SetDatabaseId(Settings.Database);
             record.SetPoolId(Settings.PoolId);
         }
     }
@@ -1224,6 +1226,7 @@ std::unique_ptr<TKqpStreamLookupWorker> CreateStreamLookupWorker(NKikimrKqp::TKq
     preparedSettings.TableId = MakeTableId(settings.GetTable());
 
     if (settings.HasPoolId()) {
+        preparedSettings.Database = settings.GetDatabase();
         preparedSettings.PoolId = settings.GetPoolId();
     }
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -455,6 +455,10 @@ private:
             *record.MutableVectorTopK() = *Settings.VectorTopK;
         }
 
+        if (!Settings.PoolId.empty()) {
+            record.SetPoolId(Settings.PoolId);
+        }
+
         YQL_ENSURE(!ranges.empty());
         if (ranges.front().Point) {
             request->Keys.reserve(ranges.size());
@@ -1097,7 +1101,7 @@ private:
             return row;
         }
 
-        bool Completed() {
+        bool Completed() const {
             return PendingReads.empty();
         }
     };
@@ -1139,6 +1143,10 @@ private:
                     request->Ranges.emplace_back(TSerializedTableRange(range));
                 }
             }
+        }
+
+        if (!Settings.PoolId.empty()) {
+            record.SetPoolId(Settings.PoolId);
         }
     }
 
@@ -1214,6 +1222,10 @@ std::unique_ptr<TKqpStreamLookupWorker> CreateStreamLookupWorker(NKikimrKqp::TKq
     TLookupSettings preparedSettings;
     preparedSettings.TablePath = std::move(settings.GetTable().GetPath());
     preparedSettings.TableId = MakeTableId(settings.GetTable());
+
+    if (settings.HasPoolId()) {
+        preparedSettings.PoolId = settings.GetPoolId();
+    }
 
     preparedSettings.AllowNullKeysPrefixSize = settings.HasAllowNullKeysPrefixSize() ? settings.GetAllowNullKeysPrefixSize() : 0;
     preparedSettings.KeepRowsOrder = settings.HasKeepRowsOrder() && settings.GetKeepRowsOrder();

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
@@ -14,6 +14,7 @@ namespace NKqp {
 struct TLookupSettings {
     TString TablePath;
     TTableId TableId;
+    TString Database;
     TString PoolId;
 
     ui32 AllowNullKeysPrefixSize;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
@@ -14,6 +14,7 @@ namespace NKqp {
 struct TLookupSettings {
     TString TablePath;
     TTableId TableId;
+    TString PoolId;
 
     ui32 AllowNullKeysPrefixSize;
     bool KeepRowsOrder;

--- a/ydb/core/kqp/runtime/kqp_vector_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.cpp
@@ -283,8 +283,11 @@ private:
     void ReadUsingActor(NTableIndex::NKMeans::TClusterId parent) {
         auto range = ParentRange(parent);
         auto arena = MakeIntrusive<NActors::TProtoArenaHolder>();
-        auto src = arena->Allocate<NKikimrTxDataShard::TKqpReadRangesSourceSettings>();
+        auto* src = arena->Allocate<NKikimrTxDataShard::TKqpReadRangesSourceSettings>();
         src->SetDatabase(Settings.GetDatabase());
+        if (Settings.HasPoolId()) {
+            src->SetPoolId(Settings.GetPoolId());
+        }
         *src->MutableTable() = Settings.GetLevelTable();
         range.Serialize(*src->MutableFullRange());
         src->SetDataFormat(NKikimrDataEvents::FORMAT_CELLVEC);

--- a/ydb/core/kqp/runtime/scheduler/fwd.h
+++ b/ydb/core/kqp/runtime/scheduler/fwd.h
@@ -55,6 +55,11 @@ namespace NKikimr::NKqp::NScheduler {
     using TSchedulableTaskPtr = std::shared_ptr<TSchedulableTask>;
     using TSchedulableTaskList = std::list<std::pair<TSchedulableTaskPtr::weak_type, std::atomic<bool> /* isThrottled */>>;
 
+    struct TSchedulableRead;
+    class TSchedulableReadFactory;
+    using TSchedulableReadPtr = std::shared_ptr<TSchedulableRead>;
+    using TSchedulableReadFactoryPtr = std::shared_ptr<TSchedulableReadFactory>;
+
     // These params are used when calculating delay for schedulable task, but are taken from the scheduler configuration.
     struct TDelayParams {
         const TDuration MaxDelay;

--- a/ydb/core/kqp/runtime/scheduler/fwd.h
+++ b/ydb/core/kqp/runtime/scheduler/fwd.h
@@ -58,7 +58,7 @@ namespace NKikimr::NKqp::NScheduler {
     struct TSchedulableRead;
     class TSchedulableReadFactory;
     using TSchedulableReadPtr = std::shared_ptr<TSchedulableRead>;
-    using TSchedulableReadFactoryPtr = std::shared_ptr<TSchedulableReadFactory>;
+    using TSchedulableReadFactoryPtr = std::unique_ptr<TSchedulableReadFactory>;
 
     // These params are used when calculating delay for schedulable task, but are taken from the scheduler configuration.
     struct TDelayParams {

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -97,7 +97,7 @@ public:
         };
         Scheduler->AddOrUpdateDatabase(ev->Get()->DatabaseId, attrs);
 
-        LOG_D("Add database: " << ev->Get()->DatabaseId);
+        LOG_D("Add database: " << ev->Get()->DatabaseId << " (" << attrs.ToString() << ")");
     }
 
     void Handle(TEvRemoveDatabase::TPtr&) {
@@ -124,7 +124,7 @@ public:
 
         Y_ASSERT(!poolId.empty());
 
-        LOG_D("Add pool: " << databaseId << "/" << poolId);
+        LOG_D("Add pool: " << databaseId << "/" << poolId << " (" << attrs.ToString() << ")");
 
         if (PoolSubscribtions.insert({std::make_pair(databaseId, poolId), {.IsFirstRemoval=false, .ExternalWeight=resourceWeight}}).second) {
             PoolExternalWeightSum += resourceWeight;
@@ -170,7 +170,7 @@ public:
 
             Scheduler->AddOrUpdatePool(databaseId, poolId, attrs);
 
-            LOG_D("Update pool: " << databaseId << "/" << poolId);
+            LOG_D("Update pool: " << databaseId << "/" << poolId << " (" << attrs.ToString() << ")");
         } else if (poolIt != PoolSubscribtions.end()) {
             if (!poolIt->second.IsFirstRemoval) {
                 // The first removal - try to re-subscribe in case it's just the pool removal from cache.

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -1,5 +1,6 @@
 #include "kqp_compute_scheduler_service.h"
 
+#include "kqp_schedulable_read.h"
 #include "log.h"
 #include "tree/dynamic.h"
 
@@ -65,6 +66,8 @@ public:
 
             hFunc(NActors::TEvents::TEvWakeup, Handle);
 
+            hFunc(TEvGetReadFactory, Handle);
+
             default:
                 LOG_E("Unexpected event: " << ev->GetTypeRewrite());
         }
@@ -112,8 +115,10 @@ public:
         if (const auto& cpuLimitPercent = ev->Get()->Params.TotalCpuLimitPercentPerNode; cpuLimitPercent >= 0) {
             if (cpuLimitPercent == 0) {
                 attrs.CpuLimit = 0;
+                attrs.ReadLimit = TDuration::Zero();
             } else {
                 attrs.CpuLimit = std::max<ui64>(1, cpuLimitPercent * Scheduler->GetTotalCpuLimit() / 100);
+                attrs.ReadLimit = TDuration::MilliSeconds(cpuLimitPercent * 10);
             }
         }
 
@@ -156,8 +161,10 @@ public:
             if (const auto& cpuLimitPercent = ev->Get()->Config->TotalCpuLimitPercentPerNode; cpuLimitPercent >= 0) {
                 if (cpuLimitPercent == 0) {
                     attrs.CpuLimit = 0;
+                    attrs.ReadLimit = TDuration::Zero();
                 } else {
                     attrs.CpuLimit = std::max<ui64>(1, cpuLimitPercent * Scheduler->GetTotalCpuLimit() / 100);
+                    attrs.ReadLimit = TDuration::MilliSeconds(cpuLimitPercent * 10);
                 }
             }
 
@@ -210,6 +217,12 @@ public:
     void Handle(NActors::TEvents::TEvWakeup::TPtr&) {
         Scheduler->UpdateFairShare();
         Schedule(Options.UpdateFairSharePeriod, new NActors::TEvents::TEvWakeup());
+    }
+
+    void Handle(TEvGetReadFactory::TPtr& ev) {
+        auto response = MakeHolder<TEvReadFactoryResponse>();
+        response->Factory = std::make_shared<TSchedulableReadFactory>(Scheduler);
+        Send(ev->Sender, response.Release(), 0, 0);
     }
 
 private:
@@ -295,7 +308,19 @@ void TComputeScheduler::AddOrUpdatePool(const TString& databaseId, const TString
     if (auto pool = database->GetPool(poolId)) {
         pool->Update(attrs);
     } else {
-        database->AddPool(std::make_shared<TPool>(poolId, KqpCounters, attrs));
+        pool = std::make_shared<TPool>(poolId, KqpCounters, attrs);
+        database->AddPool(pool);
+
+        // Add read query
+
+        bool allowMinFairShare = (!pool->CpuLimit || *pool->CpuLimit > 0)
+            && (FairShareMode >= NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+
+        // Since they are not visible by query id - use the same id for each pool
+        auto query = std::make_shared<TQuery>(READ_QUERY_ID, &DelayParams, allowMinFairShare, NHdrf::TStaticAttributes());
+        pool->AddQuery(query);
+
+        ReadQueries.emplace(poolId, query);
     }
 }
 
@@ -323,6 +348,16 @@ TQueryPtr TComputeScheduler::AddOrUpdateQuery(const NHdrf::TDatabaseId& database
     }
 
     return query;
+}
+
+NHdrf::NDynamic::TQueryPtr TComputeScheduler::GetReadQuery(const NHdrf::TPoolId& poolId) const {
+    TReadGuard lock(Mutex);
+
+    if (auto queryIt = ReadQueries.find(poolId); queryIt != ReadQueries.end()) {
+        return queryIt->second;
+    }
+
+    return {}; // TODO: no such pool?
 }
 
 bool TComputeScheduler::RemoveQuery(const NHdrf::TQueryId& queryId) {

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -319,7 +319,7 @@ void TComputeScheduler::AddOrUpdatePool(const TString& databaseId, const TString
         pool->AddQuery(query);
 
         // Add read query
-        ReadQueries.emplace(poolId, query);
+        ReadQueries.emplace(std::make_pair(databaseId, poolId), query);
     }
 }
 
@@ -349,10 +349,11 @@ TQueryPtr TComputeScheduler::AddOrUpdateQuery(const NHdrf::TDatabaseId& database
     return query;
 }
 
-NHdrf::NDynamic::TQueryPtr TComputeScheduler::GetReadQuery(const NHdrf::TPoolId& poolId) const {
+NHdrf::NDynamic::TQueryPtr TComputeScheduler::GetReadQuery(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const {
     TReadGuard lock(Mutex);
 
-    if (auto queryIt = ReadQueries.find(poolId); queryIt != ReadQueries.end()) {
+    auto databaseAndPoolId = std::make_pair(databaseId, poolId);
+    if (auto queryIt = ReadQueries.find(databaseAndPoolId); queryIt != ReadQueries.end()) {
         return queryIt->second;
     }
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -221,7 +221,7 @@ public:
 
     void Handle(TEvGetReadFactory::TPtr& ev) {
         auto response = MakeHolder<TEvReadFactoryResponse>();
-        response->Factory = std::make_shared<TSchedulableReadFactory>(Scheduler);
+        response->Factory = std::make_unique<TSchedulableReadFactory>(Scheduler);
         Send(ev->Sender, response.Release(), 0, 0);
     }
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -237,7 +237,7 @@ private:
 private:
     bool Enabled = true;
     TComputeSchedulerPtr Scheduler;
-    NScheduler::TOptions Options;
+    const NScheduler::TOptions Options;
 
     struct TPoolParams {
         bool IsFirstRemoval = false;

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -311,8 +311,6 @@ void TComputeScheduler::AddOrUpdatePool(const TString& databaseId, const TString
         pool = std::make_shared<TPool>(poolId, KqpCounters, attrs);
         database->AddPool(pool);
 
-        // Add read query
-
         bool allowMinFairShare = (!pool->CpuLimit || *pool->CpuLimit > 0)
             && (FairShareMode >= NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
 
@@ -320,6 +318,7 @@ void TComputeScheduler::AddOrUpdatePool(const TString& databaseId, const TString
         auto query = std::make_shared<TQuery>(READ_QUERY_ID, &DelayParams, allowMinFairShare, NHdrf::TStaticAttributes());
         pool->AddQuery(query);
 
+        // Add read query
         ReadQueries.emplace(poolId, query);
     }
 }

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -21,7 +21,7 @@ public:
     void AddOrUpdatePool(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId, const NHdrf::TStaticAttributes& attrs);
 
     NHdrf::NDynamic::TQueryPtr AddOrUpdateQuery(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId, const NHdrf::TQueryId& queryId, const NHdrf::TStaticAttributes& attrs);
-    NHdrf::NDynamic::TQueryPtr GetReadQuery(const NHdrf::TPoolId& poolId) const;
+    NHdrf::NDynamic::TQueryPtr GetReadQuery(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const;
     bool RemoveQuery(const NHdrf::TQueryId& queryId);
 
     void UpdateFairShare();
@@ -35,7 +35,7 @@ private:
 
     // Special virtual queries per each pool to create SchedulableRead upon them, used for datashards and columnshards.
     // TODO: get rid of read queries - just pass somehow the real query to datashards.
-    THashMap<NHdrf::TPoolId, NHdrf::NDynamic::TQueryPtr> ReadQueries; // protected by Mutex
+    THashMap<std::pair<NHdrf::TDatabaseId, NHdrf::TPoolId>, NHdrf::NDynamic::TQueryPtr> ReadQueries; // protected by Mutex
 
     const TDelayParams DelayParams;
     const NHdrf::NSnapshot::ELeafFairShare FairShareMode;

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -21,14 +21,21 @@ public:
     void AddOrUpdatePool(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId, const NHdrf::TStaticAttributes& attrs);
 
     NHdrf::NDynamic::TQueryPtr AddOrUpdateQuery(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId, const NHdrf::TQueryId& queryId, const NHdrf::TStaticAttributes& attrs);
+    NHdrf::NDynamic::TQueryPtr GetReadQuery(const NHdrf::TPoolId& poolId) const;
     bool RemoveQuery(const NHdrf::TQueryId& queryId);
 
     void UpdateFairShare();
 
 private:
+    static constexpr NHdrf::TQueryId READ_QUERY_ID = 0;
+
     TRWMutex Mutex;
     NHdrf::NDynamic::TRootPtr Root;                                // protected by Mutex
-    THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries; // protected by Mutex
+    THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries;    // protected by Mutex
+
+    // Special virtual queries per each pool to create SchedulableRead upon them, used for datashards and columnshards.
+    // TODO: get rid of read queries - just pass somehow the real query to datashards.
+    THashMap<NHdrf::TPoolId, NHdrf::NDynamic::TQueryPtr> ReadQueries; // protected by Mutex
 
     const TDelayParams DelayParams;
     const NHdrf::NSnapshot::ELeafFairShare FairShareMode;
@@ -55,6 +62,11 @@ struct TEvents {
         EvAddQuery,
         EvRemoveQuery,
         EvQueryResponse,
+
+        // Because datashard may get EvRead from another node, it's hard to use EvAddQuery+EvQueryResponse.
+        // These messages return factory that can create schedulable objects on-the-fly.
+        EvGetReadFactory,
+        EvReadFactoryResponse,
     };
 };
 
@@ -97,6 +109,14 @@ struct TEvRemoveQuery : public TEventLocal<TEvRemoveQuery, TEvents::EvRemoveQuer
 
 struct TEvQueryResponse : public TEventLocal<TEvQueryResponse, TEvents::EvQueryResponse> {
     NHdrf::NDynamic::TQueryPtr Query;
+};
+
+struct TEvGetReadFactory : public TEventLocal<TEvGetReadFactory, TEvents::EvGetReadFactory> {
+    // TODO: datashard id?
+};
+
+struct TEvReadFactoryResponse : public TEventLocal<TEvReadFactoryResponse, TEvents::EvReadFactoryResponse> {
+    TSchedulableReadFactoryPtr Factory;
 };
 
 } // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -27,7 +27,7 @@ public:
     void UpdateFairShare();
 
 private:
-    static constexpr NHdrf::TQueryId READ_QUERY_ID = 0;
+    static constexpr NHdrf::TQueryId READ_QUERY_ID = -1;
 
     TRWMutex Mutex;
     NHdrf::NDynamic::TRootPtr Root;                                // protected by Mutex

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -31,7 +31,7 @@ private:
 
     TRWMutex Mutex;
     NHdrf::NDynamic::TRootPtr Root;                                // protected by Mutex
-    THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries;    // protected by Mutex
+    THashMap<NHdrf::TQueryId, NHdrf::NDynamic::TQueryPtr> Queries; // protected by Mutex
 
     // Special virtual queries per each pool to create SchedulableRead upon them, used for datashards and columnshards.
     // TODO: get rid of read queries - just pass somehow the real query to datashards.
@@ -78,7 +78,7 @@ struct TEvAddDatabase : public TEventLocal<TEvAddDatabase, TEvents::EvAddDatabas
 };
 
 struct TEvRemoveDatabase : public TEventLocal<TEvRemoveDatabase, TEvents::EvRemoveDatabase> {
-    TString Id;
+    TString DatabaseId;
 };
 
 struct TEvAddPool : public TEventLocal<TEvAddPool, TEvents::EvAddPool> {

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
@@ -770,8 +770,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler.UpdateFairShare();
 
-        for (size_t queryId = 0; queryId < queries.size(); ++queryId) {
-            auto querySnapshot = queries[queryId]->GetSnapshot();
+        for (const auto& querie : queries) {
+            auto querySnapshot = querie->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL_C(querySnapshot->FairShare, kInternalLimit, "With zero limit overlimit should be ignored");
         }
@@ -1007,8 +1007,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         scheduler->AddOrUpdateDatabase(databaseId, {});
 
         std::vector<TString> pools = {"pool1", "pool2", "pool3"};
-        for (size_t i = 0; i < pools.size(); ++i) {
-            scheduler->AddOrUpdatePool(databaseId, pools[i], {});
+        for (const auto& pool : pools) {
+            scheduler->AddOrUpdatePool(databaseId, pool, {});
         }
 
         std::vector<NHdrf::NDynamic::TQueryPtr> queries;
@@ -1020,8 +1020,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler->UpdateFairShare();
 
-        for (const auto & query : queries) {
-             auto querySnapshot = query->GetSnapshot();
+        for (const auto& query : queries) {
+            auto querySnapshot = query->GetSnapshot();
 
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, kQueryDemand);
@@ -1043,8 +1043,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler->UpdateFairShare();
 
-        for (const auto & query : queries) {
-             auto querySnapshot = query->GetSnapshot();
+        for (const auto& query : queries) {
+            auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, kRoundedDemand);
 
@@ -1135,7 +1135,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         std::atomic<NHdrf::TQueryId> queryId = 1;
         std::atomic<bool> shutdown = false;
 
-        auto updateFairShare = [&] {
+        auto updateFairShare = [&]() -> void {
             while(!shutdown) {
                 scheduler.UpdateFairShare();
             }

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_actor.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_actor.cpp
@@ -78,7 +78,7 @@ void TSchedulableActorBase::StopExecution(bool& forcedResume) {
         TDuration timePassed = TDuration::MicroSeconds(Timer.Passed() * 1'000'000);
         SchedulableTask->Query->CurrentTasksTime -= LastExecutionTime.MicroSeconds();
         LastExecutionTime = timePassed;
-        SchedulableTask->DecreaseUsage(timePassed, forcedResume);
+        SchedulableTask->DecreaseUsage(timePassed, forcedResume ? TSchedulableTask::CPU_RESUMED : TSchedulableTask::CPU_DEFAULT);
         forcedResume = false;
         Executed = false;
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -73,6 +73,8 @@ void TSchedulableRead::ReturnQuota(NHPTimer::STime elapsedCycles) {
 }
 
 TDuration TSchedulableRead::EstimateQuotaDelay(TDuration expectedQuota) const {
+    Y_ASSERT(QuotaPerSecond != 0);
+
     auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
 
     if (AvailableQuotaMs >= static_cast<i64>(expectedQuotaMs)) {

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -3,6 +3,7 @@
 #include "tree/dynamic.h"
 
 #include <yql/essentials/utils/yql_panic.h>
+#include <yt/yt/core/utilex/random.h>
 
 namespace NKikimr::NKqp::NScheduler {
 
@@ -25,7 +26,7 @@ TSchedulableRead::TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query)
 }
 
 bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
-    // TODO: support update of pool's read quota.
+    // TODO: support update of pool's read quota - on AddOrUpdatePool().
     auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
 
     // Refill quota
@@ -35,7 +36,13 @@ bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
         LastRefill = now;
     }
 
-    if (AvailableQuotaMs <= 0 || expectedQuotaMs > static_cast<ui64>(AvailableQuotaMs) || !TryIncreaseUsage()) {
+    if (AvailableQuotaMs <= 0  || !TryIncreaseUsage()) {
+        if (AvailableQuotaMs < static_cast<i64>(expectedQuotaMs)) {
+            TStringStream ss;
+            ss << "AvailableQuotaMs: " << AvailableQuotaMs << Endl;
+            Cerr << ss.Str();
+        }
+
         return false;
     }
 
@@ -46,6 +53,11 @@ bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
 }
 
 void TSchedulableRead::ReturnQuota(NHPTimer::STime elapsedCycles) {
+    // Makes calls idempotent - useful to handle reading errors and cancellations
+    if (ReservedQuotaMs == 0) {
+        return;
+    }
+
     static const double msPerCycle = 1000.0 / NHPTimer::GetCyclesPerSecond();
 
     auto ms = static_cast<ui64>(elapsedCycles * msPerCycle);
@@ -53,6 +65,34 @@ void TSchedulableRead::ReturnQuota(NHPTimer::STime elapsedCycles) {
     ReservedQuotaMs = 0;
 
     DecreaseUsage(TDuration::MilliSeconds(ms), READ_DEFAULT);
+}
+
+TDuration TSchedulableRead::EstimateQuotaDelay(TDuration expectedQuota) const {
+    auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
+
+    if (AvailableQuotaMs >= static_cast<i64>(expectedQuotaMs)) {
+        auto delay = TDuration::MilliSeconds(10) + RandomDuration(TDuration::MilliSeconds(1));
+
+        TStringStream ss;
+        ss << "EstimateQuota (no usage): " << delay << Endl;
+        Cerr << ss.Str();
+
+        // Quota available, but TryIncreaseUsage() failed (fair-share exhausted)
+        return delay;
+    }
+
+    // Quota deficit — calculate refill time
+    i64 deficitMs = static_cast<i64>(expectedQuotaMs) - AvailableQuotaMs;
+    ui64 waitMs = static_cast<ui64>(std::ceil(deficitMs / QuotaPerSecond));
+    auto delay = TDuration::MilliSeconds(std::max<ui64>(waitMs, 1));
+
+    {
+        TStringStream ss;
+        ss << "EstimateQuota (no read): " << delay << Endl;
+        Cerr << ss.Str();
+    }
+
+    return delay;
 }
 
 TSchedulableReadFactory::TSchedulableReadFactory(TComputeSchedulerPtr scheduler)

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -37,12 +37,6 @@ bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
     }
 
     if (AvailableQuotaMs <= 0  || !TryIncreaseUsage()) {
-        if (AvailableQuotaMs < static_cast<i64>(expectedQuotaMs)) {
-            TStringStream ss;
-            ss << "AvailableQuotaMs: " << AvailableQuotaMs << Endl;
-            Cerr << ss.Str();
-        }
-
         return false;
     }
 
@@ -71,26 +65,14 @@ TDuration TSchedulableRead::EstimateQuotaDelay(TDuration expectedQuota) const {
     auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
 
     if (AvailableQuotaMs >= static_cast<i64>(expectedQuotaMs)) {
-        auto delay = TDuration::MilliSeconds(10) + RandomDuration(TDuration::MilliSeconds(1));
-
-        TStringStream ss;
-        ss << "EstimateQuota (no usage): " << delay << Endl;
-        Cerr << ss.Str();
-
         // Quota available, but TryIncreaseUsage() failed (fair-share exhausted)
-        return delay;
+        return TDuration::MilliSeconds(10) + RandomDuration(TDuration::MilliSeconds(1));
     }
 
     // Quota deficit — calculate refill time
     i64 deficitMs = static_cast<i64>(expectedQuotaMs) - AvailableQuotaMs;
     ui64 waitMs = static_cast<ui64>(std::ceil(deficitMs / QuotaPerSecond));
     auto delay = TDuration::MilliSeconds(std::max<ui64>(waitMs, 1));
-
-    {
-        TStringStream ss;
-        ss << "EstimateQuota (no read): " << delay << Endl;
-        Cerr << ss.Str();
-    }
 
     return delay;
 }

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -1,5 +1,6 @@
 #include "kqp_schedulable_read.h"
 
+#include "log.h"
 #include "tree/dynamic.h"
 
 #include <yql/essentials/utils/yql_panic.h>
@@ -10,6 +11,8 @@ namespace NKikimr::NKqp::NScheduler {
 TSchedulableRead::TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query)
     : TSchedulableTask(query)
     // TODO: we add demand to virtual query per reading datashard, which is inconvenient.
+    //       Because demand persists even if we don't have any pending read requests.
+    //       Should actualize demand depending on real requests - in best case scenario: append to real query.
 {
     if (query->GetParent()->ReadLimit) {
         MaxQuotaMs = query->GetParent()->ReadLimit->MilliSeconds();
@@ -22,12 +25,16 @@ TSchedulableRead::TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query)
     AvailableQuotaMs = MaxQuotaMs;
     LastRefill = TMonotonic::Now();
 
+    LOG_T("TSchedulableRead MaxQuotaMs: " << MaxQuotaMs);
+
     YQL_ENSURE(MaxQuotaMs <= 1000);
 }
 
 bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
-    // TODO: support update of pool's read quota - on AddOrUpdatePool().
+    // TODO: support update of the pool's read quota on AddOrUpdatePool().
     auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
+
+    LOG_T("TSchedulableRead ExpectedQuotaMs: " << expectedQuotaMs);
 
     // Refill quota
     if (const auto now = TMonotonic::Now(); Y_LIKELY(now >= LastRefill)) {
@@ -36,27 +43,31 @@ bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
         LastRefill = now;
     }
 
-    if (AvailableQuotaMs <= 0  || !TryIncreaseUsage()) {
+    LOG_T("TSchedulableRead AvailableQuotaMs: " << AvailableQuotaMs);
+
+    if (AvailableQuotaMs <= 0 || !TryIncreaseUsage()) {
         return false;
     }
 
     AvailableQuotaMs -= expectedQuotaMs;
     ReservedQuotaMs = expectedQuotaMs;
 
+    LOG_T("TSchedulableRead ReservedQuotaMs: " << ReservedQuotaMs);
+
     return true;
 }
 
 void TSchedulableRead::ReturnQuota(NHPTimer::STime elapsedCycles) {
-    // Makes calls idempotent - useful to handle reading errors and cancellations
-    if (ReservedQuotaMs == 0) {
-        return;
-    }
-
     static const double msPerCycle = 1000.0 / NHPTimer::GetCyclesPerSecond();
+
+    Y_ENSURE(ReservedQuotaMs);
 
     auto ms = static_cast<ui64>(elapsedCycles * msPerCycle);
     AvailableQuotaMs = std::min<i64>(MaxQuotaMs, AvailableQuotaMs + ReservedQuotaMs - ms);
     ReservedQuotaMs = 0;
+
+    LOG_T("TSchedulableRead ReturnedQuotaMs: " << ms);
+    LOG_T("TSchedulableRead AvailableQuotaMs: " << AvailableQuotaMs);
 
     DecreaseUsage(TDuration::MilliSeconds(ms), READ_DEFAULT);
 }

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -1,0 +1,66 @@
+#include "kqp_schedulable_read.h"
+
+#include "tree/dynamic.h"
+
+#include <yql/essentials/utils/yql_panic.h>
+
+namespace NKikimr::NKqp::NScheduler {
+
+TSchedulableRead::TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query)
+    : TSchedulableTask(query)
+{
+    if (query->GetParent()->ReadLimit) {
+        MaxQuotaMs = query->GetParent()->ReadLimit->MilliSeconds();
+        QuotaPerSecond = MaxQuotaMs / 1000.0;
+    } else {
+        MaxQuotaMs = 1000;
+        QuotaPerSecond = 1.0;
+    }
+
+    AvailableQuotaMs = MaxQuotaMs;
+    LastRefill = TMonotonic::Now();
+
+    YQL_ENSURE(MaxQuotaMs <= 1000);
+}
+
+bool TSchedulableRead::TryConsumeQuota(TDuration expectedQuota) {
+    // TODO: support update of pool's read quota.
+    auto expectedQuotaMs = std::min(expectedQuota.MilliSeconds(), MaxQuotaMs);
+
+    // Refill quota
+    if (const auto now = TMonotonic::Now(); Y_LIKELY(now >= LastRefill)) {
+        auto elapsedMs = (now - LastRefill).MilliSeconds();
+        AvailableQuotaMs = std::min<i64>(MaxQuotaMs, AvailableQuotaMs + (elapsedMs * QuotaPerSecond));
+        LastRefill = now;
+    }
+
+    if (AvailableQuotaMs <= 0 || expectedQuotaMs > static_cast<ui64>(AvailableQuotaMs) || !TryIncreaseUsage()) {
+        return false;
+    }
+
+    AvailableQuotaMs -= expectedQuotaMs;
+    ReservedQuotaMs = expectedQuotaMs;
+
+    return true;
+}
+
+void TSchedulableRead::ReturnQuota(NHPTimer::STime elapsedCycles) {
+    static const double msPerCycle = 1000.0 / NHPTimer::GetCyclesPerSecond();
+
+    auto ms = static_cast<ui64>(elapsedCycles * msPerCycle);
+    AvailableQuotaMs = std::min<i64>(MaxQuotaMs, AvailableQuotaMs + ReservedQuotaMs - ms);
+    ReservedQuotaMs = 0;
+
+    DecreaseUsage(TDuration::MilliSeconds(ms), READ_DEFAULT);
+}
+
+TSchedulableReadFactory::TSchedulableReadFactory(TComputeSchedulerPtr scheduler)
+    : Scheduler(std::move(scheduler))
+{}
+
+TSchedulableReadPtr TSchedulableReadFactory::Get(const NHdrf::TPoolId& poolId) const {
+    auto query = Scheduler->GetReadQuery(poolId);
+    return std::make_shared<TSchedulableRead>(query);
+}
+
+} // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -93,8 +93,33 @@ TSchedulableReadFactory::TSchedulableReadFactory(TComputeSchedulerPtr scheduler)
 {}
 
 TSchedulableReadPtr TSchedulableReadFactory::Get(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const {
+    const auto databaseAndPoolId = std::make_pair(databaseId, poolId);
+
+    if (auto readIt = ReadsCache.find(databaseAndPoolId); readIt != ReadsCache.end()) {
+        if (auto result = readIt->second.lock()) {
+            return result;
+        }
+        ReadsCache.erase(readIt);
+    }
+
     auto query = Scheduler->GetReadQuery(databaseId, poolId);
-    return std::make_shared<TSchedulableRead>(query);
+    auto result = std::make_shared<TSchedulableRead>(query);
+    ReadsCache.emplace(databaseAndPoolId, result);
+    return result;
+}
+
+void TSchedulableReadFactory::CleanupReadsCache() const {
+    std::list<std::pair<NHdrf::TDatabaseId, NHdrf::TPoolId>> toRemove;
+
+    for (const auto& read : ReadsCache) {
+        if (read.second.expired()) {
+            toRemove.push_back(read.first);
+        }
+    }
+
+    for (const auto& key : toRemove) {
+        ReadsCache.erase(key);
+    }
 }
 
 } // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -8,6 +8,7 @@ namespace NKikimr::NKqp::NScheduler {
 
 TSchedulableRead::TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query)
     : TSchedulableTask(query)
+    // TODO: we add demand to virtual query per reading datashard, which is inconvenient.
 {
     if (query->GetParent()->ReadLimit) {
         MaxQuotaMs = query->GetParent()->ReadLimit->MilliSeconds();

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -92,8 +92,8 @@ TSchedulableReadFactory::TSchedulableReadFactory(TComputeSchedulerPtr scheduler)
     : Scheduler(std::move(scheduler))
 {}
 
-TSchedulableReadPtr TSchedulableReadFactory::Get(const NHdrf::TPoolId& poolId) const {
-    auto query = Scheduler->GetReadQuery(poolId);
+TSchedulableReadPtr TSchedulableReadFactory::Get(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const {
+    auto query = Scheduler->GetReadQuery(databaseId, poolId);
     return std::make_shared<TSchedulableRead>(query);
 }
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "kqp_compute_scheduler_service.h"
+#include "kqp_schedulable_task.h"
+
+namespace NKikimr::NKqp::NScheduler {
+
+// Create special query on demand inside each pool - for datashards only
+struct TSchedulableRead : TSchedulableTask {
+    explicit TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query);
+
+    bool TryConsumeQuota(TDuration expectedQuota);
+    void ReturnQuota(NHPTimer::STime elapsedCycles);
+
+private:
+    // Milliseconds precision - because THPTimer::STime to TDuration has the same precision
+    ui64 MaxQuotaMs;
+    double QuotaPerSecond;
+    ui64 ReservedQuotaMs = 0;
+    i64 AvailableQuotaMs = 0;
+
+    TMonotonic LastRefill;
+};
+
+class TSchedulableReadFactory {
+public:
+    explicit TSchedulableReadFactory(TComputeSchedulerPtr scheduler);
+
+    TSchedulableReadPtr Get(const NHdrf::TPoolId& poolId) const;
+
+private:
+    TComputeSchedulerPtr Scheduler;
+};
+
+} // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
@@ -26,14 +26,18 @@ private:
     TMonotonic LastRefill;
 };
 
+// Thread-unsafe and should be used by a single actor (i.e. Datashard)
 class TSchedulableReadFactory {
 public:
     explicit TSchedulableReadFactory(TComputeSchedulerPtr scheduler);
 
     TSchedulableReadPtr Get(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const;
 
+    void CleanupReadsCache() const;
+
 private:
     TComputeSchedulerPtr Scheduler;
+    mutable THashMap<std::pair<NHdrf::TDatabaseId, NHdrf::TPoolId>, TSchedulableReadPtr::weak_type> ReadsCache;
 };
 
 } // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
@@ -10,7 +10,11 @@ struct TSchedulableRead : TSchedulableTask {
     explicit TSchedulableRead(const NHdrf::NDynamic::TQueryPtr& query);
 
     bool TryConsumeQuota(TDuration expectedQuota);
-    void ReturnQuota(NHPTimer::STime elapsedCycles);
+    void ReturnQuota(NHPTimer::STime elapsedCycles = 0);
+
+    // Estimate delay until quota becomes available.
+    // Must be called right after TryConsumeQuota fails (refill already done).
+    TDuration EstimateQuotaDelay(TDuration expectedQuota) const;
 
 private:
     // Milliseconds precision - because THPTimer::STime to TDuration has the same precision

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h
@@ -30,7 +30,7 @@ class TSchedulableReadFactory {
 public:
     explicit TSchedulableReadFactory(TComputeSchedulerPtr scheduler);
 
-    TSchedulableReadPtr Get(const NHdrf::TPoolId& poolId) const;
+    TSchedulableReadPtr Get(const NHdrf::TDatabaseId& databaseId, const NHdrf::TPoolId& poolId) const;
 
 private:
     TComputeSchedulerPtr Scheduler;

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
@@ -75,13 +75,19 @@ void TSchedulableTask::IncreaseUsage() {
     }
 }
 
-void TSchedulableTask::DecreaseUsage(const TDuration& burstUsage, bool forcedResume) {
+void TSchedulableTask::DecreaseUsage(const TDuration& burstUsage, EUsageType usageType) {
     for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
         --parent->CpuUsage;
-        if (forcedResume) {
-            parent->CpuBurstUsageResume += burstUsage.MicroSeconds();
-        } else {
-            parent->CpuBurstUsage += burstUsage.MicroSeconds();
+        switch(usageType) {
+            case CPU_DEFAULT:
+                parent->CpuBurstUsage += burstUsage.MicroSeconds();
+                break;
+            case CPU_RESUMED:
+                parent->CpuBurstUsageResume += burstUsage.MicroSeconds();
+                break;
+            case READ_DEFAULT:
+                parent->ReadBurstUsage += burstUsage.MicroSeconds();
+                break;
         }
     }
 }

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
@@ -24,9 +24,15 @@ struct TSchedulableTask : public std::enable_shared_from_this<TSchedulableTask> 
         return std::make_unique<TResumeEventType>(TAG_WAKEUP_RESUME);
     }
 
+    enum EUsageType {
+        CPU_DEFAULT,
+        CPU_RESUMED,
+        READ_DEFAULT,
+    };
+
     bool TryIncreaseUsage();
     void IncreaseUsage();
-    void DecreaseUsage(const TDuration& burstUsage, bool forcedResume);
+    void DecreaseUsage(const TDuration& burstUsage, EUsageType usageType);
 
     // Returns parent pool's 'fair-share' minus 'usage'
     size_t GetSpareUsage() const;

--- a/ydb/core/kqp/runtime/scheduler/tree/common.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/common.h
@@ -34,6 +34,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
 
         std::optional<ui64> CpuLimit;
         std::optional<ui64> CpuGuarantee;
+        std::optional<TDuration> ReadLimit; // per second
 
         auto GetCpuLimit() const {
             return CpuLimit.value_or(Infinity());
@@ -56,6 +57,9 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
             }
             if (other.CpuGuarantee) {
                 CpuGuarantee = other.CpuGuarantee;
+            }
+            if (other.ReadLimit) {
+                ReadLimit = other.ReadLimit;
             }
         }
     };
@@ -173,6 +177,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
         NMonitoring::TDynamicCounters::TCounterPtr Demand;
         NMonitoring::TDynamicCounters::TCounterPtr Usage;
         NMonitoring::TDynamicCounters::TCounterPtr UsageResume;
+        NMonitoring::TDynamicCounters::TCounterPtr Read;
         NMonitoring::TDynamicCounters::TCounterPtr Throttle;
         NMonitoring::TDynamicCounters::TCounterPtr FairShare;
         NMonitoring::TDynamicCounters::TCounterPtr InFlight;

--- a/ydb/core/kqp/runtime/scheduler/tree/common.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/common.h
@@ -5,6 +5,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/generic/hash.h>
+#include <util/string/builder.h>
 
 #include <optional>
 #include <set>
@@ -48,6 +49,10 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
             return Weight.value_or(1);
         }
 
+        auto GetReadLimit() const {
+            return ReadLimit.value_or(TDuration::Seconds(1));
+        }
+
         void Update(const TStaticAttributes& other) {
             if (other.Weight) {
                 Weight = other.Weight;
@@ -61,6 +66,14 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
             if (other.ReadLimit) {
                 ReadLimit = other.ReadLimit;
             }
+        }
+
+        TString ToString() const {
+            return TStringBuilder()
+                << "Weight: " << GetWeight()
+                << ", CpuLimit: " << GetCpuLimit()
+                << ", CpuGuarantee: " << GetCpuGuarantee()
+                << ", ReadLimit: " << GetReadLimit();
         }
     };
 

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
@@ -37,7 +37,7 @@ NSnapshot::TQuery* TQuery::TakeSnapshot() {
     CpuActualDemand = 0;
 
     // Update previous burst values and pass difference to new snapshot - to calculate adjusted satisfaction
-    const auto burstUsage = CpuBurstUsage.load() + CpuBurstUsageResume.load();
+    const auto burstUsage = CpuBurstUsage.load() + CpuBurstUsageResume.load() + ReadBurstUsage.load();
     const auto burstThrottle = CpuBurstThrottle.load();
     newQuery->CpuBurstUsage += burstUsage - PrevCpuBurstUsage;
     newQuery->CpuBurstThrottle = burstThrottle - PrevCpuBurstThrottle;
@@ -114,6 +114,7 @@ TPool::TPool(const TPoolId& id, const TIntrusivePtr<TKqpCounters>& counters, con
     Counters->Queries      = group->GetCounter("Queries",      false);
     Counters->Usage        = group->GetCounter("Usage",        true);
     Counters->UsageResume  = group->GetCounter("UsageResume",  true);
+    Counters->Read         = group->GetCounter("Read",         true);
     Counters->Throttle     = group->GetCounter("Throttle",     true);
     Counters->FairShare    = group->GetCounter("FairShare",    true);  // snapshot
 
@@ -133,6 +134,7 @@ NSnapshot::TPool* TPool::TakeSnapshot() {
         Counters->Waiting->Set(CpuThrottle * 1'000'000);
         Counters->Usage->Set(CpuBurstUsage);
         Counters->UsageResume->Set(CpuBurstUsageResume);
+        Counters->Read->Set(ReadBurstUsage);
         Counters->Throttle->Set(CpuBurstThrottle);
     }
 

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
@@ -38,8 +38,11 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic {
         std::atomic<ui64> CpuBurstUsage = 0;
         std::atomic<ui64> CpuBurstUsageResume = 0;
         std::atomic<ui64> CpuBurstThrottle = 0;
+        std::atomic<ui64> ReadBurstUsage = 0;
 
         std::atomic<ui64> CpuActualDemand = 0;
+
+        // TODO: implement Read resource - for now it's only per datashard.
 
         explicit TTreeElement(const TId& id, const TStaticAttributes& attrs = {}) : TTreeElementBase(id, attrs) {}
 

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
@@ -27,12 +27,14 @@ void TTreeElement::UpdateBottomUp(ui64 totalLimit) {
         CpuUsage = 0;
         CpuBurstUsage = 0;
         CpuBurstThrottle = 0;
+        ReadBurstUsage = 0;
         ForEachChild<TTreeElement>([&](TTreeElement* child, size_t) {
             child->UpdateBottomUp(totalLimit);
             CpuDemand += child->CpuDemand;
             CpuUsage += child->CpuUsage;
             CpuBurstUsage += child->CpuBurstUsage;
             CpuBurstThrottle += child->CpuBurstThrottle;
+            ReadBurstUsage += child->ReadBurstUsage;
         });
     }
 

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
@@ -14,6 +14,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
         ui64 CpuUsage = 0;
         ui64 CpuBurstUsage = 0;
         ui64 CpuBurstThrottle = 0;
+        ui64 ReadBurstUsage = 0;
         std::optional<float> Satisfaction;
 
         const TMonotonic Timestamp = TMonotonic::Now();

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -31,6 +31,7 @@ SRCS(
 
     scheduler/kqp_compute_scheduler_service.cpp
     scheduler/kqp_schedulable_actor.cpp
+    scheduler/kqp_schedulable_read.cpp
     scheduler/kqp_schedulable_task.cpp
     scheduler/tree/dynamic.cpp
     scheduler/tree/snapshot.cpp

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -906,6 +906,7 @@ message TKqpStreamLookupSettings {
     optional bool IsTableImmutable = 16;
     optional NKqpProto.EIsolationLevel IsolationLevel = 17 [default = ISOLATION_LEVEL_UNDEFINED];
     optional string Database = 18;
+    optional string PoolId = 21;
     optional TReadVectorTopK VectorTopK = 19;
     optional uint64 QuerySpanId = 20;
 }
@@ -941,6 +942,7 @@ message TKqpFullTextSourceSettings {
     optional TKqpSnapshot Snapshot = 10;
 
     optional string Database = 11;
+    optional string PoolId = 18;
 
     optional double K1Factor = 12;
     optional double BFactor = 13;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2294,8 +2294,9 @@ message TEvRead {
     // Optional bit flags with hints
     optional uint32 Hints = 13;
 
-    // Resource Pool to support quota via Workload Manager
-    optional string PoolId = 14;
+    // Resource Pool (and database) to support quota via Workload Manager
+    optional string DatabaseId = 14;
+    optional string PoolId = 15;
 
     // Request must contain either keys, queries or program
     // mixed requests are not supported

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -280,13 +280,14 @@ message TKqpReadRangesSourceSettings {
     optional NKqpProto.EIsolationLevel IsolationLevel = 24 [default = ISOLATION_LEVEL_UNDEFINED];
 
     optional string Database = 25;
-    optional string PoolId = 28;
 
     // Vector top-K pushdown for brute force vector search
     optional NKikimrKqp.TReadVectorTopK VectorTopK = 26;
 
     // Globally unique query trace ID for TLI log linkage
     optional uint64 QuerySpanId = 27;
+
+    optional string PoolId = 28;
 }
 
 // Takes input rows with a vector column, resolves the leaf cluster ID using the given
@@ -321,16 +322,17 @@ message TKqpVectorResolveSettings {
     // Input root cluster ID column (for the prefixed index)
     optional uint32 RootClusterColumnIndex = 16;
 
-    // Database name and pool id for KqpReadActor
+    // Database name and pool id (see below) for KqpReadActor
     optional string Database = 17;
-    optional string PoolId = 21;
-
+    
     // Parameters for finding overlapping clusters (multiple clusters per row)
     optional uint32 OverlapClusters = 18;
     optional double OverlapRatio = 19;
 
     // Globally unique query trace ID for TLI log linkage
     optional uint64 QuerySpanId = 20;
+
+    optional string PoolId = 21;
 }
 
 message TKqpTaskInfo {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -280,6 +280,7 @@ message TKqpReadRangesSourceSettings {
     optional NKqpProto.EIsolationLevel IsolationLevel = 24 [default = ISOLATION_LEVEL_UNDEFINED];
 
     optional string Database = 25;
+    optional string PoolId = 28;
 
     // Vector top-K pushdown for brute force vector search
     optional NKikimrKqp.TReadVectorTopK VectorTopK = 26;
@@ -320,8 +321,9 @@ message TKqpVectorResolveSettings {
     // Input root cluster ID column (for the prefixed index)
     optional uint32 RootClusterColumnIndex = 16;
 
-    // Database name for KqpReadActor
+    // Database name and pool id for KqpReadActor
     optional string Database = 17;
+    optional string PoolId = 21;
 
     // Parameters for finding overlapping clusters (multiple clusters per row)
     optional uint32 OverlapClusters = 18;
@@ -2289,6 +2291,9 @@ message TEvRead {
 
     // Optional bit flags with hints
     optional uint32 Hints = 13;
+
+    // Resource Pool to support quota via Workload Manager
+    optional string PoolId = 14;
 
     // Request must contain either keys, queries or program
     // mixed requests are not supported

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2385,6 +2385,10 @@ message TEvReadResult {
     // For newly-detected deferred breaks, this is the current query's SpanId.
     optional uint64 DeferredVictimQuerySpanId = 16;
 
+    // Indicates that initial read was throttled by KQP Compute Scheduler due to lack of read quota.
+    // The reader should retry after some reasonable delay.
+    optional bool Throttled = 17;
+
     // Data for the possibly partial result
     oneof ReadResult {
         TArrowBatch ArrowBatch = 900;

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4962,7 +4962,7 @@ void TDataShard::Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev) {
     CheckMediatorStateRestored();
 }
 
-void TDataShard::Handle(TEvents::TEvUndelivered::TPtr& ev) {
+void TDataShard::HandleInactive(TEvents::TEvUndelivered::TPtr& ev) {
     if (ev->Get()->SourceType == NKqp::NScheduler::TEvGetReadFactory::EventType) {
         SchedulableReadFactory = nullptr;
         CheckMediatorStateRestored();

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4951,7 +4951,9 @@ void TDataShard::OnTableCreated(TTransactionContext &txc, const TActorContext &c
 }
 
 void TDataShard::Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev) {
-    SchedulableReadFactory = ev->Get()->Factory;
+    if (!SchedulableReadFactory) {
+        SchedulableReadFactory = ev->Get()->Factory;
+    }
     CheckMediatorStateRestored();
 }
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/engine/minikql/flat_local_tx_factory.h>
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h>
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
@@ -4058,6 +4059,10 @@ void TDataShard::DoPeriodicTasks(const TActorContext &ctx) {
         LOG_NOTICE_S(ctx, NKikimrServices::TX_DATASHARD, "Stoped key access sampling at datashard: " << TabletID());
     }
 
+    if (SchedulableReadFactory && *SchedulableReadFactory) {
+        (*SchedulableReadFactory)->CleanupReadsCache();
+    }
+
     if (!PeriodicWakeupPending) {
         PeriodicWakeupPending = true;
         ctx.Schedule(TDuration::Seconds(5), new TEvPrivate::TEvPeriodicWakeup());
@@ -4952,7 +4957,7 @@ void TDataShard::OnTableCreated(TTransactionContext &txc, const TActorContext &c
 
 void TDataShard::Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev) {
     if (!SchedulableReadFactory) {
-        SchedulableReadFactory = ev->Get()->Factory;
+        SchedulableReadFactory = std::move(ev->Get()->Factory);
     }
     CheckMediatorStateRestored();
 }

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4954,6 +4954,13 @@ void TDataShard::Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev) {
     CheckMediatorStateRestored();
 }
 
+void TDataShard::Handle(TEvents::TEvUndelivered::TPtr& ev) {
+    if (ev->Get()->SourceType == NKqp::NScheduler::TEvGetReadFactory::EventType) {
+        SchedulableReadFactory = nullptr;
+        CheckMediatorStateRestored();
+    }
+}
+
 } // NDataShard
 
 TString TEvDataShard::TEvRead::ToString() const {

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -7,14 +7,15 @@
 #include <ydb/core/base/interconnect_channels.h>
 #include <ydb/core/engine/minikql/flat_local_tx_factory.h>
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
-#include <ydb/library/formats/arrow/size_calcer.h>
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/protos/datashard_config.pb.h>
+#include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
-#include <ydb/core/protos/datashard_config.pb.h>
-#include <ydb/core/protos/query_stats.pb.h>
-
 #include <ydb/library/actors/core/monotonic_provider.h>
+#include <ydb/library/formats/arrow/size_calcer.h>
+
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/api.h>
@@ -396,6 +397,9 @@ void TDataShard::OnActivateExecutor(const TActorContext& ctx) {
     if (!IsFollower()) {
         Execute(CreateTxInitSchema(), ctx);
         Become(&TThis::StateInactive);
+
+        // Get factory from KQP Scheduler
+        ctx.Send(NKqp::MakeKqpSchedulerServiceId(ctx.SelfID.NodeId()), new NKqp::NScheduler::TEvGetReadFactory);
     } else {
         SyncConfig();
         State = TShardState::Readonly;
@@ -2842,6 +2846,10 @@ bool TDataShard::NeedMediatorStateRestored() const {
 }
 
 void TDataShard::CheckMediatorStateRestored() {
+    if (!SchedulableReadFactory) {
+        return;
+    }
+
     if (!MediatorStateWaiting ||
         !RegistrationSended ||
         !MediatorTimeCastEntry ||
@@ -4941,6 +4949,11 @@ void TDataShard::OnTableCreated(TTransactionContext &txc, const TActorContext &c
         PersistUnprotectedReadsEnabled(txc);
         SendRegistrationRequestTimeCast(ctx);
     }
+}
+
+void TDataShard::Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev) {
+    SchedulableReadFactory = ev->Get()->Factory;
+    CheckMediatorStateRestored();
 }
 
 } // NDataShard

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -398,8 +398,9 @@ void TDataShard::OnActivateExecutor(const TActorContext& ctx) {
         Execute(CreateTxInitSchema(), ctx);
         Become(&TThis::StateInactive);
 
-        // Get factory from KQP Scheduler
+        // Get factory from KQP Scheduler and schedule delayed empty response as fail-safe measure
         ctx.Send(NKqp::MakeKqpSchedulerServiceId(ctx.SelfID.NodeId()), new NKqp::NScheduler::TEvGetReadFactory, IEventHandle::FlagTrackDelivery);
+        ctx.Schedule(TDuration::Seconds(1), new NKqp::NScheduler::TEvReadFactoryResponse);
     } else {
         SyncConfig();
         State = TShardState::Readonly;

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -399,7 +399,7 @@ void TDataShard::OnActivateExecutor(const TActorContext& ctx) {
         Become(&TThis::StateInactive);
 
         // Get factory from KQP Scheduler
-        ctx.Send(NKqp::MakeKqpSchedulerServiceId(ctx.SelfID.NodeId()), new NKqp::NScheduler::TEvGetReadFactory);
+        ctx.Send(NKqp::MakeKqpSchedulerServiceId(ctx.SelfID.NodeId()), new NKqp::NScheduler::TEvGetReadFactory, IEventHandle::FlagTrackDelivery);
     } else {
         SyncConfig();
         State = TShardState::Readonly;
@@ -4498,9 +4498,7 @@ void TDataShard::Handle(TEvDataShard::TEvDiscardVolatileSnapshotRequest::TPtr& e
     Execute(new TTxDiscardVolatileSnapshot(this, std::move(ev)), ctx);
 }
 
-void TDataShard::Handle(TEvents::TEvUndelivered::TPtr &ev,
-                               const TActorContext &ctx)
-{
+void TDataShard::Handle(TEvents::TEvUndelivered::TPtr &ev, const TActorContext &ctx) {
     auto op = Pipeline.FindOp(ev->Cookie);
     if (op) {
         op->AddInputEvent(ev.Release());

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3412,7 +3412,8 @@ public:
             }
         }
 
-        auto returnConsumedQuota = [&]() -> void {
+        // Return read quota after reading
+        Y_DEFER {
             if (schedulableRead) {
                 Reader->UpdateCycles();
                 schedulableRead->ReturnQuota(Reader->ElapsedCycles());
@@ -3420,8 +3421,6 @@ public:
         };
 
         if (Reader->Read(txc)) {
-            returnConsumedQuota();
-
             // Retry later when dependencies are resolved
             if (!Reader->GetVolatileReadDependencies().empty()) {
                 state.ReadContinuePending = true;
@@ -3445,8 +3444,6 @@ public:
             }
             return true;
         }
-
-        returnConsumedQuota();
         return false;
     }
 
@@ -3661,7 +3658,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         return;
     }
 
-    auto replyWithError = [&] (auto code, const auto& msg, bool throttled = false) {
+    auto replyWithError = [&] (auto code, const auto& msg) {
         auto result = MakeEvReadResult(ctx.SelfID.NodeId());
 
         SetStatusError(
@@ -3669,7 +3666,6 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
             code,
             msg);
         result->Record.SetReadId(readId.ReadId);
-        result->Record.SetThrottled(throttled);
         ctx.Send(ev->Sender, result.release());
 
         request->ReadSpan.EndError(msg);

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -1,6 +1,5 @@
 #include "datashard_failpoints.h"
 #include "datashard_impl.h"
-#include "datashard_integrity_trails.h"
 #include "datashard_read_operation.h"
 #include "setup_sys_locks.h"
 #include "datashard_locks_db.h"
@@ -11,6 +10,7 @@
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 #include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/protos/query_stats.pb.h>
+#include <ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h>
 
 #include <ydb/library/actors/core/monotonic_provider.h>
 
@@ -2487,6 +2487,14 @@ public:
             request->ReadSpan.EndOk();
             Self->DeleteReadIterator(it);
         }
+
+        if (!state.PoolId.empty()) {
+            Reader->UpdateCycles();
+
+            auto schedulableRead = Self->SchedulableReads.at(state.PoolId);
+            schedulableRead->ReturnQuota(Reader->ElapsedCycles());
+            state.PoolId.clear();
+        }
     }
 
 private:
@@ -3724,8 +3732,23 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         isHeadRead = false;
     }
 
-    // TODO: check WM Scheduler quota here - and reply overloaded in case no quota.
-    // TODO: make sure there is no instant re-read from KqpReadActor.
+    if (record.HasPoolId()) {
+        auto readIt = SchedulableReads.find(record.GetPoolId());
+        if (readIt == SchedulableReads.end()) {
+            readIt = SchedulableReads.emplace(record.GetPoolId(), SchedulableReadFactory->Get(record.GetPoolId())).first;
+            YQL_ENSURE(readIt->second);
+        }
+
+        // Default quota of 10ms is equal to internal datashard quota
+        if (!readIt->second->TryConsumeQuota(TDuration::MilliSeconds(10))) {
+            // TODO: make sure there is no instant re-read from KqpReadActor.
+            replyWithError(
+                Ydb::StatusIds::OVERLOADED,
+                TStringBuilder() << "Request " << readId.ReadId << " rejected, quota exceeded for PoolId=" << record.GetPoolId()
+                    << " (shard# " << TabletID() << " node# " << SelfId().NodeId() << " state# " << DatashardStateName(State) << ")");
+            return;
+        }
+    }
 
     TActorId sessionId;
     if (readId.Sender.NodeId() != SelfId().NodeId()) {
@@ -3751,7 +3774,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         std::forward_as_tuple(readId),
         std::forward_as_tuple(
             readId, localReadId, TPathId(record.GetTableId().GetOwnerId(), record.GetTableId().GetTableId()),
-            sessionId, readVersion, isHeadRead,
+            sessionId, readVersion, isHeadRead, record.GetPoolId(),
             AppData()->MonotonicTimeProvider->Now()));
     Y_ENSURE(pr.second);
 
@@ -4012,6 +4035,13 @@ void TDataShard::DeleteReadIterator(TReadIteratorsLocalMap::iterator localIt) {
     auto readIt = ReadIterators.find(localIt->second->ReadId);
     Y_ENSURE(readIt != ReadIterators.end());
     DeleteReadIterator(readIt);
+
+    // Return unused quota
+    if (auto* state = localIt->second; !state->PoolId.empty()) {
+        auto schedulableRead = SchedulableReads.at(state->PoolId);
+        schedulableRead->ReturnQuota(0);
+        state->PoolId.clear();
+    }
 }
 
 void TDataShard::ReadIteratorsOnNodeDisconnected(const TActorId& sessionId, const TActorContext &ctx) {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3789,7 +3789,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
     }
 
     NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
-    if (record.HasPoolId() && !record.GetPoolId().empty() && SchedulableReadFactory) {
+    if (record.HasPoolId() && !record.GetPoolId().empty() && SchedulableReadFactory && *SchedulableReadFactory) {
         schedulableRead = (*SchedulableReadFactory)->Get(record.GetPoolId());
     }
 

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3779,7 +3779,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         auto readIt = SchedulableReads.find(record.GetPoolId());
         if (readIt == SchedulableReads.end()) {
             readIt = SchedulableReads.emplace(record.GetPoolId(), SchedulableReadFactory->Get(record.GetPoolId())).first;
-            YQL_ENSURE(readIt->second);
+            Y_ENSURE(readIt->second);
         }
     }
 

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3790,7 +3790,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
 
     NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
     if (record.HasPoolId() && !record.GetPoolId().empty() && SchedulableReadFactory && *SchedulableReadFactory) {
-        schedulableRead = (*SchedulableReadFactory)->Get(record.GetPoolId());
+        schedulableRead = (*SchedulableReadFactory)->Get(record.GetDatabaseId(), record.GetPoolId());
     }
 
     ui64 localReadId = NextTieBreakerIndex++;

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3561,6 +3561,9 @@ public:
             Reader->UpdateState(state, useful);
             if (!state.IsExhausted()) {
                 state.ReadContinuePending = true;
+
+                // TODO: check WM Scheduler quota here - and delay message if no quota.
+
                 ctx.Send(
                     Self->SelfId(),
                     new TEvDataShard::TEvReadContinue(LocalReadId));
@@ -3720,6 +3723,9 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         }
         isHeadRead = false;
     }
+
+    // TODO: check WM Scheduler quota here - and reply overloaded in case no quota.
+    // TODO: make sure there is no instant re-read from KqpReadActor.
 
     TActorId sessionId;
     if (readId.Sender.NodeId() != SelfId().NodeId()) {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3775,10 +3775,10 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         isHeadRead = false;
     }
 
-    if (record.HasPoolId()) {
+    if (record.HasPoolId() && SchedulableReadFactory) {
         auto readIt = SchedulableReads.find(record.GetPoolId());
         if (readIt == SchedulableReads.end()) {
-            readIt = SchedulableReads.emplace(record.GetPoolId(), SchedulableReadFactory->Get(record.GetPoolId())).first;
+            readIt = SchedulableReads.emplace(record.GetPoolId(), (*SchedulableReadFactory)->Get(record.GetPoolId())).first;
             Y_ENSURE(readIt->second);
         }
     }

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2078,12 +2078,12 @@ public:
             }
         }
 
-        auto schedulableRead = Self->GetSchedulableRead(state.PoolId);
+        const auto& schedulableRead = state.SchedulableRead;
         if (schedulableRead && !schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
             SetStatusError(
                 Result->Record,
                 Ydb::StatusIds::OVERLOADED,
-                TStringBuilder() << "Read quota exceeded for pool " << state.PoolId
+                TStringBuilder() << "Read quota for resource pool exceeded" // TODO: add pool id
                     << " (shard# " << Self->TabletID()
                     << " node# " << ctx.SelfID.NodeId() << ")");
             Result->Record.SetThrottled(true);
@@ -3397,7 +3397,7 @@ public:
         LWTRACK(ReadExecute, state.Request->Orbit);
 
         // Try to consume schedulable read quota before reading
-        auto schedulableRead = Self->GetSchedulableRead(state.PoolId);
+        const auto& schedulableRead = state.SchedulableRead;
         if (schedulableRead) {
             if (!schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
                 // KQP read quota exhausted, reschedule with delay.
@@ -3770,14 +3770,6 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         isHeadRead = false;
     }
 
-    if (record.HasPoolId() && SchedulableReadFactory) {
-        auto readIt = SchedulableReads.find(record.GetPoolId());
-        if (readIt == SchedulableReads.end()) {
-            readIt = SchedulableReads.emplace(record.GetPoolId(), (*SchedulableReadFactory)->Get(record.GetPoolId())).first;
-            Y_ENSURE(readIt->second);
-        }
-    }
-
     TActorId sessionId;
     if (readId.Sender.NodeId() != SelfId().NodeId()) {
         Y_DEBUG_ABORT_UNLESS(ev->InterconnectSession);
@@ -3796,14 +3788,18 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         sessionId = ev->InterconnectSession;
     }
 
+    NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
+    if (record.HasPoolId() && !record.GetPoolId().empty() && SchedulableReadFactory) {
+        schedulableRead = (*SchedulableReadFactory)->Get(record.GetPoolId());
+    }
+
     ui64 localReadId = NextTieBreakerIndex++;
     auto pr = ReadIterators.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(readId),
         std::forward_as_tuple(
             readId, localReadId, TPathId(record.GetTableId().GetOwnerId(), record.GetTableId().GetTableId()),
-            sessionId, readVersion, isHeadRead, record.GetPoolId(),
-            AppData()->MonotonicTimeProvider->Now()));
+            sessionId, readVersion, isHeadRead, AppData()->MonotonicTimeProvider->Now(), schedulableRead));
     Y_ENSURE(pr.second);
 
     auto& state = pr.first->second;

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2078,9 +2078,31 @@ public:
             }
         }
 
+        if (!state.PoolId.empty()) {
+            auto schedulableRead = Self->SchedulableReads.at(state.PoolId);
+            if (!schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
+                SetStatusError(
+                    Result->Record,
+                    Ydb::StatusIds::OVERLOADED,
+                    TStringBuilder() << "Read quota exceeded for pool " << state.PoolId
+                        << " (shard# " << Self->TabletID()
+                        << " node# " << ctx.SelfID.NodeId() << ")");
+                Result->Record.SetThrottled(true);
+                return EExecutionStatus::DelayComplete;
+            }
+        }
+
         LWTRACK(ReadExecute, state.Request->Orbit);
-        if (!Read(txc, ctx, state))
+        bool readResult = Read(txc, ctx, state);
+
+        if (!state.PoolId.empty()) {
+            Reader->UpdateCycles();
+            Self->SchedulableReads.at(state.PoolId)->ReturnQuota(Reader->ElapsedCycles());
+        }
+
+        if (!readResult) {
             return EExecutionStatus::Restart;
+        }
 
         // Check if successful result depends on unresolved volatile transactions
         if (Result && !Result->Record.HasStatus() && !Reader->GetVolatileReadDependencies().empty()) {
@@ -2486,14 +2508,6 @@ public:
 
             request->ReadSpan.EndOk();
             Self->DeleteReadIterator(it);
-        }
-
-        if (!state.PoolId.empty()) {
-            Reader->UpdateCycles();
-
-            auto schedulableRead = Self->SchedulableReads.at(state.PoolId);
-            schedulableRead->ReturnQuota(Reader->ElapsedCycles());
-            state.PoolId.clear();
         }
     }
 
@@ -3375,16 +3389,44 @@ public:
         TDataShardLocksDb locksDb(*Self, txc);
         TSetupSysLocks guardLocks(state.LockId, state.LockNodeId, state.QuerySpanId, *Self, &locksDb);
 
-        Reader.reset(new TReader(
+        Reader = std::make_unique<TReader>(
             state,
             *BlockBuilder,
             TableInfo,
             AppData()->MonotonicTimeProvider->Now(),
-            Self));
+            Self);
 
         LWTRACK(ReadExecute, state.Request->Orbit);
 
+        // Try to consume schedulable read quota before reading
+        NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
+        if (!state.PoolId.empty()) {
+            schedulableRead = Self->SchedulableReads.at(state.PoolId);
+            if (!schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
+                // KQP read quota exhausted, reschedule with delay.
+                // Keep ReadContinuePending=true so that ReadAck doesn't schedule a duplicate TEvReadContinue while we wait.
+                state.ReadContinuePending = true;
+                Reader.reset();
+                Result.reset();
+                ctx.Schedule(
+                    schedulableRead->EstimateQuotaDelay(TDuration::MilliSeconds(10)),
+                    new TEvDataShard::TEvReadContinue(LocalReadId));
+                return true;
+            }
+        }
+
+        auto returnConsumedQuota = [&]() -> void {
+            if (schedulableRead) {
+                Reader->UpdateCycles();
+                if (!state.PoolId.empty()) {
+                    schedulableRead->ReturnQuota(Reader->ElapsedCycles());
+                }
+            }
+        };
+
         if (Reader->Read(txc)) {
+            returnConsumedQuota();
+
             // Retry later when dependencies are resolved
             if (!Reader->GetVolatileReadDependencies().empty()) {
                 state.ReadContinuePending = true;
@@ -3408,6 +3450,8 @@ public:
             }
             return true;
         }
+
+        returnConsumedQuota();
         return false;
     }
 
@@ -3569,8 +3613,6 @@ public:
             Reader->UpdateState(state, useful);
             if (!state.IsExhausted()) {
                 state.ReadContinuePending = true;
-
-                // TODO: check WM Scheduler quota here - and delay message if no quota.
 
                 ctx.Send(
                     Self->SelfId(),
@@ -3738,17 +3780,6 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         if (readIt == SchedulableReads.end()) {
             readIt = SchedulableReads.emplace(record.GetPoolId(), SchedulableReadFactory->Get(record.GetPoolId())).first;
             YQL_ENSURE(readIt->second);
-        }
-
-        // Default quota of 10ms is equal to internal datashard quota
-        if (!readIt->second->TryConsumeQuota(TDuration::MilliSeconds(10))) {
-            // TODO: make sure there is no instant re-read from KqpReadActor.
-            replyWithError(
-                Ydb::StatusIds::OVERLOADED,
-                TStringBuilder() << "Request " << readId.ReadId << " rejected, quota exceeded for PoolId=" << record.GetPoolId()
-                    << " (shard# " << TabletID() << " node# " << SelfId().NodeId() << " state# " << DatashardStateName(State) << ")",
-                true);
-            return;
         }
     }
 
@@ -4028,6 +4059,7 @@ void TDataShard::DeleteReadIterator(TReadIteratorsMap::iterator it) {
     if (state.EnqueuedLocalTxId) {
         Executor()->CancelTransaction(state.EnqueuedLocalTxId);
     }
+
     ReadIteratorsByLocalReadId.erase(state.LocalReadId);
     ReadIterators.erase(it);
     SetCounter(COUNTER_READ_ITERATORS_COUNT, ReadIterators.size());
@@ -4037,13 +4069,6 @@ void TDataShard::DeleteReadIterator(TReadIteratorsLocalMap::iterator localIt) {
     auto readIt = ReadIterators.find(localIt->second->ReadId);
     Y_ENSURE(readIt != ReadIterators.end());
     DeleteReadIterator(readIt);
-
-    // Return unused quota
-    if (auto* state = localIt->second; !state->PoolId.empty()) {
-        auto schedulableRead = SchedulableReads.at(state->PoolId);
-        schedulableRead->ReturnQuota(0);
-        state->PoolId.clear();
-    }
 }
 
 void TDataShard::ReadIteratorsOnNodeDisconnected(const TActorId& sessionId, const TActorContext &ctx) {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3624,7 +3624,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
         return;
     }
 
-    auto replyWithError = [&] (auto code, const auto& msg) {
+    auto replyWithError = [&] (auto code, const auto& msg, bool throttled = false) {
         auto result = MakeEvReadResult(ctx.SelfID.NodeId());
 
         SetStatusError(
@@ -3632,6 +3632,7 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
             code,
             msg);
         result->Record.SetReadId(readId.ReadId);
+        result->Record.SetThrottled(throttled);
         ctx.Send(ev->Sender, result.release());
 
         request->ReadSpan.EndError(msg);
@@ -3745,7 +3746,8 @@ void TDataShard::Handle(TEvDataShard::TEvRead::TPtr& ev, const TActorContext& ct
             replyWithError(
                 Ydb::StatusIds::OVERLOADED,
                 TStringBuilder() << "Request " << readId.ReadId << " rejected, quota exceeded for PoolId=" << record.GetPoolId()
-                    << " (shard# " << TabletID() << " node# " << SelfId().NodeId() << " state# " << DatashardStateName(State) << ")");
+                    << " (shard# " << TabletID() << " node# " << SelfId().NodeId() << " state# " << DatashardStateName(State) << ")",
+                true);
             return;
         }
     }

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -2078,26 +2078,24 @@ public:
             }
         }
 
-        if (!state.PoolId.empty()) {
-            auto schedulableRead = Self->SchedulableReads.at(state.PoolId);
-            if (!schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
-                SetStatusError(
-                    Result->Record,
-                    Ydb::StatusIds::OVERLOADED,
-                    TStringBuilder() << "Read quota exceeded for pool " << state.PoolId
-                        << " (shard# " << Self->TabletID()
-                        << " node# " << ctx.SelfID.NodeId() << ")");
-                Result->Record.SetThrottled(true);
-                return EExecutionStatus::DelayComplete;
-            }
+        auto schedulableRead = Self->GetSchedulableRead(state.PoolId);
+        if (schedulableRead && !schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
+            SetStatusError(
+                Result->Record,
+                Ydb::StatusIds::OVERLOADED,
+                TStringBuilder() << "Read quota exceeded for pool " << state.PoolId
+                    << " (shard# " << Self->TabletID()
+                    << " node# " << ctx.SelfID.NodeId() << ")");
+            Result->Record.SetThrottled(true);
+            return EExecutionStatus::DelayComplete;
         }
 
         LWTRACK(ReadExecute, state.Request->Orbit);
         bool readResult = Read(txc, ctx, state);
 
-        if (!state.PoolId.empty()) {
+        if (schedulableRead) {
             Reader->UpdateCycles();
-            Self->SchedulableReads.at(state.PoolId)->ReturnQuota(Reader->ElapsedCycles());
+            schedulableRead->ReturnQuota(Reader->ElapsedCycles());
         }
 
         if (!readResult) {
@@ -3399,9 +3397,8 @@ public:
         LWTRACK(ReadExecute, state.Request->Orbit);
 
         // Try to consume schedulable read quota before reading
-        NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
-        if (!state.PoolId.empty()) {
-            schedulableRead = Self->SchedulableReads.at(state.PoolId);
+        auto schedulableRead = Self->GetSchedulableRead(state.PoolId);
+        if (schedulableRead) {
             if (!schedulableRead->TryConsumeQuota(TDuration::MilliSeconds(10))) {
                 // KQP read quota exhausted, reschedule with delay.
                 // Keep ReadContinuePending=true so that ReadAck doesn't schedule a duplicate TEvReadContinue while we wait.
@@ -3418,9 +3415,7 @@ public:
         auto returnConsumedQuota = [&]() -> void {
             if (schedulableRead) {
                 Reader->UpdateCycles();
-                if (!state.PoolId.empty()) {
-                    schedulableRead->ReturnQuota(Reader->ElapsedCycles());
-                }
+                schedulableRead->ReturnQuota(Reader->ElapsedCycles());
             }
         };
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1481,6 +1481,8 @@ class TDataShard
 
     void Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev);
 
+    void Handle(TEvents::TEvUndelivered::TPtr& ev);
+
     void HandleByReplicationSourceOffsetsServer(STATEFN_SIG);
 
     void DoPeriodicTasks(const TActorContext &ctx);
@@ -3199,7 +3201,7 @@ private:
     TIntrusiveList<TGlobalTxIdAwaiter> GlobalTxIdAwaiters;
     TVector<ui64> GlobalTxIdCache;
 
-    NKqp::NScheduler::TSchedulableReadFactoryPtr SchedulableReadFactory;
+    std::optional<NKqp::NScheduler::TSchedulableReadFactoryPtr> SchedulableReadFactory;
     THashMap<NKqp::NScheduler::NHdrf::TPoolId, NKqp::NScheduler::TSchedulableReadPtr> SchedulableReads;
 
 public:
@@ -3300,6 +3302,7 @@ protected:
             HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
             hFunc(NKqp::NScheduler::TEvReadFactoryResponse, Handle);
+            hFunc(TEvents::TEvUndelivered, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3275,6 +3275,19 @@ public:
         ChangesQueue = std::move(changesQueue);
     }
 
+    auto GetSchedulableRead(const TString& poolId) const {
+        NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
+
+        if (!poolId.empty()) {
+            auto readIt = SchedulableReads.find(poolId);
+            if (readIt != SchedulableReads.end()) {
+                schedulableRead = readIt->second;
+            }
+        }
+
+        return schedulableRead;
+    }
+
 protected:
     // Redundant init state required by flat executor implementation
     void StateInit(TAutoPtr<NActors::IEventHandle> &ev) {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1479,7 +1479,7 @@ class TDataShard
 
     void Handle(TEvDataShard::TEvVacuum::TPtr& ev, const TActorContext& ctx);
 
-    void Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr&);
+    void Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev);
 
     void HandleByReplicationSourceOffsetsServer(STATEFN_SIG);
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3202,7 +3202,6 @@ private:
     TVector<ui64> GlobalTxIdCache;
 
     std::optional<NKqp::NScheduler::TSchedulableReadFactoryPtr> SchedulableReadFactory;
-    THashMap<NKqp::NScheduler::NHdrf::TPoolId, NKqp::NScheduler::TSchedulableReadPtr> SchedulableReads;
 
 public:
     struct TBreakerInfo {
@@ -3273,19 +3272,6 @@ public:
 
     void SetChangesQueue(THashMap<ui64, TEnqueuedRecord>&& changesQueue) {
         ChangesQueue = std::move(changesQueue);
-    }
-
-    auto GetSchedulableRead(const TString& poolId) const {
-        NKqp::NScheduler::TSchedulableReadPtr schedulableRead;
-
-        if (!poolId.empty()) {
-            auto readIt = SchedulableReads.find(poolId);
-            if (readIt != SchedulableReads.end()) {
-                schedulableRead = readIt->second;
-            }
-        }
-
-        return schedulableRead;
     }
 
 protected:

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -22,7 +22,6 @@
 #include "datashard_user_table.h"
 #include "datashard_write.h"
 #include "incr_restore_scan.h"
-#include "datashard_integrity_trails.h"
 #include "datashard_tli.h"
 #include "multi_txids.h"
 #include "progress_queue.h"
@@ -43,6 +42,7 @@
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/core/change_exchange/change_exchange.h>
 #include <ydb/core/engine/mkql_engine_flat_host.h>
+#include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/tablet/pipe_tracker.h>
 #include <ydb/core/tablet/tablet_exception.h>
@@ -1005,7 +1005,7 @@ class TDataShard
             struct Source :     Column<5, NScheme::NTypeIds::Uint8> { using Type = TChangeRecord::ESource; };
             struct UserSID :    Column<6, NScheme::NTypeIds::Utf8> { using Type = TString; };
             struct UserTraceId :  Column<7, NScheme::NTypeIds::String> { using Type = TString; };
-            
+
             using TKey = TableKey<LockId, LockOffset>;
             using TColumns = TableColumns<LockId, LockOffset, Kind, Body, Source, UserSID, UserTraceId>;
         };
@@ -1478,6 +1478,8 @@ class TDataShard
     void Handle(TEvIncrementalRestoreScan::TEvFinished::TPtr& ev, const TActorContext& ctx);
 
     void Handle(TEvDataShard::TEvVacuum::TPtr& ev, const TActorContext& ctx);
+
+    void Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr&);
 
     void HandleByReplicationSourceOffsetsServer(STATEFN_SIG);
 
@@ -3197,6 +3199,9 @@ private:
     TIntrusiveList<TGlobalTxIdAwaiter> GlobalTxIdAwaiters;
     TVector<ui64> GlobalTxIdCache;
 
+    NKqp::NScheduler::TSchedulableReadFactoryPtr SchedulableReadFactory;
+    THashMap<NKqp::NScheduler::NHdrf::TPoolId, NKqp::NScheduler::TSchedulableReadPtr> SchedulableReads;
+
 public:
     struct TBreakerInfo {
         ui64 QuerySpanId;
@@ -3294,6 +3299,7 @@ protected:
             HFuncTraced(TEvPrivate::TEvRemoveSchemaSnapshots, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
+            hFunc(NKqp::NScheduler::TEvReadFactoryResponse, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1481,7 +1481,7 @@ class TDataShard
 
     void Handle(NKqp::NScheduler::TEvReadFactoryResponse::TPtr& ev);
 
-    void Handle(TEvents::TEvUndelivered::TPtr& ev);
+    void HandleInactive(TEvents::TEvUndelivered::TPtr& ev);
 
     void HandleByReplicationSourceOffsetsServer(STATEFN_SIG);
 
@@ -3201,6 +3201,8 @@ private:
     TIntrusiveList<TGlobalTxIdAwaiter> GlobalTxIdAwaiters;
     TVector<ui64> GlobalTxIdCache;
 
+    // If value is un-set then wait in StateInactive.
+    // Also it's fine if value is set and nullptr - it means: don't use the read factory.
     std::optional<NKqp::NScheduler::TSchedulableReadFactoryPtr> SchedulableReadFactory;
 
 public:
@@ -3301,7 +3303,7 @@ protected:
             HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
             hFunc(NKqp::NScheduler::TEvReadFactoryResponse, Handle);
-            hFunc(TEvents::TEvUndelivered, Handle);
+            hFunc(TEvents::TEvUndelivered, HandleInactive);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -4054,7 +4054,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIterator) {
         AsyncDropTable(helper.Server, helper.Sender, "/Root", "table-1");
 
         runtime.SimulateSleep(TDuration::Seconds(1));
-        // Unblock execution of the read. It will now get added to the pipeline and 
+        // Unblock execution of the read. It will now get added to the pipeline and
         // would start executing if there were no additional checks on the presence of DropTable.
         blockedActivations.Stop().Unblock();
 
@@ -4153,7 +4153,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorSysTables) {
 
 Y_UNIT_TEST_SUITE(DataShardReadIteratorState) {
     Y_UNIT_TEST(ShouldCalculateQuota) {
-        NDataShard::TReadIteratorState state(TReadIteratorId({}, 0), 0, TPathId(0, 0), {}, TRowVersion::Max(), true, {});
+        NDataShard::TReadIteratorState state(TReadIteratorId({}, 0), 0, TPathId(0, 0), {}, TRowVersion::Max(), true, {}, {});
         state.Quota.Rows = 100;
         state.Quota.Bytes = 1000;
         state.ConsumeSeqNo(10, 100); // seqno1

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -303,16 +303,16 @@ struct TTestHelper {
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false);
-        init(serverSettings);
+        Init(serverSettings);
     }
 
     explicit TTestHelper(const TServerSettings& serverSettings, ui64 shardCount = 1, bool withFollower = false) {
         WithFollower = withFollower;
         ShardCount = shardCount;
-        init(serverSettings);
+        Init(serverSettings);
     }
 
-    void init(const TServerSettings& serverSettings) {
+    void Init(const TServerSettings& serverSettings) {
         Server = new TServer(serverSettings);
 
         auto &runtime = *Server->GetRuntime();

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -1,16 +1,14 @@
 #pragma once
 
 #include "datashard.h"
-#include <ydb/core/tx/locks/locks.h>
 
 #include <ydb/core/base/row_version.h>
 #include <ydb/core/tablet_flat/flat_row_eggs.h>
+#include <ydb/core/tx/locks/locks.h>
 
 #include <util/digest/multi.h>
 
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace NKikimr::NDataShard {
@@ -127,13 +125,14 @@ public:
     TReadIteratorState(
             const TReadIteratorId& readId, ui64 localReadId, const TPathId& pathId,
             const TActorId& sessionId, const TRowVersion& readVersion, bool isHeadRead,
-            TMonotonic ts)
+            const TString& poolId, TMonotonic ts)
         : ReadId(readId)
         , LocalReadId(localReadId)
         , PathId(pathId)
         , ReadVersion(readVersion)
         , IsHeadRead(isHeadRead)
         , SessionId(sessionId)
+        , PoolId(poolId)
         , StartTs(ts)
     {}
 
@@ -206,6 +205,7 @@ public:
     ui64 TotalRowsLimit = Max<ui64>();
 
     TActorId SessionId;
+    TString PoolId;
     TMonotonic StartTs;
     bool IsFinished = false;
     bool ReadContinuePending = false;

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -3,6 +3,7 @@
 #include "datashard.h"
 
 #include <ydb/core/base/row_version.h>
+#include <ydb/core/kqp/runtime/scheduler/fwd.h>
 #include <ydb/core/tablet_flat/flat_row_eggs.h>
 #include <ydb/core/tx/locks/locks.h>
 
@@ -125,14 +126,14 @@ public:
     TReadIteratorState(
             const TReadIteratorId& readId, ui64 localReadId, const TPathId& pathId,
             const TActorId& sessionId, const TRowVersion& readVersion, bool isHeadRead,
-            const TString& poolId, TMonotonic ts)
+            TMonotonic ts, NKqp::NScheduler::TSchedulableReadPtr schedulableRead)
         : ReadId(readId)
         , LocalReadId(localReadId)
         , PathId(pathId)
         , ReadVersion(readVersion)
         , IsHeadRead(isHeadRead)
+        , SchedulableRead(std::move(schedulableRead))
         , SessionId(sessionId)
-        , PoolId(poolId)
         , StartTs(ts)
     {}
 
@@ -199,13 +200,13 @@ public:
     // State itself //
 
     TQuota Quota;
+    NKqp::NScheduler::TSchedulableReadPtr SchedulableRead;
 
     // Number of rows processed so far
     ui64 TotalRows = 0;
     ui64 TotalRowsLimit = Max<ui64>();
 
     TActorId SessionId;
-    TString PoolId;
     TMonotonic StartTs;
     bool IsFinished = false;
     bool ReadContinuePending = false;

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -1,0 +1,249 @@
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+
+#include <ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.h>
+#include <ydb/core/kqp/runtime/scheduler/tree/common.h>
+
+namespace NKikimr {
+
+using namespace Tests;
+
+namespace {
+
+const TString TEST_DATABASE_ID = "/Root";
+const TString TEST_POOL_ID = "test_pool";
+
+// Minimal setup that sets up the scheduler BEFORE the shard is created.
+struct TSchedulerTestHelper {
+    Tests::TServer::TPtr Server;
+    TActorId Sender;
+
+    TTableId TableId;
+    ui64 TabletId = 0;
+    NKikimrTxDataShard::TEvGetInfoResponse::TUserTable UserTable;
+    TActorId ClientId;
+
+    explicit TSchedulerTestHelper(std::optional<ui64> readLimitMs = std::nullopt) {
+        using namespace NKqp;
+        using namespace NKqp::NScheduler;
+        using namespace NKqp::NScheduler::NHdrf;
+
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false);
+        serverSettings.AppConfig->MutableFeatureFlags()->SetEnableResourcePools(true);
+        serverSettings.AppConfig->MutableFeatureFlags()->SetEnableResourcePoolsScheduler(true);
+
+        Server = new TServer(serverSettings);
+        auto& runtime = *Server->GetRuntime();
+        Sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_INFO);
+        runtime.SetLogPriority(NKikimrServices::KQP_COMPUTE_SCHEDULER, NLog::PRI_TRACE);
+
+        // Create test database
+        {
+            auto ev = std::make_unique<TEvAddDatabase>(TEST_DATABASE_ID);
+            runtime.Send(MakeKqpSchedulerServiceId(runtime.GetFirstNodeId()), Sender, ev.release());
+        }
+
+        // Create test pool
+        {
+            auto ev = std::make_unique<TEvAddPool>(TEST_DATABASE_ID, TEST_POOL_ID);
+            if (readLimitMs.has_value()) {
+                ev->Params.TotalCpuLimitPercentPerNode = (*readLimitMs) / 10.;
+            }
+            runtime.Send(MakeKqpSchedulerServiceId(runtime.GetFirstNodeId()), Sender, ev.release());
+        }
+
+        InitRoot(Server, Sender);
+
+        TVector<TShardedTableOptions::TColumn> columns = {
+            {"key1", "Uint32", true, false},
+            {"key2", "Uint32", true, false},
+            {"key3", "Uint32", true, false},
+            {"value", "Uint32", false, false},
+        };
+
+        auto opts = TShardedTableOptions().Shards(1).Columns(columns);
+        auto [shards, tableId] = CreateShardedTable(Server, Sender, "/Root", "table-1", opts);
+
+        TableId = tableId;
+        TabletId = shards.at(0);
+
+        auto [tables, ownerId] = GetTables(Server, TabletId);
+        UserTable = tables["table-1"];
+
+        ClientId = runtime.ConnectToPipe(TabletId, Sender, 0, GetPipeConfigWithRetries());
+    }
+
+    void Upsert(ui32 key, ui32 value) const {
+        ExecSQL(Server, Sender, TStringBuilder()
+            << "UPSERT INTO `/Root/table-1` (key1, key2, key3, value) VALUES ("
+            << key << ", " << key << ", " << key << ", " << value << ");");
+    }
+
+    void UpsertMany(ui32 first, ui32 count) const {
+        for (ui32 i = 0; i < count; ++i) {
+            Upsert(first + i, (first + i) * 100);
+        }
+    }
+
+    std::unique_ptr<TEvDataShard::TEvRead> MakeReadRequest(ui64 readId,
+        NKikimrDataEvents::EDataFormat fmt = NKikimrDataEvents::FORMAT_CELLVEC) const
+    {
+        auto snapshot = CreateVolatileSnapshot(Server, {"/Root/table-1"}, TDuration::Hours(1));
+        auto request = GetBaseReadRequest(TableId, UserTable.GetDescription(), readId, fmt, snapshot);
+        request->Record.SetPoolId(TEST_POOL_ID);
+        return request;
+    }
+
+    std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(TEvDataShard::TEvRead* request) const {
+        return ::NKikimr::SendRead(Server, TabletId, request, Sender, 0,
+                                   GetPipeConfigWithRetries(), ClientId);
+    }
+
+    void SendReadAsync(TEvDataShard::TEvRead* request) const {
+        ::NKikimr::SendReadAsync(Server, TabletId, request, Sender, 0,
+                                  GetPipeConfigWithRetries(), ClientId);
+    }
+
+    std::unique_ptr<TEvDataShard::TEvReadResult> WaitResult(TDuration timeout = TDuration::Seconds(30)) const {
+        return WaitReadResult(Server, timeout);
+    }
+
+    void SendAck(const NKikimrTxDataShard::TEvReadResult& result, ui64 rows, ui64 bytes) {
+        auto& runtime = *Server->GetRuntime();
+        auto* ack = new TEvDataShard::TEvReadAck();
+        ack->Record.SetReadId(result.GetReadId());
+        ack->Record.SetSeqNo(result.GetSeqNo());
+        ack->Record.SetMaxRows(rows);
+        ack->Record.SetMaxBytes(bytes);
+        runtime.SendToPipe(TabletId, Sender, ack, 0, GetPipeConfigWithRetries(), ClientId);
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
+
+    // A plain key read with PoolId set must succeed when the scheduler service is present and quota is available.
+    Y_UNIT_TEST(ShouldReadWithSchedulerQuota) {
+        TSchedulerTestHelper helper; // default = unlimited quota
+        helper.Upsert(1, 100);
+
+        auto request = helper.MakeReadRequest(1);
+        AddKeyQuery(*request, {1, 1, 1});
+
+        Sleep(TDuration::Seconds(1));
+
+        auto result = helper.SendRead(request.release());
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+        // Verify row contents: key=(1,1,1), value=100
+        auto cells = result->GetCells(0);
+        UNIT_ASSERT_VALUES_EQUAL(cells.size(), 4u);
+        UNIT_ASSERT_VALUES_EQUAL(cells[3].AsValue<ui32>(), 100u);
+    }
+
+    // A range read that produces multiple continuation chunks must deliver all
+    // rows correctly when PoolId is set (quota is consumed and returned per chunk).
+    Y_UNIT_TEST(ShouldContinuationReadWithSchedulerQuota) {
+        constexpr ui32 kRows = 5;
+        TSchedulerTestHelper helper;
+        helper.UpsertMany(1, kRows);
+
+        auto request = helper.MakeReadRequest(1, NKikimrDataEvents::FORMAT_CELLVEC);
+        AddRangeQuery<ui32>(*request, {1, 1, 1}, true, {kRows, Max<ui32>(), Max<ui32>()}, true);
+        // Force one row per result so we exercise the continuation path.
+        request->Record.SetMaxRowsInResult(1);
+
+        helper.SendReadAsync(request.release());
+
+        ui32 rowsReceived = 0;
+        while (true) {
+            auto result = helper.WaitResult();
+            UNIT_ASSERT_C(result, "Timed out waiting for read result");
+            UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+            rowsReceived += result->GetRowsCount();
+            if (result->Record.GetFinished()) {
+                break;
+            }
+            helper.SendAck(result->Record, 1000, 50_MB);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(rowsReceived, kRows);
+    }
+
+    // When the pool's ReadLimit is 0 ms (quota permanently exhausted), an
+    // initial TEvRead with that PoolId must receive OVERLOADED — not a crash
+    // and not SUCCESS.
+    Y_UNIT_TEST(ShouldGetOverloadedOnInitialReadWhenQuotaExhausted) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/0u);
+        helper.Upsert(1, 100);
+
+        auto request = helper.MakeReadRequest(1);
+        AddKeyQuery(*request, {1, 1, 1});
+
+        auto result = helper.SendRead(request.release());
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::OVERLOADED);
+    }
+
+    // Verify that setting PoolId on a request against a scheduler with tight
+    // quota still delivers all rows — continuations must retry internally rather
+    // than returning OVERLOADED to the client.
+    // With ReadLimit=10 ms and in-test reads completing in ~0 ms, ReturnQuota
+    // refills the bucket immediately, so reads complete quickly.
+    Y_UNIT_TEST(ShouldCompleteContinuationReadWithTightQuota) {
+        constexpr ui32 kRows = 3;
+        // 10 ms per second = tight budget; in unit-tests reads take ~0 ms so
+        // ReturnQuota() restores almost all quota, allowing every continuation
+        // to proceed without a real delay.
+        TSchedulerTestHelper helper(/*readLimitMs=*/10u);
+        helper.UpsertMany(1, kRows);
+
+        auto request = helper.MakeReadRequest(1, NKikimrDataEvents::FORMAT_CELLVEC);
+        AddRangeQuery<ui32>(*request, {1, 1, 1}, true, {kRows, Max<ui32>(), Max<ui32>()}, true);
+        request->Record.SetMaxRowsInResult(1);
+
+        helper.SendReadAsync(request.release());
+
+        ui32 rowsReceived = 0;
+        while (true) {
+            auto result = helper.WaitResult();
+            UNIT_ASSERT_C(result, "Timed out waiting for read result");
+            // Continuations must never surface OVERLOADED to the client.
+            UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(),
+                                      Ydb::StatusIds::SUCCESS);
+            rowsReceived += result->GetRowsCount();
+            if (result->Record.GetFinished()) {
+                break;
+            }
+            helper.SendAck(result->Record, 1000, 50_MB);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(rowsReceived, kRows);
+    }
+
+    // Reads without PoolId must be unaffected by scheduler presence.
+    Y_UNIT_TEST(ShouldReadWithoutPoolIdUnaffectedByScheduler) {
+        TSchedulerTestHelper helper;
+        helper.Upsert(3, 300);
+
+        // Deliberately omit SetPoolId — quota machinery must not be invoked.
+        auto snapshot = CreateVolatileSnapshot(helper.Server, {"/Root/table-1"}, TDuration::Hours(1));
+        auto request = GetBaseReadRequest(helper.TableId, helper.UserTable.GetDescription(),
+                                          1, NKikimrDataEvents::FORMAT_CELLVEC, snapshot);
+        AddKeyQuery(*request, {3, 3, 3});
+
+        auto result = helper.SendRead(request.release());
+        UNIT_ASSERT(result);
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+    }
+
+} // Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler)
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -26,26 +26,29 @@ const TString TEST_POOL_ID = "test_pool";
 //                           Followers never request a scheduler factory themselves,
 //                           so quota is never applied on the follower regardless of
 //                           the pool settings.
+//   numShards             — Number of shards to create (default 1).
 struct TSchedulerTestHelper {
     Tests::TServer::TPtr Server;
     TActorId Sender;
 
     TTableId TableId;
-    ui64 TabletId = 0;
+    TVector<ui64> TabletIds;
     NKikimrTxDataShard::TEvGetInfoResponse::TUserTable UserTable;
 
-    // Default read target: follower pipe when withFollower=true, leader pipe otherwise.
-    TActorId ClientId;
-    // Always the leader pipe (available even when withFollower=true, for comparison tests).
-    TActorId LeaderClientId;
+    TVector<TActorId> ClientIds;
+    TVector<TActorId> LeaderClientIds;
 
     bool WithFollower = false;
 
     explicit TSchedulerTestHelper(std::optional<ui64> readLimitMs = std::nullopt,
                                   bool blockSchedulerFactory = false,
-                                  bool withFollower = false)
+                                  bool withFollower = false,
+                                  ui32 numShards = 1)
         : WithFollower(withFollower)
     {
+        Y_ABORT_UNLESS(!(withFollower && numShards > 1), "Follower mode with multiple shards not supported");
+        Y_ABORT_UNLESS(numShards >= 1, "numShards must be at least 1");
+
         using namespace NKqp;
         using namespace NKqp::NScheduler;
         using namespace NKqp::NScheduler::NHdrf;
@@ -97,26 +100,27 @@ struct TSchedulerTestHelper {
             {"key3", "Uint32", true, false},
             {"value", "Uint32", false, false},
         };
-        auto opts = TShardedTableOptions().Shards(1).Columns(columns);
+        auto opts = TShardedTableOptions().Shards(numShards).Columns(columns);
         if (withFollower) {
             opts.Followers(1);
         }
         auto [shards, tableId] = CreateShardedTable(Server, Sender, "/Root", "table-1", opts);
 
         TableId = tableId;
-        TabletId = shards.at(0);
+        TabletIds = shards;
 
-        auto [tables, ownerId] = GetTables(Server, TabletId);
+        auto [tables, ownerId] = GetTables(Server, TabletIds[0]);
         UserTable = tables["table-1"];
 
-        LeaderClientId = runtime.ConnectToPipe(TabletId, Sender, 0, GetPipeConfigWithRetries());
-
-        if (withFollower) {
-            auto followerConfig = GetPipeConfigWithRetries();
-            followerConfig.ForceFollower = true;
-            ClientId = runtime.ConnectToPipe(TabletId, Sender, 0, followerConfig);
-        } else {
-            ClientId = LeaderClientId;
+        for (ui64 tabletId : TabletIds) {
+            LeaderClientIds.push_back(runtime.ConnectToPipe(tabletId, Sender, 0, GetPipeConfigWithRetries()));
+            if (withFollower) {
+                auto followerConfig = GetPipeConfigWithRetries();
+                followerConfig.ForceFollower = true;
+                ClientIds.push_back(runtime.ConnectToPipe(tabletId, Sender, 0, followerConfig));
+            } else {
+                ClientIds.push_back(LeaderClientIds.back());
+            }
         }
 
         if (blockSchedulerFactory) {
@@ -125,6 +129,10 @@ struct TSchedulerTestHelper {
             runtime.SimulateSleep(TDuration::Seconds(2));
         }
     }
+
+    ui64 TabletId() const { return TabletIds[0]; }
+    TActorId ClientId() const { return ClientIds[0]; }
+    TActorId LeaderClientId() const { return LeaderClientIds[0]; }
 
     void Upsert(ui32 key, ui32 value) const {
         ExecSQL(Server, Sender, TStringBuilder()
@@ -146,21 +154,28 @@ struct TSchedulerTestHelper {
         return request;
     }
 
-    // Send to the default target (follower if WithFollower, leader otherwise).
-    std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(TEvDataShard::TEvRead* request) const {
-        return ::NKikimr::SendRead(Server, TabletId, request, Sender, 0,
-                                   GetPipeConfigWithRetries(), ClientId);
+    std::unique_ptr<TEvDataShard::TEvRead> MakeRangeReadRequest(ui64 readId, ui32 lo, ui32 hi, ui32 maxRowsInResult = 0, const TString& poolId = TEST_POOL_ID) const {
+        auto request = MakeReadRequest(readId, poolId);
+        AddRangeQuery<ui32>(*request, {lo, lo, lo}, true, {hi, hi, hi}, true);
+        if (maxRowsInResult > 0) {
+            request->Record.SetMaxRowsInResult(maxRowsInResult);
+        }
+        return request;
     }
 
-    // Always send to the leader (useful for leader-vs-follower comparison tests).
+    std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(TEvDataShard::TEvRead* request, ui32 shardIdx = 0) const {
+        return ::NKikimr::SendRead(Server, TabletIds[shardIdx], request, Sender, 0,
+                                   GetPipeConfigWithRetries(), ClientIds[shardIdx]);
+    }
+
     std::unique_ptr<TEvDataShard::TEvReadResult> SendReadToLeader(TEvDataShard::TEvRead* request) const {
-        return ::NKikimr::SendRead(Server, TabletId, request, Sender, 0,
-                                   GetPipeConfigWithRetries(), LeaderClientId);
+        return ::NKikimr::SendRead(Server, TabletId(), request, Sender, 0,
+                                   GetPipeConfigWithRetries(), LeaderClientId());
     }
 
-    void SendReadAsync(TEvDataShard::TEvRead* request) const {
-        ::NKikimr::SendReadAsync(Server, TabletId, request, Sender, 0,
-                                  GetPipeConfigWithRetries(), ClientId);
+    void SendReadAsync(TEvDataShard::TEvRead* request, ui32 shardIdx = 0) const {
+        ::NKikimr::SendReadAsync(Server, TabletIds[shardIdx], request, Sender, 0,
+                                  GetPipeConfigWithRetries(), ClientIds[shardIdx]);
     }
 
     std::unique_ptr<TEvDataShard::TEvReadResult> WaitResult(TDuration timeout = TDuration::Seconds(30)) const {
@@ -174,18 +189,21 @@ struct TSchedulerTestHelper {
         ack->Record.SetSeqNo(result.GetSeqNo());
         ack->Record.SetMaxRows(rows);
         ack->Record.SetMaxBytes(bytes);
-        runtime.SendToPipe(TabletId, Sender, ack, 0, GetPipeConfigWithRetries(), ClientId);
+        runtime.SendToPipe(TabletId(), Sender, ack, 0, GetPipeConfigWithRetries(), ClientId());
     }
 
-    // Register an extra pool with zero quota in the same database.
-    void AddZeroQuotaPool(const TString& poolId) const {
+    void UpdatePoolQuota(double totalCpuLimitPercentPerNode, const TString& poolId = TEST_POOL_ID) const {
         using namespace NKqp::NScheduler;
         auto& runtime = *Server->GetRuntime();
         NResourcePool::TPoolSettings params;
-        params.TotalCpuLimitPercentPerNode = 0.;
+        params.TotalCpuLimitPercentPerNode = totalCpuLimitPercentPerNode;
         auto ev = std::make_unique<TEvAddPool>(TEST_DATABASE_ID, poolId, params);
         runtime.Send(NKqp::MakeKqpSchedulerServiceId(runtime.GetFirstNodeId()), Sender, ev.release());
         runtime.SimulateSleep(TDuration::Zero());
+    }
+
+    void AddZeroQuotaPool(const TString& poolId) const {
+        UpdatePoolQuota(0., poolId);
     }
 };
 

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -141,6 +141,7 @@ struct TSchedulerTestHelper {
     std::unique_ptr<TEvDataShard::TEvRead> MakeReadRequest(ui64 readId, const TString& poolId = TEST_POOL_ID) const {
         auto snapshot = CreateVolatileSnapshot(Server, {"/Root/table-1"}, TDuration::Hours(1));
         auto request = GetBaseReadRequest(TableId, UserTable.GetDescription(), readId, NKikimrDataEvents::FORMAT_CELLVEC, snapshot);
+        request->Record.SetDatabaseId(TEST_DATABASE_ID);
         request->Record.SetPoolId(poolId);
         return request;
     }

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -194,14 +194,14 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
     // Verify that setting PoolId on a request against a scheduler with tight
     // quota still delivers all rows — continuations must retry internally rather
     // than returning OVERLOADED to the client.
-    // With ReadLimit=10 ms and in-test reads completing in ~0 ms, ReturnQuota
+    // With ReadLimit=5 ms and in-test reads completing in ~0 ms, ReturnQuota
     // refills the bucket immediately, so reads complete quickly.
     Y_UNIT_TEST(ShouldCompleteContinuationReadWithTightQuota) {
         constexpr ui32 kRows = 3;
-        // 10 ms per second = tight budget; in unit-tests reads take ~0 ms so
+        // 5 ms per second = tight budget; in unit-tests reads take ~0 ms so
         // ReturnQuota() restores almost all quota, allowing every continuation
         // to proceed without a real delay.
-        TSchedulerTestHelper helper(/*readLimitMs=*/10u);
+        TSchedulerTestHelper helper(/*readLimitMs=*/5u);
         helper.UpsertMany(1, kRows);
 
         auto request = helper.MakeReadRequest(1, NKikimrDataEvents::FORMAT_CELLVEC);
@@ -215,8 +215,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
             auto result = helper.WaitResult();
             UNIT_ASSERT_C(result, "Timed out waiting for read result");
             // Continuations must never surface OVERLOADED to the client.
-            UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(),
-                                      Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
             rowsReceived += result->GetRowsCount();
             if (result->Record.GetFinished()) {
                 break;

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -13,6 +13,19 @@ const TString TEST_DATABASE_ID = "/Root";
 const TString TEST_POOL_ID = "test_pool";
 
 // Minimal setup that sets up the scheduler BEFORE the shard is created.
+//
+// Parameters:
+//   readLimitMs           — ReadLimit for the test pool (nullopt = unlimited).
+//   blockSchedulerFactory — Drop every TEvGetReadFactory event so the leader
+//                           shard never receives a real factory from the scheduler.
+//                           The constructor then advances simulated time by 2 s to
+//                           let the shard's built-in 1-second fail-safe timer fire,
+//                           completing mediator-state init with a null factory.
+//   withFollower          — Create the table with one follower and route all
+//                           SendRead() calls through a ForceFollower pipe.
+//                           Followers never request a scheduler factory themselves,
+//                           so quota is never applied on the follower regardless of
+//                           the pool settings.
 struct TSchedulerTestHelper {
     Tests::TServer::TPtr Server;
     TActorId Sender;
@@ -20,9 +33,19 @@ struct TSchedulerTestHelper {
     TTableId TableId;
     ui64 TabletId = 0;
     NKikimrTxDataShard::TEvGetInfoResponse::TUserTable UserTable;
-    TActorId ClientId;
 
-    explicit TSchedulerTestHelper(std::optional<ui64> readLimitMs = std::nullopt) {
+    // Default read target: follower pipe when withFollower=true, leader pipe otherwise.
+    TActorId ClientId;
+    // Always the leader pipe (available even when withFollower=true, for comparison tests).
+    TActorId LeaderClientId;
+
+    bool WithFollower = false;
+
+    explicit TSchedulerTestHelper(std::optional<ui64> readLimitMs = std::nullopt,
+                                  bool blockSchedulerFactory = false,
+                                  bool withFollower = false)
+        : WithFollower(withFollower)
+    {
         using namespace NKqp;
         using namespace NKqp::NScheduler;
         using namespace NKqp::NScheduler::NHdrf;
@@ -41,13 +64,23 @@ struct TSchedulerTestHelper {
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_INFO);
         runtime.SetLogPriority(NKikimrServices::KQP_COMPUTE_SCHEDULER, NLog::PRI_TRACE);
 
-        // Create test database
+        if (blockSchedulerFactory) {
+            // Drop TEvGetReadFactory so the scheduler never sends a real factory
+            // to the leader shard.  The leader will rely on its 1-second fail-safe
+            // timer instead.  Follower shards never send this event at all, so
+            // dropping it has no effect on their behaviour.
+            runtime.SetObserverFunc([](TAutoPtr<IEventHandle>& ev) {
+                if (ev->GetTypeRewrite() == NKqp::NScheduler::TEvGetReadFactory::EventType) {
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            });
+        }
+
         {
             auto ev = std::make_unique<TEvAddDatabase>(TEST_DATABASE_ID);
             runtime.Send(MakeKqpSchedulerServiceId(runtime.GetFirstNodeId()), Sender, ev.release());
         }
-
-        // Create test pool
         {
             auto ev = std::make_unique<TEvAddPool>(TEST_DATABASE_ID, TEST_POOL_ID);
             if (readLimitMs.has_value()) {
@@ -64,8 +97,10 @@ struct TSchedulerTestHelper {
             {"key3", "Uint32", true, false},
             {"value", "Uint32", false, false},
         };
-
         auto opts = TShardedTableOptions().Shards(1).Columns(columns);
+        if (withFollower) {
+            opts.Followers(1);
+        }
         auto [shards, tableId] = CreateShardedTable(Server, Sender, "/Root", "table-1", opts);
 
         TableId = tableId;
@@ -74,7 +109,21 @@ struct TSchedulerTestHelper {
         auto [tables, ownerId] = GetTables(Server, TabletId);
         UserTable = tables["table-1"];
 
-        ClientId = runtime.ConnectToPipe(TabletId, Sender, 0, GetPipeConfigWithRetries());
+        LeaderClientId = runtime.ConnectToPipe(TabletId, Sender, 0, GetPipeConfigWithRetries());
+
+        if (withFollower) {
+            auto followerConfig = GetPipeConfigWithRetries();
+            followerConfig.ForceFollower = true;
+            ClientId = runtime.ConnectToPipe(TabletId, Sender, 0, followerConfig);
+        } else {
+            ClientId = LeaderClientId;
+        }
+
+        if (blockSchedulerFactory) {
+            // Advance simulated time past the 1-second fail-safe timer so the
+            // leader shard completes mediator-state restoration with a null factory.
+            runtime.SimulateSleep(TDuration::Seconds(2));
+        }
     }
 
     void Upsert(ui32 key, ui32 value) const {
@@ -89,18 +138,23 @@ struct TSchedulerTestHelper {
         }
     }
 
-    std::unique_ptr<TEvDataShard::TEvRead> MakeReadRequest(ui64 readId,
-        NKikimrDataEvents::EDataFormat fmt = NKikimrDataEvents::FORMAT_CELLVEC) const
-    {
+    std::unique_ptr<TEvDataShard::TEvRead> MakeReadRequest(ui64 readId, const TString& poolId = TEST_POOL_ID) const {
         auto snapshot = CreateVolatileSnapshot(Server, {"/Root/table-1"}, TDuration::Hours(1));
-        auto request = GetBaseReadRequest(TableId, UserTable.GetDescription(), readId, fmt, snapshot);
-        request->Record.SetPoolId(TEST_POOL_ID);
+        auto request = GetBaseReadRequest(TableId, UserTable.GetDescription(), readId, NKikimrDataEvents::FORMAT_CELLVEC, snapshot);
+        request->Record.SetPoolId(poolId);
         return request;
     }
 
+    // Send to the default target (follower if WithFollower, leader otherwise).
     std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(TEvDataShard::TEvRead* request) const {
         return ::NKikimr::SendRead(Server, TabletId, request, Sender, 0,
                                    GetPipeConfigWithRetries(), ClientId);
+    }
+
+    // Always send to the leader (useful for leader-vs-follower comparison tests).
+    std::unique_ptr<TEvDataShard::TEvReadResult> SendReadToLeader(TEvDataShard::TEvRead* request) const {
+        return ::NKikimr::SendRead(Server, TabletId, request, Sender, 0,
+                                   GetPipeConfigWithRetries(), LeaderClientId);
     }
 
     void SendReadAsync(TEvDataShard::TEvRead* request) const {
@@ -121,40 +175,81 @@ struct TSchedulerTestHelper {
         ack->Record.SetMaxBytes(bytes);
         runtime.SendToPipe(TabletId, Sender, ack, 0, GetPipeConfigWithRetries(), ClientId);
     }
+
+    // Register an extra pool with zero quota in the same database.
+    void AddZeroQuotaPool(const TString& poolId) const {
+        using namespace NKqp::NScheduler;
+        auto& runtime = *Server->GetRuntime();
+        NResourcePool::TPoolSettings params;
+        params.TotalCpuLimitPercentPerNode = 0.;
+        auto ev = std::make_unique<TEvAddPool>(TEST_DATABASE_ID, poolId, params);
+        runtime.Send(NKqp::MakeKqpSchedulerServiceId(runtime.GetFirstNodeId()), Sender, ev.release());
+        runtime.SimulateSleep(TDuration::Zero());
+    }
 };
 
 } // namespace
 
 Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
 
-    // A plain key read with PoolId set must succeed when the scheduler service is present and quota is available.
-    Y_UNIT_TEST(ShouldReadWithSchedulerQuota) {
-        TSchedulerTestHelper helper; // default = unlimited quota
+    // A plain key read with PoolId set must succeed when quota is available.
+    //
+    // For the leader (WithFollower=false):
+    //   additionally verifies that a zero-quota pool returns OVERLOADED, proving
+    //   that quota IS actively enforced.
+    //
+    // For the follower (WithFollower=true):
+    //   the zero-quota pool must also return SUCCESS, because followers skip the
+    //   quota machinery entirely (SchedulableReadFactory is never set on followers).
+    Y_UNIT_TEST_TWIN(ShouldReadWithSchedulerPoolId, WithFollower) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/std::nullopt,
+                                    /*blockSchedulerFactory=*/false,
+                                    /*withFollower=*/WithFollower);
         helper.Upsert(1, 100);
 
         auto request = helper.MakeReadRequest(1);
         AddKeyQuery(*request, {1, 1, 1});
-
         Sleep(TDuration::Seconds(1));
 
         auto result = helper.SendRead(request.release());
         UNIT_ASSERT(result);
         UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
-        // Verify row contents: key=(1,1,1), value=100
         auto cells = result->GetCells(0);
         UNIT_ASSERT_VALUES_EQUAL(cells.size(), 4u);
         UNIT_ASSERT_VALUES_EQUAL(cells[3].AsValue<ui32>(), 100u);
+
+        // Register a zero-quota pool and observe the difference between leader and follower.
+        const TString zeroPoolId = "zero_quota_pool";
+        helper.AddZeroQuotaPool(zeroPoolId);
+        auto zeroRequest = helper.MakeReadRequest(2, zeroPoolId);
+        AddKeyQuery(*zeroRequest, {1, 1, 1});
+        auto zeroResult = helper.SendRead(zeroRequest.release());
+        UNIT_ASSERT(zeroResult);
+
+        if constexpr (WithFollower) {
+            // Followers bypass the quota check — must still succeed.
+            UNIT_ASSERT_VALUES_EQUAL_C(zeroResult->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS,
+                "Follower must bypass quota even for a zero-quota pool");
+        } else {
+            // Leader enforces the quota — must reject the read.
+            UNIT_ASSERT_VALUES_EQUAL_C(zeroResult->Record.GetStatus().GetCode(), Ydb::StatusIds::OVERLOADED,
+                "Leader must return OVERLOADED for a zero-quota pool, proving quota is enforced");
+        }
     }
 
-    // A range read that produces multiple continuation chunks must deliver all
-    // rows correctly when PoolId is set (quota is consumed and returned per chunk).
-    Y_UNIT_TEST(ShouldContinuationReadWithSchedulerQuota) {
+    // A range read that produces multiple continuation chunks must deliver all rows
+    // correctly when PoolId is set.
+    // On the leader each chunk consumes quota and immediately returns it.
+    // On the follower quota is never consulted.
+    Y_UNIT_TEST_TWIN(ShouldContinuationReadWithSchedulerPoolId, WithFollower) {
         constexpr ui32 kRows = 5;
-        TSchedulerTestHelper helper;
+        TSchedulerTestHelper helper(/*readLimitMs=*/std::nullopt,
+                                    /*blockSchedulerFactory=*/false,
+                                    /*withFollower=*/WithFollower);
         helper.UpsertMany(1, kRows);
 
-        auto request = helper.MakeReadRequest(1, NKikimrDataEvents::FORMAT_CELLVEC);
+        auto request = helper.MakeReadRequest(1);
         AddRangeQuery<ui32>(*request, {1, 1, 1}, true, {kRows, Max<ui32>(), Max<ui32>()}, true);
         // Force one row per result so we exercise the continuation path.
         request->Record.SetMaxRowsInResult(1);
@@ -172,39 +267,53 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
             }
             helper.SendAck(result->Record, 1000, 50_MB);
         }
-
         UNIT_ASSERT_VALUES_EQUAL(rowsReceived, kRows);
     }
 
-    // When the pool's ReadLimit is 0 ms (quota permanently exhausted), an
-    // initial TEvRead with that PoolId must receive OVERLOADED — not a crash
-    // and not SUCCESS.
-    Y_UNIT_TEST(ShouldGetOverloadedOnInitialReadWhenQuotaExhausted) {
-        TSchedulerTestHelper helper(/*readLimitMs=*/0u);
+    // When the pool's ReadLimit is 0 ms (quota permanently exhausted):
+    //   leader  → OVERLOADED
+    //   follower → SUCCESS (quota bypass)
+    //
+    // The WithFollower=false case is the canonical "leader rejects exhausted quota"
+    // test.  The WithFollower=true case additionally verifies that the follower
+    // serves the same data successfully, demonstrating the bypass.
+    Y_UNIT_TEST_TWIN(ShouldReadWhenQuotaExhausted, WithFollower) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/0u,
+                                    /*blockSchedulerFactory=*/false,
+                                    /*withFollower=*/WithFollower);
         helper.Upsert(1, 100);
 
-        auto request = helper.MakeReadRequest(1);
-        AddKeyQuery(*request, {1, 1, 1});
+        // Leader must always return OVERLOADED regardless of follower mode.
+        {
+            auto request = helper.MakeReadRequest(1);
+            AddKeyQuery(*request, {1, 1, 1});
+            auto result = helper.SendReadToLeader(request.release());
+            UNIT_ASSERT(result);
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Record.GetStatus().GetCode(), Ydb::StatusIds::OVERLOADED,
+                "Leader must return OVERLOADED when quota is exhausted");
+        }
 
-        auto result = helper.SendRead(request.release());
-        UNIT_ASSERT(result);
-        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::OVERLOADED);
+        if constexpr (WithFollower) {
+            // Follower must succeed — it never checks quota.
+            auto request = helper.MakeReadRequest(2);
+            AddKeyQuery(*request, {1, 1, 1});
+            auto result = helper.SendRead(request.release());  // ForceFollower pipe
+            UNIT_ASSERT(result);
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS,
+                "Follower must succeed even when the leader's quota is exhausted");
+            UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+        }
     }
 
-    // Verify that setting PoolId on a request against a scheduler with tight
-    // quota still delivers all rows — continuations must retry internally rather
-    // than returning OVERLOADED to the client.
-    // With ReadLimit=5 ms and in-test reads completing in ~0 ms, ReturnQuota
-    // refills the bucket immediately, so reads complete quickly.
+    // Tight quota (5 ms/s) on the leader: continuations must retry internally
+    // rather than returning OVERLOADED to the client.
+    // This scenario only applies to the leader; followers are always quota-free.
     Y_UNIT_TEST(ShouldCompleteContinuationReadWithTightQuota) {
         constexpr ui32 kRows = 3;
-        // 5 ms per second = tight budget; in unit-tests reads take ~0 ms so
-        // ReturnQuota() restores almost all quota, allowing every continuation
-        // to proceed without a real delay.
         TSchedulerTestHelper helper(/*readLimitMs=*/5u);
         helper.UpsertMany(1, kRows);
 
-        auto request = helper.MakeReadRequest(1, NKikimrDataEvents::FORMAT_CELLVEC);
+        auto request = helper.MakeReadRequest(1);
         AddRangeQuery<ui32>(*request, {1, 1, 1}, true, {kRows, Max<ui32>(), Max<ui32>()}, true);
         request->Record.SetMaxRowsInResult(1);
 
@@ -214,7 +323,6 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
         while (true) {
             auto result = helper.WaitResult();
             UNIT_ASSERT_C(result, "Timed out waiting for read result");
-            // Continuations must never surface OVERLOADED to the client.
             UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
             rowsReceived += result->GetRowsCount();
             if (result->Record.GetFinished()) {
@@ -222,25 +330,55 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
             }
             helper.SendAck(result->Record, 1000, 50_MB);
         }
-
         UNIT_ASSERT_VALUES_EQUAL(rowsReceived, kRows);
     }
 
-    // Reads without PoolId must be unaffected by scheduler presence.
-    Y_UNIT_TEST(ShouldReadWithoutPoolIdUnaffectedByScheduler) {
-        TSchedulerTestHelper helper;
+    // Reads without PoolId must succeed regardless of scheduler presence or quota.
+    // True for both leader and follower.
+    Y_UNIT_TEST_TWIN(ShouldReadWithoutPoolIdUnaffectedByScheduler, WithFollower) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/std::nullopt,
+                                    /*blockSchedulerFactory=*/false,
+                                    /*withFollower=*/WithFollower);
         helper.Upsert(3, 300);
 
-        // Deliberately omit SetPoolId — quota machinery must not be invoked.
         auto snapshot = CreateVolatileSnapshot(helper.Server, {"/Root/table-1"}, TDuration::Hours(1));
         auto request = GetBaseReadRequest(helper.TableId, helper.UserTable.GetDescription(),
                                           1, NKikimrDataEvents::FORMAT_CELLVEC, snapshot);
+        // Deliberately omit SetPoolId — quota machinery must not be invoked.
         AddKeyQuery(*request, {3, 3, 3});
 
         auto result = helper.SendRead(request.release());
         UNIT_ASSERT(result);
         UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+    }
+
+    // When the datashard never receives a factory response from the scheduler
+    // (e.g. the scheduler is temporarily unavailable), it falls back to reading
+    // without quota after the built-in 1-second fail-safe timer fires.
+    // Reads with a PoolId must still succeed on both leader and follower.
+    //
+    // Note: followers never request a factory in the first place, so they are
+    // always in this "no-factory" state.  The blockSchedulerFactory flag here
+    // affects only the leader; it verifies that the leader's fallback path also
+    // works correctly.
+    Y_UNIT_TEST_TWIN(ShouldReadSuccessfullyWhenSchedulerDoesNotRespond, WithFollower) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/std::nullopt,
+                                    /*blockSchedulerFactory=*/true,
+                                    /*withFollower=*/WithFollower);
+        helper.Upsert(1, 100);
+
+        auto request = helper.MakeReadRequest(1);
+        AddKeyQuery(*request, {1, 1, 1});
+
+        auto result = helper.SendRead(request.release());
+        UNIT_ASSERT_C(result, "Expected read to succeed when scheduler did not respond");
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+
+        auto cells = result->GetCells(0);
+        UNIT_ASSERT_VALUES_EQUAL(cells.size(), 4u);
+        UNIT_ASSERT_VALUES_EQUAL(cells[3].AsValue<ui32>(), 100u);
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler)

--- a/ydb/core/tx/datashard/ut_read_iterator/ya.make
+++ b/ydb/core/tx/datashard/ut_read_iterator/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     library/cpp/getopt
     library/cpp/regex/pcre
     library/cpp/svnversion
+    ydb/core/kqp/runtime
     ydb/core/kqp/ut/common
     ydb/core/testlib/default
     ydb/core/tx
@@ -29,6 +30,7 @@ YQL_LAST_ABI_VERSION()
 SRCS(
     datashard_ut_read_iterator.cpp
     datashard_ut_read_iterator_ext_blobs.cpp
+    datashard_ut_read_iterator_scheduler.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Make sure that Compute Scheduler is created before any datashard.
- Each datashard gets SchedulableReadFactory while being initialized.
- All Kqp read actors sends PoolId via EvRead to datashard, to indicate which quota to use.
- Compute Scheduler uses time-bucket quota mechanics - each pool provides limited number of ms per second for each datashard.
- If EvRead can't acquire quota then it failes with OVERLOADED status.
- If EvReadContinue can't acquire quota then it delays it's execution via actor system message.
