### PR TITLE
Improve Compute Scheduler

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -89,6 +89,7 @@
 #include <ydb/core/kqp/finalize_script_service/kqp_finalize_script_service.h>
 #include <ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h>
 #include <ydb/core/kqp/compile_service/kqp_warmup_compile_actor.h>
+#include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
 
 #include <ydb/core/load_test/service_actor.h>
 
@@ -2414,6 +2415,24 @@ void TKqpServiceInitializer::InitializeServices(NActors::TActorSystemSetup* setu
             setup->LocalServices.push_back(std::make_pair(
                 NKqp::MakeKqpWarmupActorId(NodeId),
                 TActorSetupCmd(warmupActor, TMailboxType::HTSwap, appData->UserPoolId)));
+        }
+
+        // Create Compute Scheduler service
+        {
+            NKqp::NScheduler::TOptions schedulerOptions {
+                .DelayParams = {
+                    .MaxDelay = TDuration::MicroSeconds(Config.GetTableServiceConfig().GetComputeSchedulerSettings().GetMaxTaskDelayUs()),
+                    .MinDelay = TDuration::MicroSeconds(Config.GetTableServiceConfig().GetComputeSchedulerSettings().GetMinTaskDelayUs()),
+                    .AttemptBonus = TDuration::MicroSeconds(Config.GetTableServiceConfig().GetComputeSchedulerSettings().GetAttemptTaskBonusUs()),
+                    .MaxRandomDelay = TDuration::MicroSeconds(Config.GetTableServiceConfig().GetComputeSchedulerSettings().GetMaxTaskRandomDelayUs()),
+                },
+                .UpdateFairSharePeriod = TDuration::MilliSeconds(Config.GetTableServiceConfig().GetComputeSchedulerSettings().GetUpdateFairShareMs()),
+            };
+            auto* computeSchedulerActor = NKqp::CreateKqpComputeSchedulerService(schedulerOptions);
+            setup->LocalServices.push_back(std::make_pair(
+                NKqp::MakeKqpSchedulerServiceId(NodeId),
+                TActorSetupCmd(computeSchedulerActor, TMailboxType::HTSwap, appData->UserPoolId)
+            ));
         }
     }
 }

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -918,8 +918,7 @@ protected:
 
             // TODO: deliberately create the database here - since database doesn't have any useful scheduling properties for now.
             //       Replace with more precise database events in the future.
-            auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>();
-            addDatabaseEvent->Id = databaseId;
+            auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>(databaseId);
             this->Send(schedulerServiceId, addDatabaseEvent.Release());
 
             // TODO: replace with more precise pool events.

--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -96,8 +96,7 @@ public:
 
             // TODO: deliberately create the database here - since database doesn't have any useful scheduling properties for now.
             //       Replace with more precise database events in the future.
-            auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>();
-            addDatabaseEvent->Id = databaseId;
+            auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>(databaseId);
             this->Send(schedulerServiceId, addDatabaseEvent.Release());
 
             // TODO: replace with more precise pool events.

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -349,19 +349,22 @@ public:
         TActivationContext::ActorSystem()->RegisterLocalService(
             MakeKqpWorkloadServiceId(SelfId().NodeId()), KqpWorkloadService);
 
