### PR TITLE
Revert "Fix flaky TLI tests: propagate VictimQuerySpanId for STATUS_LOCKS_BROKEN without TxLocks (#37349)

### DIFF
--- a/ydb/core/kqp/common/kqp_locks_tli_helpers.h
+++ b/ydb/core/kqp/common/kqp_locks_tli_helpers.h
@@ -2,31 +2,24 @@
 
 #include <ydb/core/kqp/common/kqp_tx_manager.h>
 #include <ydb/core/protos/data_events.pb.h>
-#include <ydb/core/protos/query_stats.pb.h>
 
 namespace NKikimr {
 namespace NKqp {
 
-// Helper: resolve VictimQuerySpanId from broken locks and set it on TxManager.
+// Helper: look up VictimQuerySpanId from broken locks stored in TxManager and set it.
+// Used when STATUS_LOCKS_BROKEN is received and we need to find
+// the victim's QuerySpanId from TxManager's stored lock entries.
 template <typename TLockCollection>
 inline void SetVictimQuerySpanIdFromBrokenLocks(
     ui64 shardId,
     const TLockCollection& locks,
-    const IKqpTransactionManagerPtr& txManager,
-    const NKikimrDataEvents::TEvWriteResult* writeResult = nullptr)
+    const IKqpTransactionManagerPtr& txManager)
 {
-    // Try to look up from TxManager's stored lock entries via the provided locks.
     for (const auto& lock : locks) {
         if (auto victimSpanId = txManager->LookupVictimQuerySpanId(shardId, lock)) {
             txManager->SetVictimQuerySpanId(*victimSpanId);
             return;
         }
-    }
-    // Fallback to DeferredVictimQuerySpanId from TxStats, set by the shard when TxLocks
-    // are not populated (e.g. EnsureCurrentLock or serialization conflict paths).
-    if (writeResult && writeResult->HasTxStats()
-            && writeResult->GetTxStats().HasDeferredVictimQuerySpanId()) {
-        txManager->SetVictimQuerySpanId(writeResult->GetTxStats().GetDeferredVictimQuerySpanId());
     }
 }
 

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1028,7 +1028,7 @@ public:
             TxManager->BreakLock(brokenShardId);
             YQL_ENSURE(TxManager->BrokenLocks());
 
-            SetVictimQuerySpanIdFromBrokenLocks(brokenShardId, ev->Get()->Record.GetTxLocks(), TxManager, &ev->Get()->Record);
+            SetVictimQuerySpanIdFromBrokenLocks(brokenShardId, ev->Get()->Record.GetTxLocks(), TxManager);
             if (TableWriteActorSpan) {
                 TableWriteActorSpan.EndError("LOCKS_BROKEN");
             }
@@ -4640,7 +4640,7 @@ public:
             CollectTliStats(ev->Get()->Record);
             TxManager->BreakLock(ev->Get()->Record.GetOrigin());
             YQL_ENSURE(TxManager->BrokenLocks());
-            SetVictimQuerySpanIdFromBrokenLocks(ev->Get()->Record.GetOrigin(), ev->Get()->Record.GetTxLocks(), TxManager, &ev->Get()->Record);
+            SetVictimQuerySpanIdFromBrokenLocks(ev->Get()->Record.GetOrigin(), ev->Get()->Record.GetTxLocks(), TxManager);
             if (TryDeferLocksBrokenError(ev->Get()->Record.GetOrigin(), MakeLockIssues(TxManager, getIssues()))) {
                 return;
             }

--- a/ydb/core/protos/query_stats.proto
+++ b/ydb/core/protos/query_stats.proto
@@ -49,7 +49,6 @@ message TTxStats {
     repeated uint64 BreakerQuerySpanIds = 9; // QuerySpanIds of queries that wrote to this shard and broke other locks
     repeated uint64 DeferredBreakerQuerySpanIds = 10; // QuerySpanIds of breakers found via deferred lock validation at commit
     repeated uint32 DeferredBreakerNodeIds = 11; // Node IDs matching DeferredBreakerQuerySpanIds
-    optional uint64 DeferredVictimQuerySpanId = 12; // Victim's QuerySpanId set by the shard for STATUS_LOCKS_BROKEN paths that don't populate TxLocks
 
     // TODO:
     // optional uint64 CommitLatencyUsec = 3;

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -41,10 +41,7 @@ public:
         return !op->HasRuntimeConflicts();
     }
 
-    void FillDeferredFields(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
-        if (auto victimSpanId = DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId)) {
-            txStats->SetDeferredVictimQuerySpanId(*victimSpanId);
-        }
+    void FillDeferredBreakerInfo(ui64 lockTxId, NKikimrQueryStats::TTxStats* txStats) {
         auto lockInfo = DataShard.SysLocksTable().GetRawLock(lockTxId);
         if (!lockInfo || !lockInfo->GetBreakVersion()) {
             return;
@@ -254,7 +251,7 @@ public:
                                               lockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(lockTxId) : Nothing(),
                                               querySpanId ? TMaybe<ui64>(querySpanId) : Nothing());
             if (lockTxId) {
-                FillDeferredFields(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
+                FillDeferredBreakerInfo(lockTxId, writeOp.GetWriteResult()->Record.MutableTxStats());
             }
         } else {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
@@ -483,7 +480,7 @@ public:
                     NDataIntegrity::LogVictimDetected(ctx, tabletId, "Write transaction was a victim of broken locks",
                                                       DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId),
                                                       guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
-                    FillDeferredFields(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                    FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
                     return EExecutionStatus::Executed;
                 };
 
@@ -546,7 +543,7 @@ public:
                 {
                     auto* txStats = writeOp->GetWriteResult()->Record.MutableTxStats();
                     for (const auto& brokenLock : brokenLocks) {
-                        FillDeferredFields(brokenLock.GetLockId(), txStats);
+                        FillDeferredBreakerInfo(brokenLock.GetLockId(), txStats);
                     }
                 }
 
@@ -746,7 +743,7 @@ public:
                                               guardLocks.LockTxId ? DataShard.SysLocksTable().GetVictimQuerySpanIdForLock(guardLocks.LockTxId) : Nothing(),
                                               guardLocks.QuerySpanId ? TMaybe<ui64>(guardLocks.QuerySpanId) : Nothing());
             if (guardLocks.LockTxId) {
-                FillDeferredFields(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
+                FillDeferredBreakerInfo(guardLocks.LockTxId, writeOp->GetWriteResult()->Record.MutableTxStats());
             }
 
             ResetChanges(userDb, txc);


### PR DESCRIPTION
This reverts commit 20c543cde7e365cad94bbc359e124a5d0c2a78af.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The fallback doesn't help. It's better to remove it.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
