### PR TITLE
Fix reflected Origin CORS on /login and /logout

### DIFF
--- a/ydb/core/security/audit_ut.cpp
+++ b/ydb/core/security/audit_ut.cpp
@@ -33,7 +33,12 @@ void EatWholeString(NHttp::THttpIncomingRequestPtr request, const TString& data)
     request->Advance(size);
 }
 
-NHttp::THttpIncomingRequestPtr MakeLoginRequest(const TString& user, const TString& password) {
+NHttp::THttpIncomingRequestPtr MakeLoginRequest(
+    const TString& user,
+    const TString& password,
+    TStringBuf origin = TStringBuf(),
+    TStringBuf host = TStringBuf("test.ydb"))
+{
     TString payload = [](const auto& user, const auto& password) {
         NJson::TJsonValue value;
         value["user"] = user;
@@ -42,11 +47,29 @@ NHttp::THttpIncomingRequestPtr MakeLoginRequest(const TString& user, const TStri
     }(user, password);
     TStringBuilder text;
     text << "POST /login HTTP/1.1\r\n"
-        << "Host: test.ydb\r\n"
-        << "Content-Type: application/json\r\n"
+        << "Host: " << host << "\r\n";
+    if (origin) {
+        text << "Origin: " << origin << "\r\n";
+    }
+    text << "Content-Type: application/json\r\n"
         << "Content-Length: " << payload.size() << "\r\n"
         << "\r\n"
         << payload;
+    NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest();
+    EatWholeString(request, text);
+    // WebLoginService will crash without address
+    request->Address = std::make_shared<TSockAddrInet>("127.0.0.1", 0);
+    return request;
+}
+
+NHttp::THttpIncomingRequestPtr MakeLoginOptionsRequest(TStringBuf origin = TStringBuf(), TStringBuf host = TStringBuf("test.ydb")) {
+    TStringBuilder text;
+    text << "OPTIONS /login HTTP/1.1\r\n"
+        << "Host: " << host << "\r\n";
+    if (origin) {
+        text << "Origin: " << origin << "\r\n";
+    }
+    text << "\r\n";
     NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest();
     EatWholeString(request, text);
     // WebLoginService will crash without address
@@ -588,7 +611,10 @@ Y_UNIT_TEST_SUITE(WebLoginServiceAudit) {
             UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
             {
                 NHttp::THeaders headers(responseEv->Response->Headers);
-                UNIT_ASSERT_STRINGS_EQUAL(headers["Set-Cookie"], "ydb_session_id=; Max-Age=0");
+                TStringBuf setCookie = headers["Set-Cookie"];
+                UNIT_ASSERT_STRING_CONTAINS(setCookie, "ydb_session_id=; Max-Age=0");
+                UNIT_ASSERT_STRING_CONTAINS(setCookie, "HttpOnly");
+                UNIT_ASSERT_STRING_CONTAINS(setCookie, "SameSite=Strict");
             }
 
             // After logout, we should have 1 additional audit log entry
@@ -604,6 +630,146 @@ Y_UNIT_TEST_SUITE(WebLoginServiceAudit) {
             UNIT_ASSERT_STRING_CONTAINS(last, "sanitized_token=");
             UNIT_ASSERT(last.find("sanitized_token={none}") == std::string::npos);
         }
+    }
+
+    Y_UNIT_TEST(LoginCorsAllowsSameOrigin) {
+        TTestEnv env;
+        CreateUser(env, "user1", "password1");
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "http://test.ydb")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+        NHttp::THeaders headers(responseEv->Response->Headers);
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Origin"], "http://test.ydb");
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Credentials"], "true");
+
+        TStringBuf setCookie = headers["Set-Cookie"];
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, "HttpOnly");
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, "SameSite=Strict");
+    }
+
+    Y_UNIT_TEST(LoginCorsRejectsCrossOrigin) {
+        TTestEnv env;
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "https://evil-attacker.com")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "400");
+        UNIT_ASSERT_STRING_CONTAINS(responseEv->Response->Body, "Invalid CORS origin");
+    }
+
+    Y_UNIT_TEST(LoginCorsAllowsConfiguredOriginAllowlist) {
+        TTestEnvSettings settings;
+        settings.MonitoringAllowOrigin = "https://*.trusted.test";
+        TTestEnv env(settings);
+        CreateUser(env, "user1", "password1");
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "https://foo.trusted.test")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+        NHttp::THeaders headers(responseEv->Response->Headers);
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Origin"], "https://foo.trusted.test");
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Credentials"], "true");
+    }
+
+    Y_UNIT_TEST(LoginCorsRejectsNullOrigin) {
+        TTestEnv env;
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "null")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "400");
+        UNIT_ASSERT_STRING_CONTAINS(responseEv->Response->Body, "Invalid CORS origin");
+    }
+
+    Y_UNIT_TEST(LoginCorsAllowsSameOriginIpv6BracketedHost) {
+        TTestEnv env;
+        CreateUser(env, "user1", "password1");
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "http://[::1]", "[::1]")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+        NHttp::THeaders headers(responseEv->Response->Headers);
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Origin"], "http://[::1]");
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Credentials"], "true");
+    }
+
+    Y_UNIT_TEST(LoginCorsAllowsSameOriginIpv6HostWithExplicitPort) {
+        TTestEnv env;
+        CreateUser(env, "user1", "password1");
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "http://[::1]:8443", "[::1]:8443")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+        NHttp::THeaders headers(responseEv->Response->Headers);
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Origin"], "http://[::1]:8443");
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Credentials"], "true");
+    }
+
+    Y_UNIT_TEST(LoginCorsRejectsIpv6HostPortMismatch) {
+        TTestEnv env;
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginRequest("user1", "password1", "http://[::1]:8443", "[::1]:8444")
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "400");
+        UNIT_ASSERT_STRING_CONTAINS(responseEv->Response->Body, "Invalid CORS origin");
+    }
+
+    Y_UNIT_TEST(LoginCorsOptionsWithoutOriginDoesNotAllowCredentials) {
+        TTestEnv env;
+
+        const auto target = env.GetWebLoginService();
+        const auto edge = env.GetServer().GetRuntime()->AllocateEdgeActor();
+        env.GetServer().GetRuntime()->Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+            MakeLoginOptionsRequest()
+        )));
+
+        TAutoPtr<IEventHandle> handle;
+        auto responseEv = env.GetServer().GetRuntime()->GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "204");
+        NHttp::THeaders headers(responseEv->Response->Headers);
+        UNIT_ASSERT_STRINGS_EQUAL(headers["Access-Control-Allow-Origin"], "*");
+        UNIT_ASSERT(!headers.Has("Access-Control-Allow-Credentials"));
     }
 
     Y_UNIT_TEST(AuditLogCreateModifyUser) {

--- a/ydb/core/security/login_page.cpp
+++ b/ydb/core/security/login_page.cpp
@@ -1,10 +1,14 @@
 #include "login_page.h"
 #include "login_shared_func.h"
 
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/mon/mon.h>
+#include <ydb/core/util/wildcard.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
+#include <library/cpp/string_utils/url/url.h>
 
 #include <ydb/core/util/address_classifier.h>
 #include <ydb/core/audit/audit_log.h>
@@ -18,11 +22,121 @@
 #include <ydb/library/security/util.h>
 
 #include <util/datetime/base.h>  // for ToInstant
+#include <util/string/ascii.h>
+
+#include <optional>
 
 
 namespace {
 
 using namespace NKikimr;
+
+struct TWebLoginCorsParams {
+    TString AllowOrigin;
+    bool AllowCredentials = false;
+};
+
+static bool WebLoginHostsEqual(TStringBuf left, TStringBuf right) {
+    return left.size() == right.size() && AsciiEqualsIgnoreCase(left, right);
+}
+
+static std::optional<TWebLoginCorsParams> ResolveWebLoginCors(
+    const NHttp::THttpIncomingRequestPtr& request,
+    TStringBuf configuredAllowOrigin)
+{
+    NHttp::THeaders headers(request->Headers);
+    TString requestOrigin = TString(headers["Origin"]);
+
+    if (requestOrigin.empty()) {
+        TWebLoginCorsParams params;
+        params.AllowOrigin = "*";
+        params.AllowCredentials = false;
+        return params;
+    }
+
+    if (configuredAllowOrigin) {
+        if (IsMatchesWildcards(requestOrigin, configuredAllowOrigin)) {
+            TWebLoginCorsParams params;
+            params.AllowOrigin = std::move(requestOrigin);
+            params.AllowCredentials = true;
+            return params;
+        }
+        return std::nullopt;
+    }
+
+    if (requestOrigin == TStringBuf("null")) {
+        return std::nullopt;
+    }
+
+    TStringBuf originScheme;
+    TStringBuf originHost;
+    ui16 originPort = 0;
+    if (!TryGetSchemeHostAndPort(requestOrigin, originScheme, originHost, originPort)) {
+        return std::nullopt;
+    }
+    if (originScheme != TStringBuf("http://") && originScheme != TStringBuf("https://")) {
+        return std::nullopt;
+    }
+
+    const bool secure = request->Endpoint && request->Endpoint->Secure;
+    const TStringBuf requestScheme = secure ? TStringBuf("https://") : TStringBuf("http://");
+    if (originScheme != requestScheme) {
+        return std::nullopt;
+    }
+
+    // Same-origin uses Host + this hop's TLS; behind TLS-terminating proxy use MonitoringConfig.AllowOrigin.
+    TString syntheticRequestUrl = TStringBuilder() << requestScheme << request->Host;
+    TStringBuf unusedScheme;
+    TStringBuf requestHost;
+    ui16 requestPort = 0;
+    if (!TryGetSchemeHostAndPort(syntheticRequestUrl, unusedScheme, requestHost, requestPort)) {
+        return std::nullopt;
+    }
+
+    if (!WebLoginHostsEqual(originHost, requestHost) || originPort != requestPort) {
+        return std::nullopt;
+    }
+
+    TWebLoginCorsParams params;
+    params.AllowOrigin = std::move(requestOrigin);
+    params.AllowCredentials = true;
+    return params;
+}
+
+static void ApplyWebLoginCorsHeaders(NHttp::THeadersBuilder& headers, const TWebLoginCorsParams& cors) {
+    headers.Set("Access-Control-Allow-Origin", cors.AllowOrigin);
+    if (cors.AllowCredentials) {
+        headers.Set("Access-Control-Allow-Credentials", "true");
+    }
+    headers.Set("Access-Control-Allow-Headers", "Content-Type,Authorization,Origin,Accept");
+    headers.Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST");
+}
+
+static void AppendWebSessionCookieAttributes(TStringBuilder& builder, const NHttp::THttpIncomingRequestPtr& request) {
+    builder << "; Path=/; HttpOnly; SameSite=Strict";
+    if (request->Endpoint && request->Endpoint->Secure) {
+        builder << "; Secure";
+    }
+}
+
+static bool TryInitWebLoginCors(
+    const NHttp::THttpIncomingRequestPtr& request,
+    const NActors::TActorContext& ctx,
+    TWebLoginCorsParams* out)
+{
+    TStringBuf configuredAllowOrigin;
+    if (TAppData* appData = AppData(ctx)) {
+        if (appData->Mon) {
+            configuredAllowOrigin = TStringBuf(appData->Mon->GetConfig().AllowOrigin);
+        }
+    }
+    auto resolved = ResolveWebLoginCors(request, configuredAllowOrigin);
+    if (!resolved) {
+        return false;
+    }
+    *out = std::move(*resolved);
+    return true;
+}
 
 void AuditLogWebUILogout(const NHttp::THttpIncomingRequest& request, const TString& userSID, const TString& sanitizedToken) {
     static const TString WebLoginComponentName = "web-login";
@@ -101,6 +215,10 @@ public:
     void Bootstrap() {
         ALOG_WARN(NActorsServices::HTTP, Request->Address << " " << Request->Method << " " << Request->GetURI());
 
+        if (!TryInitWebLoginCors(Request, ActorContext(), &Cors_)) {
+            return ReplyCorsForbiddenAndPassAway();
+        }
+
         if (Request->Method == "OPTIONS") {
             return ReplyOptionsAndPassAway();
         }
@@ -177,30 +295,26 @@ public:
 
     void ReplyOptionsAndPassAway() {
         NHttp::THeadersBuilder headers;
-        SetCORS(headers);
+        ApplyWebLoginCorsHeaders(headers, Cors_);
         headers.Set("Allow", "OPTIONS, POST");
         Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponse("204", "No Content", headers)));
         PassAway();
     }
 
-    void SetCORS(NHttp::THeadersBuilder& headers) {
-        TStringBuilder res;
-        TString origin = TString(NHttp::THeaders(Request->Headers)["Origin"]);
-        if (origin.empty()) {
-            origin = "*";
-        }
-        headers.Set("Access-Control-Allow-Origin", origin);
-        headers.Set("Access-Control-Allow-Credentials", "true");
-        headers.Set("Access-Control-Allow-Headers", "Content-Type,Authorization,Origin,Accept");
-        headers.Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST");
+    void ReplyCorsForbiddenAndPassAway() {
+        Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponseBadRequest("Invalid CORS origin")));
+        PassAway();
     }
 
     void ReplyCookieAndPassAway(const TString& cookie) {
         ALOG_DEBUG(NActorsServices::HTTP, "Login success for " << User);
         NHttp::THeadersBuilder headers;
-        SetCORS(headers);
+        ApplyWebLoginCorsHeaders(headers, Cors_);
         TDuration maxAge = ToInstant(NLogin::TLoginProvider::GetTokenExpiresAt(cookie)) - TInstant::Now();
-        headers.Set("Set-Cookie", TStringBuilder() << "ydb_session_id=" << cookie << "; Max-Age=" << maxAge.Seconds());
+        TStringBuilder cookieHeader;
+        cookieHeader << "ydb_session_id=" << cookie << "; Max-Age=" << maxAge.Seconds();
+        AppendWebSessionCookieAttributes(cookieHeader, Request);
+        headers.Set("Set-Cookie", cookieHeader);
         Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponse("200", "OK", headers)));
         PassAway();
     }
