### PR TITLE
Added the aggregator of all detailed metrics on a single node

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -293,5 +293,5 @@ message TFeatureFlags {
     optional bool EnableTicketParserErrorBasedOnPeernameFormat = 255 [default = false];
     optional bool UseRealUserIpForBlackbox = 256 [default = false];
     optional bool EnableNodeShutdownHints = 257 [default = false];
-
-}   
+    optional bool EnableDetailedMetrics = 258 [default = false];
+}

--- a/ydb/core/tablet/detailed_metrics/metric_value_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/metric_value_aggregator.cpp
@@ -14,7 +14,8 @@ void THistogramMetricAggregator::AggregateValue(NMonitoring::THistogramPtr sourc
 
     Y_ABORT_UNLESS(
         snapshot1->Count() == snapshot2->Count(),
-        "Unable to aggregate histograms with a different number of buckets (%u vs %u)",
+        "Unable to aggregate histograms with a different number of buckets "
+        "(%" PRIu64 " vs %" PRIu64 ")",
         snapshot1->Count(),
         snapshot2->Count()
     );

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -29,7 +29,7 @@ void TNodeDatabaseMetricsAggregator::HandleDatabaseSchemaVersionChange(
                 << message->TableMetricsConfig->TenantDbSchemaVersion
                 << ", the current known tenant database schema version "
                 << tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion
-                << ") received from for the tablet ID "
+                << ") received from the tablet ID "
                 << message->TabletID
                 << " (type "
                 << TTabletTypes::TypeToStr(message->TabletType)
@@ -201,7 +201,7 @@ void TNodeDatabaseMetricsAggregator::HandleDatabaseSchemaVersionChange(
                 << TTabletTypes::TypeToStr(message->TabletType)
                 << "), new tenant database schema version "
                 << message->TableMetricsConfig->TenantDbSchemaVersion
-                << " (changed from  "
+                << " (changed from "
                 << tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion
                 << ")) for the table "
                 << tableMetricsIt->second.TableMetricsConfig.TablePath
@@ -249,7 +249,7 @@ void TNodeDatabaseMetricsAggregator::HandleTableSchemaVersionChange(
                 << message->TableMetricsConfig->TableSchemaVersion
                 << ", the current known table schema version "
                 << tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion
-                << ") received from for the tablet ID "
+                << ") received from the tablet ID "
                 << message->TabletID
                 << " (type "
                 << TTabletTypes::TypeToStr(message->TabletType)
@@ -386,7 +386,7 @@ void TNodeDatabaseMetricsAggregator::ProcessTabletCounters(
         // This is an existing table, make sure all tablets have the same type
         Y_ABORT_UNLESS(
             message->TabletType == tableMetricsIt->second.PartitionReplicaTabletType,
-            "The tablet ID %" PRIu64 " (type %s) of the table %s (table ID % " PRIu64
+            "The tablet ID %" PRIu64 " (type %s) of the table %s (table ID %" PRIu64
             ") uses an inconsistent type (expected %s)",
             message->TabletID,
             TTabletTypes::TypeToStr(message->TabletType),

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -226,7 +226,7 @@ void TNodeDatabaseMetricsAggregator::HandleTableSchemaVersionChange(
     std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
     TEvTabletCounters::TEvTabletAddCounters* message
 ) {
-    // First, check if the database schema version has changed
+    // First, check if the table schema version has changed
     if (message->TableMetricsConfig->TableSchemaVersion
             < tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion) {
         // NOTE: The table schema version in the message is lower than the version,
@@ -277,8 +277,8 @@ void TNodeDatabaseMetricsAggregator::HandleTableSchemaVersionChange(
     //       (as far as table IDs are concerned).
     Y_ABORT_UNLESS(
         message->TableMetricsConfig->TablePath == tableMetricsIt->second.TableMetricsConfig.TablePath,
-        "The table path for the table ID %u changed from %s to %s "
-        "when the table schema version changed from %u to %u",
+        "The table path for the table ID %" PRIu64 " changed from %s to %s "
+        "when the table schema version changed from %" PRIu64 " to %" PRIu64,
         tableMetricsIt->second.TableMetricsConfig.TableId,
         tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
         message->TableMetricsConfig->TablePath.c_str(),
@@ -386,7 +386,8 @@ void TNodeDatabaseMetricsAggregator::ProcessTabletCounters(
         // This is an existing table, make sure all tablets have the same type
         Y_ABORT_UNLESS(
             message->TabletType == tableMetricsIt->second.PartitionReplicaTabletType,
-            "The tablet ID %u (type %s) of the table %s (table ID %u) uses an inconsistent type (expected %s)",
+            "The tablet ID %" PRIu64 " (type %s) of the table %s (table ID % " PRIu64
+            ") uses an inconsistent type (expected %s)",
             message->TabletID,
             TTabletTypes::TypeToStr(message->TabletType),
             tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
@@ -500,9 +501,10 @@ void TNodeDatabaseMetricsAggregator::ProcessTabletCounters(
 
         Y_ABORT_UNLESS(
             inserted.second,
-            "The combination of the tablet ID %u (type %s) and the follower ID %u is already "
-            "present for the table ID %u when adding a new entry for detailed metrics "
-            "for the table %s (table ID %u)",
+            "The combination of the tablet ID %" PRIu64 " (type %s) and "
+            "the follower ID %" PRIu32 " is already present for the table ID %" PRIu64
+            " when adding a new entry for detailed metrics for the table %s "
+            "(table ID %" PRIu64 ")",
             message->TabletID,
             TTabletTypes::TypeToStr(message->TabletType),
             message->FollowerId,
@@ -602,19 +604,26 @@ void TNodeDatabaseMetricsAggregator::ForgetTablet(ui64 tabletId, ui32 followerId
 
     Y_ABORT_UNLESS(
         tableMetricsIt != PerTableMetrics.end(),
-        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
-        "is missing for the table ID %u in the tables map",
+        "The entry for the detailed metrics for the tablet ID %" PRIu64
+        " and the follower ID %" PRIu32 " is missing for the table ID %" PRIu64
+        " in the tables map",
         tabletId,
         followerId,
         lookupIt->second
     );
 
+    // NOTE: The entry in the TabletIdFollowerIdToTableIdMap map is no longer needed,
+    //       remove it now to be able to use "return" in the code below without
+    //       forgetting to remove the entry from this map
+    TabletIdFollowerIdToTableIdMap.erase(lookupIt);
+
     auto partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.find(tabletId);
 
     Y_ABORT_UNLESS(
         partitionMetricsIt != tableMetricsIt->second.PerPartitionMetrics.end(),
-        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
-        "is missing for the table %s (table ID %u) in the partitions map",
+        "The entry for the detailed metrics for the tablet ID %" PRIu64
+        " and the follower ID %" PRIu32 " is missing for the table %s "
+        "(table ID %" PRIu64 ") in the partitions map",
         tabletId,
         followerId,
         tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
@@ -625,8 +634,9 @@ void TNodeDatabaseMetricsAggregator::ForgetTablet(ui64 tabletId, ui32 followerId
 
     Y_ABORT_UNLESS(
         replicaMetricsIt != partitionMetricsIt->second.PerReplicaMetrics.end(),
-        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
-        "is missing for the table %s (table ID %u) in the replicas map",
+        "The entry for the detailed metrics for the tablet ID %" PRIu64
+        " and the follower ID %" PRIu32 " is missing for the table %s "
+        "(table ID %" PRIu64 ") in the replicas map",
         tabletId,
         followerId,
         tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
@@ -738,7 +748,6 @@ void TNodeDatabaseMetricsAggregator::ForgetTablet(ui64 tabletId, ui32 followerId
     }
 
     PerTableMetrics.erase(tableMetricsIt);
-    TabletIdFollowerIdToTableIdMap.erase(lookupIt);
 }
 
 } // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -1,0 +1,744 @@
+#include "node_database_metrics_aggregator.h"
+
+namespace NKikimr {
+
+void TNodeDatabaseMetricsAggregator::HandleDatabaseSchemaVersionChange(
+    std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+    TEvTabletCounters::TEvTabletAddCounters* message
+) {
+    // First, check if the database schema version has changed
+    if (message->TableMetricsConfig->TenantDbSchemaVersion
+            < tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion) {
+        // NOTE: The database schema version in the message is lower than the version,
+        //       stored in the hash-table in this class. This means that there is
+        //       at least one Data Shard instance, which has seen the schema change
+        //       for the given database and has sent the TEvTabletAddCounters message
+        //       to the Tablet Counters Aggregator (which forwarded it here).
+        //       The Data Shard instance, which sent this particular TEvTabletAddCounters
+        //       message has not seen the schema change for this table.
+        //       Thus, the lower schema version in the message.
+        //
+        //       Sooner or later this lagging Data Shard instance will see
+        //       the schema change for this database and will do the right thing.
+        //       For now, it is necessary to ignore the entire TableMetricsConfig
+        //       structure in the message because it is outdated.
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Ignoring the detailed metrics configuration (received tenant database schema version "
+                << message->TableMetricsConfig->TenantDbSchemaVersion
+                << ", the current known tenant database schema version "
+                << tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion
+                << ") received from for the tablet ID "
+                << message->TabletID
+                << " (type "
+                << TTabletTypes::TypeToStr(message->TabletType)
+                << "), table "
+                << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID "
+                << tableMetricsIt->second.TableMetricsConfig.TableId
+                << "), tenant database "
+                << TenantPathId
+        );
+
+        return;
+    }
+
+    // If the database schema version in the message is the same, there is nothing to do
+    if (message->TableMetricsConfig->TenantDbSchemaVersion
+            == tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion) {
+        return;
+    }
+
+    // NOTE: The database schema version for this table specified in this message
+    //       is newer that what is known so far. The change to each field
+    //       in the metrics configuration require specific actions.
+
+    // Changing the monitoring project ID is simple - need to add or remove
+    // the corresponding label from all sensors
+    if (message->TableMetricsConfig->MonitoringProjectId
+            != tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId) {
+        if (!tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId) {
+            // There was no monitoring project ID before and a new one is added,
+            // add a new group for it and move the table group under it
+            LOG_INFO_S(
+                *TlsActivationContext,
+                NKikimrServices::TABLET_AGGREGATOR,
+                "Adding the monitoring project ID "
+                    << (*message->TableMetricsConfig->MonitoringProjectId)
+                    << " (update received from the tablet ID "
+                    << message->TabletID
+                    << ", follower ID "
+                    << message->FollowerId
+                    << " (type "
+                    << TTabletTypes::TypeToStr(message->TabletType)
+                    << "), new tenant database schema version "
+                    << message->TableMetricsConfig->TenantDbSchemaVersion
+                    << ") for the table "
+                    << tableMetricsIt->second.TableMetricsConfig.TablePath
+                    << " (table ID "
+                    << tableMetricsIt->second.TableMetricsConfig.TableId
+                    << "), tenant database "
+                    << TenantPathId
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup =
+                DatabaseCounterGroup->GetSubgroup(
+                    "monitoring_project_id",
+                    *message->TableMetricsConfig->MonitoringProjectId
+                );
+
+            DatabaseCounterGroup->RemoveSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RegisterSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup
+            );
+        } else if (!message->TableMetricsConfig->MonitoringProjectId) {
+            // There was a monitoring project ID before and it is removed,
+            // move the corresponding table group up to the database group,
+            // but do not remove the group for the monitoring project ID
+            // because there is no way to know if there are any tables
+            // under it
+            LOG_INFO_S(
+                *TlsActivationContext,
+                NKikimrServices::TABLET_AGGREGATOR,
+                "Removing the monitoring project ID "
+                    << (*tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId)
+                    << " (update received from the tablet ID "
+                    << message->TabletID
+                    << ", follower ID "
+                    << message->FollowerId
+                    << " (type "
+                    << TTabletTypes::TypeToStr(message->TabletType)
+                    << "), new tenant database schema version "
+                    << message->TableMetricsConfig->TenantDbSchemaVersion
+                    << ") for the table "
+                    << tableMetricsIt->second.TableMetricsConfig.TablePath
+                    << " (table ID "
+                    << tableMetricsIt->second.TableMetricsConfig.TableId
+                    << "), tenant database "
+                    << TenantPathId
+            );
+
+            DatabaseCounterGroup->RegisterSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup.Reset();
+        } else {
+            // There was a monitoring project ID before and it is changed now,
+            // add a new group for the new project ID and move the table group
+            // under it, but do not remove the group for the old project ID
+            // because there is no way to know if there are any tables under it
+            LOG_INFO_S(
+                *TlsActivationContext,
+                NKikimrServices::TABLET_AGGREGATOR,
+                "Changing the monitoring project ID from "
+                    << (*tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId)
+                    << " to "
+                    << (*message->TableMetricsConfig->MonitoringProjectId)
+                    << " (update received from the tablet ID "
+                    << message->TabletID
+                    << ", follower ID "
+                    << message->FollowerId
+                    << " (type "
+                    << TTabletTypes::TypeToStr(message->TabletType)
+                    << "), new tenant database schema version "
+                    << message->TableMetricsConfig->TenantDbSchemaVersion
+                    << ") for the table "
+                    << tableMetricsIt->second.TableMetricsConfig.TablePath
+                    << " (table ID "
+                    << tableMetricsIt->second.TableMetricsConfig.TableId
+                    << "), tenant database "
+                    << TenantPathId
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath
+            );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup =
+                DatabaseCounterGroup->GetSubgroup(
+                    "monitoring_project_id",
+                    *message->TableMetricsConfig->MonitoringProjectId
+                );
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RegisterSubgroup(
+                "table",
+                tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup
+            );
+        }
+    } else {
+        // The database schema version is changed, but the monitoring project ID is not
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Not changing the monitoring project ID "
+                << (
+                    (tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId)
+                        ? (*tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId)
+                        : "NOT_SPECIFIED"
+                )
+                << " (update received from the tablet ID "
+                << message->TabletID
+                << ", follower ID "
+                << message->FollowerId
+                << " (type "
+                << TTabletTypes::TypeToStr(message->TabletType)
+                << "), new tenant database schema version "
+                << message->TableMetricsConfig->TenantDbSchemaVersion
+                << " (changed from  "
+                << tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion
+                << ")) for the table "
+                << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID "
+                << tableMetricsIt->second.TableMetricsConfig.TableId
+                << "), tenant database "
+                << TenantPathId
+        );
+    }
+
+    // All the actions needed to apply the new configuration are done,
+    // copy all the fields into our hash maps
+    tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion =
+        message->TableMetricsConfig->TenantDbSchemaVersion;
+
+    tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId =
+        message->TableMetricsConfig->MonitoringProjectId;
+}
+
+
+void TNodeDatabaseMetricsAggregator::HandleTableSchemaVersionChange(
+    std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+    TEvTabletCounters::TEvTabletAddCounters* message
+) {
+    // First, check if the database schema version has changed
+    if (message->TableMetricsConfig->TableSchemaVersion
+            < tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion) {
+        // NOTE: The table schema version in the message is lower than the version,
+        //       stored in the hash-tables in this class. This means that there is
+        //       at least one Data Shard instance, which has seen the schema change
+        //       for the given table and has sent the TEvTabletAddCounters message
+        //       to the Tablet Counters Aggregator (which forwarded it here).
+        //       The Data Shard instance, which sent this particular TEvTabletAddCounters
+        //       message has not seen the schema change for this table.
+        //       Thus, the lower schema version in the message.
+        //
+        //       Sooner or later this lagging Data Shard instance will see
+        //       the schema change for this table and will do the right thing.
+        //       For now, it is necessary to ignore the entire TableMetricsConfig
+        //       structure in the message because it is outdated.
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Ignoring the detailed metrics configuration (received table schema version "
+                << message->TableMetricsConfig->TableSchemaVersion
+                << ", the current known table schema version "
+                << tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion
+                << ") received from for the tablet ID "
+                << message->TabletID
+                << " (type "
+                << TTabletTypes::TypeToStr(message->TabletType)
+                << "), table "
+                << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID "
+                << tableMetricsIt->second.TableMetricsConfig.TableId
+                << "), tenant database "
+                << TenantPathId
+        );
+
+        return;
+    }
+
+    // If the table schema version in the message is the same, there is nothing to do
+    if (message->TableMetricsConfig->TableSchemaVersion
+            == tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion) {
+        return;
+    }
+
+    // NOTE: The table path must not change even when the schema version is increased.
+    //       Changing the table path (a.k.a. renaming a table) should produce a new PathId,
+    //       which is going to change the table ID. In other words, renaming a table
+    //       effectively deletes the old table and creates a new table
+    //       (as far as table IDs are concerned).
+    Y_ABORT_UNLESS(
+        message->TableMetricsConfig->TablePath == tableMetricsIt->second.TableMetricsConfig.TablePath,
+        "The table path for the table ID %u changed from %s to %s "
+        "when the table schema version changed from %u to %u",
+        tableMetricsIt->second.TableMetricsConfig.TableId,
+        tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        message->TableMetricsConfig->TablePath.c_str(),
+        tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion,
+        message->TableMetricsConfig->TableSchemaVersion
+    );
+
+    /**
+     * @todo Analyze MetricsLevel and TableId.
+     */
+}
+
+void TNodeDatabaseMetricsAggregator::ProcessTabletCounters(
+    TEvTabletCounters::TEvTabletAddCounters* message
+) {
+    // Do not process metrics, which do not have the metrics configuration set
+    if (!message->TableMetricsConfig) {
+        return;
+    }
+
+    // Process detailed metrics only from known types
+    switch (message->TabletType) {
+    case TTabletTypes::DataShard:
+        break;
+
+    default:
+        return;
+    }
+
+    // Add a new table entry, if this table has never been seen before
+    auto tableMetricsIt = PerTableMetrics.find(message->TableMetricsConfig->TableId);
+
+    if (tableMetricsIt == PerTableMetrics.end()) {
+        // This is a new entry for a new table, process detailed metrics
+        // only if the metrics level is above DATABASE
+        switch (message->TableMetricsConfig->MetricsLevel) {
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
+            break;
+
+        default:
+            return;
+        }
+
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the table "
+                << message->TableMetricsConfig->TablePath
+                << " (table ID "
+                << message->TableMetricsConfig->TableId
+                << "), metrics level "
+                << NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(
+                    message->TableMetricsConfig->MetricsLevel
+                )
+                << ", tenant database "
+                << TenantPathId
+                << ", monitoring project ID "
+                << (
+                    (message->TableMetricsConfig->MonitoringProjectId)
+                        ? (*message->TableMetricsConfig->MonitoringProjectId)
+                        : "NOT_SPECIFIED"
+                )
+        );
+
+        // Place all table metrics into a subgroup with the "monitoring_project_id" label,
+        // if the monitoring project ID is known
+        auto parentCounterGroup = DatabaseCounterGroup;
+        NMonitoring::TDynamicCounterPtr monitoringProjectCounterGroup;
+
+        if (message->TableMetricsConfig->MonitoringProjectId) {
+            monitoringProjectCounterGroup = DatabaseCounterGroup->GetSubgroup(
+                "monitoring_project_id",
+                *message->TableMetricsConfig->MonitoringProjectId
+            );
+
+            parentCounterGroup = monitoringProjectCounterGroup;
+        }
+
+        auto tableCounterGroup = parentCounterGroup->GetSubgroup(
+            "table",
+            message->TableMetricsConfig->TablePath
+        );
+
+        // Allocate a new entry for this new table
+        tableMetricsIt = PerTableMetrics.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(message->TableMetricsConfig->TableId),
+            std::forward_as_tuple(TTableMetricsInfo{
+                .TableMetricsConfig = *message->TableMetricsConfig,
+                .PartitionReplicaTabletType = message->TabletType,
+                .TableCounterGroup = tableCounterGroup,
+                .MonitoringProjectCounterGroup = monitoringProjectCounterGroup,
+                .PerPartitionCounterGroup = tableCounterGroup->GetSubgroup(
+                    "detailed_metrics",
+                    "per_partition"
+                ),
+                .PerPartitionTableYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(
+                    message->TabletType,
+                    tableCounterGroup
+                ),
+            })
+        ).first;
+    } else {
+        // This is an existing table, make sure all tablets have the same type
+        Y_ABORT_UNLESS(
+            message->TabletType == tableMetricsIt->second.PartitionReplicaTabletType,
+            "The tablet ID %u (type %s) of the table %s (table ID %u) uses an inconsistent type (expected %s)",
+            message->TabletID,
+            TTabletTypes::TypeToStr(message->TabletType),
+            tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+            tableMetricsIt->second.TableMetricsConfig.TableId,
+            TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType)
+        );
+
+        /**
+         * @todo Once per-table metrics are added (from Scheme Shard), the code here
+         *       should be changed to verify that the tablet type for per-partition
+         *       metrics (should be Data Shard or Column Shard) is different from
+         *       the tablet type for per-table metrics (should be Scheme Shard).
+         *       If the same tablet type is used for reporting both per-partition
+         *       and per-table metrics, the code in this class as it is written now
+         *       will get confused and will lose metrics values - the counters
+         *       at the table level will get overwritten by per-table and per-partition
+         *       metrics.
+         */
+
+        // Process any schema changes, if necessary
+        HandleDatabaseSchemaVersionChange(tableMetricsIt, message);
+        HandleTableSchemaVersionChange(tableMetricsIt, message);
+    }
+
+    // Add a new partition entry, if this partition has never been seen before
+    auto partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.find(message->TabletID);
+
+    if (partitionMetricsIt == tableMetricsIt->second.PerPartitionMetrics.end()) {
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the tablet ID "
+                << message->TabletID
+                << " (type "
+                << TTabletTypes::TypeToStr(message->TabletType)
+                << "), table "
+                << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID "
+                << tableMetricsIt->second.TableMetricsConfig.TableId
+                << "), tenant database "
+                << TenantPathId
+        );
+
+        auto partitionCounterGroup = tableMetricsIt->second.PerPartitionCounterGroup->GetSubgroup(
+            "tablet_id",
+            ToString(message->TabletID)
+        );
+
+        auto allFollowersCounterGroup = partitionCounterGroup->GetSubgroup(
+            "follower_id",
+            "replicas_only"
+        );
+
+        // Allocate a new entry for this new partition
+        partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(message->TabletID),
+            std::forward_as_tuple(TPartitionMetricsInfo{
+                .PartitionCounterGroup = partitionCounterGroup,
+                .PartitionYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(
+                    message->TabletType,
+                    partitionCounterGroup
+                ),
+                .AllFollowersCounterGroup = allFollowersCounterGroup,
+                .AllFollowersYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(
+                    message->TabletType,
+                    allFollowersCounterGroup
+                ),
+            })
+        ).first;
+
+        // Connect the metrics aggregators for this partition to the corresponding parents
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->AddSourceCountersGroup(
+            "replicas_only",
+            allFollowersCounterGroup
+        );
+
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->AddSourceCountersGroup(
+            ToString(message->TabletID),
+            partitionCounterGroup
+        );
+    }
+
+    // Add a new replica entry, if this follower/leader has never been seen before
+    auto replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.find(message->FollowerId);
+
+    if (replicaMetricsIt == partitionMetricsIt->second.PerReplicaMetrics.end()) {
+        LOG_INFO_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the follower ID "
+                << message->FollowerId
+                << ", tablet ID "
+                << message->TabletID
+                << " (type "
+                << TTabletTypes::TypeToStr(message->TabletType)
+                << "), table "
+                << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID "
+                << tableMetricsIt->second.TableMetricsConfig.TableId
+                << "), tenant database "
+                << TenantPathId
+        );
+
+        // Since this is a new TabletId/FollowerId pair, update the reverse lookup map
+        // to make it easier to find the corresponding table on the ForgetTablet() path
+        auto inserted = TabletIdFollowerIdToTableIdMap.emplace(
+            std::make_pair(message->TabletID, message->FollowerId),
+            tableMetricsIt->second.TableMetricsConfig.TableId
+        );
+
+        Y_ABORT_UNLESS(
+            inserted.second,
+            "The combination of the tablet ID %u (type %s) and the follower ID %u is already "
+            "present for the table ID %u when adding a new entry for detailed metrics "
+            "for the table %s (table ID %u)",
+            message->TabletID,
+            TTabletTypes::TypeToStr(message->TabletType),
+            message->FollowerId,
+            inserted.first->second,
+            tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+            tableMetricsIt->second.TableMetricsConfig.TableId
+        );
+
+        auto replicaCounterGroup = partitionMetricsIt->second.PartitionCounterGroup->GetSubgroup(
+            "follower_id",
+            ToString(message->FollowerId)
+        );
+
+        // Allocate a new entry for this new replica
+        replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(message->FollowerId),
+            std::forward_as_tuple(TPartitionReplicaMetricsInfo{
+                .ReplicaCounterGroup = replicaCounterGroup,
+                .TabletCountersProcessor = CreateTabletCountersProcessor(
+                    replicaCounterGroup,
+                    message->TabletType
+                ),
+                .TabletYdbMetricsMapper = CreateYdbMetricsMapperByTabletType(
+                    message->TabletType,
+                    replicaCounterGroup,
+                    replicaCounterGroup
+                ),
+            })
+        ).first;
+
+        // Connect the metrics aggregators for this partition to the corresponding parents
+        if (message->FollowerId == 0) {
+            // The leader goes directly to the partition metrics
+            partitionMetricsIt->second.PartitionYdbMetricsAggregator->AddSourceCountersGroup(
+                ToString(message->FollowerId),
+                replicaCounterGroup
+            );
+        } else {
+            // All followers go to the "replicas_only" group and then (indirectly)
+            // to the partition metrics
+            partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->AddSourceCountersGroup(
+                ToString(message->FollowerId),
+                replicaCounterGroup
+            );
+        }
+    }
+
+    // Update the received metrics and update all aggregates
+    //
+    // WARNING: The TTabletCountersForTabletType class (the one, which really implements
+    //          the ITabletCountersProcessor interface) is written in such away,
+    //          that the ProcessTabletCounters() function updates only the values
+    //          of direct counters, which derive their values directly from the tablet
+    //          counters. Any aggregate values (e.g. "SUM(DbUniqueRowsTotal)" or
+    //          "HIST(ConsumedCPU)") are not updated. To see the updated values,
+    //          the RecalculateAggregatedValues() function must be called explicitly.
+    replicaMetricsIt->second.TabletCountersProcessor->ProcessTabletCounters(
+        message->TabletID,
+        message->ExecutorCounters.Get(),
+        message->AppCounters.Get(),
+        message->TabletType
+    );
+
+    replicaMetricsIt->second.TabletCountersProcessor->RecalculateAggregatedValues();
+    replicaMetricsIt->second.TabletYdbMetricsMapper->TransferCounterValues();
+
+    if (message->FollowerId != 0) {
+        // Recalculate replica metrics only if the update is coming from an actual follower
+        partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RecalculateAllTargetCounters();
+    }
+
+    partitionMetricsIt->second.PartitionYdbMetricsAggregator->RecalculateAllTargetCounters();
+    tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+}
+
+void TNodeDatabaseMetricsAggregator::ForgetTablet(ui64 tabletId, ui32 followerId) {
+    // There is no table information on this path, so look up the table just by IDs
+    auto lookupIt = TabletIdFollowerIdToTableIdMap.find(std::make_pair(tabletId, followerId));
+
+    if (lookupIt == TabletIdFollowerIdToTableIdMap.end()) {
+        LOG_WARN_S(
+            *TlsActivationContext,
+            NKikimrServices::TABLET_AGGREGATOR,
+            "Not deleting the entry for detailed metrics for an unknown tablet ID "
+                << tabletId
+                << " (requested follower ID "
+                << followerId
+                << "), tenant database "
+                << TenantPathId
+        );
+
+        return;
+    }
+
+    auto tableMetricsIt = PerTableMetrics.find(lookupIt->second);
+
+    Y_ABORT_UNLESS(
+        tableMetricsIt != PerTableMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
+        "is missing for the table ID %u in the tables map",
+        tabletId,
+        followerId,
+        lookupIt->second
+    );
+
+    auto partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.find(tabletId);
+
+    Y_ABORT_UNLESS(
+        partitionMetricsIt != tableMetricsIt->second.PerPartitionMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
+        "is missing for the table %s (table ID %u) in the partitions map",
+        tabletId,
+        followerId,
+        tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        tableMetricsIt->second.TableMetricsConfig.TableId
+    );
+
+    auto replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.find(followerId);
+
+    Y_ABORT_UNLESS(
+        replicaMetricsIt != partitionMetricsIt->second.PerReplicaMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %u and the follower ID %u "
+        "is missing for the table %s (table ID %u) in the replicas map",
+        tabletId,
+        followerId,
+        tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        tableMetricsIt->second.TableMetricsConfig.TableId
+    );
+
+    // Remove the entry for this follower ID and update the parent partition
+    LOG_INFO_S(
+        *TlsActivationContext,
+        NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the follower ID "
+            << followerId
+            << ", tablet ID "
+            << tabletId
+            << " (type "
+            << TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType)
+            << "), table "
+            << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID "
+            << tableMetricsIt->second.TableMetricsConfig.TableId
+            << "), tenant database "
+            << TenantPathId
+    );
+
+    partitionMetricsIt->second.PartitionCounterGroup->RemoveSubgroup(
+        "follower_id",
+        ToString(followerId)
+    );
+
+    if (followerId == 0) {
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->RemoveSourceCountersGroup(
+            ToString(followerId)
+        );
+    } else {
+        partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RemoveSourceCountersGroup(
+            ToString(followerId)
+        );
+    }
+
+    partitionMetricsIt->second.PerReplicaMetrics.erase(replicaMetricsIt);
+
+    if (!partitionMetricsIt->second.PerReplicaMetrics.empty()) {
+        // The parent partition still contains some replicas, just update the counters
+        if (followerId != 0) {
+            partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RecalculateAllTargetCounters();
+        }
+
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->RecalculateAllTargetCounters();
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+
+        return;
+    }
+
+    // The parent partition does not contain any followers/leaders, delete the entry
+    LOG_INFO_S(
+        *TlsActivationContext,
+        NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the tablet ID "
+            << tabletId
+            << " (type "
+            << TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType)
+            << "), table "
+            << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID "
+            << tableMetricsIt->second.TableMetricsConfig.TableId
+            << "), tenant database "
+            << TenantPathId
+    );
+
+    tableMetricsIt->second.PerPartitionCounterGroup->RemoveSubgroup(
+        "tablet_id",
+        ToString(tabletId)
+    );
+
+    tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RemoveSourceCountersGroup(
+        ToString(tabletId)
+    );
+
+    tableMetricsIt->second.PerPartitionMetrics.erase(partitionMetricsIt);
+
+    if (!tableMetricsIt->second.PerPartitionMetrics.empty()) {
+        // The parent table still contains some partitions, just update the counters
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+        return;
+    }
+
+    // The parent table does not contain any partitions, delete the entry
+    LOG_INFO_S(
+        *TlsActivationContext,
+        NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the table "
+            << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID "
+            << tableMetricsIt->second.TableMetricsConfig.TableId
+            << "), tenant database "
+            << TenantPathId
+    );
+
+    if (tableMetricsIt->second.MonitoringProjectCounterGroup) {
+        tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup(
+            "table",
+            tableMetricsIt->second.TableMetricsConfig.TablePath
+        );
+    } else {
+        DatabaseCounterGroup->RemoveSubgroup(
+            "table",
+            tableMetricsIt->second.TableMetricsConfig.TablePath
+        );
+    }
+
+    PerTableMetrics.erase(tableMetricsIt);
+    TabletIdFollowerIdToTableIdMap.erase(lookupIt);
+}
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -297,16 +297,6 @@ private:
     };
 
     /**
-     * The custom equality calculator, which allows using std::pair<ui64, ui32>
-     * as a key in standard maps and sets.
-     */
-    struct TabletIdFollowerIdPairEqual {
-        bool operator()(const std::pair<ui64, ui32>& p1, const std::pair<ui64, ui32>& p2) const {
-            return (p1.first == p2.first) && (p1.second == p2.second);
-        }
-    };
-
-    /**
      * The reverse lookup map, which provides a fast mechanism to figure out,
      * which table the given tablet ID + follower ID pair belongs to.
      *
@@ -316,8 +306,7 @@ private:
     std::unordered_map<
         std::pair<ui64, ui32>,
         ui64,
-        TabletIdFollowerIdPairHash,
-        TabletIdFollowerIdPairEqual
+        TabletIdFollowerIdPairHash
     > TabletIdFollowerIdToTableIdMap;
 };
 

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -1,0 +1,326 @@
+#pragma once
+
+#include "ydb_metrics_aggregator.h"
+#include "ydb_metrics_mapper.h"
+
+#include <ydb/core/base/tablet_types.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <util/generic/ptr.h>
+
+namespace NKikimr {
+
+/**
+ * The aggregator for all metrics for the given database for the given node.
+ */
+class TNodeDatabaseMetricsAggregator : public TThrRefBase {
+public:
+    /**
+     * The constructor, which creates the counter group for all metrics
+     * aggregated for the given database.
+     *
+     * @param[in] tenantPathId The tenant path ID for the database for the given aggregator
+     * @param[in] parentCounterGroup The parent group, where counters for all databases are stored
+     */
+    TNodeDatabaseMetricsAggregator(
+        const TPathId& tenantPathId,
+        NMonitoring::TDynamicCounterPtr parentCounterGroup
+    ) : TenantPathId(tenantPathId)
+      , DatabasePath(
+            // NOTE: There is no easy way to resolve the tenant path ID to the corresponding
+            //       database path. When the aggregator starts, use a fake path constructed
+            //       from the tenant path ID. Once the database path is resolved, the corresponding
+            //       counter groups will be updated to use the correct "database" label.
+            TStringBuilder()
+                << tenantPathId.OwnerId
+                << "-"
+                << tenantPathId.LocalPathId
+        )
+      , ParentCounterGroup(parentCounterGroup)
+      , DatabaseCounterGroup(parentCounterGroup->GetSubgroup("database", DatabasePath))
+    {
+    }
+
+    /**
+     * Delete all counters for the given database.
+     */
+    void DeleteAllDatabaseCounters() {
+        ParentCounterGroup->RemoveSubgroup("database", DatabasePath);
+    }
+
+    /**
+     * Process a single batch of tablet counters and apply them to the corresponding
+     * metrics counters.
+     *
+     * @note This function assumes that the given counters are differential
+     *       (as a delta) from the previous batch.
+     *
+     * @param[in] message The TEvTabletAddCounters message with the batch to process
+     */
+    void ProcessTabletCounters(TEvTabletCounters::TEvTabletAddCounters* message);
+
+    /**
+     * Remove the values supplied by the given tablet from all counters.
+     *
+     * @param[in] tabletId The ID of the tablet
+     * @param[in] followerId The ID of the follower
+     */
+    void ForgetTablet(ui64 tabletId, ui32 followerId);
+
+private:
+    /**
+     * The container for all the pieces needed to track detailed metrics
+     * for the given follower (or the leader) for the given partition.
+     */
+    struct TPartitionReplicaMetricsInfo {
+        /**
+         * The counter group, which contains all counters (both high-level and low-level)
+         * for the given follower/leader.
+         *
+         * @note Public YDB metrics (for example, table.datashard.*) are created
+         *       directly in this counter group. Low level metrics for each tablet type
+         *       are created in child subgroups. For example, low level metrics
+         *       for Data Shard tablets are created in the subgroup labelled
+         *       as "type"="DataShard".
+         *
+         * @note This corresponds to the "follower_id" = "<follower_id>" label.
+         */
+        NMonitoring::TDynamicCounterPtr ReplicaCounterGroup;
+
+        /**
+         * The processor for low-level counters for the given replica.
+         *
+         * @note This processor is responsible for translating the counter values
+         *       coming directly from the tablet (see TEvTabletAddCounters)
+         *       into the actual metrics counters stored inside the corresponding
+         *       subgroup (e.g., the one labelled as "type"="DataShard") inside
+         *       the ReplicaCounterGroup counter group.
+         */
+        ITabletCountersProcessorPtr TabletCountersProcessor;
+
+        /**
+         * The mapper from the low-level metrics for the given replica
+         * to the corresponding high-level metrics (for example, table.datashard.*).
+         *
+         * @note This mapper translates the low level metrics from the corresponding
+         *       type subgroup directly into the the ReplicaCounterGroup counter group.
+         */
+        TYdbMetricsMapperPtr TabletYdbMetricsMapper;
+    };
+
+    /**
+     * The container for all the pieces needed to track detailed metrics
+     * for the given partition.
+     */
+    struct TPartitionMetricsInfo {
+        /**
+         * The counter group, which contains all high-level counters for the given partition.
+         *
+         * @note Public YDB metrics (for example, table.datashard.*) are created
+         *       directly in this counter group. These counters contain aggregated
+         *       values across all replicas of the given partition.
+         *
+         * @note This corresponds to the "tablet_id" = "<table_id>" label.
+         */
+        NMonitoring::TDynamicCounterPtr PartitionCounterGroup;
+
+        /**
+         * The aggregator for the high-level metrics for the given partition.
+         */
+        TYdbMetricsAggregatorPtr PartitionYdbMetricsAggregator;
+
+        /**
+         * The counter group, which contains all high-level counters
+         * aggregated across all followers (excluding the leader) for the given partition.
+         *
+         * @note This corresponds to the "follower_id" = "replicas_only" label.
+         */
+        NMonitoring::TDynamicCounterPtr AllFollowersCounterGroup;
+
+        /**
+         * The aggregator for the high-level metrics for all followers (excluding the leader)
+         * for the given partition.
+         */
+        TYdbMetricsAggregatorPtr AllFollowersYdbMetricsAggregator;
+
+        /**
+         * The list of metrics info-containers for each replica (including the leader)
+         * for the given partition.
+         *
+         * @note The key here is the follower ID (0 == the leader).
+         */
+        std::unordered_map<ui32, TPartitionReplicaMetricsInfo> PerReplicaMetrics;
+    };
+
+    /**
+     * The container for all the pieces needed to track detailed metrics
+     * for the given table.
+     */
+    struct TTableMetricsInfo {
+        /**
+         * The last known detailed metrics configuration for the given table.
+         *
+         * @note This information is transmitted in each TEvTabletAddCounters message
+         *       by each tablet. The TTableMetricsConfig::SchemaVersion field
+         *       is used to resolve conflicts and choose the most recent configuration.
+         */
+        TEvTabletCounters::TTableMetricsConfig TableMetricsConfig;
+
+        /**
+         * The type for all tablets (both followers and leaders) holding the data
+         * for all partitions the given table.
+         *
+         * @warning This assumes that all followers/leaders for all partitions
+         *          of the given table are of the same type. In other words,
+         *          per-replica per-partition detailed metrics can be coming
+         *          from tables only of this type. This does not apply
+         *          to the detailed metrics for the entire table - they can be coming
+         *          from tablets of different types (multiple).
+         */
+        TTabletTypes::EType PartitionReplicaTabletType;
+
+        /**
+         * The counter group, which contains all high-level counters for the given table.
+         *
+         * @note Public YDB metrics (for example, table.datashard.*) are created
+         *       directly in this counter group. These counters contain aggregated
+         *       values across all partitions of the given table.
+         *
+         * @note This corresponds to the "table" = "<table_path>" label.
+         */
+        NMonitoring::TDynamicCounterPtr TableCounterGroup;
+
+        /**
+         * The counter group, which holds the Monitoring project ID for all detailed metrics
+         * for the given table.
+         *
+         * @note If the TTableMetricsConfig::MonitoringProjectId field is set,
+         *       then this counter group is the parent group for the TableCounterGroup group.
+         *       If this field is not set, then the TableCounterGroup group
+         *       is created directly in the parent counter group for the given
+         *       database (see DatabaseCounterGroup).
+         *
+         * @note This corresponds to the "monitoring_project_id" = "<project_id>" label.
+         */
+        NMonitoring::TDynamicCounterPtr MonitoringProjectCounterGroup;
+
+        /**
+         * The counter group, which contains all high-level counters grouped
+         * by the partition ID.
+         *
+         * @note This corresponds to the "detailed_metrics" = "per_partition" label.
+         */
+        NMonitoring::TDynamicCounterPtr PerPartitionCounterGroup;
+
+        /**
+         * The aggregator for the high-level metrics for the given table.
+         *
+         * @note This aggregator is responsible aggregating high-level metrics
+         *       from all replicas of all partitions for the given table
+         *       (from PerPartitionMetrics). Per-table metrics are aggregated
+         *       separately.
+         */
+        TYdbMetricsAggregatorPtr PerPartitionTableYdbMetricsAggregator;
+
+        /**
+         * The list of metrics info-containers for each partition for the given table.
+         *
+         * @note The key here is the partition ID (as TabletId).
+         */
+        std::unordered_map<ui64, TPartitionMetricsInfo> PerPartitionMetrics;
+    };
+
+    /**
+     * Check, if the schema version for the given table has changed and,
+     * if necessary, perform the necessary actions to handle the changes.
+     *
+     * @param[in] tableMetricsIt The iterator for the table metrics entry
+     * @param[in] message The TEvTabletAddCounters message (may contain the new schema version)
+     */
+    void HandleTableSchemaVersionChange(
+        std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+        TEvTabletCounters::TEvTabletAddCounters* message
+    );
+
+    /**
+     * Check, if the schema version for the given tenant database has changed and,
+     * if necessary, perform the necessary actions to handle the changes.
+     *
+     * @param[in] tableMetricsIt The iterator for the table metrics entry
+     * @param[in] message The TEvTabletAddCounters message (may contain the new schema version)
+     */
+    void HandleDatabaseSchemaVersionChange(
+        std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+        TEvTabletCounters::TEvTabletAddCounters* message
+    );
+
+    /**
+     * The tenant path ID for the database, which is handled by the given aggregator.
+     */
+    const TPathId TenantPathId;
+
+    /**
+     * The database path for the database, which is handled by the given aggregator.
+     *
+     * @warning Until the database path is resolved, this is constructed from TenantPathId.
+     */
+    TString DatabasePath;
+
+    /**
+     * The parent group, where counters for all databases are stored
+     */
+    NMonitoring::TDynamicCounterPtr ParentCounterGroup;
+
+    /**
+     * The counter group where all the aggregated counters for the given database will be created.
+     *
+     * @note This corresponds to the "database" = "<database_path>" label.
+     */
+    NMonitoring::TDynamicCounterPtr DatabaseCounterGroup;
+
+    /**
+     * The list of metrics info-containers for each table for the given database.
+     *
+     * @note The key here is the table ID (as PathId).
+     */
+    std::unordered_map<ui64, TTableMetricsInfo> PerTableMetrics;
+
+    /**
+     * The custom hash calculator, which allows using std::pair<ui64, ui32>
+     * as a key in standard maps and sets.
+     */
+    struct TabletIdFollowerIdPairHash {
+        std::size_t operator()(const std::pair<ui64, ui32>& p) const {
+            return std::hash<ui64>{}(p.first) ^ std::hash<ui32>{}(p.second);
+        }
+    };
+
+    /**
+     * The custom equality calculator, which allows using std::pair<ui64, ui32>
+     * as a key in standard maps and sets.
+     */
+    struct TabletIdFollowerIdPairEqual {
+        bool operator()(const std::pair<ui64, ui32>& p1, const std::pair<ui64, ui32>& p2) const {
+            return (p1.first == p2.first) && (p1.second == p2.second);
+        }
+    };
+
+    /**
+     * The reverse lookup map, which provides a fast mechanism to figure out,
+     * which table the given tablet ID + follower ID pair belongs to.
+     *
+     * @note The key in this map is the {TabletId, FollowerId} pair.
+     *       And the value is the corresponding TableId.
+     */
+    std::unordered_map<
+        std::pair<ui64, ui32>,
+        ui64,
+        TabletIdFollowerIdPairHash,
+        TabletIdFollowerIdPairEqual
+    > TabletIdFollowerIdToTableIdMap;
+};
+
+using TNodeDatabaseMetricsAggregatorPtr = TIntrusivePtr<TNodeDatabaseMetricsAggregator>;
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -107,6 +107,61 @@ R"json(
     }
 
     /**
+     * Verify that the Tablet Counters Aggregator (leaders) does not process
+     * any detailed metrics, if the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsFeatureFlagDisabled) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(
+            runtime,
+            false /* forFollowers */,
+            false /* enableDetailedMetrics */
+        );
+
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Send an update for detailed metrics, but it should not be processed
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 101, 0, &tableMetricsConfig);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
      * Verify that the Tablet Counters Aggregator ignores detailed metrics
      * for new tables with the given low metrics level.
      *

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -1,0 +1,10124 @@
+#include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
+
+#include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+#include <ydb/core/tablet/tablet_counters_app.h>
+#include <ydb/core/tablet_flat/flat_executor_counters.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <library/cpp/monlib/dynamic_counters/encode.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NDetailedMetricsTests;
+using namespace NKikimr::NTabletFlatExecutor;
+
+namespace {
+
+/**
+ * Retrieve the given private counters as a JSON string.
+ *
+ * @param[in] counters The counters for which to retrieve the JSON
+ *
+ * @return The corresponding JSON as a string
+ */
+TString GetPrivateJsonForCounters(const NMonitoring::TDynamicCounters& counters) {
+    TStringStream stream;
+
+    counters.Accept(
+        TString{},
+        TString{},
+        *(NMonitoring::CreateEncoder(
+            &stream,
+            NMonitoring::EFormat::JSON,
+            "sensor",
+            NMonitoring::TCountableBase::EVisibility::Private
+        ).Get())
+    );
+
+    return stream.Str();
+}
+
+} // namespace <anonymous>
+
+/**
+ * Unit tests for the per-node per-database metrics aggregator class (TNodeDatabaseMetricsAggregator).
+ */
+Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) exposes no detailed metrics,
+     * if there are no tablets reporting detailed metrics.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsLeaders) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (followers) does not try to expose
+     * detailed metrics at all.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        InitializeTabletCountersAggregator(runtime, true /* forFollowers */);
+
+        // The "ydb_detailed_raw" counter group should not exist
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(!detailedCounters);
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with the given low metrics level.
+     *
+     * @param[in] metricsLevel The metrics level to test with
+     */
+    void VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Send detailed metrics with the given metrics level (too low)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = metricsLevel,
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 0, 20, &tableMetricsConfig);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with low metrics level (UNSPECIFIED).
+     */
+    Y_UNIT_TEST(NoDetailedMetricsNewTableForLowMetricsLevelUnspecified) {
+        VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with low metrics level (DISABLED).
+     */
+    Y_UNIT_TEST(NoDetailedMetricsNewTableForLowMetricsLevelDisabled) {
+        VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) correctly handles
+     * the case when the TEvTabletCountersForgetTablet message is received
+     * for an unknown follower ID or for an unknown tablet ID.
+     */
+    Y_UNIT_TEST(ForgetUnknownFollowerOrTablet) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 1 table with 1 partition and only leaders for each of them
+        // and try to delete an unknown follower
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 101, 0, &tableMetricsConfig);
+
+        // Try deleting unknown tablet/follower
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 1, 123456789); // Unknown follower
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 987654321, 101); // Unknown tablet
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for this tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "1")
+                                    .StartNested("follower_id", "101")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1)
+                                        .AddRate("table.datashard.erase.bytes", 120001)
+                                        .AddRate("table.datashard.erase.rows", 110001)
+                                        .AddRate("table.datashard.read.bytes", 70190002)
+                                        .AddRate("table.datashard.read.rows", 30150002)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 160001)
+                                        .AddRate("table.datashard.scan.rows", 150001)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60001)
+                                        .AddRate("table.datashard.write.rows", 50001)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1)
+                                        .AddRate("table.datashard.erase.bytes", 120001)
+                                        .AddRate("table.datashard.erase.rows", 110001)
+                                        .AddRate("table.datashard.read.bytes", 70190002)
+                                        .AddRate("table.datashard.read.rows", 30150002)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 160001)
+                                        .AddRate("table.datashard.scan.rows", 150001)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60001)
+                                        .AddRate("table.datashard.write.rows", 50001)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                            .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                            .AddRate("table.datashard.cache_hit.bytes", 30001)
+                            .AddRate("table.datashard.cache_miss.bytes", 40001)
+                            .AddRate("table.datashard.consumed_cpu_us", 1)
+                            .AddRate("table.datashard.erase.bytes", 120001)
+                            .AddRate("table.datashard.erase.rows", 110001)
+                            .AddRate("table.datashard.read.bytes", 70190002)
+                            .AddRate("table.datashard.read.rows", 30150002)
+                            .AddGauge("table.datashard.row_count", 10001)
+                            .AddRate("table.datashard.scan.bytes", 160001)
+                            .AddRate("table.datashard.scan.rows", 150001)
+                            .AddGauge("table.datashard.size_bytes", 20001)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                            .AddRate("table.datashard.write.bytes", 60001)
+                            .AddRate("table.datashard.write.rows", 50001)
+                        .EndNested()
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include only leaders
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardLeaders) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions and only leaders for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x01, 0, 20, &tableMetricsConfig1);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x02, 0, 40, &tableMetricsConfig1);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x04, 0, 60, &tableMetricsConfig1);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x10, 0, 10, &tableMetricsConfig2);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x20, 0, 30, &tableMetricsConfig2);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x40, 0, 50, &tableMetricsConfig2);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "16")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("tablet_id", "32")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("tablet_id", "64")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 420112)
+                            .AddRate("table.datashard.bulk_upsert.rows", 390112)
+                            .AddRate("table.datashard.cache_hit.bytes", 90112)
+                            .AddRate("table.datashard.cache_miss.bytes", 120112)
+                            .AddRate("table.datashard.consumed_cpu_us", 900112)
+                            .AddRate("table.datashard.erase.bytes", 360112)
+                            .AddRate("table.datashard.erase.rows", 330112)
+                            .AddRate("table.datashard.read.bytes", 210570224)
+                            .AddRate("table.datashard.read.rows", 90450224)
+                            .AddGauge("table.datashard.row_count", 30112)
+                            .AddRate("table.datashard.scan.bytes", 480112)
+                            .AddRate("table.datashard.scan.rows", 450112)
+                            .AddGauge("table.datashard.size_bytes", 60112)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {40, 1},
+                                    {60, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 180112)
+                            .AddRate("table.datashard.write.rows", 150112)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "1")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                .AddRate("table.datashard.erase.bytes", 120001)
+                                .AddRate("table.datashard.erase.rows", 110001)
+                                .AddRate("table.datashard.read.bytes", 70190002)
+                                .AddRate("table.datashard.read.rows", 30150002)
+                                .AddGauge("table.datashard.row_count", 10001)
+                                .AddRate("table.datashard.scan.bytes", 160001)
+                                .AddRate("table.datashard.scan.rows", 150001)
+                                .AddGauge("table.datashard.size_bytes", 20001)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                .AddRate("table.datashard.write.bytes", 60001)
+                                .AddRate("table.datashard.write.rows", 50001)
+                            .EndNested()
+                            .StartNested("tablet_id", "2")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                .AddRate("table.datashard.consumed_cpu_us", 400002)
+                                .AddRate("table.datashard.erase.bytes", 120002)
+                                .AddRate("table.datashard.erase.rows", 110002)
+                                .AddRate("table.datashard.read.bytes", 70190004)
+                                .AddRate("table.datashard.read.rows", 30150004)
+                                .AddGauge("table.datashard.row_count", 10002)
+                                .AddRate("table.datashard.scan.bytes", 160002)
+                                .AddRate("table.datashard.scan.rows", 150002)
+                                .AddGauge("table.datashard.size_bytes", 20002)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                .AddRate("table.datashard.write.bytes", 60002)
+                                .AddRate("table.datashard.write.rows", 50002)
+                            .EndNested()
+                            .StartNested("tablet_id", "4")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                .AddRate("table.datashard.erase.bytes", 120004)
+                                .AddRate("table.datashard.erase.rows", 110004)
+                                .AddRate("table.datashard.read.bytes", 70190008)
+                                .AddRate("table.datashard.read.rows", 30150008)
+                                .AddGauge("table.datashard.row_count", 10004)
+                                .AddRate("table.datashard.scan.bytes", 160004)
+                                .AddRate("table.datashard.scan.rows", 150004)
+                                .AddGauge("table.datashard.size_bytes", 20004)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                .AddRate("table.datashard.write.bytes", 60004)
+                                .AddRate("table.datashard.write.rows", 50004)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 420007)
+                        .AddRate("table.datashard.bulk_upsert.rows", 390007)
+                        .AddRate("table.datashard.cache_hit.bytes", 90007)
+                        .AddRate("table.datashard.cache_miss.bytes", 120007)
+                        .AddRate("table.datashard.consumed_cpu_us", 1200007)
+                        .AddRate("table.datashard.erase.bytes", 360007)
+                        .AddRate("table.datashard.erase.rows", 330007)
+                        .AddRate("table.datashard.read.bytes", 210570014)
+                        .AddRate("table.datashard.read.rows", 90450014)
+                        .AddGauge("table.datashard.row_count", 30007)
+                        .AddRate("table.datashard.scan.bytes", 480007)
+                        .AddRate("table.datashard.scan.rows", 450007)
+                        .AddGauge("table.datashard.size_bytes", 60007)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {30, 1},
+                                {50, 1},
+                                {70, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 180007)
+                        .AddRate("table.datashard.write.rows", 150007)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second partition for each table
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x02, 0, 80, &tableMetricsConfig1, 0x08);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x20, 0, 60, &tableMetricsConfig2, 0x80);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "16")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("tablet_id", "32")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280160)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260160)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60160)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80160)
+                                        .AddRate("table.datashard.consumed_cpu_us", 900160)
+                                        .AddRate("table.datashard.erase.bytes", 240160)
+                                        .AddRate("table.datashard.erase.rows", 220160)
+                                        .AddRate("table.datashard.read.bytes", 140380320)
+                                        .AddRate("table.datashard.read.rows", 60300320)
+                                        .AddGauge("table.datashard.row_count", 10128)
+                                        .AddRate("table.datashard.scan.bytes", 320160)
+                                        .AddRate("table.datashard.scan.rows", 300160)
+                                        .AddGauge("table.datashard.size_bytes", 20128)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120160)
+                                        .AddRate("table.datashard.write.rows", 100160)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280160)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260160)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60160)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80160)
+                                    .AddRate("table.datashard.consumed_cpu_us", 900160)
+                                    .AddRate("table.datashard.erase.bytes", 240160)
+                                    .AddRate("table.datashard.erase.rows", 220160)
+                                    .AddRate("table.datashard.read.bytes", 140380320)
+                                    .AddRate("table.datashard.read.rows", 60300320)
+                                    .AddGauge("table.datashard.row_count", 10128)
+                                    .AddRate("table.datashard.scan.bytes", 320160)
+                                    .AddRate("table.datashard.scan.rows", 300160)
+                                    .AddGauge("table.datashard.size_bytes", 20128)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120160)
+                                    .AddRate("table.datashard.write.rows", 100160)
+                                .EndNested()
+                                .StartNested("tablet_id", "64")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                            .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                            .AddRate("table.datashard.cache_hit.bytes", 120240)
+                            .AddRate("table.datashard.cache_miss.bytes", 160240)
+                            .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                            .AddRate("table.datashard.erase.bytes", 480240)
+                            .AddRate("table.datashard.erase.rows", 440240)
+                            .AddRate("table.datashard.read.bytes", 280760480)
+                            .AddRate("table.datashard.read.rows", 120600480)
+                            .AddGauge("table.datashard.row_count", 30208)
+                            .AddRate("table.datashard.scan.bytes", 640240)
+                            .AddRate("table.datashard.scan.rows", 600240)
+                            .AddGauge("table.datashard.size_bytes", 60208)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {60, 1},
+                                    {70, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 240240)
+                            .AddRate("table.datashard.write.rows", 200240)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "1")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                .AddRate("table.datashard.erase.bytes", 120001)
+                                .AddRate("table.datashard.erase.rows", 110001)
+                                .AddRate("table.datashard.read.bytes", 70190002)
+                                .AddRate("table.datashard.read.rows", 30150002)
+                                .AddGauge("table.datashard.row_count", 10001)
+                                .AddRate("table.datashard.scan.bytes", 160001)
+                                .AddRate("table.datashard.scan.rows", 150001)
+                                .AddGauge("table.datashard.size_bytes", 20001)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                .AddRate("table.datashard.write.bytes", 60001)
+                                .AddRate("table.datashard.write.rows", 50001)
+                            .EndNested()
+                            .StartNested("tablet_id", "2")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1200010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 10008)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 20008)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                            .StartNested("tablet_id", "4")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                .AddRate("table.datashard.erase.bytes", 120004)
+                                .AddRate("table.datashard.erase.rows", 110004)
+                                .AddRate("table.datashard.read.bytes", 70190008)
+                                .AddRate("table.datashard.read.rows", 30150008)
+                                .AddGauge("table.datashard.row_count", 10004)
+                                .AddRate("table.datashard.scan.bytes", 160004)
+                                .AddRate("table.datashard.scan.rows", 150004)
+                                .AddGauge("table.datashard.size_bytes", 20004)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                .AddRate("table.datashard.write.bytes", 60004)
+                                .AddRate("table.datashard.write.rows", 50004)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                        .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                        .AddRate("table.datashard.cache_hit.bytes", 120015)
+                        .AddRate("table.datashard.cache_miss.bytes", 160015)
+                        .AddRate("table.datashard.consumed_cpu_us", 2000015)
+                        .AddRate("table.datashard.erase.bytes", 480015)
+                        .AddRate("table.datashard.erase.rows", 440015)
+                        .AddRate("table.datashard.read.bytes", 280760030)
+                        .AddRate("table.datashard.read.rows", 120600030)
+                        .AddGauge("table.datashard.row_count", 30013)
+                        .AddRate("table.datashard.scan.bytes", 640015)
+                        .AddRate("table.datashard.scan.rows", 600015)
+                        .AddGauge("table.datashard.size_bytes", 60013)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {30, 1},
+                                {70, 1},
+                                {90, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 240015)
+                        .AddRate("table.datashard.write.rows", 200015)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second partition for each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x02, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x20, 0);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting leaders):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "16")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("tablet_id", "64")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280080)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260080)
+                            .AddRate("table.datashard.cache_hit.bytes", 60080)
+                            .AddRate("table.datashard.cache_miss.bytes", 80080)
+                            .AddRate("table.datashard.consumed_cpu_us", 600080)
+                            .AddRate("table.datashard.erase.bytes", 240080)
+                            .AddRate("table.datashard.erase.rows", 220080)
+                            .AddRate("table.datashard.read.bytes", 140380160)
+                            .AddRate("table.datashard.read.rows", 60300160)
+                            .AddGauge("table.datashard.row_count", 20080)
+                            .AddRate("table.datashard.scan.bytes", 320080)
+                            .AddRate("table.datashard.scan.rows", 300080)
+                            .AddGauge("table.datashard.size_bytes", 40080)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {60, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 120080)
+                            .AddRate("table.datashard.write.rows", 100080)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "1")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                .AddRate("table.datashard.consumed_cpu_us", 200001)
+                                .AddRate("table.datashard.erase.bytes", 120001)
+                                .AddRate("table.datashard.erase.rows", 110001)
+                                .AddRate("table.datashard.read.bytes", 70190002)
+                                .AddRate("table.datashard.read.rows", 30150002)
+                                .AddGauge("table.datashard.row_count", 10001)
+                                .AddRate("table.datashard.scan.bytes", 160001)
+                                .AddRate("table.datashard.scan.rows", 150001)
+                                .AddGauge("table.datashard.size_bytes", 20001)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                .AddRate("table.datashard.write.bytes", 60001)
+                                .AddRate("table.datashard.write.rows", 50001)
+                            .EndNested()
+                            .StartNested("tablet_id", "4")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                .AddRate("table.datashard.consumed_cpu_us", 600004)
+                                .AddRate("table.datashard.erase.bytes", 120004)
+                                .AddRate("table.datashard.erase.rows", 110004)
+                                .AddRate("table.datashard.read.bytes", 70190008)
+                                .AddRate("table.datashard.read.rows", 30150008)
+                                .AddGauge("table.datashard.row_count", 10004)
+                                .AddRate("table.datashard.scan.bytes", 160004)
+                                .AddRate("table.datashard.scan.rows", 150004)
+                                .AddGauge("table.datashard.size_bytes", 20004)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                .AddRate("table.datashard.write.bytes", 60004)
+                                .AddRate("table.datashard.write.rows", 50004)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                        .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                        .AddRate("table.datashard.cache_hit.bytes", 60005)
+                        .AddRate("table.datashard.cache_miss.bytes", 80005)
+                        .AddRate("table.datashard.consumed_cpu_us", 800005)
+                        .AddRate("table.datashard.erase.bytes", 240005)
+                        .AddRate("table.datashard.erase.rows", 220005)
+                        .AddRate("table.datashard.read.bytes", 140380010)
+                        .AddRate("table.datashard.read.rows", 60300010)
+                        .AddGauge("table.datashard.row_count", 20005)
+                        .AddRate("table.datashard.scan.bytes", 320005)
+                        .AddRate("table.datashard.scan.rows", 300005)
+                        .AddGauge("table.datashard.size_bytes", 40005)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {30, 1},
+                                {70, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 120005)
+                        .AddRate("table.datashard.write.rows", 100005)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x01, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x04, 0);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "16")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("tablet_id", "64")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280080)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260080)
+                            .AddRate("table.datashard.cache_hit.bytes", 60080)
+                            .AddRate("table.datashard.cache_miss.bytes", 80080)
+                            .AddRate("table.datashard.consumed_cpu_us", 600080)
+                            .AddRate("table.datashard.erase.bytes", 240080)
+                            .AddRate("table.datashard.erase.rows", 220080)
+                            .AddRate("table.datashard.read.bytes", 140380160)
+                            .AddRate("table.datashard.read.rows", 60300160)
+                            .AddGauge("table.datashard.row_count", 20080)
+                            .AddRate("table.datashard.scan.bytes", 320080)
+                            .AddRate("table.datashard.scan.rows", 300080)
+                            .AddGauge("table.datashard.size_bytes", 40080)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {60, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 120080)
+                            .AddRate("table.datashard.write.rows", 100080)
+                        .EndNested()
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x10, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x40, 0);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include only followers
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions and only followers for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 10101, 10, &tableMetricsConfig1, 0x0001);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 20, &tableMetricsConfig1, 0x0002);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 30101, 30, &tableMetricsConfig1, 0x0004);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 10201, 40, &tableMetricsConfig1, 0x0010);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 50, &tableMetricsConfig1, 0x0020);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 30201, 60, &tableMetricsConfig1, 0x0040);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 10301, 70, &tableMetricsConfig1, 0x0100);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 80, &tableMetricsConfig1, 0x0200);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 30301, 90, &tableMetricsConfig1, 0x0400);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 10102, 10, &tableMetricsConfig2, 0x0002);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 20, &tableMetricsConfig2, 0x0004);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 30102, 30, &tableMetricsConfig2, 0x0008);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 10202, 40, &tableMetricsConfig2, 0x0020);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 50, &tableMetricsConfig2, 0x0040);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 30202, 60, &tableMetricsConfig2, 0x0080);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 10302, 70, &tableMetricsConfig2, 0x0200);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 80, &tableMetricsConfig2, 0x0400);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 30302, 90, &tableMetricsConfig2, 0x0800);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200004)
+                                        .AddRate("table.datashard.erase.bytes", 120004)
+                                        .AddRate("table.datashard.erase.rows", 110004)
+                                        .AddRate("table.datashard.read.bytes", 70190008)
+                                        .AddRate("table.datashard.read.rows", 30150008)
+                                        .AddGauge("table.datashard.row_count", 10004)
+                                        .AddRate("table.datashard.scan.bytes", 160004)
+                                        .AddRate("table.datashard.scan.rows", 150004)
+                                        .AddGauge("table.datashard.size_bytes", 20004)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60004)
+                                        .AddRate("table.datashard.write.rows", 50004)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140008)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130008)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30008)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40008)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300008)
+                                        .AddRate("table.datashard.erase.bytes", 120008)
+                                        .AddRate("table.datashard.erase.rows", 110008)
+                                        .AddRate("table.datashard.read.bytes", 70190016)
+                                        .AddRate("table.datashard.read.rows", 30150016)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 160008)
+                                        .AddRate("table.datashard.scan.rows", 150008)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60008)
+                                        .AddRate("table.datashard.write.rows", 50008)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 420014)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 390014)
+                                        .AddRate("table.datashard.cache_hit.bytes", 90014)
+                                        .AddRate("table.datashard.cache_miss.bytes", 120014)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600014)
+                                        .AddRate("table.datashard.erase.bytes", 360014)
+                                        .AddRate("table.datashard.erase.rows", 330014)
+                                        .AddRate("table.datashard.read.bytes", 210570028)
+                                        .AddRate("table.datashard.read.rows", 90450028)
+                                        .AddGauge("table.datashard.row_count", 30014)
+                                        .AddRate("table.datashard.scan.bytes", 480014)
+                                        .AddRate("table.datashard.scan.rows", 450014)
+                                        .AddGauge("table.datashard.size_bytes", 60014)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {20, 1},
+                                                {30, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 180014)
+                                        .AddRate("table.datashard.write.rows", 150014)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420014)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390014)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90014)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120014)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600014)
+                                    .AddRate("table.datashard.erase.bytes", 360014)
+                                    .AddRate("table.datashard.erase.rows", 330014)
+                                    .AddRate("table.datashard.read.bytes", 210570028)
+                                    .AddRate("table.datashard.read.rows", 90450028)
+                                    .AddGauge("table.datashard.row_count", 30014)
+                                    .AddRate("table.datashard.scan.bytes", 480014)
+                                    .AddRate("table.datashard.scan.rows", 450014)
+                                    .AddGauge("table.datashard.size_bytes", 60014)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {30, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180014)
+                                    .AddRate("table.datashard.write.rows", 150014)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140128)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130128)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30128)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40128)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600128)
+                                        .AddRate("table.datashard.erase.bytes", 120128)
+                                        .AddRate("table.datashard.erase.rows", 110128)
+                                        .AddRate("table.datashard.read.bytes", 70190256)
+                                        .AddRate("table.datashard.read.rows", 30150256)
+                                        .AddGauge("table.datashard.row_count", 10128)
+                                        .AddRate("table.datashard.scan.bytes", 160128)
+                                        .AddRate("table.datashard.scan.rows", 150128)
+                                        .AddGauge("table.datashard.size_bytes", 20128)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60128)
+                                        .AddRate("table.datashard.write.rows", 50128)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 420224)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 390224)
+                                        .AddRate("table.datashard.cache_hit.bytes", 90224)
+                                        .AddRate("table.datashard.cache_miss.bytes", 120224)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1500224)
+                                        .AddRate("table.datashard.erase.bytes", 360224)
+                                        .AddRate("table.datashard.erase.rows", 330224)
+                                        .AddRate("table.datashard.read.bytes", 210570448)
+                                        .AddRate("table.datashard.read.rows", 90450448)
+                                        .AddGauge("table.datashard.row_count", 30224)
+                                        .AddRate("table.datashard.scan.bytes", 480224)
+                                        .AddRate("table.datashard.scan.rows", 450224)
+                                        .AddGauge("table.datashard.size_bytes", 60224)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {50, 1},
+                                                {60, 1},
+                                                {70, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 180224)
+                                        .AddRate("table.datashard.write.rows", 150224)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420224)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390224)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90224)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120224)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500224)
+                                    .AddRate("table.datashard.erase.bytes", 360224)
+                                    .AddRate("table.datashard.erase.rows", 330224)
+                                    .AddRate("table.datashard.read.bytes", 210570448)
+                                    .AddRate("table.datashard.read.rows", 90450448)
+                                    .AddGauge("table.datashard.row_count", 30224)
+                                    .AddRate("table.datashard.scan.bytes", 480224)
+                                    .AddRate("table.datashard.scan.rows", 450224)
+                                    .AddGauge("table.datashard.size_bytes", 60224)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {60, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180224)
+                                    .AddRate("table.datashard.write.rows", 150224)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                        .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                        .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                        .AddRate("table.datashard.consumed_cpu_us", 801024)
+                                        .AddRate("table.datashard.erase.bytes", 121024)
+                                        .AddRate("table.datashard.erase.rows", 111024)
+                                        .AddRate("table.datashard.read.bytes", 70192048)
+                                        .AddRate("table.datashard.read.rows", 30152048)
+                                        .AddGauge("table.datashard.row_count", 11024)
+                                        .AddRate("table.datashard.scan.bytes", 161024)
+                                        .AddRate("table.datashard.scan.rows", 151024)
+                                        .AddGauge("table.datashard.size_bytes", 21024)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 61024)
+                                        .AddRate("table.datashard.write.rows", 51024)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 142048)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 132048)
+                                        .AddRate("table.datashard.cache_hit.bytes", 32048)
+                                        .AddRate("table.datashard.cache_miss.bytes", 42048)
+                                        .AddRate("table.datashard.consumed_cpu_us", 902048)
+                                        .AddRate("table.datashard.erase.bytes", 122048)
+                                        .AddRate("table.datashard.erase.rows", 112048)
+                                        .AddRate("table.datashard.read.bytes", 70194096)
+                                        .AddRate("table.datashard.read.rows", 30154096)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 162048)
+                                        .AddRate("table.datashard.scan.rows", 152048)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 62048)
+                                        .AddRate("table.datashard.write.rows", 52048)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 423584)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 393584)
+                                        .AddRate("table.datashard.cache_hit.bytes", 93584)
+                                        .AddRate("table.datashard.cache_miss.bytes", 123584)
+                                        .AddRate("table.datashard.consumed_cpu_us", 2403584)
+                                        .AddRate("table.datashard.erase.bytes", 363584)
+                                        .AddRate("table.datashard.erase.rows", 333584)
+                                        .AddRate("table.datashard.read.bytes", 210577168)
+                                        .AddRate("table.datashard.read.rows", 90457168)
+                                        .AddGauge("table.datashard.row_count", 33584)
+                                        .AddRate("table.datashard.scan.bytes", 483584)
+                                        .AddRate("table.datashard.scan.rows", 453584)
+                                        .AddGauge("table.datashard.size_bytes", 63584)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {80, 1},
+                                                {90, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 183584)
+                                        .AddRate("table.datashard.write.rows", 153584)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 423584)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 393584)
+                                    .AddRate("table.datashard.cache_hit.bytes", 93584)
+                                    .AddRate("table.datashard.cache_miss.bytes", 123584)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2403584)
+                                    .AddRate("table.datashard.erase.bytes", 363584)
+                                    .AddRate("table.datashard.erase.rows", 333584)
+                                    .AddRate("table.datashard.read.bytes", 210577168)
+                                    .AddRate("table.datashard.read.rows", 90457168)
+                                    .AddGauge("table.datashard.row_count", 33584)
+                                    .AddRate("table.datashard.scan.bytes", 483584)
+                                    .AddRate("table.datashard.scan.rows", 453584)
+                                    .AddGauge("table.datashard.size_bytes", 63584)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {90, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 183584)
+                                    .AddRate("table.datashard.write.rows", 153584)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 1263822)
+                            .AddRate("table.datashard.bulk_upsert.rows", 1173822)
+                            .AddRate("table.datashard.cache_hit.bytes", 273822)
+                            .AddRate("table.datashard.cache_miss.bytes", 363822)
+                            .AddRate("table.datashard.consumed_cpu_us", 4503822)
+                            .AddRate("table.datashard.erase.bytes", 1083822)
+                            .AddRate("table.datashard.erase.rows", 993822)
+                            .AddRate("table.datashard.read.bytes", 631717644)
+                            .AddRate("table.datashard.read.rows", 271357644)
+                            .AddGauge("table.datashard.row_count", 93822)
+                            .AddRate("table.datashard.scan.bytes", 1443822)
+                            .AddRate("table.datashard.scan.rows", 1353822)
+                            .AddGauge("table.datashard.size_bytes", 183822)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {30, 1},
+                                    {40, 1},
+                                    {50, 1},
+                                    {60, 1},
+                                    {70, 1},
+                                    {80, 1},
+                                    {90, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 543822)
+                            .AddRate("table.datashard.write.rows", 453822)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "20101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "30101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420007)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390007)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90007)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120007)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600007)
+                                    .AddRate("table.datashard.erase.bytes", 360007)
+                                    .AddRate("table.datashard.erase.rows", 330007)
+                                    .AddRate("table.datashard.read.bytes", 210570014)
+                                    .AddRate("table.datashard.read.rows", 90450014)
+                                    .AddGauge("table.datashard.row_count", 30007)
+                                    .AddRate("table.datashard.scan.bytes", 480007)
+                                    .AddRate("table.datashard.scan.rows", 450007)
+                                    .AddGauge("table.datashard.size_bytes", 60007)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {30, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180007)
+                                    .AddRate("table.datashard.write.rows", 150007)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 420007)
+                                .AddRate("table.datashard.bulk_upsert.rows", 390007)
+                                .AddRate("table.datashard.cache_hit.bytes", 90007)
+                                .AddRate("table.datashard.cache_miss.bytes", 120007)
+                                .AddRate("table.datashard.consumed_cpu_us", 600007)
+                                .AddRate("table.datashard.erase.bytes", 360007)
+                                .AddRate("table.datashard.erase.rows", 330007)
+                                .AddRate("table.datashard.read.bytes", 210570014)
+                                .AddRate("table.datashard.read.rows", 90450014)
+                                .AddGauge("table.datashard.row_count", 30007)
+                                .AddRate("table.datashard.scan.bytes", 480007)
+                                .AddRate("table.datashard.scan.rows", 450007)
+                                .AddGauge("table.datashard.size_bytes", 60007)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {20, 1},
+                                        {30, 1},
+                                        {40, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 180007)
+                                .AddRate("table.datashard.write.rows", 150007)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "20201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("follower_id", "30201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420112)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390112)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90112)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120112)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500112)
+                                    .AddRate("table.datashard.erase.bytes", 360112)
+                                    .AddRate("table.datashard.erase.rows", 330112)
+                                    .AddRate("table.datashard.read.bytes", 210570224)
+                                    .AddRate("table.datashard.read.rows", 90450224)
+                                    .AddGauge("table.datashard.row_count", 30112)
+                                    .AddRate("table.datashard.scan.bytes", 480112)
+                                    .AddRate("table.datashard.scan.rows", 450112)
+                                    .AddGauge("table.datashard.size_bytes", 60112)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {60, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180112)
+                                    .AddRate("table.datashard.write.rows", 150112)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 420112)
+                                .AddRate("table.datashard.bulk_upsert.rows", 390112)
+                                .AddRate("table.datashard.cache_hit.bytes", 90112)
+                                .AddRate("table.datashard.cache_miss.bytes", 120112)
+                                .AddRate("table.datashard.consumed_cpu_us", 1500112)
+                                .AddRate("table.datashard.erase.bytes", 360112)
+                                .AddRate("table.datashard.erase.rows", 330112)
+                                .AddRate("table.datashard.read.bytes", 210570224)
+                                .AddRate("table.datashard.read.rows", 90450224)
+                                .AddGauge("table.datashard.row_count", 30112)
+                                .AddRate("table.datashard.scan.bytes", 480112)
+                                .AddRate("table.datashard.scan.rows", 450112)
+                                .AddGauge("table.datashard.size_bytes", 60112)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {50, 1},
+                                        {60, 1},
+                                        {70, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 180112)
+                                .AddRate("table.datashard.write.rows", 150112)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "20301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "30301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                    .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                    .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                    .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                    .AddRate("table.datashard.erase.bytes", 121024)
+                                    .AddRate("table.datashard.erase.rows", 111024)
+                                    .AddRate("table.datashard.read.bytes", 70192048)
+                                    .AddRate("table.datashard.read.rows", 30152048)
+                                    .AddGauge("table.datashard.row_count", 11024)
+                                    .AddRate("table.datashard.scan.bytes", 161024)
+                                    .AddRate("table.datashard.scan.rows", 151024)
+                                    .AddGauge("table.datashard.size_bytes", 21024)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 61024)
+                                    .AddRate("table.datashard.write.rows", 51024)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 421792)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 391792)
+                                    .AddRate("table.datashard.cache_hit.bytes", 91792)
+                                    .AddRate("table.datashard.cache_miss.bytes", 121792)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2401792)
+                                    .AddRate("table.datashard.erase.bytes", 361792)
+                                    .AddRate("table.datashard.erase.rows", 331792)
+                                    .AddRate("table.datashard.read.bytes", 210573584)
+                                    .AddRate("table.datashard.read.rows", 90453584)
+                                    .AddGauge("table.datashard.row_count", 31792)
+                                    .AddRate("table.datashard.scan.bytes", 481792)
+                                    .AddRate("table.datashard.scan.rows", 451792)
+                                    .AddGauge("table.datashard.size_bytes", 61792)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {90, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 181792)
+                                    .AddRate("table.datashard.write.rows", 151792)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 421792)
+                                .AddRate("table.datashard.bulk_upsert.rows", 391792)
+                                .AddRate("table.datashard.cache_hit.bytes", 91792)
+                                .AddRate("table.datashard.cache_miss.bytes", 121792)
+                                .AddRate("table.datashard.consumed_cpu_us", 2401792)
+                                .AddRate("table.datashard.erase.bytes", 361792)
+                                .AddRate("table.datashard.erase.rows", 331792)
+                                .AddRate("table.datashard.read.bytes", 210573584)
+                                .AddRate("table.datashard.read.rows", 90453584)
+                                .AddGauge("table.datashard.row_count", 31792)
+                                .AddRate("table.datashard.scan.bytes", 481792)
+                                .AddRate("table.datashard.scan.rows", 451792)
+                                .AddGauge("table.datashard.size_bytes", 61792)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {80, 1},
+                                        {90, 1},
+                                        {100, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 181792)
+                                .AddRate("table.datashard.write.rows", 151792)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 1261911)
+                        .AddRate("table.datashard.bulk_upsert.rows", 1171911)
+                        .AddRate("table.datashard.cache_hit.bytes", 271911)
+                        .AddRate("table.datashard.cache_miss.bytes", 361911)
+                        .AddRate("table.datashard.consumed_cpu_us", 4501911)
+                        .AddRate("table.datashard.erase.bytes", 1081911)
+                        .AddRate("table.datashard.erase.rows", 991911)
+                        .AddRate("table.datashard.read.bytes", 631713822)
+                        .AddRate("table.datashard.read.rows", 271353822)
+                        .AddGauge("table.datashard.row_count", 91911)
+                        .AddRate("table.datashard.scan.bytes", 1441911)
+                        .AddRate("table.datashard.scan.rows", 1351911)
+                        .AddGauge("table.datashard.size_bytes", 181911)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {20, 1},
+                                {30, 1},
+                                {40, 1},
+                                {50, 1},
+                                {60, 1},
+                                {70, 1},
+                                {80, 1},
+                                {90, 1},
+                                {100, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 541911)
+                        .AddRate("table.datashard.write.rows", 451911)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second follower for each partition for each table
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 0, &tableMetricsConfig1, 0x0008);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 0, &tableMetricsConfig1, 0x0080);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 0, &tableMetricsConfig1, 0x0800);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 0, &tableMetricsConfig2, 0x0001);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 0, &tableMetricsConfig2, 0x0010);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 0, &tableMetricsConfig2, 0x0100);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60005)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80005)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200005)
+                                        .AddRate("table.datashard.erase.bytes", 240005)
+                                        .AddRate("table.datashard.erase.rows", 220005)
+                                        .AddRate("table.datashard.read.bytes", 140380010)
+                                        .AddRate("table.datashard.read.rows", 60300010)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 320005)
+                                        .AddRate("table.datashard.scan.rows", 300005)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120005)
+                                        .AddRate("table.datashard.write.rows", 100005)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140008)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130008)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30008)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40008)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300008)
+                                        .AddRate("table.datashard.erase.bytes", 120008)
+                                        .AddRate("table.datashard.erase.rows", 110008)
+                                        .AddRate("table.datashard.read.bytes", 70190016)
+                                        .AddRate("table.datashard.read.rows", 30150016)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 160008)
+                                        .AddRate("table.datashard.scan.rows", 150008)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60008)
+                                        .AddRate("table.datashard.write.rows", 50008)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                        .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                        .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                        .AddRate("table.datashard.erase.bytes", 480015)
+                                        .AddRate("table.datashard.erase.rows", 440015)
+                                        .AddRate("table.datashard.read.bytes", 280760030)
+                                        .AddRate("table.datashard.read.rows", 120600030)
+                                        .AddGauge("table.datashard.row_count", 30011)
+                                        .AddRate("table.datashard.scan.bytes", 640015)
+                                        .AddRate("table.datashard.scan.rows", 600015)
+                                        .AddGauge("table.datashard.size_bytes", 60011)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {20, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 240015)
+                                        .AddRate("table.datashard.write.rows", 200015)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                    .AddRate("table.datashard.erase.bytes", 480015)
+                                    .AddRate("table.datashard.erase.rows", 440015)
+                                    .AddRate("table.datashard.read.bytes", 280760030)
+                                    .AddRate("table.datashard.read.rows", 120600030)
+                                    .AddGauge("table.datashard.row_count", 30011)
+                                    .AddRate("table.datashard.scan.bytes", 640015)
+                                    .AddRate("table.datashard.scan.rows", 600015)
+                                    .AddGauge("table.datashard.size_bytes", 60011)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240015)
+                                    .AddRate("table.datashard.write.rows", 200015)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280080)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260080)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60080)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80080)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500080)
+                                        .AddRate("table.datashard.erase.bytes", 240080)
+                                        .AddRate("table.datashard.erase.rows", 220080)
+                                        .AddRate("table.datashard.read.bytes", 140380160)
+                                        .AddRate("table.datashard.read.rows", 60300160)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320080)
+                                        .AddRate("table.datashard.scan.rows", 300080)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120080)
+                                        .AddRate("table.datashard.write.rows", 100080)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140128)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130128)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30128)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40128)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600128)
+                                        .AddRate("table.datashard.erase.bytes", 120128)
+                                        .AddRate("table.datashard.erase.rows", 110128)
+                                        .AddRate("table.datashard.read.bytes", 70190256)
+                                        .AddRate("table.datashard.read.rows", 30150256)
+                                        .AddGauge("table.datashard.row_count", 10128)
+                                        .AddRate("table.datashard.scan.bytes", 160128)
+                                        .AddRate("table.datashard.scan.rows", 150128)
+                                        .AddGauge("table.datashard.size_bytes", 20128)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60128)
+                                        .AddRate("table.datashard.write.rows", 50128)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                        .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                        .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                        .AddRate("table.datashard.erase.bytes", 480240)
+                                        .AddRate("table.datashard.erase.rows", 440240)
+                                        .AddRate("table.datashard.read.bytes", 280760480)
+                                        .AddRate("table.datashard.read.rows", 120600480)
+                                        .AddGauge("table.datashard.row_count", 30176)
+                                        .AddRate("table.datashard.scan.bytes", 640240)
+                                        .AddRate("table.datashard.scan.rows", 600240)
+                                        .AddGauge("table.datashard.size_bytes", 60176)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {50, 1},
+                                                {70, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 240240)
+                                        .AddRate("table.datashard.write.rows", 200240)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                    .AddRate("table.datashard.erase.bytes", 480240)
+                                    .AddRate("table.datashard.erase.rows", 440240)
+                                    .AddRate("table.datashard.read.bytes", 280760480)
+                                    .AddRate("table.datashard.read.rows", 120600480)
+                                    .AddGauge("table.datashard.row_count", 30176)
+                                    .AddRate("table.datashard.scan.bytes", 640240)
+                                    .AddRate("table.datashard.scan.rows", 600240)
+                                    .AddGauge("table.datashard.size_bytes", 60176)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {50, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240240)
+                                    .AddRate("table.datashard.write.rows", 200240)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 281280)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 261280)
+                                        .AddRate("table.datashard.cache_hit.bytes", 61280)
+                                        .AddRate("table.datashard.cache_miss.bytes", 81280)
+                                        .AddRate("table.datashard.consumed_cpu_us", 801280)
+                                        .AddRate("table.datashard.erase.bytes", 241280)
+                                        .AddRate("table.datashard.erase.rows", 221280)
+                                        .AddRate("table.datashard.read.bytes", 140382560)
+                                        .AddRate("table.datashard.read.rows", 60302560)
+                                        .AddGauge("table.datashard.row_count", 10256)
+                                        .AddRate("table.datashard.scan.bytes", 321280)
+                                        .AddRate("table.datashard.scan.rows", 301280)
+                                        .AddGauge("table.datashard.size_bytes", 20256)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 121280)
+                                        .AddRate("table.datashard.write.rows", 101280)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 142048)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 132048)
+                                        .AddRate("table.datashard.cache_hit.bytes", 32048)
+                                        .AddRate("table.datashard.cache_miss.bytes", 42048)
+                                        .AddRate("table.datashard.consumed_cpu_us", 902048)
+                                        .AddRate("table.datashard.erase.bytes", 122048)
+                                        .AddRate("table.datashard.erase.rows", 112048)
+                                        .AddRate("table.datashard.read.bytes", 70194096)
+                                        .AddRate("table.datashard.read.rows", 30154096)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 162048)
+                                        .AddRate("table.datashard.scan.rows", 152048)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 62048)
+                                        .AddRate("table.datashard.write.rows", 52048)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                        .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                        .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                        .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                        .AddRate("table.datashard.erase.bytes", 483840)
+                                        .AddRate("table.datashard.erase.rows", 443840)
+                                        .AddRate("table.datashard.read.bytes", 280767680)
+                                        .AddRate("table.datashard.read.rows", 120607680)
+                                        .AddGauge("table.datashard.row_count", 32816)
+                                        .AddRate("table.datashard.scan.bytes", 643840)
+                                        .AddRate("table.datashard.scan.rows", 603840)
+                                        .AddGauge("table.datashard.size_bytes", 62816)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {80, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 243840)
+                                        .AddRate("table.datashard.write.rows", 203840)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                    .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                    .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                    .AddRate("table.datashard.erase.bytes", 483840)
+                                    .AddRate("table.datashard.erase.rows", 443840)
+                                    .AddRate("table.datashard.read.bytes", 280767680)
+                                    .AddRate("table.datashard.read.rows", 120607680)
+                                    .AddGauge("table.datashard.row_count", 32816)
+                                    .AddRate("table.datashard.scan.bytes", 643840)
+                                    .AddRate("table.datashard.scan.rows", 603840)
+                                    .AddGauge("table.datashard.size_bytes", 62816)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 243840)
+                                    .AddRate("table.datashard.write.rows", 203840)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 1684095)
+                            .AddRate("table.datashard.bulk_upsert.rows", 1564095)
+                            .AddRate("table.datashard.cache_hit.bytes", 364095)
+                            .AddRate("table.datashard.cache_miss.bytes", 484095)
+                            .AddRate("table.datashard.consumed_cpu_us", 4504095)
+                            .AddRate("table.datashard.erase.bytes", 1444095)
+                            .AddRate("table.datashard.erase.rows", 1324095)
+                            .AddRate("table.datashard.read.bytes", 842288190)
+                            .AddRate("table.datashard.read.rows", 361808190)
+                            .AddGauge("table.datashard.row_count", 93003)
+                            .AddRate("table.datashard.scan.bytes", 1924095)
+                            .AddRate("table.datashard.scan.rows", 1804095)
+                            .AddGauge("table.datashard.size_bytes", 183003)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {10, 3},
+                                    {20, 1},
+                                    {40, 1},
+                                    {50, 1},
+                                    {70, 1},
+                                    {80, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 724095)
+                            .AddRate("table.datashard.write.rows", 604095)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "20101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 10008)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 20008)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                                .StartNested("follower_id", "30101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                    .AddRate("table.datashard.erase.bytes", 480015)
+                                    .AddRate("table.datashard.erase.rows", 440015)
+                                    .AddRate("table.datashard.read.bytes", 280760030)
+                                    .AddRate("table.datashard.read.rows", 120600030)
+                                    .AddGauge("table.datashard.row_count", 30013)
+                                    .AddRate("table.datashard.scan.bytes", 640015)
+                                    .AddRate("table.datashard.scan.rows", 600015)
+                                    .AddGauge("table.datashard.size_bytes", 60013)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240015)
+                                    .AddRate("table.datashard.write.rows", 200015)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                .AddRate("table.datashard.erase.bytes", 480015)
+                                .AddRate("table.datashard.erase.rows", 440015)
+                                .AddRate("table.datashard.read.bytes", 280760030)
+                                .AddRate("table.datashard.read.rows", 120600030)
+                                .AddGauge("table.datashard.row_count", 30013)
+                                .AddRate("table.datashard.scan.bytes", 640015)
+                                .AddRate("table.datashard.scan.rows", 600015)
+                                .AddGauge("table.datashard.size_bytes", 60013)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {20, 1},
+                                        {40, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 240015)
+                                .AddRate("table.datashard.write.rows", 200015)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "20201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280160)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260160)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60160)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80160)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500160)
+                                    .AddRate("table.datashard.erase.bytes", 240160)
+                                    .AddRate("table.datashard.erase.rows", 220160)
+                                    .AddRate("table.datashard.read.bytes", 140380320)
+                                    .AddRate("table.datashard.read.rows", 60300320)
+                                    .AddGauge("table.datashard.row_count", 10128)
+                                    .AddRate("table.datashard.scan.bytes", 320160)
+                                    .AddRate("table.datashard.scan.rows", 300160)
+                                    .AddGauge("table.datashard.size_bytes", 20128)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120160)
+                                    .AddRate("table.datashard.write.rows", 100160)
+                                .EndNested()
+                                .StartNested("follower_id", "30201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                    .AddRate("table.datashard.erase.bytes", 480240)
+                                    .AddRate("table.datashard.erase.rows", 440240)
+                                    .AddRate("table.datashard.read.bytes", 280760480)
+                                    .AddRate("table.datashard.read.rows", 120600480)
+                                    .AddGauge("table.datashard.row_count", 30208)
+                                    .AddRate("table.datashard.scan.bytes", 640240)
+                                    .AddRate("table.datashard.scan.rows", 600240)
+                                    .AddGauge("table.datashard.size_bytes", 60208)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {50, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240240)
+                                    .AddRate("table.datashard.write.rows", 200240)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                .AddRate("table.datashard.erase.bytes", 480240)
+                                .AddRate("table.datashard.erase.rows", 440240)
+                                .AddRate("table.datashard.read.bytes", 280760480)
+                                .AddRate("table.datashard.read.rows", 120600480)
+                                .AddGauge("table.datashard.row_count", 30208)
+                                .AddRate("table.datashard.scan.bytes", 640240)
+                                .AddRate("table.datashard.scan.rows", 600240)
+                                .AddGauge("table.datashard.size_bytes", 60208)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {50, 1},
+                                        {70, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 240240)
+                                .AddRate("table.datashard.write.rows", 200240)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "20301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                    .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                    .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                    .AddRate("table.datashard.consumed_cpu_us", 802560)
+                                    .AddRate("table.datashard.erase.bytes", 242560)
+                                    .AddRate("table.datashard.erase.rows", 222560)
+                                    .AddRate("table.datashard.read.bytes", 140385120)
+                                    .AddRate("table.datashard.read.rows", 60305120)
+                                    .AddGauge("table.datashard.row_count", 12048)
+                                    .AddRate("table.datashard.scan.bytes", 322560)
+                                    .AddRate("table.datashard.scan.rows", 302560)
+                                    .AddGauge("table.datashard.size_bytes", 22048)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 122560)
+                                    .AddRate("table.datashard.write.rows", 102560)
+                                .EndNested()
+                                .StartNested("follower_id", "30301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                    .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                    .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                    .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                    .AddRate("table.datashard.erase.bytes", 121024)
+                                    .AddRate("table.datashard.erase.rows", 111024)
+                                    .AddRate("table.datashard.read.bytes", 70192048)
+                                    .AddRate("table.datashard.read.rows", 30152048)
+                                    .AddGauge("table.datashard.row_count", 11024)
+                                    .AddRate("table.datashard.scan.bytes", 161024)
+                                    .AddRate("table.datashard.scan.rows", 151024)
+                                    .AddGauge("table.datashard.size_bytes", 21024)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 61024)
+                                    .AddRate("table.datashard.write.rows", 51024)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                    .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                    .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                    .AddRate("table.datashard.erase.bytes", 483840)
+                                    .AddRate("table.datashard.erase.rows", 443840)
+                                    .AddRate("table.datashard.read.bytes", 280767680)
+                                    .AddRate("table.datashard.read.rows", 120607680)
+                                    .AddGauge("table.datashard.row_count", 33328)
+                                    .AddRate("table.datashard.scan.bytes", 643840)
+                                    .AddRate("table.datashard.scan.rows", 603840)
+                                    .AddGauge("table.datashard.size_bytes", 63328)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 243840)
+                                    .AddRate("table.datashard.write.rows", 203840)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                .AddRate("table.datashard.erase.bytes", 483840)
+                                .AddRate("table.datashard.erase.rows", 443840)
+                                .AddRate("table.datashard.read.bytes", 280767680)
+                                .AddRate("table.datashard.read.rows", 120607680)
+                                .AddGauge("table.datashard.row_count", 33328)
+                                .AddRate("table.datashard.scan.bytes", 643840)
+                                .AddRate("table.datashard.scan.rows", 603840)
+                                .AddGauge("table.datashard.size_bytes", 63328)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {80, 1},
+                                        {100, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 243840)
+                                .AddRate("table.datashard.write.rows", 203840)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 1684095)
+                        .AddRate("table.datashard.bulk_upsert.rows", 1564095)
+                        .AddRate("table.datashard.cache_hit.bytes", 364095)
+                        .AddRate("table.datashard.cache_miss.bytes", 484095)
+                        .AddRate("table.datashard.consumed_cpu_us", 4504095)
+                        .AddRate("table.datashard.erase.bytes", 1444095)
+                        .AddRate("table.datashard.erase.rows", 1324095)
+                        .AddRate("table.datashard.read.bytes", 842288190)
+                        .AddRate("table.datashard.read.rows", 361808190)
+                        .AddGauge("table.datashard.row_count", 93549)
+                        .AddRate("table.datashard.scan.bytes", 1924095)
+                        .AddRate("table.datashard.scan.rows", 1804095)
+                        .AddGauge("table.datashard.size_bytes", 183549)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {10, 3},
+                                {20, 1},
+                                {40, 1},
+                                {50, 1},
+                                {70, 1},
+                                {80, 1},
+                                {100, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 724095)
+                        .AddRate("table.datashard.write.rows", 604095)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second follower for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 20101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 20201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 20301);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 20102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 20202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 20302);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting followers):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140008)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130008)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30008)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40008)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300008)
+                                        .AddRate("table.datashard.erase.bytes", 120008)
+                                        .AddRate("table.datashard.erase.rows", 110008)
+                                        .AddRate("table.datashard.read.bytes", 70190016)
+                                        .AddRate("table.datashard.read.rows", 30150016)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 160008)
+                                        .AddRate("table.datashard.scan.rows", 150008)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60008)
+                                        .AddRate("table.datashard.write.rows", 50008)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 20010)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 40010)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {20, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 20010)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 40010)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140128)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130128)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30128)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40128)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600128)
+                                        .AddRate("table.datashard.erase.bytes", 120128)
+                                        .AddRate("table.datashard.erase.rows", 110128)
+                                        .AddRate("table.datashard.read.bytes", 70190256)
+                                        .AddRate("table.datashard.read.rows", 30150256)
+                                        .AddGauge("table.datashard.row_count", 10128)
+                                        .AddRate("table.datashard.scan.bytes", 160128)
+                                        .AddRate("table.datashard.scan.rows", 150128)
+                                        .AddGauge("table.datashard.size_bytes", 20128)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60128)
+                                        .AddRate("table.datashard.write.rows", 50128)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280160)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260160)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60160)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80160)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000160)
+                                        .AddRate("table.datashard.erase.bytes", 240160)
+                                        .AddRate("table.datashard.erase.rows", 220160)
+                                        .AddRate("table.datashard.read.bytes", 140380320)
+                                        .AddRate("table.datashard.read.rows", 60300320)
+                                        .AddGauge("table.datashard.row_count", 20160)
+                                        .AddRate("table.datashard.scan.bytes", 320160)
+                                        .AddRate("table.datashard.scan.rows", 300160)
+                                        .AddGauge("table.datashard.size_bytes", 40160)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {50, 1},
+                                                {70, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120160)
+                                        .AddRate("table.datashard.write.rows", 100160)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280160)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260160)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60160)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80160)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1000160)
+                                    .AddRate("table.datashard.erase.bytes", 240160)
+                                    .AddRate("table.datashard.erase.rows", 220160)
+                                    .AddRate("table.datashard.read.bytes", 140380320)
+                                    .AddRate("table.datashard.read.rows", 60300320)
+                                    .AddGauge("table.datashard.row_count", 20160)
+                                    .AddRate("table.datashard.scan.bytes", 320160)
+                                    .AddRate("table.datashard.scan.rows", 300160)
+                                    .AddGauge("table.datashard.size_bytes", 40160)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120160)
+                                    .AddRate("table.datashard.write.rows", 100160)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 142048)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 132048)
+                                        .AddRate("table.datashard.cache_hit.bytes", 32048)
+                                        .AddRate("table.datashard.cache_miss.bytes", 42048)
+                                        .AddRate("table.datashard.consumed_cpu_us", 902048)
+                                        .AddRate("table.datashard.erase.bytes", 122048)
+                                        .AddRate("table.datashard.erase.rows", 112048)
+                                        .AddRate("table.datashard.read.bytes", 70194096)
+                                        .AddRate("table.datashard.read.rows", 30154096)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 162048)
+                                        .AddRate("table.datashard.scan.rows", 152048)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 62048)
+                                        .AddRate("table.datashard.write.rows", 52048)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                        .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                        .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                        .AddRate("table.datashard.erase.bytes", 242560)
+                                        .AddRate("table.datashard.erase.rows", 222560)
+                                        .AddRate("table.datashard.read.bytes", 140385120)
+                                        .AddRate("table.datashard.read.rows", 60305120)
+                                        .AddGauge("table.datashard.row_count", 22560)
+                                        .AddRate("table.datashard.scan.bytes", 322560)
+                                        .AddRate("table.datashard.scan.rows", 302560)
+                                        .AddGauge("table.datashard.size_bytes", 42560)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {80, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 122560)
+                                        .AddRate("table.datashard.write.rows", 102560)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                    .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                    .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                    .AddRate("table.datashard.erase.bytes", 242560)
+                                    .AddRate("table.datashard.erase.rows", 222560)
+                                    .AddRate("table.datashard.read.bytes", 140385120)
+                                    .AddRate("table.datashard.read.rows", 60305120)
+                                    .AddGauge("table.datashard.row_count", 22560)
+                                    .AddRate("table.datashard.scan.bytes", 322560)
+                                    .AddRate("table.datashard.scan.rows", 302560)
+                                    .AddGauge("table.datashard.size_bytes", 42560)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 122560)
+                                    .AddRate("table.datashard.write.rows", 102560)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 842730)
+                            .AddRate("table.datashard.bulk_upsert.rows", 782730)
+                            .AddRate("table.datashard.cache_hit.bytes", 182730)
+                            .AddRate("table.datashard.cache_miss.bytes", 242730)
+                            .AddRate("table.datashard.consumed_cpu_us", 3002730)
+                            .AddRate("table.datashard.erase.bytes", 722730)
+                            .AddRate("table.datashard.erase.rows", 662730)
+                            .AddRate("table.datashard.read.bytes", 421145460)
+                            .AddRate("table.datashard.read.rows", 180905460)
+                            .AddGauge("table.datashard.row_count", 62730)
+                            .AddRate("table.datashard.scan.bytes", 962730)
+                            .AddRate("table.datashard.scan.rows", 902730)
+                            .AddGauge("table.datashard.size_bytes", 122730)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {40, 1},
+                                    {50, 1},
+                                    {70, 1},
+                                    {80, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 362730)
+                            .AddRate("table.datashard.write.rows", 302730)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "30101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60005)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80005)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400005)
+                                    .AddRate("table.datashard.erase.bytes", 240005)
+                                    .AddRate("table.datashard.erase.rows", 220005)
+                                    .AddRate("table.datashard.read.bytes", 140380010)
+                                    .AddRate("table.datashard.read.rows", 60300010)
+                                    .AddGauge("table.datashard.row_count", 20005)
+                                    .AddRate("table.datashard.scan.bytes", 320005)
+                                    .AddRate("table.datashard.scan.rows", 300005)
+                                    .AddGauge("table.datashard.size_bytes", 40005)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120005)
+                                    .AddRate("table.datashard.write.rows", 100005)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                                .AddRate("table.datashard.cache_hit.bytes", 60005)
+                                .AddRate("table.datashard.cache_miss.bytes", 80005)
+                                .AddRate("table.datashard.consumed_cpu_us", 400005)
+                                .AddRate("table.datashard.erase.bytes", 240005)
+                                .AddRate("table.datashard.erase.rows", 220005)
+                                .AddRate("table.datashard.read.bytes", 140380010)
+                                .AddRate("table.datashard.read.rows", 60300010)
+                                .AddGauge("table.datashard.row_count", 20005)
+                                .AddRate("table.datashard.scan.bytes", 320005)
+                                .AddRate("table.datashard.scan.rows", 300005)
+                                .AddGauge("table.datashard.size_bytes", 40005)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {20, 1},
+                                        {40, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120005)
+                                .AddRate("table.datashard.write.rows", 100005)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "30201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280080)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260080)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60080)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80080)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1000080)
+                                    .AddRate("table.datashard.erase.bytes", 240080)
+                                    .AddRate("table.datashard.erase.rows", 220080)
+                                    .AddRate("table.datashard.read.bytes", 140380160)
+                                    .AddRate("table.datashard.read.rows", 60300160)
+                                    .AddGauge("table.datashard.row_count", 20080)
+                                    .AddRate("table.datashard.scan.bytes", 320080)
+                                    .AddRate("table.datashard.scan.rows", 300080)
+                                    .AddGauge("table.datashard.size_bytes", 40080)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120080)
+                                    .AddRate("table.datashard.write.rows", 100080)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280080)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260080)
+                                .AddRate("table.datashard.cache_hit.bytes", 60080)
+                                .AddRate("table.datashard.cache_miss.bytes", 80080)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000080)
+                                .AddRate("table.datashard.erase.bytes", 240080)
+                                .AddRate("table.datashard.erase.rows", 220080)
+                                .AddRate("table.datashard.read.bytes", 140380160)
+                                .AddRate("table.datashard.read.rows", 60300160)
+                                .AddGauge("table.datashard.row_count", 20080)
+                                .AddRate("table.datashard.scan.bytes", 320080)
+                                .AddRate("table.datashard.scan.rows", 300080)
+                                .AddGauge("table.datashard.size_bytes", 40080)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {50, 1},
+                                        {70, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120080)
+                                .AddRate("table.datashard.write.rows", 100080)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "30301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                    .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                    .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                    .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                    .AddRate("table.datashard.erase.bytes", 121024)
+                                    .AddRate("table.datashard.erase.rows", 111024)
+                                    .AddRate("table.datashard.read.bytes", 70192048)
+                                    .AddRate("table.datashard.read.rows", 30152048)
+                                    .AddGauge("table.datashard.row_count", 11024)
+                                    .AddRate("table.datashard.scan.bytes", 161024)
+                                    .AddRate("table.datashard.scan.rows", 151024)
+                                    .AddGauge("table.datashard.size_bytes", 21024)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 61024)
+                                    .AddRate("table.datashard.write.rows", 51024)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 281280)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 261280)
+                                    .AddRate("table.datashard.cache_hit.bytes", 61280)
+                                    .AddRate("table.datashard.cache_miss.bytes", 81280)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1601280)
+                                    .AddRate("table.datashard.erase.bytes", 241280)
+                                    .AddRate("table.datashard.erase.rows", 221280)
+                                    .AddRate("table.datashard.read.bytes", 140382560)
+                                    .AddRate("table.datashard.read.rows", 60302560)
+                                    .AddGauge("table.datashard.row_count", 21280)
+                                    .AddRate("table.datashard.scan.bytes", 321280)
+                                    .AddRate("table.datashard.scan.rows", 301280)
+                                    .AddGauge("table.datashard.size_bytes", 41280)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 121280)
+                                    .AddRate("table.datashard.write.rows", 101280)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 281280)
+                                .AddRate("table.datashard.bulk_upsert.rows", 261280)
+                                .AddRate("table.datashard.cache_hit.bytes", 61280)
+                                .AddRate("table.datashard.cache_miss.bytes", 81280)
+                                .AddRate("table.datashard.consumed_cpu_us", 1601280)
+                                .AddRate("table.datashard.erase.bytes", 241280)
+                                .AddRate("table.datashard.erase.rows", 221280)
+                                .AddRate("table.datashard.read.bytes", 140382560)
+                                .AddRate("table.datashard.read.rows", 60302560)
+                                .AddGauge("table.datashard.row_count", 21280)
+                                .AddRate("table.datashard.scan.bytes", 321280)
+                                .AddRate("table.datashard.scan.rows", 301280)
+                                .AddGauge("table.datashard.size_bytes", 41280)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {80, 1},
+                                        {100, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 121280)
+                                .AddRate("table.datashard.write.rows", 101280)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 841365)
+                        .AddRate("table.datashard.bulk_upsert.rows", 781365)
+                        .AddRate("table.datashard.cache_hit.bytes", 181365)
+                        .AddRate("table.datashard.cache_miss.bytes", 241365)
+                        .AddRate("table.datashard.consumed_cpu_us", 3001365)
+                        .AddRate("table.datashard.erase.bytes", 721365)
+                        .AddRate("table.datashard.erase.rows", 661365)
+                        .AddRate("table.datashard.read.bytes", 421142730)
+                        .AddRate("table.datashard.read.rows", 180902730)
+                        .AddGauge("table.datashard.row_count", 61365)
+                        .AddRate("table.datashard.scan.bytes", 961365)
+                        .AddRate("table.datashard.scan.rows", 901365)
+                        .AddGauge("table.datashard.size_bytes", 121365)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {20, 1},
+                                {40, 1},
+                                {50, 1},
+                                {70, 1},
+                                {80, 1},
+                                {100, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 361365)
+                        .AddRate("table.datashard.write.rows", 301365)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for the second partition in each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 10201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 30201);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 10202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 30202);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting partitions):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140008)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130008)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30008)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40008)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300008)
+                                        .AddRate("table.datashard.erase.bytes", 120008)
+                                        .AddRate("table.datashard.erase.rows", 110008)
+                                        .AddRate("table.datashard.read.bytes", 70190016)
+                                        .AddRate("table.datashard.read.rows", 30150016)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 160008)
+                                        .AddRate("table.datashard.scan.rows", 150008)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60008)
+                                        .AddRate("table.datashard.write.rows", 50008)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 20010)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 40010)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {20, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 20010)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 40010)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 142048)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 132048)
+                                        .AddRate("table.datashard.cache_hit.bytes", 32048)
+                                        .AddRate("table.datashard.cache_miss.bytes", 42048)
+                                        .AddRate("table.datashard.consumed_cpu_us", 902048)
+                                        .AddRate("table.datashard.erase.bytes", 122048)
+                                        .AddRate("table.datashard.erase.rows", 112048)
+                                        .AddRate("table.datashard.read.bytes", 70194096)
+                                        .AddRate("table.datashard.read.rows", 30154096)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 162048)
+                                        .AddRate("table.datashard.scan.rows", 152048)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 62048)
+                                        .AddRate("table.datashard.write.rows", 52048)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                        .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                        .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                        .AddRate("table.datashard.erase.bytes", 242560)
+                                        .AddRate("table.datashard.erase.rows", 222560)
+                                        .AddRate("table.datashard.read.bytes", 140385120)
+                                        .AddRate("table.datashard.read.rows", 60305120)
+                                        .AddGauge("table.datashard.row_count", 22560)
+                                        .AddRate("table.datashard.scan.bytes", 322560)
+                                        .AddRate("table.datashard.scan.rows", 302560)
+                                        .AddGauge("table.datashard.size_bytes", 42560)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {80, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 122560)
+                                        .AddRate("table.datashard.write.rows", 102560)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                    .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                    .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                    .AddRate("table.datashard.erase.bytes", 242560)
+                                    .AddRate("table.datashard.erase.rows", 222560)
+                                    .AddRate("table.datashard.read.bytes", 140385120)
+                                    .AddRate("table.datashard.read.rows", 60305120)
+                                    .AddGauge("table.datashard.row_count", 22560)
+                                    .AddRate("table.datashard.scan.bytes", 322560)
+                                    .AddRate("table.datashard.scan.rows", 302560)
+                                    .AddGauge("table.datashard.size_bytes", 42560)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 122560)
+                                    .AddRate("table.datashard.write.rows", 102560)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 562570)
+                            .AddRate("table.datashard.bulk_upsert.rows", 522570)
+                            .AddRate("table.datashard.cache_hit.bytes", 122570)
+                            .AddRate("table.datashard.cache_miss.bytes", 162570)
+                            .AddRate("table.datashard.consumed_cpu_us", 2002570)
+                            .AddRate("table.datashard.erase.bytes", 482570)
+                            .AddRate("table.datashard.erase.rows", 442570)
+                            .AddRate("table.datashard.read.bytes", 280765140)
+                            .AddRate("table.datashard.read.rows", 120605140)
+                            .AddGauge("table.datashard.row_count", 42570)
+                            .AddRate("table.datashard.scan.bytes", 642570)
+                            .AddRate("table.datashard.scan.rows", 602570)
+                            .AddGauge("table.datashard.size_bytes", 82570)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {40, 1},
+                                    {80, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 242570)
+                            .AddRate("table.datashard.write.rows", 202570)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "30101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60005)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80005)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400005)
+                                    .AddRate("table.datashard.erase.bytes", 240005)
+                                    .AddRate("table.datashard.erase.rows", 220005)
+                                    .AddRate("table.datashard.read.bytes", 140380010)
+                                    .AddRate("table.datashard.read.rows", 60300010)
+                                    .AddGauge("table.datashard.row_count", 20005)
+                                    .AddRate("table.datashard.scan.bytes", 320005)
+                                    .AddRate("table.datashard.scan.rows", 300005)
+                                    .AddGauge("table.datashard.size_bytes", 40005)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120005)
+                                    .AddRate("table.datashard.write.rows", 100005)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280005)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260005)
+                                .AddRate("table.datashard.cache_hit.bytes", 60005)
+                                .AddRate("table.datashard.cache_miss.bytes", 80005)
+                                .AddRate("table.datashard.consumed_cpu_us", 400005)
+                                .AddRate("table.datashard.erase.bytes", 240005)
+                                .AddRate("table.datashard.erase.rows", 220005)
+                                .AddRate("table.datashard.read.bytes", 140380010)
+                                .AddRate("table.datashard.read.rows", 60300010)
+                                .AddGauge("table.datashard.row_count", 20005)
+                                .AddRate("table.datashard.scan.bytes", 320005)
+                                .AddRate("table.datashard.scan.rows", 300005)
+                                .AddGauge("table.datashard.size_bytes", 40005)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {20, 1},
+                                        {40, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120005)
+                                .AddRate("table.datashard.write.rows", 100005)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "30301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                    .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                    .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                    .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                    .AddRate("table.datashard.erase.bytes", 121024)
+                                    .AddRate("table.datashard.erase.rows", 111024)
+                                    .AddRate("table.datashard.read.bytes", 70192048)
+                                    .AddRate("table.datashard.read.rows", 30152048)
+                                    .AddGauge("table.datashard.row_count", 11024)
+                                    .AddRate("table.datashard.scan.bytes", 161024)
+                                    .AddRate("table.datashard.scan.rows", 151024)
+                                    .AddGauge("table.datashard.size_bytes", 21024)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 61024)
+                                    .AddRate("table.datashard.write.rows", 51024)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 281280)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 261280)
+                                    .AddRate("table.datashard.cache_hit.bytes", 61280)
+                                    .AddRate("table.datashard.cache_miss.bytes", 81280)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1601280)
+                                    .AddRate("table.datashard.erase.bytes", 241280)
+                                    .AddRate("table.datashard.erase.rows", 221280)
+                                    .AddRate("table.datashard.read.bytes", 140382560)
+                                    .AddRate("table.datashard.read.rows", 60302560)
+                                    .AddGauge("table.datashard.row_count", 21280)
+                                    .AddRate("table.datashard.scan.bytes", 321280)
+                                    .AddRate("table.datashard.scan.rows", 301280)
+                                    .AddGauge("table.datashard.size_bytes", 41280)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 121280)
+                                    .AddRate("table.datashard.write.rows", 101280)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 281280)
+                                .AddRate("table.datashard.bulk_upsert.rows", 261280)
+                                .AddRate("table.datashard.cache_hit.bytes", 61280)
+                                .AddRate("table.datashard.cache_miss.bytes", 81280)
+                                .AddRate("table.datashard.consumed_cpu_us", 1601280)
+                                .AddRate("table.datashard.erase.bytes", 241280)
+                                .AddRate("table.datashard.erase.rows", 221280)
+                                .AddRate("table.datashard.read.bytes", 140382560)
+                                .AddRate("table.datashard.read.rows", 60302560)
+                                .AddGauge("table.datashard.row_count", 21280)
+                                .AddRate("table.datashard.scan.bytes", 321280)
+                                .AddRate("table.datashard.scan.rows", 301280)
+                                .AddGauge("table.datashard.size_bytes", 41280)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {80, 1},
+                                        {100, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 121280)
+                                .AddRate("table.datashard.write.rows", 101280)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 561285)
+                        .AddRate("table.datashard.bulk_upsert.rows", 521285)
+                        .AddRate("table.datashard.cache_hit.bytes", 121285)
+                        .AddRate("table.datashard.cache_miss.bytes", 161285)
+                        .AddRate("table.datashard.consumed_cpu_us", 2001285)
+                        .AddRate("table.datashard.erase.bytes", 481285)
+                        .AddRate("table.datashard.erase.rows", 441285)
+                        .AddRate("table.datashard.read.bytes", 280762570)
+                        .AddRate("table.datashard.read.rows", 120602570)
+                        .AddGauge("table.datashard.row_count", 41285)
+                        .AddRate("table.datashard.scan.bytes", 641285)
+                        .AddRate("table.datashard.scan.rows", 601285)
+                        .AddGauge("table.datashard.size_bytes", 81285)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {20, 1},
+                                {40, 1},
+                                {80, 1},
+                                {100, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 241285)
+                        .AddRate("table.datashard.write.rows", 201285)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 10101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 30101);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 10301);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 30301);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140008)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130008)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30008)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40008)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300008)
+                                        .AddRate("table.datashard.erase.bytes", 120008)
+                                        .AddRate("table.datashard.erase.rows", 110008)
+                                        .AddRate("table.datashard.read.bytes", 70190016)
+                                        .AddRate("table.datashard.read.rows", 30150016)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 160008)
+                                        .AddRate("table.datashard.scan.rows", 150008)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60008)
+                                        .AddRate("table.datashard.write.rows", 50008)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 20010)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 40010)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {20, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 20010)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 40010)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "30302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 142048)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 132048)
+                                        .AddRate("table.datashard.cache_hit.bytes", 32048)
+                                        .AddRate("table.datashard.cache_miss.bytes", 42048)
+                                        .AddRate("table.datashard.consumed_cpu_us", 902048)
+                                        .AddRate("table.datashard.erase.bytes", 122048)
+                                        .AddRate("table.datashard.erase.rows", 112048)
+                                        .AddRate("table.datashard.read.bytes", 70194096)
+                                        .AddRate("table.datashard.read.rows", 30154096)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 162048)
+                                        .AddRate("table.datashard.scan.rows", 152048)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 62048)
+                                        .AddRate("table.datashard.write.rows", 52048)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                        .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                        .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                        .AddRate("table.datashard.erase.bytes", 242560)
+                                        .AddRate("table.datashard.erase.rows", 222560)
+                                        .AddRate("table.datashard.read.bytes", 140385120)
+                                        .AddRate("table.datashard.read.rows", 60305120)
+                                        .AddGauge("table.datashard.row_count", 22560)
+                                        .AddRate("table.datashard.scan.bytes", 322560)
+                                        .AddRate("table.datashard.scan.rows", 302560)
+                                        .AddGauge("table.datashard.size_bytes", 42560)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {80, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 122560)
+                                        .AddRate("table.datashard.write.rows", 102560)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 282560)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 262560)
+                                    .AddRate("table.datashard.cache_hit.bytes", 62560)
+                                    .AddRate("table.datashard.cache_miss.bytes", 82560)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1602560)
+                                    .AddRate("table.datashard.erase.bytes", 242560)
+                                    .AddRate("table.datashard.erase.rows", 222560)
+                                    .AddRate("table.datashard.read.bytes", 140385120)
+                                    .AddRate("table.datashard.read.rows", 60305120)
+                                    .AddGauge("table.datashard.row_count", 22560)
+                                    .AddRate("table.datashard.scan.bytes", 322560)
+                                    .AddRate("table.datashard.scan.rows", 302560)
+                                    .AddGauge("table.datashard.size_bytes", 42560)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 122560)
+                                    .AddRate("table.datashard.write.rows", 102560)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 562570)
+                            .AddRate("table.datashard.bulk_upsert.rows", 522570)
+                            .AddRate("table.datashard.cache_hit.bytes", 122570)
+                            .AddRate("table.datashard.cache_miss.bytes", 162570)
+                            .AddRate("table.datashard.consumed_cpu_us", 2002570)
+                            .AddRate("table.datashard.erase.bytes", 482570)
+                            .AddRate("table.datashard.erase.rows", 442570)
+                            .AddRate("table.datashard.read.bytes", 280765140)
+                            .AddRate("table.datashard.read.rows", 120605140)
+                            .AddGauge("table.datashard.row_count", 42570)
+                            .AddRate("table.datashard.scan.bytes", 642570)
+                            .AddRate("table.datashard.scan.rows", 602570)
+                            .AddGauge("table.datashard.size_bytes", 82570)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {40, 1},
+                                    {80, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 242570)
+                            .AddRate("table.datashard.write.rows", 202570)
+                        .EndNested()
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 6: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 10102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 30102);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 10302);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 30302);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include both leaders and followers
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardLeadersAndsFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions with the leader + 2 followers for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101,     0,  10, &tableMetricsConfig1, 0x0001);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 10101,  20, &tableMetricsConfig1, 0x0002);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101,  30, &tableMetricsConfig1, 0x0004);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201,     0,  40, &tableMetricsConfig1, 0x0010);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 10201,  50, &tableMetricsConfig1, 0x0020);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201,  60, &tableMetricsConfig1, 0x0040);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301,     0,  70, &tableMetricsConfig1, 0x0100);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 10301,  80, &tableMetricsConfig1, 0x0200);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301,  90, &tableMetricsConfig1, 0x0400);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102,     0,  10, &tableMetricsConfig2, 0x0001);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 10102,  20, &tableMetricsConfig2, 0x0002);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102,  30, &tableMetricsConfig2, 0x0004);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202,     0,  40, &tableMetricsConfig2, 0x0010);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 10202,  50, &tableMetricsConfig2, 0x0020);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202,  60, &tableMetricsConfig2, 0x0040);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302,     0,  70, &tableMetricsConfig2, 0x0100);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 10302,  80, &tableMetricsConfig2, 0x0200);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302,  90, &tableMetricsConfig2, 0x0400);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                        .AddRate("table.datashard.erase.bytes", 120001)
+                                        .AddRate("table.datashard.erase.rows", 110001)
+                                        .AddRate("table.datashard.read.bytes", 70190002)
+                                        .AddRate("table.datashard.read.rows", 30150002)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 160001)
+                                        .AddRate("table.datashard.scan.rows", 150001)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60001)
+                                        .AddRate("table.datashard.write.rows", 50001)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                        .AddRate("table.datashard.erase.bytes", 120004)
+                                        .AddRate("table.datashard.erase.rows", 110004)
+                                        .AddRate("table.datashard.read.bytes", 70190008)
+                                        .AddRate("table.datashard.read.rows", 30150008)
+                                        .AddGauge("table.datashard.row_count", 10004)
+                                        .AddRate("table.datashard.scan.bytes", 160004)
+                                        .AddRate("table.datashard.scan.rows", 150004)
+                                        .AddGauge("table.datashard.size_bytes", 20004)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60004)
+                                        .AddRate("table.datashard.write.rows", 50004)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280006)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260006)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60006)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80006)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500006)
+                                        .AddRate("table.datashard.erase.bytes", 240006)
+                                        .AddRate("table.datashard.erase.rows", 220006)
+                                        .AddRate("table.datashard.read.bytes", 140380012)
+                                        .AddRate("table.datashard.read.rows", 60300012)
+                                        .AddGauge("table.datashard.row_count", 20006)
+                                        .AddRate("table.datashard.scan.bytes", 320006)
+                                        .AddRate("table.datashard.scan.rows", 300006)
+                                        .AddGauge("table.datashard.size_bytes", 40006)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {30, 1},
+                                                {40, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120006)
+                                        .AddRate("table.datashard.write.rows", 100006)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420007)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390007)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90007)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120007)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600007)
+                                    .AddRate("table.datashard.erase.bytes", 360007)
+                                    .AddRate("table.datashard.erase.rows", 330007)
+                                    .AddRate("table.datashard.read.bytes", 210570014)
+                                    .AddRate("table.datashard.read.rows", 90450014)
+                                    .AddGauge("table.datashard.row_count", 30007)
+                                    .AddRate("table.datashard.scan.bytes", 480007)
+                                    .AddRate("table.datashard.scan.rows", 450007)
+                                    .AddGauge("table.datashard.size_bytes", 60007)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {30, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180007)
+                                    .AddRate("table.datashard.write.rows", 150007)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600064)
+                                        .AddRate("table.datashard.erase.bytes", 120064)
+                                        .AddRate("table.datashard.erase.rows", 110064)
+                                        .AddRate("table.datashard.read.bytes", 70190128)
+                                        .AddRate("table.datashard.read.rows", 30150128)
+                                        .AddGauge("table.datashard.row_count", 10064)
+                                        .AddRate("table.datashard.scan.bytes", 160064)
+                                        .AddRate("table.datashard.scan.rows", 150064)
+                                        .AddGauge("table.datashard.size_bytes", 20064)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60064)
+                                        .AddRate("table.datashard.write.rows", 50064)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280096)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260096)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60096)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80096)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1100096)
+                                        .AddRate("table.datashard.erase.bytes", 240096)
+                                        .AddRate("table.datashard.erase.rows", 220096)
+                                        .AddRate("table.datashard.read.bytes", 140380192)
+                                        .AddRate("table.datashard.read.rows", 60300192)
+                                        .AddGauge("table.datashard.row_count", 20096)
+                                        .AddRate("table.datashard.scan.bytes", 320096)
+                                        .AddRate("table.datashard.scan.rows", 300096)
+                                        .AddGauge("table.datashard.size_bytes", 40096)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {60, 1},
+                                                {70, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 120096)
+                                        .AddRate("table.datashard.write.rows", 100096)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420112)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390112)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90112)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120112)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500112)
+                                    .AddRate("table.datashard.erase.bytes", 360112)
+                                    .AddRate("table.datashard.erase.rows", 330112)
+                                    .AddRate("table.datashard.read.bytes", 210570224)
+                                    .AddRate("table.datashard.read.rows", 90450224)
+                                    .AddGauge("table.datashard.row_count", 30112)
+                                    .AddRate("table.datashard.scan.bytes", 480112)
+                                    .AddRate("table.datashard.scan.rows", 450112)
+                                    .AddGauge("table.datashard.size_bytes", 60112)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {60, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180112)
+                                    .AddRate("table.datashard.write.rows", 150112)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                        .AddRate("table.datashard.erase.bytes", 120256)
+                                        .AddRate("table.datashard.erase.rows", 110256)
+                                        .AddRate("table.datashard.read.bytes", 70190512)
+                                        .AddRate("table.datashard.read.rows", 30150512)
+                                        .AddGauge("table.datashard.row_count", 10256)
+                                        .AddRate("table.datashard.scan.bytes", 160256)
+                                        .AddRate("table.datashard.scan.rows", 150256)
+                                        .AddGauge("table.datashard.size_bytes", 20256)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60256)
+                                        .AddRate("table.datashard.write.rows", 50256)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                        .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                        .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                        .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                        .AddRate("table.datashard.erase.bytes", 121024)
+                                        .AddRate("table.datashard.erase.rows", 111024)
+                                        .AddRate("table.datashard.read.bytes", 70192048)
+                                        .AddRate("table.datashard.read.rows", 30152048)
+                                        .AddGauge("table.datashard.row_count", 11024)
+                                        .AddRate("table.datashard.scan.bytes", 161024)
+                                        .AddRate("table.datashard.scan.rows", 151024)
+                                        .AddGauge("table.datashard.size_bytes", 21024)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 61024)
+                                        .AddRate("table.datashard.write.rows", 51024)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 281536)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 261536)
+                                        .AddRate("table.datashard.cache_hit.bytes", 61536)
+                                        .AddRate("table.datashard.cache_miss.bytes", 81536)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1701536)
+                                        .AddRate("table.datashard.erase.bytes", 241536)
+                                        .AddRate("table.datashard.erase.rows", 221536)
+                                        .AddRate("table.datashard.read.bytes", 140383072)
+                                        .AddRate("table.datashard.read.rows", 60303072)
+                                        .AddGauge("table.datashard.row_count", 21536)
+                                        .AddRate("table.datashard.scan.bytes", 321536)
+                                        .AddRate("table.datashard.scan.rows", 301536)
+                                        .AddGauge("table.datashard.size_bytes", 41536)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {90, 1},
+                                                {100, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 121536)
+                                        .AddRate("table.datashard.write.rows", 101536)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 421792)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 391792)
+                                    .AddRate("table.datashard.cache_hit.bytes", 91792)
+                                    .AddRate("table.datashard.cache_miss.bytes", 121792)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2401792)
+                                    .AddRate("table.datashard.erase.bytes", 361792)
+                                    .AddRate("table.datashard.erase.rows", 331792)
+                                    .AddRate("table.datashard.read.bytes", 210573584)
+                                    .AddRate("table.datashard.read.rows", 90453584)
+                                    .AddGauge("table.datashard.row_count", 31792)
+                                    .AddRate("table.datashard.scan.bytes", 481792)
+                                    .AddRate("table.datashard.scan.rows", 451792)
+                                    .AddGauge("table.datashard.size_bytes", 61792)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {90, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 181792)
+                                    .AddRate("table.datashard.write.rows", 151792)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 1261911)
+                            .AddRate("table.datashard.bulk_upsert.rows", 1171911)
+                            .AddRate("table.datashard.cache_hit.bytes", 271911)
+                            .AddRate("table.datashard.cache_miss.bytes", 361911)
+                            .AddRate("table.datashard.consumed_cpu_us", 4501911)
+                            .AddRate("table.datashard.erase.bytes", 1081911)
+                            .AddRate("table.datashard.erase.rows", 991911)
+                            .AddRate("table.datashard.read.bytes", 631713822)
+                            .AddRate("table.datashard.read.rows", 271353822)
+                            .AddGauge("table.datashard.row_count", 91911)
+                            .AddRate("table.datashard.scan.bytes", 1441911)
+                            .AddRate("table.datashard.scan.rows", 1351911)
+                            .AddGauge("table.datashard.size_bytes", 181911)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {30, 1},
+                                    {40, 1},
+                                    {50, 1},
+                                    {60, 1},
+                                    {70, 1},
+                                    {80, 1},
+                                    {90, 1},
+                                    {100, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 541911)
+                            .AddRate("table.datashard.write.rows", 451911)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "20101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280006)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260006)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60006)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80006)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500006)
+                                    .AddRate("table.datashard.erase.bytes", 240006)
+                                    .AddRate("table.datashard.erase.rows", 220006)
+                                    .AddRate("table.datashard.read.bytes", 140380012)
+                                    .AddRate("table.datashard.read.rows", 60300012)
+                                    .AddGauge("table.datashard.row_count", 20006)
+                                    .AddRate("table.datashard.scan.bytes", 320006)
+                                    .AddRate("table.datashard.scan.rows", 300006)
+                                    .AddGauge("table.datashard.size_bytes", 40006)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {30, 1},
+                                            {40, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120006)
+                                    .AddRate("table.datashard.write.rows", 100006)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 420007)
+                                .AddRate("table.datashard.bulk_upsert.rows", 390007)
+                                .AddRate("table.datashard.cache_hit.bytes", 90007)
+                                .AddRate("table.datashard.cache_miss.bytes", 120007)
+                                .AddRate("table.datashard.consumed_cpu_us", 600007)
+                                .AddRate("table.datashard.erase.bytes", 360007)
+                                .AddRate("table.datashard.erase.rows", 330007)
+                                .AddRate("table.datashard.read.bytes", 210570014)
+                                .AddRate("table.datashard.read.rows", 90450014)
+                                .AddGauge("table.datashard.row_count", 30007)
+                                .AddRate("table.datashard.scan.bytes", 480007)
+                                .AddRate("table.datashard.scan.rows", 450007)
+                                .AddGauge("table.datashard.size_bytes", 60007)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {20, 1},
+                                        {30, 1},
+                                        {40, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 180007)
+                                .AddRate("table.datashard.write.rows", 150007)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("follower_id", "20201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140064)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130064)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30064)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40064)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600064)
+                                    .AddRate("table.datashard.erase.bytes", 120064)
+                                    .AddRate("table.datashard.erase.rows", 110064)
+                                    .AddRate("table.datashard.read.bytes", 70190128)
+                                    .AddRate("table.datashard.read.rows", 30150128)
+                                    .AddGauge("table.datashard.row_count", 10064)
+                                    .AddRate("table.datashard.scan.bytes", 160064)
+                                    .AddRate("table.datashard.scan.rows", 150064)
+                                    .AddGauge("table.datashard.size_bytes", 20064)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{70, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60064)
+                                    .AddRate("table.datashard.write.rows", 50064)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280096)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260096)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60096)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80096)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1100096)
+                                    .AddRate("table.datashard.erase.bytes", 240096)
+                                    .AddRate("table.datashard.erase.rows", 220096)
+                                    .AddRate("table.datashard.read.bytes", 140380192)
+                                    .AddRate("table.datashard.read.rows", 60300192)
+                                    .AddGauge("table.datashard.row_count", 20096)
+                                    .AddRate("table.datashard.scan.bytes", 320096)
+                                    .AddRate("table.datashard.scan.rows", 300096)
+                                    .AddGauge("table.datashard.size_bytes", 40096)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {60, 1},
+                                            {70, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120096)
+                                    .AddRate("table.datashard.write.rows", 100096)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 420112)
+                                .AddRate("table.datashard.bulk_upsert.rows", 390112)
+                                .AddRate("table.datashard.cache_hit.bytes", 90112)
+                                .AddRate("table.datashard.cache_miss.bytes", 120112)
+                                .AddRate("table.datashard.consumed_cpu_us", 1500112)
+                                .AddRate("table.datashard.erase.bytes", 360112)
+                                .AddRate("table.datashard.erase.rows", 330112)
+                                .AddRate("table.datashard.read.bytes", 210570224)
+                                .AddRate("table.datashard.read.rows", 90450224)
+                                .AddGauge("table.datashard.row_count", 30112)
+                                .AddRate("table.datashard.scan.bytes", 480112)
+                                .AddRate("table.datashard.scan.rows", 450112)
+                                .AddGauge("table.datashard.size_bytes", 60112)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {50, 1},
+                                        {60, 1},
+                                        {70, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 180112)
+                                .AddRate("table.datashard.write.rows", 150112)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "20301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 141024)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 131024)
+                                    .AddRate("table.datashard.cache_hit.bytes", 31024)
+                                    .AddRate("table.datashard.cache_miss.bytes", 41024)
+                                    .AddRate("table.datashard.consumed_cpu_us", 901024)
+                                    .AddRate("table.datashard.erase.bytes", 121024)
+                                    .AddRate("table.datashard.erase.rows", 111024)
+                                    .AddRate("table.datashard.read.bytes", 70192048)
+                                    .AddRate("table.datashard.read.rows", 30152048)
+                                    .AddGauge("table.datashard.row_count", 11024)
+                                    .AddRate("table.datashard.scan.bytes", 161024)
+                                    .AddRate("table.datashard.scan.rows", 151024)
+                                    .AddGauge("table.datashard.size_bytes", 21024)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 61024)
+                                    .AddRate("table.datashard.write.rows", 51024)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 281536)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 261536)
+                                    .AddRate("table.datashard.cache_hit.bytes", 61536)
+                                    .AddRate("table.datashard.cache_miss.bytes", 81536)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1701536)
+                                    .AddRate("table.datashard.erase.bytes", 241536)
+                                    .AddRate("table.datashard.erase.rows", 221536)
+                                    .AddRate("table.datashard.read.bytes", 140383072)
+                                    .AddRate("table.datashard.read.rows", 60303072)
+                                    .AddGauge("table.datashard.row_count", 21536)
+                                    .AddRate("table.datashard.scan.bytes", 321536)
+                                    .AddRate("table.datashard.scan.rows", 301536)
+                                    .AddGauge("table.datashard.size_bytes", 41536)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {90, 1},
+                                            {100, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 121536)
+                                    .AddRate("table.datashard.write.rows", 101536)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 421792)
+                                .AddRate("table.datashard.bulk_upsert.rows", 391792)
+                                .AddRate("table.datashard.cache_hit.bytes", 91792)
+                                .AddRate("table.datashard.cache_miss.bytes", 121792)
+                                .AddRate("table.datashard.consumed_cpu_us", 2401792)
+                                .AddRate("table.datashard.erase.bytes", 361792)
+                                .AddRate("table.datashard.erase.rows", 331792)
+                                .AddRate("table.datashard.read.bytes", 210573584)
+                                .AddRate("table.datashard.read.rows", 90453584)
+                                .AddGauge("table.datashard.row_count", 31792)
+                                .AddRate("table.datashard.scan.bytes", 481792)
+                                .AddRate("table.datashard.scan.rows", 451792)
+                                .AddGauge("table.datashard.size_bytes", 61792)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {80, 1},
+                                        {90, 1},
+                                        {100, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 181792)
+                                .AddRate("table.datashard.write.rows", 151792)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 1261911)
+                        .AddRate("table.datashard.bulk_upsert.rows", 1171911)
+                        .AddRate("table.datashard.cache_hit.bytes", 271911)
+                        .AddRate("table.datashard.cache_miss.bytes", 361911)
+                        .AddRate("table.datashard.consumed_cpu_us", 4501911)
+                        .AddRate("table.datashard.erase.bytes", 1081911)
+                        .AddRate("table.datashard.erase.rows", 991911)
+                        .AddRate("table.datashard.read.bytes", 631713822)
+                        .AddRate("table.datashard.read.rows", 271353822)
+                        .AddGauge("table.datashard.row_count", 91911)
+                        .AddRate("table.datashard.scan.bytes", 1441911)
+                        .AddRate("table.datashard.scan.rows", 1351911)
+                        .AddGauge("table.datashard.size_bytes", 181911)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {20, 1},
+                                {30, 1},
+                                {40, 1},
+                                {50, 1},
+                                {60, 1},
+                                {70, 1},
+                                {80, 1},
+                                {90, 1},
+                                {100, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 541911)
+                        .AddRate("table.datashard.write.rows", 451911)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second follower for each partition for each table
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 0, &tableMetricsConfig1, 0x0008);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 0, &tableMetricsConfig1, 0x0080);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 0, &tableMetricsConfig1, 0x0800);
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 0, &tableMetricsConfig2, 0x0008);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 0, &tableMetricsConfig2, 0x0080);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 0, &tableMetricsConfig2, 0x0800);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                        .AddRate("table.datashard.erase.bytes", 120001)
+                                        .AddRate("table.datashard.erase.rows", 110001)
+                                        .AddRate("table.datashard.read.bytes", 70190002)
+                                        .AddRate("table.datashard.read.rows", 30150002)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 160001)
+                                        .AddRate("table.datashard.scan.rows", 150001)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60001)
+                                        .AddRate("table.datashard.write.rows", 50001)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280012)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260012)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60012)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80012)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300012)
+                                        .AddRate("table.datashard.erase.bytes", 240012)
+                                        .AddRate("table.datashard.erase.rows", 220012)
+                                        .AddRate("table.datashard.read.bytes", 140380024)
+                                        .AddRate("table.datashard.read.rows", 60300024)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320012)
+                                        .AddRate("table.datashard.scan.rows", 300012)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120012)
+                                        .AddRate("table.datashard.write.rows", 100012)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 420014)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 390014)
+                                        .AddRate("table.datashard.cache_hit.bytes", 90014)
+                                        .AddRate("table.datashard.cache_miss.bytes", 120014)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500014)
+                                        .AddRate("table.datashard.erase.bytes", 360014)
+                                        .AddRate("table.datashard.erase.rows", 330014)
+                                        .AddRate("table.datashard.read.bytes", 210570028)
+                                        .AddRate("table.datashard.read.rows", 90450028)
+                                        .AddGauge("table.datashard.row_count", 20010)
+                                        .AddRate("table.datashard.scan.bytes", 480014)
+                                        .AddRate("table.datashard.scan.rows", 450014)
+                                        .AddGauge("table.datashard.size_bytes", 40010)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {30, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 180014)
+                                        .AddRate("table.datashard.write.rows", 150014)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                    .AddRate("table.datashard.erase.bytes", 480015)
+                                    .AddRate("table.datashard.erase.rows", 440015)
+                                    .AddRate("table.datashard.read.bytes", 280760030)
+                                    .AddRate("table.datashard.read.rows", 120600030)
+                                    .AddGauge("table.datashard.row_count", 30011)
+                                    .AddRate("table.datashard.scan.bytes", 640015)
+                                    .AddRate("table.datashard.scan.rows", 600015)
+                                    .AddGauge("table.datashard.size_bytes", 60011)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {20, 1},
+                                            {30, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240015)
+                                    .AddRate("table.datashard.write.rows", 200015)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280192)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260192)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60192)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80192)
+                                        .AddRate("table.datashard.consumed_cpu_us", 600192)
+                                        .AddRate("table.datashard.erase.bytes", 240192)
+                                        .AddRate("table.datashard.erase.rows", 220192)
+                                        .AddRate("table.datashard.read.bytes", 140380384)
+                                        .AddRate("table.datashard.read.rows", 60300384)
+                                        .AddGauge("table.datashard.row_count", 10128)
+                                        .AddRate("table.datashard.scan.bytes", 320192)
+                                        .AddRate("table.datashard.scan.rows", 300192)
+                                        .AddGauge("table.datashard.size_bytes", 20128)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120192)
+                                        .AddRate("table.datashard.write.rows", 100192)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 420224)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 390224)
+                                        .AddRate("table.datashard.cache_hit.bytes", 90224)
+                                        .AddRate("table.datashard.cache_miss.bytes", 120224)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1100224)
+                                        .AddRate("table.datashard.erase.bytes", 360224)
+                                        .AddRate("table.datashard.erase.rows", 330224)
+                                        .AddRate("table.datashard.read.bytes", 210570448)
+                                        .AddRate("table.datashard.read.rows", 90450448)
+                                        .AddGauge("table.datashard.row_count", 20160)
+                                        .AddRate("table.datashard.scan.bytes", 480224)
+                                        .AddRate("table.datashard.scan.rows", 450224)
+                                        .AddGauge("table.datashard.size_bytes", 40160)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {60, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 180224)
+                                        .AddRate("table.datashard.write.rows", 150224)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                    .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                    .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                    .AddRate("table.datashard.erase.bytes", 480240)
+                                    .AddRate("table.datashard.erase.rows", 440240)
+                                    .AddRate("table.datashard.read.bytes", 280760480)
+                                    .AddRate("table.datashard.read.rows", 120600480)
+                                    .AddGauge("table.datashard.row_count", 30176)
+                                    .AddRate("table.datashard.scan.bytes", 640240)
+                                    .AddRate("table.datashard.scan.rows", 600240)
+                                    .AddGauge("table.datashard.size_bytes", 60176)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {50, 1},
+                                            {60, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 240240)
+                                    .AddRate("table.datashard.write.rows", 200240)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                        .AddRate("table.datashard.erase.bytes", 120256)
+                                        .AddRate("table.datashard.erase.rows", 110256)
+                                        .AddRate("table.datashard.read.bytes", 70190512)
+                                        .AddRate("table.datashard.read.rows", 30150512)
+                                        .AddGauge("table.datashard.row_count", 10256)
+                                        .AddRate("table.datashard.scan.bytes", 160256)
+                                        .AddRate("table.datashard.scan.rows", 150256)
+                                        .AddGauge("table.datashard.size_bytes", 20256)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60256)
+                                        .AddRate("table.datashard.write.rows", 50256)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "20302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 283072)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 263072)
+                                        .AddRate("table.datashard.cache_hit.bytes", 63072)
+                                        .AddRate("table.datashard.cache_miss.bytes", 83072)
+                                        .AddRate("table.datashard.consumed_cpu_us", 903072)
+                                        .AddRate("table.datashard.erase.bytes", 243072)
+                                        .AddRate("table.datashard.erase.rows", 223072)
+                                        .AddRate("table.datashard.read.bytes", 140386144)
+                                        .AddRate("table.datashard.read.rows", 60306144)
+                                        .AddGauge("table.datashard.row_count", 12048)
+                                        .AddRate("table.datashard.scan.bytes", 323072)
+                                        .AddRate("table.datashard.scan.rows", 303072)
+                                        .AddGauge("table.datashard.size_bytes", 22048)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                        .AddRate("table.datashard.write.bytes", 123072)
+                                        .AddRate("table.datashard.write.rows", 103072)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 423584)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 393584)
+                                        .AddRate("table.datashard.cache_hit.bytes", 93584)
+                                        .AddRate("table.datashard.cache_miss.bytes", 123584)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1703584)
+                                        .AddRate("table.datashard.erase.bytes", 363584)
+                                        .AddRate("table.datashard.erase.rows", 333584)
+                                        .AddRate("table.datashard.read.bytes", 210577168)
+                                        .AddRate("table.datashard.read.rows", 90457168)
+                                        .AddGauge("table.datashard.row_count", 22560)
+                                        .AddRate("table.datashard.scan.bytes", 483584)
+                                        .AddRate("table.datashard.scan.rows", 453584)
+                                        .AddGauge("table.datashard.size_bytes", 42560)
+                                        .AddCpuHistogram(
+                                            "table.datashard.used_core_percents",
+                                            {
+                                                {10, 1},
+                                                {90, 1},
+                                            }
+                                        )
+                                        .AddRate("table.datashard.write.bytes", 183584)
+                                        .AddRate("table.datashard.write.rows", 153584)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                    .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                    .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                    .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                    .AddRate("table.datashard.erase.bytes", 483840)
+                                    .AddRate("table.datashard.erase.rows", 443840)
+                                    .AddRate("table.datashard.read.bytes", 280767680)
+                                    .AddRate("table.datashard.read.rows", 120607680)
+                                    .AddGauge("table.datashard.row_count", 32816)
+                                    .AddRate("table.datashard.scan.bytes", 643840)
+                                    .AddRate("table.datashard.scan.rows", 603840)
+                                    .AddGauge("table.datashard.size_bytes", 62816)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {80, 1},
+                                            {90, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 243840)
+                                    .AddRate("table.datashard.write.rows", 203840)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 1684095)
+                            .AddRate("table.datashard.bulk_upsert.rows", 1564095)
+                            .AddRate("table.datashard.cache_hit.bytes", 364095)
+                            .AddRate("table.datashard.cache_miss.bytes", 484095)
+                            .AddRate("table.datashard.consumed_cpu_us", 4504095)
+                            .AddRate("table.datashard.erase.bytes", 1444095)
+                            .AddRate("table.datashard.erase.rows", 1324095)
+                            .AddRate("table.datashard.read.bytes", 842288190)
+                            .AddRate("table.datashard.read.rows", 361808190)
+                            .AddGauge("table.datashard.row_count", 93003)
+                            .AddRate("table.datashard.scan.bytes", 1924095)
+                            .AddRate("table.datashard.scan.rows", 1804095)
+                            .AddGauge("table.datashard.size_bytes", 183003)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {10, 3},
+                                    {20, 1},
+                                    {30, 1},
+                                    {50, 1},
+                                    {60, 1},
+                                    {80, 1},
+                                    {90, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 724095)
+                            .AddRate("table.datashard.write.rows", 604095)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "20101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280012)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260012)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60012)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80012)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300012)
+                                    .AddRate("table.datashard.erase.bytes", 240012)
+                                    .AddRate("table.datashard.erase.rows", 220012)
+                                    .AddRate("table.datashard.read.bytes", 140380024)
+                                    .AddRate("table.datashard.read.rows", 60300024)
+                                    .AddGauge("table.datashard.row_count", 10008)
+                                    .AddRate("table.datashard.scan.bytes", 320012)
+                                    .AddRate("table.datashard.scan.rows", 300012)
+                                    .AddGauge("table.datashard.size_bytes", 20008)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120012)
+                                    .AddRate("table.datashard.write.rows", 100012)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420014)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390014)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90014)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120014)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500014)
+                                    .AddRate("table.datashard.erase.bytes", 360014)
+                                    .AddRate("table.datashard.erase.rows", 330014)
+                                    .AddRate("table.datashard.read.bytes", 210570028)
+                                    .AddRate("table.datashard.read.rows", 90450028)
+                                    .AddGauge("table.datashard.row_count", 20010)
+                                    .AddRate("table.datashard.scan.bytes", 480014)
+                                    .AddRate("table.datashard.scan.rows", 450014)
+                                    .AddGauge("table.datashard.size_bytes", 40010)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {30, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180014)
+                                    .AddRate("table.datashard.write.rows", 150014)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 560015)
+                                .AddRate("table.datashard.bulk_upsert.rows", 520015)
+                                .AddRate("table.datashard.cache_hit.bytes", 120015)
+                                .AddRate("table.datashard.cache_miss.bytes", 160015)
+                                .AddRate("table.datashard.consumed_cpu_us", 600015)
+                                .AddRate("table.datashard.erase.bytes", 480015)
+                                .AddRate("table.datashard.erase.rows", 440015)
+                                .AddRate("table.datashard.read.bytes", 280760030)
+                                .AddRate("table.datashard.read.rows", 120600030)
+                                .AddGauge("table.datashard.row_count", 30011)
+                                .AddRate("table.datashard.scan.bytes", 640015)
+                                .AddRate("table.datashard.scan.rows", 600015)
+                                .AddGauge("table.datashard.size_bytes", 60011)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {20, 1},
+                                        {30, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 240015)
+                                .AddRate("table.datashard.write.rows", 200015)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("follower_id", "20201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280192)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260192)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60192)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80192)
+                                    .AddRate("table.datashard.consumed_cpu_us", 600192)
+                                    .AddRate("table.datashard.erase.bytes", 240192)
+                                    .AddRate("table.datashard.erase.rows", 220192)
+                                    .AddRate("table.datashard.read.bytes", 140380384)
+                                    .AddRate("table.datashard.read.rows", 60300384)
+                                    .AddGauge("table.datashard.row_count", 10128)
+                                    .AddRate("table.datashard.scan.bytes", 320192)
+                                    .AddRate("table.datashard.scan.rows", 300192)
+                                    .AddGauge("table.datashard.size_bytes", 20128)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120192)
+                                    .AddRate("table.datashard.write.rows", 100192)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 420224)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 390224)
+                                    .AddRate("table.datashard.cache_hit.bytes", 90224)
+                                    .AddRate("table.datashard.cache_miss.bytes", 120224)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1100224)
+                                    .AddRate("table.datashard.erase.bytes", 360224)
+                                    .AddRate("table.datashard.erase.rows", 330224)
+                                    .AddRate("table.datashard.read.bytes", 210570448)
+                                    .AddRate("table.datashard.read.rows", 90450448)
+                                    .AddGauge("table.datashard.row_count", 20160)
+                                    .AddRate("table.datashard.scan.bytes", 480224)
+                                    .AddRate("table.datashard.scan.rows", 450224)
+                                    .AddGauge("table.datashard.size_bytes", 40160)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {60, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 180224)
+                                    .AddRate("table.datashard.write.rows", 150224)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 560240)
+                                .AddRate("table.datashard.bulk_upsert.rows", 520240)
+                                .AddRate("table.datashard.cache_hit.bytes", 120240)
+                                .AddRate("table.datashard.cache_miss.bytes", 160240)
+                                .AddRate("table.datashard.consumed_cpu_us", 1500240)
+                                .AddRate("table.datashard.erase.bytes", 480240)
+                                .AddRate("table.datashard.erase.rows", 440240)
+                                .AddRate("table.datashard.read.bytes", 280760480)
+                                .AddRate("table.datashard.read.rows", 120600480)
+                                .AddGauge("table.datashard.row_count", 30176)
+                                .AddRate("table.datashard.scan.bytes", 640240)
+                                .AddRate("table.datashard.scan.rows", 600240)
+                                .AddGauge("table.datashard.size_bytes", 60176)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {50, 1},
+                                        {60, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 240240)
+                                .AddRate("table.datashard.write.rows", 200240)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "20301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 283072)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 263072)
+                                    .AddRate("table.datashard.cache_hit.bytes", 63072)
+                                    .AddRate("table.datashard.cache_miss.bytes", 83072)
+                                    .AddRate("table.datashard.consumed_cpu_us", 903072)
+                                    .AddRate("table.datashard.erase.bytes", 243072)
+                                    .AddRate("table.datashard.erase.rows", 223072)
+                                    .AddRate("table.datashard.read.bytes", 140386144)
+                                    .AddRate("table.datashard.read.rows", 60306144)
+                                    .AddGauge("table.datashard.row_count", 12048)
+                                    .AddRate("table.datashard.scan.bytes", 323072)
+                                    .AddRate("table.datashard.scan.rows", 303072)
+                                    .AddGauge("table.datashard.size_bytes", 22048)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{10, 1}})
+                                    .AddRate("table.datashard.write.bytes", 123072)
+                                    .AddRate("table.datashard.write.rows", 103072)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 423584)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 393584)
+                                    .AddRate("table.datashard.cache_hit.bytes", 93584)
+                                    .AddRate("table.datashard.cache_miss.bytes", 123584)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1703584)
+                                    .AddRate("table.datashard.erase.bytes", 363584)
+                                    .AddRate("table.datashard.erase.rows", 333584)
+                                    .AddRate("table.datashard.read.bytes", 210577168)
+                                    .AddRate("table.datashard.read.rows", 90457168)
+                                    .AddGauge("table.datashard.row_count", 22560)
+                                    .AddRate("table.datashard.scan.bytes", 483584)
+                                    .AddRate("table.datashard.scan.rows", 453584)
+                                    .AddGauge("table.datashard.size_bytes", 42560)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {10, 1},
+                                            {90, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 183584)
+                                    .AddRate("table.datashard.write.rows", 153584)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 563840)
+                                .AddRate("table.datashard.bulk_upsert.rows", 523840)
+                                .AddRate("table.datashard.cache_hit.bytes", 123840)
+                                .AddRate("table.datashard.cache_miss.bytes", 163840)
+                                .AddRate("table.datashard.consumed_cpu_us", 2403840)
+                                .AddRate("table.datashard.erase.bytes", 483840)
+                                .AddRate("table.datashard.erase.rows", 443840)
+                                .AddRate("table.datashard.read.bytes", 280767680)
+                                .AddRate("table.datashard.read.rows", 120607680)
+                                .AddGauge("table.datashard.row_count", 32816)
+                                .AddRate("table.datashard.scan.bytes", 643840)
+                                .AddRate("table.datashard.scan.rows", 603840)
+                                .AddGauge("table.datashard.size_bytes", 62816)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {10, 1},
+                                        {80, 1},
+                                        {90, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 243840)
+                                .AddRate("table.datashard.write.rows", 203840)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 1684095)
+                        .AddRate("table.datashard.bulk_upsert.rows", 1564095)
+                        .AddRate("table.datashard.cache_hit.bytes", 364095)
+                        .AddRate("table.datashard.cache_miss.bytes", 484095)
+                        .AddRate("table.datashard.consumed_cpu_us", 4504095)
+                        .AddRate("table.datashard.erase.bytes", 1444095)
+                        .AddRate("table.datashard.erase.rows", 1324095)
+                        .AddRate("table.datashard.read.bytes", 842288190)
+                        .AddRate("table.datashard.read.rows", 361808190)
+                        .AddGauge("table.datashard.row_count", 93003)
+                        .AddRate("table.datashard.scan.bytes", 1924095)
+                        .AddRate("table.datashard.scan.rows", 1804095)
+                        .AddGauge("table.datashard.size_bytes", 183003)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {10, 3},
+                                {20, 1},
+                                {30, 1},
+                                {50, 1},
+                                {60, 1},
+                                {80, 1},
+                                {90, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 724095)
+                        .AddRate("table.datashard.write.rows", 604095)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second follower for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 20101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 20201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 20301);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 20102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 20202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 20302);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting followers):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                        .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                        .AddRate("table.datashard.erase.bytes", 120001)
+                                        .AddRate("table.datashard.erase.rows", 110001)
+                                        .AddRate("table.datashard.read.bytes", 70190002)
+                                        .AddRate("table.datashard.read.rows", 30150002)
+                                        .AddGauge("table.datashard.row_count", 10001)
+                                        .AddRate("table.datashard.scan.bytes", 160001)
+                                        .AddRate("table.datashard.scan.rows", 150001)
+                                        .AddGauge("table.datashard.size_bytes", 20001)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60001)
+                                        .AddRate("table.datashard.write.rows", 50001)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280003)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260003)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60003)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80003)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300003)
+                                    .AddRate("table.datashard.erase.bytes", 240003)
+                                    .AddRate("table.datashard.erase.rows", 220003)
+                                    .AddRate("table.datashard.read.bytes", 140380006)
+                                    .AddRate("table.datashard.read.rows", 60300006)
+                                    .AddGauge("table.datashard.row_count", 20003)
+                                    .AddRate("table.datashard.scan.bytes", 320003)
+                                    .AddRate("table.datashard.scan.rows", 300003)
+                                    .AddGauge("table.datashard.size_bytes", 40003)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {20, 1},
+                                            {30, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120003)
+                                    .AddRate("table.datashard.write.rows", 100003)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                        .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                        .AddRate("table.datashard.erase.bytes", 120016)
+                                        .AddRate("table.datashard.erase.rows", 110016)
+                                        .AddRate("table.datashard.read.bytes", 70190032)
+                                        .AddRate("table.datashard.read.rows", 30150032)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 160016)
+                                        .AddRate("table.datashard.scan.rows", 150016)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60016)
+                                        .AddRate("table.datashard.write.rows", 50016)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280048)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260048)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60048)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80048)
+                                    .AddRate("table.datashard.consumed_cpu_us", 900048)
+                                    .AddRate("table.datashard.erase.bytes", 240048)
+                                    .AddRate("table.datashard.erase.rows", 220048)
+                                    .AddRate("table.datashard.read.bytes", 140380096)
+                                    .AddRate("table.datashard.read.rows", 60300096)
+                                    .AddGauge("table.datashard.row_count", 20048)
+                                    .AddRate("table.datashard.scan.bytes", 320048)
+                                    .AddRate("table.datashard.scan.rows", 300048)
+                                    .AddGauge("table.datashard.size_bytes", 40048)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {50, 1},
+                                            {60, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120048)
+                                    .AddRate("table.datashard.write.rows", 100048)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                        .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                        .AddRate("table.datashard.erase.bytes", 120256)
+                                        .AddRate("table.datashard.erase.rows", 110256)
+                                        .AddRate("table.datashard.read.bytes", 70190512)
+                                        .AddRate("table.datashard.read.rows", 30150512)
+                                        .AddGauge("table.datashard.row_count", 10256)
+                                        .AddRate("table.datashard.scan.bytes", 160256)
+                                        .AddRate("table.datashard.scan.rows", 150256)
+                                        .AddGauge("table.datashard.size_bytes", 20256)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60256)
+                                        .AddRate("table.datashard.write.rows", 50256)
+                                    .EndNested()
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280768)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260768)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60768)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80768)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1500768)
+                                    .AddRate("table.datashard.erase.bytes", 240768)
+                                    .AddRate("table.datashard.erase.rows", 220768)
+                                    .AddRate("table.datashard.read.bytes", 140381536)
+                                    .AddRate("table.datashard.read.rows", 60301536)
+                                    .AddGauge("table.datashard.row_count", 20768)
+                                    .AddRate("table.datashard.scan.bytes", 320768)
+                                    .AddRate("table.datashard.scan.rows", 300768)
+                                    .AddGauge("table.datashard.size_bytes", 40768)
+                                    .AddCpuHistogram(
+                                        "table.datashard.used_core_percents",
+                                        {
+                                            {80, 1},
+                                            {90, 1},
+                                        }
+                                    )
+                                    .AddRate("table.datashard.write.bytes", 120768)
+                                    .AddRate("table.datashard.write.rows", 100768)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 840819)
+                            .AddRate("table.datashard.bulk_upsert.rows", 780819)
+                            .AddRate("table.datashard.cache_hit.bytes", 180819)
+                            .AddRate("table.datashard.cache_miss.bytes", 240819)
+                            .AddRate("table.datashard.consumed_cpu_us", 2700819)
+                            .AddRate("table.datashard.erase.bytes", 720819)
+                            .AddRate("table.datashard.erase.rows", 660819)
+                            .AddRate("table.datashard.read.bytes", 421141638)
+                            .AddRate("table.datashard.read.rows", 180901638)
+                            .AddGauge("table.datashard.row_count", 60819)
+                            .AddRate("table.datashard.scan.bytes", 960819)
+                            .AddRate("table.datashard.scan.rows", 900819)
+                            .AddGauge("table.datashard.size_bytes", 120819)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {20, 1},
+                                    {30, 1},
+                                    {50, 1},
+                                    {60, 1},
+                                    {80, 1},
+                                    {90, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 360819)
+                            .AddRate("table.datashard.write.rows", 300819)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280003)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260003)
+                                .AddRate("table.datashard.cache_hit.bytes", 60003)
+                                .AddRate("table.datashard.cache_miss.bytes", 80003)
+                                .AddRate("table.datashard.consumed_cpu_us", 300003)
+                                .AddRate("table.datashard.erase.bytes", 240003)
+                                .AddRate("table.datashard.erase.rows", 220003)
+                                .AddRate("table.datashard.read.bytes", 140380006)
+                                .AddRate("table.datashard.read.rows", 60300006)
+                                .AddGauge("table.datashard.row_count", 20003)
+                                .AddRate("table.datashard.scan.bytes", 320003)
+                                .AddRate("table.datashard.scan.rows", 300003)
+                                .AddGauge("table.datashard.size_bytes", 40003)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {20, 1},
+                                        {30, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120003)
+                                .AddRate("table.datashard.write.rows", 100003)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140016)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130016)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30016)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40016)
+                                    .AddRate("table.datashard.consumed_cpu_us", 400016)
+                                    .AddRate("table.datashard.erase.bytes", 120016)
+                                    .AddRate("table.datashard.erase.rows", 110016)
+                                    .AddRate("table.datashard.read.bytes", 70190032)
+                                    .AddRate("table.datashard.read.rows", 30150032)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 160016)
+                                    .AddRate("table.datashard.scan.rows", 150016)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{50, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60016)
+                                    .AddRate("table.datashard.write.rows", 50016)
+                                .EndNested()
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280048)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260048)
+                                .AddRate("table.datashard.cache_hit.bytes", 60048)
+                                .AddRate("table.datashard.cache_miss.bytes", 80048)
+                                .AddRate("table.datashard.consumed_cpu_us", 900048)
+                                .AddRate("table.datashard.erase.bytes", 240048)
+                                .AddRate("table.datashard.erase.rows", 220048)
+                                .AddRate("table.datashard.read.bytes", 140380096)
+                                .AddRate("table.datashard.read.rows", 60300096)
+                                .AddGauge("table.datashard.row_count", 20048)
+                                .AddRate("table.datashard.scan.bytes", 320048)
+                                .AddRate("table.datashard.scan.rows", 300048)
+                                .AddGauge("table.datashard.size_bytes", 40048)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {50, 1},
+                                        {60, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120048)
+                                .AddRate("table.datashard.write.rows", 100048)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140256)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130256)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30256)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40256)
+                                    .AddRate("table.datashard.consumed_cpu_us", 700256)
+                                    .AddRate("table.datashard.erase.bytes", 120256)
+                                    .AddRate("table.datashard.erase.rows", 110256)
+                                    .AddRate("table.datashard.read.bytes", 70190512)
+                                    .AddRate("table.datashard.read.rows", 30150512)
+                                    .AddGauge("table.datashard.row_count", 10256)
+                                    .AddRate("table.datashard.scan.bytes", 160256)
+                                    .AddRate("table.datashard.scan.rows", 150256)
+                                    .AddGauge("table.datashard.size_bytes", 20256)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60256)
+                                    .AddRate("table.datashard.write.rows", 50256)
+                                .EndNested()
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280768)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260768)
+                                .AddRate("table.datashard.cache_hit.bytes", 60768)
+                                .AddRate("table.datashard.cache_miss.bytes", 80768)
+                                .AddRate("table.datashard.consumed_cpu_us", 1500768)
+                                .AddRate("table.datashard.erase.bytes", 240768)
+                                .AddRate("table.datashard.erase.rows", 220768)
+                                .AddRate("table.datashard.read.bytes", 140381536)
+                                .AddRate("table.datashard.read.rows", 60301536)
+                                .AddGauge("table.datashard.row_count", 20768)
+                                .AddRate("table.datashard.scan.bytes", 320768)
+                                .AddRate("table.datashard.scan.rows", 300768)
+                                .AddGauge("table.datashard.size_bytes", 40768)
+                                .AddCpuHistogram(
+                                    "table.datashard.used_core_percents",
+                                    {
+                                        {80, 1},
+                                        {90, 1},
+                                    }
+                                )
+                                .AddRate("table.datashard.write.bytes", 120768)
+                                .AddRate("table.datashard.write.rows", 100768)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 840819)
+                        .AddRate("table.datashard.bulk_upsert.rows", 780819)
+                        .AddRate("table.datashard.cache_hit.bytes", 180819)
+                        .AddRate("table.datashard.cache_miss.bytes", 240819)
+                        .AddRate("table.datashard.consumed_cpu_us", 2700819)
+                        .AddRate("table.datashard.erase.bytes", 720819)
+                        .AddRate("table.datashard.erase.rows", 660819)
+                        .AddRate("table.datashard.read.bytes", 421141638)
+                        .AddRate("table.datashard.read.rows", 180901638)
+                        .AddGauge("table.datashard.row_count", 60819)
+                        .AddRate("table.datashard.scan.bytes", 960819)
+                        .AddRate("table.datashard.scan.rows", 900819)
+                        .AddGauge("table.datashard.size_bytes", 120819)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {20, 1},
+                                {30, 1},
+                                {50, 1},
+                                {60, 1},
+                                {80, 1},
+                                {90, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 360819)
+                        .AddRate("table.datashard.write.rows", 300819)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for the leader for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 0);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 0);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting leaders):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "10202")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                        .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                        .AddRate("table.datashard.erase.bytes", 120032)
+                                        .AddRate("table.datashard.erase.rows", 110032)
+                                        .AddRate("table.datashard.read.bytes", 70190064)
+                                        .AddRate("table.datashard.read.rows", 30150064)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 160032)
+                                        .AddRate("table.datashard.scan.rows", 150032)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60032)
+                                        .AddRate("table.datashard.write.rows", 50032)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 420546)
+                            .AddRate("table.datashard.bulk_upsert.rows", 390546)
+                            .AddRate("table.datashard.cache_hit.bytes", 90546)
+                            .AddRate("table.datashard.cache_miss.bytes", 120546)
+                            .AddRate("table.datashard.consumed_cpu_us", 1500546)
+                            .AddRate("table.datashard.erase.bytes", 360546)
+                            .AddRate("table.datashard.erase.rows", 330546)
+                            .AddRate("table.datashard.read.bytes", 210571092)
+                            .AddRate("table.datashard.read.rows", 90451092)
+                            .AddGauge("table.datashard.row_count", 30546)
+                            .AddRate("table.datashard.scan.bytes", 480546)
+                            .AddRate("table.datashard.scan.rows", 450546)
+                            .AddGauge("table.datashard.size_bytes", 60546)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {30, 1},
+                                    {60, 1},
+                                    {90, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 180546)
+                            .AddRate("table.datashard.write.rows", 150546)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                .AddRate("table.datashard.erase.bytes", 120002)
+                                .AddRate("table.datashard.erase.rows", 110002)
+                                .AddRate("table.datashard.read.bytes", 70190004)
+                                .AddRate("table.datashard.read.rows", 30150004)
+                                .AddGauge("table.datashard.row_count", 10002)
+                                .AddRate("table.datashard.scan.bytes", 160002)
+                                .AddRate("table.datashard.scan.rows", 150002)
+                                .AddGauge("table.datashard.size_bytes", 20002)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                .AddRate("table.datashard.write.bytes", 60002)
+                                .AddRate("table.datashard.write.rows", 50002)
+                            .EndNested()
+                            .StartNested("tablet_id", "201")
+                                .StartNested("follower_id", "10201")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                    .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                    .AddRate("table.datashard.erase.bytes", 120032)
+                                    .AddRate("table.datashard.erase.rows", 110032)
+                                    .AddRate("table.datashard.read.bytes", 70190064)
+                                    .AddRate("table.datashard.read.rows", 30150064)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 160032)
+                                    .AddRate("table.datashard.scan.rows", 150032)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60032)
+                                    .AddRate("table.datashard.write.rows", 50032)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140032)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130032)
+                                .AddRate("table.datashard.cache_hit.bytes", 30032)
+                                .AddRate("table.datashard.cache_miss.bytes", 40032)
+                                .AddRate("table.datashard.consumed_cpu_us", 500032)
+                                .AddRate("table.datashard.erase.bytes", 120032)
+                                .AddRate("table.datashard.erase.rows", 110032)
+                                .AddRate("table.datashard.read.bytes", 70190064)
+                                .AddRate("table.datashard.read.rows", 30150064)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 160032)
+                                .AddRate("table.datashard.scan.rows", 150032)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{60, 1}})
+                                .AddRate("table.datashard.write.bytes", 60032)
+                                .AddRate("table.datashard.write.rows", 50032)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                .AddRate("table.datashard.erase.bytes", 120512)
+                                .AddRate("table.datashard.erase.rows", 110512)
+                                .AddRate("table.datashard.read.bytes", 70191024)
+                                .AddRate("table.datashard.read.rows", 30151024)
+                                .AddGauge("table.datashard.row_count", 10512)
+                                .AddRate("table.datashard.scan.bytes", 160512)
+                                .AddRate("table.datashard.scan.rows", 150512)
+                                .AddGauge("table.datashard.size_bytes", 20512)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 60512)
+                                .AddRate("table.datashard.write.rows", 50512)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 420546)
+                        .AddRate("table.datashard.bulk_upsert.rows", 390546)
+                        .AddRate("table.datashard.cache_hit.bytes", 90546)
+                        .AddRate("table.datashard.cache_miss.bytes", 120546)
+                        .AddRate("table.datashard.consumed_cpu_us", 1500546)
+                        .AddRate("table.datashard.erase.bytes", 360546)
+                        .AddRate("table.datashard.erase.rows", 330546)
+                        .AddRate("table.datashard.read.bytes", 210571092)
+                        .AddRate("table.datashard.read.rows", 90451092)
+                        .AddGauge("table.datashard.row_count", 30546)
+                        .AddRate("table.datashard.scan.bytes", 480546)
+                        .AddRate("table.datashard.scan.rows", 450546)
+                        .AddGauge("table.datashard.size_bytes", 60546)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {30, 1},
+                                {60, 1},
+                                {90, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 180546)
+                        .AddRate("table.datashard.write.rows", 150546)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for the second partition in each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 10201);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 10202);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting partitions):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280514)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260514)
+                            .AddRate("table.datashard.cache_hit.bytes", 60514)
+                            .AddRate("table.datashard.cache_miss.bytes", 80514)
+                            .AddRate("table.datashard.consumed_cpu_us", 1000514)
+                            .AddRate("table.datashard.erase.bytes", 240514)
+                            .AddRate("table.datashard.erase.rows", 220514)
+                            .AddRate("table.datashard.read.bytes", 140381028)
+                            .AddRate("table.datashard.read.rows", 60301028)
+                            .AddGauge("table.datashard.row_count", 20514)
+                            .AddRate("table.datashard.scan.bytes", 320514)
+                            .AddRate("table.datashard.scan.rows", 300514)
+                            .AddGauge("table.datashard.size_bytes", 40514)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {30, 1},
+                                    {90, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 120514)
+                            .AddRate("table.datashard.write.rows", 100514)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "10101")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                .AddRate("table.datashard.erase.bytes", 120002)
+                                .AddRate("table.datashard.erase.rows", 110002)
+                                .AddRate("table.datashard.read.bytes", 70190004)
+                                .AddRate("table.datashard.read.rows", 30150004)
+                                .AddGauge("table.datashard.row_count", 10002)
+                                .AddRate("table.datashard.scan.bytes", 160002)
+                                .AddRate("table.datashard.scan.rows", 150002)
+                                .AddGauge("table.datashard.size_bytes", 20002)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                .AddRate("table.datashard.write.bytes", 60002)
+                                .AddRate("table.datashard.write.rows", 50002)
+                            .EndNested()
+                            .StartNested("tablet_id", "301")
+                                .StartNested("follower_id", "10301")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                .AddRate("table.datashard.erase.bytes", 120512)
+                                .AddRate("table.datashard.erase.rows", 110512)
+                                .AddRate("table.datashard.read.bytes", 70191024)
+                                .AddRate("table.datashard.read.rows", 30151024)
+                                .AddGauge("table.datashard.row_count", 10512)
+                                .AddRate("table.datashard.scan.bytes", 160512)
+                                .AddRate("table.datashard.scan.rows", 150512)
+                                .AddGauge("table.datashard.size_bytes", 20512)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 60512)
+                                .AddRate("table.datashard.write.rows", 50512)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 280514)
+                        .AddRate("table.datashard.bulk_upsert.rows", 260514)
+                        .AddRate("table.datashard.cache_hit.bytes", 60514)
+                        .AddRate("table.datashard.cache_miss.bytes", 80514)
+                        .AddRate("table.datashard.consumed_cpu_us", 1000514)
+                        .AddRate("table.datashard.erase.bytes", 240514)
+                        .AddRate("table.datashard.erase.rows", 220514)
+                        .AddRate("table.datashard.read.bytes", 140381028)
+                        .AddRate("table.datashard.read.rows", 60301028)
+                        .AddGauge("table.datashard.row_count", 20514)
+                        .AddRate("table.datashard.scan.bytes", 320514)
+                        .AddRate("table.datashard.scan.rows", 300514)
+                        .AddGauge("table.datashard.size_bytes", 40514)
+                        .AddCpuHistogram(
+                            "table.datashard.used_core_percents",
+                            {
+                                {30, 1},
+                                {90, 1},
+                            }
+                        )
+                        .AddRate("table.datashard.write.bytes", 120514)
+                        .AddRate("table.datashard.write.rows", 100514)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 6: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 10101);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 10301);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "102")
+                                    .StartNested("follower_id", "10102")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                                .StartNested("tablet_id", "302")
+                                    .StartNested("follower_id", "10302")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                        .AddRate("table.datashard.erase.bytes", 120512)
+                                        .AddRate("table.datashard.erase.rows", 110512)
+                                        .AddRate("table.datashard.read.bytes", 70191024)
+                                        .AddRate("table.datashard.read.rows", 30151024)
+                                        .AddGauge("table.datashard.row_count", 10512)
+                                        .AddRate("table.datashard.scan.bytes", 160512)
+                                        .AddRate("table.datashard.scan.rows", 150512)
+                                        .AddGauge("table.datashard.size_bytes", 20512)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60512)
+                                        .AddRate("table.datashard.write.rows", 50512)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140512)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130512)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30512)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40512)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800512)
+                                    .AddRate("table.datashard.erase.bytes", 120512)
+                                    .AddRate("table.datashard.erase.rows", 110512)
+                                    .AddRate("table.datashard.read.bytes", 70191024)
+                                    .AddRate("table.datashard.read.rows", 30151024)
+                                    .AddGauge("table.datashard.row_count", 10512)
+                                    .AddRate("table.datashard.scan.bytes", 160512)
+                                    .AddRate("table.datashard.scan.rows", 150512)
+                                    .AddGauge("table.datashard.size_bytes", 20512)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60512)
+                                    .AddRate("table.datashard.write.rows", 50512)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280514)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260514)
+                            .AddRate("table.datashard.cache_hit.bytes", 60514)
+                            .AddRate("table.datashard.cache_miss.bytes", 80514)
+                            .AddRate("table.datashard.consumed_cpu_us", 1000514)
+                            .AddRate("table.datashard.erase.bytes", 240514)
+                            .AddRate("table.datashard.erase.rows", 220514)
+                            .AddRate("table.datashard.read.bytes", 140381028)
+                            .AddRate("table.datashard.read.rows", 60301028)
+                            .AddGauge("table.datashard.row_count", 20514)
+                            .AddRate("table.datashard.scan.bytes", 320514)
+                            .AddRate("table.datashard.scan.rows", 300514)
+                            .AddGauge("table.datashard.size_bytes", 40514)
+                            .AddCpuHistogram(
+                                "table.datashard.used_core_percents",
+                                {
+                                    {30, 1},
+                                    {90, 1},
+                                }
+                            )
+                            .AddRate("table.datashard.write.bytes", 120514)
+                            .AddRate("table.datashard.write.rows", 100514)
+                        .EndNested()
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 7: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 10102);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 10302);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @param[in] hasOldMonitoringProjectId Indicates if the current monitoring
+     *                                      project ID (to change from) is set
+     * @param[in] newMonitoringProjectId The new monitoring project ID (to change to)
+     */
+    void VerifyChangeMonitoringProjectIdOldSchemaVersion(
+        bool hasOldMonitoringProjectId,
+        const std::optional<TString>& newMonitoringProjectId
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 3 tables, one without a monitoring project ID and two with different
+        // monitoring project IDs set (all three with a single partition and a leader)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 12340001,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 10, &tableMetricsConfig1, 0x01);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 12340002,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-2"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 20, &tableMetricsConfig2, 0x02);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig3 = {
+            .TableId = 12340003,
+            .TablePath = "/Root/fake-db/fake-table3",
+            .TableSchemaVersion = 1000333,
+            .TenantDbSchemaVersion = 2000333,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-3"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 30, &tableMetricsConfig3, 0x04);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                            .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                            .AddRate("table.datashard.cache_hit.bytes", 30002)
+                            .AddRate("table.datashard.cache_miss.bytes", 40002)
+                            .AddRate("table.datashard.consumed_cpu_us", 200002)
+                            .AddRate("table.datashard.erase.bytes", 120002)
+                            .AddRate("table.datashard.erase.rows", 110002)
+                            .AddRate("table.datashard.read.bytes", 70190004)
+                            .AddRate("table.datashard.read.rows", 30150004)
+                            .AddGauge("table.datashard.row_count", 10002)
+                            .AddRate("table.datashard.scan.bytes", 160002)
+                            .AddRate("table.datashard.scan.rows", 150002)
+                            .AddGauge("table.datashard.size_bytes", 20002)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                            .AddRate("table.datashard.write.bytes", 60002)
+                            .AddRate("table.datashard.write.rows", 50002)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                        .StartNested("table", "/Root/fake-db/fake-table3")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "303")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                        .AddRate("table.datashard.erase.bytes", 120004)
+                                        .AddRate("table.datashard.erase.rows", 110004)
+                                        .AddRate("table.datashard.read.bytes", 70190008)
+                                        .AddRate("table.datashard.read.rows", 30150008)
+                                        .AddGauge("table.datashard.row_count", 10004)
+                                        .AddRate("table.datashard.scan.bytes", 160004)
+                                        .AddRate("table.datashard.scan.rows", 150004)
+                                        .AddGauge("table.datashard.size_bytes", 20004)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60004)
+                                        .AddRate("table.datashard.write.rows", 50004)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                            .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                            .AddRate("table.datashard.cache_hit.bytes", 30004)
+                            .AddRate("table.datashard.cache_miss.bytes", 40004)
+                            .AddRate("table.datashard.consumed_cpu_us", 300004)
+                            .AddRate("table.datashard.erase.bytes", 120004)
+                            .AddRate("table.datashard.erase.rows", 110004)
+                            .AddRate("table.datashard.read.bytes", 70190008)
+                            .AddRate("table.datashard.read.rows", 30150008)
+                            .AddGauge("table.datashard.row_count", 10004)
+                            .AddRate("table.datashard.scan.bytes", 160004)
+                            .AddRate("table.datashard.scan.rows", 150004)
+                            .AddGauge("table.datashard.size_bytes", 20004)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                            .AddRate("table.datashard.write.bytes", 60004)
+                            .AddRate("table.datashard.write.rows", 50004)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                .AddRate("table.datashard.erase.bytes", 120001)
+                                .AddRate("table.datashard.erase.rows", 110001)
+                                .AddRate("table.datashard.read.bytes", 70190002)
+                                .AddRate("table.datashard.read.rows", 30150002)
+                                .AddGauge("table.datashard.row_count", 10001)
+                                .AddRate("table.datashard.scan.bytes", 160001)
+                                .AddRate("table.datashard.scan.rows", 150001)
+                                .AddGauge("table.datashard.size_bytes", 20001)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                .AddRate("table.datashard.write.bytes", 60001)
+                                .AddRate("table.datashard.write.rows", 50001)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                        .AddRate("table.datashard.consumed_cpu_us", 100001)
+                        .AddRate("table.datashard.erase.bytes", 120001)
+                        .AddRate("table.datashard.erase.rows", 110001)
+                        .AddRate("table.datashard.read.bytes", 70190002)
+                        .AddRate("table.datashard.read.rows", 30150002)
+                        .AddGauge("table.datashard.row_count", 10001)
+                        .AddRate("table.datashard.scan.bytes", 160001)
+                        .AddRate("table.datashard.scan.rows", 150001)
+                        .AddGauge("table.datashard.size_bytes", 20001)
+                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                        .AddRate("table.datashard.write.bytes", 60001)
+                        .AddRate("table.datashard.write.rows", 50001)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // Try changing the monitoring project ID with an old schema version
+        if (hasOldMonitoringProjectId) {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig2 = tableMetricsConfig2;
+
+            invalidTableMetricsConfig2.TenantDbSchemaVersion = 2000221;
+            invalidTableMetricsConfig2.MonitoringProjectId = newMonitoringProjectId;
+
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &invalidTableMetricsConfig2, 0x08);
+
+            // Update the other two tables to make sure the regular updates work
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &tableMetricsConfig1, 0x10);
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        } else {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig1 = tableMetricsConfig1;
+
+            invalidTableMetricsConfig1.TenantDbSchemaVersion = 2000110;
+            invalidTableMetricsConfig1.MonitoringProjectId = newMonitoringProjectId;
+
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &invalidTableMetricsConfig1, 0x10);
+
+            // Update the other two tables to make sure the regular updates work
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &tableMetricsConfig2, 0x08);
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        }
+
+        // Verify all counters in the "ydb_detailed_raw" group - the counters should change,
+        // but the monitoring project IDs should not
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 10008)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 20008)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                            .AddRate("table.datashard.erase.bytes", 240010)
+                            .AddRate("table.datashard.erase.rows", 220010)
+                            .AddRate("table.datashard.read.bytes", 140380020)
+                            .AddRate("table.datashard.read.rows", 60300020)
+                            .AddGauge("table.datashard.row_count", 10008)
+                            .AddRate("table.datashard.scan.bytes", 320010)
+                            .AddRate("table.datashard.scan.rows", 300010)
+                            .AddGauge("table.datashard.size_bytes", 20008)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                            .AddRate("table.datashard.write.bytes", 120010)
+                            .AddRate("table.datashard.write.rows", 100010)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                        .StartNested("table", "/Root/fake-db/fake-table3")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "303")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                    .AddRate("table.datashard.erase.bytes", 240036)
+                                    .AddRate("table.datashard.erase.rows", 220036)
+                                    .AddRate("table.datashard.read.bytes", 140380072)
+                                    .AddRate("table.datashard.read.rows", 60300072)
+                                    .AddGauge("table.datashard.row_count", 10032)
+                                    .AddRate("table.datashard.scan.bytes", 320036)
+                                    .AddRate("table.datashard.scan.rows", 300036)
+                                    .AddGauge("table.datashard.size_bytes", 20032)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120036)
+                                    .AddRate("table.datashard.write.rows", 100036)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                            .AddRate("table.datashard.erase.bytes", 240036)
+                            .AddRate("table.datashard.erase.rows", 220036)
+                            .AddRate("table.datashard.read.bytes", 140380072)
+                            .AddRate("table.datashard.read.rows", 60300072)
+                            .AddGauge("table.datashard.row_count", 10032)
+                            .AddRate("table.datashard.scan.bytes", 320036)
+                            .AddRate("table.datashard.scan.rows", 300036)
+                            .AddGauge("table.datashard.size_bytes", 20032)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                            .AddRate("table.datashard.write.bytes", 120036)
+                            .AddRate("table.datashard.write.rows", 100036)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                .AddRate("table.datashard.erase.bytes", 240017)
+                                .AddRate("table.datashard.erase.rows", 220017)
+                                .AddRate("table.datashard.read.bytes", 140380034)
+                                .AddRate("table.datashard.read.rows", 60300034)
+                                .AddGauge("table.datashard.row_count", 10016)
+                                .AddRate("table.datashard.scan.bytes", 320017)
+                                .AddRate("table.datashard.scan.rows", 300017)
+                                .AddGauge("table.datashard.size_bytes", 20016)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                .AddRate("table.datashard.write.bytes", 120017)
+                                .AddRate("table.datashard.write.rows", 100017)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                        .AddRate("table.datashard.erase.bytes", 240017)
+                        .AddRate("table.datashard.erase.rows", 220017)
+                        .AddRate("table.datashard.read.bytes", 140380034)
+                        .AddRate("table.datashard.read.rows", 60300034)
+                        .AddGauge("table.datashard.row_count", 10016)
+                        .AddRate("table.datashard.scan.bytes", 320017)
+                        .AddRate("table.datashard.scan.rows", 300017)
+                        .AddGauge("table.datashard.size_bytes", 20016)
+                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                        .AddRate("table.datashard.write.bytes", 120017)
+                        .AddRate("table.datashard.write.rows", 100017)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being removed.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdRemoved) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            {} // Empty std::optional == remove the monitoring project ID
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdAddedNew) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1" // Does not match any table
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdAddedExisting) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3" // Matches table 3
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdChangedToNew) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1" // Does not match any table
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdChangedToExisting) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3" // Matches table 3
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed, if the tenant database schema version is newer than the current one.
+     *
+     * @param[in] hasOldMonitoringProjectId Indicates if the current monitoring
+     *                                      project ID (to change from) is set
+     * @param[in] newMonitoringProjectId The new monitoring project ID (to change to)
+     * @param[in] finalExectedJson The final expected JSON for all counters (after all updates)
+     */
+    void VerifyChangeMonitoringProjectIdNewSchemaVersion(
+        bool hasOldMonitoringProjectId,
+        const std::optional<TString>& newMonitoringProjectId,
+        const TString& finalExpectedJson
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 3 tables, one without a monitoring project ID and two with different
+        // monitoring project IDs set (all three with a single partition and a leader)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 12340001,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 10, &tableMetricsConfig1, 0x01);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 12340002,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-2"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 20, &tableMetricsConfig2, 0x02);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig3 = {
+            .TableId = 12340003,
+            .TablePath = "/Root/fake-db/fake-table3",
+            .TableSchemaVersion = 1000333,
+            .TenantDbSchemaVersion = 2000333,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-3"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 30, &tableMetricsConfig3, 0x04);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                        .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                        .AddRate("table.datashard.erase.bytes", 120002)
+                                        .AddRate("table.datashard.erase.rows", 110002)
+                                        .AddRate("table.datashard.read.bytes", 70190004)
+                                        .AddRate("table.datashard.read.rows", 30150004)
+                                        .AddGauge("table.datashard.row_count", 10002)
+                                        .AddRate("table.datashard.scan.bytes", 160002)
+                                        .AddRate("table.datashard.scan.rows", 150002)
+                                        .AddGauge("table.datashard.size_bytes", 20002)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60002)
+                                        .AddRate("table.datashard.write.rows", 50002)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30002)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40002)
+                                    .AddRate("table.datashard.consumed_cpu_us", 200002)
+                                    .AddRate("table.datashard.erase.bytes", 120002)
+                                    .AddRate("table.datashard.erase.rows", 110002)
+                                    .AddRate("table.datashard.read.bytes", 70190004)
+                                    .AddRate("table.datashard.read.rows", 30150004)
+                                    .AddGauge("table.datashard.row_count", 10002)
+                                    .AddRate("table.datashard.scan.bytes", 160002)
+                                    .AddRate("table.datashard.scan.rows", 150002)
+                                    .AddGauge("table.datashard.size_bytes", 20002)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60002)
+                                    .AddRate("table.datashard.write.rows", 50002)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 140002)
+                            .AddRate("table.datashard.bulk_upsert.rows", 130002)
+                            .AddRate("table.datashard.cache_hit.bytes", 30002)
+                            .AddRate("table.datashard.cache_miss.bytes", 40002)
+                            .AddRate("table.datashard.consumed_cpu_us", 200002)
+                            .AddRate("table.datashard.erase.bytes", 120002)
+                            .AddRate("table.datashard.erase.rows", 110002)
+                            .AddRate("table.datashard.read.bytes", 70190004)
+                            .AddRate("table.datashard.read.rows", 30150004)
+                            .AddGauge("table.datashard.row_count", 10002)
+                            .AddRate("table.datashard.scan.bytes", 160002)
+                            .AddRate("table.datashard.scan.rows", 150002)
+                            .AddGauge("table.datashard.size_bytes", 20002)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}})
+                            .AddRate("table.datashard.write.bytes", 60002)
+                            .AddRate("table.datashard.write.rows", 50002)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                        .StartNested("table", "/Root/fake-db/fake-table3")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "303")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                        .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                        .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                        .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                        .AddRate("table.datashard.erase.bytes", 120004)
+                                        .AddRate("table.datashard.erase.rows", 110004)
+                                        .AddRate("table.datashard.read.bytes", 70190008)
+                                        .AddRate("table.datashard.read.rows", 30150008)
+                                        .AddGauge("table.datashard.row_count", 10004)
+                                        .AddRate("table.datashard.scan.bytes", 160004)
+                                        .AddRate("table.datashard.scan.rows", 150004)
+                                        .AddGauge("table.datashard.size_bytes", 20004)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                        .AddRate("table.datashard.write.bytes", 60004)
+                                        .AddRate("table.datashard.write.rows", 50004)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30004)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40004)
+                                    .AddRate("table.datashard.consumed_cpu_us", 300004)
+                                    .AddRate("table.datashard.erase.bytes", 120004)
+                                    .AddRate("table.datashard.erase.rows", 110004)
+                                    .AddRate("table.datashard.read.bytes", 70190008)
+                                    .AddRate("table.datashard.read.rows", 30150008)
+                                    .AddGauge("table.datashard.row_count", 10004)
+                                    .AddRate("table.datashard.scan.bytes", 160004)
+                                    .AddRate("table.datashard.scan.rows", 150004)
+                                    .AddGauge("table.datashard.size_bytes", 20004)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60004)
+                                    .AddRate("table.datashard.write.rows", 50004)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 140004)
+                            .AddRate("table.datashard.bulk_upsert.rows", 130004)
+                            .AddRate("table.datashard.cache_hit.bytes", 30004)
+                            .AddRate("table.datashard.cache_miss.bytes", 40004)
+                            .AddRate("table.datashard.consumed_cpu_us", 300004)
+                            .AddRate("table.datashard.erase.bytes", 120004)
+                            .AddRate("table.datashard.erase.rows", 110004)
+                            .AddRate("table.datashard.read.bytes", 70190008)
+                            .AddRate("table.datashard.read.rows", 30150008)
+                            .AddGauge("table.datashard.row_count", 10004)
+                            .AddRate("table.datashard.scan.bytes", 160004)
+                            .AddRate("table.datashard.scan.rows", 150004)
+                            .AddGauge("table.datashard.size_bytes", 20004)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{40, 1}})
+                            .AddRate("table.datashard.write.bytes", 60004)
+                            .AddRate("table.datashard.write.rows", 50004)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .StartNested("detailed_metrics", "per_partition")
+                            .StartNested("tablet_id", "101")
+                                .StartNested("follower_id", "0")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                    .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                    .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                    .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                    .AddRate("table.datashard.erase.bytes", 120001)
+                                    .AddRate("table.datashard.erase.rows", 110001)
+                                    .AddRate("table.datashard.read.bytes", 70190002)
+                                    .AddRate("table.datashard.read.rows", 30150002)
+                                    .AddGauge("table.datashard.row_count", 10001)
+                                    .AddRate("table.datashard.scan.bytes", 160001)
+                                    .AddRate("table.datashard.scan.rows", 150001)
+                                    .AddGauge("table.datashard.size_bytes", 20001)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                    .AddRate("table.datashard.write.bytes", 60001)
+                                    .AddRate("table.datashard.write.rows", 50001)
+                                .EndNested()
+                                .StartNested("follower_id", "replicas_only")
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                    .AddRate("table.datashard.cache_hit.bytes", 0)
+                                    .AddRate("table.datashard.cache_miss.bytes", 0)
+                                    .AddRate("table.datashard.consumed_cpu_us", 0)
+                                    .AddRate("table.datashard.erase.bytes", 0)
+                                    .AddRate("table.datashard.erase.rows", 0)
+                                    .AddRate("table.datashard.read.bytes", 0)
+                                    .AddRate("table.datashard.read.rows", 0)
+                                    .AddGauge("table.datashard.row_count", 0)
+                                    .AddRate("table.datashard.scan.bytes", 0)
+                                    .AddRate("table.datashard.scan.rows", 0)
+                                    .AddGauge("table.datashard.size_bytes", 0)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                    .AddRate("table.datashard.write.bytes", 0)
+                                    .AddRate("table.datashard.write.rows", 0)
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                                .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                                .AddRate("table.datashard.cache_hit.bytes", 30001)
+                                .AddRate("table.datashard.cache_miss.bytes", 40001)
+                                .AddRate("table.datashard.consumed_cpu_us", 100001)
+                                .AddRate("table.datashard.erase.bytes", 120001)
+                                .AddRate("table.datashard.erase.rows", 110001)
+                                .AddRate("table.datashard.read.bytes", 70190002)
+                                .AddRate("table.datashard.read.rows", 30150002)
+                                .AddGauge("table.datashard.row_count", 10001)
+                                .AddRate("table.datashard.scan.bytes", 160001)
+                                .AddRate("table.datashard.scan.rows", 150001)
+                                .AddGauge("table.datashard.size_bytes", 20001)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                                .AddRate("table.datashard.write.bytes", 60001)
+                                .AddRate("table.datashard.write.rows", 50001)
+                            .EndNested()
+                        .EndNested()
+                        .AddRate("table.datashard.bulk_upsert.bytes", 140001)
+                        .AddRate("table.datashard.bulk_upsert.rows", 130001)
+                        .AddRate("table.datashard.cache_hit.bytes", 30001)
+                        .AddRate("table.datashard.cache_miss.bytes", 40001)
+                        .AddRate("table.datashard.consumed_cpu_us", 100001)
+                        .AddRate("table.datashard.erase.bytes", 120001)
+                        .AddRate("table.datashard.erase.rows", 110001)
+                        .AddRate("table.datashard.read.bytes", 70190002)
+                        .AddRate("table.datashard.read.rows", 30150002)
+                        .AddGauge("table.datashard.row_count", 10001)
+                        .AddRate("table.datashard.scan.bytes", 160001)
+                        .AddRate("table.datashard.scan.rows", 150001)
+                        .AddGauge("table.datashard.size_bytes", 20001)
+                        .AddCpuHistogram("table.datashard.used_core_percents", {{20, 1}})
+                        .AddRate("table.datashard.write.bytes", 60001)
+                        .AddRate("table.datashard.write.rows", 50001)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // Try changing the monitoring project ID with a new schema version
+        if (hasOldMonitoringProjectId) {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig2 = tableMetricsConfig2;
+
+            invalidTableMetricsConfig2.TenantDbSchemaVersion = 2000223;
+            invalidTableMetricsConfig2.MonitoringProjectId = newMonitoringProjectId;
+
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &invalidTableMetricsConfig2, 0x08);
+
+            // Update the other two tables to make sure the regular updates work
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &tableMetricsConfig1, 0x10);
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        } else {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig1 = tableMetricsConfig1;
+
+            invalidTableMetricsConfig1.TenantDbSchemaVersion = 2000112;
+            invalidTableMetricsConfig1.MonitoringProjectId = newMonitoringProjectId;
+
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &invalidTableMetricsConfig1, 0x10);
+
+            // Update the other two tables to make sure the regular updates work
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &tableMetricsConfig2, 0x08);
+            SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        }
+
+        // Verify all counters in the "ydb_detailed_raw" group - the counters should change,
+        // but the monitoring project IDs should not
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            finalExpectedJson,
+            "Expected JSON:" << Endl << finalExpectedJson
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being removed.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdRemoved) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            {}, // Empty std::optional == remove the monitoring project ID
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "101")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                            .AddRate("table.datashard.erase.bytes", 240017)
+                            .AddRate("table.datashard.erase.rows", 220017)
+                            .AddRate("table.datashard.read.bytes", 140380034)
+                            .AddRate("table.datashard.read.rows", 60300034)
+                            .AddGauge("table.datashard.row_count", 10016)
+                            .AddRate("table.datashard.scan.bytes", 320017)
+                            .AddRate("table.datashard.scan.rows", 300017)
+                            .AddGauge("table.datashard.size_bytes", 20016)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                            .AddRate("table.datashard.write.bytes", 120017)
+                            .AddRate("table.datashard.write.rows", 100017)
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "202")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                    .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                    .AddRate("table.datashard.erase.bytes", 240010)
+                                    .AddRate("table.datashard.erase.rows", 220010)
+                                    .AddRate("table.datashard.read.bytes", 140380020)
+                                    .AddRate("table.datashard.read.rows", 60300020)
+                                    .AddGauge("table.datashard.row_count", 10008)
+                                    .AddRate("table.datashard.scan.bytes", 320010)
+                                    .AddRate("table.datashard.scan.rows", 300010)
+                                    .AddGauge("table.datashard.size_bytes", 20008)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120010)
+                                    .AddRate("table.datashard.write.rows", 100010)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                            .AddRate("table.datashard.erase.bytes", 240010)
+                            .AddRate("table.datashard.erase.rows", 220010)
+                            .AddRate("table.datashard.read.bytes", 140380020)
+                            .AddRate("table.datashard.read.rows", 60300020)
+                            .AddGauge("table.datashard.row_count", 10008)
+                            .AddRate("table.datashard.scan.bytes", 320010)
+                            .AddRate("table.datashard.scan.rows", 300010)
+                            .AddGauge("table.datashard.size_bytes", 20008)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                            .AddRate("table.datashard.write.bytes", 120010)
+                            .AddRate("table.datashard.write.rows", 100010)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdAddedNew) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1", // Does not match any table
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-1")
+                            .StartNested("table", "/Root/fake-db/fake-table1")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "101")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                            .AddRate("table.datashard.erase.bytes", 240017)
+                                            .AddRate("table.datashard.erase.rows", 220017)
+                                            .AddRate("table.datashard.read.bytes", 140380034)
+                                            .AddRate("table.datashard.read.rows", 60300034)
+                                            .AddGauge("table.datashard.row_count", 10016)
+                                            .AddRate("table.datashard.scan.bytes", 320017)
+                                            .AddRate("table.datashard.scan.rows", 300017)
+                                            .AddGauge("table.datashard.size_bytes", 20016)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120017)
+                                            .AddRate("table.datashard.write.rows", 100017)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                .AddRate("table.datashard.erase.bytes", 240017)
+                                .AddRate("table.datashard.erase.rows", 220017)
+                                .AddRate("table.datashard.read.bytes", 140380034)
+                                .AddRate("table.datashard.read.rows", 60300034)
+                                .AddGauge("table.datashard.row_count", 10016)
+                                .AddRate("table.datashard.scan.bytes", 320017)
+                                .AddRate("table.datashard.scan.rows", 300017)
+                                .AddGauge("table.datashard.size_bytes", 20016)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                .AddRate("table.datashard.write.bytes", 120017)
+                                .AddRate("table.datashard.write.rows", 100017)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdAddedExisting) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3", // Matches table 3
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table1")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "101")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                            .AddRate("table.datashard.erase.bytes", 240017)
+                                            .AddRate("table.datashard.erase.rows", 220017)
+                                            .AddRate("table.datashard.read.bytes", 140380034)
+                                            .AddRate("table.datashard.read.rows", 60300034)
+                                            .AddGauge("table.datashard.row_count", 10016)
+                                            .AddRate("table.datashard.scan.bytes", 320017)
+                                            .AddRate("table.datashard.scan.rows", 300017)
+                                            .AddGauge("table.datashard.size_bytes", 20016)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120017)
+                                            .AddRate("table.datashard.write.rows", 100017)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                .AddRate("table.datashard.erase.bytes", 240017)
+                                .AddRate("table.datashard.erase.rows", 220017)
+                                .AddRate("table.datashard.read.bytes", 140380034)
+                                .AddRate("table.datashard.read.rows", 60300034)
+                                .AddGauge("table.datashard.row_count", 10016)
+                                .AddRate("table.datashard.scan.bytes", 320017)
+                                .AddRate("table.datashard.scan.rows", 300017)
+                                .AddGauge("table.datashard.size_bytes", 20016)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                .AddRate("table.datashard.write.bytes", 120017)
+                                .AddRate("table.datashard.write.rows", 100017)
+                            .EndNested()
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdChangedToNew) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1", // Does not match any table
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-1")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "101")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                            .AddRate("table.datashard.erase.bytes", 240017)
+                            .AddRate("table.datashard.erase.rows", 220017)
+                            .AddRate("table.datashard.read.bytes", 140380034)
+                            .AddRate("table.datashard.read.rows", 60300034)
+                            .AddGauge("table.datashard.row_count", 10016)
+                            .AddRate("table.datashard.scan.bytes", 320017)
+                            .AddRate("table.datashard.scan.rows", 300017)
+                            .AddGauge("table.datashard.size_bytes", 20016)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                            .AddRate("table.datashard.write.bytes", 120017)
+                            .AddRate("table.datashard.write.rows", 100017)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdChangedToExisting) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3", // Matches table 3
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "101")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                            .AddRate("table.datashard.erase.bytes", 240017)
+                            .AddRate("table.datashard.erase.rows", 220017)
+                            .AddRate("table.datashard.read.bytes", 140380034)
+                            .AddRate("table.datashard.read.rows", 60300034)
+                            .AddGauge("table.datashard.row_count", 10016)
+                            .AddRate("table.datashard.scan.bytes", 320017)
+                            .AddRate("table.datashard.scan.rows", 300017)
+                            .AddGauge("table.datashard.size_bytes", 20016)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                            .AddRate("table.datashard.write.bytes", 120017)
+                            .AddRate("table.datashard.write.rows", 100017)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is not changed
+     *       at all (was not set before) even though the tenant database schema version
+     *       is increased.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdNotChangedUnset) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            {}, // Empty std::optional == unset monitoring project ID (the current value)
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "101")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                            .AddRate("table.datashard.erase.bytes", 240017)
+                            .AddRate("table.datashard.erase.rows", 220017)
+                            .AddRate("table.datashard.read.bytes", 140380034)
+                            .AddRate("table.datashard.read.rows", 60300034)
+                            .AddGauge("table.datashard.row_count", 10016)
+                            .AddRate("table.datashard.scan.bytes", 320017)
+                            .AddRate("table.datashard.scan.rows", 300017)
+                            .AddGauge("table.datashard.size_bytes", 20016)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                            .AddRate("table.datashard.write.bytes", 120017)
+                            .AddRate("table.datashard.write.rows", 100017)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is not changed
+     *       at all (was set before) even though the tenant database schema version
+     *       is increased.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdNotChangedSet) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-2", // Matches table 2 (the current value)
+            NormalizeJson(
+                TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "202")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                            .AddRate("table.datashard.erase.bytes", 240010)
+                                            .AddRate("table.datashard.erase.rows", 220010)
+                                            .AddRate("table.datashard.read.bytes", 140380020)
+                                            .AddRate("table.datashard.read.rows", 60300020)
+                                            .AddGauge("table.datashard.row_count", 10008)
+                                            .AddRate("table.datashard.scan.bytes", 320010)
+                                            .AddRate("table.datashard.scan.rows", 300010)
+                                            .AddGauge("table.datashard.size_bytes", 20008)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120010)
+                                            .AddRate("table.datashard.write.rows", 100010)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                        .AddRate("table.datashard.erase.bytes", 240010)
+                                        .AddRate("table.datashard.erase.rows", 220010)
+                                        .AddRate("table.datashard.read.bytes", 140380020)
+                                        .AddRate("table.datashard.read.rows", 60300020)
+                                        .AddGauge("table.datashard.row_count", 10008)
+                                        .AddRate("table.datashard.scan.bytes", 320010)
+                                        .AddRate("table.datashard.scan.rows", 300010)
+                                        .AddGauge("table.datashard.size_bytes", 20008)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120010)
+                                        .AddRate("table.datashard.write.rows", 100010)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280010)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260010)
+                                .AddRate("table.datashard.cache_hit.bytes", 60010)
+                                .AddRate("table.datashard.cache_miss.bytes", 80010)
+                                .AddRate("table.datashard.consumed_cpu_us", 1000010)
+                                .AddRate("table.datashard.erase.bytes", 240010)
+                                .AddRate("table.datashard.erase.rows", 220010)
+                                .AddRate("table.datashard.read.bytes", 140380020)
+                                .AddRate("table.datashard.read.rows", 60300020)
+                                .AddGauge("table.datashard.row_count", 10008)
+                                .AddRate("table.datashard.scan.bytes", 320010)
+                                .AddRate("table.datashard.scan.rows", 300010)
+                                .AddGauge("table.datashard.size_bytes", 20008)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{90, 1}})
+                                .AddRate("table.datashard.write.bytes", 120010)
+                                .AddRate("table.datashard.write.rows", 100010)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .StartNested("detailed_metrics", "per_partition")
+                                    .StartNested("tablet_id", "303")
+                                        .StartNested("follower_id", "0")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                            .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                            .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                            .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                            .AddRate("table.datashard.erase.bytes", 240036)
+                                            .AddRate("table.datashard.erase.rows", 220036)
+                                            .AddRate("table.datashard.read.bytes", 140380072)
+                                            .AddRate("table.datashard.read.rows", 60300072)
+                                            .AddGauge("table.datashard.row_count", 10032)
+                                            .AddRate("table.datashard.scan.bytes", 320036)
+                                            .AddRate("table.datashard.scan.rows", 300036)
+                                            .AddGauge("table.datashard.size_bytes", 20032)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                            .AddRate("table.datashard.write.bytes", 120036)
+                                            .AddRate("table.datashard.write.rows", 100036)
+                                        .EndNested()
+                                        .StartNested("follower_id", "replicas_only")
+                                            .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                            .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                            .AddRate("table.datashard.cache_hit.bytes", 0)
+                                            .AddRate("table.datashard.cache_miss.bytes", 0)
+                                            .AddRate("table.datashard.consumed_cpu_us", 0)
+                                            .AddRate("table.datashard.erase.bytes", 0)
+                                            .AddRate("table.datashard.erase.rows", 0)
+                                            .AddRate("table.datashard.read.bytes", 0)
+                                            .AddRate("table.datashard.read.rows", 0)
+                                            .AddGauge("table.datashard.row_count", 0)
+                                            .AddRate("table.datashard.scan.bytes", 0)
+                                            .AddRate("table.datashard.scan.rows", 0)
+                                            .AddGauge("table.datashard.size_bytes", 0)
+                                            .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                            .AddRate("table.datashard.write.bytes", 0)
+                                            .AddRate("table.datashard.write.rows", 0)
+                                        .EndNested()
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                        .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                        .AddRate("table.datashard.erase.bytes", 240036)
+                                        .AddRate("table.datashard.erase.rows", 220036)
+                                        .AddRate("table.datashard.read.bytes", 140380072)
+                                        .AddRate("table.datashard.read.rows", 60300072)
+                                        .AddGauge("table.datashard.row_count", 10032)
+                                        .AddRate("table.datashard.scan.bytes", 320036)
+                                        .AddRate("table.datashard.scan.rows", 300036)
+                                        .AddGauge("table.datashard.size_bytes", 20032)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120036)
+                                        .AddRate("table.datashard.write.rows", 100036)
+                                    .EndNested()
+                                .EndNested()
+                                .AddRate("table.datashard.bulk_upsert.bytes", 280036)
+                                .AddRate("table.datashard.bulk_upsert.rows", 260036)
+                                .AddRate("table.datashard.cache_hit.bytes", 60036)
+                                .AddRate("table.datashard.cache_miss.bytes", 80036)
+                                .AddRate("table.datashard.consumed_cpu_us", 1200036)
+                                .AddRate("table.datashard.erase.bytes", 240036)
+                                .AddRate("table.datashard.erase.rows", 220036)
+                                .AddRate("table.datashard.read.bytes", 140380072)
+                                .AddRate("table.datashard.read.rows", 60300072)
+                                .AddGauge("table.datashard.row_count", 10032)
+                                .AddRate("table.datashard.scan.bytes", 320036)
+                                .AddRate("table.datashard.scan.rows", 300036)
+                                .AddGauge("table.datashard.size_bytes", 20032)
+                                .AddCpuHistogram("table.datashard.used_core_percents", {{100, 1}})
+                                .AddRate("table.datashard.write.bytes", 120036)
+                                .AddRate("table.datashard.write.rows", 100036)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "101")
+                                    .StartNested("follower_id", "0")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                        .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                        .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                        .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                        .AddRate("table.datashard.erase.bytes", 240017)
+                                        .AddRate("table.datashard.erase.rows", 220017)
+                                        .AddRate("table.datashard.read.bytes", 140380034)
+                                        .AddRate("table.datashard.read.rows", 60300034)
+                                        .AddGauge("table.datashard.row_count", 10016)
+                                        .AddRate("table.datashard.scan.bytes", 320017)
+                                        .AddRate("table.datashard.scan.rows", 300017)
+                                        .AddGauge("table.datashard.size_bytes", 20016)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                        .AddRate("table.datashard.write.bytes", 120017)
+                                        .AddRate("table.datashard.write.rows", 100017)
+                                    .EndNested()
+                                    .StartNested("follower_id", "replicas_only")
+                                        .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                                        .AddRate("table.datashard.bulk_upsert.rows", 0)
+                                        .AddRate("table.datashard.cache_hit.bytes", 0)
+                                        .AddRate("table.datashard.cache_miss.bytes", 0)
+                                        .AddRate("table.datashard.consumed_cpu_us", 0)
+                                        .AddRate("table.datashard.erase.bytes", 0)
+                                        .AddRate("table.datashard.erase.rows", 0)
+                                        .AddRate("table.datashard.read.bytes", 0)
+                                        .AddRate("table.datashard.read.rows", 0)
+                                        .AddGauge("table.datashard.row_count", 0)
+                                        .AddRate("table.datashard.scan.bytes", 0)
+                                        .AddRate("table.datashard.scan.rows", 0)
+                                        .AddGauge("table.datashard.size_bytes", 0)
+                                        .AddCpuHistogram("table.datashard.used_core_percents", {})
+                                        .AddRate("table.datashard.write.bytes", 0)
+                                        .AddRate("table.datashard.write.rows", 0)
+                                    .EndNested()
+                                    .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                                    .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                                    .AddRate("table.datashard.cache_hit.bytes", 60017)
+                                    .AddRate("table.datashard.cache_miss.bytes", 80017)
+                                    .AddRate("table.datashard.consumed_cpu_us", 800017)
+                                    .AddRate("table.datashard.erase.bytes", 240017)
+                                    .AddRate("table.datashard.erase.rows", 220017)
+                                    .AddRate("table.datashard.read.bytes", 140380034)
+                                    .AddRate("table.datashard.read.rows", 60300034)
+                                    .AddGauge("table.datashard.row_count", 10016)
+                                    .AddRate("table.datashard.scan.bytes", 320017)
+                                    .AddRate("table.datashard.scan.rows", 300017)
+                                    .AddGauge("table.datashard.size_bytes", 20016)
+                                    .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                                    .AddRate("table.datashard.write.bytes", 120017)
+                                    .AddRate("table.datashard.write.rows", 100017)
+                                .EndNested()
+                            .EndNested()
+                            .AddRate("table.datashard.bulk_upsert.bytes", 280017)
+                            .AddRate("table.datashard.bulk_upsert.rows", 260017)
+                            .AddRate("table.datashard.cache_hit.bytes", 60017)
+                            .AddRate("table.datashard.cache_miss.bytes", 80017)
+                            .AddRate("table.datashard.consumed_cpu_us", 800017)
+                            .AddRate("table.datashard.erase.bytes", 240017)
+                            .AddRate("table.datashard.erase.rows", 220017)
+                            .AddRate("table.datashard.read.bytes", 140380034)
+                            .AddRate("table.datashard.read.rows", 60300034)
+                            .AddGauge("table.datashard.row_count", 10016)
+                            .AddRate("table.datashard.scan.bytes", 320017)
+                            .AddRate("table.datashard.scan.rows", 300017)
+                            .AddGauge("table.datashard.size_bytes", 20016)
+                            .AddCpuHistogram("table.datashard.used_core_percents", {{80, 1}})
+                            .AddRate("table.datashard.write.bytes", 120017)
+                            .AddRate("table.datashard.write.rows", 100017)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson()
+            )
+        );
+    }
+}

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
@@ -61,16 +61,15 @@ TString NormalizeJson(
     );
 }
 
