### PR TITLE
Showed access levels for anonymous users in WhoAmI cli command

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -119,7 +119,11 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
             result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
             result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
         if (hasAnyAccess) {
-            Cout << Endl << "Access levels:" << Endl;
+            if (!userName.empty()) {
+                Cout << Endl;
+            }
+
+            Cout << "Access levels:" << Endl;
             if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
             if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
             if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -110,22 +110,22 @@ void TCommandWhoAmI::PrintResponse(NDiscovery::TWhoAmIResult& result) {
                 Cout << Endl << "User has no groups" << Endl;
             }
         }
+    }
 
-        // Show access list if --access-list or --all is specified
-        bool showAccessList = WithAccessList || WithAll;
-        if (showAccessList) {
-            bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
-                result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
-                result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
-            if (hasAnyAccess) {
-                Cout << Endl << "Access levels:" << Endl;
-                if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
-                if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
-                if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
-                if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
-                if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
-                if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
-            }
+    // Show access list if --access-list or --all is specified
+    bool showAccessList = WithAccessList || WithAll;
+    if (showAccessList) {
+        bool hasAnyAccess = result.IsDatabaseAllowed() || result.IsViewerAllowed() ||
+            result.IsMonitoringAllowed() || result.IsAdministrationAllowed() ||
+            result.IsRegisterNodeAllowed() || result.IsBootstrapAllowed();
+        if (hasAnyAccess) {
+            Cout << Endl << "Access levels:" << Endl;
+            if (result.IsDatabaseAllowed()) Cout << "Database" << Endl;
+            if (result.IsViewerAllowed()) Cout << "Viewer" << Endl;
+            if (result.IsMonitoringAllowed()) Cout << "Monitoring" << Endl;
+            if (result.IsAdministrationAllowed()) Cout << "Administration" << Endl;
+            if (result.IsRegisterNodeAllowed()) Cout << "Register node" << Endl;
+            if (result.IsBootstrapAllowed()) Cout << "Bootstrap" << Endl;
         }
     }
 }


### PR DESCRIPTION
Previously anonymous requests were forbidden to WhoAmI rpc handler but if anonymous requests are allowed in YDB then anonymous user can have access levels. So it's coherent to show access levels in cli command.
