### PR TITLE
Make restore request POST instead of GET in system tablet backup

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -587,11 +587,13 @@ public:
         }
 
         auto cgi = ev->Get()->Cgi();
-        if (const auto& path = cgi.Get("restoreBackup")) {
-            if (RestoreState == ERestoreState::NotStarted) {
-                bool skipChecksum = cgi.Has("skipChecksumValidation");
-                bool dryRun = cgi.Has("dryRun");
-                StartRestore(path, {}, skipChecksum, dryRun);
+        if (ev->Get()->GetMethod() == HTTP_METHOD_POST) {
+            if (const auto& path = cgi.Get("restoreBackup")) {
+                if (RestoreState == ERestoreState::NotStarted) {
+                    bool skipChecksum = cgi.Has("skipChecksumValidation");
+                    bool dryRun = cgi.Has("dryRun");
+                    StartRestore(path, {}, skipChecksum, dryRun);
+                }
             }
         }
 
@@ -675,9 +677,8 @@ public:
                             }
 
                             $.ajax({
-                                type: "GET",
-                                url: window.location.href,
-                                data: form.serialize(),
+                                type: "POST",
+                                url: window.location.href + '&' + form.serialize(),
                                 success: function(response) {
                                     $('body').html(response);
                                 },

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -587,14 +587,22 @@ public:
         }
 
         auto cgi = ev->Get()->Cgi();
-        if (ev->Get()->GetMethod() == HTTP_METHOD_POST) {
-            if (const auto& path = cgi.Get("restoreBackup")) {
+        if (const auto& path = cgi.Get("restoreBackup")) {
+            if (ev->Get()->GetMethod() == HTTP_METHOD_POST) {
                 if (RestoreState == ERestoreState::NotStarted) {
                     bool skipChecksum = cgi.Has("skipChecksumValidation");
                     bool dryRun = cgi.Has("dryRun");
                     StartRestore(path, {}, skipChecksum, dryRun);
                 }
-            }
+            } else {
+                ctx.Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+                    "HTTP/1.1 405 Method Not Allowed\r\n"
+                    "Content-Type: text/plain\r\n"
+                    "Allow: POST\r\n"
+                    "\r\n"
+                    "restoreBackup requires POST"));
+                return true;
+            } 
         }
 
         TStringStream str;

--- a/ydb/tests/stress/system_tablet_backup/workload/__init__.py
+++ b/ydb/tests/stress/system_tablet_backup/workload/__init__.py
@@ -310,7 +310,7 @@ class BackupValidator:
 
     def _start_restore(self, hostname, tablet_id, backup_path):
         url = (f"{self._node_mon_url(hostname)}/tablets/app?TabletID={tablet_id}&restoreBackup={quote(backup_path, safe='')}")
-        response = requests.get(url, timeout=30)
+        response = requests.post(url, timeout=30)
         response.raise_for_status()
         return response.text
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR switches the “restore backup” trigger in the system tablet recovery monitoring UI (and the corresponding stress workload) from **HTTP GET** to **HTTP POST**, reducing the chance of accidental restore triggers via link prefetching/crawlers and aligning with “state-changing actions should not be GET”.
