### PR TITLE
fix state storage impact on total health check result

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -3562,6 +3562,7 @@ public:
             }
             ui32 disabledRings = 0;
             ui32 badRings = 0;
+	    auto statusBefore = currentContext->OverallStatus;
             for (size_t ringIdx = 0; ringIdx < ringGroup.Rings.size(); ++ringIdx) {
                 const auto& ring = ringGroup.Rings[ringIdx];
                 TSelfCheckContext ringContext(currentContext, TStringBuilder() << type << "_RING");
@@ -3583,6 +3584,7 @@ public:
                     ++badRings;
                 }
             }
+            currentContext->OverallStatus = statusBefore;
             if (disabledRings + badRings > (ringGroup.NToSelect - 1) / 2) {
                 currentContext->ReportStatus(Ydb::Monitoring::StatusFlag::RED, "There is not enough functional rings", ETags::StateStorage);
             } else if (badRings > 1) {

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -3562,7 +3562,7 @@ public:
             }
             ui32 disabledRings = 0;
             ui32 badRings = 0;
-	    auto statusBefore = currentContext->OverallStatus;
+            auto statusBefore = currentContext->OverallStatus;
             for (size_t ringIdx = 0; ringIdx < ringGroup.Rings.size(); ++ringIdx) {
                 const auto& ring = ringGroup.Rings[ringIdx];
                 TSelfCheckContext ringContext(currentContext, TStringBuilder() << type << "_RING");

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -3055,9 +3055,27 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
             CheckHcResultHasIssuesWithStatus(result, "STATE_STORAGE", *expectedStatus, 1);
             CheckHcResultHasIssuesWithStatus(result, "SCHEME_BOARD", *expectedStatus, 1);
             CheckHcResultHasIssuesWithStatus(result, "BOARD", *expectedStatus, 1);
-        } else {
-            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
         }
+
+        auto statusToResult = [](std::optional<Ydb::Monitoring::StatusFlag::Status> status) {
+            if (!status) {
+                return Ydb::Monitoring::SelfCheck::GOOD;
+            }
+            switch (*status) {
+            case Ydb::Monitoring::StatusFlag::GREEN:
+            case Ydb::Monitoring::StatusFlag::YELLOW:
+            default:
+                return Ydb::Monitoring::SelfCheck::GOOD;
+            case Ydb::Monitoring::StatusFlag::BLUE:
+                return Ydb::Monitoring::SelfCheck::DEGRADED;
+            case Ydb::Monitoring::StatusFlag::ORANGE:
+                return Ydb::Monitoring::SelfCheck::MAINTENANCE_REQUIRED;
+            case Ydb::Monitoring::StatusFlag::RED:
+                return Ydb::Monitoring::SelfCheck::EMERGENCY;
+            }
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), statusToResult(expectedStatus));
     }
 
     Y_UNIT_TEST(TestStateStorageOk) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fix an issue that could lead to incorrect cluster status in healthcheck

### Changelog category <!-- remove all except one -->

* Not for changelog 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Низкоуровневые статусы прорастают в OverallStatus, так что при кастомной логике вычисления статуса его нужно отдельно сбросить. Нет, внезапно, ReportStatus, который зовётся ниже не понижает статус.