### PR TITLE
DataShard: compute the max lag across both DataTx and WriteTx for TxCompleteLag metric

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3071,7 +3071,7 @@ bool TDataShard::CheckDataTxReject(const TString& opDescr,
     }
 
     ui64 txInfly = TxInFly();
-    TDuration lag = GetDataTxCompleteLag();
+    TDuration lag = GetTxCompleteLag();
     if (txInfly > 1 && lag > TDuration::MilliSeconds(MaxTxLagMilliseconds)) {
         reject = true;
         rejectReasons |= ERejectReasons::OverloadByLag;
@@ -4037,11 +4037,11 @@ void TDataShard::DoPeriodicTasks(TEvPrivate::TEvPeriodicWakeup::TPtr&, const TAc
 }
 
 void TDataShard::UpdateLagCounters(const TActorContext &ctx) {
-    TDuration dataTxCompleteLag = GetDataTxCompleteLag();
-    TabletCounters->Simple()[COUNTER_TX_COMPLETE_LAG].Set(dataTxCompleteLag.MilliSeconds());
-    if (dataTxCompleteLag > TDuration::Minutes(5)) {
+    TDuration txCompleteLag = GetTxCompleteLag();
+    TabletCounters->Simple()[COUNTER_TX_COMPLETE_LAG].Set(txCompleteLag.MilliSeconds());
+    if (txCompleteLag > TDuration::Minutes(5)) {
         LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD,
-                   "Tx completion lag (" << dataTxCompleteLag << ") is > 5 min on tablet "
+                   "Tx completion lag (" << txCompleteLag << ") is > 5 min on tablet "
                    << TabletID());
     }
 

--- a/ydb/core/tx/datashard/datashard__monitoring.cpp
+++ b/ydb/core/tx/datashard/datashard__monitoring.cpp
@@ -109,7 +109,7 @@ void TDataShard::Handle(TEvDataShard::TEvGetInfoRequest::TPtr& ev) {
     activities.SetLastCompletedStep(Pipeline.GetLastCompleteTx().Step);
     activities.SetUtmostCompletedTx(Pipeline.GetUtmostCompleteTx().TxId);
     activities.SetUtmostCompletedStep(Pipeline.GetUtmostCompleteTx().Step);
-    activities.SetDataTxCompleteLag(GetDataTxCompleteLag().MilliSeconds());
+    activities.SetDataTxCompleteLag(GetTxCompleteLag().MilliSeconds());
     activities.SetScanTxCompleteLag(GetScanTxCompleteLag().MilliSeconds());
 
     auto& pcfg = *response->Record.MutablePipelineConfig();

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1470,10 +1470,10 @@ class TDataShard
     void DoPeriodicTasks(const TActorContext &ctx);
     void DoPeriodicTasks(TEvPrivate::TEvPeriodicWakeup::TPtr&, const TActorContext &ctx);
 
-    TDuration GetDataTxCompleteLag()
+    TDuration GetTxCompleteLag()
     {
         ui64 mediatorTime = MediatorTimeCastEntry ? MediatorTimeCastEntry->Get(TabletID()) : 0;
-        return TDuration::MilliSeconds(Pipeline.GetDataTxCompleteLag(mediatorTime));
+        return TDuration::MilliSeconds(Pipeline.GetTxCompleteLag(mediatorTime));
     }
     TDuration GetScanTxCompleteLag()
     {

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1211,9 +1211,11 @@ ui64 TPipeline::GetTxCompleteLag(EOperationKind kind, ui64 timecastStep) const
     return 0;
 }
 
-ui64 TPipeline::GetDataTxCompleteLag(ui64 timecastStep) const
+ui64 TPipeline::GetTxCompleteLag(ui64 timecastStep) const
 {
-    return GetTxCompleteLag(EOperationKind::DataTx, timecastStep);
+    return Max(
+        GetTxCompleteLag(EOperationKind::DataTx, timecastStep),
+        GetTxCompleteLag(EOperationKind::WriteTx, timecastStep));
 }
 
 ui64 TPipeline::GetScanTxCompleteLag(ui64 timecastStep) const

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -153,7 +153,7 @@ public:
     TStepOrder GetUtmostCompleteTx() const { return UtmostCompleteTx; }
 
     ui64 GetTxCompleteLag(EOperationKind kind, ui64 timecastStep) const;
-    ui64 GetDataTxCompleteLag(ui64 timecastStep) const;
+    ui64 GetTxCompleteLag(ui64 timecastStep) const;
     ui64 GetScanTxCompleteLag(ui64 timecastStep) const;
 
     // schema ops


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

EvWrite which has a WriteTx type can be used instead of EvProposeTransaction with a DataTx type. Therefore, we need to calculate  the CompleteLag not only for the DataTx, but also for the WriteTx.