-        NScheduler::TOptions schedulerOptions {
-            .Counters = Counters,
-            .DelayParams = {
-                .MaxDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMaxTaskDelayUs()),
-                .MinDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMinTaskDelayUs()),
-                .AttemptBonus = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetAttemptTaskBonusUs()),
-                .MaxRandomDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMaxTaskRandomDelayUs()),
-            },
-            .UpdateFairSharePeriod = TDuration::MilliSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetUpdateFairShareMs()),
-        };
-        KqpComputeSchedulerService = TActivationContext::Register(CreateKqpComputeSchedulerService(schedulerOptions));
-        TActivationContext::ActorSystem()->RegisterLocalService(
-            MakeKqpSchedulerServiceId(SelfId().NodeId()), KqpComputeSchedulerService);
+        // A lot of tests create ProxyService but don't create KqpServiceInitializer
+        if (!TActivationContext::ActorSystem()->LookupLocalService(MakeKqpSchedulerServiceId(SelfId().NodeId()))) {
+            NScheduler::TOptions schedulerOptions {
+                .DelayParams = {
+                    .MaxDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMaxTaskDelayUs()),
+                    .MinDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMinTaskDelayUs()),
+                    .AttemptBonus = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetAttemptTaskBonusUs()),
+                    .MaxRandomDelay = TDuration::MicroSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetMaxTaskRandomDelayUs()),
+                },
+                .UpdateFairSharePeriod = TDuration::MilliSeconds(TableServiceConfig.GetComputeSchedulerSettings().GetUpdateFairShareMs()),
+            };
+
+            KqpComputeSchedulerService = TActivationContext::Register(CreateKqpComputeSchedulerService(schedulerOptions));
+            TActivationContext::ActorSystem()->RegisterLocalService(
+                MakeKqpSchedulerServiceId(SelfId().NodeId()), KqpComputeSchedulerService);
+        }
 
         NActors::TMon* mon = AppData()->Mon;
         if (mon) {
@@ -480,7 +483,9 @@ public:
         Send(KqpNodeService, new TEvents::TEvPoison);
 
         Send(KqpWorkloadService, new TEvents::TEvPoison());
-        Send(KqpComputeSchedulerService, new TEvents::TEvPoison());
+        if (KqpComputeSchedulerService) {
+            Send(KqpComputeSchedulerService, new TEvents::TEvPoison());
+        }
         Send(KqpQueryTextCacheService, new TEvents::TEvPoison());
         if (RowDispatcherService) {
             Send(RowDispatcherService, new TEvents::TEvPoison());
@@ -680,8 +685,7 @@ public:
         }
 
         // TODO: not the best place for adding database.
-        auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>();
-        addDatabaseEvent->Id = ev->Get()->GetDatabaseId();
+        auto addDatabaseEvent = MakeHolder<NScheduler::TEvAddDatabase>(ev->Get()->GetDatabaseId());
         Send(MakeKqpSchedulerServiceId(SelfId().NodeId()), addDatabaseEvent.Release());
 
         const TString& database = ev->Get()->GetDatabase();
@@ -763,7 +767,7 @@ public:
                 return;
             }
             LocalSessions->AttachQueryText(sessionInfo, ev->Get()->GetQuery());
-            
+
             // Pass WmState from session to the event
             Y_ABORT_UNLESS(sessionInfo->WmState, "WmState must be initialized in session constructor");
             ev->Get()->SetWmSessionUpdater(sessionInfo->WmState);
@@ -1072,7 +1076,7 @@ public:
             for (const auto& resource : PeerProxyNodeResources) {
                 nodeIds.push_back(resource.GetNodeId());
             }
-            KQP_PROXY_LOG_I("Discovered " << PeerProxyNodeResources.size() 
+            KQP_PROXY_LOG_I("Discovered " << PeerProxyNodeResources.size()
                 << " proxy nodes, starting warmup");
             Send(MakeKqpWarmupActorId(SelfId().NodeId()), new TEvStartWarmup(PeerProxyNodeResources.size(), std::move(nodeIds)));
         }

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -1,5 +1,6 @@
 #include "kqp_compute_scheduler_service.h"
 
+#include "log.h"
 #include "tree/dynamic.h"
 
 #include <ydb/core/base/appdata_fwd.h>
@@ -13,14 +14,6 @@
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/subsystems/stats.h>
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-#define LOG_C(stream) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
-
 using namespace NKikimr;
 using namespace NKikimr::NKqp;
 using namespace NKikimr::NKqp::NScheduler;
