### PR TITLE
chore: typo `occured` -> `occurred` in util/ comments

### DIFF
--- a/util/string/subst.cpp
+++ b/util/string/subst.cpp
@@ -63,7 +63,7 @@ static inline size_t SubstGlobalImpl(TStringType& s, const TStringViewType from,
         TStringType result;
         for (; (off = TStringViewType(s).find(from, off)) != TStringType::npos; off += fromSize) {
             if (!replacementsCount) {
-                // first replacement occured, we can prepare result string
+                // first replacement occurred, we can prepare result string
                 result.reserve(s.size() + s.size() / 3);
             }
             result.append(s.begin() + srcPos, s.begin() + off);

--- a/util/string/subst.h
+++ b/util/string/subst.h
@@ -11,7 +11,7 @@
  * @param with      Substring to use as replacement.
  * @param from      Position at with to start replacement.
  *
- * @return          Number of replacements occured.
+ * @return          Number of replacements occurred.
  */
 size_t SubstGlobal(TString& text, TStringBuf what, TStringBuf with, size_t from = 0);
 size_t SubstGlobal(std::string& text, TStringBuf what, TStringBuf with, size_t from = 0);
@@ -26,7 +26,7 @@ size_t SubstGlobal(TUtf32String& text, TUtf32StringBuf what, TUtf32StringBuf wit
  * @param with      Character to use as replacement.
  * @param from      Position at with to start replacement.
  *
- * @return          Number of replacements occured.
+ * @return          Number of replacements occurred.
  */
 size_t SubstGlobal(TString& text, char what, char with, size_t from = 0);
 size_t SubstGlobal(std::string& text, char what, char with, size_t from = 0);

--- a/util/system/shellcommand.h
+++ b/util/system/shellcommand.h
@@ -403,7 +403,7 @@ public:
     const TString& GetError() const;
 
     /**
-     * @brief return the internal error occured while watching
+     * @brief return the internal error occurred while watching
      * the command execution. Should be called if execution
      * status is SHELL_INTERNAL_ERROR
      *


### PR DESCRIPTION
Four single-character typo fixes in comments, no functional change:

- `util/string/subst.cpp:66`, inline comment
- `util/string/subst.h:14,29`, two `@return Number of replacements occured` -> `occurred`
- `util/system/shellcommand.h:406`, `@brief` mentioning "internal error occured"

contrib/ and vendor/ matches left alone, those are external trees.