@@ -208,7 +322,7 @@ public:
     void ReplyErrorAndPassAway(const TString& status, const TString& message, const TString& error) {
         ALOG_ERROR(NActorsServices::HTTP, "Login fail for " << User << ": " << error);
         NHttp::THeadersBuilder headers;
-        SetCORS(headers);
+        ApplyWebLoginCorsHeaders(headers, Cors_);
         headers.Set("Content-Type", "application/json");
         NJson::TJsonValue body;
         body["error"] = error;
@@ -219,6 +333,7 @@ public:
 protected:
     TActorId Sender;
     NHttp::THttpIncomingRequestPtr Request;
+    TWebLoginCorsParams Cors_;
     TDuration Timeout = TDuration::Seconds(60);
     TString User;
     TString Database;
@@ -246,6 +361,10 @@ public:
 
     void Bootstrap() {
         ALOG_WARN(NActorsServices::HTTP, Request->Address << " " << Request->Method << " " << Request->GetURI());
+
+        if (!TryInitWebLoginCors(Request, ActorContext(), &Cors_)) {
+            return ReplyCorsForbiddenAndPassAway();
+        }
 
         if (Request->Method == "OPTIONS") {
             return ReplyOptionsAndPassAway();
@@ -293,28 +412,25 @@ public:
 
     void ReplyOptionsAndPassAway() {
         NHttp::THeadersBuilder headers;
+        ApplyWebLoginCorsHeaders(headers, Cors_);
         headers.Set("Allow", "OPTIONS, POST");
         Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponse("204", "No Content", headers)));
         PassAway();
     }
 
-    void SetCORS(NHttp::THeadersBuilder& headers) {
-        TStringBuilder res;
-        TString origin = TString(NHttp::THeaders(Request->Headers)["Origin"]);
-        if (origin.empty()) {
-            origin = "*";
-        }
-        headers.Set("Access-Control-Allow-Origin", origin);
-        headers.Set("Access-Control-Allow-Credentials", "true");
-        headers.Set("Access-Control-Allow-Headers", "Content-Type,Authorization,Origin,Accept");
-        headers.Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST");
+    void ReplyCorsForbiddenAndPassAway() {
+        Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponseBadRequest("Invalid CORS origin")));
+        PassAway();
     }
 
     void ReplyDeleteCookieAndPassAway(const TString& userSID, const TString& sanitizedToken) {
         ALOG_DEBUG(NActorsServices::HTTP, "Logout success");
         NHttp::THeadersBuilder headers;
-        SetCORS(headers);
-        headers.Set("Set-Cookie", "ydb_session_id=; Max-Age=0");
+        ApplyWebLoginCorsHeaders(headers, Cors_);
+        TStringBuilder cookieHeader;
+        cookieHeader << "ydb_session_id=; Max-Age=0";
+        AppendWebSessionCookieAttributes(cookieHeader, Request);
+        headers.Set("Set-Cookie", cookieHeader);
         Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(Request->CreateResponse("200", "OK", headers)));
 
         AuditLogWebUILogout(*Request, userSID, sanitizedToken);