-/**
- * Create and initialize the Tablet Counters Aggregator actor.
- *
- * @param[in] runtime The test runtime
- *
- * @return The ID of the Tablet Counters Aggregator actor
- */
-TActorId InitializeTabletCountersAggregator(TTestBasicRuntime& runtime, bool forFollowers) {
-    // Enable the per-database counters in the Tablet Counters Aggregator
+TActorId InitializeTabletCountersAggregator(
+    TTestBasicRuntime& runtime,
+    bool forFollowers,
+    bool enableDetailedMetrics
+) {
+    // NOTE: Enable the per-database counters in the Tablet Counters Aggregator
+    //       (required to use detailed metrics)
     runtime.GetAppData().FeatureFlags.SetEnableDbCounters(true);
+    runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
     // Register the Tablet Counters Aggregator actor
     TActorId aggregatorId = runtime.Register(CreateTabletCountersAggregator(forFollowers));

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
@@ -1,18 +1,49 @@
 #include "ut_helpers.h"
 
+#include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/tablet/tablet_counters_app.h>
+#include <ydb/core/tablet_flat/flat_executor_counters.h>
+#include <ydb/core/testlib/basics/appdata.h>
+
 #include <library/cpp/json/json_prettifier.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
-
 #include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+using namespace NKikimr::NTabletFlatExecutor;
 
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {
 
-TString NormalizeJson(const TString& jsonString) {
+TString NormalizeJson(
+    const TString& jsonString,
+    const std::unordered_map<TString, std::unordered_set<TString>>& removeSensorsByLabels
+) {
     NJson::TJsonValue parsedJson;
     UNIT_ASSERT(NJson::ReadJsonTree(TStringBuf(jsonString), &parsedJson));
+
+    // Filter some sensors, if requested
+    if (!removeSensorsByLabels.empty()) {
+        auto& sensorsArray = parsedJson["sensors"];
+
+        for (size_t i = 0; i < sensorsArray.GetArraySafe().size(); ++i) {
+            for (const auto& [labelName, labelValue] : sensorsArray[i]["labels"].GetMapSafe()) {
+                auto labelIt = removeSensorsByLabels.find(labelName);
+
+                if (labelIt != removeSensorsByLabels.end()) {
+                    if (labelIt->second.contains(labelValue.GetStringSafe())) {
+                        // This sensor should be excluded
+                        sensorsArray.EraseValue(i);
+                        --i; // To process the next element
+
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
     // NOTE: The prettifier is needed here to make sure all brackets (both [] and {})
     //       are aligned "Python style" with the opening bracket placed on the starting line.
@@ -27,6 +58,149 @@ TString NormalizeJson(const TString& jsonString) {
         ),
         false /* unquote */,
         2 /* padding */
+    );
+}
+
+/**
+ * Create and initialize the Tablet Counters Aggregator actor.
+ *
+ * @param[in] runtime The test runtime
+ *
+ * @return The ID of the Tablet Counters Aggregator actor
+ */
+TActorId InitializeTabletCountersAggregator(TTestBasicRuntime& runtime, bool forFollowers) {
+    // Enable the per-database counters in the Tablet Counters Aggregator
+    runtime.GetAppData().FeatureFlags.SetEnableDbCounters(true);
+
+    // Register the Tablet Counters Aggregator actor
+    TActorId aggregatorId = runtime.Register(CreateTabletCountersAggregator(forFollowers));
+    runtime.EnableScheduleForActor(aggregatorId);
+
+    // Wait for the TEvBootstrap event to be processed, after this the actor is ready
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
+
+    runtime.DispatchEvents(options);
+    return aggregatorId;
+}
+
+void SendDataShardMetrics(
+    TTestBasicRuntime& runtime,
+    const TActorId& aggregatorId,
+    const TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId,
+    ui32 cpuLoadPercentage,
+    TEvTabletCounters::TTableMetricsConfig* tableMetricsConfig,
+    std::optional<ui64> metricsOffset
+) {
+    // Use the tablet ID as the default metrics offset
+    if (!metricsOffset) {
+        metricsOffset = tabletId;
+    }
+
+    // Populate executor counters with some fake values
+    auto executorCounters = MakeHolder<TExecutorCounters>();
+    auto executorCountersBaseline = MakeHolder<TExecutorCounters>();
+
+    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
+
+    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_ROWS_TOTAL] = 10000 + (*metricsOffset);
+    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_DATA_BYTES] = 20000 + (*metricsOffset);
+
+    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(30000 + (*metricsOffset));
+    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(40000 + (*metricsOffset));
+
+    // Populate DataShard counters with some fake values
+    auto tabletCounters = CreateAppCountersByTabletType(TTabletTypes::DataShard);
+    auto tabletCountersBaseline = CreateAppCountersByTabletType(TTabletTypes::DataShard);
+
+    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
+
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW].Increment(50000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW_BYTES].Increment(60000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW].Increment(10070000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_ROWS].Increment(20080000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW_BYTES].Increment(30090000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_BYTES].Increment(40100000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW].Increment(110000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW_BYTES].Increment(120000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS].Increment(130000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS_BYTES].Increment(140000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_ROWS].Increment(150000 + (*metricsOffset));
+    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_BYTES].Increment(160000 + (*metricsOffset));
+
+    // Send these counters to the Tablet Counters Aggregator
+    runtime.Send(
+        new IEventHandle(
+            aggregatorId,
+            edgeActorId,
+            new TEvTabletCounters::TEvTabletAddCounters(
+                new TEvTabletCounters::TInFlightCookie(),
+                tabletId,
+                followerId,
+                TTabletTypes::DataShard,
+                TPathId(1113, 1001),
+                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
+                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline),
+                tableMetricsConfig
+            )
+        )
+    );
+
+    // NOTE: Tablet Counters Aggregator automatically differentiates cumulative
+    //       counters and uses the differential to update the associated histograms
+    //       (if present). It uses the time between consecutive TEvTabletAddCounters
+    //       messages (per tablet ID) to calculate the differential.
+    //
+    //       The code here sends the main update with all counters as needed,
+    //       but the CPU consumption value is set to zero. Then the time is moved
+    //       forward by exactly 1 second and a new update is sent with only
+    //       the CPU consumption value.
+    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
+    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
+
+    executorCounters->Cumulative()[TExecutorCounters::CONSUMED_CPU].Increment(
+        cpuLoadPercentage * 10000 + (*metricsOffset)
+    );
+
+    runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+    runtime.Send(
+        new IEventHandle(
+            aggregatorId,
+            edgeActorId,
+            new TEvTabletCounters::TEvTabletAddCounters(
+                new TEvTabletCounters::TInFlightCookie(),
+                tabletId,
+                followerId,
+                TTabletTypes::DataShard,
+                TPathId(1113, 1001),
+                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
+                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline),
+                tableMetricsConfig
+            )
+        )
+    );
+}
+
+void SendForgetDataShardTablet(
+    NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId
+) {
+    runtime.Send(
+        new IEventHandle(
+            aggregatorId,
+            edgeActorId,
+            new TEvTabletCounters::TEvTabletCountersForgetTablet(
+                tabletId,
+                followerId,
+                TTabletTypes::DataShard,
+                TPathId(1113, 1001)
+            )
+        )
     );
 }
 

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.h
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.h
@@ -5,6 +5,10 @@
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/testlib/basics/runtime.h>
 
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.h
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.h
@@ -2,6 +2,9 @@
 
 #include <util/generic/string.h>
 
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {
@@ -16,10 +19,75 @@ namespace NDetailedMetricsTests {
  *          to compare sensor arrays directly without sorting them.
  *
  * @param[in] jsonString The JSON to normalize (as a string)
+ * @param[in] removeSensorsByLabels If specified, sensors with the given labels are removed
+ *                                  from the given JSON (the key is the label name,
+ *                                  the value is the set of label values to remove)
  *
  * @return The corresponding normalized JSON
  */
-TString NormalizeJson(const TString& jsonString);
+TString NormalizeJson(
+    const TString& jsonString,
+    const std::unordered_map<TString, std::unordered_set<TString>>& removeSensorsByLabels = {}
+);
+
+/**
+ * Create and initialize the Tablet Counters Aggregator actor.
+ *
+ * @param[in] runtime The test runtime
+ * @param[in] forFollowers Indicates if the aggregator should process leaders or followers data
+ *
+ * @return The ID of the Tablet Counters Aggregator actor
+ */
+NActors::TActorId InitializeTabletCountersAggregator(
+    NActors::TTestBasicRuntime& runtime,
+    bool forFollowers
+);
+
+/**
+ * Send low level metrics to the Tablet Counters Aggregator for the given DataShard tablet.
+ *
+ * @note This function generates all metric values with an offset of 10000.
+ *       The lower 3 digits are supposed to be used for tablet IDs. For example,
+ *       using non-overlapping values like 1, 20, 300 allows tests to verify
+ *       that metric values from different tablet IDs are correctly aggregated
+ *       correctly (1 + 20 + 300 = 123).
+ *
+ * @param[in] runtime The test runtime
+ * @param[in] aggregatorId The ID of the Tablet Counters Aggregator actor
+ * @param[in] edgeActorId The ID of the edge actor used for sending all messages
+ * @param[in] tabletId The ID of the DataShard tablet to send the metrics for
+ * @param[in] followerId The ID of the follower to send the metrics for
+ * @param[in] cpuLoadPercentage The CPU load percentage to report for this tablet
+ * @param[in] tableMetricsConfig The metrics configuration for the table (if needed)
+ * @param[in] metricsOffset The offset for all metrics values (if not set, tabletId is used)
+ */
+void SendDataShardMetrics(
+    NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId,
+    ui32 cpuLoadPercentage,
+    TEvTabletCounters::TTableMetricsConfig* tableMetricsConfig = nullptr,
+    std::optional<ui64> metricsOffset = {}
+);
+
+/**
+ * Send a message to the Tablet Counters Aggregator to forget the given Data Shard tablet.
+ *
+ * @param[in] runtime The test runtime
+ * @param[in] aggregatorId The ID of the Tablet Counters Aggregator actor
+ * @param[in] edgeActorId The ID of the edge actor used for sending all messages
+ * @param[in] tabletId The ID of the DataShard tablet to forget
+ * @param[in] followerId The ID of the follower to forget
+ */
+void SendForgetDataShardTablet(
+    NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId
+);
 
 } // namespace NDetailedMetricsTests
 

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.h
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.h
@@ -39,12 +39,14 @@ TString NormalizeJson(
  *
  * @param[in] runtime The test runtime
  * @param[in] forFollowers Indicates if the aggregator should process leaders or followers data
+ * @param[in] enableDetailedMetrics Indicates whether to enable the feature flag for detailed metrics
  *
  * @return The ID of the Tablet Counters Aggregator actor
  */
 NActors::TActorId InitializeTabletCountersAggregator(
     NActors::TTestBasicRuntime& runtime,
-    bool forFollowers
+    bool forFollowers,
+    bool enableDetailedMetrics = true
 );
 
 /**

--- a/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
+++ b/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+
+namespace NDetailedMetricsTests {
+
+/**
+ * The builder for an array of JSON sensors, potentially nested.
+ */
+class TSensorsJsonBuilder {
+public:
+    /**
+     * Start the building process for a new JSON of sensors.
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    static TSensorsJsonBuilder Start() {
+        return TSensorsJsonBuilder();
+    }
+
+    /**
+     * Finalize the building process and create the final JSON of sensors.
+     *
+     * @return The corresponding JSON of sensors
+     */
+    TString BuildJson() {
+        Y_ABORT_UNLESS(ParentBuilder == nullptr, "The sensors JSON should be created at the root level");
+        return NJson::WriteJson(RootJson);
+    }
+
+    /**
+     * Start a new nested level of sensors with the given label.
+     *
+     * @param[in] labelKey The key for the nested label
+     * @param[in] labelValue The value for the nested label
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    TSensorsJsonBuilder StartNested(const TString& labelKey, const TString& labelValue) {
+        return TSensorsJsonBuilder(*this, labelKey, labelValue);
+    }
+
+    /**
+     * Finish the current level of sensors and return back to the parent level.
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    TSensorsJsonBuilder& EndNested() {
+        Y_ABORT_UNLESS(ParentBuilder != nullptr, "Unable to finish the root level of sensors");
+        return *ParentBuilder;
+    }
+
+    /**
+     * Add a new GAUGE sensor at the current level of sensors.
+     *
+     * @param[in] name The name of the GAUGE sensor to add
+     * @param[in] value The value of the new GAUGE sensor
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    TSensorsJsonBuilder& AddGauge(const TString& name, ui64 value) {
+        AddSimpleSensor(TSensorKind::GAUGE, name, value);
+        return *this;
+    }
+
+    /**
+     * Add a new RATE sensor at the current level of sensors.
+     *
+     * @param[in] name The name of the RATE sensor to add
+     * @param[in] value The value of the new RATE sensor
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    TSensorsJsonBuilder& AddRate(const TString& name, ui64 value) {
+        AddSimpleSensor(TSensorKind::RATE, name, value);
+        return *this;
+    }
+
+    /**
+     * Add a new HIST sensor for the CPU usage at the current level of sensors.
+     *
+     * @warning This function creates buckets with the 10% step (0%, 10% ... 100%).
+     *          The keys in the specified buckets parameter must use one of these
+     *          values. Unspecified buckets are assumed to have zero values.
+     *
+     * @param[in] name The name of the HIST sensor to add
+     * @param[in] buckets The list of buckets for the new HIST sensor
+     * @param[in] infValue The value for the infinity bucket
+     *
+     * @return The corresponding instance of the builder to use
+     */
+    TSensorsJsonBuilder& AddCpuHistogram(
+        const TString& name,
+        const std::unordered_map<ui64, ui64>& buckets,
+        ui64 infValue = 0
+    ) {
+        auto &record = SensorsJson.AppendValue(NJson::JSON_MAP);
+        record["kind"] = TSensorKind::HIST;
+
+        auto& histRecord = record.InsertValue("hist", NJson::JSON_MAP);
+        histRecord["inf"] = infValue;
+
+        auto& boundsRecord = histRecord.InsertValue("bounds", NJson::JSON_ARRAY);
+        auto& bucketsRecord = histRecord.InsertValue("buckets", NJson::JSON_ARRAY);
+
+        // First, copy the values into the full list of buckets to assign defaults
+        // and verify all bucket keys
+        std::unordered_map<ui64, ui64> fullBuckets = {
+            {0, 0},
+            {10, 0},
+            {20, 0},
+            {30, 0},
+            {40, 0},
+            {50, 0},
+            {60, 0},
+            {70, 0},
+            {80, 0},
+            {90, 0},
+            {100, 0},
+        };
+
+        for (auto [key, value] : buckets) {
+            Y_ABORT_UNLESS(fullBuckets.contains(key), "Invalid bucket key %u", key);
+            fullBuckets[key] = value;
+        }
+
+        // Second, copy the bucket boundaries and values into the JSON values
+        for (ui64 i = 0; i <= 100; i += 10) {
+            boundsRecord.AppendValue(i);
+            bucketsRecord.AppendValue(fullBuckets.at(i));
+        }
+
+        auto& labelsRecord = record.InsertValue("labels", NJson::JSON_MAP);
+        labelsRecord["name"] = name;
+
+        for (const auto& [key, value] : Labels ) {
+            labelsRecord[key] = value;
+        }
+
+        return *this;
+    }
+
+private:
+    /**
+     * The constructor for the root level builder.
+     */
+    TSensorsJsonBuilder()
+        : ParentBuilder(nullptr)
+        , RootJson(NJson::JSON_MAP)
+        , SensorsJson(RootJson.InsertValue("sensors", NJson::JSON_ARRAY)) {
+    }
+
+    /**
+     * The constructor for the nested level builder.
+     *
+     * @param[in] parentBuilder The builder for the parent level of sensors
+     * @param[in] nestedLabelKey The key for the nested label for this level
+     * @param[in] nestedLabelValue The value for the nestd label for this level
+     */
+    TSensorsJsonBuilder(
+        TSensorsJsonBuilder& parentBuilder,
+        const TString& nestedLabelKey,
+        const TString& nestedLabelValue
+    ) : ParentBuilder(&parentBuilder)
+      , SensorsJson(parentBuilder.SensorsJson)
+      , Labels(parentBuilder.Labels) {
+        // Also include the nested label for all nested sensors
+        Labels[nestedLabelKey] = nestedLabelValue;
+    }
+
+    /**
+     * Add a new simple sensor (RATE or GAUGE) at the current level of sensors.
+     *
+     * @param[in] kind The kind of the sensor to add
+     * @param[in] name The name of the sensor to add
+     * @param[in] value The value of the new sensor
+     */
+    void AddSimpleSensor(const char* kind, const TString& name, ui64 value) {
+        auto& record = SensorsJson.AppendValue(NJson::JSON_MAP);
+
+        record["kind"] = kind;
+        record["value"] = value;
+
+        auto& labelsRecord = record.InsertValue("labels", NJson::JSON_MAP);
+        labelsRecord["name"] = name;
+
+        for (const auto& [key, value] : Labels ) {
+            labelsRecord[key] = value;
+        }
+    }
+
+    /**
+     * The holder for all sensor kinds.
+     */
+    class TSensorKind {
+    public:
+        static constexpr const char* RATE = "RATE";
+        static constexpr const char* GAUGE = "GAUGE";
+        static constexpr const char* HIST = "HIST";
+    };
+
+    /**
+     * The parent JSON builder (used for nested arrays of sensors).
+     */
+    TSensorsJsonBuilder* ParentBuilder;
+
+    /**
+     * The holder for the root level JSON value (populated only for the root builder).
+     */
+    NJson::TJsonValue RootJson;
+
+    /**
+     * The JSON value, which accumulates sensors for all levels.
+     */
+    NJson::TJsonValue& SensorsJson;
+
+    /**
+     * The full set of labels, which should be assigned to all sensors at this level.
+     */
+    std::unordered_map<TString, TString> Labels;
+};
+
+} // namespace NDetailedMetricsTests
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
+++ b/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
@@ -3,6 +3,8 @@
 #include <library/cpp/json/json_writer.h>
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <unordered_map>
+
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {
@@ -123,7 +125,7 @@ public:
         };
 
         for (auto [key, value] : buckets) {
-            Y_ABORT_UNLESS(fullBuckets.contains(key), "Invalid bucket key %u", key);
+            Y_ABORT_UNLESS(fullBuckets.contains(key), "Invalid bucket key %" PRIu64, key);
             fullBuckets[key] = value;
         }
 

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.cpp
@@ -348,4 +348,4 @@ TYdbMetricsAggregatorPtr CreateYdbMetricsAggregatorByTabletType(
     }
 }
 
-}
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.h
@@ -95,7 +95,8 @@ using TYdbMetricsAggregatorPtr = TIntrusivePtr<TYdbMetricsAggregator>;
  */
 TYdbMetricsAggregatorPtr CreateYdbMetricsAggregatorByTabletType(
     TTabletTypes::EType tabletType,
-    NMonitoring::TDynamicCounterPtr targetCounterGroup);
+    NMonitoring::TDynamicCounterPtr targetCounterGroup
+);
 
 
 } // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator_ut.cpp
