### PR TITLE
[CBO] Rename remaining types/functions in KQP CBO: Dq -> Kqp

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join.cpp
@@ -53,7 +53,7 @@ NYql::NDq::TEquiJoinCallbacks MakeCallbacks(TKqpStatsStore& kqpStats, const TOpt
 
 } // namespace
 
-NYql::NNodes::TExprBase DqRewriteEquiJoin(
+NYql::NNodes::TExprBase KqpRewriteEquiJoin(
     const NYql::NNodes::TExprBase& node,
     EHashJoinMode mode,
     bool useCBO,
@@ -63,10 +63,10 @@ NYql::NNodes::TExprBase DqRewriteEquiJoin(
     const TOptimizerHints& kqpHints)
 {
     int dummyJoinCounter = 0;
-    return DqRewriteEquiJoin(node, mode, useCBO, ctx, typeCtx, kqpStats, dummyJoinCounter, kqpHints);
+    return KqpRewriteEquiJoin(node, mode, useCBO, ctx, typeCtx, kqpStats, dummyJoinCounter, kqpHints);
 }
 
-NYql::NNodes::TExprBase DqRewriteEquiJoin(
+NYql::NNodes::TExprBase KqpRewriteEquiJoin(
     const NYql::NNodes::TExprBase& node,
     EHashJoinMode mode,
     bool useCBO,

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NKqp {
 
-NYql::NNodes::TExprBase DqRewriteEquiJoin(
+NYql::NNodes::TExprBase KqpRewriteEquiJoin(
     const NYql::NNodes::TExprBase& node,
     NYql::NDq::EHashJoinMode mode,
     bool useCBO,
@@ -15,7 +15,7 @@ NYql::NNodes::TExprBase DqRewriteEquiJoin(
     TKqpStatsStore& kqpStats,
     const TOptimizerHints& hints = {});
 
-NYql::NNodes::TExprBase DqRewriteEquiJoin(
+NYql::NNodes::TExprBase KqpRewriteEquiJoin(
     const NYql::NNodes::TExprBase& node,
     NYql::NDq::EHashJoinMode mode,
     bool useCBO,

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cbo_factory.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cbo_factory.cpp
@@ -6,7 +6,7 @@
 namespace NKikimr::NKqp {
 
 namespace {
-class TDqOptimizerFactory : public IOptimizerFactory {
+class TKqpOptimizerFactory : public IOptimizerFactory {
 public:
     virtual IOptimizerNew::TPtr MakeJoinCostBasedOptimizerNative(IProviderContext& pctx, NYql::TExprContext& ectx, const TCBOSettings& settings) const override {
       return IOptimizerNew::TPtr(MakeNativeOptimizerNew(pctx, settings, ectx, false, nullptr));
@@ -19,7 +19,7 @@ public:
 }
 
 IOptimizerFactory::TPtr MakeCBOOptimizerFactory() {
-    return std::make_shared<TDqOptimizerFactory>();
+    return std::make_shared<TKqpOptimizerFactory>();
 }
 
 }

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -24,7 +24,7 @@ using NYql::NDq::BuildAtom;
 /*
  * Collects EquiJoin inputs with statistics for cost based optimization
  */
-bool DqCollectJoinRelationsWithStats(
+bool KqpCollectJoinRelationsWithStats(
     TVector<std::shared_ptr<TRelOptimizerNode>>& rels,
     TKqpStatsStore& kqpStats,
     const TCoEquiJoin& equiJoin,
@@ -630,7 +630,7 @@ void CollectInterestingOrderingsFromJoinTree(
     YQL_CLOG(TRACE, CoreDq) << "Collected EquiJoin interesting ordering idxes: " << JoinSeq(", ", interestingOrderingIdxes);
 }
 
-TExprBase DqOptimizeEquiJoinWithCosts(
+TExprBase KqpOptimizeEquiJoinWithCosts(
     const TExprBase& node,
     TExprContext& ctx,
     TTypeAnnotationContext& typesCtx,
@@ -643,7 +643,7 @@ TExprBase DqOptimizeEquiJoinWithCosts(
     TShufflingOrderingsByJoinLabels* shufflingOrderingsByJoinLabels
 ) {
     int dummyEquiJoinCounter = 0;
-    return DqOptimizeEquiJoinWithCosts(
+    return KqpOptimizeEquiJoinWithCosts(
         node,
         ctx,
         typesCtx,
@@ -658,7 +658,7 @@ TExprBase DqOptimizeEquiJoinWithCosts(
     );
 }
 
-TExprBase DqOptimizeEquiJoinWithCosts(
+TExprBase KqpOptimizeEquiJoinWithCosts(
     const TExprBase& node,
     TExprContext& ctx,
     TTypeAnnotationContext& typesCtx,
@@ -698,7 +698,7 @@ TExprBase DqOptimizeEquiJoinWithCosts(
     // The arguments of the EquiJoin are 1..n-2, n-2 is the  join tree
     // of the EquiJoin and n-1 argument are the parameters to EquiJoin
 
-    if (!DqCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, providerCollect)){
+    if (!KqpCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, providerCollect)){
         ctx.AddWarning(
             YqlIssue(ctx.GetPosition(equiJoin.Pos()), TIssuesIds::CBO_MISSING_TABLE_STATS,
             "Cost Based Optimizer could not be applied to this query: couldn't load statistics"

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.h
@@ -11,7 +11,7 @@ namespace NKikimr::NKqp {
 using TProviderCollectFunction =
     std::function<void(TVector<std::shared_ptr<TRelOptimizerNode>>&, TStringBuf, const NYql::TExprNode::TPtr, const std::shared_ptr<TOptimizerStatistics>&)>;
 
-bool DqCollectJoinRelationsWithStats(
+bool KqpCollectJoinRelationsWithStats(
     TVector<std::shared_ptr<TRelOptimizerNode>>& rels,
     TKqpStatsStore& kqpStats,
     const NYql::NNodes::TCoEquiJoin& equiJoin,
@@ -26,7 +26,7 @@ bool DqCollectJoinRelationsWithStats(
  *
  * Then it optimizes the join tree.
 */
-NYql::NNodes::TExprBase DqOptimizeEquiJoinWithCosts(
+NYql::NNodes::TExprBase KqpOptimizeEquiJoinWithCosts(
     const NYql::NNodes::TExprBase& node,
     NYql::TExprContext& ctx,
     NYql::TTypeAnnotationContext& typesCtx,
@@ -39,7 +39,7 @@ NYql::NNodes::TExprBase DqOptimizeEquiJoinWithCosts(
     TShufflingOrderingsByJoinLabels* shufflingOrderingsByJoinLabels = nullptr
 );
 
-NYql::NNodes::TExprBase DqOptimizeEquiJoinWithCosts(
+NYql::NNodes::TExprBase KqpOptimizeEquiJoinWithCosts(
     const NYql::NNodes::TExprBase& node,
     NYql::TExprContext& ctx,
     NYql::TTypeAnnotationContext& typesCtx,

--- a/ydb/core/kqp/opt/cbo/solver/ut/kqp_cbo_ut.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/ut/kqp_cbo_ut.cpp
@@ -292,16 +292,16 @@ Y_UNIT_TEST(RelCollector) {
 
     TKqpStatsStore kqpStats;
     TVector<std::shared_ptr<TRelOptimizerNode>> rels;
-    UNIT_ASSERT(DqCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
+    UNIT_ASSERT(KqpCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
 
     kqpStats.SetStats(tables[1].Ptr()->Child(0), std::make_shared<TOptimizerStatistics>(BaseTable, 1, 1, 1));
-    UNIT_ASSERT(DqCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
+    UNIT_ASSERT(KqpCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
 
     kqpStats.SetStats(tables[0].Ptr()->Child(0), std::make_shared<TOptimizerStatistics>(BaseTable, 1, 1, 1));
     kqpStats.SetStats(tables[2].Ptr()->Child(0), std::make_shared<TOptimizerStatistics>(BaseTable, 1, 1, 1));
 
     TVector<TString> labels;
-    UNIT_ASSERT(DqCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto label, auto, auto) { labels.emplace_back(label); }) == true);
+    UNIT_ASSERT(KqpCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto label, auto, auto) { labels.emplace_back(label); }) == true);
     UNIT_ASSERT(labels.size() == 3);
     UNIT_ASSERT_STRINGS_EQUAL(labels[0], "orders");
     UNIT_ASSERT_STRINGS_EQUAL(labels[1], "customer");
@@ -320,10 +320,10 @@ Y_UNIT_TEST(RelCollectorBrokenEquiJoin) {
 
     TKqpStatsStore kqpStats;
     TVector<std::shared_ptr<TRelOptimizerNode>> rels;
-    UNIT_ASSERT(DqCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
+    UNIT_ASSERT(KqpCollectJoinRelationsWithStats(rels, kqpStats, equiJoin, [&](auto, auto, auto, auto) {}) == false);
 }
 
-void _DqOptimizeEquiJoinWithCosts(const std::function<IOptimizerNew*()>& optFactory, NYql::TExprContext& ctx) {
+void _KqpOptimizeEquiJoinWithCosts(const std::function<IOptimizerNew*()>& optFactory, NYql::TExprContext& ctx) {
     NYql::TTypeAnnotationContext typeCtx;
     TKqpStatsStore kqpStats;
     auto pos = ctx.AppendPosition({});
@@ -360,7 +360,7 @@ void _DqOptimizeEquiJoinWithCosts(const std::function<IOptimizerNew*()>& optFact
         auto rel = std::make_shared<TRelOptimizerNode>(TString(label), *stats);
         rels.push_back(rel);
     };
-    auto res = DqOptimizeEquiJoinWithCosts(equiJoin, ctx, typeCtx, kqpStats, 2, *opt, providerCollect);
+    auto res = KqpOptimizeEquiJoinWithCosts(equiJoin, ctx, typeCtx, kqpStats, 2, *opt, providerCollect);
     UNIT_ASSERT(equiJoin.Ptr() != res.Ptr());
     UNIT_ASSERT(equiJoin.Ptr()->ChildrenSize() == res.Ptr()->ChildrenSize());
     UNIT_ASSERT(equiJoin.Maybe<TCoEquiJoin>());
@@ -373,14 +373,14 @@ void _DqOptimizeEquiJoinWithCosts(const std::function<IOptimizerNew*()>& optFact
     UNIT_ASSERT_STRINGS_EQUAL(expected, resStr);
 }
 
-Y_UNIT_TEST(DqOptimizeEquiJoinWithCostsNative) {
+Y_UNIT_TEST(KqpOptimizeEquiJoinWithCostsNative) {
     NYql::TExprContext ctx;
     TBaseProviderContext pctx;
     std::function<IOptimizerNew*()> optFactory = [&]() {
         TCBOSettings settings{};
         return MakeNativeOptimizerNew(pctx, settings, ctx, false);
     };
-    _DqOptimizeEquiJoinWithCosts(optFactory, ctx);
+    _KqpOptimizeEquiJoinWithCosts(optFactory, ctx);
 }
 
 } // KqpCBO

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -213,7 +213,7 @@ protected:
         auto stats = KqpCtx.KqpStats.GetStats(node.Raw());
         TTableAliasMap* tableAliases = stats? stats->TableAliases.Get(): nullptr;
         auto opt = std::unique_ptr<IOptimizerNew>(MakeNativeOptimizerNew(providerCtx, settings, ctx, enableShuffleElimination, KqpCtx.KqpStats.ShufflingsFSM, tableAliases));
-        TExprBase output = DqOptimizeEquiJoinWithCosts(node, ctx, TypesCtx, KqpCtx.KqpStats, optLevel,
+        TExprBase output = KqpOptimizeEquiJoinWithCosts(node, ctx, TypesCtx, KqpCtx.KqpStats, optLevel,
             *opt, [](auto& rels, auto label, auto node, auto stat) {
                 rels.emplace_back(std::make_shared<TKqpRelOptimizerNode>(TString(label), *stat, node));
             },
@@ -228,7 +228,7 @@ protected:
 
     TMaybeNode<TExprBase> RewriteEquiJoin(TExprBase node, TExprContext& ctx) {
         bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->GetDefaultCostBasedOptimizationLevel()) >= 2;
-        TExprBase output = NKikimr::NKqp::DqRewriteEquiJoin(node, KqpCtx.Config->GetHashJoinMode(), useCBO, ctx, TypesCtx, KqpCtx.KqpStats, KqpCtx.JoinsCount, KqpCtx.GetOptimizerHints());
+        TExprBase output = NKikimr::NKqp::KqpRewriteEquiJoin(node, KqpCtx.Config->GetHashJoinMode(), useCBO, ctx, TypesCtx, KqpCtx.KqpStats, KqpCtx.JoinsCount, KqpCtx.GetOptimizerHints());
         DumpAppliedRule("RewriteEquiJoin", node.Ptr(), output.Ptr(), ctx);
         return output;
     }


### PR DESCRIPTION
After the forking of YQL CBO to KQP CBO some of the types and functions still had "Dq" in their name. This PR is a simple rename that fixes this inconsistency.