@@ -325,7 +441,7 @@ public:
     void ReplyErrorAndPassAway(const TString& status, const TString& message, const TString& error) {
         ALOG_ERROR(NActorsServices::HTTP, "Logout: " << error);
         NHttp::THeadersBuilder headers;
-        SetCORS(headers);
+        ApplyWebLoginCorsHeaders(headers, Cors_);
         headers.Set("Content-Type", "application/json");
         NJson::TJsonValue body;
         body["error"] = error;
@@ -336,6 +452,7 @@ public:
 protected:
     TActorId Sender;
     NHttp::THttpIncomingRequestPtr Request;
+    TWebLoginCorsParams Cors_;
     TDuration Timeout = TDuration::Seconds(5);
 };
 

--- a/ydb/core/security/ut_common.cpp
+++ b/ydb/core/security/ut_common.cpp
@@ -47,6 +47,9 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, const TTestEnvSettings& 
     NKikimrConfig::TAppConfig appConfig;
     *appConfig.MutableFeatureFlags() = Settings->FeatureFlags;
     appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenCheckRequirement(true);
+    if (settings.MonitoringAllowOrigin) {
+        appConfig.MutableMonitoringConfig()->SetAllowOrigin(settings.MonitoringAllowOrigin);
+    }
 
     auto& securityConfig = *appConfig.MutableDomainsConfig()->MutableSecurityConfig();
     securityConfig.SetHideAuthenticationFailureReasons(false);