@@ -1,5 +1,6 @@
 #include "ydb_metrics_aggregator.h"
 #include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
 
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
@@ -144,152 +145,24 @@ Y_UNIT_TEST_SUITE(TYdbMetricsAggregatorTest) {
         Cerr << "TEST Target counters (initial):" << Endl << countersJson << Endl;
 
         TString expectedJsonAllZeros = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 0
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 0
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                .AddRate("table.datashard.bulk_upsert.rows", 0)
+                .AddRate("table.datashard.cache_hit.bytes", 0)
+                .AddRate("table.datashard.cache_miss.bytes", 0)
+                .AddRate("table.datashard.consumed_cpu_us", 0)
+                .AddRate("table.datashard.erase.bytes", 0)
+                .AddRate("table.datashard.erase.rows", 0)
+                .AddRate("table.datashard.read.bytes", 0)
+                .AddRate("table.datashard.read.rows", 0)
+                .AddGauge("table.datashard.row_count", 0)
+                .AddRate("table.datashard.scan.bytes", 0)
+                .AddRate("table.datashard.scan.rows", 0)
+                .AddGauge("table.datashard.size_bytes", 0)
+                .AddCpuHistogram("table.datashard.used_core_percents", {})
+                .AddRate("table.datashard.write.bytes", 0)
+                .AddRate("table.datashard.write.rows", 0)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -307,152 +180,40 @@ R"json(
         Cerr << "TEST Target counters (2 source groups added):" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 21020
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 21018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 21026
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 21028
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 21030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 21016
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 21014
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 21012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 21010
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 21002
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 21024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 21022
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 21004
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          21002,
-          21004,
-          21006,
-          21008,
-          21010,
-          21012,
-          21014,
-          21016,
-          21018,
-          21020,
-          21022
-        ],
-        "inf": 21024
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 21008
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 21006
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddRate("table.datashard.bulk_upsert.bytes", 21020)
+                .AddRate("table.datashard.bulk_upsert.rows", 21018)
+                .AddRate("table.datashard.cache_hit.bytes", 21026)
+                .AddRate("table.datashard.cache_miss.bytes", 21028)
+                .AddRate("table.datashard.consumed_cpu_us", 21030)
+                .AddRate("table.datashard.erase.bytes", 21016)
+                .AddRate("table.datashard.erase.rows", 21014)
+                .AddRate("table.datashard.read.bytes", 21012)
+                .AddRate("table.datashard.read.rows", 21010)
+                .AddGauge("table.datashard.row_count", 21002)
+                .AddRate("table.datashard.scan.bytes", 21024)
+                .AddRate("table.datashard.scan.rows", 21022)
+                .AddGauge("table.datashard.size_bytes", 21004)
+                .AddCpuHistogram(
+                    "table.datashard.used_core_percents",
+                    {
+                      {0,   21002},
+                      {10,  21004},
+                      {20,  21006},
+                      {30,  21008},
+                      {40,  21010},
+                      {50,  21012},
+                      {60,  21014},
+                      {70,  21016},
+                      {80,  21018},
+                      {90,  21020},
+                      {100, 21022},
+                    },
+                    21024
+                )
+                .AddRate("table.datashard.write.bytes", 21008)
+                .AddRate("table.datashard.write.rows", 21006)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -469,152 +230,40 @@ R"json(
         Cerr << "TEST Target counters (all source groups added):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 321030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 321027
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 321039
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 321042
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 321045
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 321024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 321021
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 321018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 321015
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 321003
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 321036
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 321033
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 321006
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          321003,
-          321006,
-          321009,
-          321012,
-          321015,
-          321018,
-          321021,
-          321024,
-          321027,
-          321030,
-          321033
-        ],
-        "inf": 321036
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 321012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 321009
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddRate("table.datashard.bulk_upsert.bytes", 321030)
+                .AddRate("table.datashard.bulk_upsert.rows", 321027)
+                .AddRate("table.datashard.cache_hit.bytes", 321039)
+                .AddRate("table.datashard.cache_miss.bytes", 321042)
+                .AddRate("table.datashard.consumed_cpu_us", 321045)
+                .AddRate("table.datashard.erase.bytes", 321024)
+                .AddRate("table.datashard.erase.rows", 321021)
+                .AddRate("table.datashard.read.bytes", 321018)
+                .AddRate("table.datashard.read.rows", 321015)
+                .AddGauge("table.datashard.row_count", 321003)
+                .AddRate("table.datashard.scan.bytes", 321036)
+                .AddRate("table.datashard.scan.rows", 321033)
+                .AddGauge("table.datashard.size_bytes", 321006)
+                .AddCpuHistogram(
+                    "table.datashard.used_core_percents",
+                    {
+                      {0,   321003},
+                      {10,  321006},
+                      {20,  321009},
+                      {30,  321012},
+                      {40,  321015},
+                      {50,  321018},
+                      {60,  321021},
+                      {70,  321024},
+                      {80,  321027},
+                      {90,  321030},
+                      {100, 321033},
+                    },
+                    321036
+                )
+                .AddRate("table.datashard.write.bytes", 321012)
+                .AddRate("table.datashard.write.rows", 321009)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -623,7 +272,7 @@ R"json(
             "Expected JSON (all source groups added):" << Endl << expectedJson
         );
 
