### PR TITLE
Fix off-by-one error in formatting of explain table

### DIFF
--- a/ydb/public/lib/ydb_cli/common/pretty_table.cpp
+++ b/ydb/public/lib/ydb_cli/common/pretty_table.cpp
@@ -114,7 +114,7 @@ private:
 
         size_t i = PrintedIndexByColumnIndex_[columnIndex];
 
-        for (; i < column.size() && printedSymbols < Widths_[columnIndex];) {
+        for (; i < column.size();) {
             if (column[i] == COLOR_BEGIN) {
                 while (i < column.size() && column[i] != COLOR_END) {
                     Output_ << column[i++];
@@ -127,6 +127,11 @@ private:
                 continue;
             }
 
+            // Break here so trailing color escape codes are consumed
+            // before determining that the line has reached max width.
+            if (printedSymbols >= Widths_[columnIndex]) {
+                break;
+            }
 
             Output_ << column[i++];
             while (i < column.size() && IsUTF8ContinuationByte(column[i])) {


### PR DESCRIPTION
Resolves #28650

Before this PR:
```
┌───────┬────────┬───────────┬──────────┬───────────┬──────────────────────────────┐
│ A-Cpu │ A-Rows │ E-Cost    │ E-Rows   │ E-Size    │ Operation                    │
├───────┼────────┼───────────┼──────────┼───────────┼──────────────────────────────┤
│       │        │           │          │           │ ┌> ResultSet                 │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │ └─┬> Map                     │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │   └─┬> Aggregate             │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │     └─┬> Map                 │
│       │        │ 2.925e+08 │ 15000000 │ 30000000  │       └─┬> Join              │
│       │        │           │          │           │         ├─┬> HashShuffle     │
│       │        │ 0         │ 1500000  │ 1.500e+08 │         │ └──> TableFullScan │
│       │        │           │          │           │                              │
│       │        │           │          │           │         └─┬> HashShuffle     │
│       │        │ 0         │ 150000   │ 15000000  │           └──> TableFullScan │
│       │        │           │          │           │                              │
└───────┴────────┴───────────┴──────────┴───────────┴──────────────────────────────┘
```

After this PR:
```
┌───────┬────────┬───────────┬──────────┬───────────┬──────────────────────────────┐
│ A-Cpu │ A-Rows │ E-Cost    │ E-Rows   │ E-Size    │ Operation                    │
├───────┼────────┼───────────┼──────────┼───────────┼──────────────────────────────┤
│       │        │           │          │           │ ┌> ResultSet                 │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │ └─┬> Map                     │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │   └─┬> Aggregate             │
│       │        │ 2.925e+08 │ 15000000 │ 5000000   │     └─┬> Map                 │
│       │        │ 2.925e+08 │ 15000000 │ 30000000  │       └─┬> Join              │
│       │        │           │          │           │         ├─┬> HashShuffle     │
│       │        │ 0         │ 1500000  │ 1.500e+08 │         │ └──> TableFullScan │
│       │        │           │          │           │         └─┬> HashShuffle     │
│       │        │ 0         │ 150000   │ 15000000  │           └──> TableFullScan │
└───────┴────────┴───────────┴──────────┴───────────┴──────────────────────────────┘
```

The problem arises when the length of the longest line equals to the available column width and ends with a color reset sequence of bytes. In such a case the width is estimated incorrectly (because color symbol takes no space, but counted as if it did) and it's carried over to the next line, which isn't supposed to happen.

This changes how the line is consumed - all colors before AND AFTER (that's the addition) are now consumed before the rest of the line is considered for carrying over.