### PR TITLE
cc kqp: refine metric histogram buckets for better low-range granularity

### DIFF
--- a/ydb/core/kqp/counters/kqp_counters.cpp
+++ b/ydb/core/kqp/counters/kqp_counters.cpp
@@ -116,7 +116,7 @@ void TKqpCountersBase::Init() {
     QueriesWithFullScan = KqpGroup->GetCounter("Query/WithFullScan", true);
 
     QueryAffectedShardsCount = KqpGroup->GetHistogram("Query/AffectedShards",
-        NMonitoring::ExplicitHistogram({1, 9, 49, 99, 499, 999}));
+        NMonitoring::ExplicitHistogram({1, 2, 4, 8, 16, 64, 512, 1024}));
     QueryReadSetsCount = KqpGroup->GetHistogram("Query/ReadSets",
         NMonitoring::ExplicitHistogram({99, 999, 9999, 99999}));
     QueryReadBytes = KqpGroup->GetHistogram("Query/ReadBytes",


### PR DESCRIPTION
At the same time, larger shard counts remain covered with coarser buckets, which keeps cardinality and metric overhead under control while still allowing us to spot outliers and broad distribution shifts.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->
График числа затронутых запросами шардов следует делать более гранулярным в районе небольшого числа шардов, что бывает важно для shard-aware профилей нагрузки. Бакеты 1, 9, 49 не дают достаточной картинки для понимания.

https://st.yandex-team.ru/YDBREQUESTS-7600
...