-        // TEST 4: Update the first source groups and make sure the target counters are updated
+        // TEST 4: Update the first source group and make sure the target counters are updated
         PopulateDataShardPublicCounters(runtime, "source-group-1", 1000);
         aggregator->RecalculateAllTargetCounters();
 
@@ -631,152 +280,40 @@ R"json(
         Cerr << "TEST Target counters (the first group updated):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 1320030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 1320027
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 1320039
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 1320042
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 1320045
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 1320024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 1320021
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 1320018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 1320015
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 1320003
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 1320036
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 1320033
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 1320006
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          1320003,
-          1320006,
-          1320009,
-          1320012,
-          1320015,
-          1320018,
-          1320021,
-          1320024,
-          1320027,
-          1320030,
-          1320033
-        ],
-        "inf": 1320036
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 1320012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 1320009
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddRate("table.datashard.bulk_upsert.bytes", 1320030)
+                .AddRate("table.datashard.bulk_upsert.rows", 1320027)
+                .AddRate("table.datashard.cache_hit.bytes", 1320039)
+                .AddRate("table.datashard.cache_miss.bytes", 1320042)
+                .AddRate("table.datashard.consumed_cpu_us", 1320045)
+                .AddRate("table.datashard.erase.bytes", 1320024)
+                .AddRate("table.datashard.erase.rows", 1320021)
+                .AddRate("table.datashard.read.bytes", 1320018)
+                .AddRate("table.datashard.read.rows", 1320015)
+                .AddGauge("table.datashard.row_count", 1320003)
+                .AddRate("table.datashard.scan.bytes", 1320036)
+                .AddRate("table.datashard.scan.rows", 1320033)
+                .AddGauge("table.datashard.size_bytes", 1320006)
+                .AddCpuHistogram(
+                    "table.datashard.used_core_percents",
+                    {
+                      {0,   1320003},
+                      {10,  1320006},
+                      {20,  1320009},
+                      {30,  1320012},
+                      {40,  1320015},
+                      {50,  1320018},
+                      {60,  1320021},
+                      {70,  1320024},
+                      {80,  1320027},
+                      {90,  1320030},
+                      {100, 1320033},
+                    },
+                    1320036
+                )
+                .AddRate("table.datashard.write.bytes", 1320012)
+                .AddRate("table.datashard.write.rows", 1320009)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -793,152 +330,40 @@ R"json(
         Cerr << "TEST Target counters (the first source group removed):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 320020
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 320018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 320026
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 320028
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 320030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 320016
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 320014
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 320012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 320010
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 320002
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 320024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 320022
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 320004
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          320002,
-          320004,
-          320006,
-          320008,
-          320010,
-          320012,
-          320014,
-          320016,
-          320018,
-          320020,
-          320022
-        ],
-        "inf": 320024
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 320008
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 320006
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddRate("table.datashard.bulk_upsert.bytes", 320020)
+                .AddRate("table.datashard.bulk_upsert.rows", 320018)
+                .AddRate("table.datashard.cache_hit.bytes", 320026)
+                .AddRate("table.datashard.cache_miss.bytes", 320028)
+                .AddRate("table.datashard.consumed_cpu_us", 320030)
+                .AddRate("table.datashard.erase.bytes", 320016)
+                .AddRate("table.datashard.erase.rows", 320014)
+                .AddRate("table.datashard.read.bytes", 320012)
+                .AddRate("table.datashard.read.rows", 320010)
+                .AddGauge("table.datashard.row_count", 320002)
+                .AddRate("table.datashard.scan.bytes", 320024)
+                .AddRate("table.datashard.scan.rows", 320022)
+                .AddGauge("table.datashard.size_bytes", 320004)
+                .AddCpuHistogram(
+                    "table.datashard.used_core_percents",
+                    {
+                      {0,   320002},
+                      {10,  320004},
+                      {20,  320006},
+                      {30,  320008},
+                      {40,  320010},
+                      {50,  320012},
+                      {60,  320014},
+                      {70,  320016},
+                      {80,  320018},
+                      {90,  320020},
+                      {100, 320022},
+                    },
+                    320024
+                )
+                .AddRate("table.datashard.write.bytes", 320008)
+                .AddRate("table.datashard.write.rows", 320006)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_target_counters_base.h
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_target_counters_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "ydb_metrics_aggregator.h"
-
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_ut.cpp
@@ -1,11 +1,7 @@
 #include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
 