--- a/ydb/core/security/ut_common.h
+++ b/ydb/core/security/ut_common.h
@@ -9,6 +9,7 @@ namespace NKikimr {
 
 struct TTestEnvSettings {
     NKikimrProto::TAuthConfig AuthConfig = {};
+    TString MonitoringAllowOrigin = {};
     bool EnableLDAP = false;
     LdapMock::TLdapMockResponses LDAPResponses = {};
 };

--- a/ydb/core/security/ya.make
+++ b/ydb/core/security/ya.make
@@ -11,17 +11,19 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/library/actors/core
-    ydb/library/actors/http
-    ydb/library/grpc/actor_client
     library/cpp/monlib/service/pages
     library/cpp/openssl/io
+    library/cpp/string_utils/url
     ydb/core/audit
     ydb/core/base
+    ydb/core/mon
     ydb/core/protos
     ydb/core/security/util
     ydb/library/aclib
     ydb/library/aclib/protos
+    ydb/library/actors/core
+    ydb/library/actors/http
+    ydb/library/grpc/actor_client
     ydb/library/login
     ydb/library/login/protos
     ydb/library/ncloud/impl

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -236,7 +236,8 @@ namespace NActors {
                 node->Mon.Reset(new NActors::TMon({
                     .Port = port,
                     .Threads = 10,
-                    .Title = "KIKIMR monitoring"
+                    .Title = "KIKIMR monitoring",
+                    .AllowOrigin = MonitoringAllowOrigin_,
                 }));
                 nodeAppData->Mon = node->Mon.Get();
                 node->Mon->RegisterCountersPage("counters", "Counters", node->DynamicCounters);

--- a/ydb/core/testlib/actors/test_runtime.h
+++ b/ydb/core/testlib/actors/test_runtime.h
@@ -122,6 +122,10 @@ namespace NActors {
             return *this;
         }
 
+        void SetMonitoringAllowOrigin(TString allowOrigin) {
+            MonitoringAllowOrigin_ = std::move(allowOrigin);
+        }
+
         static bool DefaultScheduledFilterFunc(TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event, TDuration delay, TInstant& deadline);
 
     public:
@@ -148,6 +152,7 @@ namespace NActors {
         TKeyConfigGenerator KeyConfigGenerator;
         THolder<IDestructable> Opaque;
         TVector<ui16> MonPorts;
+        TString MonitoringAllowOrigin_;
         TVector<std::function<void(ui32, NKikimr::TAppData&)>> AppDataInit_;
         bool NeedStatsCollectors = false;
         std::optional<TActorSystemSetupConfig> ActorSystemSetupConfig;

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -532,6 +532,12 @@ namespace Tests {
             Runtime->SetupStatsCollectors();
         }
         Runtime->SetupMonitoring(Settings->MonitoringPortOffset, Settings->MonitoringTypeAsync);
+        if (Settings->AppConfig) {
+            const auto& monCfg = Settings->AppConfig->GetMonitoringConfig();
+            if (monCfg.HasAllowOrigin() && !monCfg.GetAllowOrigin().empty()) {
+                Runtime->SetMonitoringAllowOrigin(monCfg.GetAllowOrigin());
+            }
+        }
         Runtime->SetLogBackend(Settings->LogBackend);
 
         SetupActorSystemConfig();


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Ticket: https://nda.ya.ru/t/6jcWpLdj7Zy6F8
Исправлена небезопасная конфигурация CORS на HTTP-эндпоинтах /login и /logout: раньше в Access-Control-Allow-Origin подставлялся любой присланный заголовок Origin при включённом Access-Control-Allow-Allow-Credentials, что позволяло вредоносной странице получать доступ к ответу в браузере. Теперь разрешены только origins из allowlist (MonitoringConfig.AllowOrigin, те же wildcard, что и для monitoring), либо same-origin (согласование Origin с Host и схемой TLS на текущем соединении); иначе возвращается ошибка с текстом про невалидный CORS origin.

Для cookie ydb_session_id добавлены атрибуты Path=/, HttpOnly, SameSite=Strict, а Secure выставляется только при HTTPS на endpoint (чтобы не ломать HTTP в dev). То же применено к очистке cookie при logout.

Добавлены unit-тесты на CORS (same-origin, запрет чужого origin, allowlist, Origin: null, OPTIONS без Origin, IPv6 в Host/Origin). В тестовом окружении добавлена опциональная настройка MonitoringAllowOrigin в TTestEnvSettings.

Тестовая инфраструктура: в проде allowlist для web-login читается из TMon::GetConfig().AllowOrigin, заполняемого при старте ноды из MonitoringConfig (см. run.cpp). В TTestActorRuntime TMon раньше создавался без AllowOrigin, поэтому в UTs allowlist «терялся» и CORS уходил в same-origin. Добавлена передача Settings->AppConfig->GetMonitoringConfig().GetAllowOrigin() в конфиг TMon при поднятии тестового сервера (через SetMonitoringAllowOrigin + инициализацию TMon), чтобы поведение в тестах совпадало с продом и allowlist-регрессии реально шли по тому же коду.

!!**Важно**!!: если веб-UI с другого origin, нужно явно перечислить wildcard’ом все доверенные origin’ы клиентских интерфейсов, с которых выполняются CORS-запросы с credentials.

Нет Origin в запросе → Access-Control-Allow-Origin: *, без Allow-Credentials.
Есть MonitoringConfig.AllowOrigin → пускаем только если Origin matчится allowlist; иначе 400. Host не смотрим.
AllowOrigin пуст → только same-origin (схема + Host:порт = Origin); иначе 400.