### PR TITLE
MLP: send blocked hashes to support FIFO reading after partition split

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -439,11 +439,11 @@ void TConsumerActor::UpdateChildPartitionsOnCommit() {
     }
     bool update = false;
     if (LastCommittedOffset == PartitionEndOffset) {
-        update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::ParentDone, Storage->GetMetrics().InflightMessageCount);
+        update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Done, Storage->GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents());
     }
     if (!update) {
         if (PartitionEndOffset <= Storage->GetLastOffset()) {
-            update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetMetrics().InflightMessageCount);
+            update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents());
         }
     }
     if (update) {
@@ -699,6 +699,9 @@ void TConsumerActor::ProcessEventQueue() {
         const NKikimrPQ::TEvMLPUpdateExternalLockedMessageGroupsId& record = ev->Get()->Record;
         auto updateResult = Storage->UpdateExternalLockedMessageGroupsId(record.GetUpdate());
         LOG_D("UpdateExternalLockedMessageGroupsId: " << "Applied=" << updateResult.Applied << ", " << "Invalid=" << updateResult.Invalid << ", " << "ModeChanged=" << updateResult.ModeChanged << ", " << "SetChanged=" << updateResult.SetChanged << ", " << "VersionChanged=" << updateResult.VersionChanged << "; " << ShortDebugString(record.GetUpdate()));
+        if (updateResult.Applied) {
+            ChildPartitionsOrderManager.SetSendFullStateToAll(updateResult.ModeChanged ? TChildPartitionsOrderManager::ESendReasons::ParentChange : TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents());
+        }
     }
     UpdateExternalLockedMessageGroupsIdRequestsQueue.clear();
 
@@ -1140,7 +1143,7 @@ void TConsumerActor::UpdateLockedGroupsIdInChildPartitions(bool force) {
     const NKikimrPQ::ETopicPartitionStatus status = partitionConfig.GetStatus();
     Y_ASSERT(status != ETopicPartitionStatus::Active);
     const bool almostAllRead = (PartitionEndOffset <= Storage->GetLastOffset());
-    const bool allRead = almostAllRead && (Storage->GetMessageCount() == 0);
+    const bool allRead = almostAllRead && (Storage->GetMessageCount() == 0) && Storage->ReadWithKeepOrder() == EReadWithKeepOrder::READ_WITH_KEEP_ORDER_ALLOW_ALL;
     const EReadWithKeepOrder childMode = allRead
         ? EReadWithKeepOrder::READ_WITH_KEEP_ORDER_ALLOW_ALL
         : almostAllRead && ChildPartitionsOrderManager.EnableSendFullBlacklist
@@ -1162,9 +1165,13 @@ void TConsumerActor::UpdateLockedGroupsIdInChildPartitions(bool force) {
         update->SetMode(childMode);
         if (childMode == EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
             auto* list = update->MutableFullBlacklist();
-            for (ui32 lockedHash : Storage->GetMessageGroupsIdFromSelfAndParent()) {
+            auto append = [list](ui32 lockedHash) {
                 list->AddParentLockedMessageGroupsIdHash(lockedHash);
+            };
+            for (ui32 lockedHash : Storage->GetMessageGroupsIdFromSelf()) {
+                append(lockedHash);
             }
+            Storage->IterateMessageGroupsIdExclusiveFromParent(append);
         }
         LOG_D("UpdateLockedGroupsIdInChildPartitions: updating child partition " << childPartitionId << "; reason=" << state.SendFullStateReasonsAsString() << "; update=" << ShortDebugString(record));
         auto forward = std::make_unique<TEvPipeCache::TEvForward>(ev.release(), state.TabletId, true, state.Cookie);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -434,13 +434,18 @@ void TConsumerActor::CommitIfNeeded() {
 }
 
 void TConsumerActor::UpdateChildPartitionsOnCommit() {
-    if (LastCommittedOffset != PartitionEndOffset) {
-        return;
-    }
     if (GetPartitionConfig().GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active) {
         return;
     }
-    bool update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::ParentDone);
+    bool update = false;
+    if (LastCommittedOffset == PartitionEndOffset) {
+        update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::ParentDone, Storage->GetMetrics().InflightMessageCount);
+    }
+    if (!update) {
+        if (PartitionEndOffset <= Storage->GetLastOffset()) {
+           update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetMetrics().InflightMessageCount);
+        }
+    }
     if (update) {
         UpdateLockedGroupsIdInChildPartitions(false);
     }
@@ -1113,7 +1118,7 @@ bool TConsumerActor::EnumerateChildrenPartitionsWithKeepOrder() {
         ChildPartitionsOrderManager.ChildrenPartitionWithKeepOrder[childPartitionId] = TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder{
             .TabletId = childTabletId,
             .Cookie = ChildrenPartitionWithKeepOrderCookie++,
-            .SendFullStateReasons = TChildPartitionsOrderManager::ESendReasons::Initial,
+            .SendReasons = {.Reasons = TChildPartitionsOrderManager::ESendReasons::Initial},
         };
     }
     return !ChildPartitionsOrderManager.Empty();
@@ -1134,9 +1139,12 @@ void TConsumerActor::UpdateLockedGroupsIdInChildPartitions(bool force) {
     const auto& partitionConfig = GetPartitionConfig();
     const NKikimrPQ::ETopicPartitionStatus status = partitionConfig.GetStatus();
     Y_ASSERT(status != ETopicPartitionStatus::Active);
-    const bool allRead = (PartitionEndOffset <= Storage->GetLastOffset()) && (Storage->GetMessageCount() == 0);
+    const bool almostAllRead = (PartitionEndOffset <= Storage->GetLastOffset());
+    const bool allRead = almostAllRead && (Storage->GetMessageCount() == 0);
     const EReadWithKeepOrder childMode = allRead
         ? EReadWithKeepOrder::READ_WITH_KEEP_ORDER_ALLOW_ALL
+        : almostAllRead && ChildPartitionsOrderManager.EnableSendFullBlacklist
+        ? EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST
         : EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL;
     for (auto& [childPartitionId, state] : ChildPartitionsOrderManager.ChildrenPartitionWithKeepOrder) {
         if (!(force || state.NeedSendFullState())) {
@@ -1152,7 +1160,12 @@ void TConsumerActor::UpdateLockedGroupsIdInChildPartitions(bool force) {
         update->SetConsumerGeneration(Config.GetGeneration());
         update->SetStep(ChildPartitionsOrderManager.ConsumerStep);
         update->SetMode(childMode);
-
+        if (childMode == EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
+            auto* list = update->MutableFullBlacklist();
+            for (ui32 lockedHash : Storage->GetMessageGroupsIdFromSelfAndParent()) {
+                list->AddParentLockedMessageGroupsIdHash(lockedHash);
+            }
+        }
         LOG_D("UpdateLockedGroupsIdInChildPartitions: updating child partition " << childPartitionId << "; reason=" << state.SendFullStateReasonsAsString() << "; update=" << ShortDebugString(record));
         auto forward = std::make_unique<TEvPipeCache::TEvForward>(ev.release(), state.TabletId, true, state.Cookie);
         Send(MakePipePerNodeCacheID(false), forward.release(), IEventHandle::FlagTrackDelivery);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer.cpp
@@ -443,7 +443,7 @@ void TConsumerActor::UpdateChildPartitionsOnCommit() {
     }
     if (!update) {
         if (PartitionEndOffset <= Storage->GetLastOffset()) {
-           update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetMetrics().InflightMessageCount);
+            update = ChildPartitionsOrderManager.SetSendFullStateToAll(TChildPartitionsOrderManager::ESendReasons::Commit, Storage->GetMetrics().InflightMessageCount);
         }
     }
     if (update) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_app.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_app.cpp
@@ -36,7 +36,7 @@ void TConsumerActor::Handle(TEvPQ::TEvMLPConsumerMonRequest::TPtr& ev) {
                             PROPERTY("Last offset", Storage->GetLastOffset());
                             PROPERTY("Message counts", Storage->GetMessageCount());
                             PROPERTY("Keep message order", Storage->GetKeepMessageOrder() ? "Yes" : "No");
-                            PROPERTY("Locked message groups", Storage->GetLockedMessageGroupsId().size());
+                            PROPERTY("Locked message groups", Storage->GetLockedMessageGroupsIdSize());
                             PROPERTY("Free message groups", freeMessageGroups.size());
                         }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.cpp
@@ -13,31 +13,48 @@
 namespace NKikimr::NPQ::NMLP {
 
     bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::NeedSendFullState() const {
-        if (LastSendFullStateReasons == ESendReasons::ParentDone && SendFullStateReasons == ESendReasons::ParentDone) {
+        if (LastSendReasons.Defined() && LastSendReasons->Reasons == ESendReasons::ParentDone && SendReasons.Reasons == ESendReasons::ParentDone) {
             return false;
         }
-        return SendFullStateReasons != ESendReasons::None;
+        return SendReasons.Reasons != ESendReasons::None;
     }
 
     void TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::MarkAsSent() {
-        LastSendFullStateReasons = std::exchange(SendFullStateReasons, ESendReasons::None);
+        LastSendReasons = std::exchange(SendReasons, TFullState{ESendReasons::None, SendReasons.InflightMessagesCount});
     }
 
     bool TChildPartitionsOrderManager::Empty() const {
         return ChildrenPartitionWithKeepOrder.empty();
     }
 
-    bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason) {
-        ESendReasons n = static_cast<ESendReasons>(static_cast<ui32>(SendFullStateReasons) | static_cast<ui32>(reason));
-        std::swap(SendFullStateReasons, n);
-        return SendFullStateReasons != n;
+    bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason, ui64 inflightMessagesCount) {
+        if (reason == ESendReasons::Commit) {
+            if (!EnableSendFullBlacklist) {
+                return false;
+            }
+            if (LastSendReasons.Defined() && LastSendReasons->Reasons == ESendReasons::Commit) {
+                if (inflightMessagesCount * 2 > LastSendReasons->InflightMessagesCount) {
+                    return false;
+                }
+            }
+        }
+
+        ESendReasons n = static_cast<ESendReasons>(static_cast<ui32>(SendReasons.Reasons) | static_cast<ui32>(reason));
+        TFullState newState{n, inflightMessagesCount};
+        std::swap(SendReasons, newState);
+        return SendReasons.Reasons != newState.Reasons;
     }
 
-    bool TChildPartitionsOrderManager::SetSendFullStateToAll(ESendReasons reason) {
+    bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason) {
+        Y_ASSERT(reason != ESendReasons::Commit);
+        return AddSendFullStateReason(reason, SendReasons.InflightMessagesCount);
+    }
+
+    bool TChildPartitionsOrderManager::SetSendFullStateToAll(ESendReasons reason, ui64 inflightMessagesCount) {
         Y_ASSERT(reason != ESendReasons::None);
         bool update = false;
         for (auto& [_, state] : ChildrenPartitionWithKeepOrder) {
-            if (state.AddSendFullStateReason(reason)) {
+            if (state.AddSendFullStateReason(reason, inflightMessagesCount)) {
                 update = true;
             }
         }
@@ -56,7 +73,7 @@ namespace NKikimr::NPQ::NMLP {
     }
 
     TString TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::SendFullStateReasonsAsString() const {
-        return SendReasonsToString(SendFullStateReasons);
+        return SendReasonsToString(SendReasons.Reasons);
     }
 
     TString TChildPartitionsOrderManager::SendReasonsToString(const ESendReasons reasons) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.cpp
@@ -13,48 +13,48 @@
 namespace NKikimr::NPQ::NMLP {
 
     bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::NeedSendFullState() const {
-        if (LastSendReasons.Defined() && LastSendReasons->Reasons == ESendReasons::ParentDone && SendReasons.Reasons == ESendReasons::ParentDone) {
+        if (LastSendReasons.Defined() && LastSendReasons->Reasons == ESendReasons::Done && SendReasons.Reasons == ESendReasons::Done) {
             return false;
         }
         return SendReasons.Reasons != ESendReasons::None;
     }
 
     void TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::MarkAsSent() {
-        LastSendReasons = std::exchange(SendReasons, TFullState{ESendReasons::None, SendReasons.InflightMessagesCount});
+        LastSendReasons = std::exchange(SendReasons, TFullState{ESendReasons::None, SendReasons.GroupsCount});
     }
 
     bool TChildPartitionsOrderManager::Empty() const {
         return ChildrenPartitionWithKeepOrder.empty();
     }
 
-    bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason, ui64 inflightMessagesCount) {
+    bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason, ui64 groupsCount) {
         if (reason == ESendReasons::Commit) {
             if (!EnableSendFullBlacklist) {
                 return false;
             }
             if (LastSendReasons.Defined() && LastSendReasons->Reasons == ESendReasons::Commit) {
-                if (inflightMessagesCount * 2 > LastSendReasons->InflightMessagesCount) {
+                if (groupsCount * 2 > LastSendReasons->GroupsCount) { // Send an update to the child section only if the number of groups has been reduced by at least half.
                     return false;
                 }
             }
         }
 
         ESendReasons n = static_cast<ESendReasons>(static_cast<ui32>(SendReasons.Reasons) | static_cast<ui32>(reason));
-        TFullState newState{n, inflightMessagesCount};
+        TFullState newState{n, groupsCount};
         std::swap(SendReasons, newState);
         return SendReasons.Reasons != newState.Reasons;
     }
 
     bool TChildPartitionsOrderManager::TChildrenPartitionWithKeepOrder::AddSendFullStateReason(ESendReasons reason) {
         Y_ASSERT(reason != ESendReasons::Commit);
-        return AddSendFullStateReason(reason, SendReasons.InflightMessagesCount);
+        return AddSendFullStateReason(reason, SendReasons.GroupsCount);
     }
 
-    bool TChildPartitionsOrderManager::SetSendFullStateToAll(ESendReasons reason, ui64 inflightMessagesCount) {
+    bool TChildPartitionsOrderManager::SetSendFullStateToAll(ESendReasons reason, ui64 groupsCount) {
         Y_ASSERT(reason != ESendReasons::None);
         bool update = false;
         for (auto& [_, state] : ChildrenPartitionWithKeepOrder) {
-            if (state.AddSendFullStateReason(reason, inflightMessagesCount)) {
+            if (state.AddSendFullStateReason(reason, groupsCount)) {
                 update = true;
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
@@ -30,7 +30,7 @@ namespace NKikimr::NPQ::NMLP {
             ui32 Cookie = 0;
             struct TFullState {
                 ESendReasons Reasons = ESendReasons::None;
-                ui64 InflightMessagesCount = -1;
+                ui64 InflightMessagesCount = Max<ui64>();
             };
 
             TFullState SendReasons;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
@@ -15,7 +15,7 @@ namespace NKikimr::NPQ::NMLP {
 
     struct TChildPartitionsOrderManager {
     public:
-        static constexpr bool EnableSendFullBlacklist = true;
+        static constexpr bool EnableSendFullBlacklist = false;
 
         enum class ESendReasons: ui8 {
             None = 0,

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
@@ -15,7 +15,7 @@ namespace NKikimr::NPQ::NMLP {
 
     struct TChildPartitionsOrderManager {
     public:
-        static constexpr bool EnableSendFullBlacklist = false;
+        static constexpr bool EnableSendFullBlacklist = true;
 
         enum class ESendReasons: ui8 {
             None = 0,

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
@@ -22,7 +22,8 @@ namespace NKikimr::NPQ::NMLP {
             Initial = 1 << 0,
             DeliveryProblem = 1 << 1,
             Commit = 1 << 2,
-            ParentDone = 1 << 3,
+            Done = 1 << 3, // current partition has been read to the end
+            ParentChange = 1 << 4, // propagate change from (grand-)parent partition
         };
 
         struct TChildrenPartitionWithKeepOrder {
@@ -30,7 +31,7 @@ namespace NKikimr::NPQ::NMLP {
             ui32 Cookie = 0;
             struct TFullState {
                 ESendReasons Reasons = ESendReasons::None;
-                ui64 InflightMessagesCount = Max<ui64>();
+                ui64 GroupsCount = Max<ui64>();
             };
 
             TFullState SendReasons;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_order.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/util/backoff.h>
 #include <util/generic/map.h>
+#include <util/generic/maybe.h>
 #include <util/generic/string.h>
 #include <util/datetime/base.h>
 
@@ -14,6 +15,8 @@ namespace NKikimr::NPQ::NMLP {
 
     struct TChildPartitionsOrderManager {
     public:
+        static constexpr bool EnableSendFullBlacklist = true;
+
         enum class ESendReasons: ui8 {
             None = 0,
             Initial = 1 << 0,
@@ -25,9 +28,15 @@ namespace NKikimr::NPQ::NMLP {
         struct TChildrenPartitionWithKeepOrder {
             ui64 TabletId = 0;
             ui32 Cookie = 0;
-            ESendReasons SendFullStateReasons = ESendReasons::None;
-            ESendReasons LastSendFullStateReasons = ESendReasons::None;
+            struct TFullState {
+                ESendReasons Reasons = ESendReasons::None;
+                ui64 InflightMessagesCount = -1;
+            };
 
+            TFullState SendReasons;
+            TMaybe<TFullState> LastSendReasons;
+
+            bool AddSendFullStateReason(ESendReasons reason, ui64 inflightMessagesCount);
             bool AddSendFullStateReason(ESendReasons reason);
             bool NeedSendFullState() const;
             void MarkAsSent(); // stores last sent reasons and reset current ones
@@ -35,7 +44,7 @@ namespace NKikimr::NPQ::NMLP {
         };
 
         bool Empty() const;
-        bool SetSendFullStateToAll(ESendReasons reason);
+        bool SetSendFullStateToAll(ESendReasons reason, ui64 inflightMessagesCount);
         bool SetSendFullStateByCookie(ui32 cookie, ESendReasons reason);
 
         static TString SendReasonsToString(ESendReasons reason);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/persqueue/ut/common/autoscaling_ut_common.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/library/actors/core/mon.h>
+#include <library/cpp/iterator/iterate_keys.h>
 #include <library/cpp/iterator/iterate_values.h>
 #include <util/string/split.h>
 #include <atomic>
@@ -117,10 +118,15 @@ public:
     TPartitionSplitter()
         : Leaves_({{0, 0x00, 0xFF}})
         , TotalPartitions_(1)
-    {}
+    {
+        PartitionsAtLevel_[0] = {0};
+    }
 
     size_t TotalPartitions() const { return TotalPartitions_; }
     const std::vector<TLeafPartition>& Leaves() const { return Leaves_; }
+    TSet<ui32> PartitionsAtLevel(size_t level) const {
+        return PartitionsAtLevel_.at(level);
+    }
 
     void SplitAllPartitions(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& dir, const TString& topic) {
         std::map<ui32, TString> boundaries;
@@ -133,13 +139,9 @@ public:
         AdvanceLeaves();
     }
 
-    void SplitLeaf(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& dir, const TString& topic, ui32 leafId, TString boundary) {
-        NKikimr::NPQ::NTest::SplitPartition(runtime, txId, dir, topic, leafId, std::move(boundary));
-        AdvanceLeaves();
-    }
-
 private:
     void AdvanceLeaves() {
+        size_t level = PartitionsAtLevel_.size();
         std::vector<TLeafPartition> newLeaves;
         for (size_t i = 0; i < Leaves_.size(); ++i) {
             const auto& leaf = Leaves_[i];
@@ -148,14 +150,55 @@ private:
             ui32 rightId = (ui32)(TotalPartitions_ + i * 2 + 1);
             newLeaves.push_back({leftId, leaf.Lo, mid});
             newLeaves.push_back({rightId, (unsigned char)(mid + 1), leaf.Hi});
+            PartitionsAtLevel_[level].insert(leftId);
+            PartitionsAtLevel_[level].insert(rightId);
         }
         TotalPartitions_ += Leaves_.size() * 2;
         Leaves_ = std::move(newLeaves);
     }
 
     std::vector<TLeafPartition> Leaves_;
+    TMap<size_t, TSet<ui32>> PartitionsAtLevel_;
     size_t TotalPartitions_;
 };
+
+struct TCounter {
+    int Write = 0;
+    int Read = 0;
+    int Commit = 0;
+    TString LastReadBody = {};
+    TVector<int> WriteByStage;
+    TVector<int> ReadByStage;
+    TVector<int> CommitByStage;
+
+
+    void IncWrite(int stage) {
+        Adjust(Write, WriteByStage, 1, stage);
+    }
+
+    void IncRead(int stage) {
+        Adjust(Read, ReadByStage, 1, stage);
+    }
+
+    void IncCommit(int stage) {
+        Adjust(Commit, CommitByStage, 1, stage);
+    }
+
+    void DecRead(int stage) {
+        Adjust(Read, ReadByStage, -1, stage);
+    }
+
+    void Adjust(int& value, TVector<int>& vec, int diff, int stage) {
+
+        while (std::cmp_less_equal(vec.size(), stage)) {
+            vec.push_back(0);
+        }
+        value += diff;
+        vec[stage] += diff;
+    }
+};
+
+using TGroupCounter = TMap<TString, TCounter>;
 
 Y_UNIT_TEST_SUITE(TMLPConsumerFIFOWithSplit) {
 
@@ -178,18 +221,46 @@ static void DumpStorageState(std::shared_ptr<TTopicSdkTestSetup>& setup, const T
 }
 
 struct TReadCommitCount {
-    size_t ReadCount = 0;
+    size_t Count = 0;
     bool CommitLast = true;
     // If CommitLast is true, all ReadCount messages are committed.
     // If CommitLast is false, the last message is left uncommitted (locked).
     // Effective CommitCount == ReadCount - !CommitLast
+    //
+    // For non-first stages, at the beginning of read processing:
+    //   If ReadCount > 0: commit previous stage's uncommitted message (if any), then read.
+    //   If ReadCount == 0 && CommitLast == true: commit previous stage's uncommitted message (if any).
+    //   If ReadCount == 0 && CommitLast == false: leave previous uncommitted message as-is.
+};
+
+struct TStage {
+    size_t WriteCount = 0;
+    TReadCommitCount Read;
 };
 
 struct TGroupDescription {
-    size_t SizeBeforeSplit = 0;
-    size_t SizeAfterSplit = 0;
-    TReadCommitCount ReadBeforeSplit;
+    TStage Root;
+    std::optional<TStage> IntermediateSplit;
+    TStage LastSplit;
 };
+
+
+static bool HasIntermediateSplit(const TMap<TString, TGroupDescription>& groups) {
+    for (const auto& [_, desc] : groups) {
+        if (desc.IntermediateSplit.has_value()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static TSet<ui32> AllPartitionIds(size_t totalPartitions) {
+    TSet<ui32> ids;
+    for (ui32 i = 0; i < totalPartitions; ++i) {
+        ids.insert(i);
+    }
+    return ids;
+}
 
 static TString JoinMessageIds(std::span<const TMessageId> messages) {
     TStringBuilder ss;
@@ -226,11 +297,25 @@ static auto Unlock(NActors::TTestActorRuntime& runtime, const TString& topicName
     return commitResult;
 }
 
+static TSet<TString> JoinKeys(const auto& m1, const auto& m2) {
+    TSet<TString> result;
+    for (const auto& [k, _] : m1) {
+        result.insert(k);
+    }
+    for (const auto& [k, _] : m2) {
+        result.insert(k);
+    }
+    return result;
+}
+
+
 TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
     NActors::TTestActorRuntime& runtime,
     const TString& topicName,
     const TString& consumer,
     TMap<TString, size_t>& remainingReads,
+    TGroupCounter& groupCounter,
+    int stageIdx,
     TStringBuf phase,
     int retries
 ) {
@@ -238,21 +323,28 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
     TMap<TString, TMessageId> lastMessageOfTheGroup;
     for (int readIteration = 1; ; ++readIteration) {
         {
-            TStringBuilder sb;
+            TBufferedCerr sb;
             sb << phase << " ReadAndCommitFIFOExceptLast iteration=" << readIteration << ", retries left=" << retries << ":\n";
-            for (auto& [g, n] : remainingReads) {
-                sb << "  " << g << ": read=" << n << Endl;
-            }
-            if (lastMessageOfTheGroup.size() > 0) {
-                sb << "Last messages (" << lastMessageOfTheGroup.size() << "):\n";
-                for (auto& [g, m] : lastMessageOfTheGroup) {
-                    sb << "  group=" << g
-                       << " partition=" << m.PartitionId
-                       << " offset=" << m.Offset << Endl;
+            for (const auto& g : JoinKeys(remainingReads, groupCounter)) {
+                size_t n = remainingReads.Value(g, 0);
+                sb << "  " << g << ": read remaining=" << n << " ";
+                auto* lm = lastMessageOfTheGroup.FindPtr(g);
+                if (lm) {
+                    sb << "- 1";
+                } else {
+                    sb << "- 0";
                 }
+                sb << "\t";
+                sb << groupCounter.Value(g, TCounter{});
+                sb << "\t";
+                if (lm) {
+                    sb << "Last message: ";
+                    sb << " partition=" << lm->PartitionId;
+                    sb << " offset=" << lm->Offset << Endl;
+                }
+                sb << "\n";
             }
             sb << "\n";
-            ACerr << sb << Endl;
         }
         const size_t toRead = [&]() {
             size_t r = 0;
@@ -271,7 +363,7 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
                                     .Consumer = consumer,
                                     .WaitTime = TDuration::Seconds(3),
                                     .ProcessingTimeout = TDuration::Seconds(300),
-                                    .MaxNumberOfMessage = 10});
+                                    .MaxNumberOfMessage = 50});
         auto readResult = GetReadResponse(runtime);
         UNIT_ASSERT_VALUES_EQUAL_C(readResult->Status, Ydb::StatusIds::SUCCESS, phase);
         if (readResult->Messages.empty()) {
@@ -284,15 +376,19 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
         std::vector<TMessageId> messagesToCommit;
         for (auto& msg : readResult->Messages) {
             const TString& groupId = msg.MessageGroupId;
+            groupCounter[groupId].IncRead(stageIdx);
+
             ACerr << ">>>>> " << phase << " ReadAndCommitFIFOExceptLast read: " << msg.Data
                  << " group=" << groupId
                  << " partition=" << msg.MessageId.PartitionId
                  << " offset=" << msg.MessageId.Offset << Endl;
             UNIT_ASSERT_C(!lastMessageOfTheGroup.contains(groupId), LabeledOutput(groupId));
-
+            UNIT_ASSERT_LE_C(groupCounter[groupId].LastReadBody, msg.Data, LabeledOutput(groupId, groupCounter[groupId].LastReadBody, msg.Data));
+            groupCounter[groupId].LastReadBody = msg.Data;
             if (remainingReads.Value(groupId, 0) > 1) {
                 messagesToCommit.push_back(msg.MessageId);
                 remainingReads[groupId]--;
+                groupCounter[groupId].IncCommit(stageIdx);
             } else {
                 lastMessageOfTheGroup[groupId] = msg.MessageId;
             }
@@ -311,12 +407,14 @@ TMap<TString, TMessageId> ReadAndCommitFIFOExceptLast(
         if (remainingReads.Value(groupId, 0) > 1) {
             messagesToCommit.push_back(message);
             remainingReads[groupId]--;
+            groupCounter[groupId].IncCommit(stageIdx);
         } else if (remainingReads.Value(groupId, 0) == 1) {
             remainingReads[groupId]--;
             uncommitedMessages[groupId] = message;
         } else {
             Y_ASSERT(remainingReads.Value(groupId, 0) == 0);
             messagesToUnlock.push_back(message);
+            groupCounter[groupId].DecRead(stageIdx);
         }
     }
     if (!messagesToCommit.empty()) {
@@ -335,16 +433,24 @@ TMap<TString, TMessageId> ReadAndCommitFIFO(
     const TString& topicName,
     const TString& consumer,
     const TMap<TString, TReadCommitCount>& operations,
+    TGroupCounter& groupCounter,
+    int stageIdx,
     TStringBuf phase,
-    int retries = 0
+    bool allowPartialRead,
+    int retries
 ) {
     TMap<TString, size_t> remainingReads;
     for (const auto& [groupId, op] : operations) {
-        remainingReads[groupId] = op.ReadCount;
+        remainingReads[groupId] = op.Count;
     }
-    TMap<TString, TMessageId> last = ReadAndCommitFIFOExceptLast(runtime, topicName, consumer, remainingReads, phase, retries);
+    TMap<TString, TMessageId> last = ReadAndCommitFIFOExceptLast(runtime, topicName, consumer, remainingReads, groupCounter, stageIdx, phase, retries);
     for (const auto& [groupId, cnt] : remainingReads) {
-        UNIT_ASSERT_VALUES_EQUAL_C(cnt, 0, phase << ": Not enough messages for group " << groupId << "; " << cnt << " more required");
+        if (!allowPartialRead) {
+            UNIT_ASSERT_VALUES_EQUAL_C(cnt, 0, phase << ": Not enough messages for group " << groupId << "; " << cnt << " more required (" << operations.at(groupId).Count << " total)");
+        }
+        if (cnt != 0) {
+            ACerr << phase << ": Not enough messages for group " << groupId << "; " << cnt << " more required (" << operations.at(groupId).Count << " total)" << Endl;
+        }
     }
     TMap<TString, TMessageId> uncommited;
     std::vector<TMessageId> messagesToCommit;
@@ -352,6 +458,7 @@ TMap<TString, TMessageId> ReadAndCommitFIFO(
         const auto& op = operations.at(groupId);
         if (op.CommitLast) {
             messagesToCommit.push_back(message);
+            groupCounter[groupId].IncCommit(stageIdx);
         } else {
             uncommited[groupId] = message;
         }
@@ -360,273 +467,354 @@ TMap<TString, TMessageId> ReadAndCommitFIFO(
         auto commitResult = Commit(runtime, topicName, consumer, messagesToCommit);
         UNIT_ASSERT_VALUES_EQUAL_C(commitResult->Status, Ydb::StatusIds::SUCCESS, phase);
     }
+    {
+        TBufferedCerr sb;
+        sb << phase << "ReadAndCommitFIFO result\n";
+        for (const auto& g : JoinKeys(remainingReads, groupCounter)) {
+            size_t n = remainingReads.Value(g, 0);
+            sb << "  " << g << ": read remaining=" << n << " ";
+            sb << "\t";
+            sb << groupCounter.Value(g, TCounter{});
+            sb << "\t";
+            const TReadCommitCount op = operations.Value(g, TReadCommitCount{});
+            sb << LabeledOutput(op.Count, op.CommitLast);
+            sb << "\n";
+        }
+        sb << "\n";
+    }
+
     return uncommited;
 }
 
+// return unexpected errornous groups
+TMap<TString, TVector<TMessageId>> ReadAndCommitFIFOAll(
+    NActors::TTestActorRuntime& runtime,
+    const TString& topicName,
+    const TString& consumer,
+    TMap<TString, size_t>& remainingReads,
+    TGroupCounter& groupCounter,
+    int stageIdx,
+    TStringBuf phase,
+    int retries
+) {
+    TMap<TString, TVector<TMessageId>> unexpected;
+    for (int readIteration = 1; ; ++readIteration) {
+        {
+            TBufferedCerr sb;
+            sb << phase << " ReadAndCommitFIFOExceptLast iteration=" << readIteration << ", retries left=" << retries << ":\n";
+            for (const auto& g : JoinKeys(remainingReads, groupCounter)) {
+                size_t n = remainingReads.Value(g, 0);
+                sb << "  " << g << ": read remaining=" << n << " ";
+                sb << "\t";
+                sb << groupCounter.Value(g, TCounter{});
+                sb << "\t";
+                sb << "\n";
+            }
+            sb << "\n";
+        }
+        const size_t toRead = [&]() {
+            size_t r = 0;
+            for (auto& [g, n] : remainingReads) {
+                    r += n;
+            }
+            return r;
+        }();
+        if (toRead == 0) {
+            break;
+        }
+        CreateReaderActor(runtime, {.DatabasePath = "/Root",
+                                    .TopicName = topicName,
+                                    .Consumer = consumer,
+                                    .WaitTime = TDuration::Seconds(3),
+                                    .ProcessingTimeout = TDuration::Seconds(300),
+                                    .MaxNumberOfMessage = 50});
+        auto readResult = GetReadResponse(runtime);
+        UNIT_ASSERT_VALUES_EQUAL_C(readResult->Status, Ydb::StatusIds::SUCCESS, phase);
+        if (readResult->Messages.empty()) {
+            if (retries-- <= 0) {
+                break;
+            } else {
+                continue;
+            }
+        }
+        std::vector<TMessageId> messagesToCommit;
+        for (auto& msg : readResult->Messages) {
+            const TString& groupId = msg.MessageGroupId;
+            groupCounter[groupId].IncRead(stageIdx);
+
+            ACerr << ">>>>> " << phase << " ReadAndCommitFIFOExceptLast read: " << msg.Data
+                 << " group=" << groupId
+                 << " partition=" << msg.MessageId.PartitionId
+                 << " offset=" << msg.MessageId.Offset << Endl;
+            UNIT_ASSERT_LE_C(groupCounter[groupId].LastReadBody, msg.Data, LabeledOutput(groupId, groupCounter[groupId].LastReadBody, msg.Data));
+            groupCounter[groupId].LastReadBody = msg.Data;
+            if (remainingReads.Value(groupId, 0) > 0) {
+                remainingReads[groupId]--;
+            } else {
+                unexpected[groupId].push_back(msg.MessageId);
+            }
+            messagesToCommit.push_back(msg.MessageId);
+            groupCounter[groupId].IncCommit(stageIdx);
+        }
+        if (!messagesToCommit.empty()) {
+            auto commitResult = Commit(runtime, topicName, consumer, messagesToCommit);
+            UNIT_ASSERT_VALUES_EQUAL_C(commitResult->Status, Ydb::StatusIds::SUCCESS, phase);
+        }
+    }
+    return unexpected;
+}
+
+
+
 void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescription>& groups, const std::span<const ui32> partitionsToRestart = {}) {
+    const bool doIntermediateSplit = HasIntermediateSplit(groups);
     auto setup = CreateSetup();
     auto& runtime = setup->GetRuntime();
 
-    ACerr << ">>>>> Phase 1: Create topic with autoscaling and shared consumer with KeepMessageOrder(true)" << Endl;
-
+    ACerr << ">>>>> Phase 1: Create topic with autoscaling and shared consumer with KeepMessageOrder(true)\n";
     ACerr << ">>>>> groups:\n";
     for (const auto& [g, desc] : groups) {
-        ACerr << "  " << g << ": "
-             << LabeledOutput(desc.SizeBeforeSplit, desc.SizeAfterSplit,
-                              desc.ReadBeforeSplit.ReadCount, desc.ReadBeforeSplit.CommitLast) << "\n";
+        auto printStage = [&](TStringBuf name, const TStage& s) {
+            ACerr << "    " << name << ": WriteCount=" << s.WriteCount << " Read={ReadCount=" << s.Read.Count << " CommitLast=" << s.Read.CommitLast << "}\n";
+        };
+        ACerr << "  " << g << ":\n";
+        printStage("Root", desc.Root);
+        if (desc.IntermediateSplit.has_value()) {
+            printStage("IntermediateSplit", *desc.IntermediateSplit);
+        }
+        printStage("LastSplit", desc.LastSplit);
     }
     ACerr << Endl;
     CreateSetupFIFOTopic(setup, "/Root/topic1");
 
-    ACerr << ">>>>> Phase 2: Write messages to parent partition (partition 0)" << Endl;
-
-    for (const auto& [groupId, desc] : groups) {
-        if (desc.SizeBeforeSplit == 0) {
-            continue;
-        }
-
-        std::vector<TWriterSettings::TMessage> messages;
-        for (size_t i = 0; i < desc.SizeBeforeSplit; ++i) {
-            messages.push_back({
-                .Index = i,
-                .MessageBody = TStringBuilder() << "msg-" << groupId << "-" << (i + 1),
-                .MessageGroupId = groupId,
-            });
-        }
-
-        CreateWriterActor(runtime, {
-            .DatabasePath = "/Root",
-            .TopicName = "/Root/topic1",
-            .Messages = std::move(messages),
-        });
-        auto writeResp = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), desc.SizeBeforeSplit,
-            "phase 2: write before split for group " << groupId);
-        for (auto& msg : writeResp->Messages) {
-            UNIT_ASSERT_VALUES_EQUAL_C(msg.Status, Ydb::StatusIds::SUCCESS,
-                "phase 2: write before split for group " << groupId);
-        }
-    }
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
-
-    ACerr << ">>>>> Phase 3: Read and commit/unlock messages before split" << Endl;
-
-    TMap<TString, TReadCommitCount> readBeforeSplit;
-    for (const auto& [groupId, desc] : groups) {
-        if (desc.ReadBeforeSplit.ReadCount > 0) {
-            readBeforeSplit[groupId] = desc.ReadBeforeSplit;
-        }
-    }
-    auto inflyMessages = ReadAndCommitFIFO(runtime, "/Root/topic1", "mlp-consumer", readBeforeSplit, "phase 3");
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0});
-
-    ACerr << ">>>>> Phase 4: Force partition split" << Endl;
-
+    // inflyMessages: per-group uncommitted message carried over from the previous stage's Read (CommitLast=false)
+    TMap<TString, TMessageId> inflyMessages;
+    TGroupCounter groupCounter;
     TPartitionSplitter splitter;
     ui64 txId = 1006;
+
+    auto dumpGroupStatistics = [&]() {
+        TBufferedCerr log;
+        log << "Group statistics:\n";
+        for (const auto& [groupId, desc] : groups) {
+            const TCounter c = groupCounter.Value(groupId, TCounter{});
+            log << "    " << groupId << ": write=" << c.Write << " read=" << c.Read << " commit=" << c.Commit << "\n";
+       }
+    };
+
+    auto executeStage = [&](size_t stageIdx, auto getStage, TStringBuf phaseName) {
+        ACerr << ">>>>> Stage " << stageIdx << " (" << phaseName << "): write\n";
+        for (const auto& [groupId, desc] : groups) {
+            const TStage& stage = getStage(desc);
+            if (stage.WriteCount == 0) {
+                continue;
+            }
+            std::vector<TWriterSettings::TMessage> messages;
+            for (size_t i = 0; i < stage.WriteCount; ++i) {
+                messages.push_back({
+                    .Index = i,
+                    .MessageBody = TStringBuilder() << "msg-" << groupId << "-s" << LeftPad(stageIdx, 3, '0') << "-" << LeftPad(i + 1, 8, '0'),
+                    .MessageGroupId = groupId,
+                });
+                groupCounter[groupId].IncWrite(stageIdx);
+            }
+            ACerr << "    write for group " << groupId << ": " << messages.size() << " messages\n";
+            CreateWriterActor(runtime, {.DatabasePath = "/Root", .TopicName = "/Root/topic1", .Messages = std::move(messages)});
+            auto writeResp = GetWriteResponse(runtime);
+            UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), stage.WriteCount, phaseName << ": write for group " << groupId);
+            for (auto& msg : writeResp->Messages) {
+                UNIT_ASSERT_VALUES_EQUAL_C(msg.Status, Ydb::StatusIds::SUCCESS, phaseName << ": write for group " << groupId);
+            }
+        }
+        DumpStorageState(setup, "/Root/topic1", "mlp-consumer", AllPartitionIds(splitter.TotalPartitions()));
+
+        ACerr << ">>>>> Stage " << stageIdx << " (" << phaseName << "): read\n";
+        if (stageIdx > 0) {
+            std::vector<TMessageId> toCommit;
+            {
+                TBufferedCerr log;
+                for (const auto& [groupId, desc] : groups) {
+                    const TStage& stage = getStage(desc);
+                    auto* inflyMsg = inflyMessages.FindPtr(groupId);
+                    if (!inflyMsg) {
+                        continue;
+                    }
+                    if (stage.Read.Count > 0 || stage.Read.CommitLast) {
+                        toCommit.push_back(*inflyMsg);
+                        inflyMessages.erase(groupId);
+                        groupCounter[groupId].IncCommit(stageIdx - 1);
+                        log << "    commit inflight message for group " << groupId << "\n";
+                    } else {
+                        log << "    keep inflight message for group " << groupId << "\n";
+                    }
+                }
+            }
+            if (!toCommit.empty()) {
+                auto commitResult = Commit(runtime, "/Root/topic1", "mlp-consumer", toCommit);
+                UNIT_ASSERT_VALUES_EQUAL_C(commitResult->Status, Ydb::StatusIds::SUCCESS, phaseName << " (commit prev inflight)");
+            }
+        }
+        TMap<TString, TReadCommitCount> readOps;
+        {
+            TBufferedCerr log;
+            for (const auto& [groupId, desc] : groups) {
+                const TStage& stage = getStage(desc);
+                if (stage.Read.Count > 0) {
+                    readOps[groupId] = stage.Read;
+                    log << "    read from group " << groupId << ": " << stage.Read.Count << " messages\n";
+                }
+            }
+        }
+        if (!readOps.empty()) {
+            bool allowPartialRead = stageIdx == 1;
+            auto newInfly = ReadAndCommitFIFO(runtime, "/Root/topic1", "mlp-consumer", readOps, groupCounter, stageIdx, phaseName, allowPartialRead, 1);
+            for (auto& [groupId, msgId] : newInfly) {
+                inflyMessages[groupId] = msgId;
+            }
+        }
+        DumpStorageState(setup, "/Root/topic1", "mlp-consumer", AllPartitionIds(splitter.TotalPartitions()));
+        dumpGroupStatistics();
+    };
+
+    executeStage(0, [](const TGroupDescription& d) -> const TStage& { return d.Root; }, "root");
+
+    ACerr << ">>>>> First split\n";
     splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
-
-    ACerr << ">>>>> Phase 4b: Wait for child partitions to be created and verify partition count" << Endl;
-
-    auto partitionCount = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
-    UNIT_ASSERT_VALUES_EQUAL_C(partitionCount, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after split");
-
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
-
-    ACerr << ">>>>> Phase 5: Write messages to child partitions" << Endl;
-
-    for (const auto& [groupId, desc] : groups) {
-        if (desc.SizeAfterSplit == 0) {
-            continue;
-        }
-
-        std::vector<TWriterSettings::TMessage> messages;
-        for (size_t i = 0; i < desc.SizeAfterSplit; ++i) {
-            messages.push_back({
-                .Index = i,
-                .MessageBody = TStringBuilder() << "msg-" << groupId << "-child-" << (i + 1),
-                .MessageGroupId = groupId,
-            });
-        }
-
-        CreateWriterActor(runtime, {
-            .DatabasePath = "/Root",
-            .TopicName = "/Root/topic1",
-            .Messages = std::move(messages),
-        });
-        auto writeResp = GetWriteResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL_C(writeResp->Messages.size(), desc.SizeAfterSplit,
-            "phase 5: write after split for group " << groupId);
-        for (auto& msg : writeResp->Messages) {
-            UNIT_ASSERT_VALUES_EQUAL_C(msg.Status, Ydb::StatusIds::SUCCESS,
-                "phase 5: write after split for group " << groupId);
-        }
+    {
+        auto pc = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+        UNIT_ASSERT_VALUES_EQUAL_C(pc, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after first split");
     }
 
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
+    if (doIntermediateSplit) {
+        executeStage(1, [](const TGroupDescription& d) -> const TStage& { return d.IntermediateSplit.has_value() ? *d.IntermediateSplit : Default<TStage>(); }, "intermediate-split");
+
+        ACerr << ">>>>> Second split\n";
+        splitter.SplitAllPartitions(runtime, ++txId, "/Root", "topic1");
+        {
+            auto pc = WaitForPartitionCount(setup, "/Root/topic1", splitter.TotalPartitions());
+            UNIT_ASSERT_VALUES_EQUAL_C(pc, splitter.TotalPartitions(), "Expected " << splitter.TotalPartitions() << " partitions after first split");
+        }
+
+        DumpStorageState(setup, "/Root/topic1", "mlp-consumer", AllPartitionIds(splitter.TotalPartitions()));
+    }
+
+    executeStage(2, [](const TGroupDescription& d) -> const TStage& { return d.LastSplit; }, "last-split");
 
     for (ui32 partitionId : partitionsToRestart) {
         ACerr << ">>>>> Restart partition " << partitionId << Endl;
         ReloadPQTablet(setup, "/Root", "/Root/topic1", partitionId);
     }
 
-    ACerr << ">>>>> Phase 6: Verify that we cannot read any messages written to the child partitions, if not all messages from the parent partition was commited" << Endl;
-
-    // Determine which groups have all parent messages committed.
-    // A group is "fully committed in parent" if effective CommitCount >= SizeBeforeSplit.
-    // Groups that are not fully committed have child messages blocked by FIFO ordering.
-    THashSet<TString> groupsFullyCommittedInParent;
-    THashSet<TString> groupsWithUncommittedParent;
-    for (const auto& [groupId, desc] : groups) {
-        if (desc.SizeBeforeSplit == 0) {
-            continue; // No parent messages for this group
-        }
-        const size_t effectiveCommitCount = desc.ReadBeforeSplit.ReadCount
-            - (desc.ReadBeforeSplit.CommitLast ? 0 : 1);
-        if (effectiveCommitCount >= desc.SizeBeforeSplit) {
-            groupsFullyCommittedInParent.insert(groupId);
-        } else {
-            groupsWithUncommittedParent.insert(groupId);
-        }
+    for (const auto& [groupId, counter] : groupCounter) {
+        int inflyCnt = counter.Read - counter.Commit;
+        UNIT_ASSERT_C(EqualToOneOf(inflyCnt, 0, 1), LabeledOutput(inflyCnt));
+        UNIT_ASSERT_VALUES_EQUAL(inflyCnt, inflyMessages.contains(groupId));
     }
 
-    ACerr << ">>>>> Phase 6: groupsFullyCommittedInParent: " << JoinSeq(", ", groupsFullyCommittedInParent) << "\n";
-    ACerr << ">>>>> Phase 6: groupsWithUncommittedParent: " << JoinSeq(", ", groupsWithUncommittedParent) << "\n";
-
-    // Probe read: attempt to read messages and verify FIFO invariant.
-    // We do a single read with MaxNumberOfMessage=10 to see what's available.
-    // Due to FIFO: at most 1 message per group, and groups with inflight (locked)
-    // messages from Phase 3 won't return new messages.
-    //
-    // Expected readable messages:
-    // - For groups with all parent committed and no inflight: child messages (from child partitions)
-    // - For groups with uncommitted parent and no inflight: next parent message (from partition 0)
-    // - For groups with inflight messages: nothing (blocked by FIFO)
-    // - For groups with SizeBeforeSplit == 0: child messages (no parent messages exist)
     {
-        CreateReaderActor(runtime, {.DatabasePath = "/Root",
-                                    .TopicName = "/Root/topic1",
-                                    .Consumer = "mlp-consumer",
+        // Probe read: attempt to read messages and verify FIFO invariant.
+        // We do a single read with to see what's available.
+        // Due to FIFO: at most 1 message per group, and groups with inflight (locked)
+        // messages from Phase 3 won't return new messages.
+        TSet<TString> expectedAvailableGroups;
+        for (const auto& [groupId, counter] : groupCounter) {
+            if (!(counter.Write > counter.Read && counter.Read == counter.Commit)) {
+                continue;
+            }
+            expectedAvailableGroups.insert(groupId);
+        }
+        ACerr << ">>>>> Validation: expectedAvailableGroups: " << JoinSeq(", ", expectedAvailableGroups) << "\n";
+        CreateReaderActor(runtime, {.DatabasePath = "/Root", .TopicName = "/Root/topic1", .Consumer = "mlp-consumer",
                                     .WaitTime = TDuration::Seconds(3),
                                     .ProcessingTimeout = TDuration::Seconds(30),
-                                    .MaxNumberOfMessage = 10});
+                                    .MaxNumberOfMessage = 50});
         auto readResult = GetReadResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL_C(readResult->Status, Ydb::StatusIds::SUCCESS, "phase 6");
-
-        // Validate FIFO invariant: at most 1 message per group in a single read response
+        UNIT_ASSERT_VALUES_EQUAL_C(readResult->Status, Ydb::StatusIds::SUCCESS, "validation probe read");
         THashSet<TString> seenGroups;
         for (const auto& msg : readResult->Messages) {
-            UNIT_ASSERT_C(!seenGroups.contains(msg.MessageGroupId),
-                "FIFO violation in Phase 6: duplicate group " << msg.MessageGroupId
-                << " in single read response");
+            UNIT_ASSERT_C(!seenGroups.contains(msg.MessageGroupId), "FIFO violation in validation: duplicate group " << msg.MessageGroupId << " in single read response");
+            groupCounter[msg.MessageGroupId].IncRead(4);
             seenGroups.insert(msg.MessageGroupId);
-
-            ACerr << ">>>>> Phase 6 read: " << msg.Data
-                 << " group=" << msg.MessageGroupId
-                 << " partition=" << msg.MessageId.PartitionId
-                 << " offset=" << msg.MessageId.Offset << Endl;
-
-            // Verify that groups with uncommitted parent messages only return parent messages
-            if (groupsWithUncommittedParent.contains(msg.MessageGroupId)) {
-                UNIT_ASSERT_C(msg.MessageId.PartitionId == 0,
-                    "FIFO ordering violation: group " << msg.MessageGroupId
-                    << " has uncommitted parent messages but returned child message from partition "
-                    << msg.MessageId.PartitionId);
-            }
+            ACerr << ">>>>> Validation read: " << msg.Data << " group=" << msg.MessageGroupId << " partition=" << msg.MessageId.PartitionId << " offset=" << msg.MessageId.Offset << Endl;
+            UNIT_ASSERT_C(expectedAvailableGroups.contains(msg.MessageGroupId), "Unexpected group " << msg.MessageGroupId << " in read response");
+            UNIT_ASSERT_LE_C(groupCounter[msg.MessageGroupId].LastReadBody, msg.Data, LabeledOutput(msg.MessageGroupId, groupCounter[msg.MessageGroupId].LastReadBody, msg.Data));
+            groupCounter[msg.MessageGroupId].LastReadBody = msg.Data;
         }
-
-        // Groups with inflight messages from Phase 3 should NOT appear in the read
         for (const auto& [groupId, messageId] : inflyMessages) {
             UNIT_ASSERT_C(!seenGroups.contains(groupId),
-                "FIFO violation: group " << groupId
-                << " has an inflight (locked) message but appeared in read response");
+                          "FIFO violation: group " << groupId << " has an inflight (locked) message but appeared in read response");
         }
-
-        // Unlock all messages we just read (we're only probing, not consuming)
         if (!readResult->Messages.empty()) {
             std::vector<TMessageId> toUnlock;
             for (const auto& msg : readResult->Messages) {
                 toUnlock.push_back(msg.MessageId);
+                groupCounter[msg.MessageGroupId].DecRead(4);
             }
             auto unlockResult = Unlock(runtime, "/Root/topic1", "mlp-consumer", toUnlock);
-            UNIT_ASSERT_VALUES_EQUAL_C(unlockResult->Status, Ydb::StatusIds::SUCCESS, "phase 6");
+            UNIT_ASSERT_VALUES_EQUAL_C(unlockResult->Status, Ydb::StatusIds::SUCCESS, "validation probe unlock");
         }
     }
 
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
+    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", AllPartitionIds(splitter.TotalPartitions()));
 
-    ACerr << ">>>>> Phase 7: Commit all remaining messages from the parent partition" << Endl;
-
-    // First, commit any inflight messages from Phase 3
+    // Finalization: commit all inflight, then read remaining messages from each stage
     if (!inflyMessages.empty()) {
-        std::vector<TMessageId> messagesToCommit;
+        std::vector<TMessageId> toCommit;
         for (const auto& [groupId, messageId] : inflyMessages) {
-            messagesToCommit.push_back(messageId);
-            ACerr << ">>>>> Phase 7: Committing inflight message from Phase 3: group=" << groupId
-                 << " partition=" << messageId.PartitionId
-                 << " offset=" << messageId.Offset << Endl;
+            toCommit.push_back(messageId);
+            ACerr << ">>>>> Finalization: committing inflight group=" << groupId
+                  << " partition=" << messageId.PartitionId << " offset=" << messageId.Offset << Endl;
+            groupCounter[groupId].IncCommit(4);
         }
-        auto commitResult = Commit(runtime, "/Root/topic1", "mlp-consumer", messagesToCommit);
-        UNIT_ASSERT_VALUES_EQUAL_C(commitResult->Status, Ydb::StatusIds::SUCCESS, "phase 7");
+        auto commitResult = Commit(runtime, "/Root/topic1", "mlp-consumer", toCommit);
+        UNIT_ASSERT_VALUES_EQUAL_C(commitResult->Status, Ydb::StatusIds::SUCCESS, "finalization commit inflight");
+        inflyMessages.clear();
     }
-
-    // Read and commit all remaining parent messages.
-    // After Phase 3, ReadBeforeSplit.ReadCount messages were read per group.
-    // The inflight messages (at most 1 per group when !CommitLast) were just committed above.
-    // So we need to read (SizeBeforeSplit - ReadCount) more messages per group.
+    dumpGroupStatistics();
+    // Read remaining messages
     {
-        TMap<TString, TReadCommitCount> remainingParentOps;
-        for (const auto& [groupId, desc] : groups) {
-            size_t alreadyRead = desc.ReadBeforeSplit.ReadCount;
-            size_t remaining = desc.SizeBeforeSplit - alreadyRead;
-            if (remaining > 0) {
-                remainingParentOps[groupId] = {.ReadCount = remaining, .CommitLast = true};
+        TMap<TString, size_t> remainingReads;
+        for (const auto& [groupId, counter] : groupCounter) {
+            UNIT_ASSERT_VALUES_EQUAL_C(counter.Read, counter.Commit, groupId);
+            if (size_t remaining = counter.Write - counter.Commit; remaining > 0) {
+                remainingReads[groupId] = remaining;
             }
         }
-
-        if (!remainingParentOps.empty()) {
-            auto phase7Uncommitted = ReadAndCommitFIFO(runtime, "/Root/topic1", "mlp-consumer", remainingParentOps, "phase 7", 3);
-            UNIT_ASSERT_C(phase7Uncommitted.empty(),
-                "Phase 7: Expected all remaining parent messages to be committed, but "
-                << phase7Uncommitted.size() << " groups have uncommitted messages");
-        }
-    }
-
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
-
-    ACerr << ">>>>> Phase 8: Verify that we can read all remaining messages from child partitions" << Endl;
-
-    // Now all parent messages are committed. All child messages should be readable.
-    {
-        TMap<TString, TReadCommitCount> childOps;
-        for (const auto& [groupId, desc] : groups) {
-            if (desc.SizeAfterSplit > 0) {
-                childOps[groupId] = {.ReadCount = desc.SizeAfterSplit, .CommitLast = true};
+        if (!remainingReads.empty()) {
+            TMap<TString, TVector<TMessageId>> unexpected = ReadAndCommitFIFOAll(runtime, "/Root/topic1", "mlp-consumer", remainingReads, groupCounter, 4, "finalization", 10);
+            {
+                TBufferedCerr log;
+                if (unexpected.empty()) {
+                    log << "finalization: no unexpected messages\n";
+                } else {
+                    log << "finalization: unexpected messages:\n";
+                    for (const auto& [groupId, messages] : unexpected) {
+                        log << "  group=" << groupId << " messages=" << JoinMessageIds(messages) << "\n";
+                    }
+                }
+                for (const auto& groupId : JoinKeys(remainingReads, groupCounter)) {
+                    log << "  group=" << groupId << " remaining=" << remainingReads.Value(groupId, 0) << "\t" << groupCounter.Value(groupId, TCounter{}) << "\n";
+                }
+            }
+            UNIT_ASSERT_C(unexpected.empty(), "finalization: expected all remaining messages committed");
+            for (const auto& [groupId, remaining] : remainingReads) {
+                UNIT_ASSERT_VALUES_EQUAL_C(remaining, 0, "finalization: expected all remaining messages committed in group " << groupId);
             }
         }
-
-        if (!childOps.empty()) {
-            auto phase8Uncommitted = ReadAndCommitFIFO(runtime, "/Root/topic1", "mlp-consumer", childOps, "phase 8", 3);
-            UNIT_ASSERT_C(phase8Uncommitted.empty(),
-                "Phase 8: Expected all child messages to be committed, but "
-                << phase8Uncommitted.size() << " groups have uncommitted messages");
-        }
     }
 
-    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", {0, 1, 2});
+    dumpGroupStatistics();
+    DumpStorageState(setup, "/Root/topic1", "mlp-consumer", AllPartitionIds(splitter.TotalPartitions()));
 
     // Final verification: try to read more messages - should get nothing
     {
-        CreateReaderActor(runtime, {.DatabasePath = "/Root",
-                                    .TopicName = "/Root/topic1",
-                                    .Consumer = "mlp-consumer",
+        CreateReaderActor(runtime, {.DatabasePath = "/Root", .TopicName = "/Root/topic1", .Consumer = "mlp-consumer",
                                     .WaitTime = TDuration::Seconds(3),
                                     .ProcessingTimeout = TDuration::Seconds(30),
                                     .MaxNumberOfMessage = 10});
         auto finalRead = GetReadResponse(runtime);
-        UNIT_ASSERT_VALUES_EQUAL_C(finalRead->Status, Ydb::StatusIds::SUCCESS, "phase 8 final");
-        UNIT_ASSERT_C(finalRead->Messages.empty(),
-            "Expected no more messages, but got " << finalRead->Messages.size());
+        UNIT_ASSERT_VALUES_EQUAL_C(finalRead->Status, Ydb::StatusIds::SUCCESS, "finalization final read");
+        UNIT_ASSERT_C(finalRead->Messages.empty(), "Expected no more messages, but got " << finalRead->Messages.size());
     }
 
     ACerr << ">>>>> All phases completed successfully" << Endl;
@@ -636,11 +824,11 @@ void PartitionSplitWithMessageGroupOrdering(const TMap<TString, TGroupDescriptio
 // Expected: child messages for all groups (A, B, C) are immediately available.
 Y_UNIT_TEST(Order_AllCommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
@@ -648,11 +836,11 @@ Y_UNIT_TEST(Order_AllCommittedBeforeSplit) {
 // Expected: child messages for all groups are blocked until parent messages are committed.
 Y_UNIT_TEST(Order_NoneCommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
@@ -661,11 +849,11 @@ Y_UNIT_TEST(Order_NoneCommittedBeforeSplit) {
 // Expected: child messages for A and B available; C blocked until parent committed.
 Y_UNIT_TEST(Order_GroupAB_CommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
@@ -673,11 +861,11 @@ Y_UNIT_TEST(Order_GroupAB_CommittedBeforeSplit) {
 // Expected: child messages for all groups are available (partial commit unblocks).
 Y_UNIT_TEST(Order_OnePerGroupCommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
@@ -686,148 +874,254 @@ Y_UNIT_TEST(Order_OnePerGroupCommittedBeforeSplit) {
 // Expected: child messages for all groups are available.
 Y_UNIT_TEST(Order_GroupAB_OneCCommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
 Y_UNIT_TEST(Order_GroupBC_OneACommittedBeforeSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
 Y_UNIT_TEST(Order_AllCommittedBeforeSplit_RestartParentPartition) {
     static constexpr ui32 restartPartitions[] = {0};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_AllCommittedBeforeSplit_RestartChildPartition) {
     static constexpr ui32 restartPartitions[] = {1};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_NoneCommittedBeforeSplit_RestartParentPartition) {
     static constexpr ui32 restartPartitions[] = {0};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_NoneCommittedBeforeSplit_RestartChildPartition) {
     static constexpr ui32 restartPartitions[] = {1};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_GroupAB_CommittedBeforeSplit_RestartParentPartition) {
     static constexpr ui32 restartPartitions[] = {0};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_GroupAB_CommittedBeforeSplit_RestartChildPartition) {
     static constexpr ui32 restartPartitions[] = {1};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 3,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 0,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 3}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_GroupBC_OneACommittedBeforeSplit_RestartParentPartition) {
     static constexpr ui32 restartPartitions[] = {0};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 Y_UNIT_TEST(Order_GroupBC_OneACommittedBeforeSplit_RestartChildPartition) {
     static constexpr ui32 restartPartitions[] = {1};
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 3, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-C", {.SizeBeforeSplit = 2, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 2,}}},
-        {"group-D", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
-        {"group-E", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 3, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-D", {.LastSplit = {.WriteCount = 1}}},
+        {"group-E", {.LastSplit = {.WriteCount = 1}}},
     }, restartPartitions);
 }
 
 // Sanity check: minimal test with two groups, one message each before and after split.
 Y_UNIT_TEST(Order_TwoGroups_Minimal) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
     });
 }
 
 // Sanity check: two groups before split, one new group only after split.
 Y_UNIT_TEST(Order_NewGroupAfterSplit) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-B", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1,}}},
-        {"group-C", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
+        {"group-C", {.LastSplit = {.WriteCount = 1}}},
     });
 }
 
 // Sanity check: single group, uncommitted before split.
 Y_UNIT_TEST(Order_SingleGroup_Uncommitted) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1, .CommitLast = false}}},
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = false}}, .LastSplit = {.WriteCount = 1, .Read = {.CommitLast = false}}}},
     });
 }
 
 // Sanity check: single group, committed before split.
 Y_UNIT_TEST(Order_SingleGroup_Committed) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 1, .SizeAfterSplit = 1, .ReadBeforeSplit = {.ReadCount = 1, .CommitLast = true}}},
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = {.WriteCount = 1}}},
     });
 }
 
 // Sanity check: single group before split, new group after split, committed before split.
 Y_UNIT_TEST(Order_UnrelatedGroup_Committed) {
     PartitionSplitWithMessageGroupOrdering({
-        {"group-A", {.SizeBeforeSplit = 1, .SizeAfterSplit = 0, .ReadBeforeSplit = {.ReadCount = 1, .CommitLast = true}}},
-        {"group-B", {.SizeBeforeSplit = 0, .SizeAfterSplit = 1}},
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1}}}},
+        {"group-B", {.LastSplit = {.WriteCount = 1}}},
+    });
+}
+
+// Double split: single group, locked before first split, write after second split.
+// Steps: write 1 msg → read+lock → split → split again → write 1 msg → verify blocked → commit → read all.
+Y_UNIT_TEST(Order_DoubleSplit_SingleGroup_LockedBeforeSplit) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = false}}, .IntermediateSplit = TStage{.Read = {.CommitLast = false}}, .LastSplit = TStage{.WriteCount = 1}}},
+    });
+}
+
+Y_UNIT_TEST(Order_DoubleSplit_MultipleGroups_R1) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-00", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 3}}},
+    });
+}
+
+Y_UNIT_TEST(Order_DoubleSplit_MultipleGroups_R2) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-00", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 3}}},
+        {"group-01", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+    });
+}
+
+Y_UNIT_TEST(Order_DoubleSplit_MultipleGroups_R7) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-00", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 3}}},
+        {"group-01", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+        {"group-02", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 2, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-03", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-04", {.Root = {.WriteCount = 5, .Read = {.Count = 3, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 2, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-05", {.Root = {.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-06", {.Root = {.WriteCount = 3, .Read = {.Count = 2, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+    });
+}
+
+Y_UNIT_TEST(Order_DoubleSplit_MultipleGroups_R8) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-00", {.Root = {.WriteCount = 4, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 5, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-01", {.Root = {.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-02", {.Root = {.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 6, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-03", {.Root = {.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-04", {.Root = {.WriteCount = 3, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-05", {.Root = {.WriteCount = 3, .Read = {.Count = 2, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-06", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 3, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-07", {.Root = {.WriteCount = 2, .Read = {.Count = 1, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 1, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+    });
+}
+
+Y_UNIT_TEST(Order_DoubleSplit_MultipleGroups_R32) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-00", {.Root = {.WriteCount = 4, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 5, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-01", {.Root = {.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-02", {.Root = {.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 6, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-03", {.Root = {.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-04", {.Root = {.WriteCount = 3, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-05", {.Root = {.WriteCount = 3, .Read = {.Count = 2, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-06", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 3, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-07", {.Root = {.WriteCount = 2, .Read = {.Count = 1, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 1, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+        {"group-08", {.Root = {.WriteCount = 4, .Read = {.Count = 2, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 3, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-09", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 2, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-10", {.Root = {.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-11", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-12", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-13", {.Root = {.WriteCount = 5, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 4, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-14", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-15", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-16", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 2, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-17", {.Root = {.WriteCount = 2, .Read = {.Count = 1, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 3, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-18", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 3, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-19", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-20", {.Root = {.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 3, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-21", {.Root = {.WriteCount = 2, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-22", {.Root = {.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 5, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 3}}},
+        {"group-23", {.Root = {.WriteCount = 3, .Read = {.Count = 2, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 1, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 4}}},
+        {"group-24", {.Root = {.WriteCount = 1, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 2, .Read = {.Count = 1, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 0}}},
+        {"group-25", {.Root = {.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 1, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-26", {.Root = {.WriteCount = 4, .Read = {.Count = 3, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 5, .Read = {.Count = 2, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-27", {.Root = {.WriteCount = 3, .Read = {.Count = 1, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 3, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-28", {.Root = {.WriteCount = 3, .Read = {.Count = 3, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 0, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-29", {.Root = {.WriteCount = 3, .Read = {.Count = 0, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 4, .CommitLast = 1}}, .LastSplit = TStage{.WriteCount = 5}}},
+        {"group-30", {.Root = {.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 1}}, .IntermediateSplit = TStage{.WriteCount = 3, .Read = {.Count = 6, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 2}}},
+        {"group-31", {.Root = {.WriteCount = 4, .Read = {.Count = 2, .CommitLast = 0}}, .IntermediateSplit = TStage{.WriteCount = 4, .Read = {.Count = 0, .CommitLast = 0}}, .LastSplit = TStage{.WriteCount = 0}}},
+    });
+}
+
+// Double split: multiple groups, mixed commit states before first split.
+Y_UNIT_TEST(Order_DoubleSplit_MixedGroups) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = false}}, .IntermediateSplit = TStage{.Read = {.CommitLast = false}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 2, .Read = {.Count = 2}}, .LastSplit = TStage{.WriteCount = 1}}},
+        {"group-C", {.LastSplit = TStage{.WriteCount = 1}}},
+    });
+}
+
+// Double split: writes between splits and after second split.
+Y_UNIT_TEST(Order_DoubleSplit_WritesBetweenSplits) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-A", {.Root = {.WriteCount = 1, .Read = {.Count = 1, .CommitLast = false}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.CommitLast = false}}, .LastSplit = TStage{.WriteCount = 1}}},
+    });
+}
+
+// Double split: read between splits.
+Y_UNIT_TEST(Order_DoubleSplit_ReadBetweenSplits) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-A", {.Root = {.WriteCount = 2, .Read = {.Count = 1}}, .IntermediateSplit = TStage{.WriteCount = 1, .Read = {.Count = 1}}, .LastSplit = TStage{.WriteCount = 1}}},
     });
 }
 
@@ -899,7 +1193,7 @@ static std::vector<TCollectedMessage> ReadAllAndCommit(
             TStringBuilder sb;
             sb << phase << " ReadAllAndCommit iteration=" << readIteration << ", retries left=" << retries << ":\n";
             for (auto& [g, n] : remainingReads) {
-                sb << "  " << g << ": remaining=" << n << Endl;
+                sb << "  " << g << ": read remaining=" << n << Endl;
             }
             ACerr << sb << Endl;
         }
@@ -1850,5 +2144,18 @@ void Out<NKikimr::NPQ::NMLP::TDedupWriteSpec>(IOutputStream& os, const NKikimr::
     os << "Body=" << w.Body << ", ";
     os << "DedupId=" << w.DedupId << ", ";
     os << "GroupId=" << w.GroupId;
+    os << "}";
+}
+
+template<>
+void Out<NKikimr::NPQ::NMLP::TCounter>(IOutputStream& os, const NKikimr::NPQ::NMLP::TCounter& c) {
+    os << "{";
+    os << "w:" << c.Write << " [" << JoinSeq(",", c.WriteByStage) << "]";
+    os << ", ";
+    os << "r:" << c.Read << " [" << JoinSeq(",", c.ReadByStage) << "]";
+    os << ", ";
+    os << "c:" << c.Commit << " [" << JoinSeq(",", c.CommitByStage) << "]";
+    os << ", ";
+    os << "last: " << c.LastReadBody;
     os << "}";
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -459,14 +459,14 @@ size_t TStorage::Compact() {
                 case EMessageStatus::DLQ:
                     break;
             }
-            RemoveFirstMessageFromMessages();
+            RemoveFirstMessageFromFastZone();
             ++removed;
         }
     }
 
     // Remove already committed messages
     while(!Messages.empty() && FirstOffset < FirstUncommittedOffset) {
-        RemoveFirstMessageFromMessages();
+        RemoveFirstMessageFromFastZone();
         ++removed;
     }
 
@@ -710,7 +710,7 @@ void TStorage::RemoveMessage(ui64 offset, const TMessage& message) {
     }
 }
 
-void TStorage::RemoveFirstMessageFromMessages() {
+void TStorage::RemoveFirstMessageFromFastZone() {
     AFL_ENSURE(!Messages.empty());
     auto& message = Messages.front();
     RemoveMessage(FirstOffset, message);
@@ -733,7 +733,7 @@ bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupId
     AFL_ENSURE(offset >= GetLastOffset())("l", offset)("r", GetLastOffset());
 
     while (!Messages.empty() && offset > GetLastOffset()) {
-        RemoveFirstMessageFromMessages();
+        RemoveFirstMessageFromFastZone();
     }
 
     if (Messages.size() >= MaxFastMessages) {
@@ -751,7 +751,7 @@ bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupId
                     ++FirstOffset;
                     break;
                 case EMessageStatus::Committed:
-                    RemoveFirstMessageFromMessages();
+                    RemoveFirstMessageFromFastZone();
                     break;
             }
         }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -76,8 +76,9 @@ NKikimrPQ::EReadWithKeepOrder TStorage::ReadWithKeepOrder() const {
     for (const auto& parentPartitionExternalLockInfo : ParentPartitionExternalLockInfo) {
         switch (parentPartitionExternalLockInfo.ReadWithKeepOrder) {
             case READ_WITH_KEEP_ORDER_BLOCK_ALL:
+            case READ_WITH_KEEP_ORDER_BLACKLIST:
             case READ_WITH_KEEP_ORDER_ALLOW_ALL:
-                static_assert(READ_WITH_KEEP_ORDER_BLOCK_ALL < READ_WITH_KEEP_ORDER_ALLOW_ALL);
+                static_assert(READ_WITH_KEEP_ORDER_BLOCK_ALL < READ_WITH_KEEP_ORDER_BLACKLIST && READ_WITH_KEEP_ORDER_BLACKLIST < READ_WITH_KEEP_ORDER_ALLOW_ALL);
                 result = std::min(result, parentPartitionExternalLockInfo.ReadWithKeepOrder);
                 break;
             case READ_WITH_KEEP_ORDER_UNSPECIFIED:
@@ -99,7 +100,10 @@ bool TStorage::HasUnlockedMessageGroupsId() const {
     if (ReadWithKeepOrder() == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL) {
         return false;
     }
-    return LockedMessageGroupsId.size() < GetMessageCount(); // approximate
+    if (MessageGroups.UnlockedMessageGroupsId.size() > 0) {
+        return true;
+    }
+    return MessageGroups.UnorderedOffsets.size() > 0;
 }
 
 std::optional<ui32> TStorage::GetRetentionDeadlineDelta() const {
@@ -113,14 +117,39 @@ std::optional<ui32> TStorage::GetRetentionDeadlineDelta() const {
     return std::nullopt;
 }
 
+bool TStorage::CanReadMessageGroupIdHashFromParentPartition(const ui32 messageGroupIdHash) const {
+    if (!KeepMessageOrder) {
+        return true;
+    }
+    using enum NKikimrPQ::EReadWithKeepOrder;
+    if (auto order = ReadWithKeepOrder(); EqualToOneOf(order, READ_WITH_KEEP_ORDER_BLOCK_ALL, READ_WITH_KEEP_ORDER_ALLOW_ALL)) {
+        return order == READ_WITH_KEEP_ORDER_ALLOW_ALL;
+    }
+    for (const auto& parentPartitionExternalLockInfo : ParentPartitionExternalLockInfo) {
+        switch (parentPartitionExternalLockInfo.ReadWithKeepOrder) {
+            case READ_WITH_KEEP_ORDER_BLOCK_ALL:
+                Y_ASSERT(false && "checked before");
+                return false;
+            case READ_WITH_KEEP_ORDER_BLACKLIST:
+                if (parentPartitionExternalLockInfo.LockedMessageGroupsIdSet.contains(messageGroupIdHash)) {
+                    return false;
+                }
+                break;
+            case READ_WITH_KEEP_ORDER_ALLOW_ALL:
+                break;
+            case READ_WITH_KEEP_ORDER_UNSPECIFIED:
+                AFL_ENSURE(false)("ReadWithKeepOrder", NKikimrPQ::EReadWithKeepOrder_Name(parentPartitionExternalLockInfo.ReadWithKeepOrder));
+                break;
+        }
+    }
+    return true;
+}
+
 bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     if (!KeepMessageOrder) {
         return true;
     }
-    if (ReadWithKeepOrder() == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL) {
-        return false;
-    }
-    return !LockedMessageGroupsId.contains(messageGroupIdHash);
+    return MessageGroups.UnlockedMessageGroupsId.contains(messageGroupIdHash);
 }
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
@@ -245,7 +274,7 @@ bool TStorage::Purge(ui64 endOffset) {
     Messages.clear();
     DLQQueue.clear();
     DLQMessages.clear();
-    LockedMessageGroupsId.clear();
+    MessageGroups.Clear();
 
     FirstOffset = endOffset;
     FirstUncommittedOffset = endOffset;
@@ -318,6 +347,17 @@ TStorage::TUpdateExternalLockedMessageGroupsResult TStorage::DoUpdateExternalLoc
     if (info->ReadWithKeepOrder <= record.GetMode()) {
         info->ReadWithKeepOrder = record.GetMode();
     }
+    if (info->ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
+        Y_ASSERT(record.HasFullBlacklist());
+    }
+    if (record.HasFullBlacklist() || info->ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
+        const auto& list = record.GetFullBlacklist().GetParentLockedMessageGroupsIdHash();
+        absl::flat_hash_set<ui32> lockedMessageGroupsIdSet(list.begin(), list.end());
+        info->LockedMessageGroupsIdSet.swap(lockedMessageGroupsIdSet);
+        UpdadeMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, lockedMessageGroupsIdSet, result.ModeChanged);
+    } else if (result.ModeChanged) {
+        UpdadeMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, info->LockedMessageGroupsIdSet, result.ModeChanged);
+    }
     if (!loadState) {
         Batch.SetUpdateExternalLockedMessageGroupsId(parentPartitionId);
     }
@@ -367,13 +407,7 @@ size_t TStorage::ProccessDeadlines() {
             }
         }
     };
-
-    for (auto& [offset, message] : SlowMessages) {
-        unlockIfNeed(offset, message);
-    }
-    for (size_t i = 0; i < Messages.size(); ++i) {
-        unlockIfNeed(FirstOffset + i, Messages[i]);
-    }
+    IterateAllMessagesInOrder(unlockIfNeed);
 
     return count;
 }
@@ -404,9 +438,7 @@ size_t TStorage::Compact() {
         };
 
         for (auto it = SlowMessages.begin(); it != SlowMessages.end() && canRemove(it->second);) {
-            auto& message = it->second;
-            RemoveMessage(it->first, message);
-            it = SlowMessages.erase(it);
+            it = RemoveMessageFromSlowZone(it);
             ++removed;
             ++Metrics.TotalDeletedByRetentionMessageCount;
         }
@@ -424,20 +456,14 @@ size_t TStorage::Compact() {
                 case EMessageStatus::DLQ:
                     break;
             }
-
-            RemoveMessage(FirstOffset, message);
-            Messages.pop_front();
-            ++FirstOffset;
+            RemoveFirstMessageFromMessages();
             ++removed;
         }
     }
 
     // Remove already committed messages
     while(!Messages.empty() && FirstOffset < FirstUncommittedOffset) {
-        auto& message = Messages.front();
-        RemoveMessage(FirstOffset, message);
-        Messages.pop_front();
-        ++FirstOffset;
+        RemoveFirstMessageFromMessages();
         ++removed;
     }
 
@@ -460,10 +486,196 @@ size_t TStorage::Compact() {
 
     return removed;
 }
+static bool TrackMessageStatusInLockedGroups(const TStorage::EMessageStatus status) {
+    return !EqualToOneOf(status, TStorage::EMessageStatus::Committed);
+}
+
+static bool TrackMessageStatusInLockedGroups(const TStorage::TMessage& message) {
+    return TrackMessageStatusInLockedGroups(message.GetStatus());
+}
+
+static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash) {
+    if (locked.IsAccessible()) {
+        messageGroups.UnlockedMessageGroupsId.insert(messageGroupIdHash);
+        messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
+    } else {
+        messageGroups.UnlockedMessageGroupsId.erase(messageGroupIdHash);
+        if (locked.LockedSelf) {
+            messageGroups.LockedMessageGroupsId.insert(messageGroupIdHash);
+        } else {
+            messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
+        }
+    }
+}
+
+void TStorage::UpdadeMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged) {
+    auto update = [this](ui32 messageGroupIdHash, TSingleMessageGroupIdInfo& group) {
+        bool newLockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
+        if (group.Locked.LockedParent == newLockedParent) {
+            return;
+        }
+        group.Locked.LockedParent = newLockedParent;
+        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash);
+    };
+    bool updateAll = currLocked.size() + prevLocked.size() >= MessageGroups.Groups.size();
+    if (modeChanged || updateAll) {
+        for (auto& [messageGroupIdHash, group] : MessageGroups.Groups) {
+            update(messageGroupIdHash, group);
+        }
+    } else {
+        for (auto messageGroupIdHash : currLocked) {
+            if (prevLocked.contains(messageGroupIdHash)) {
+                continue;
+            }
+            // unlocked -> locked
+            Y_VERIFY_DEBUG_S(false, "Parent lock strictened; messageGroupIdHash=" << messageGroupIdHash);
+            auto* group = MapFindPtr(MessageGroups.Groups, messageGroupIdHash);
+            if (group) {
+                update(messageGroupIdHash, *group);
+            }
+        }
+        for (auto messageGroupIdHash : prevLocked) {
+            if (currLocked.contains(messageGroupIdHash)) {
+                continue;
+            }
+            // locked -> unlocked
+            auto* group = MapFindPtr(MessageGroups.Groups, messageGroupIdHash);
+            if (group) {
+                update(messageGroupIdHash, *group);
+            }
+        }
+    }
+}
+
+void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& message) {
+    auto messageGroupIterator = MessageGroups.Groups.find(message.MessageGroupIdHash);
+    AFL_ENSURE(messageGroupIterator != MessageGroups.Groups.end());
+    TSingleMessageGroupIdInfo* ptr = &messageGroupIterator->second;
+    AFL_ENSURE(ptr->Size > 0);
+    ptr->Size -= 1;
+    AFL_ENSURE((ptr->Size == 0) == message.NextMessageGroupIdOffset().Empty())("size", ptr->Size)("next", message.NextMessageGroupIdOffset());
+    AFL_ENSURE(ptr->FirstOffset <= offset)("first", ptr->FirstOffset)("offset", offset);
+
+    auto nextOffset = message.NextMessageGroupIdOffset();
+    if (nextOffset.Empty()) {
+        MessageGroups.Groups.erase(messageGroupIterator);
+        MessageGroups.LockedMessageGroupsId.erase(message.MessageGroupIdHash);
+        MessageGroups.UnlockedMessageGroupsId.erase(message.MessageGroupIdHash);
+        return;
+    }
+    ptr->FirstOffset = *nextOffset;
+    auto [nextMessage, _] = GetMessageInt(*nextOffset);
+    AFL_ENSURE(nextMessage != nullptr);
+    ptr->Locked.FillFromStatus(nextMessage->GetStatus());
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+}
+
+void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus) {
+    if (!KeepMessageOrder) {
+        return;
+    }
+    if (!message.HasMessageGroupId) {
+        if (EqualToOneOf(newStatus, EMessageStatus::Unprocessed)) {
+            MessageGroups.UnorderedOffsets.insert(offset);
+        } else {
+            MessageGroups.UnorderedOffsets.erase(offset);
+        }
+        return;
+    }
+    if (!TrackMessageStatusInLockedGroups(message)) {
+        return;
+    }
+    if (message.GetStatus() == newStatus) {
+        return;
+    }
+
+    if (!TrackMessageStatusInLockedGroups(newStatus)) {
+        UpdateMessageGroupToNextMessage(offset, message);
+        return;
+    }
+
+    TSingleMessageGroupIdInfo* ptr = MapFindPtr(MessageGroups.Groups, message.MessageGroupIdHash);
+    AFL_ENSURE(ptr != nullptr)("offset", offset)("messageGroupIdHash", message.MessageGroupIdHash);
+    ptr->Locked.FillFromStatus(newStatus);
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+}
+
+void TStorage::UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message) {
+    if (!KeepMessageOrder) {
+        return;
+    }
+    if (!message.HasMessageGroupId) {
+        MessageGroups.UnorderedOffsets.erase(offset);
+        return;
+    }
+    if (!TrackMessageStatusInLockedGroups(message)) {
+        return;
+    }
+
+    auto messageGroupIterator = MessageGroups.Groups.find(message.MessageGroupIdHash);
+    TSingleMessageGroupIdInfo* ptr = (messageGroupIterator == MessageGroups.Groups.end()) ? nullptr : &messageGroupIterator->second;
+    AFL_ENSURE(ptr != nullptr)("offset", offset)("messageGroupIdHash", message.MessageGroupIdHash);
+
+    if (message.GetStatus() == EMessageStatus::Locked) {
+        AFL_ENSURE(ptr->Locked.LockedSelf);
+        ptr->Locked.LockedSelf = false;
+    }
+    if (message.GetStatus() == EMessageStatus::Delayed) {
+        ptr->Locked.Delayed = false;
+    }
+
+    UpdateMessageGroupToNextMessage(offset, message);
+}
+
+void TStorage::UpdateMessageGroupForNewMessage(ui64 offset, TMessage& message) {
+    if (!KeepMessageOrder) {
+        return;
+    }
+    if (!message.HasMessageGroupId) {
+        if (message.GetStatus() == EMessageStatus::Unprocessed) {
+            MessageGroups.UnorderedOffsets.insert(offset);
+        }
+        return;
+    }
+    if (!TrackMessageStatusInLockedGroups(message)) {
+        return;
+    }
+
+    const auto messageGroupIdHash = message.MessageGroupIdHash;
+    auto [it, firstMessageInGroup] = MessageGroups.Groups.try_emplace(ui32(message.MessageGroupIdHash));
+    bool firstReadableMessageInGroup = false;
+    TSingleMessageGroupIdInfo& group = it->second;
+    group.Size++;
+    if (firstMessageInGroup) {
+        group.FirstOffset = offset;
+        firstReadableMessageInGroup = TrackMessageStatusInLockedGroups(message); // may be false on snapshot restore
+    } else {
+        auto [prev, _] = GetMessageInt(group.LastOffset);
+        AFL_ENSURE(prev != nullptr);
+        prev->SetNextMessageGroupIdOffset(offset);
+        if (!TrackMessageStatusInLockedGroups(*prev)) {
+            firstReadableMessageInGroup = true;
+        }
+    }
+    if (firstReadableMessageInGroup) {
+        group.FirstOffset = offset;
+    }
+    group.LastOffset = offset;
+    if (message.GetStatus() == EMessageStatus::Locked) {
+        AFL_ENSURE(firstReadableMessageInGroup)("offset", offset)("groupSize", group.Size);
+    }
+    if (firstReadableMessageInGroup) {
+        group.Locked.LockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
+        group.Locked.FillFromStatus(message.GetStatus());
+        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash);
+    }
+}
 
 void TStorage::RemoveMessage(ui64 offset, const TMessage& message) {
     AFL_ENSURE(Metrics.InflightMessageCount > 0);
     --Metrics.InflightMessageCount;
+
+    UpdateMessageGroupForRemovedMessage(offset, message);
 
     switch(message.GetStatus()) {
         case EMessageStatus::Unprocessed:
@@ -473,7 +685,7 @@ void TStorage::RemoveMessage(ui64 offset, const TMessage& message) {
         case EMessageStatus::Locked:
             AFL_ENSURE(Metrics.LockedMessageCount > 0);
             --Metrics.LockedMessageCount;
-            if (KeepMessageOrder && message.HasMessageGroupId && LockedMessageGroupsId.erase(message.MessageGroupIdHash)) {
+            if (KeepMessageOrder && message.HasMessageGroupId) {
                 AFL_ENSURE(Metrics.LockedMessageGroupCount > 0);
                 --Metrics.LockedMessageGroupCount;
             }
@@ -495,14 +707,30 @@ void TStorage::RemoveMessage(ui64 offset, const TMessage& message) {
     }
 }
 
+void TStorage::RemoveFirstMessageFromMessages() {
+    AFL_ENSURE(!Messages.empty());
+    auto& message = Messages.front();
+    RemoveMessage(FirstOffset, message);
+    Messages.pop_front();
+    ++FirstOffset;
+}
+
+TStorage::TSlowMessagesMap::iterator TStorage::RemoveMessageFromSlowZone(TSlowMessagesMap::iterator it) {
+    RemoveMessage(it->first, it->second);
+    return SlowMessages.erase(it);
+}
+
+void TStorage::RemoveMessageFromSlowZone(ui64 offset) {
+    auto it = SlowMessages.find(offset);
+    AFL_ENSURE(it != SlowMessages.end())("offset", offset);
+    RemoveMessageFromSlowZone(it);
+}
+
 bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupIdHash, TInstant writeTimestamp, TDuration delay) {
     AFL_ENSURE(offset >= GetLastOffset())("l", offset)("r", GetLastOffset());
 
     while (!Messages.empty() && offset > GetLastOffset()) {
-        auto message = Messages.front();
-        RemoveMessage(FirstOffset, message);
-        Messages.pop_front();
-        ++FirstOffset;
+        RemoveFirstMessageFromMessages();
     }
 
     if (Messages.size() >= MaxFastMessages) {
@@ -514,15 +742,15 @@ bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupId
                 case EMessageStatus::Locked:
                 case EMessageStatus::Delayed:
                 case EMessageStatus::DLQ:
-                    SlowMessages[FirstOffset] = message;
+                    SlowMessages.insert_or_assign(FirstOffset, message);
                     Batch.MoveToSlow(FirstOffset);
+                    Messages.pop_front();
+                    ++FirstOffset;
                     break;
                 case EMessageStatus::Committed:
-                    RemoveMessage(FirstOffset, message);
+                    RemoveFirstMessageFromMessages();
                     break;
             }
-            Messages.pop_front();
-            ++FirstOffset;
         }
     }
 
@@ -557,7 +785,7 @@ bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupId
 
     ui32 deadlineDelta = delay == TDuration::Zero() ? 0 : NormalizeDeadline(writeTimestamp + delay);
 
-    Messages.push_back({
+    Messages.emplace_back(TMessageData{
         .Status = static_cast<ui32>(deadlineDelta ? EMessageStatus::Delayed : EMessageStatus::Unprocessed),
         .ProcessingCount = 0,
         .DeadlineDelta = deadlineDelta,
@@ -565,6 +793,8 @@ bool TStorage::AddMessage(ui64 offset, bool hasMessagegroup, ui32 messageGroupId
         .MessageGroupIdHash = messageGroupIdHash,
         .WriteTimestampDelta = ui32(writeTimestampDelta)
     });
+
+    UpdateMessageGroupForNewMessage(offset, Messages.back());
 
     Batch.AddNewMessage(offset);
 
@@ -637,6 +867,7 @@ bool TStorage::WakeUpDLQ() {
     for (auto [offset, _] : DLQMessages) {
         auto [message, slowZone] = GetMessageInt(offset, EMessageStatus::DLQ);
         if (message) {
+            UpdateMessageGroupOnMessageStatusChange(offset, *message, EMessageStatus::Unprocessed);
             message->SetStatus(EMessageStatus::Unprocessed);
             if (!slowZone) {
                 FirstUnlockedOffset = std::min(FirstUnlockedOffset, offset);
@@ -731,7 +962,11 @@ std::deque<TDLQMessage> TStorage::GetDLQMessages() {
 }
 
 const absl::flat_hash_set<ui32>& TStorage::GetLockedMessageGroupsId() const {
-    return LockedMessageGroupsId;
+    return MessageGroups.LockedMessageGroupsId;
+}
+
+size_t TStorage::GetLockedMessageGroupsIdSize() const {
+    return MessageGroups.LockedMessageGroupsId.size();
 }
 
 bool TStorage::HasRetentionExpiredMessages() const {
@@ -790,6 +1025,7 @@ ui64 TStorage::DoLock(ui64 offset, TMessage& message, const TInstant deadline) {
     auto now = TimeProvider->Now();
 
     AFL_VERIFY(message.GetStatus() == EMessageStatus::Unprocessed)("status", message.GetStatus());
+    UpdateMessageGroupOnMessageStatusChange(offset, message, EMessageStatus::Locked);
     message.SetStatus(EMessageStatus::Locked);
     message.DeadlineDelta = NormalizeDeadline(deadline);
     if (message.ProcessingCount < MAX_PROCESSING_COUNT) {
@@ -800,13 +1036,9 @@ ui64 TStorage::DoLock(ui64 offset, TMessage& message, const TInstant deadline) {
     SetMessageLockingTime(message, now, BaseDeadline);
 
     Batch.AddChange(offset);
-
     if (KeepMessageOrder && message.HasMessageGroupId) {
-        LockedMessageGroupsId.insert(message.MessageGroupIdHash);
-
         ++Metrics.LockedMessageGroupCount;
     }
-
     ++Metrics.LockedMessageCount;
     AFL_ENSURE(Metrics.UnprocessedMessageCount > 0)("o", offset);
     --Metrics.UnprocessedMessageCount;
@@ -850,26 +1082,19 @@ bool TStorage::DoCommit(ui64 offset, size_t& totalMetrics) {
         return false;
     }
 
+    UpdateMessageGroupOnMessageStatusChange(offset, *message, EMessageStatus::Committed);
     switch(message->GetStatus()) {
         case EMessageStatus::Unprocessed:
-            if (!slowZone) {
-                Batch.AddChange(offset);
-                ++Metrics.CommittedMessageCount;
-            }
-
+            ++Metrics.CommittedMessageCount;
             AFL_ENSURE(Metrics.UnprocessedMessageCount > 0)("o", offset);
             --Metrics.UnprocessedMessageCount;
             ++totalMetrics;
             break;
         case EMessageStatus::Locked: {
-            if (!slowZone) {
-                Batch.AddChange(offset);
-                ++Metrics.CommittedMessageCount;
-            }
-
+            ++Metrics.CommittedMessageCount;
             AFL_ENSURE(Metrics.LockedMessageCount > 0)("o", offset);
             --Metrics.LockedMessageCount;
-            if (KeepMessageOrder && message->HasMessageGroupId && LockedMessageGroupsId.erase(message->MessageGroupIdHash)) {
+            if (KeepMessageOrder && message->HasMessageGroupId) {
                 AFL_ENSURE(Metrics.LockedMessageGroupCount > 0)("o", offset);
                 --Metrics.LockedMessageGroupCount;
             }
@@ -883,11 +1108,7 @@ bool TStorage::DoCommit(ui64 offset, size_t& totalMetrics) {
             break;
         }
         case EMessageStatus::Delayed:
-            if (!slowZone) {
-                Batch.AddChange(offset);
-                ++Metrics.CommittedMessageCount;
-            }
-
+            ++Metrics.CommittedMessageCount;
             AFL_ENSURE(Metrics.DelayedMessageCount > 0)("o", offset);
             --Metrics.DelayedMessageCount;
             ++totalMetrics;
@@ -895,25 +1116,21 @@ bool TStorage::DoCommit(ui64 offset, size_t& totalMetrics) {
         case EMessageStatus::Committed:
             return false;
         case EMessageStatus::DLQ:
-            if (!slowZone) {
-                Batch.AddChange(offset);
-                ++Metrics.CommittedMessageCount;
-            }
-
+            ++Metrics.CommittedMessageCount;
             DLQMessages.erase(offset);
             AFL_ENSURE(Metrics.DLQMessageCount > 0)("o", offset);
             --Metrics.DLQMessageCount;
             break;
     }
+    message->SetStatus(EMessageStatus::Committed);
+    message->DeadlineDelta = 0;
 
     if (slowZone) {
+        RemoveMessage(offset, *message);
         SlowMessages.erase(offset);
         Batch.DeleteFromSlow(offset);
-        AFL_ENSURE(Metrics.InflightMessageCount > 0)("o", offset);
-        --Metrics.InflightMessageCount;
     } else {
-        message->SetStatus(EMessageStatus::Committed);
-        message->DeadlineDelta = 0;
+        Batch.AddChange(offset);
     }
 
     UpdateFirstUncommittedOffset();
@@ -934,7 +1151,7 @@ bool TStorage::DoUnlock(ui64 offset) {
 
 void TStorage::DoUnlock(ui64 offset, TMessage& message) {
     UpdateMessageLockingDurationMetrics(message);
-
+    UpdateMessageGroupOnMessageStatusChange(offset, message, EMessageStatus::Unprocessed);
     message.SetStatus(EMessageStatus::Unprocessed);
     message.DeadlineDelta = 0;
     message.LockingTimestampMilliSecondsDelta = 0;
@@ -944,7 +1161,7 @@ void TStorage::DoUnlock(ui64 offset, TMessage& message) {
 
     ++Metrics.UnprocessedMessageCount;
 
-    if (KeepMessageOrder && message.HasMessageGroupId && LockedMessageGroupsId.erase(message.MessageGroupIdHash)) {
+    if (KeepMessageOrder && message.HasMessageGroupId) {
         AFL_ENSURE(Metrics.LockedMessageGroupCount > 0)("o", offset);
         --Metrics.LockedMessageGroupCount;
     }
@@ -955,6 +1172,7 @@ void TStorage::DoUnlock(ui64 offset, TMessage& message) {
     if (message.ProcessingCount >= MaxMessageProcessingCount && DeadLetterPolicy) {
         switch (DeadLetterPolicy.value()) {
             case NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE: {
+                 UpdateMessageGroupOnMessageStatusChange(offset, message, EMessageStatus::DLQ);
                 message.SetStatus(EMessageStatus::DLQ);
 
                 auto seqNo = ++Metrics.TotalScheduledToDLQMessageCount;
@@ -989,6 +1207,7 @@ bool TStorage::DoUndelay(ui64 offset) {
         return false;
     }
 
+    UpdateMessageGroupOnMessageStatusChange(offset, *message, EMessageStatus::Unprocessed);
     message->SetStatus(EMessageStatus::Unprocessed);
     message->DeadlineDelta = 0;
 
@@ -1125,7 +1344,7 @@ TString TStorage::DebugString() const {
         dump(FirstOffset + i, Messages[i], 'f');
     }
 
-    sb << "] LockedGroups [" << JoinSeq(", ", LockedMessageGroupsId) << "]";
+    sb << "] LockedGroups [" << JoinSeq(", ", GetLockedMessageGroupsId()) << "]";
     sb << " DLQQueue [" << JoinSeq(", ", DLQQueue) << "]";
     sb << " DLQMessages [" << JoinSeq(", ", DLQMessages | std::views::transform(AsTDLQMessage)) << "]";
     sb << " Metrics {"
@@ -1251,7 +1470,7 @@ TStorage::TMessageWrapper TStorage::TMessageIterator::operator*() const {
         .WriteTimestamp = Storage.BaseWriteTimestamp + TDuration::Seconds(message->WriteTimestampDelta),
         .LockingTimestamp = Storage.GetMessageLockingTime(*message),
         .MessageGroupIdHash = message->HasMessageGroupId ? std::optional<ui32>(message->MessageGroupIdHash) : std::nullopt,
-        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && Storage.LockedMessageGroupsId.contains(message->MessageGroupIdHash),
+        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.contains(message->MessageGroupIdHash),
     };
 }
 
@@ -1300,6 +1519,13 @@ void TStorage::InitMetrics() {
     }
 
     Metrics.InflightMessageCount = Messages.size() + SlowMessages.size();
+}
+
+void TStorage::TMessageGroups::Clear() {
+    Groups.clear();
+    UnlockedMessageGroupsId.clear();
+    LockedMessageGroupsId.clear();
+    UnorderedOffsets.clear();
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -354,9 +354,9 @@ TStorage::TUpdateExternalLockedMessageGroupsResult TStorage::DoUpdateExternalLoc
         const auto& list = record.GetFullBlacklist().GetParentLockedMessageGroupsIdHash();
         absl::flat_hash_set<ui32> lockedMessageGroupsIdSet(list.begin(), list.end());
         info->LockedMessageGroupsIdSet.swap(lockedMessageGroupsIdSet);
-        UpdadeMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, lockedMessageGroupsIdSet, result.ModeChanged);
+        UpdateMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, lockedMessageGroupsIdSet, result.ModeChanged);
     } else if (result.ModeChanged) {
-        UpdadeMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, info->LockedMessageGroupsIdSet, result.ModeChanged);
+        UpdateMessageGroupsParentLocks(info->LockedMessageGroupsIdSet, info->LockedMessageGroupsIdSet, result.ModeChanged);
     }
     if (!loadState) {
         Batch.SetUpdateExternalLockedMessageGroupsId(parentPartitionId);
@@ -508,7 +508,7 @@ static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messa
     }
 }
 
-void TStorage::UpdadeMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged) {
+void TStorage::UpdateMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged) {
     auto update = [this](ui32 messageGroupIdHash, TSingleMessageGroupIdInfo& group) {
         bool newLockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
         if (group.Locked.LockedParent == newLockedParent) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -350,6 +350,9 @@ TStorage::TUpdateExternalLockedMessageGroupsResult TStorage::DoUpdateExternalLoc
     if (info->ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
         Y_ASSERT(record.HasFullBlacklist());
     }
+    if (info->ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_ALLOW_ALL) {
+        info->LockedMessageGroupsIdSet.clear(); // free blacklist if any
+    }
     if (record.HasFullBlacklist() || info->ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
         const auto& list = record.GetFullBlacklist().GetParentLockedMessageGroupsIdHash();
         absl::flat_hash_set<ui32> lockedMessageGroupsIdSet(list.begin(), list.end());
@@ -1526,6 +1529,43 @@ void TStorage::TMessageGroups::Clear() {
     UnlockedMessageGroupsId.clear();
     LockedMessageGroupsId.clear();
     UnorderedOffsets.clear();
+}
+
+void TStorage::IterateMessageGroupsIdExclusiveFromParent(const std::function<void(ui32)>& callback) const {
+    // handle case, when current partition is exhaused, but parent partition is still contains some unprocessed messages
+
+    if (ParentPartitionExternalLockInfo.size() <= 1) [[likely]] {
+        for (const auto& parentLockInfo : ParentPartitionExternalLockInfo) {
+            for (const auto& messageGroupsId : parentLockInfo.LockedMessageGroupsIdSet) {
+                if (MessageGroups.Groups.contains(messageGroupsId)) {
+                    continue;
+                }
+                callback(messageGroupsId);
+            }
+        }
+        return;
+    }
+
+    absl::flat_hash_set<ui32> processed;
+    for (const auto& parentLockInfo : ParentPartitionExternalLockInfo) {
+        for (const auto& messageGroupsId : parentLockInfo.LockedMessageGroupsIdSet) {
+            if (MessageGroups.Groups.contains(messageGroupsId)) {
+                continue;
+            }
+            if (!processed.insert(messageGroupsId).second) {
+                continue;
+            }
+            callback(messageGroupsId);
+        }
+    }
+}
+
+size_t TStorage::GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents() const {
+    size_t n = MessageGroups.Groups.size();
+    for (const auto& parentLockInfo : ParentPartitionExternalLockInfo) {
+        n += parentLockInfo.LockedMessageGroupsIdSet.size();
+    }
+    return n;
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -58,8 +58,6 @@ public:
         Delayed = 4,
     };
 
-    struct TIntrusiveListGroupIdTag {};
-
     struct TMessageData {
         ui32 Status: 3 = static_cast<ui32>(EMessageStatus::Unprocessed);
         ui32 Reserve: 3 = 0;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -296,7 +296,7 @@ private:
     void RemoveMessage(ui64 offset, const TMessage& message);
     TSlowMessagesMap::iterator RemoveMessageFromSlowZone(TSlowMessagesMap::iterator it);
     void RemoveMessageFromSlowZone(ui64 offset);
-    void RemoveFirstMessageFromMessages();
+    void RemoveFirstMessageFromFastZone();
     void UpdateMessageMetrics(const TMessage& message);
 
     std::optional<ui32> GetRetentionDeadlineDelta() const;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -6,10 +6,13 @@
 #include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
 #include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
 
+#include <library/cpp/iterator/iterate_keys.h>
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/pqdata_mlp.pb.h>
 
 #include <library/cpp/time_provider/time_provider.h>
+
+#include <util/generic/intrlist.h>
 
 #include <deque>
 #include <map>
@@ -55,7 +58,9 @@ public:
         Delayed = 4,
     };
 
-    struct TMessage {
+    struct TIntrusiveListGroupIdTag {};
+
+    struct TMessageData {
         ui32 Status: 3 = static_cast<ui32>(EMessageStatus::Unprocessed);
         ui32 Reserve: 3 = 0;
         // It stores how many times the message was submitted to work.
@@ -83,7 +88,37 @@ public:
             Status = static_cast<ui32>(status);
         }
     };
-    static_assert(sizeof(TMessage) == sizeof(ui32) * 4);
+    static_assert(sizeof(TMessageData) == sizeof(ui32) * 4);
+
+    class TMessage: public TMessageData {
+    public:
+        explicit TMessage(const TMessageData& data)
+            : TMessageData(data)
+            , NextMessageGroupIdOffset_(LastMessageGroupIdOffset)
+        {
+        }
+
+        TMaybe<ui64> NextMessageGroupIdOffset() const {
+            if (!HasMessageGroupId) {
+                return Nothing();
+            }
+            if (NextMessageGroupIdOffset_ == LastMessageGroupIdOffset) {
+                return Nothing();
+            }
+            return NextMessageGroupIdOffset_;
+        }
+
+        void SetNextMessageGroupIdOffset(ui64 offset) {
+            Y_ASSERT(NextMessageGroupIdOffset_ == LastMessageGroupIdOffset && "attempt to overwrite next link");
+            NextMessageGroupIdOffset_ = offset;
+        }
+
+    private:
+        ui64 NextMessageGroupIdOffset_;
+        static constexpr ui64 LastMessageGroupIdOffset = -1;
+    };
+//    static_assert(sizeof(TMessage) == sizeof(ui32) * 4 + sizeof(TIntrusiveListItem<TMessage, TIntrusiveListGroupIdTag>));
+
 
     struct TMessageWrapper {
         bool SlowZone;
@@ -97,8 +132,10 @@ public:
         bool MessageGroupIsLocked;
     };
 
+    using TSlowMessagesMap = std::map<ui64, TMessage>; // offset -> TMessage
+
     struct TMessageIterator {
-        TMessageIterator(const TStorage& storage, std::map<ui64, TMessage>::const_iterator it, ui64 offset);
+        TMessageIterator(const TStorage& storage, TSlowMessagesMap::const_iterator it, ui64 offset);
 
         TMessageIterator& operator++();
         TMessageWrapper operator*() const;
@@ -106,7 +143,7 @@ public:
 
     private:
         const TStorage& Storage;
-        std::map<ui64, TMessage>::const_iterator Iterator;
+        TSlowMessagesMap::const_iterator Iterator;
         ui64 Offset;
     };
 
@@ -159,7 +196,7 @@ public:
         size_t MinMessages = MIN_MESSAGES;
         size_t MaxMessages = MAX_MESSAGES;
         bool KeepMessageOrder = false;
-        std::vector<ui32> ParentPartitionId; // 0 - root, 1 - merge, 2 - split
+        std::vector<ui32> ParentPartitionId; // length=0 for root, length=1 for split, length=2 for merge
     };
 
     explicit TStorage(TIntrusivePtr<ITimeProvider> timeProvider, const TStorageSettings& settings);
@@ -180,6 +217,8 @@ public:
     bool DLQEmpty() const;
     std::deque<TDLQMessage> GetDLQMessages();
     const absl::flat_hash_set<ui32>& GetLockedMessageGroupsId() const;
+    auto GetMessageGroupsIdFromSelfAndParent() const;
+    size_t GetLockedMessageGroupsIdSize() const;
     void InitMetrics();
     bool HasRetentionExpiredMessages() const;
     bool GetKeepMessageOrder() const;
@@ -246,6 +285,8 @@ private:
     bool DoUndelay(ui64 offset);
     TUpdateExternalLockedMessageGroupsResult DoUpdateExternalLockedMessageGroupsId(const NKikimrPQ::TExternalLockedMessageGroupsId&, bool loadState);
     bool CanReadMessageGroupIdHash(ui32 messageGroupIdHash) const;
+    bool CanReadMessageGroupIdHashFromParentPartition(const ui32 messageGroupIdHash) const;
+
 
     void UpdateFirstUncommittedOffset();
 
@@ -255,6 +296,9 @@ private:
     void MoveBaseDeadline(TInstant newBaseDeadline, TInstant newBaseWriteTimestamp);
 
     void RemoveMessage(ui64 offset, const TMessage& message);
+    TSlowMessagesMap::iterator RemoveMessageFromSlowZone(TSlowMessagesMap::iterator it);
+    void RemoveMessageFromSlowZone(ui64 offset);
+    void RemoveFirstMessageFromMessages();
     void UpdateMessageMetrics(const TMessage& message);
 
     std::optional<ui32> GetRetentionDeadlineDelta() const;
@@ -267,14 +311,7 @@ private:
     void BuildAndLinkMessageGroups();
 
     template <class Fn>
-    void IterateAllMessagesInOrder(Fn&& fn) {
-        for (auto& [offset, m] : SlowMessages) {
-            fn(offset, m);
-        }
-        for (size_t i = 0; i < Messages.size(); ++i) {
-            fn(FirstOffset + i, Messages[i]);
-        }
-    }
+    void IterateAllMessagesInOrder(Fn&& fn);
 
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
@@ -295,8 +332,48 @@ private:
     TInstant NextVacuumRun;
 
     std::deque<TMessage> Messages;
-    std::map<ui64, TMessage> SlowMessages;
-    absl::flat_hash_set<ui32> LockedMessageGroupsId;
+    TSlowMessagesMap SlowMessages;
+
+
+    // TODO: в counter message-group отгружать только сигнал от родителя
+
+    struct TLockedGroup {
+        bool LockedSelf : 1 = false;
+        bool LockedParent : 1 = false;
+        bool Delayed : 1 = false;
+        bool WaitDLQ : 1 = false;
+
+        bool IsAccessible() const {
+            return !IsOnlyLocked() && !Delayed && !WaitDLQ;
+        }
+
+        bool IsOnlyLocked() const {
+            return LockedSelf || LockedParent;
+        }
+
+        void FillFromStatus(EMessageStatus status) {
+            LockedSelf = status == EMessageStatus::Locked;
+            Delayed = status == EMessageStatus::Delayed;
+            WaitDLQ = status == EMessageStatus::DLQ;
+        }
+    };
+    struct TSingleMessageGroupIdInfo {
+        ui32 Size = 0;
+        TLockedGroup Locked;
+        ui64 FirstOffset; // exclude DLQ
+        ui64 LastOffset;
+    };
+
+    struct TMessageGroups {
+        absl::flat_hash_map<ui32, TSingleMessageGroupIdInfo> Groups;
+        absl::flat_hash_set<ui32> UnlockedMessageGroupsId; // without parents
+        absl::flat_hash_set<ui32> LockedMessageGroupsId; // without parents
+        absl::flat_hash_set<ui64> UnorderedOffsets; // Groupless
+
+        void Clear();
+    };
+    TMessageGroups MessageGroups;
+
     std::deque<TDLQMessage> DLQQueue;
     // offset->seqNo
     absl::flat_hash_map<ui64, ui64> DLQMessages;
@@ -304,6 +381,8 @@ private:
     struct TParentPartitionExternalLockInfo {
         ui32 PartitionId = 0;
         NKikimrPQ::EReadWithKeepOrder ReadWithKeepOrder = NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL;
+        absl::flat_hash_set<ui32> LockedMessageGroupsIdSet;
+
         ui64 TabletGeneration = 0;
         ui64 ConsumerGeneration = 0;
         ui64 ConsumerStep = 0;
@@ -314,6 +393,20 @@ private:
     TMetrics Metrics;
 };
 
+inline auto TStorage::GetMessageGroupsIdFromSelfAndParent() const {
+    // Return all keys.
+    // Child partition forbidden to read even unlocked groups, if they have unprocessed messages
+    return IterateKeys(MessageGroups.Groups);
+}
 
+template <class Fn>
+inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) {
+    for (auto& [offset, m] : SlowMessages) {
+        fn(offset, m);
+    }
+    for (size_t i = 0; i < Messages.size(); ++i) {
+        fn(FirstOffset + i, Messages[i]);
+    }
+}
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -259,6 +259,23 @@ private:
 
     std::optional<ui32> GetRetentionDeadlineDelta() const;
 
+    void UpdateMessageGroupForNewMessage(ui64 offset, TMessage& message);
+    void UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message);
+    void UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus);
+    void UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& message);
+    void UpdadeMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged);
+    void BuildAndLinkMessageGroups();
+
+    template <class Fn>
+    void IterateAllMessagesInOrder(Fn&& fn) {
+        for (auto& [offset, m] : SlowMessages) {
+            fn(offset, m);
+        }
+        for (size_t i = 0; i < Messages.size(); ++i) {
+            fn(FirstOffset + i, Messages[i]);
+        }
+    }
+
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -94,7 +94,7 @@ public:
     public:
         explicit TMessage(const TMessageData& data)
             : TMessageData(data)
-            , NextMessageGroupIdOffset_(LastMessageGroupIdOffset)
+            , NextMessageGroupIdOffset_(LastMessageGroupIdOffsetSentinel)
         {
         }
 
@@ -102,23 +102,21 @@ public:
             if (!HasMessageGroupId) {
                 return Nothing();
             }
-            if (NextMessageGroupIdOffset_ == LastMessageGroupIdOffset) {
+            if (NextMessageGroupIdOffset_ == LastMessageGroupIdOffsetSentinel) {
                 return Nothing();
             }
             return NextMessageGroupIdOffset_;
         }
 
         void SetNextMessageGroupIdOffset(ui64 offset) {
-            Y_ASSERT(NextMessageGroupIdOffset_ == LastMessageGroupIdOffset && "attempt to overwrite next link");
+            Y_ASSERT(NextMessageGroupIdOffset_ == LastMessageGroupIdOffsetSentinel && "attempt to overwrite next link");
             NextMessageGroupIdOffset_ = offset;
         }
 
     private:
-        ui64 NextMessageGroupIdOffset_;
-        static constexpr ui64 LastMessageGroupIdOffset = -1;
+        ui64 NextMessageGroupIdOffset_; // not serialized
+        static constexpr ui64 LastMessageGroupIdOffsetSentinel = Max<ui64>();
     };
-//    static_assert(sizeof(TMessage) == sizeof(ui32) * 4 + sizeof(TIntrusiveListItem<TMessage, TIntrusiveListGroupIdTag>));
-
 
     struct TMessageWrapper {
         bool SlowZone;
@@ -307,7 +305,7 @@ private:
     void UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message);
     void UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus);
     void UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& message);
-    void UpdadeMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged);
+    void UpdateMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& currLocked, const absl::flat_hash_set<ui32>& prevLocked, bool modeChanged);
     void BuildAndLinkMessageGroups();
 
     template <class Fn>
@@ -334,9 +332,6 @@ private:
     std::deque<TMessage> Messages;
     TSlowMessagesMap SlowMessages;
 
-
-    // TODO: в counter message-group отгружать только сигнал от родителя
-
     struct TLockedGroup {
         bool LockedSelf : 1 = false;
         bool LockedParent : 1 = false;
@@ -344,10 +339,10 @@ private:
         bool WaitDLQ : 1 = false;
 
         bool IsAccessible() const {
-            return !IsOnlyLocked() && !Delayed && !WaitDLQ;
+            return !IsLocked() && !Delayed && !WaitDLQ;
         }
 
-        bool IsOnlyLocked() const {
+        bool IsLocked() const {
             return LockedSelf || LockedParent;
         }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -215,8 +215,10 @@ public:
     bool DLQEmpty() const;
     std::deque<TDLQMessage> GetDLQMessages();
     const absl::flat_hash_set<ui32>& GetLockedMessageGroupsId() const;
-    auto GetMessageGroupsIdFromSelfAndParent() const;
-    size_t GetLockedMessageGroupsIdSize() const;
+    auto GetMessageGroupsIdFromSelf() const;
+    void IterateMessageGroupsIdExclusiveFromParent(const std::function<void(ui32)>& callback) const;
+    size_t GetLockedMessageGroupsIdSize() const; // from current partition only
+    size_t GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents() const;
     void InitMetrics();
     bool HasRetentionExpiredMessages() const;
     bool GetKeepMessageOrder() const;
@@ -388,9 +390,7 @@ private:
     TMetrics Metrics;
 };
 
-inline auto TStorage::GetMessageGroupsIdFromSelfAndParent() const {
-    // Return all keys.
-    // Child partition forbidden to read even unlocked groups, if they have unprocessed messages
+inline auto TStorage::GetMessageGroupsIdFromSelf() const {
     return IterateKeys(MessageGroups.Groups);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage__serialization.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage__serialization.cpp
@@ -90,6 +90,7 @@ struct TItemSerializer {
     void Serialize(TString& buffer, const TMsg& msg) {
         buffer.append(reinterpret_cast<const char*>(&msg), sizeof(TMsg));
     }
+    static_assert(std::is_trivially_copyable_v<TMsg>);
 };
 
 template<typename TMsg>
@@ -104,6 +105,7 @@ struct TItemDeserializer {
 
         return true;
     }
+    static_assert(std::is_trivially_copyable_v<TMsg>);
 };
 
 template<>
@@ -336,8 +338,6 @@ void DeserializeMetrics(TMetrics& metrics, const NKikimrPQ::TMLPMetrics& storedM
 bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
     AFL_ENSURE(snapshot.GetFormatVersion() == 1)("v", snapshot.GetFormatVersion());
 
-    Messages.resize(snapshot.GetMessages().length() / (sizeof(TSnapshotMessage::Common) + 1));
-
     auto& meta = snapshot.GetMeta();
     FirstOffset = meta.GetFirstOffset();
     FirstUncommittedOffset = FirstOffset;
@@ -348,7 +348,7 @@ bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
     DeserializeMetrics(Metrics, snapshot.GetMetrics());
 
     auto fromSnapshot = [](const TSnapshotMessage& message) -> TMessage {
-        TMessage result = {
+        TMessageData result = {
             .Status = message.Common.Fields.Status,
             .Reserve = message.Common.Fields.Reserve,
             .ProcessingCount = message.Common.Fields.ProcessingCount,
@@ -365,7 +365,7 @@ bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
             result.LockingTimestampSign = message.LockingTimestampMilliSecondsDelta < 0;
         }
 
-        return result;
+        return TMessage{std::move(result)};
     };
 
     {
@@ -374,18 +374,11 @@ bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
 
         TDeserializer<TSnapshotMessage> deserializer(snapshot.GetMessages());
         TSnapshotMessage snapshot;
-        for (size_t i = 0; deserializer.Next(snapshot); ++i) {
+        while (deserializer.Next(snapshot)) {
             auto message = fromSnapshot(snapshot);
-            if (i < Messages.size()) {
-                Messages[i] = message;
-            } else {
-                Messages.push_back(message);
-            }
+            Messages.push_back(message);
 
             const auto& messageStatus = message.GetStatus();
-            if (messageStatus == EMessageStatus::Locked && KeepMessageOrder && message.HasMessageGroupId) {
-                LockedMessageGroupsId.insert(message.MessageGroupIdHash);
-            }
 
             moveUnlockedOffset = moveUnlockedOffset && messageStatus != EMessageStatus::Delayed && messageStatus != EMessageStatus::Unprocessed;
             moveUncommittedOffset = moveUncommittedOffset && messageStatus != EMessageStatus::Unprocessed && messageStatus != EMessageStatus::DLQ && messageStatus != EMessageStatus::Locked;
@@ -406,10 +399,7 @@ bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
         TSnapshotMessage snapshot;
         while (deserializer.Next(offset, snapshot)) {
             auto message = fromSnapshot(snapshot);
-            SlowMessages[offset] = message;
-            if (message.GetStatus() == EMessageStatus::Locked && KeepMessageOrder && message.HasMessageGroupId) {
-                LockedMessageGroupsId.insert(message.MessageGroupIdHash);
-            }
+            SlowMessages.insert_or_assign(offset, message);
         }
     }
 
@@ -429,7 +419,19 @@ bool TStorage::Initialize(const NKikimrPQ::TMLPStorageSnapshot& snapshot) {
         DoUpdateExternalLockedMessageGroupsId(externalLockedMessageGroupsId, true);
     }
 
+    BuildAndLinkMessageGroups();
     return true;
+}
+
+void TStorage::BuildAndLinkMessageGroups() {
+    AFL_ENSURE(MessageGroups.Groups.empty())("size", MessageGroups.Groups.size()); // multiple calls?
+    if (!KeepMessageOrder) {
+        return;
+    }
+    auto linkMessage = [this](ui64 offset, TMessage& message) {
+        UpdateMessageGroupForNewMessage(offset, message);
+    };
+    IterateAllMessagesInOrder(linkMessage);
 }
 
 bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
@@ -445,10 +447,6 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
 
     auto removeMessage = [this](const TMessage& message) {
         const auto& messageStatus = message.GetStatus();
-        if (messageStatus == EMessageStatus::Locked && KeepMessageOrder && message.HasMessageGroupId) {
-            LockedMessageGroupsId.erase(message.MessageGroupIdHash);
-        }
-
         if (messageStatus == EMessageStatus::DLQ) {
             DLQMessages.erase(FirstOffset);
         }
@@ -473,14 +471,14 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
             auto [message, slowZone] = GetMessageInt(offset);
             if (message) {
                 AFL_ENSURE(!slowZone)("o", offset);
-                SlowMessages[offset] = *message;
+                SlowMessages.insert_or_assign(offset, *message);
                 continue;
             }
 
             auto it = newMessages.find(offset);
             AFL_ENSURE(it != newMessages.end())("o", offset);
             auto& msg = it->second;
-            SlowMessages[offset] = TMessage{
+            TMessageData msgData = TMessageData{
                 .Status = static_cast<ui32>(EMessageStatus::Unprocessed),
                 .ProcessingCount = 0,
                 .DeadlineDelta = 0,
@@ -490,12 +488,15 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
                 .LockingTimestampMilliSecondsDelta = 0,
                 .LockingTimestampSign = 0,
             };
+            auto messageIt = SlowMessages.insert_or_assign(offset, TMessage{std::move(msgData)}).first;
+            UpdateMessageGroupForNewMessage(offset, messageIt->second);
         }
     }
 
     while (!Messages.empty() && FirstOffset < wal.GetFirstOffset()) {
         auto& message = Messages.front();
         if (!SlowMessages.contains(FirstOffset)) {
+            UpdateMessageGroupForRemovedMessage(FirstOffset, message);
             removeMessage(message);
         }
         Messages.pop_front();
@@ -511,7 +512,7 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
         TAddedMessage msg;
         while (deserializer.Next(offset, msg)) {
             if (offset >= GetLastOffset()) {
-                Messages.push_back({
+                Messages.emplace_back(TMessageData{
                     .Status = static_cast<ui32>(EMessageStatus::Unprocessed),
                     .ProcessingCount = 0,
                     .DeadlineDelta = 0,
@@ -521,6 +522,7 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
                     .LockingTimestampMilliSecondsDelta = 0,
                     .LockingTimestampSign = 0,
                 });
+                UpdateMessageGroupForNewMessage(offset, Messages.back());
             }
         }
     }
@@ -540,16 +542,12 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
             if (statusChanged) {
                 removeMessage(*message);
             }
-
+            UpdateMessageGroupOnMessageStatusChange(offset, *message, static_cast<EMessageStatus>(msg.Common.Fields.Status));
             message->Status = msg.Common.Fields.Status;
             message->DeadlineDelta = msg.Common.Fields.DeadlineDelta;
             message->ProcessingCount = msg.Common.Fields.ProcessingCount;
 
             if (statusChanged && message->GetStatus() == EMessageStatus::Locked) {
-                if (KeepMessageOrder && message->HasMessageGroupId) {
-                    LockedMessageGroupsId.insert(message->MessageGroupIdHash);
-                }
-
                 message->LockingTimestampMilliSecondsDelta = std::abs(msg.LockingTimestampMilliSecondsDelta);
                 message->LockingTimestampSign = msg.LockingTimestampMilliSecondsDelta < 0;
             }
@@ -562,6 +560,7 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
             offset += diff;
             auto it = SlowMessages.find(offset);
             AFL_ENSURE(it != SlowMessages.end())("o", offset);
+            UpdateMessageGroupForRemovedMessage(offset, it->second);
             removeMessage(it->second);
             SlowMessages.erase(it);
         }
@@ -572,7 +571,7 @@ bool TStorage::ApplyWAL(const NKikimrPQ::TMLPStorageWAL& wal) {
         if (it->first >= firstSlowOffset) {
             break;
         }
-
+        UpdateMessageGroupForRemovedMessage(it->first, it->second);
         removeMessage(it->second);
         it = SlowMessages.erase(it);
     }
@@ -818,6 +817,13 @@ void TStorage::SerializeFullExternalLockedMessageGroupsIdTo(NKikimrPQ::TExternal
     msg.SetConsumerGeneration(info.ConsumerGeneration);
     msg.SetStep(info.ConsumerStep);
     msg.SetMode(info.ReadWithKeepOrder);
+    if (info.ReadWithKeepOrder == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST) {
+        auto* blacklist = msg.MutableFullBlacklist();
+        blacklist->MutableParentLockedMessageGroupsIdHash()->Reserve(info.LockedMessageGroupsIdSet.size());
+        for (const auto& messageGroupHash : info.LockedMessageGroupsIdSet) {
+            blacklist->AddParentLockedMessageGroupsIdHash(messageGroupHash);
+        }
+    }
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -1,7 +1,10 @@
 #include "mlp_storage.h"
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <ydb/core/protos/pqconfig.pb.h>
+#include <ydb/core/protos/pqdata_mlp.pb.h>
 #include <util/string/join.h>
+#include <util/stream/labeled.h>
 
 namespace NKikimr::NPQ::NMLP {
 
@@ -56,8 +59,13 @@ struct MockTimeProvider : public ITimeProvider {
 
 struct TUtils {
     TUtils()
+        : TUtils(TStorage::TStorageSettings{.MinMessages = 1, .MaxMessages = 8, .KeepMessageOrder = true})
+    {
+    }
+
+    explicit TUtils( TStorage::TStorageSettings storageSettings)
         : TimeProvider(TIntrusivePtr<MockTimeProvider>(new MockTimeProvider()))
-        , Storage(TimeProvider, TStorage::TStorageSettings{.MinMessages = 1, .MaxMessages = 8, .KeepMessageOrder = true})
+        , Storage(TimeProvider, std::move(storageSettings))
         , BaseWriteTimestamp(TimeProvider->Now() - TDuration::Seconds(8))
     {
         Storage.SetMaxMessageProcessingCount(1);
@@ -93,7 +101,8 @@ struct TUtils {
 
     void AssertLoad() {
         {
-            TUtils utils;
+            Cerr << "LOAD BeginSnapshot+WAL\n";
+            TUtils utils(TStorage::TStorageSettings{.KeepMessageOrder = Storage.GetKeepMessageOrder()});
             utils.LoadSnapshot(BeginSnapshot);
             utils.LoadWAL(WAL);
             utils.Storage.InitMetrics();
@@ -101,7 +110,8 @@ struct TUtils {
             utils.AssertEquals(*this);
         }
         {
-            TUtils utils;
+            Cerr << "LOAD EndSnapshot+WAL\n";
+            TUtils utils(TStorage::TStorageSettings{.KeepMessageOrder = Storage.GetKeepMessageOrder()});
             utils.LoadSnapshot(EndSnapshot);
             utils.Storage.InitMetrics();
             utils.AssertEquals(*this);
@@ -171,11 +181,17 @@ struct TUtils {
         return std::nullopt;
     }
 
-    ui64 Next(TDuration timeout = TDuration::Seconds(8)) {
+    ui64 Next(TDuration timeout = TDuration::Seconds(8), TStringBuf descr = {}) {
         TStorage::TPosition position;
         auto result = Storage.Next(TimeProvider->Now() + timeout, position);
-        UNIT_ASSERT(result);
+        UNIT_ASSERT_C(result.has_value(), descr);
         return result.value().Offset;
+    }
+
+    void CheckNoNext(TDuration timeout = TDuration::Seconds(8), TStringBuf descr = {}) {
+        TStorage::TPosition position;
+        auto result = Storage.Next(TimeProvider->Now() + timeout, position);
+        UNIT_ASSERT_C(!result.has_value(), descr);
     }
 
     bool Commit(ui64 offset) {
@@ -573,11 +589,12 @@ Y_UNIT_TEST(AddMessageWithZeroDelay) {
     utils.AssertLoad();
 }
 
-Y_UNIT_TEST(AddMessageWithDelay_Unlock) {
-    TUtils utils;
+void AddMessageWithDelay_UnlockImpl(bool keepMessageOrder, bool differentGroups) {
+    TUtils utils(TStorage::TStorageSettings{.MinMessages = 1, .MaxMessages = 8, .KeepMessageOrder = keepMessageOrder});
 
-    utils.Storage.AddMessage(3, true, 0, utils.TimeProvider->Now(), TDuration::Seconds(1));
-    utils.Storage.AddMessage(4, true, 0, utils.TimeProvider->Now());
+    ui32 groupHash = 100;
+    utils.Storage.AddMessage(3, true, groupHash += differentGroups, utils.TimeProvider->Now(), TDuration::Seconds(1));
+    utils.Storage.AddMessage(4, true, groupHash += differentGroups, utils.TimeProvider->Now());
 
     auto result = utils.Next(TDuration::Seconds(10));
     UNIT_ASSERT_VALUES_EQUAL(result, 4); // offset 3 delayed by 1 second, so it should be the next message
@@ -598,7 +615,57 @@ Y_UNIT_TEST(AddMessageWithDelay_Unlock) {
     UNIT_ASSERT_VALUES_EQUAL(metrics.InflightMessageCount, 2);
     UNIT_ASSERT_VALUES_EQUAL(metrics.UnprocessedMessageCount, 1);
     UNIT_ASSERT_VALUES_EQUAL(metrics.LockedMessageCount, 1);
-    UNIT_ASSERT_VALUES_EQUAL(metrics.LockedMessageGroupCount, 1);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.LockedMessageGroupCount, keepMessageOrder ? 1 : 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.CommittedMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.DeadlineExpiredMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.DLQMessageCount, 0);
+
+    AssertMessagesLocks(metrics.MessageLocks, {{0, 1}, {1, 1}});
+
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalCommittedMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalMovedToDLQMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalScheduledToDLQMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalPurgedMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalDeletedByDeadlinePolicyMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.TotalDeletedByRetentionMessageCount, 0);
+
+    utils.End();
+    utils.AssertLoad();
+}
+
+Y_UNIT_TEST(AddMessageWithDelay_Unlock) {
+    AddMessageWithDelay_UnlockImpl(false, false);
+}
+
+Y_UNIT_TEST(AddMessageWithDelayWithKeepOrderDifferentGroups_Unlock) {
+    AddMessageWithDelay_UnlockImpl(true, true);
+}
+
+Y_UNIT_TEST(AddMessageWithDelayWithKeepOrder_Unlock) {
+    TUtils utils(TStorage::TStorageSettings{.MinMessages = 1, .MaxMessages = 8, .KeepMessageOrder = true});
+
+    utils.Storage.AddMessage(3, true, 0, utils.TimeProvider->Now(), TDuration::Seconds(1));
+    utils.Storage.AddMessage(4, true, 0, utils.TimeProvider->Now());
+
+    utils.CheckNoNext(TDuration::Seconds(10)); // offset 3 delayed by 1 second, but 4 should wait for it
+
+    utils.Begin();
+
+    utils.TimeProvider->Tick(TDuration::Seconds(2)); // delay of message with offset 3 expired
+    utils.Storage.ProccessDeadlines();
+
+    auto it = utils.Storage.begin();
+    UNIT_ASSERT(it != utils.Storage.end());
+    auto message = *it;
+    UNIT_ASSERT_VALUES_EQUAL(message.Offset, 3);
+    UNIT_ASSERT_VALUES_EQUAL(message.Status, TStorage::EMessageStatus::Unprocessed);
+    UNIT_ASSERT_VALUES_EQUAL(message.ProcessingDeadline, TInstant::Zero());
+
+    auto& metrics = utils.Storage.GetMetrics();
+    UNIT_ASSERT_VALUES_EQUAL(metrics.InflightMessageCount, 2);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.UnprocessedMessageCount, 2);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.LockedMessageCount, 0);
+    UNIT_ASSERT_VALUES_EQUAL(metrics.LockedMessageGroupCount, 0);
     UNIT_ASSERT_VALUES_EQUAL(metrics.CommittedMessageCount, 0);
     UNIT_ASSERT_VALUES_EQUAL(metrics.DeadlineExpiredMessageCount, 0);
     UNIT_ASSERT_VALUES_EQUAL(metrics.DLQMessageCount, 0);
@@ -2718,6 +2785,71 @@ Y_UNIT_TEST(LockedStorageGeneration) {
     }
 }
 
+Y_UNIT_TEST(NextFromBlacklistedStorage) {
+    constexpr TDuration deadline = TDuration::Seconds(50000);
+    TStorage storage(CreateDefaultTimeProvider(), {.KeepMessageOrder = true, .ParentPartitionId = {4}});
+
+    storage.AddMessage(3, true, 3, TInstant::Now());
+    storage.AddMessage(4, true, 4, TInstant::Now());
+    storage.AddMessage(5, true, 5, TInstant::Now());
+    storage.AddMessage(6, true, 6, TInstant::Now());
+    UNIT_ASSERT_VALUES_EQUAL(storage.GetFirstOffset(), 3);
+    UNIT_ASSERT_VALUES_EQUAL(storage.GetLastOffset(), 7);
+
+    {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now(), position);
+        UNIT_ASSERT(!result.has_value());
+    }
+
+    auto setLocked = [&, step = 10](std::vector<ui32> locked) mutable {
+        NKikimrPQ::TExternalLockedMessageGroupsId unlock;
+        unlock.SetParentPartitionId(4);
+        unlock.SetGeneration(1);
+        unlock.SetConsumerGeneration(1);
+        unlock.SetStep(step++);
+        unlock.SetMode(NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST);
+        auto* blacklist = unlock.MutableFullBlacklist();
+        for (auto hash : locked) {
+            blacklist->AddParentLockedMessageGroupsIdHash(hash);
+        }
+        storage.UpdateExternalLockedMessageGroupsId(unlock);
+    };
+    setLocked({3, 5, 6});
+    {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + deadline, position);
+        UNIT_ASSERT(result.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(result->Offset, 4);
+
+        result = storage.Next(TInstant::Now() + deadline, position);
+        UNIT_ASSERT(!result.has_value());
+    }
+    setLocked({3, 6});
+    {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + deadline, position);
+        UNIT_ASSERT(result.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(result->Offset, 5);
+
+        result = storage.Next(TInstant::Now() + deadline, position);
+        UNIT_ASSERT(!result.has_value());
+    }
+    setLocked({});
+    {
+        TStorage::TPosition position;
+        THashSet<ui64> expected = {{3, 6}};
+        while (expected.size() > 0) {
+            const TString caseDesc = TStringBuilder() << "Expected=[" << JoinSeq(",", expected) << "]";
+            auto result = storage.Next(TInstant::Now() + deadline, position);
+            UNIT_ASSERT_C(result.has_value(), caseDesc);
+            UNIT_ASSERT_C(expected.contains(result->Offset), LabeledOutput(result->Offset) << " " << caseDesc);
+            expected.erase(result->Offset);
+        }
+        auto result = storage.Next(TInstant::Now() + deadline, position);
+        UNIT_ASSERT(!result.has_value());
+    }
+}
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/ya.make
@@ -13,6 +13,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/iterator
     ydb/core/persqueue/common
     ydb/core/persqueue/common/proxy
     ydb/core/persqueue/events

--- a/ydb/core/protos/pqdata_mlp.proto
+++ b/ydb/core/protos/pqdata_mlp.proto
@@ -31,8 +31,13 @@ message TMLPMetrics {
 enum EReadWithKeepOrder {
     READ_WITH_KEEP_ORDER_UNSPECIFIED = 0;
     READ_WITH_KEEP_ORDER_BLOCK_ALL = 1; /* reading from a partition returns an empty list of messages */
+    READ_WITH_KEEP_ORDER_BLACKLIST = 2; /* reading returns only messages whose message group id is not included in the locked list */
     READ_WITH_KEEP_ORDER_ALLOW_ALL = 3; /* no reading restrictions */
 }
+
+message TFullBlacklist {
+    repeated fixed32 ParentLockedMessageGroupsIdHash = 1 [packed = true];
+};
 
 message TExternalLockedMessageGroupsId {
     optional uint32 ParentPartitionId = 1;
@@ -41,6 +46,9 @@ message TExternalLockedMessageGroupsId {
     optional uint64 Step = 4; /* increases when the new full state is sent */
 
     optional EReadWithKeepOrder Mode = 5;
+    oneof BlacklistUpdate {
+       TFullBlacklist FullBlacklist = 6; /* full list of locked message group id */
+    }
 }
 
 message TMLPStorageSnapshot {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Отправляем в дочерние партиции Blacklist messageGroupId, которые им запрещено читать.
В него попадает собственные uncommited сообщения и все заблокированные из родителей (если они есть и ещё не дочитаны до конца).
DLQ тоже блокирует чтение из дочерних партиций, т.к. при неудачной записи в DLQ сообщение в FIFO очереди снова возвращается в обработку.

Сообщение посылается при
1. разрыве пайпы;
2. при обновлении статуса у родителя родителя;
3. при полном завершении чтения текущей партиции;
4. при коммите, когда число uncommited сообщений уменьшилось хотя бы вдвое (чтобы суммарно было линейное число посылок).








### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBORKER-10301