-#include <ydb/core/protos/counters_datashard.pb.h>
-#include <ydb/core/tablet/tablet_counters_aggregator.h>
-#include <ydb/core/tablet/tablet_counters_app.h>
-#include <ydb/core/tablet_flat/flat_executor_counters.h>
 #include <ydb/core/testlib/basics/appdata.h>
-#include <ydb/core/testlib/basics/runtime.h>
 
 #include <library/cpp/monlib/dynamic_counters/encode.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -13,29 +9,8 @@
 using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NDetailedMetricsTests;
-using namespace NKikimr::NTabletFlatExecutor;
 
 namespace {
-
-/**
- * Create and initialize the Tablet Counters Aggregator actor.
- *
- * @param[in] runtime The test runtime
- *
- * @return The ID of the Tablet Counters Aggregator actor
- */
-TActorId InitializeTabletCountersAggregator(TTestBasicRuntime& runtime) {
-    // Register the Tablet Counters Aggregator actor
-    TActorId aggregatorId = runtime.Register(CreateTabletCountersAggregator(false /* follower */));
-    runtime.EnableScheduleForActor(aggregatorId);
-
-    // Wait for the TEvBootstrap event to be processed, after this the actor is ready
-    TDispatchOptions options;
-    options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
-
-    runtime.DispatchEvents(options);
-    return aggregatorId;
-}
 
 /**
  * Force the Tablet Counters Aggregator actor to recalculate and update all YDB metrics.
@@ -61,102 +36,6 @@ void ForceCounterRecalculation(
     );
 }
 
-/**
- * Send low level metrics to the Tablet Counters Aggregator for the given DataShard tablet.
- *
- * @param[in] runtime The test runtime
- * @param[in] aggregatorId The ID of the Tablet Counters Aggregator actor
- * @param[in] edgeActorId The ID of the edge actor used for sending all messages
- * @param[in] tabletId The ID of the DataShard tablet
- * @param[in] cpuLoadPercentage The CPU load percentage to report for this tablet
- */
-void SendDataShardMetrics(
-    TTestBasicRuntime& runtime,
-    const TActorId& aggregatorId,
-    const TActorId& edgeActorId,
-    ui64 tabletId,
-    ui32 cpuLoadPercentage
-) {
-    // Populate executor counters with some fake values
-    auto executorCounters = MakeHolder<TExecutorCounters>();
-    auto executorCountersBaseline = MakeHolder<TExecutorCounters>();
-
-    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
-
-    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_ROWS_TOTAL] = 1000 + tabletId;
-    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_DATA_BYTES] = 2000 + tabletId;
-
-    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(3000 + tabletId);
-    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(4000 + tabletId);
-
-    // Populate DataShard counters with some fake values
-    auto tabletCounters = CreateAppCountersByTabletType(TTabletTypes::DataShard);
-    auto tabletCountersBaseline = CreateAppCountersByTabletType(TTabletTypes::DataShard);
-
-    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
-
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW].Increment(5000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW_BYTES].Increment(6000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW].Increment(10007000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_ROWS].Increment(20008000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW_BYTES].Increment(30009000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_BYTES].Increment(40010000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW].Increment(11000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW_BYTES].Increment(12000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS].Increment(13000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS_BYTES].Increment(14000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_ROWS].Increment(15000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_BYTES].Increment(16000 + tabletId);
-
-    // Send these counters to the Tablet Counters Aggregator
-    runtime.Send(
-        new IEventHandle(
-            aggregatorId,
-            edgeActorId,
-            new TEvTabletCounters::TEvTabletAddCounters(
-                new TEvTabletCounters::TInFlightCookie(),
-                tabletId,
-                TTabletTypes::DataShard,
-                TPathId(1113, 1001),
-                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
-                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline)
-            )
-        )
-    );
-
-    // NOTE: Tablet Counters Aggregator automatically differentiates cumulative
-    //       counters and uses the differential to update the associated histograms
-    //       (if present). It uses the time between consecutive TEvTabletAddCounters
-    //       messages (per tablet ID) to calculate the differential.
-    //
-    //       The code here sends the main update with all counters as needed,
-    //       but the CPU consumption value is set to zero. Then the time is moved
-    //       forward by exactly 1 second and a new update is sent with only
-    //       the CPU consumption value.
-    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
-    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
-
-    executorCounters->Cumulative()[TExecutorCounters::CONSUMED_CPU].Increment(
-        cpuLoadPercentage * 10000 + tabletId
-    );
-
-    runtime.AdvanceCurrentTime(TDuration::Seconds(1));
-    runtime.Send(
-        new IEventHandle(
-            aggregatorId,
-            edgeActorId,
-            new TEvTabletCounters::TEvTabletAddCounters(
-                new TEvTabletCounters::TInFlightCookie(),
-                tabletId,
-                TTabletTypes::DataShard,
-                TPathId(1113, 1001),
-                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
-                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline)
-            )
-        )
-    );
-}
-
 } // namespace <anonymous>
 
 /**
@@ -171,7 +50,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorYdbMetricsTest) {
         TTestBasicRuntime runtime(1);
         runtime.Initialize(TAppPrepare().Unwrap());
 
-        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime);
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
         TActorId edgeActorId = runtime.AllocateEdgeActor();
 
         // Do not send any tablet metrics, just force the YDB metrics to be recalculated
@@ -185,313 +64,47 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorYdbMetricsTest) {
         Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.topic.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.limit_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.reserved_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.throughput.limit_bytes_per_second"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.used_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 0
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 0
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGauge("resources.storage.limit_bytes", 0)
+                .AddGauge("resources.storage.limit_bytes.hdd", 0)
+                .AddGauge("resources.storage.limit_bytes.ssd", 0)
+                .AddGauge("resources.storage.table.used_bytes", 0)
+                .AddGauge("resources.storage.table.used_bytes.hdd", 0)
+                .AddGauge("resources.storage.table.used_bytes.ssd", 0)
+                .AddGauge("resources.storage.topic.used_bytes", 0)
+                .AddGauge("resources.storage.used_bytes", 0)
+                .AddGauge("resources.storage.used_bytes.hdd", 0)
+                .AddGauge("resources.storage.used_bytes.ssd", 0)
+                .AddGauge("resources.stream.limit_shards", 0)
+                .AddGauge("resources.stream.storage.limit_bytes", 0)
+                .AddGauge("resources.stream.storage.reserved_bytes", 0)
+                .AddGauge("resources.stream.throughput.limit_bytes_per_second", 0)
+                .AddGauge("resources.stream.used_shards", 0)
+                .AddRate("table.columnshard.bulk_upsert.bytes", 0)
+                .AddRate("table.columnshard.bulk_upsert.rows", 0)
+                .AddRate("table.columnshard.erase.bytes", 0)
+                .AddRate("table.columnshard.erase.rows", 0)
+                .AddRate("table.columnshard.scan.bytes", 0)
+                .AddRate("table.columnshard.scan.rows", 0)
+                .AddRate("table.columnshard.write.bytes", 0)
+                .AddRate("table.columnshard.write.rows", 0)
+                .AddRate("table.datashard.bulk_upsert.bytes", 0)
+                .AddRate("table.datashard.bulk_upsert.rows", 0)
+                .AddRate("table.datashard.cache_hit.bytes", 0)
+                .AddRate("table.datashard.cache_miss.bytes", 0)
+                .AddRate("table.datashard.consumed_cpu_us", 0)
+                .AddRate("table.datashard.erase.bytes", 0)
+                .AddRate("table.datashard.erase.rows", 0)
+                .AddRate("table.datashard.read.bytes", 0)
+                .AddRate("table.datashard.read.rows", 0)
+                .AddGauge("table.datashard.row_count", 0)
+                .AddRate("table.datashard.scan.bytes", 0)
+                .AddRate("table.datashard.scan.rows", 0)
+                .AddGauge("table.datashard.size_bytes", 0)
+                .AddCpuHistogram("table.datashard.used_core_percents", {})
+                .AddRate("table.datashard.write.bytes", 0)
+                .AddRate("table.datashard.write.rows", 0)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -509,13 +122,13 @@ R"json(
         TTestBasicRuntime runtime(1);
         runtime.Initialize(TAppPrepare().Unwrap());
 
-        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime);
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
         TActorId edgeActorId = runtime.AllocateEdgeActor();
 
         // Send some fake DataShard metrics and force the YDB metrics to be recalculated
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 20);
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 20, 40);
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 300, 60);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 0, 20);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 20, 0, 40);
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 300, 0, 60);
 
         ForceCounterRecalculation(runtime, aggregatorId, edgeActorId);
 
@@ -527,313 +140,47 @@ R"json(
         Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.topic.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.limit_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.reserved_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.throughput.limit_bytes_per_second"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.used_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 42321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 39321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 9321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 12321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 1200321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 36321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 33321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 210057642
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 90045642
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 3321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 48321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 45321
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 6321
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          1,
-          0,
-          1,
-          0,
-          1,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 18321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 15321
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGauge("resources.storage.limit_bytes", 0)
+                .AddGauge("resources.storage.limit_bytes.hdd", 0)
+                .AddGauge("resources.storage.limit_bytes.ssd", 0)
+                .AddGauge("resources.storage.table.used_bytes", 0)
+                .AddGauge("resources.storage.table.used_bytes.hdd", 0)
+                .AddGauge("resources.storage.table.used_bytes.ssd", 0)
+                .AddGauge("resources.storage.topic.used_bytes", 0)
+                .AddGauge("resources.storage.used_bytes", 0)
+                .AddGauge("resources.storage.used_bytes.hdd", 0)
+                .AddGauge("resources.storage.used_bytes.ssd", 0)
+                .AddGauge("resources.stream.limit_shards", 0)
+                .AddGauge("resources.stream.storage.limit_bytes", 0)
+                .AddGauge("resources.stream.storage.reserved_bytes", 0)
+                .AddGauge("resources.stream.throughput.limit_bytes_per_second", 0)
+                .AddGauge("resources.stream.used_shards", 0)
+                .AddRate("table.columnshard.bulk_upsert.bytes", 0)
+                .AddRate("table.columnshard.bulk_upsert.rows", 0)
+                .AddRate("table.columnshard.erase.bytes", 0)
+                .AddRate("table.columnshard.erase.rows", 0)
+                .AddRate("table.columnshard.scan.bytes", 0)
+                .AddRate("table.columnshard.scan.rows", 0)
+                .AddRate("table.columnshard.write.bytes", 0)
+                .AddRate("table.columnshard.write.rows", 0)
+                .AddRate("table.datashard.bulk_upsert.bytes", 420321)
+                .AddRate("table.datashard.bulk_upsert.rows", 390321)
+                .AddRate("table.datashard.cache_hit.bytes", 90321)
+                .AddRate("table.datashard.cache_miss.bytes", 120321)
+                .AddRate("table.datashard.consumed_cpu_us", 1200321)
+                .AddRate("table.datashard.erase.bytes", 360321)
+                .AddRate("table.datashard.erase.rows", 330321)
+                .AddRate("table.datashard.read.bytes", 210570642)
+                .AddRate("table.datashard.read.rows", 90450642)
+                .AddGauge("table.datashard.row_count", 30321)
+                .AddRate("table.datashard.scan.bytes", 480321)
+                .AddRate("table.datashard.scan.rows", 450321)
+                .AddGauge("table.datashard.size_bytes", 60321)
+                .AddCpuHistogram("table.datashard.used_core_percents", {{30, 1}, {50, 1}, {70, 1}})
+                .AddRate("table.datashard.write.bytes", 180321)
+                .AddRate("table.datashard.write.rows", 150321)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -2,6 +2,7 @@
 #include "tablet_counters_app.h"
 #include "labeled_counters_merger.h"
 #include "labeled_db_counters.h"
+#include "detailed_metrics/node_database_metrics_aggregator.h"
 #include "detailed_metrics/ydb_metrics_mapper.h"
 #include "private/aggregated_counters.h"
 #include "private/labeled_db_counters.h"
@@ -92,40 +93,83 @@ public:
         if (!IsFollower) {
             YdbCounters = MakeIntrusive<TYdbTabletCounters>(GetServiceCounters(counters, "ydb"), Counters);
         }
-    }
 
-    void Apply(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId,
-        const TTabletCountersBase* executorCounters, const TTabletCountersBase* appCounters,
-        const TActorContext& ctx)
-    {
-        AllTypes->Apply(tabletId, executorCounters, nullptr, tabletType);
-        //
-        auto typeCounters = GetOrAddCountersByTabletType(tabletType, CountersByTabletType, Counters);
-        if (typeCounters) {
-            typeCounters->Apply(tabletId, executorCounters, appCounters, tabletType);
-        }
-        //
-        if (!IsFollower && DbWatcherActorId && tenantPathId) {
-            auto dbCounters = GetDbCounters(tenantPathId, ctx);
-            if (dbCounters) {
-                auto* limitedAppCounters = GetOrAddLimitedAppCounters(tabletType);
-                dbCounters->Apply(tabletId, executorCounters, appCounters, tabletType, limitedAppCounters);
+        // NOTE: The detailed metrics are processed only by the instance of the Tablet
+        //       Counters Aggregator, which handles counters from leaders.
+        //       Followers also send their counters to this instance, but follower counters
+        //       are counted only in the detailed metrics, not the main set of metrics.
+        if (!IsFollower) {
+            // NOTE: The generic GetSubgroup() API does not allow specifying the visibility
+            //       for the new group. Thus, this subgroup must be created explicitly,
+            //       then attached to the global metrics storage. This is, obviously,
+            //       not thread safe, but there is no other way to do this. This works
+            //       only if there is only one actor, which does this and does this once
+            //       for the lifetime of the process.
+            DetailedMetricsRoot = counters->FindSubgroup("counters", "ydb_detailed_raw");
+
+            if (DetailedMetricsRoot == nullptr) {
+                // NOTE: The root counter group for all detailed metrics in the given node
+                //       should be created as "private". This way it will be not visible
+                //       through the generic HTTP URL, which is used by Monitoring to collect
+                //       metrics from the node. If necessary, these metrics can be retrieved
+                //       from the node by specifying the @private parameter in the HTTP URL.
+                DetailedMetricsRoot = MakeIntrusive<NMonitoring::TDynamicCounters>(
+                    NMonitoring::TCountableBase::EVisibility::Private
+                );
+
+                counters->RegisterSubgroup("counters", "ydb_detailed_raw", DetailedMetricsRoot);
+
+                LOG_INFO_S(
+                    *TlsActivationContext,
+                    NKikimrServices::TABLET_AGGREGATOR,
+                    "Successfully created the 'ydb_detailed_raw' counter group"
+                );
+            } else {
+                LOG_INFO_S(
+                    *TlsActivationContext,
+                    NKikimrServices::TABLET_AGGREGATOR,
+                    "The 'ydb_detailed_raw' counter group already exists, reusing it"
+                );
             }
         }
+    }
 
-        //
-        auto& quietStats = QuietTabletCounters[tabletId];
+    void Apply(TEvTabletCounters::TEvTabletAddCounters* message, const TActorContext& ctx)
+    {
+        AllTypes->Apply(
+            message->TabletID,
+            message->ExecutorCounters.Get(),
+            nullptr,
+            message->TabletType
+        );
 
-        if (executorCounters) {
-            if (quietStats.first == nullptr)
-                quietStats.first = new TTabletCountersBase();
-            quietStats.first->Populate(*executorCounters);
+        auto typeCounters = GetOrAddCountersByTabletType(message->TabletType, CountersByTabletType, Counters);
+        if (typeCounters) {
+            typeCounters->Apply(
+                message->TabletID,
+                message->ExecutorCounters.Get(),
+                message->AppCounters.Get(),
+                message->TabletType
+            );
         }
 
-        if (appCounters) {
+        if (DbWatcherActorId && message->TenantPathId) {
+            auto dbCounters = GetDbCounters(message->TenantPathId, ctx);
+            dbCounters->Apply(message, GetOrAddLimitedAppCounters(message->TabletType));
+        }
+
+        auto& quietStats = QuietTabletCounters[message->TabletID];
+
+        if (message->ExecutorCounters.Get()) {
+            if (quietStats.first == nullptr)
+                quietStats.first = new TTabletCountersBase();
+            quietStats.first->Populate(*message->ExecutorCounters.Get());
+        }
+
+        if (message->AppCounters.Get()) {
             if (quietStats.second == nullptr)
                 quietStats.second = new TTabletCountersBase();
-            quietStats.second->Populate(*appCounters);
+            quietStats.second->Populate(*message->AppCounters.Get());
         }
     }
 
@@ -176,7 +220,7 @@ public:
         iterDbLabeled->Apply(tabletId, labeledCounters);
     }
 
-    void ForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId) {
+    void ForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId) {
         AllTypes->Forget(tabletId);
         // and now erase from every other path
         auto iterTabletType = CountersByTabletType.find(tabletType);
@@ -185,7 +229,7 @@ public:
         }
         // from db counters
         if (auto itPath = CountersByPathId.find(tenantPathId); itPath != CountersByPathId.end()) {
-            itPath->second->Forget(tabletId, tabletType);
+            itPath->second->Forget(tabletId, followerId, tabletType);
         }
 
         for (auto iter = LabeledDbCounters.begin(); iter != LabeledDbCounters.end(); ++iter) {
@@ -205,9 +249,6 @@ public:
         }
 
         QuietTabletCounters.erase(tabletId);
-
-        TString tabletIdStr = Sprintf("%" PRIu64, tabletId);
-        Counters->RemoveSubgroup("tabletid", tabletIdStr.data());
     }
 
     void Query(const NKikimrTabletCountersAggregator::TEvTabletCountersRequest& request, NKikimrTabletCountersAggregator::TEvTabletCountersResponse& response) {
@@ -327,7 +368,12 @@ public:
     }
 
     void RemoveTabletsByPathId(TPathId pathId) {
-        CountersByPathId.erase(pathId);
+        auto dbCountersIt = CountersByPathId.find(pathId);
+
+        if (dbCountersIt != CountersByPathId.end()) {
+            dbCountersIt->second->DeleteAllDatabaseCounters();
+            CountersByPathId.erase(dbCountersIt);
+        }
     }
 
     void RemoveTabletsByDbPath(const TString& dbPath) {
@@ -344,9 +390,9 @@ public:
         return {};
     }
 
-private:
+public:
     // subgroups
-    class TTabletCountersForTabletType : public TThrRefBase {
+    class TTabletCountersForTabletType : public ITabletCountersProcessor {
     public:
         //
         TTabletCountersForTabletType(::NMonitoring::TDynamicCounters* owner, const char* category, const char* name)
@@ -354,8 +400,25 @@ private:
             , TabletExecutorCountersSection(TabletCountersSection->GetSubgroup("category", "executor"))
             , TabletAppCountersSection(TabletCountersSection->GetSubgroup("category", "app"))
             , TabletExecutorCounters(TabletExecutorCountersSection)
-            , TabletAppCounters(TabletAppCountersSection)
-        {}
+            , TabletAppCounters(TabletAppCountersSection) {
+        }
+
+        virtual void ProcessTabletCounters(
+            ui64 tabletId,
+            const TTabletCountersBase* executorCounters,
+            const TTabletCountersBase* applicationCounters,
+            TTabletTypes::EType tabletType
+        ) override {
+            Apply(tabletId, executorCounters, applicationCounters, tabletType);
+        }
+
+        virtual void RecalculateAggregatedValues() override {
+            RecalcAll();
+        }
+
+        virtual void ForgetTablet(ui64 tabletId) override {
+            Forget(tabletId);
+        }
 
         void Apply(ui64 tabletId,
             const TTabletCountersBase* executorCounters,
@@ -740,6 +803,7 @@ private:
         TSolomonCounters TabletAppCounters;
     };
 
+private:
     using TTabletCountersForTabletTypePtr = TIntrusivePtr<TTabletCountersForTabletType>;
     typedef TMap<TTabletTypes::EType, TTabletCountersForTabletTypePtr> TCountersByTabletType;
 
@@ -995,9 +1059,24 @@ private:
 public:
     class TTabletCountersForDb : public NSysView::IDbCounters {
     public:
-        TTabletCountersForDb()
-            : SolomonCounters(new ::NMonitoring::TDynamicCounters)
-        {}
+        /**
+         * The constructor, which is used to track database metrics for the Tablet Counters Aggregator.
+         *
+         * @param[in] detailedMetricsRoot The root counter group for all detailed metrics on this node
+         * @param[in] tenantPathId The tenant path ID for the given database
+         */
+        TTabletCountersForDb(
+            NMonitoring::TDynamicCounterPtr detailedMetricsRoot,
+            const TPathId& tenantPathId
+        ) : SolomonCounters(new ::NMonitoring::TDynamicCounters)
+          , NodeDatabaseMetricsAggregator(
+                MakeIntrusive<TNodeDatabaseMetricsAggregator>(
+                    tenantPathId,
+                    detailedMetricsRoot
+                )
+            )
+        {
+        }
 
         TTabletCountersForDb(::NMonitoring::TDynamicCounterPtr externalGroup,
             ::NMonitoring::TDynamicCounterPtr internalGroup,
@@ -1039,23 +1118,47 @@ public:
             }
         }
 
