### PR TITLE
Prevent CMS from crashing when it receives a state storage config with a missing node.

### DIFF
--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -957,10 +957,19 @@ void TClusterInfo::ApplyStateStorageInfo(TIntrusiveConstPtr<TStateStorageInfo> i
                 ringInfo->SetDisabled();
 
             for(auto replica : ring.Replicas) {
-                CheckNodeExistenceWithVerify(replica.NodeId());
-                ringInfo->AddNode(Nodes[replica.NodeId()]);
-                StateStorageReplicas.insert(replica.NodeId());
-                StateStorageNodeToRingId[replica.NodeId()] = ringId;
+                const ui32 nodeId = replica.NodeId();
+                if (!HasNode(nodeId)) {
+                    // we do not want to abort here constantly, so we just add down stub replica
+                    BLOG_ERROR("Node " << nodeId << " referenced by state storage ring " << ringId << " in ring group " << rGroupId
+                               << " does not exist in cluster. State storage is probably not reconfigured yet. Treating the replica as down.");
+                    TNodeInfoPtr stub = MakeIntrusive<TNodeInfo>();
+                    stub->NodeId = nodeId;
+                    ringInfo->AddNode(stub);
+                    continue;
+                }
+                ringInfo->AddNode(Nodes[nodeId]);
+                StateStorageReplicas.insert(nodeId);
+                StateStorageNodeToRingId[nodeId] = ringId;
             }
 
             StateStorageRings[rGroupId].push_back(ringInfo);

--- a/ydb/core/cms/cluster_info_ut.cpp
+++ b/ydb/core/cms/cluster_info_ut.cpp
@@ -1,7 +1,9 @@
 #include "cluster_info.h"
 #include "ut_helpers.h"
 
+#include <ydb/core/base/statestorage.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
+#include <ydb/core/testlib/actor_helpers.h>
 
 #include <ydb/library/actors/interconnect/interconnect.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -466,6 +468,80 @@ Y_UNIT_TEST_SUITE(TClusterInfoTest) {
                             "request-1", "user-1", 1,
                             "request-4", "user-4", 4);
 
+    }
+
+    Y_UNIT_TEST(ApplyStateStorageInfoWithMissingNode) {
+        // simulates the situation where the node was removed from cluster config
+        // but still referenced by state storage config
+        TActorSystemStub stub;
+
+        TClusterInfoPtr cluster(new TClusterInfo);
+        cluster->AddNode({1, "::1", "host1", "host1", 1, TNodeLocation()}, nullptr);
+        cluster->AddNode({2, "::2", "host2", "host2", 1, TNodeLocation()}, nullptr);
+        cluster->AddNode({3, "::3", "host3", "host3", 1, TNodeLocation()}, nullptr);
+
+        cluster->SetNodeState(1, NKikimrCms::UP, MakeSystemStateInfo("1"));
+        cluster->SetNodeState(2, NKikimrCms::UP, MakeSystemStateInfo("1"));
+        cluster->SetNodeState(3, NKikimrCms::UP, MakeSystemStateInfo("1"));
+
+        auto info = MakeIntrusive<TStateStorageInfo>();
+        info->RingGroups.emplace_back();
+        auto& group = info->RingGroups.back();
+        group.NToSelect = 3;
+        group.Rings.resize(3);
+        group.Rings[0].Replicas.push_back(TActorId(1, 0, 0, 0));
+        group.Rings[0].Replicas.push_back(TActorId(2, 0, 0, 0));
+
+        group.Rings[1].Replicas.push_back(TActorId(3, 0, 0, 0));
+        group.Rings[1].Replicas.push_back(TActorId(42, 0, 0, 0));
+        group.Rings[2].Replicas.push_back(TActorId(99, 0, 0, 0));
+
+        cluster->ApplyStateStorageInfo(info);
+
+        UNIT_ASSERT_VALUES_EQUAL(cluster->StateStorageRings.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->StateStorageRings[0].size(), 3);
+
+        auto& ring0 = *cluster->StateStorageRings[0][0];
+        auto& ring1 = *cluster->StateStorageRings[0][1];
+        auto& ring2 = *cluster->StateStorageRings[0][2];
+
+        UNIT_ASSERT_VALUES_EQUAL(ring0.Replicas.size(), 2);
+        UNIT_ASSERT(!ring0.IsDisabled);
+
+        UNIT_ASSERT_VALUES_EQUAL(ring1.Replicas.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ring1.Replicas[0]->NodeId, 3);
+        UNIT_ASSERT_VALUES_EQUAL(ring1.Replicas[1]->NodeId, 42);
+        UNIT_ASSERT(!ring1.IsDisabled);
+
+        UNIT_ASSERT_VALUES_EQUAL(ring2.Replicas.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ring2.Replicas[0]->NodeId, 99);
+        UNIT_ASSERT(!ring2.IsDisabled);
+
+        const auto now = Now();
+        const auto retry = TDuration::Seconds(1);
+        const auto duration = TDuration::Minutes(1);
+        const TString requestId = "test-request";
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(ring0.CountState(now, retry, duration, requestId)),
+            static_cast<int>(TStateStorageRingInfo::Ok));
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(ring1.CountState(now, retry, duration, requestId)),
+            static_cast<int>(TStateStorageRingInfo::Restart));
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(ring2.CountState(now, retry, duration, requestId)),
+            static_cast<int>(TStateStorageRingInfo::Restart));
+
+        UNIT_ASSERT(cluster->IsStateStorageReplicaNode(1));
+        UNIT_ASSERT(cluster->IsStateStorageReplicaNode(2));
+        UNIT_ASSERT(cluster->IsStateStorageReplicaNode(3));
+        UNIT_ASSERT(!cluster->IsStateStorageReplicaNode(42));
+        UNIT_ASSERT(!cluster->IsStateStorageReplicaNode(99));
+        UNIT_ASSERT(!cluster->HasNode(42));
+        UNIT_ASSERT(!cluster->HasNode(99));
+
+        UNIT_ASSERT_VALUES_EQUAL(cluster->GetRingId(1), 0);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->GetRingId(2), 0);
+        UNIT_ASSERT_VALUES_EQUAL(cluster->GetRingId(3), 1);
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Prevent CMS from crashing when it receives a state storage config with a missing node.

With the new logic of the state storage self-heal, we can possibly remove a node from the config before the self-heal ends. After that, CMS will enter an abort loop.
 
We replace the missing node with a stub containing an empty NodeInfo, so CMS algorithms (CountState) treat ring with node as RESTART. We do not want to mark this ring as DISABLED intentionally.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
