### PR TITLE
NBYDB-1931 Make FreeSpace compacton strategy threshold configurable

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -41,6 +41,7 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , MaxChunksToDefragInflight(10, 1, 1000)
     , FreshCompMaxInFlightWrites(10, 1, 1000)
     , FreshCompMaxInFlightReads(10, 1, 1000)
+    , HullCompFreeSpaceThresholdPerMille(2000, 0, 100'000)
     , HullCompMaxInFlightWrites(10, 1, 1000)
     , HullCompMaxInFlightReads(20, 1, 1000)
     , HullCompFullCompPeriodSec(0, 0, 7 * 24 * 60 * 60)
@@ -397,7 +398,6 @@ void TNodeWarden::Bootstrap() {
     if (actorSystem && actorSystem->AppData<TAppData>() && actorSystem->AppData<TAppData>()->Icb) {
         const TIntrusivePtr<NKikimr::TControlBoard>& icb = actorSystem->AppData<TAppData>()->Icb;
 
-
         TControlBoard::RegisterLocalControl(EnablePutBatching, icb->BlobStorage.EnablePutBatching);
         TControlBoard::RegisterLocalControl(EnableVPatch, icb->BlobStorage.EnableVPatch);
         TControlBoard::RegisterSharedControl(EnableLocalSyncLogDataCutting, icb->VDiskControls.EnableLocalSyncLogDataCutting);
@@ -415,6 +415,7 @@ void TNodeWarden::Bootstrap() {
         TControlBoard::RegisterSharedControl(HullCompFullCompPeriodSec, icb->VDiskControls.HullCompFullCompPeriodSec);
         TControlBoard::RegisterSharedControl(HullCompThrottlerBytesRate, icb->VDiskControls.HullCompThrottlerBytesRate);
         TControlBoard::RegisterSharedControl(GarbageThresholdToRunFullCompactionPerMille, icb->VDiskControls.GarbageThresholdToRunFullCompactionPerMille);
+        TControlBoard::RegisterSharedControl(HullCompFreeSpaceThresholdPerMille, icb->VDiskControls.HullCompFreeSpaceThresholdPerMille);
         TControlBoard::RegisterSharedControl(DefragThrottlerBytesRate, icb->VDiskControls.DefragThrottlerBytesRate);
 
         TControlBoard::RegisterSharedControl(ThrottlingDryRun, icb->VDiskControls.ThrottlingDryRun);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -220,6 +220,7 @@ namespace NKikimr::NStorage {
         TControlWrapper MaxChunksToDefragInflight;
         TControlWrapper FreshCompMaxInFlightWrites;
         TControlWrapper FreshCompMaxInFlightReads;
+        TControlWrapper HullCompFreeSpaceThresholdPerMille;
         TControlWrapper HullCompMaxInFlightWrites;
         TControlWrapper HullCompMaxInFlightReads;
         TControlWrapper HullCompFullCompPeriodSec;

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -219,6 +219,7 @@ namespace NKikimr::NStorage {
             vdiskConfig->HullCompFullCompPeriodSec = HullCompFullCompPeriodSec;
             vdiskConfig->HullCompThrottlerBytesRate = HullCompThrottlerBytesRate;
             vdiskConfig->GarbageThresholdToRunFullCompactionPerMille = GarbageThresholdToRunFullCompactionPerMille;
+            vdiskConfig->HullCompFreeSpaceThresholdPerMille = HullCompFreeSpaceThresholdPerMille;
             vdiskConfig->MaxActiveCompactionsPerPDisk = MaxActiveCompactionsPerPDisk;
             vdiskConfig->DefragThrottlerBytesRate = DefragThrottlerBytesRate;
             vdiskConfig->EnableLocalSyncLogDataCutting = EnableLocalSyncLogDataCutting;

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -574,7 +574,7 @@ config:
                 ADD_ICB_CONTROL(VDiskControls.EnablePhantomFlagStorage, true, false, true, Settings.EnablePhantomFlagStorage);
                 ADD_ICB_CONTROL(VDiskControls.PhantomFlagStorageLimitPerVDiskBytes, 10'000'000, 0, 100'000'000'000, Settings.PhantomFlagStorageLimitPerVDiskBytes);
                 ADD_ICB_CONTROL(VDiskControls.EnableChunkKeeper, true, false, true, Settings.EnableChunkKeeper);
-
+                ADD_ICB_CONTROL(VDiskControls.HullCompFreeSpaceThresholdPerMille, 2000, 0, 100'000, 2000);
 #undef ADD_ICB_CONTROL
 
                 {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
@@ -38,7 +38,7 @@ namespace NKikimr {
         HullCompLevel0MaxSstsAtOnce = 8u;
         HullCompSortedPartsNum = 8u;
         HullCompLevelRateThreshold = 1.0;
-        HullCompFreeSpaceThreshold = 2.0;
+        HullCompFreeSpaceThresholdPerMille = 2000; // default ratio is 2x
         FreshCompMaxInFlightWrites = 10;
         FreshCompMaxInFlightReads = 10; // when moving huge blobs
         HullCompMaxInFlightWrites = 10;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -127,7 +127,7 @@ namespace NKikimr {
         ui32 HullCompLevel0MaxSstsAtOnce;
         ui32 HullCompSortedPartsNum;
         double HullCompLevelRateThreshold;
-        double HullCompFreeSpaceThreshold;
+        TControlWrapper HullCompFreeSpaceThresholdPerMille;
         TControlWrapper FreshCompMaxInFlightWrites;
         TControlWrapper FreshCompMaxInFlightReads;
         TControlWrapper HullCompMaxInFlightWrites;

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.cpp
@@ -109,9 +109,8 @@ namespace NKikimr {
 
     THullCtx::THullCtx(TVDiskContextPtr vctx, const TIntrusivePtr<TVDiskConfig> vcfg, ui32 chunkSize, ui32 compWorthReadSize,
             bool freshCompaction, bool gcOnlySynced, bool allowKeepFlags, bool barrierValidation, ui32 hullSstSizeInChunksFresh,
-            ui32 hullSstSizeInChunksLevel, double hullCompFreeSpaceThreshold, double hullCompReadBatchEfficiencyThreshold,
-            TDuration hullCompStorageRatioCalcPeriod, TDuration hullCompStorageRatioMaxCalcDuration,
-            ui32 hullCompLevel0MaxSstsAtOnce, ui32 hullCompSortedPartsNum)
+            ui32 hullSstSizeInChunksLevel, double hullCompReadBatchEfficiencyThreshold, TDuration hullCompStorageRatioCalcPeriod,
+            TDuration hullCompStorageRatioMaxCalcDuration, ui32 hullCompLevel0MaxSstsAtOnce, ui32 hullCompSortedPartsNum)
         : VCtx(std::move(vctx))
         , VCfg(vcfg)
         , IngressCache(TIngressCache::Create(VCtx->Top, VCtx->ShortSelfVDisk))
@@ -123,7 +122,6 @@ namespace NKikimr {
         , BarrierValidation(barrierValidation)
         , HullSstSizeInChunksFresh(hullSstSizeInChunksFresh)
         , HullSstSizeInChunksLevel(hullSstSizeInChunksLevel)
-        , HullCompFreeSpaceThreshold(hullCompFreeSpaceThreshold)
         , HullCompReadBatchEfficiencyThreshold(hullCompReadBatchEfficiencyThreshold)
         , HullCompStorageRatioCalcPeriod(hullCompStorageRatioCalcPeriod)
         , HullCompStorageRatioMaxCalcDuration(hullCompStorageRatioMaxCalcDuration)

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.h
@@ -131,7 +131,6 @@ namespace NKikimr {
         const bool BarrierValidation;
         const ui32 HullSstSizeInChunksFresh;
         const ui32 HullSstSizeInChunksLevel;
-        const double HullCompFreeSpaceThreshold;
         const double HullCompReadBatchEfficiencyThreshold;
         const TDuration HullCompStorageRatioCalcPeriod;
         const TDuration HullCompStorageRatioMaxCalcDuration;
@@ -154,7 +153,6 @@ namespace NKikimr {
                 bool barrierValidation,
                 ui32 hullSstSizeInChunksFresh,
                 ui32 hullSstSizeInChunksLevel,
-                double hullCompFreeSpaceThreshold,
                 double hullCompReadBatchEfficiencyThreshold,
                 TDuration hullCompStorageRatioCalcPeriod,
                 TDuration hullCompStorageRatioMaxCalcDuration,

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h
@@ -27,7 +27,6 @@ namespace NKikimr {
                         true,
                         1,      // HullSstSizeInChunksFresh
                         1,      // HullSstSizeInChunksLevel
-                        2.0,
                         0.5,
                         TDuration::Minutes(5),
                         TDuration::Seconds(1),

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
@@ -65,7 +65,7 @@ namespace NKikimr {
                 return action;
             }
 
-            // try to find what to compact base on storage consumption
+            // try to find what to compact based on storage consumption
             action = TStrategyFreeSpace(HullCtx, LevelSnap, Task).Select();
             if (action != ActNothing) {
                 ++HullCtx->CompactionStrategyGroup.BlobsFreeSpace();

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_space.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_space.h
@@ -74,10 +74,15 @@ namespace NKikimr {
                 {}
 
                 void Add(TLevelSstPtr &&p) {
+                    if (FreeSpaceThreshold <= 0) {
+                        return;
+                    }
+
                     TSstRatioPtr ratio = p.SstPtr->StorageRatio.Get();
                     if (ratio) {
                         const ui64 garbageHugeSize = ratio->HugeDataTotal - ratio->HugeDataKeep;
-                        const double rank = (double)garbageHugeSize / ChunkSize;
+                        // Normalize rank so that 1.0 means the configured free-space threshold is reached.
+                        const double rank = (double)garbageHugeSize / ChunkSize / FreeSpaceThreshold;
                         if (rank > Rank) {
                             LevelSstPtr = std::move(p);
                             Rank = rank;
@@ -87,7 +92,7 @@ namespace NKikimr {
                 }
 
                 bool CompactSstToFreeSpace() const {
-                    return Present && Rank > FreeSpaceThreshold;
+                    return FreeSpaceThreshold > 0 && Present && Rank >= 1.0;
                 }
 
                 TString ToString() const {
@@ -108,6 +113,16 @@ namespace NKikimr {
             EAction FreeSpace() {
                 EAction action = ActNothing;
 
+                if (HullCtx->HullCompFreeSpaceThreshold <= 0) {
+                    if (HullCtx->VCtx->ActorSystem) {
+                        LOG_DEBUG_S(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP,
+                                HullCtx->VCtx->VDiskLogPrefix
+                                << " TStrategyFreeSpace is disabled because HullCompFreeSpaceThreshold is "
+                                << HullCtx->HullCompFreeSpaceThreshold);
+                    }
+                    return ActNothing;
+                }
+
                 // find most abusing sst (which wastes space)
                 TLevelSliceSnapshot sliceSnap = LevelSnap.SliceSnap;
                 TSstIterator it(&sliceSnap);
@@ -126,7 +141,7 @@ namespace NKikimr {
                     // free space by compacting this Sst
                     LOG_INFO_S(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP,
                             HullCtx->VCtx->VDiskLogPrefix << " TStrategyFreeSpace decided to compact Ssts " << Task->CompactSsts.ToString()
-                            << " because of high garbage/data retio " << Candidate.ToString());
+                            << " because of high garbage/data ratio " << Candidate.ToString());
                     action = ActCompactSsts;
                     TUtils::SqueezeOneSst(LevelSnap.SliceSnap, Candidate.LevelSstPtr, Task->CompactSsts);
                 }

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_space.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_space.h
@@ -31,7 +31,8 @@ namespace NKikimr {
                 : HullCtx(std::move(hullCtx))
                 , LevelSnap(levelSnap)
                 , Task(task)
-                , Candidate(HullCtx->ChunkSize, HullCtx->HullCompFreeSpaceThreshold)
+                , FreeSpaceThreshold(GetCurrentFreeSpaceThreshold(*HullCtx))
+                , Candidate(HullCtx->ChunkSize, FreeSpaceThreshold)
             {}
 
             EAction Select() {
@@ -46,9 +47,9 @@ namespace NKikimr {
                     LOG_LOG(*HullCtx->VCtx->ActorSystem, action == ActNothing ? NLog::PRI_DEBUG : NLog::PRI_INFO,
                             NKikimrServices::BS_HULLCOMP,
                             VDISKP(HullCtx->VCtx->VDiskLogPrefix,
-                                "%s: FreeSpace: action# %s timeSpent# %s candidate# %s",
+                                "%s: FreeSpace: action# %s timeSpent# %s freeSpaceThreshold# %g candidate# %s",
                                 PDiskSignatureForHullDbKey<TKey>().ToString().data(),
-                                ActionToStr(action), (finishTime - startTime).ToString().data(),
+                                ActionToStr(action), (finishTime - startTime).ToString().data(), FreeSpaceThreshold,
                                 Candidate.ToString().data()));
                 }
 
@@ -56,6 +57,10 @@ namespace NKikimr {
             }
 
         private:
+            static double GetCurrentFreeSpaceThreshold(const THullCtx& hullCtx) {
+                return static_cast<double>(hullCtx.VCfg->HullCompFreeSpaceThresholdPerMille) / 1000.0;
+            }
+
             ////////////////////////////////////////////////////////////////////////
             // NHullComp::NPriv::TMostAbusingSst
             ////////////////////////////////////////////////////////////////////////
@@ -108,17 +113,18 @@ namespace NKikimr {
             TIntrusivePtr<THullCtx> HullCtx;
             const TLevelIndexSnapshot &LevelSnap;
             TTask *Task;
+            const double FreeSpaceThreshold;
             TMostAbusingSst Candidate;
 
             EAction FreeSpace() {
                 EAction action = ActNothing;
 
-                if (HullCtx->HullCompFreeSpaceThreshold <= 0) {
+                if (FreeSpaceThreshold <= 0) {
                     if (HullCtx->VCtx->ActorSystem) {
                         LOG_DEBUG_S(*HullCtx->VCtx->ActorSystem, NKikimrServices::BS_HULLCOMP,
                                 HullCtx->VCtx->VDiskLogPrefix
                                 << " TStrategyFreeSpace is disabled because HullCompFreeSpaceThreshold is "
-                                << HullCtx->HullCompFreeSpaceThreshold);
+                                << FreeSpaceThreshold);
                     }
                     return ActNothing;
                 }

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -627,7 +627,7 @@ namespace NKikimr {
                         Config->BarrierValidation,
                         Config->HullSstSizeInChunksFresh,
                         Config->HullSstSizeInChunksLevel,
-                        Config->HullCompFreeSpaceThreshold,
+                        static_cast<double>(Config->HullCompFreeSpaceThresholdPerMille) / 1000.0,
                         Config->HullCompReadBatchEfficiencyThreshold,
                         Config->HullCompStorageRatioCalcPeriod,
                         Config->HullCompStorageRatioMaxCalcDuration,

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -627,7 +627,6 @@ namespace NKikimr {
                         Config->BarrierValidation,
                         Config->HullSstSizeInChunksFresh,
                         Config->HullSstSizeInChunksLevel,
-                        static_cast<double>(Config->HullCompFreeSpaceThresholdPerMille) / 1000.0,
                         Config->HullCompReadBatchEfficiencyThreshold,
                         Config->HullCompStorageRatioCalcPeriod,
                         Config->HullCompStorageRatioMaxCalcDuration,

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
@@ -40,7 +40,7 @@ TVDiskContextPtr CreateVDiskContext(const TBlobStorageGroupInfo& info) {
 TIntrusivePtr<THullCtx> CreateHullCtx(const TBlobStorageGroupInfo& info, ui32 chunkSize, ui32 compWorthReadSize) {
     auto baseInfo = TVDiskConfig::TBaseInfo::SampleForTests();
     return MakeIntrusive<THullCtx>(CreateVDiskContext(info), MakeIntrusive<TVDiskConfig>(baseInfo), chunkSize, compWorthReadSize, true, true, true, true, 1u,
-        1u, 2.0, 0.5, TDuration::Minutes(5), TDuration::Seconds(1), 8u, 8u);
+        1u, 0.5, TDuration::Minutes(5), TDuration::Seconds(1), 8u, 8u);
 }
 
 TIntrusivePtr<THullDs> CreateHullDs(const TBlobStorageGroupInfo& info) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1701,7 +1701,7 @@ message TImmediateControlsConfig {
             MaxValue: 300,
             DefaultValue: 0 }];
         optional uint64 HullCompFreeSpaceThresholdPerMille = 41 [(ControlOptions) = {
-            Description: "Free-space compaction threshold, converted to float and divided by 1'000 before ranking SST garbage/space ratio",
+            Description: "Garbage threshold for FreeSpace compaction strategy. This value is divided by 1000 and converted to double. Zero value entirely disables the FreeSpace compaction strategy.",
             MinValue: 0,
             MaxValue: 100000,
             DefaultValue: 2000 }];

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1700,6 +1700,11 @@ message TImmediateControlsConfig {
             MinValue: 0,
             MaxValue: 300,
             DefaultValue: 0 }];
+        optional uint64 HullCompFreeSpaceThresholdPerMille = 41 [(ControlOptions) = {
+            Description: "Free-space compaction threshold, converted to float and divided by 1'000 before ranking SST garbage/space ratio",
+            MinValue: 0,
+            MaxValue: 100000,
+            DefaultValue: 2000 }];
 
         reserved 14;
         optional uint64 ThrottlingDryRun = 26 [(ControlOptions) = {


### PR DESCRIPTION
Add the `HullCompFreeSpaceThresholdPerMille` setting to get control over the garbage to free space ratio threshold to trigger the FreeSpace compaction strategy. 

### Changelog category <!-- remove all except one -->

* Improvement