-        void Apply(ui64 tabletId, const TTabletCountersBase* executorCounters,
-            const TTabletCountersBase* appCounters, TTabletTypes::EType type,
-            const TTabletCountersBase* limitedAppCounters)
-        {
+        void Apply(
+            TEvTabletCounters::TEvTabletAddCounters* message,
+            const TTabletCountersBase* limitedAppCounters
+        ) {
+            // Aggregate all detailed metrics (both for leaders and followers)
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->ProcessTabletCounters(message);
+            }
+
+            /**
+             * @todo Do not process counters from followers - only from leaders.
+             *       See the TODO note in the GetDbCounters() function for more details
+             */
+            if (message->FollowerId) {
+                return;
+            }
+
             auto allTypes = GetOrAddCounters(TTabletTypes::Unknown);
             {
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(TTabletTypes::Unknown).GetLock());
-                allTypes->Apply(tabletId, executorCounters, nullptr, type);
+                allTypes->Apply(
+                    message->TabletID,
+                    message->ExecutorCounters.Get(),
+                    nullptr,
+                    message->TabletType
+                );
             }
-            auto typeCounters = GetOrAddCounters(type);
+            auto typeCounters = GetOrAddCounters(message->TabletType);
             {
-                TWriteGuard guard(CountersByTabletType.GetBucketForKey(type).GetLock());
-                typeCounters->Apply(tabletId, executorCounters, appCounters, type, limitedAppCounters);
+                TWriteGuard guard(CountersByTabletType.GetBucketForKey(message->TabletType).GetLock());
+                typeCounters->Apply(
+                    message->TabletID,
+                    message->ExecutorCounters.Get(),
+                    message->AppCounters.Get(),
+                    message->TabletType,
+                    limitedAppCounters
+                );
             }
         }
 
