### PR TITLE
PQ tablets for predicate

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -129,18 +129,44 @@ namespace {
         }
     }
 
-    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager) {
+    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager, ui64 recipientTopicTabletId) {
         transaction.SetOp(NKikimrPQ::TDataTransaction::Commit);
 
         if (!isImmediateCommit) {
             const auto prepareSettings = txManager->GetPrepareTransactionInfo();
+            const auto& topicOps = txManager->GetTopicOperations();
+
+            THashSet<ui64> topicTabletPeers;
+            const bool omitPeerTopicTablets = topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange();
+            if (omitPeerTopicTablets) {
+                for (ui64 id : topicOps.GetReceivingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+                for (ui64 id : topicOps.GetSendingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+            }
+
+            const auto keepShardForPropose = [&](ui64 shardId) {
+                if (!omitPeerTopicTablets) {
+                    return true;
+                }
+                if (!topicTabletPeers.contains(shardId)) {
+                    return true;
+                }
+                return shardId == recipientTopicTabletId;
+            };
 
             if (!prepareSettings.ArbiterColumnShard) {
                 for (const ui64 sendingShardId : prepareSettings.SendingShards) {
-                    transaction.AddSendingShards(sendingShardId);
+                    if (keepShardForPropose(sendingShardId)) {
+                        transaction.AddSendingShards(sendingShardId);
+                    }
                 }
                 for (const ui64 receivingShardId : prepareSettings.ReceivingShards) {
-                    transaction.AddReceivingShards(receivingShardId);
+                    if (keepShardForPropose(receivingShardId)) {
+                        transaction.AddReceivingShards(receivingShardId);
+                    }
                 }
             } else {
                 transaction.AddSendingShards(*prepareSettings.ArbiterColumnShard);
@@ -3885,7 +3911,7 @@ public:
         for (auto& [tabletId, t] : topicTxs) {
             auto& transaction = t.tx;
 
-            FillTopicsCommit(isImmediateCommit, transaction, TxManager);
+            FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId);
 
             if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
                 auto* w = transaction.MutableWriteId();

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -129,23 +129,12 @@ namespace {
         }
     }
 
-    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager, ui64 recipientTopicTabletId) {
+    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager, ui64 recipientTopicTabletId,
+                          bool omitPeerTopicTablets, const THashSet<ui64>& topicTabletPeers) {
         transaction.SetOp(NKikimrPQ::TDataTransaction::Commit);
 
         if (!isImmediateCommit) {
             const auto prepareSettings = txManager->GetPrepareTransactionInfo();
-            const auto& topicOps = txManager->GetTopicOperations();
-
-            THashSet<ui64> topicTabletPeers;
-            const bool omitPeerTopicTablets = topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange();
-            if (omitPeerTopicTablets) {
-                for (ui64 id : topicOps.GetReceivingTabletIds()) {
-                    topicTabletPeers.insert(id);
-                }
-                for (ui64 id : topicOps.GetSendingTabletIds()) {
-                    topicTabletPeers.insert(id);
-                }
-            }
 
             const auto keepShardForPropose = [&](ui64 shardId) {
                 if (!omitPeerTopicTablets) {
@@ -3908,10 +3897,25 @@ public:
         }
         bool kafkaTransaction = TxManager->GetTopicOperations().HasKafkaOperations();
 
+        THashSet<ui64> topicTabletPeers;
+        bool omitPeerTopicTablets = false;
+        if (!isImmediateCommit) {
+            const auto& topicOps = TxManager->GetTopicOperations();
+            omitPeerTopicTablets = topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange();
+            if (omitPeerTopicTablets) {
+                for (ui64 id : topicOps.GetReceivingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+                for (ui64 id : topicOps.GetSendingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+            }
+        }
+
         for (auto& [tabletId, t] : topicTxs) {
             auto& transaction = t.tx;
 
-            FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId);
+            FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId, omitPeerTopicTablets, topicTabletPeers);
 
             if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
                 auto* w = transaction.MutableWriteId();

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -698,4 +698,9 @@ bool TTopicOperations::CalcSkipConflictCheck() const
     return !TrackProducerId_ && SkipConflictCheck_;
 }
 
+bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
+{
+    return CalcSkipConflictCheck() && !HasReadOperations();
+}
+
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -187,8 +187,11 @@ public:
     void SetSkipConflictCheck(bool skipConflictCheck);
     void SetTrackProducerId(bool trackProducerId);
 
-    // When true, peer PQ tablets in the same transaction do not need a distributed
-    // predicate (ReadSet) exchange between each other; KQP omits them from TDataTransaction shards
+    // Returns true when KQP may omit other PQ tablets of this transaction from
+    // TDataTransaction SendingShards/ReceivingShards (so PQ does not run a distributed
+    // predicate / ReadSet exchange only between topic peers). Preconditions:
+    // CalcSkipConflictCheck() is true (!TrackProducerId_ && SkipConflictCheck_) and
+    // there are no topic read operations (no consumer / offset-commit reads).
     bool ShouldOmitPeerTopicTabletsForPredicateExchange() const;
 
 private:

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -187,6 +187,10 @@ public:
     void SetSkipConflictCheck(bool skipConflictCheck);
     void SetTrackProducerId(bool trackProducerId);
 
+    // When true, peer PQ tablets in the same transaction do not need a distributed
+    // predicate (ReadSet) exchange between each other; KQP omits them from TDataTransaction shards
+    bool ShouldOmitPeerTopicTabletsForPredicateExchange() const;
+
 private:
     void MergeSkipConflictCheck(bool rhs);
     void MergeTrackProducerId(bool rhs);

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -255,6 +255,34 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) 
     TestReadWriteOperationsOnePartition(true, true);
 }
 
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_WriteOnlySkipConflict) {
+    const TString TOPIC = "topic";
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
+
+    AddWriteOperation(topicOps, TOPIC, 0, {});
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, {});
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenConsumerReads) {
+    const TString TOPIC = "topic";
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
+
+    AddReadOperation(topicOps, TOPIC, 0, 1, 2, "c");
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, {});
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -286,6 +286,38 @@ Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenConsumerReads) {
     UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
 }
 
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenSkipConflictCheckOff) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(false);
+    topicOps.SetTrackProducerId(false);
+
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenTrackProducerId) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(true);
+
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -257,13 +257,15 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) 
 
 Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_WriteOnlySkipConflict) {
     const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
     NTopic::TTopicOperations topicOps;
     topicOps.SetSkipConflictCheck(true);
     topicOps.SetTrackProducerId(false);
 
-    AddWriteOperation(topicOps, TOPIC, 0, {});
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
     topicOps.SetTabletId(TOPIC, 0, 100);
-    AddWriteOperation(topicOps, TOPIC, 1, {});
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
     topicOps.SetTabletId(TOPIC, 1, 200);
 
     UNIT_ASSERT(topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
@@ -271,13 +273,14 @@ Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_WriteOnlySkipConflict) {
 
 Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenConsumerReads) {
     const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID = 100'001;
     NTopic::TTopicOperations topicOps;
     topicOps.SetSkipConflictCheck(true);
     topicOps.SetTrackProducerId(false);
 
     AddReadOperation(topicOps, TOPIC, 0, 1, 2, "c");
     topicOps.SetTabletId(TOPIC, 0, 100);
-    AddWriteOperation(topicOps, TOPIC, 1, {});
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID);
     topicOps.SetTabletId(TOPIC, 1, 200);
 
     UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR optimizes KQP topic transaction commits by allowing peer topic (PQ) tablets in the same distributed transaction to be omitted from the predicate (ReadSet) exchange when the transaction is write-only and conflict checking is skipped.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
