### PR TITLE
Add LDAP filter escaping for special characters in search filters

### DIFF
--- a/ydb/core/security/ldap_auth_provider/ldap_utils.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_utils.cpp
@@ -5,20 +5,54 @@
 
 namespace NKikimr {
 
+namespace {
+
+// Escape LDAP filter value according to https://www.rfc-editor.org/rfc/rfc2254#page-5
+TString EscapeLdapFilterValue(TStringBuf value) {
+    TStringBuilder escaped;
+    escaped.reserve(value.size() + 4);
+    for (unsigned char ch : value) {
+        switch (ch) {
+            case '*':
+                escaped << "\\2a";
+                break;
+            case '(':
+                escaped << "\\28";
+                break;
+            case ')':
+                escaped << "\\29";
+                break;
+            case '\\':
+                escaped << "\\5c";
+                break;
+            case '\0':
+                escaped << "\\00";
+                break;
+            default:
+                escaped << static_cast<char>(ch);
+                break;
+        }
+    }
+    return TString{escaped};
+}
+
+} // namespace
+
 TSearchFilterCreator::TSearchFilterCreator(const NKikimrProto::TLdapAuthentication& settings)
     : Settings(settings)
 {}
 
 TString TSearchFilterCreator::GetFilter(const TString& userName) const {
+    const TString escapedUserName = EscapeLdapFilterValue(userName);
     if (!Settings.GetSearchFilter().empty()) {
-        return GetFormatSearchFilter(userName);
+        return GetFormatSearchFilter(escapedUserName);
     } else if (!Settings.GetSearchAttribute().empty()) {
-        return Settings.GetSearchAttribute() + "=" + userName;
+        return Settings.GetSearchAttribute() + "=" + escapedUserName;
     }
-    return "uid=" + userName;
+    return "uid=" + escapedUserName;
 }
 
-TString TSearchFilterCreator::GetFormatSearchFilter(const TString& userName) const {
+TString TSearchFilterCreator::GetFormatSearchFilter(const TString& escapedUserName) const {
     const TStringBuf namePlaceHolder = "$username";
     const TString& searchFilter = Settings.GetSearchFilter();
     size_t n = searchFilter.find(namePlaceHolder);
@@ -28,7 +62,7 @@ TString TSearchFilterCreator::GetFormatSearchFilter(const TString& userName) con
     TStringStream result;
     size_t pos = 0;
     while (n != TString::npos) {
-        result << searchFilter.substr(pos, n - pos) << userName;
+        result << searchFilter.substr(pos, n - pos) << escapedUserName;
         pos = n + namePlaceHolder.size();
         n = searchFilter.find(namePlaceHolder, pos);
     }

--- a/ydb/core/security/ldap_auth_provider/ldap_utils.h
+++ b/ydb/core/security/ldap_auth_provider/ldap_utils.h
@@ -10,7 +10,8 @@ public:
     TString GetFilter(const TString& userName) const;
 
 private:
-    TString GetFormatSearchFilter(const TString& userName) const;
+    // Must already be RFC 2254 filter-escaped for embedding in a filter
+    TString GetFormatSearchFilter(const TString& escapedUserName) const;
 
 private:
     const NKikimrProto::TLdapAuthentication& Settings;

--- a/ydb/core/security/ldap_auth_provider/ldap_utils_ut.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_utils_ut.cpp
@@ -1,4 +1,5 @@
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/strbuf.h>
 #include "ldap_utils.h"
 
 namespace NKikimr {
@@ -59,6 +60,47 @@ Y_UNIT_TEST_SUITE(TLdapUtilsSearchFilterCreatorTest) {
         const TString expectedFilter {getFilterString(login)};
         const TString filter = filterCreator.GetFilter(login);
         UNIT_ASSERT_STRINGS_EQUAL(expectedFilter, filter);
+    }
+
+    Y_UNIT_TEST(EscapeSpecialCharsInDefaultUidFilter) {
+        NKikimrProto::TLdapAuthentication settings;
+        TSearchFilterCreator filterCreator(settings);
+        static constexpr char LOGIN_BYTES[] = {'u', '*', '(', ')', '\\', '\0', 'x'};
+        const TString login(TStringBuf(LOGIN_BYTES, sizeof(LOGIN_BYTES)));
+        const TString filter = filterCreator.GetFilter(login);
+        UNIT_ASSERT_STRINGS_EQUAL(R"(uid=u\2a\28\29\5c\00x)", filter);
+    }
+
+    Y_UNIT_TEST(EscapeSpecialCharsInSearchAttributeFilter) {
+        NKikimrProto::TLdapAuthentication settings;
+        settings.SetSearchAttribute("mail");
+        TSearchFilterCreator filterCreator(settings);
+        const TString login("a)admin");
+        const TString filter = filterCreator.GetFilter(login);
+        UNIT_ASSERT_STRINGS_EQUAL(R"(mail=a\29admin)", filter);
+    }
+
+    Y_UNIT_TEST(EscapeInjectionInTemplatePlaceholder) {
+        NKikimrProto::TLdapAuthentication settings;
+        settings.SetSearchFilter("(&(uid=$username)(objectClass=person))");
+        TSearchFilterCreator filterCreator(settings);
+        const TString login(")(|(uid=*");
+        const TString filter = filterCreator.GetFilter(login);
+        UNIT_ASSERT_STRINGS_EQUAL("(&(uid=\\29\\28|\\28uid=\\2a)(objectClass=person))", filter);
+    }
+
+    Y_UNIT_TEST(EscapeSpecialCharsWithTwoUsernamePlaceholders) {
+        auto getFilterString = [](const TString& name) {
+            return "|(&(uid=" + name + ")(groupid=1234))(&(login=" + name + ")(groupid=9876))";
+        };
+        NKikimrProto::TLdapAuthentication settings;
+        settings.SetSearchFilter(getFilterString("$username"));
+        TSearchFilterCreator filterCreator(settings);
+        const TString login(")(|(uid=*");
+        const TString filter = filterCreator.GetFilter(login);
+        const TString escaped = "\\29\\28|\\28uid=\\2a";
+        const TString expected = "|(&(uid=" + escaped + ")(groupid=1234))(&(login=" + escaped + ")(groupid=9876))";
+        UNIT_ASSERT_STRINGS_EQUAL(expected, filter);
     }
 }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Ссылка на задачу:**
https://nda.ya.ru/t/IR4WjqUH7a6PLH

**Связанный PR в main:**
https://github.com/ydb-platform/ydb/pull/38425

Условия, при которых пользователь мог столкнуться с проблемой:

В кластере включена аутентификация через LDAP, используется поисковый фильтр с подстановкой имени пользователя из входящего запроса.
Злоумышленник может передать в качестве имени пользователя строку со специальными символами синтаксиса LDAP-фильтра (*, (, ), \, NUL и т.п.), которые ранее не экранировались перед подстановкой в фильтр.

Проявление проблемы:

Возможна манипуляция LDAP-фильтром (в т.ч. обход ограничений поиска / логики сопоставления учётной записи), что относится к классу LDAP filter injection при небезопасной сборке фильтра из недоверенных данных.
С точки зрения пользователя легитимного сценария это может выглядеть как отказ или некорректное поведение аутентификации; с точки зрения безопасности — как использование специальных символов в имени пользователя для влияния на запрос к LDAP.

Способ исправления:

Перед подстановкой в шаблон поискового фильтра экранируются специальные символы в имени пользователя по правилам LDAP-фильтра; добавлены/расширены unit-тесты на такие входные данные.
Логика «как устроен LDAP» не меняется принципиально: меняется только безопасная подготовка строки для вставки в фильтр.