### PR TITLE
Fix to Shuffle elimination when used with HashJoinMode pragma

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_phy.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_phy.cpp
@@ -2985,6 +2985,10 @@ TExprBase DqBuildJoin(
     const bool rightIsUnionAll = join.RightInput().Maybe<TDqCnUnionAll>().IsValid();
 
     auto joinAlgo = FromString<EJoinAlgoType>(join.JoinAlgo().StringValue());
+    if (joinAlgo == EJoinAlgoType::Undefined) {
+        shuffleElimination = false;
+        shuffleEliminationWithMap = false;
+    }
     const bool mapJoinCanBeApplied = joinType != "Full"sv && joinType != "Exclusion"sv;
     if (joinAlgo == EJoinAlgoType::MapJoin && mapJoinCanBeApplied) {
         hashJoin = EHashJoinMode::Map;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed issue: https://github.com/ydb-platform/ydb/issues/38435
https://st.yandex-team.ru/YDB-3312

HashJoinMode is set to 'grace' on YQ clusters and kqp_run, and it doesn't work correctly with SE when CBO didn't run

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
