### PR TITLE
Fix manual reassign target validation

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/donor.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/donor.cpp
@@ -100,6 +100,159 @@ Y_UNIT_TEST_SUITE(Donor) {
         UNIT_ASSERT(found);
     }
 
+    struct TManualReassignScenario {
+        ui32 GroupId;
+        NKikimrBlobStorage::TBaseConfig::TVSlot Source;
+        NKikimrBlobStorage::TBaseConfig::TPDisk SparePDisk;
+    };
+
+    TManualReassignScenario PrepareManualCrossNodeReassignScenario(TEnvironmentSetup& env) {
+        const ui32 groupId = env.GetGroups().front();
+
+        NKikimrBlobStorage::TBaseConfig baseConfig = env.FetchBaseConfig();
+        const NKikimrBlobStorage::TBaseConfig::TVSlot *source = nullptr;
+        THashSet<ui32> usedNodes;
+        for (const auto& slot : baseConfig.GetVSlot()) {
+            if (slot.GetGroupId() == groupId) {
+                usedNodes.insert(slot.GetVSlotId().GetNodeId());
+                if (!source) {
+                    source = &slot;
+                }
+            }
+        }
+        UNIT_ASSERT_C(source, "expected a source slot in the group");
+
+        const NKikimrBlobStorage::TBaseConfig::TPDisk *sparePDisk = nullptr;
+        for (const auto& pdisk : baseConfig.GetPDisk()) {
+            if (!usedNodes.contains(pdisk.GetNodeId())) {
+                sparePDisk = &pdisk;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(sparePDisk, "expected a spare PDisk on an unused node");
+
+        return {
+            .GroupId = groupId,
+            .Source = *source,
+            .SparePDisk = *sparePDisk,
+        };
+    }
+
+    NKikimrBlobStorage::TConfigResponse InvokeManualReassign(TEnvironmentSetup& env, ui32 groupId,
+            const NKikimrBlobStorage::TBaseConfig::TVSlot& slot, ui32 targetNodeId, ui32 targetPDiskId) {
+        NKikimrBlobStorage::TConfigRequest request;
+        auto *cmd = request.AddCommand()->MutableReassignGroupDisk();
+        cmd->SetGroupId(groupId);
+        cmd->SetGroupGeneration(slot.GetGroupGeneration());
+        cmd->SetFailRealmIdx(slot.GetFailRealmIdx());
+        cmd->SetFailDomainIdx(slot.GetFailDomainIdx());
+        cmd->SetVDiskIdx(slot.GetVDiskIdx());
+        auto *target = cmd->MutableTargetPDiskId();
+        target->SetNodeId(targetNodeId);
+        target->SetPDiskId(targetPDiskId);
+        return env.Invoke(request);
+    }
+
+    const NKikimrBlobStorage::TBaseConfig::TVSlot *FindSlotByLocation(const NKikimrBlobStorage::TBaseConfig& baseConfig,
+            ui32 groupId, ui32 failRealmIdx, ui32 failDomainIdx, ui32 vdiskIdx) {
+        for (const auto& slot : baseConfig.GetVSlot()) {
+            if (slot.GetGroupId() == groupId
+                    && slot.GetFailRealmIdx() == failRealmIdx
+                    && slot.GetFailDomainIdx() == failDomainIdx
+                    && slot.GetVDiskIdx() == vdiskIdx) {
+                return &slot;
+            }
+        }
+        return nullptr;
+    }
+
+    const NKikimrBlobStorage::TBaseConfig::TVSlot *FindSlotById(const NKikimrBlobStorage::TBaseConfig& baseConfig,
+            const NKikimrBlobStorage::TVSlotId& vslotId) {
+        for (const auto& slot : baseConfig.GetVSlot()) {
+            if (slot.GetVSlotId().GetNodeId() == vslotId.GetNodeId()
+                    && slot.GetVSlotId().GetPDiskId() == vslotId.GetPDiskId()
+                    && slot.GetVSlotId().GetVSlotId() == vslotId.GetVSlotId()) {
+                return &slot;
+            }
+        }
+        return nullptr;
+    }
+
+    Y_UNIT_TEST(ManualCrossNodeReassignMustKeepDonorForbiddenOnRetry) {
+        TEnvironmentSetup env{{
+            .NodeCount = 12,
+            .VDiskReplPausedAtStart = true,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+
+        env.EnableDonorMode();
+        env.CreateBoxAndPool(2, 1);
+        env.CommenceReplication();
+        env.Sim(TDuration::Seconds(30));
+
+        const auto scenario = PrepareManualCrossNodeReassignScenario(env);
+        auto response = InvokeManualReassign(env, scenario.GroupId, scenario.Source, scenario.SparePDisk.GetNodeId(),
+            scenario.SparePDisk.GetPDiskId());
+        UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+        UNIT_ASSERT_C(response.GetStatus(0).GetSuccess(), response.DebugString());
+
+        NKikimrBlobStorage::TBaseConfig baseConfig = env.FetchBaseConfig();
+        const NKikimrBlobStorage::TBaseConfig::TVSlot *acceptor = FindSlotByLocation(baseConfig, scenario.GroupId,
+            scenario.Source.GetFailRealmIdx(), scenario.Source.GetFailDomainIdx(), scenario.Source.GetVDiskIdx());
+        NKikimrBlobStorage::TBaseConfig_TVSlot_TDonorDisk donor;
+        UNIT_ASSERT_C(acceptor, "expected a donor-backed slot after the initial cross-node reassign");
+        UNIT_ASSERT_VALUES_EQUAL(acceptor->DonorsSize(), 1);
+        donor = acceptor->GetDonors(0);
+
+        const auto& acceptorId = acceptor->GetVSlotId();
+        const auto& donorId = donor.GetVSlotId();
+        UNIT_ASSERT_C(acceptorId.GetNodeId() != donorId.GetNodeId(),
+            "test requires cross-node donor relocation path");
+
+        {
+            NKikimrBlobStorage::TConfigRequest request;
+            auto *cmd = request.AddCommand()->MutableUpdateSettings();
+            cmd->AddTryToRelocateBrokenDisksLocallyFirst(true);
+            auto response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+        }
+
+        NKikimrBlobStorage::TConfigRequest request;
+        auto *cmd = request.AddCommand()->MutableReassignGroupDisk();
+        cmd->SetGroupId(scenario.GroupId);
+        cmd->SetGroupGeneration(acceptor->GetGroupGeneration());
+        cmd->SetFailRealmIdx(acceptor->GetFailRealmIdx());
+        cmd->SetFailDomainIdx(acceptor->GetFailDomainIdx());
+        cmd->SetVDiskIdx(acceptor->GetVDiskIdx());
+        auto *target = cmd->MutableTargetPDiskId();
+        target->SetNodeId(donorId.GetNodeId());
+        target->SetPDiskId(donorId.GetPDiskId());
+
+        response = env.Invoke(request);
+        UNIT_ASSERT_C(!response.GetSuccess(), response.DebugString());
+        UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+        UNIT_ASSERT_C(!response.GetStatus(0).GetSuccess(), response.DebugString());
+        UNIT_ASSERT_C(response.GetStatus(0).GetErrorDescription().Contains("Group fit error"), response.DebugString());
+
+        baseConfig = env.FetchBaseConfig();
+        bool found = false;
+        for (const auto& slot : baseConfig.GetVSlot()) {
+            const auto& slotId = slot.GetVSlotId();
+            if (slot.GetGroupId() == scenario.GroupId
+                    && slotId.GetNodeId() == acceptorId.GetNodeId()
+                    && slotId.GetPDiskId() == acceptorId.GetPDiskId()
+                    && slotId.GetVSlotId() == acceptorId.GetVSlotId()) {
+                found = true;
+                UNIT_ASSERT_VALUES_EQUAL(slot.DonorsSize(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(slot.GetDonors(0).GetVSlotId().GetNodeId(), donorId.GetNodeId());
+                UNIT_ASSERT_VALUES_EQUAL(slot.GetDonors(0).GetVSlotId().GetPDiskId(), donorId.GetPDiskId());
+                UNIT_ASSERT_VALUES_EQUAL(slot.GetDonors(0).GetVSlotId().GetVSlotId(), donorId.GetVSlotId());
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found, "acceptor slot must stay unchanged after rejected manual reassign");
+    }
+
     Y_UNIT_TEST(SkipBadDonor) {
         TEnvironmentSetup env{{
             .NodeCount = 8,

--- a/ydb/core/blobstorage/ut_blobstorage/donor.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/donor.cpp
@@ -166,18 +166,6 @@ Y_UNIT_TEST_SUITE(Donor) {
         return nullptr;
     }
 
-    const NKikimrBlobStorage::TBaseConfig::TVSlot *FindSlotById(const NKikimrBlobStorage::TBaseConfig& baseConfig,
-            const NKikimrBlobStorage::TVSlotId& vslotId) {
-        for (const auto& slot : baseConfig.GetVSlot()) {
-            if (slot.GetVSlotId().GetNodeId() == vslotId.GetNodeId()
-                    && slot.GetVSlotId().GetPDiskId() == vslotId.GetPDiskId()
-                    && slot.GetVSlotId().GetVSlotId() == vslotId.GetVSlotId()) {
-                return &slot;
-            }
-        }
-        return nullptr;
-    }
-
     Y_UNIT_TEST(ManualCrossNodeReassignMustKeepDonorForbiddenOnRetry) {
         TEnvironmentSetup env{{
             .NodeCount = 12,

--- a/ydb/core/blobstorage/ut_blobstorage/donor.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/donor.cpp
@@ -138,18 +138,18 @@ Y_UNIT_TEST_SUITE(Donor) {
         };
     }
 
-    NKikimrBlobStorage::TConfigResponse InvokeManualReassign(TEnvironmentSetup& env, ui32 groupId,
-            const NKikimrBlobStorage::TBaseConfig::TVSlot& slot, ui32 targetNodeId, ui32 targetPDiskId) {
+    NKikimrBlobStorage::TConfigResponse InvokeManualReassign(TEnvironmentSetup& env,
+            const TManualReassignScenario& scenario) {
         NKikimrBlobStorage::TConfigRequest request;
         auto *cmd = request.AddCommand()->MutableReassignGroupDisk();
-        cmd->SetGroupId(groupId);
-        cmd->SetGroupGeneration(slot.GetGroupGeneration());
-        cmd->SetFailRealmIdx(slot.GetFailRealmIdx());
-        cmd->SetFailDomainIdx(slot.GetFailDomainIdx());
-        cmd->SetVDiskIdx(slot.GetVDiskIdx());
+        cmd->SetGroupId(scenario.GroupId);
+        cmd->SetGroupGeneration(scenario.Source.GetGroupGeneration());
+        cmd->SetFailRealmIdx(scenario.Source.GetFailRealmIdx());
+        cmd->SetFailDomainIdx(scenario.Source.GetFailDomainIdx());
+        cmd->SetVDiskIdx(scenario.Source.GetVDiskIdx());
         auto *target = cmd->MutableTargetPDiskId();
-        target->SetNodeId(targetNodeId);
-        target->SetPDiskId(targetPDiskId);
+        target->SetNodeId(scenario.SparePDisk.GetNodeId());
+        target->SetPDiskId(scenario.SparePDisk.GetPDiskId());
         return env.Invoke(request);
     }
 
@@ -191,8 +191,7 @@ Y_UNIT_TEST_SUITE(Donor) {
         env.Sim(TDuration::Seconds(30));
 
         const auto scenario = PrepareManualCrossNodeReassignScenario(env);
-        auto response = InvokeManualReassign(env, scenario.GroupId, scenario.Source, scenario.SparePDisk.GetNodeId(),
-            scenario.SparePDisk.GetPDiskId());
+        auto response = InvokeManualReassign(env, scenario);
         UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
         UNIT_ASSERT_C(response.GetStatus(0).GetSuccess(), response.DebugString());
 

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -324,11 +324,21 @@ namespace NKikimr {
 
                     if (replace) {
                         auto& g = getGroup();
-                        // get the current PDisk in the desired slot and replace it with the target one; if the target
-                        // PDisk id is zero, then new PDisk will be picked up automatically
-                        g[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx] = targetPDiskId;
-                        if (State.Self.UseSelfHealLocalPolicy && it != State.ExplicitReconfigureMap.end()) {
-                            hardConstraints[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx].NodeId = vslot->VSlotId.ComprisingPDiskId().NodeId;
+                        if (targetPDiskId != TPDiskId() && IgnoreGroupSanityChecks) {
+                            // Preserve the legacy override semantics when layout correctness checks are explicitly
+                            // disabled for the whole request.
+                            g[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx] = targetPDiskId;
+                        } else {
+                            // Explicit target PDisk must go through the same allocation checks as automatically
+                            // selected candidates, so leave the slot empty and express the manual choice as a hard
+                            // constraint.
+                            g[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx] = TPDiskId();
+                            if (targetPDiskId != TPDiskId()) {
+                                hardConstraints[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx].PDiskId = targetPDiskId;
+                            } else if (State.Self.UseSelfHealLocalPolicy && it != State.ExplicitReconfigureMap.end()) {
+                                hardConstraints[vslot->RingIdx][vslot->FailDomainIdx][vslot->VDiskIdx].NodeId =
+                                    vslot->VSlotId.ComprisingPDiskId().NodeId;
+                            }
                         }
                         replacedSlots.emplace(vslot->GetShortVDiskId(), vslot->VSlotId);
                     } else {
@@ -411,12 +421,16 @@ namespace NKikimr {
                             for (const auto& [vdiskId, vslotId] : replacedSlots) {
                                 replacedDisks.emplace(vdiskId, vslotId.ComprisingPDiskId());
                             }
+                            // Retry with hard constraints must keep the full forbidden set assembled above,
+                            // including donor and VSlotsBeingDeleted exclusions, even though the soft attempt
+                            // takes ownership of `forbid`.
+                            auto forbidForRetry = forbid;
                             try {
                                 TGroupMapper::MergeTargetDiskConstraints(hardConstraints, softConstraints);
                                 AllocateOrSanitizeGroup(groupId, group, softConstraints, replacedDisks, std::move(forbid), groupSizeInUnits, requiredSpace,
                                     AllowUnusableDisks, groupInfo->BridgePileId, &TGroupGeometryInfo::AllocateGroup);
                             } catch (const TExFitGroupError& ex) {
-                                AllocateOrSanitizeGroup(groupId, group, hardConstraints, replacedDisks, std::move(forbid), groupSizeInUnits, requiredSpace,
+                                AllocateOrSanitizeGroup(groupId, group, hardConstraints, replacedDisks, std::move(forbidForRetry), groupSizeInUnits, requiredSpace,
                                     AllowUnusableDisks, groupInfo->BridgePileId, &TGroupGeometryInfo::AllocateGroup);
                             }
                         }

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -536,7 +536,8 @@ namespace NKikimr::NBsController {
                 const TPDiskInfo& pdisk,
                 const TTargetDiskConstraints& constraints
             ) {
-                return !constraints.NodeId.has_value() || constraints.NodeId.value() == pdisk.PDiskId.NodeId;
+                return (!constraints.NodeId.has_value() || constraints.NodeId.value() == pdisk.PDiskId.NodeId)
+                    && (!constraints.PDiskId.has_value() || constraints.PDiskId.value() == pdisk.PDiskId);
             }
 
             TAllocateResult AllocateWholeEntity(TAllocateDisk, TGroup& group, const TGroupConstraints& constraints, TUndoLog& undo, ui32 index, TDiskRange range,

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -79,12 +79,16 @@ namespace NKikimr {
 
             struct TTargetDiskConstraints {
                 std::optional<ui32> NodeId = std::nullopt;
+                std::optional<TPDiskId> PDiskId = std::nullopt;
             };
             using TGroupConstraintsDefinition = TGroupDefinitionBase<TTargetDiskConstraints>;
 
             static void MergeTargetDiskConstraints(const TTargetDiskConstraints& from, TTargetDiskConstraints& to) {
                 if (from.NodeId.has_value()) {
                     to.NodeId = from.NodeId;
+                }
+                if (from.PDiskId.has_value()) {
+                    to.PDiskId = from.PDiskId;
                 }
             }
             template<class T>

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -1341,6 +1341,82 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         }
     }
 
+    Y_UNIT_TEST(ManualTargetPDiskConstraint) {
+        TTestContext context(1, 1, 12, 1, 2);
+        const auto geometry = TTestContext::CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block);
+
+        TGroupMapper mapper(geometry);
+        context.PopulateGroupMapper(mapper, 8);
+
+        TGroupMapper::TGroupDefinition group;
+        const ui32 groupId = context.AllocateGroup(mapper, group);
+
+        struct TPlacement {
+            TVDiskIdShort VDisk;
+            TPDiskId PDisk;
+        };
+
+        TVector<TPlacement> placements;
+        TSet<ui32> usedNodes;
+        TGroupMapper::Traverse(group, [&](TVDiskIdShort vdiskId, TPDiskId pdiskId) {
+            placements.push_back({vdiskId, pdiskId});
+            usedNodes.insert(pdiskId.NodeId);
+        });
+
+        const size_t expectedSlots = geometry.GetNumFailRealms()
+            * geometry.GetNumFailDomainsPerFailRealm()
+            * geometry.GetNumVDisksPerFailDomain();
+        UNIT_ASSERT_VALUES_EQUAL(placements.size(), expectedSlots);
+
+        const auto source = placements.front();
+        const auto conflicting = placements[1];
+
+        std::optional<TPDiskId> invalidTarget;
+        std::optional<TPDiskId> validTarget;
+        context.IteratePDisks([&](const TPDiskId& pdiskId, const auto&) {
+            if (!invalidTarget && pdiskId.NodeId == conflicting.PDisk.NodeId && pdiskId != conflicting.PDisk) {
+                invalidTarget = pdiskId;
+            }
+            if (!validTarget && !usedNodes.count(pdiskId.NodeId)) {
+                validTarget = pdiskId;
+            }
+        });
+
+        UNIT_ASSERT(invalidTarget);
+        UNIT_ASSERT(validTarget);
+
+        auto allocateWithTarget = [&](TPDiskId target) {
+            TGroupMapper localMapper(geometry);
+            context.PopulateGroupMapper(localMapper, 8);
+
+            auto candidate = group;
+            candidate[source.VDisk.FailRealm][source.VDisk.FailDomain][source.VDisk.VDisk] = TPDiskId();
+
+            TGroupMapper::TGroupConstraintsDefinition constraints;
+            UNIT_ASSERT(geometry.ResizeGroup(constraints));
+            constraints[source.VDisk.FailRealm][source.VDisk.FailDomain][source.VDisk.VDisk].PDiskId = target;
+
+            THashMap<TVDiskIdShort, TPDiskId> replacedDisks;
+            replacedDisks.emplace(source.VDisk, source.PDisk);
+
+            TGroupMapperError error;
+            const bool success = localMapper.AllocateGroup(groupId, candidate, constraints, replacedDisks, {}, 0, 0, false,
+                TBridgePileId(), error);
+            return std::make_pair(success, candidate);
+        };
+
+        {
+            auto [success, candidate] = allocateWithTarget(*validTarget);
+            UNIT_ASSERT_C(success, "expected exact target PDisk to be allocatable");
+            UNIT_ASSERT_VALUES_EQUAL(candidate[source.VDisk.FailRealm][source.VDisk.FailDomain][source.VDisk.VDisk], *validTarget);
+        }
+
+        {
+            auto [success, candidate] = allocateWithTarget(*invalidTarget);
+            UNIT_ASSERT_C(!success, "target on an already occupied node must be rejected");
+        }
+    }
+
     Y_UNIT_TEST(SanitizeGroupTest3dc) {
         const ui32 numDataCenters = 3;
         const ui32 numRacks = 5;

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -565,6 +565,49 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
 
     Y_UNIT_TEST(ReassignGroupDisk) {
         const ui32 numNodes = 12;
+        const ui32 numGroups = 8;
+        TEnvironmentSetup env(numNodes, 1);
+
+        RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
+            TFinalizer finalizer(env);
+            env.Prepare(dispatchName, setup, outActiveZone);
+
+            NKikimrBlobStorage::TConfigRequest request;
+            NKikimrBlobStorage::TConfigResponse response;
+
+            auto invoke = [&] {
+                response = env.Invoke(std::exchange(request, {}));
+                auto fmt = [&] {
+                    google::protobuf::TextFormat::Printer p;
+                    p.SetSingleLineMode(true);
+                    TString s;
+                    p.PrintToString(response, &s);
+                    return s;
+                };
+                Cerr << Sprintf("Response# %s", fmt().data());
+            };
+
+            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}}, env.GetNodes(), request);
+            env.DefineStoragePool(1, 1, "storage pool", numGroups, NKikimrBlobStorage::ROT, {}, request);
+
+            invoke();
+
+            auto *cmd = request.AddCommand()->MutableUpdateDriveStatus();
+            cmd->MutableHostKey()->SetNodeId(1);
+            cmd->SetPath("/dev/disk");
+            cmd->SetStatus(NKikimrBlobStorage::INACTIVE);
+
+            invoke();
+
+            auto *cmd2 = request.AddCommand()->MutableReassignGroupDisk();
+            cmd2->SetGroupId(2147483649);
+            cmd2->SetGroupGeneration(1);
+            cmd2->SetFailDomainIdx(3);
+        });
+    }
+
+    Y_UNIT_TEST(ReassignGroupDiskRejectsInvalidManualTarget) {
+        const ui32 numNodes = 12;
         const ui32 numGroups = 1;
         TEnvironmentSetup env(numNodes, 1);
 

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -21,6 +21,8 @@
 
 #include <google/protobuf/text_format.h>
 
+#include <optional>
+
 using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NBsController;
@@ -563,7 +565,7 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
 
     Y_UNIT_TEST(ReassignGroupDisk) {
         const ui32 numNodes = 12;
-        const ui32 numGroups = 8;
+        const ui32 numGroups = 1;
         TEnvironmentSetup env(numNodes, 1);
 
         RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
@@ -571,36 +573,189 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
             env.Prepare(dispatchName, setup, outActiveZone);
 
             NKikimrBlobStorage::TConfigRequest request;
-            NKikimrBlobStorage::TConfigResponse response;
-
-            auto invoke = [&] {
-                response = env.Invoke(std::exchange(request, {}));
-                auto fmt = [&] {
-                    google::protobuf::TextFormat::Printer p;
-                    p.SetSingleLineMode(true);
-                    TString s;
-                    p.PrintToString(response, &s);
-                    return s;
-                };
-                Cerr << Sprintf("Response# %s", fmt().data());
+            env.DefineBox(1, "box", {
+                {"/dev/disk1", NKikimrBlobStorage::ROT, false, false, 0},
+                {"/dev/disk2", NKikimrBlobStorage::ROT, false, false, 0},
+            }, env.GetNodes(), request);
+            env.DefineStoragePool(1, 1, "storage pool", numGroups, NKikimrBlobStorage::ROT, {}, request);
+            auto invoke = [&](NKikimrBlobStorage::TConfigRequest req) {
+                auto response = env.Invoke(req);
+                google::protobuf::TextFormat::Printer printer;
+                printer.SetSingleLineMode(true);
+                TString text;
+                printer.PrintToString(response, &text);
+                Cerr << "Response# " << text << Endl;
+                return response;
             };
 
-            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}}, env.GetNodes(), request);
-            env.DefineStoragePool(1, 1, "storage pool", numGroups, NKikimrBlobStorage::ROT, {}, request);
+            NKikimrBlobStorage::TConfigResponse response = invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
 
-            invoke();
+            auto queryBaseConfig = [&] {
+                NKikimrBlobStorage::TConfigRequest query;
+                query.AddCommand()->MutableQueryBaseConfig();
+                NKikimrBlobStorage::TConfigResponse resp = invoke(query);
+                UNIT_ASSERT_C(resp.GetSuccess(), resp.GetErrorDescription());
+                UNIT_ASSERT(resp.GetStatus(0).GetSuccess());
+                return resp.GetStatus(0).GetBaseConfig();
+            };
 
-            auto *cmd = request.AddCommand()->MutableUpdateDriveStatus();
-            cmd->MutableHostKey()->SetNodeId(1);
-            cmd->SetPath("/dev/disk");
-            cmd->SetStatus(NKikimrBlobStorage::INACTIVE);
+            struct TVSlotPlacement {
+                ui32 NodeId = 0;
+                ui32 PDiskId = 0;
+                ui32 FailRealmIdx = 0;
+                ui32 FailDomainIdx = 0;
+                ui32 VDiskIdx = 0;
+            };
 
-            invoke();
+            auto getGroupSlots = [](const NKikimrBlobStorage::TBaseConfig& baseConfig, ui32 groupId) {
+                TMap<TVSlotId, const NKikimrBlobStorage::TBaseConfig::TVSlot*> slotsById;
+                for (const auto& vslot : baseConfig.GetVSlot()) {
+                    slotsById.emplace(TVSlotId(vslot.GetVSlotId()), &vslot);
+                }
 
-            auto *cmd2 = request.AddCommand()->MutableReassignGroupDisk();
-            cmd2->SetGroupId(2147483649);
-            cmd2->SetGroupGeneration(1);
-            cmd2->SetFailDomainIdx(3);
+                const NKikimrBlobStorage::TBaseConfig::TGroup *group = nullptr;
+                for (const auto& item : baseConfig.GetGroup()) {
+                    if (item.GetGroupId() == groupId) {
+                        group = &item;
+                        break;
+                    }
+                }
+                UNIT_ASSERT(group);
+
+                TVector<TVSlotPlacement> res;
+                for (const auto& vslotIdProto : group->GetVSlotId()) {
+                    const auto it = slotsById.find(TVSlotId(vslotIdProto));
+                    UNIT_ASSERT(it != slotsById.end());
+                    const auto& vslot = *it->second;
+                    TVSlotPlacement placement;
+                    placement.NodeId = vslot.GetVSlotId().GetNodeId();
+                    placement.PDiskId = vslot.GetVSlotId().GetPDiskId();
+                    placement.FailRealmIdx = vslot.GetFailRealmIdx();
+                    placement.FailDomainIdx = vslot.GetFailDomainIdx();
+                    placement.VDiskIdx = vslot.GetVDiskIdx();
+                    res.push_back(placement);
+                }
+                return res;
+            };
+
+            auto findSlot = [](const TVector<TVSlotPlacement>& slots, ui32 failRealmIdx, ui32 failDomainIdx, ui32 vdiskIdx) {
+                for (const auto& slot : slots) {
+                    if (slot.FailRealmIdx == failRealmIdx
+                            && slot.FailDomainIdx == failDomainIdx
+                            && slot.VDiskIdx == vdiskIdx) {
+                        return slot;
+                    }
+                }
+                UNIT_ASSERT_C(false, "requested slot not found");
+                return TVSlotPlacement{};
+            };
+
+            const auto baseConfig = queryBaseConfig();
+            UNIT_ASSERT(!baseConfig.GetGroup().empty());
+            const auto& group = baseConfig.GetGroup(0);
+            const ui32 groupId = group.GetGroupId();
+            const ui32 groupGeneration = group.GetGroupGeneration();
+            const auto slots = getGroupSlots(baseConfig, groupId);
+            UNIT_ASSERT_VALUES_EQUAL(slots.size(), 8);
+
+            auto describeResponse = [](const NKikimrBlobStorage::TConfigResponse& response) {
+                return TStringBuilder()
+                    << "success# " << response.GetSuccess()
+                    << " error# " << response.GetErrorDescription()
+                    << " debug# " << response.DebugString();
+            };
+
+            auto findAlternatePDiskOnNode = [&](ui32 nodeId, ui32 excludePDiskId) -> std::optional<NKikimrBlobStorage::TPDiskId> {
+                for (const auto& pdisk : baseConfig.GetPDisk()) {
+                    if (pdisk.GetNodeId() == nodeId && pdisk.GetPDiskId() != excludePDiskId) {
+                        NKikimrBlobStorage::TPDiskId target;
+                        target.SetNodeId(pdisk.GetNodeId());
+                        target.SetPDiskId(pdisk.GetPDiskId());
+                        return target;
+                    }
+                }
+                return std::nullopt;
+            };
+
+            auto findInvalidTargetForSlot = [&](const TVSlotPlacement& sourceSlot,
+                    const TVector<TVSlotPlacement>& currentSlots) {
+                const auto& conflictingNodeSlot = currentSlots[1].NodeId == sourceSlot.NodeId ? currentSlots[2] : currentSlots[1];
+                auto invalidTarget = findAlternatePDiskOnNode(conflictingNodeSlot.NodeId, conflictingNodeSlot.PDiskId);
+                UNIT_ASSERT(invalidTarget);
+                return *invalidTarget;
+            };
+
+            auto reassignWithTarget = [&](const TVSlotPlacement& sourceSlot, const NKikimrBlobStorage::TPDiskId& target,
+                    std::function<void(NKikimrBlobStorage::TConfigRequest&)> configureRequest = {}) {
+                NKikimrBlobStorage::TConfigRequest req;
+                if (configureRequest) {
+                    configureRequest(req);
+                }
+                auto *cmd = req.AddCommand()->MutableReassignGroupDisk();
+                cmd->SetGroupId(groupId);
+                cmd->SetGroupGeneration(groupGeneration);
+                cmd->SetFailRealmIdx(sourceSlot.FailRealmIdx);
+                cmd->SetFailDomainIdx(sourceSlot.FailDomainIdx);
+                cmd->SetVDiskIdx(sourceSlot.VDiskIdx);
+                cmd->MutableTargetPDiskId()->CopyFrom(target);
+                return invoke(req);
+            };
+
+            const auto failedSlot = slots.front();
+            const auto source = slots[1].NodeId != failedSlot.NodeId ? slots[1] : slots[2];
+            const auto invalidTarget = findInvalidTargetForSlot(source, slots);
+            TString failedPath;
+            for (const auto& pdisk : baseConfig.GetPDisk()) {
+                if (pdisk.GetNodeId() == failedSlot.NodeId && pdisk.GetPDiskId() == failedSlot.PDiskId) {
+                    failedPath = pdisk.GetPath();
+                    break;
+                }
+            }
+            UNIT_ASSERT(failedPath);
+
+            request.Clear();
+            auto *statusCmd = request.AddCommand()->MutableUpdateDriveStatus();
+            statusCmd->MutableHostKey()->SetNodeId(failedSlot.NodeId);
+            statusCmd->SetPath(failedPath);
+            statusCmd->SetStatus(NKikimrBlobStorage::INACTIVE);
+            response = invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+
+            response = reassignWithTarget(source, invalidTarget);
+            UNIT_ASSERT_C(!response.GetSuccess(), describeResponse(response));
+            UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+            UNIT_ASSERT_C(!response.GetStatus(0).GetSuccess(), describeResponse(response));
+            UNIT_ASSERT_C(response.GetStatus(0).GetErrorDescription().Contains("Group fit error"),
+                describeResponse(response));
+
+            const auto afterFailedReassign = queryBaseConfig();
+            const auto unchanged = findSlot(getGroupSlots(afterFailedReassign, groupId),
+                source.FailRealmIdx, source.FailDomainIdx, source.VDiskIdx);
+            UNIT_ASSERT_VALUES_EQUAL(unchanged.NodeId, source.NodeId);
+            UNIT_ASSERT_VALUES_EQUAL(unchanged.PDiskId, source.PDiskId);
+            response = reassignWithTarget(source, invalidTarget, [](NKikimrBlobStorage::TConfigRequest& req) {
+                req.SetIgnoreGroupSanityChecks(true);
+            });
+            UNIT_ASSERT_C(!response.GetSuccess(), describeResponse(response));
+            UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+            UNIT_ASSERT_C(response.GetStatus(0).GetErrorDescription().Contains("Group may lose data"),
+                describeResponse(response));
+
+            response = reassignWithTarget(source, invalidTarget, [](NKikimrBlobStorage::TConfigRequest& req) {
+                req.SetIgnoreGroupSanityChecks(true);
+                req.SetIgnoreGroupFailModelChecks(true);
+            });
+            UNIT_ASSERT_C(response.GetSuccess(), describeResponse(response));
+            UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+            UNIT_ASSERT_C(response.GetStatus(0).GetSuccess(), describeResponse(response));
+            UNIT_ASSERT_VALUES_EQUAL(response.GetStatus(0).ReassignedItemSize(), 1);
+
+            const auto afterIgnoredSanity = queryBaseConfig();
+            const auto moved = findSlot(getGroupSlots(afterIgnoredSanity, groupId),
+                source.FailRealmIdx, source.FailDomainIdx, source.VDiskIdx);
+            UNIT_ASSERT_VALUES_EQUAL(moved.NodeId, invalidTarget.GetNodeId());
+            UNIT_ASSERT_VALUES_EQUAL(moved.PDiskId, invalidTarget.GetPDiskId());
         });
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implemented validation for manual VDisk reassignment when the target destination is specified explicitly.
Added tests to cover invalid manual targets.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
