### PR TITLE
Speed up tests for truncate table

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
@@ -7,8 +7,6 @@
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/subdomain.h>
 
-#include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
-
 namespace {
 
 using namespace NKikimr;

--- a/ydb/core/tx/schemeshard/ut_truncate_table_simple/ya.make
+++ b/ydb/core/tx/schemeshard/ut_truncate_table_simple/ya.make
@@ -1,5 +1,7 @@
 UNITTEST_FOR(ydb/core/tx/schemeshard)
 
+FORK_SUBTESTS()
+
 PEERDIR(
     ydb/core/kqp/ut/common
     ydb/core/testlib/default


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

There are flapping tests for truncate: [first](https://github.com/orgs/ydb-platform/projects/32/views/4?pane=issue&itemId=175220457&issue=ydb-platform%7Cydb%7C38001), [second](https://github.com/orgs/ydb-platform/projects/32/views/4?pane=issue&itemId=175219489&issue=ydb-platform%7Cydb%7C38000)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
