### PR TITLE
fix for error handling flow in wrtite_mode: pbufferReplication

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -520,8 +520,9 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
             lsn,
             TBlockRange64::WithLength(0, range.Size()),
             range,
-            locationMask.OnlyDDisk() ? TRangeLock(this, range, locationMask)
-                                     : TRangeLock(this, lsn));
+            locationMask.OnlyDDiskAndNotEmpty()
+                ? TRangeLock(this, range, locationMask)
+                : TRangeLock(this, lsn));
     };
 
     if (!Inflight.HasOverlaps(range)) {
@@ -648,6 +649,10 @@ void TBlocksDirtyMap::WriteFinished(
 {
     Y_ABORT_UNLESS(requested.OnlyPBuffer());
     Y_ABORT_UNLESS(confirmed.OnlyPBuffer());
+
+    if (confirmed.Count() < QuorumDirectBlockGroupHostCount) {
+        return;
+    }
 
     const bool inserted = Inflight.AddRange(
         lsn,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.cpp
@@ -321,7 +321,12 @@ bool TLocationMask::HasDDisk() const
 
 bool TLocationMask::OnlyDDisk() const
 {
-    return (Mask != 0) && ((Mask & AllDDisks) == Mask);
+    return (Mask & AllDDisks) == Mask;
+}
+
+bool TLocationMask::OnlyDDiskAndNotEmpty() const
+{
+    return (Mask != 0) && OnlyDDisk();
 }
 
 bool TLocationMask::HasPBuffer() const
@@ -331,7 +336,12 @@ bool TLocationMask::HasPBuffer() const
 
 bool TLocationMask::OnlyPBuffer() const
 {
-    return (Mask != 0) && (Mask & AllPBuffers) == Mask;
+    return (Mask & AllPBuffers) == Mask;
+}
+
+bool TLocationMask::OnlyPBufferAndNotEmpty() const
+{
+    return (Mask != 0) && OnlyPBuffer();
 }
 
 std::optional<ELocation> TLocationMask::GetLocation(size_t tryNumber) const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.h
@@ -152,8 +152,10 @@ public:
     [[nodiscard]] size_t Count() const;
     [[nodiscard]] bool HasDDisk() const;
     [[nodiscard]] bool OnlyDDisk() const;
+    [[nodiscard]] bool OnlyDDiskAndNotEmpty() const;
     [[nodiscard]] bool HasPBuffer() const;
     [[nodiscard]] bool OnlyPBuffer() const;
+    [[nodiscard]] bool OnlyPBufferAndNotEmpty() const;
     [[nodiscard]] std::optional<ELocation> GetLocation(size_t tryNumber) const;
 
     bool operator==(const TLocationMask& other) const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location_ut.cpp
@@ -51,8 +51,8 @@ Y_UNIT_TEST_SUITE(TLocationTest)
         UNIT_ASSERT_VALUES_EQUAL(0, mask.Count());
         UNIT_ASSERT(!mask.HasDDisk());
         UNIT_ASSERT(!mask.HasPBuffer());
-        UNIT_ASSERT(!mask.OnlyDDisk());
-        UNIT_ASSERT(!mask.OnlyPBuffer());
+        UNIT_ASSERT(!mask.OnlyDDiskAndNotEmpty());
+        UNIT_ASSERT(!mask.OnlyPBufferAndNotEmpty());
     }
 
     Y_UNIT_TEST(TestLocationMaskMakePBuffer)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Изменил поток обработки ошибки записи.
теперь не падаем на ассерте, а передаем ошибку клиенту.
...
