### PR TITLE
[NEW RBO] Show shuffles in the new explain

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_plan_to_json.cpp
@@ -28,10 +28,33 @@ NJson::TJsonValue GetExplainJsonRec(const TIntrusivePtr<IOperator>& op, ui64& no
     operatorList.AppendValue(MakeJson(op, explainFlags));
     result["Operators"] = operatorList;
 
+    auto getChildJson = [&](const auto& child) {
+        auto childJson = GetExplainJsonRec(child, nodeCounter, explainFlags);
+
+        // Insert shuffle connections if needed
+        // (currently always needed for GraceJoin)
+        NJson::TJsonValue connectionJson = childJson;
+        if (op->Kind == EOperator::Join) {
+            auto join = CastOperator<TOpJoin>(op);
+            if (join->Props.JoinAlgo == NKikimr::NKqp::EJoinAlgoType::GraceJoin) {
+                connectionJson = NJson::TJsonValue(NJson::EJsonValueType::JSON_MAP);
+                connectionJson["PlanNodeType"] = "Connection";
+                connectionJson["Node Type"] = "HashShuffle";
+                connectionJson["PlanNodeId"] = nodeCounter++;
+
+                NJson::TJsonValue plans(NJson::EJsonValueType::JSON_ARRAY);
+                plans.AppendValue(childJson);
+                connectionJson["Plans"] = plans;
+            }
+        }
+
+        return connectionJson;
+    };
+
     if (op->Children.size()){
         NJson::TJsonValue plans = NJson::TJsonValue(NJson::EJsonValueType::JSON_ARRAY);
-        for (const auto & child : op->Children) {
-            plans.AppendValue(GetExplainJsonRec(child, nodeCounter, explainFlags));
+        for (const auto& child : op->Children) {
+            plans.AppendValue(getChildJson(child));
         }
         result["Plans"] = plans;
     }

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -202,12 +202,21 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         {
             auto db = kikimr.GetTableClient();
             auto session = db.CreateSession().GetValueSync().GetSession();
-            TString t = R"(CREATE TABLE `/Root/t1` (
+            TString t = R"(
+                CREATE TABLE `/Root/t1` (
                     a Int64	NOT NULL,
                     b Int64,
                     c Int64,
                     primary key(a)
-                ))";
+                );
+
+                CREATE TABLE `/Root/t2` (
+                    a Int64	NOT NULL,
+                    b Int64,
+                    c Int64,
+                    primary key(a)
+                );
+            )";
 
             Y_ENSURE(session.ExecuteSchemeQuery(t).GetValueSync().IsSuccess());
         }
@@ -222,7 +231,9 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
                 session.ExecuteQuery(
                     R"(
                         PRAGMA YqlSelect = 'force';
-                        select count(*) from `/Root/t1` as t1;
+                        select count(*)
+                        from `/Root/t1` as t1
+                        inner join `/Root/t2` as t2 on t1.a = t2.b;
                     )",
                     NYdb::NQuery::TTxControl::NoTx(),
                     NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain)


### PR DESCRIPTION
Display shuffle connections in the new explain. Currently it will always show `HashShuffle` on both sides of `GraceJoin`, but when shuffle elimination will be merged (check out #37956) it will also check `Is(Left|Right)ShuffleEliminated` flags.