@@ -32,19 +25,20 @@ constexpr double Epsilon = 1e-8;
 
 class TComputeSchedulerService : public NActors::TActorBootstrapped<TComputeSchedulerService> {
 public:
-    explicit TComputeSchedulerService(const NScheduler::TOptions& options)
-        : Scheduler(std::make_shared<NScheduler::TComputeScheduler>(options.Counters, options.DelayParams))
-        , UpdateFairSharePeriod(options.UpdateFairSharePeriod)
-    {}
+    explicit TComputeSchedulerService(const NScheduler::TOptions& options) : Options(options) {}
 
     void Bootstrap() {
+        auto counters = MakeIntrusive<TKqpCounters>(AppData()->Counters, &NActors::TActivationContext::AsActorContext());
+        Scheduler = std::make_shared<NScheduler::TComputeScheduler>(counters, Options.DelayParams);
+
         Send(
             NConsole::MakeConfigsDispatcherID(SelfId().NodeId()),
             new NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest({(ui32)NKikimrConsole::TConfigItem::FeatureFlagsItem}),
             NActors::IEventHandle::FlagTrackDelivery
         );
 
-        if (Enabled = AppData()->FeatureFlags.GetEnableResourcePools()) {
+        Enabled = AppData()->FeatureFlags.GetEnableResourcePoolsScheduler();
+        if (Enabled) {
             LOG_I("Enabled on start");
         } else {
             LOG_I("Disabled on start");
@@ -53,7 +47,7 @@ public:
         Scheduler->SetTotalCpuLimit(CalculateTotalCpuLimit()); // TODO: take total cpu limit from outside
 
         Become(&TComputeSchedulerService::State);
-        Schedule(UpdateFairSharePeriod, new NActors::TEvents::TEvWakeup());
+        Schedule(Options.UpdateFairSharePeriod, new NActors::TEvents::TEvWakeup());
     }
 
     STATEFN(State) {
@@ -83,7 +77,8 @@ public:
     void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr& ev) {
         const auto& event = ev->Get()->Record;
 
-        if (Enabled = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsScheduler()) {
+        Enabled = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsScheduler();
+        if (Enabled) {
             LOG_I("Become enabled");
         } else {
             LOG_I("Become disabled");
@@ -97,9 +92,9 @@ public:
         NHdrf::TStaticAttributes const attrs {
             .Weight = ev->Get()->Weight, // TODO: weight shouldn't be negative!
         };
-        Scheduler->AddOrUpdateDatabase(ev->Get()->Id, attrs);
+        Scheduler->AddOrUpdateDatabase(ev->Get()->DatabaseId, attrs);
 
-        LOG_D("Add database: " << ev->Get()->Id);
+        LOG_D("Add database: " << ev->Get()->DatabaseId);
     }
 
     void Handle(TEvRemoveDatabase::TPtr&) {
@@ -114,15 +109,19 @@ public:
             .Weight = ev->Get()->Weight, // TODO: weight shouldn't be negative!
         };
 
-        if (ev->Get()->Params.TotalCpuLimitPercentPerNode >= 0) {
-            attrs.CpuLimit = ev->Get()->Params.TotalCpuLimitPercentPerNode * Scheduler->GetTotalCpuLimit() / 100;
+        if (const auto& cpuLimitPercent = ev->Get()->Params.TotalCpuLimitPercentPerNode; cpuLimitPercent >= 0) {
+            if (cpuLimitPercent == 0) {
+                attrs.CpuLimit = 0;
+            } else {
+                attrs.CpuLimit = std::max<ui64>(1, cpuLimitPercent * Scheduler->GetTotalCpuLimit() / 100);
+            }
         }
 
         Y_ASSERT(!poolId.empty());
 
         LOG_D("Add pool: " << databaseId << "/" << poolId);
 
-        if (PoolSubscribtions.insert({std::make_pair(databaseId, poolId), {false, resourceWeight}}).second) {
+        if (PoolSubscribtions.insert({std::make_pair(databaseId, poolId), {.IsFirstRemoval=false, .ExternalWeight=resourceWeight}}).second) {
             PoolExternalWeightSum += resourceWeight;
             Scheduler->AddOrUpdatePool(databaseId, poolId, attrs);
             Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(databaseId, poolId));
@@ -145,6 +144,8 @@ public:
             Y_ENSURE(poolIt != PoolSubscribtions.end());
             poolIt->second.IsFirstRemoval = false;
 
+            NHdrf::TStaticAttributes attrs;
+
             // Update external weight
             PoolExternalWeightSum -= poolIt->second.ExternalWeight;
             poolIt->second.ExternalWeight = ev->Get()->Config->ResourceWeight;
@@ -152,11 +153,17 @@ public:
             UpdatePoolsGuarantee();
 
             // Update limit
-            if (ev->Get()->Config->TotalCpuLimitPercentPerNode >= 0) {
-                Scheduler->AddOrUpdatePool(databaseId, poolId, {
-                    .CpuLimit = ev->Get()->Config->TotalCpuLimitPercentPerNode * Scheduler->GetTotalCpuLimit() / 100,
-                });
+            if (const auto& cpuLimitPercent = ev->Get()->Config->TotalCpuLimitPercentPerNode; cpuLimitPercent >= 0) {
+                if (cpuLimitPercent == 0) {
+                    attrs.CpuLimit = 0;
+                } else {
+                    attrs.CpuLimit = std::max<ui64>(1, cpuLimitPercent * Scheduler->GetTotalCpuLimit() / 100);
+                }
             }
+
+            Scheduler->AddOrUpdatePool(databaseId, poolId, attrs);
+
+            LOG_D("Update pool: " << databaseId << "/" << poolId);
         } else if (poolIt != PoolSubscribtions.end()) {
             if (!poolIt->second.IsFirstRemoval) {
                 // The first removal - try to re-subscribe in case it's just the pool removal from cache.
@@ -202,7 +209,7 @@ public:
 
     void Handle(NActors::TEvents::TEvWakeup::TPtr&) {
         Scheduler->UpdateFairShare();
-        Schedule(UpdateFairSharePeriod, new NActors::TEvents::TEvWakeup());
+        Schedule(Options.UpdateFairSharePeriod, new NActors::TEvents::TEvWakeup());
     }
 
 private:
@@ -230,7 +237,7 @@ private:
 private:
     bool Enabled = true;
     TComputeSchedulerPtr Scheduler;
-    const TDuration UpdateFairSharePeriod;
+    NScheduler::TOptions Options;
 
     struct TPoolParams {
         bool IsFirstRemoval = false;
@@ -246,7 +253,7 @@ namespace NKikimr::NKqp {
 
 namespace NScheduler {
 
-TComputeScheduler::TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams, NHdrf::NSnapshot::ELeafFairShare fairShareMode)
+TComputeScheduler::TComputeScheduler(const TIntrusivePtr<TKqpCounters>& counters, const TDelayParams& delayParams, NHdrf::NSnapshot::ELeafFairShare fairShareMode)
     : Root(std::make_shared<TRoot>(counters))
     , DelayParams(delayParams)
     , FairShareMode(fairShareMode)
@@ -304,7 +311,8 @@ TQueryPtr TComputeScheduler::AddOrUpdateQuery(const NHdrf::TDatabaseId& database
     Y_ENSURE(attrs.GetWeight() > 0.0, "Weight should be positive");
     TQueryPtr query;
 
-    if (query = std::static_pointer_cast<TQuery>(pool->GetQuery(queryId))) {
+    query = std::static_pointer_cast<TQuery>(pool->GetQuery(queryId));
+    if (query) {
         query->Update(attrs);
     } else {
         bool allowMinFairShare = (!pool->CpuLimit || *pool->CpuLimit > 0)

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h
@@ -10,7 +10,7 @@ namespace NKikimr::NKqp::NScheduler {
 
 class TComputeScheduler : public std::enable_shared_from_this<TComputeScheduler> {
 public:
-    TComputeScheduler(TIntrusivePtr<TKqpCounters> counters, const TDelayParams& delayParams,
+    TComputeScheduler(const TIntrusivePtr<TKqpCounters>& counters, const TDelayParams& delayParams,
         NHdrf::NSnapshot::ELeafFairShare fairShareMode = NHdrf::NSnapshot::ELeafFairShare::EQUAL_TO_PARENT);
 
     void SetTotalCpuLimit(ui64 cpu);
@@ -42,7 +42,6 @@ private:
 using TComputeSchedulerPtr = std::shared_ptr<TComputeScheduler>;
 
 struct TOptions {
-    TIntrusivePtr<TKqpCounters> Counters;
     TDelayParams DelayParams;
     TDuration UpdateFairSharePeriod;
 };
@@ -60,7 +59,9 @@ struct TEvents {
 };
 
 struct TEvAddDatabase : public TEventLocal<TEvAddDatabase, TEvents::EvAddDatabase> {
-    TString Id;
+    explicit TEvAddDatabase(const TString& databaseId) : DatabaseId(databaseId) {}
+
+    TString DatabaseId;
     double Weight = 1.;
 };
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service_ut.cpp
@@ -12,7 +12,7 @@ Y_UNIT_TEST_SUITE(KqpComputeSchedulerService) {
         - Create resource pool with zero CPU.
         - Enable or disable Scheduler on start.
         - Run query inside this pool.
-        - Query shouldn't timeout or should be cancelled by timeout.
+        - Query shouldn't timeout or shouldn't be cancelled by timeout.
      */
     Y_UNIT_TEST_TWIN(FeatureFlagOnStart, Enabled) {
         auto ydb = TYdbSetupSettings()

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_ut.cpp
@@ -8,6 +8,8 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/library/testlib/helpers.h>
 
+#include <utility>
+
 namespace NKikimr::NKqp::NScheduler {
 
 namespace {
@@ -21,11 +23,12 @@ namespace {
 
     constexpr TDuration kDefaultUpdateFairSharePeriod = TDuration::MilliSeconds(500);
 
-    std::vector<TSchedulableTaskPtr> CreateDemandTasks(NHdrf::NDynamic::TQueryPtr query, ui64 demand) {
+    std::vector<TSchedulableTaskPtr> CreateDemandTasks(const NHdrf::NDynamic::TQueryPtr& query, ui64 demand) {
         std::vector<TSchedulableTaskPtr> tasks;
 
         // Currently Demand for query snapshot is set as (Demand + ActualDemand) / 2.
         // ActualDemand is set to 0 after each snapshot take, so to avoid updating is every time this workaround was implemented
+        tasks.reserve(2 * demand);
         for (ui64 i = 0; i < 2 * demand; ++i) {
             tasks.emplace_back(std::make_shared<TSchedulableTask>(query));
         }
@@ -53,16 +56,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 2;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -106,12 +109,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 5;
         constexpr ui64 kQueryDemand = 1;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::DEFAULT_FIFO);
+        TComputeScheduler scheduler(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::DEFAULT_FIFO);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -158,12 +161,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 5;
         constexpr ui64 kQueryDemand = 1;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+        TComputeScheduler scheduler(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -206,12 +209,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 5;
         constexpr ui64 kQueryDemand = 1;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::EQUAL_TO_PARENT);
+        TComputeScheduler scheduler(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::EQUAL_TO_PARENT);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -255,12 +258,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 4;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -286,15 +289,15 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         auto* poolSnapshot1 = queries[0].front()->GetSnapshot()->GetParent();
         UNIT_ASSERT(poolSnapshot1);
-        UNIT_ASSERT_VALUES_EQUAL(poolSnapshot1->CpuDemand, kCpuLimit);
+        UNIT_ASSERT_VALUES_EQUAL(poolSnapshot1->CpuDemand.load(), kCpuLimit);
 
         auto* poolSnapshot2 = queries[1].front()->GetSnapshot()->GetParent();
         UNIT_ASSERT(poolSnapshot2);
-        UNIT_ASSERT_VALUES_EQUAL(poolSnapshot2->CpuDemand, kCpuLimit);
+        UNIT_ASSERT_VALUES_EQUAL(poolSnapshot2->CpuDemand.load(), kCpuLimit);
 
         auto* databaseSnapshot = poolSnapshot1->GetParent();
         UNIT_ASSERT(databaseSnapshot);
-        UNIT_ASSERT_VALUES_EQUAL(databaseSnapshot->CpuDemand, kCpuLimit);
+        UNIT_ASSERT_VALUES_EQUAL(databaseSnapshot->CpuDemand.load(), kCpuLimit);
     }
 
     Y_UNIT_TEST_TWIN(LeftFairShareIsDistributed, DefaultFairShareMode) {
@@ -308,16 +311,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 4;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -336,7 +339,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler->UpdateFairShare();
 
-        const std::vector<ui64> fairShares = {kQueryDemand, kQueryDemand, kCpuLimit - 2 * kQueryDemand};
+        const std::vector<ui64> fairShares = {kQueryDemand, kQueryDemand, kCpuLimit - (2 * kQueryDemand)};
         for (NHdrf::TQueryId queryId = 0; queryId < kNQueries; ++queryId) {
             auto querySnapshot = queries[queryId]->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
@@ -362,16 +365,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr ui64 kCpuLimit = 12;
         constexpr ui64 kWeightedFairShare = 4;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -396,7 +399,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         scheduler->UpdateFairShare();
 
         for (size_t i = 0; i < databaseIds.size(); ++i) {
-            auto query = queries[i];
+            const auto& query = queries[i];
             auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, !DefaultFairShareMode
@@ -428,16 +431,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kWeightedFairShare = 4;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -466,7 +469,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         scheduler->UpdateFairShare();
 
         for (size_t queryId = 0; queryId < kNQueries; ++queryId) {
-            auto query = queries[queryId];
+            const auto& query = queries[queryId];
             auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, !DefaultFairShareMode
@@ -546,16 +549,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
     Y_UNIT_TEST_TWIN(MultipleDatabasesPoolsQueries, DefaultFairShareMode) {
         constexpr ui64 kCpuLimit = 20;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -608,7 +611,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
             fairShares = {4, 4, 2, 2, 5, 5, 1};
         }
         for (size_t i = 0; i < queries.size(); ++i) {
-            auto query = queries[i];
+            const auto& query = queries[i];
             auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, fairShares[i]);
@@ -635,7 +638,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
             sumOfFairShares += fairshare;
         }
 
-        auto root = queries[0]->GetSnapshot()->GetParent()->GetParent()->GetParent();
+        auto* root = queries[0]->GetSnapshot()->GetParent()->GetParent()->GetParent();
         UNIT_ASSERT_VALUES_EQUAL(root->FairShare, sumOfFairShares);
     }
 
@@ -647,12 +650,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         */
         constexpr ui64 kCpuLimit = 12;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -678,7 +681,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         UNIT_ASSERT(databaseSnapshot);
         UNIT_ASSERT_VALUES_EQUAL(databaseSnapshot->FairShare, 0);
 
-        auto root = databaseSnapshot->GetParent();
+        auto* root = databaseSnapshot->GetParent();
         UNIT_ASSERT(root);
         UNIT_ASSERT_VALUES_EQUAL(root->FairShare, 0);
     }
@@ -694,12 +697,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 2;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -744,12 +747,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 2;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -789,12 +792,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         */
         constexpr ui64 kCpuLimit = 10;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -821,17 +824,17 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 5;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
 
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -904,16 +907,16 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr size_t kNQueries = 3;
         constexpr ui64 kQueryDemand = 5;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -939,7 +942,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
             fairShares = {kCpuLimit, kCpuLimit, kCpuLimit};
         }
         for (size_t queryId = 0; queryId < queries.size(); ++queryId) {
-            auto query = queries[queryId];
+            const auto& query = queries[queryId];
             auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, fairShares[queryId]);
@@ -986,17 +989,17 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         constexpr ui64 kQueryDemand = 3;
         constexpr ui64 kRoundedDemand = 2;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
 
         std::unique_ptr<TComputeScheduler> scheduler;
         if (DefaultFairShareMode) {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams);
         } else {
-            scheduler = std::make_unique<TComputeScheduler>(options.Counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
+            scheduler = std::make_unique<TComputeScheduler>(counters, options.DelayParams, NHdrf::NSnapshot::ELeafFairShare::ALLOW_OVERLIMIT);
         }
         scheduler->SetTotalCpuLimit(kCpuLimit);
 
@@ -1017,9 +1020,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler->UpdateFairShare();
 
-        for (size_t queryId = 0; queryId < queries.size(); ++queryId) {
-            auto query = queries[queryId];
-            auto querySnapshot = query->GetSnapshot();
+        for (const auto & query : queries) {
+             auto querySnapshot = query->GetSnapshot();
 
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, kQueryDemand);
@@ -1041,9 +1043,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         scheduler->UpdateFairShare();
 
-        for (size_t queryId = 0; queryId < queries.size(); ++queryId) {
-            auto query = queries[queryId];
-            auto querySnapshot = query->GetSnapshot();
+        for (const auto & query : queries) {
+             auto querySnapshot = query->GetSnapshot();
             UNIT_ASSERT(querySnapshot);
             UNIT_ASSERT_VALUES_EQUAL(querySnapshot->FairShare, kRoundedDemand);
 
@@ -1062,7 +1063,7 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
 
         const std::vector<ui64> poolsFairShares = {4, 2, 2, 2};
         for (size_t queryId = 0; queryId < queries.size(); ++queryId) {
-            auto query = queries[queryId];
+            const auto& query = queries[queryId];
             auto querySnapshot = query->GetSnapshot();
             auto* poolSnapshot = querySnapshot->GetParent();
 
@@ -1089,12 +1090,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         */
         constexpr ui64 kCpuLimit = 12;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
             .UpdateFairSharePeriod = kDefaultUpdateFairSharePeriod
         };
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -1118,12 +1119,12 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
     Y_UNIT_TEST(StressTest) {
         constexpr ui64 kCpuLimit = 100;
 
+        auto counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>());
         const TOptions options{
-            .Counters = MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()),
             .DelayParams = kDefaultDelayParams,
         };
 
-        TComputeScheduler scheduler(options.Counters, options.DelayParams);
+        TComputeScheduler scheduler(counters, options.DelayParams);
         scheduler.SetTotalCpuLimit(kCpuLimit);
 
         const TString databaseId = "db1";
@@ -1141,7 +1142,8 @@ Y_UNIT_TEST_SUITE(KqpComputeScheduler) {
         };
 
         struct TSchedulableActorMock : public TSchedulableActorBase {
-            explicit TSchedulableActorMock(NHdrf::NDynamic::TQueryPtr query) : TSchedulableActorBase({query, true}) {}
+            explicit TSchedulableActorMock(NHdrf::NDynamic::TQueryPtr query)
+                : TSchedulableActorBase({.Query=std::move(query), .IsSchedulable=true}) {}
 
             void ExecuteAndPassAway(std::atomic<bool>& shutdown) {
                 std::thread([&shutdown, this] {

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
@@ -27,7 +27,6 @@ void TSchedulableTask::Resume() {
     NActors::TActivationContext::Send(ActorId, GetResumeEvent());
 }
 
-// TODO: referring to the pool's usage - to support all-equal fair-share query mode.
 bool TSchedulableTask::TryIncreaseUsage() {
     bool increased = false;
     ui64 fairShare = 0;
@@ -36,6 +35,14 @@ bool TSchedulableTask::TryIncreaseUsage() {
     if (const auto snapshot = Query->GetSnapshot()) {
         fairShare = snapshot->FairShare;
         poolOrQuery = Query->GetParent();
+
+        // Special case for zero demand and zero fair-share - there are pending tasks but snapshot is not updated yet.
+        if (fairShare == 0 && snapshot->CpuDemand == 0) {
+            auto prevDemand = snapshot->CpuDemand.fetch_add(1);
+            if (prevDemand == 0) {
+                fairShare = Query->AllowMinFairShare;
+            }
+        }
     } else { // TODO: check directly for the pool snapshot - even if there is no query snapshot yet.
         fairShare = Query->AllowMinFairShare;
         poolOrQuery = Query.get();

--- a/ydb/core/kqp/runtime/scheduler/log.h
+++ b/ydb/core/kqp/runtime/scheduler/log.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ydb/library/actors/core/log.h>
+
+#define LOG_T(stream) LOG_TRACE_S (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_D(stream) LOG_DEBUG_S (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_I(stream) LOG_INFO_S  (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_N(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_W(stream) LOG_WARN_S  (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_E(stream) LOG_ERROR_S (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)
+#define LOG_C(stream) LOG_CRIT_S  (*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE_SCHEDULER, stream)

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
@@ -10,7 +10,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
         ui64 TotalLimit = Infinity();
         ui64 FairShare = 0;
 
-        ui64 CpuDemand = 0;
+        std::atomic<ui64> CpuDemand = 0;
         ui64 CpuUsage = 0;
         ui64 CpuBurstUsage = 0;
         ui64 CpuBurstThrottle = 0;

--- a/ydb/library/testlib/helpers.h
+++ b/ydb/library/testlib/helpers.h
@@ -18,7 +18,7 @@
             TCurrentTest::AddTest(TTestCase##N<false>::CreateOff);                                                 \
         }                                                                                                          \
     };                                                                                                             \
-    static TTestRegistration##N testRegistration##N;                                                               \
+    static const TTestRegistration##N testRegistration##N;                                                         \
     template <bool OPT>                                                                                            \
     void TTestCase##N<OPT>::Execute_(NUnitTest::TTestContext& ut_context Y_DECLARE_UNUSED)
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Initialize Compute Scheduler Service using both KQP service initializers and KQP proxy - for tests.
- Allow to acquire 1 CPU for the first query in empty pool, if HDRF snapshot is not updated yet.
- Fix name of feature-flag for enabling scheduler on cluster start.