### PR TITLE
[ICRDMA] Fix memory corruption in case of rdma allocation failure durng clone call. NBYDB-2129

### DIFF
--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -70,6 +70,45 @@ namespace NInterconnect::NRdma {
     static void* allocateMemory(size_t size, size_t alignment, bool hp);
     static void freeMemory(void* ptr) noexcept;
 
+    class TRegularMemChunk : public IContiguousChunk {
+    public:
+        explicit TRegularMemChunk(TRcBuf buffer)
+            : Buffer(std::move(buffer))
+        {}
+
+        static TIntrusivePtr<TRegularMemChunk> Allocate(size_t size, bool pageAligned) {
+            return MakeIntrusive<TRegularMemChunk>(
+                pageAligned ? TRcBuf::UninitializedPageAligned(size) : TRcBuf::Uninitialized(size));
+        }
+
+        TContiguousSpan GetData() const override {
+            return Buffer.GetContiguousSpan();
+        }
+
+        TMutableContiguousSpan UnsafeGetDataMut() override {
+            return Buffer.UnsafeGetContiguousSpanMut();
+        }
+
+        bool IsPrivate() const override {
+            return RefCount() == 1 && Buffer.IsPrivate();
+        }
+
+        size_t GetOccupiedMemorySize() const override {
+            return Buffer.GetOccupiedMemorySize();
+        }
+
+        IContiguousChunk::TPtr Clone() noexcept override {
+            static const ui64 pageAlignMask = NSystemInfo::GetPageSize() - 1;
+            const bool pageAligned = (reinterpret_cast<ui64>(Buffer.GetData()) & pageAlignMask) == 0;
+            auto cloned = Allocate(Buffer.GetSize(), pageAligned);
+            ::memcpy(cloned->UnsafeGetDataMut().GetData(), Buffer.GetData(), Buffer.GetSize());
+            return cloned;
+        }
+
+    private:
+        TRcBuf Buffer;
+    };
+
     class TChunk: public NNonCopyable::TMoveOnly, public TAtomicRefCount<TChunk>, public TIntrusiveListItem<TChunk> {
         friend class TMemPoolBase;
     public:
@@ -268,11 +307,19 @@ namespace NInterconnect::NRdma {
 
     IContiguousChunk::TPtr TMemRegion::Clone() noexcept {
         static const ui64 pageAlign = NSystemInfo::GetPageSize() - 1;
-        const IMemPool::Flags flag = (((ui64)GetAddr() & pageAlign) == 0) ? IMemPool::PAGE_ALIGNED : IMemPool::EMPTY;
-        TMemRegionPtr newRegion = Chunk->AllocMr(GetSize(), flag);
-        auto span = newRegion->UnsafeGetDataMut();
-        ::memcpy(span.GetData(), GetAddr(), GetSize());
-        return newRegion;
+        const bool pageAligned = ((reinterpret_cast<ui64>(GetAddr()) & pageAlign) == 0);
+        const IMemPool::Flags flag = pageAligned ? IMemPool::PAGE_ALIGNED : IMemPool::EMPTY;
+        if (TMemRegionPtr newRegion = Chunk->AllocMr(GetSize(), flag)) {
+            auto span = newRegion->UnsafeGetDataMut();
+            ::memcpy(span.GetData(), GetAddr(), GetSize());
+            return newRegion;
+        }
+
+        // Fallback to regular memory if RDMA pool can't allocate clone buffer.
+        // Preserve page alignment requirement when source region is page aligned.
+        auto fallback = TRegularMemChunk::Allocate(GetSize(), pageAligned);
+        ::memcpy(fallback->UnsafeGetDataMut().GetData(), GetAddr(), GetSize());
+        return fallback;
     }
 
     TMemRegionSlice::TMemRegionSlice(TIntrusivePtr<TMemRegion> memRegion, uint32_t offset, uint32_t size) noexcept

--- a/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit_32/allocator_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut_mem_pool_limit_32/allocator_ut.cpp
@@ -6,6 +6,7 @@
 
 #include <util/random/fast.h>
 #include <util/random/random.h>
+#include <util/system/info.h>
 
 #include <thread>
 
@@ -49,6 +50,13 @@ TEST_F(TAllocatorSuite32, SlotPoolLimit) {
         regions.push_back(reg);
     }
 
+    // Expected behavior check: even with exhausted RDMA pool, clone falls back
+    // to regular memory and preserves size.
+    auto cloned = regions.front()->Clone();
+    ASSERT_TRUE(cloned) << "clone failed";
+    ASSERT_TRUE(cloned->GetData().data()) << "invalid cloned address";
+    ASSERT_TRUE(cloned->GetData().size() == regions.front()->GetSize()) << "invalid cloned size";
+
     regions.erase(regions.begin()); // free one region
 
     {
@@ -59,6 +67,34 @@ TEST_F(TAllocatorSuite32, SlotPoolLimit) {
     }
 
     regions.clear();
+
+    {
+        static const ui64 pageAlignMask = NSystemInfo::GetPageSize() - 1;
+        std::vector<NInterconnect::NRdma::TMemRegionPtr> pageAlignedRegions;
+        pageAlignedRegions.reserve(8);
+        size_t j = 0;
+        for (;; ++j) {
+            auto reg = pool->Alloc(sz, NInterconnect::NRdma::IMemPool::PAGE_ALIGNED);
+            if (!reg) {
+                UNIT_ASSERT(j == 8); // 32 / 4
+                break;
+            }
+            ASSERT_TRUE(reg->GetAddr()) << "invalid address";
+            ASSERT_TRUE(reg->GetSize() == sz) << "invalid size of allocated chunk";
+            ASSERT_TRUE((reinterpret_cast<ui64>(reg->GetAddr()) & pageAlignMask) == 0ull) << "source is not page aligned";
+            pageAlignedRegions.push_back(reg);
+        }
+
+        // One more fallback-triggered scope: exhausted pool + page-aligned source clone.
+        auto clonedAligned = pageAlignedRegions.front()->Clone();
+        ASSERT_TRUE(clonedAligned) << "clone failed";
+        ASSERT_TRUE(clonedAligned->GetData().data()) << "invalid cloned address";
+        ASSERT_TRUE(clonedAligned->GetData().size() == pageAlignedRegions.front()->GetSize()) << "invalid cloned size";
+        ASSERT_TRUE((reinterpret_cast<ui64>(clonedAligned->GetData().data()) & pageAlignMask) == 0ull)
+            << "cloned region is not page aligned";
+
+        pageAlignedRegions.clear();
+    }
 }
 
 TEST_F(TAllocatorSuite32, SlotPoolHugeAlloc) {


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The Rope infrastructure does not check clone result. But in case of rdma memory clone can fail to allocate new rdma region. Fallback to regular region in this case

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