-        void Forget(ui64 tabletId, TTabletTypes::EType type) {
+        void Forget(ui64 tabletId, ui32 followerId, TTabletTypes::EType type) {
             auto allTypes = GetCounters(TTabletTypes::Unknown);
             if (allTypes) {
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(TTabletTypes::Unknown).GetLock());
@@ -1066,6 +1169,11 @@ public:
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(type).GetLock());
                 typeCounters->Forget(tabletId);
             }
+
+            // Also remove this tabled from the detailed metrics
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->ForgetTablet(tabletId, followerId);
+            }
         }
 
         void RecalcAll() {
@@ -1074,6 +1182,15 @@ public:
                 for (auto& [_, tabletCounters] : bucket.GetMap()) {
                     tabletCounters->RecalcAll();
                 }
+            }
+        }
+
+        /**
+         * Delete all counters for the given database.
+         */
+        void DeleteAllDatabaseCounters() {
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->DeleteAllDatabaseCounters();
             }
         }
 
@@ -1105,6 +1222,11 @@ public:
         TConcurrentRWHashMap<TTabletTypes::EType, TTabletCountersForTabletTypePtr, 16> CountersByTabletType;
 
         TYdbTabletCountersPtr YdbCounters;
+
+        /**
+         * The aggregator for all detailed metrics for the given database on this node.
+         */
+        TNodeDatabaseMetricsAggregatorPtr NodeDatabaseMetricsAggregator;
     };
 
     class TTabletsDbWatcherCallback : public NKikimr::NSysView::TDbWatcherCallback {
@@ -1129,12 +1251,20 @@ private:
             return it->second;
         }
 
