### PR TITLE
Logic to build stats when the size exceeds the limit.

### DIFF
--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -370,11 +370,6 @@ public:
         const double n = simpleStats.GetCount();
         const double ndv = simpleStats.GetCountDistinct();
 
-        // if (ndv >= 0.8 * n) {
-        //     // Too many distinct values i.e. domain is close to be PK
-        //     return TPtr{};
-        // }
-
         const double cbrtN = std::cbrt(n);
         const double numBucketsEstimate = std::ceil(
             std::min(std::sqrt(n), cbrtN * n / ndv));

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -185,6 +185,7 @@ public:
         const double ndv = simpleStats.GetCountDistinct();
 
         if (ndv >= 0.8 * n) {
+            // Too many distinct values i.e. domain is close to be PK
             return TPtr{};
         }
 
@@ -369,6 +370,10 @@ public:
         const double n = simpleStats.GetCount();
         const double ndv = simpleStats.GetCountDistinct();
 
+        if (ndv >= 0.8 * n) {
+            // Too many distinct values i.e. domain is close to be PK
+            return TPtr{};
+        }
 
         const double cbrtN = std::cbrt(n);
         const double numBucketsEstimate = std::ceil(

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -370,10 +370,10 @@ public:
         const double n = simpleStats.GetCount();
         const double ndv = simpleStats.GetCountDistinct();
 
-        if (ndv >= 0.8 * n) {
-            // Too many distinct values i.e. domain is close to be PK
-            return TPtr{};
-        }
+        // if (ndv >= 0.8 * n) {
+        //     // Too many distinct values i.e. domain is close to be PK
+        //     return TPtr{};
+        // }
 
         const double cbrtN = std::cbrt(n);
         const double numBucketsEstimate = std::ceil(

--- a/ydb/core/statistics/aggregator/column_statistic_eval.cpp
+++ b/ydb/core/statistics/aggregator/column_statistic_eval.cpp
@@ -164,8 +164,11 @@ class TCMSEval : public IStage2ColumnStatisticEval {
     std::optional<ui32> Seq;
     std::unique_ptr<TCountMinSketch> IntermediateState;
 
+    // current upper limit is 8_MB per columnar statistics
+    static constexpr ui64 MAX_WIDTH = 262144;
     static constexpr ui64 MIN_WIDTH = 4096;
     static constexpr ui64 DEFAULT_DEPTH = 8;
+    static constexpr double RELATIVE_ERROR = 10;
 
 public:
     TCMSEval(ui64 width) : Width(width) {}
@@ -185,15 +188,19 @@ public:
             return TPtr{};
         }
 
-        const double c = 10;
-        const double eps = (c - 1) * (1 + std::log10(n / ndv)) / ndv;
-        const ui64 cmsWidth = std::max((ui64)MIN_WIDTH, (ui64)ceil(std::numbers::e_v<double> / eps));
+        const double eps = (RELATIVE_ERROR - 1) * (1 + std::log10(n / ndv)) / ndv;
+        ui64 cmsWidth = std::max((ui64)MIN_WIDTH, (ui64)ceil(std::numbers::e_v<double> / eps));
+        if (cmsWidth > MAX_WIDTH - 1) {
+            // to accommodate for the other class variables' memory consumption,
+            //  negative 1 from width at each depth.
+            cmsWidth = MAX_WIDTH - 1;
+        }
         return std::make_unique<TCMSEval>(cmsWidth);
     }
 
     EStatType GetType() const final { return EStatType::COUNT_MIN_SKETCH; }
 
-    size_t EstimateSize() const final { return Width * Depth * sizeof(ui32); }
+    size_t EstimateSize() const final { return TCountMinSketch::StaticSize(Width, Depth); }
 
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "CMS", Width, Depth);
@@ -263,6 +270,10 @@ private:
         };
         return NAggFuncs::TEWHAggFunc::CreateState(ColumnType.GetTypeId(), params);
     }
+
+    // current upper limit is 8_MB per columnar statistics
+    static constexpr ui32 MAX_BUCKETS = 1048576;
+    static constexpr ui32 MIN_BUCKETS = 1;
 
 public:
     TEWHEval(NScheme::TTypeInfo columnType, ui32 numBuckets, TBorder rangeStart, TBorder rangeEnd)
@@ -358,10 +369,6 @@ public:
         const double n = simpleStats.GetCount();
         const double ndv = simpleStats.GetCountDistinct();
 
-        if (ndv >= 0.8 * n) {
-            // Too many distinct values
-            return TPtr{};
-        }
 
         const double cbrtN = std::cbrt(n);
         const double numBucketsEstimate = std::ceil(
@@ -370,7 +377,10 @@ public:
             ? numBucketsEstimate
             : std::numeric_limits<ui32>::max());
         if (numBuckets == 0) {
-            numBuckets = 1;
+            numBuckets = MIN_BUCKETS;
+        } else if (numBuckets > MAX_BUCKETS - 24) {
+            // to accommodate for the other class variables' memory consumption.
+            numBuckets = MAX_BUCKETS - 24;
         }
 
         auto domainRange = GetDomainRange(
@@ -384,7 +394,7 @@ public:
 
     EStatType GetType() const final { return EStatType::EQ_WIDTH_HISTOGRAM; }
 
-    size_t EstimateSize() const final { return NumBuckets * sizeof(ui64); }
+    size_t EstimateSize() const final { return TEqWidthHistogram::GetBinarySize(NumBuckets); }
 
     void AddAggregations(const TString& columnName, TSelectBuilder& builder) final {
         Seq = builder.AddUDAFAggregation(columnName, "EWH", NumBuckets, RangeStart, RangeEnd);

--- a/ydb/core/statistics/service/ut/ut_column_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_column_statistics.cpp
@@ -203,8 +203,18 @@ Y_UNIT_TEST_SUITE(ColumnStatistics) {
                 "NearNumericLimits",
             });
 
-        UNIT_ASSERT(!responses.at(0).Success);
         UNIT_ASSERT(!responses.at(1).Success);
+
+        {
+            // Basic column
+            const auto& resp = responses.at(0);
+            UNIT_ASSERT(resp.Success);
+            const auto& histogram = resp.EqWidthHistogram.Data;
+            UNIT_ASSERT(histogram);
+            UNIT_ASSERT(histogram->GetType() == EHistogramValueType::Uint64);
+            auto estimator = TEqWidthHistogramEstimator(histogram);
+            UNIT_ASSERT_VALUES_EQUAL(estimator.EstimateLess<ui64>(5), 1);
+        }
 
         {
             // LowCardinalityInt column


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improving the logic of building columnar statistics.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adding the following logic when the calculated size of a columnar statistic exceeds the memory limit of 8MB:
"If the computed size exceeds the limit of 8MB, build statistic with a size that can fit into 8MB."