-        auto dbCounters = MakeIntrusive<TTabletMon::TTabletCountersForDb>();
+        auto dbCounters = MakeIntrusive<TTabletMon::TTabletCountersForDb>(DetailedMetricsRoot, pathId);
         CountersByPathId[pathId] = dbCounters;
 
-        auto evRegister = MakeHolder<NSysView::TEvSysView::TEvRegisterDbCounters>(
-            NKikimrSysView::TABLETS, pathId, dbCounters);
-        ctx.Send(NSysView::MakeSysViewServiceID(ctx.SelfID.NodeId()), evRegister.Release());
+        /**
+         * @todo The SysView service (and the processor) are not yet ready to handle
+         *       counters from followers. For now they can handle only counters from leaders.
+         *       For now, the TTabletCountersForDb instance is created here both for leaders
+         *       and followers, but only the one for leaders is sent to the SysView service.
+         */
+        if (!IsFollower) {
+            auto evRegister = MakeHolder<NSysView::TEvSysView::TEvRegisterDbCounters>(
+                NKikimrSysView::TABLETS, pathId, dbCounters);
+            ctx.Send(NSysView::MakeSysViewServiceID(ctx.SelfID.NodeId()), evRegister.Release());
+        }
 
         if (DbWatcherActorId) {
             auto evWatch = MakeHolder<NSysView::TEvSysView::TEvWatchDatabase>(pathId);
@@ -1184,6 +1314,13 @@ private:
     TLabeledCountersByDbPath LabeledDbCounters;
     TLabeledCountersByTabletTypeAndGroup LabeledCountersByTabletTypeAndGroup;
     TQuietTabletCounters QuietTabletCounters;
+
+    /**
+     * The counter group, where all detailed metrics for the given node are stored.
+     *
+     * @note This counter group corresponds to the "counters" = "ydb_detailed_raw" label.
+     */
+    NMonitoring::TDynamicCounterPtr DetailedMetricsRoot;
 };
 
 
@@ -1194,6 +1331,17 @@ TIntrusivePtr<NSysView::IDbCounters> CreateTabletDbCounters(
 {
     return MakeIntrusive<TTabletMon::TTabletCountersForDb>(
         externalGroup, internalGroup, std::move(executorCounters));
+}
+
+ITabletCountersProcessorPtr CreateTabletCountersProcessor(
+    NMonitoring::TDynamicCounterPtr parentCounterGroup,
+    TTabletTypes::EType tabletType
+) {
+    return MakeIntrusive<TTabletMon::TTabletCountersForTabletType>(
+        parentCounterGroup.Get(),
+        "type",
+        TTabletTypes::TypeToStr(tabletType)
+    );
 }
 
 ////////////////////////////////////////////
@@ -1282,9 +1430,7 @@ TTabletCountersAggregatorActor::Bootstrap(const TActorContext &ctx) {
 ////////////////////////////////////////////
 void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletAddCounters::TPtr &ev, const TActorContext &ctx) {
-    Y_UNUSED(ctx);
-    TEvTabletCounters::TEvTabletAddCounters* msg = ev->Get();
-    TabletMon->Apply(msg->TabletID, msg->TabletType, msg->TenantPathId, msg->ExecutorCounters.Get(), msg->AppCounters.Get(), ctx);
+    TabletMon->Apply(ev->Get(), ctx);
 }
 
 ////////////////////////////////////////////
@@ -1320,7 +1466,7 @@ void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletCountersForgetTablet::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ctx);
     TEvTabletCounters::TEvTabletCountersForgetTablet* msg = ev->Get();
-    TabletMon->ForgetTablet(msg->TabletID, msg->TabletType, msg->TenantPathId);
+    TabletMon->ForgetTablet(msg->TabletID, msg->FollowerId, msg->TabletType, msg->TenantPathId);
 }
 
 ////////////////////////////////////////////
@@ -1600,9 +1746,9 @@ CreateTabletCountersAggregator(bool follower) {
     return new TTabletCountersAggregatorActor(follower);
 }
 
-void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity) {
+void TabletCountersForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity) {
     const TActorId countersAggregator = MakeTabletCountersAggregatorID(identity.NodeId(), follower);
-    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, tabletType, tenantPathId));
+    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, followerId, tabletType, tenantPathId));
 }
 
 ///////////////////////////////////////////

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -1069,13 +1069,13 @@ public:
             NMonitoring::TDynamicCounterPtr detailedMetricsRoot,
             const TPathId& tenantPathId
         ) : SolomonCounters(new ::NMonitoring::TDynamicCounters)
-          , NodeDatabaseMetricsAggregator(
-                MakeIntrusive<TNodeDatabaseMetricsAggregator>(
+        {
+            if (AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+                NodeDatabaseMetricsAggregator = MakeIntrusive<TNodeDatabaseMetricsAggregator>(
                     tenantPathId,
                     detailedMetricsRoot
-                )
-            )
-        {
+                );
+            }
         }
 
         TTabletCountersForDb(::NMonitoring::TDynamicCounterPtr externalGroup,

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -1170,7 +1170,7 @@ public:
                 typeCounters->Forget(tabletId);
             }
 
-            // Also remove this tabled from the detailed metrics
+            // Also remove this tablet from the detailed metrics
             if (NodeDatabaseMetricsAggregator) {
                 NodeDatabaseMetricsAggregator->ForgetTablet(tabletId, followerId);
             }

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -9,6 +9,7 @@
 #include <ydb/library/actors/core/event.h>
 
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/labeled_counters.pb.h>
 #include <ydb/core/protos/tablet_counters_aggregator.pb.h>
 #include <ydb/core/sys_view/common/events.h>
@@ -40,11 +41,51 @@ struct TEvTabletCounters {
 
     static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_TABLET_COUNTERS_AGGREGATOR), "expect EvEnd < EventSpaceEnd(TKikimrEvents::ES_TABLET_COUNTERS)");
 
+    /**
+     * The metrics configuration for the given table.
+     */
+    struct TTableMetricsConfig {
+        /**
+         * The ID of the given table (as PathId).
+         */
+        ui64 TableId;
+
+        /**
+         * The full path for the given table (as /Root/TenantDb/TableName).
+         */
+        TString TablePath;
+
+        /**
+         * The current schema version for the given table.
+         *
+         * @note This field is used to determine changes to the MetricsLevel,
+         *       TableId and TablePath fields.
+         */
+        ui64 TableSchemaVersion;
+
+        /**
+         * The current schema version for the parent tenant database.
+         *
+         * @note This field is used to determine changes to the MonitoringProjectId field.
+         */
+        ui64 TenantDbSchemaVersion;
+
+        /**
+         * The metrics level for the given table.
+         */
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel MetricsLevel;
+
+        /**
+         * The ID of the project in the Monitoring system, where the detailed metrics
+         * should be sent to.
+         */
+        std::optional<TString> MonitoringProjectId;
+    };
+
     // Used just as an atomic counter
     struct TInFlightCookie : TThrRefBase {};
 
     struct TEvTabletAddCounters : public TEventLocal<TEvTabletAddCounters, EvTabletAddCounters> {
-        //
         const ui64 TabletID;
         const TTabletTypes::EType TabletType;
         const TPathId TenantPathId;
@@ -52,15 +93,40 @@ struct TEvTabletCounters {
         TAutoPtr<TTabletCountersBase> AppCounters;
         TIntrusivePtr<TInFlightCookie> InFlightCounter;     // Used to detect when previous event has been consumed by the aggregator
 
-        TEvTabletAddCounters(TIntrusivePtr<TInFlightCookie> inFlightCounter, ui64 tabletID, TTabletTypes::EType tabletType, TPathId tenantPathId,
-            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters)
+        /**
+         * The follower ID, which produced the given set of counters.
+         */
+        const ui32 FollowerId;
+
+        /**
+         * The metrics configuration for the table, which corresponds
+         * to the given tablet (if known).
+         */
+        std::optional<TTableMetricsConfig> TableMetricsConfig;
+
+        TEvTabletAddCounters(
+            TIntrusivePtr<TInFlightCookie> inFlightCounter,
+            ui64 tabletID,
+            ui32 followerId,
+            TTabletTypes::EType tabletType,
+            TPathId tenantPathId,
+            TAutoPtr<TTabletCountersBase> executorCounters,
+            TAutoPtr<TTabletCountersBase> appCounters,
+            TTableMetricsConfig* tableMetricsConfig = nullptr
+        )
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
             , ExecutorCounters(executorCounters)
             , AppCounters(appCounters)
             , InFlightCounter(inFlightCounter)
-        {}
+            , FollowerId(followerId)
+        {
+            if (tableMetricsConfig != nullptr) {
+                // Make a full copy of the configuration to avoid locking between actors
+                TableMetricsConfig = (*tableMetricsConfig);
+            }
+        }
     };
 
     struct TEvTabletAddLabeledCounters : public TEventLocal<TEvTabletAddLabeledCounters, EvTabletAddLabeledCounters> {
@@ -78,15 +144,20 @@ struct TEvTabletCounters {
 
     //
     struct TEvTabletCountersForgetTablet : public TEventLocal<TEvTabletCountersForgetTablet, EvTabletCountersForgetTablet> {
-        //
         const ui64 TabletID;
         const TTabletTypes::EType TabletType;
         const TPathId TenantPathId;
 
-        TEvTabletCountersForgetTablet(ui64 tabletID, TTabletTypes::EType tabletType, TPathId tenantPathId)
+        /**
+         * The follower ID, for which to forget all counters.
+         */
+        const ui32 FollowerId;
+
+        TEvTabletCountersForgetTablet(ui64 tabletID, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
+            , FollowerId(followerId)
         {}
     };
 
@@ -125,8 +196,78 @@ struct TTabletLabeledCountersResponseContext {
     ui32 GetNameId(TStringBuf name);
 };
 
+/**
+ * The generic interface for the class, which translates low level metric values
+ * (both executor counters and application counters) to the corresponding metrics counters.
+ *
+ * @note Essentially, this is a way to expose the TTabletCountersForTabletType class
+ *       from the Tablets Counters Aggregator implementation to the outside so that
+ *       it can be reused for other purposes, more specifically, to manage and to aggregate
+ *       detailed metrics on the same node.
+ */
+class ITabletCountersProcessor : public virtual TThrRefBase {
+public:
+    /**
+     * Process a single batch of tablet counters and apply them to the corresponding
+     * metrics counters.
+     *
+     * @note This function assumes that the given counters are differential
+     *       (as a delta) from the previous batch.
+     *
+     * @warning This function updates only the values of direct counters, which derive
+     *          their values directly from the tablet counters. Any aggregate values
+     *          (e.g. "SUM(DbUniqueRowsTotal)" or "HIST(ConsumedCPU)") are not updated.
+     *          To see the updated values, the RecalculateAggregatedValues() function
+     *          must be called explicitly.
+     *
+     * @param[in] tabletId The ID of the tablet
+     * @param[in] executorCounters The executor counters to process (differential)
+     * @param[in] applicationCounters The application counters to process (differential)
+     * @param[in] tabletType The type of the tablet
+     */
+    virtual void ProcessTabletCounters(
+        ui64 tabletId,
+        const TTabletCountersBase* executorCounters,
+        const TTabletCountersBase* applicationCounters,
+        TTabletTypes::EType tabletType
+    ) = 0;
+
+    /**
+     * Remove the values supplied by the given tablet from all counters.
+     *
+     * @param[in] tabletId The ID of the tablet
+     */
+    virtual void ForgetTablet(ui64 tabletId) = 0;
+
+    /**
+     * Recalculate the values of all counters, which are aggregates of low level
+     * counters reported by the tablet, for example, min, max, etc.
+     */
+    virtual void RecalculateAggregatedValues() = 0;
+};
+
+using ITabletCountersProcessorPtr = TIntrusivePtr<ITabletCountersProcessor>;
+
+/**
+ * Create the processor of tablet counters for the given tablet type.
+ *
+ * @note This functions creates a subgroup with the label "type"="tabletType"
+ *       under the parent counter group (specified by parentCounterGroup).
+ *       For example, for Data Shard counters, the "type"="DataShard" label
+ *       is used.
+ *
+ * @param[in] parentCounterGroup The parent counter group for all tablet counters
+ * @param[in] tabletType The type of the tablet to be handled by this processor
+ *
+ * @return The processor of tablet counters for the given tablet type
+ */
+ITabletCountersProcessorPtr CreateTabletCountersProcessor(
+    NMonitoring::TDynamicCounterPtr parentCounterGroup,
+    TTabletTypes::EType tabletType
+);
+
 ////////////////////////////////////////////
-void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity);
+void TabletCountersForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity);
 
 TStringBuf GetHistogramAggregateSimpleName(TStringBuf name);
 bool IsHistogramAggregateSimpleName(TStringBuf name);

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -134,7 +134,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregator) {
             AppCounters->RememberCurrentStateAsBaseline(*AppCountersBaseline);
 
             runtime.Send(new IEventHandle(aggregatorId, sender, new TEvTabletCounters::TEvTabletAddCounters(
-                CounterEventsInFlight, TabletId, TabletType, TenantPathId, executorCounters, appCounters)));
+                CounterEventsInFlight, TabletId, 0, TabletType, TenantPathId, executorCounters, appCounters)));
 
             // force recalc
             runtime.Send(new IEventHandle(aggregatorId, sender, new NActors::TEvents::TEvWakeup()));
@@ -144,7 +144,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregator) {
             runtime.Send(new IEventHandle(
                 aggregatorId,
                 sender,
-                new TEvTabletCounters::TEvTabletCountersForgetTablet(TabletId, TabletType, TenantPathId)));
+                new TEvTabletCounters::TEvTabletCountersForgetTablet(TabletId, 0, TabletType, TenantPathId)));
 
             // force recalc
             runtime.Send(new IEventHandle(aggregatorId, sender, new NActors::TEvents::TEvWakeup()));

--- a/ydb/core/tablet/tablet_counters_protobuf.h
+++ b/ydb/core/tablet/tablet_counters_protobuf.h
@@ -143,7 +143,7 @@ public:
      *
      * @warning This function can be called only if ParseSourceCounters is set.
      *
-     * @param index The enum index for which to retrieve the source counters
+     * @param[in] index The enum index for which to retrieve the source counters
      *
      * @return The corresponding source counters
      */

--- a/ydb/core/tablet/ut/ya.make
+++ b/ydb/core/tablet/ut/ya.make
@@ -27,8 +27,10 @@ SRCS(
     tablet_req_blockbs_ut.cpp
     tablet_resolver_ut.cpp
     tablet_state_ut.cpp
+    detailed_metrics/node_database_metrics_aggregator_ut.cpp
     detailed_metrics/ut_helpers.cpp
     detailed_metrics/ut_helpers.h
+    detailed_metrics/ut_sensors_json_builder.h
     detailed_metrics/ydb_metrics_aggregator_ut.cpp
     detailed_metrics/ydb_metrics_ut.cpp
 )

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -56,6 +56,8 @@ SRCS(
     tablet_tracing_signals.h
     detailed_metrics/metric_value_aggregator.cpp
     detailed_metrics/metric_value_aggregator.h
+    detailed_metrics/node_database_metrics_aggregator.cpp
+    detailed_metrics/node_database_metrics_aggregator.h
     detailed_metrics/ydb_metrics_aggregator.cpp
     detailed_metrics/ydb_metrics_aggregator.h
     detailed_metrics/ydb_metrics_mapper.cpp

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -250,7 +250,7 @@ void TExecutor::Broken(EBrokenReason reason) {
 
     if (Owner) {
         ForceSendCounters();
-        TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+        TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
             Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
         Owner->Detach(OwnerCtx());
     }
@@ -865,7 +865,7 @@ TExecutorCaches TExecutor::CleanupState() {
 void TExecutor::Boot(TEvTablet::TEvBoot::TPtr &ev, const TActorContext &ctx) {
     if (Stats->IsFollower()) {
         ForceSendCounters();
-        TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+        TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
             Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
     }
 
@@ -956,7 +956,7 @@ void TExecutor::Restored(TEvTablet::TEvRestored::TPtr &ev, const TActorContext &
 
 void TExecutor::DetachTablet() {
     ForceSendCounters();
-    TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+    TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
         Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
     return PassAway();
 }
@@ -4064,7 +4064,7 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, FollowerId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
 
         if (ResourceMetrics) {
             ResourceMetrics->TryUpdate(ctx);
@@ -4093,7 +4093,7 @@ void TExecutor::ForceSendCounters() {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, FollowerId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
     }
 }
 

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,6 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardSplitKeySelection)
     FEATURE_FLAG_SETTER(EnableDataShardSplitHistogramOmission)
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
+    FEATURE_FLAG_SETTER(EnableDetailedMetrics)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -114,6 +114,17 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
     }
 
     if (copyAlter.HasDetailedMetricsSettings()) {
+        // Do not allow changing detailed metrics settings without the feature flag
+        if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+            errStr =
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)";
+
+            status = NKikimrScheme::StatusInvalidParameter;
+            return nullptr;
+        }
+
         // New detailed metrics settings are specified in the request,
         // make sure the detailed metrics settings are valid (correct metrics level etc)
         if (!ValidateTableDetailedMetricsSettings(
@@ -176,6 +187,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
         .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
         .EnableSetColumnConstraint = AppData()->FeatureFlags.GetEnableSetColumnConstraint(),
+        .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
     };
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -748,6 +748,7 @@ public:
             .EnableTablePgTypes = true,
             .EnableTableDatetime64 = true,
             .EnableParameterizedDecimal = true,
+            .EnableDetailedMetrics = true,
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(nullptr, schema, *typeRegistry,
             limits, *domainInfo, featureFlags, errStr, LocalSequences);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -547,6 +547,18 @@ public:
         }
 
         if (schema.HasDetailedMetricsSettings()) {
+            // Do not allow changing detailed metrics settings without the feature flag
+            if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+                result->SetError(
+                    NKikimrScheme::StatusInvalidParameter,
+                    "The detailed metrics settings are specified in the request, "
+                    "but the detailed metrics feature is disabled by the corresponding "
+                    "feature flag (EnableDetailedMetrics)"
+                );
+
+                return result;
+            }
+
             TString errorString;
 
             // Make sure the detailed metrics settings are valid (correct metrics level etc)
@@ -617,6 +629,7 @@ public:
             .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
             .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
             .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
+            .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(
             nullptr,

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -676,7 +676,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->MutableTTLSettings()->CopyFrom(ttl);
     }
 
-    if (op.HasDetailedMetricsSettings()) {
+    if (featureFlags.EnableDetailedMetrics && op.HasDetailedMetricsSettings()) {
         switch (op.GetDetailedMetricsSettings().GetStatusCase()) {
         case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
             if (op.GetDetailedMetricsSettings().HasConfigured()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -835,6 +835,7 @@ public:
         bool EnableTableDatetime64;
         bool EnableParameterizedDecimal;
         bool EnableSetColumnConstraint = false; // This flag is used in alter table operation only
+        bool EnableDetailedMetrics;
     };
 
     static TAlterDataPtr CreateAlterData(

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -56,12 +56,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
      *
-     * @note This test also verifies that the detailed metrics settings are preserved
+     * @note This function also verifies that the detailed metrics settings are preserved
      *       across SchemeShard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevel) {
+    void VerifyCreateTableNoDetailedMetricsLevel(bool enableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         TestCreateTable(
             runtime,
@@ -93,12 +97,38 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(false /* enableDetailedMetrics */);
+    }
+
+    /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(true /* enableDetailedMetrics */);
+    }
+
+    /**
      * Verify that CREATE TABLE with the detailed metrics settings explicitly dropped
      * is not allowed and fails with an error.
      */
     Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowed) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -129,6 +159,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         TestCreateTable(
             runtime,
             100,
@@ -152,6 +184,109 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE fails correctly, when the given detailed metrics
+     * level (or an explicit "drop") is specified in the request and
+     * the EnableDetailedMetrics feature flag is disabled.
+     *
+     * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
+     */
+    void VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        std::optional<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel> metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            (!metricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    DetailedMetricsSettings {
+                        NotConfigured {
+                        }
+                    }
+                )"
+                : Sprintf(
+                    R"(
+                        Name: "TestTable"
+                        Columns { Name: "key"   Type: "Uint64" }
+                        Columns { Name: "value" Type: "String" }
+                        KeyColumnNames: ["key"]
+                        DetailedMetricsSettings {
+                            Configured {
+                                MetricsLevel: %s
+                            }
+                        }
+                    )",
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(*metricsLevel).c_str()
+                ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when dropping detailed metrics level
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            {}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level UNSPECIFIED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelUnspecifiedNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level DISABLED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelDisabledNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level TABLE
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelTableNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level PARTITION
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelPartitionNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
      * Verify that CREATE TABLE works correctly, when the given valid
      * detailed metrics level is specified in the request.
      *
@@ -165,6 +300,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -261,10 +398,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
      *
      * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
+    void VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+        bool enableDetailedMetrics
+    ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -310,6 +453,36 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            false /* enableDetailedMetrics */
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            true /* enableDetailedMetrics */
+        );
+    }
+
+    /**
      * Verify that ALTER TABLE with the detailed metrics level explicitly removed
      * works correctly.
      *
@@ -322,6 +495,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     void VerifyAlterTableRemoveDetailedMetricsLevel(bool sourceHasMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -401,6 +576,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         // First, create a table without any detailed metrics settings
         TestCreateTable(
             runtime,
@@ -453,6 +630,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -591,6 +770,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with some detailed metrics settings configured
         TestCreateTable(


### PR DESCRIPTION
### Changelog entry

Added an aggregator for detailed per-table/per-partition metrics on a single node.

### Changelog category

* New feature

### Description for reviewers

* Added the TNodeDatabaseMetricsAggregator class
* Added an instance of TNodeDatabaseMetricsAggregator to TTabletCountersForDb
* Changed TEvTabletAddCounters to add the information about detailed metrics
* Changed TEvTabletAddCounters to add the follower ID
* Changed TEvTabletCountersForgetTablet to add the follower ID
* Added a helper class to verify sensors JSONs for unit tests
