### PR TITLE
[Schemeshard] ignore duplicate filestore TEvUpdateConfigResponse. NBYDB-2136

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
@@ -137,7 +137,7 @@ public:
     {
         IgnoreMessages(DebugHint(), {
             TEvHive::TEvCreateTabletReply::EventType,
-            TEvFileStore::TEvUpdateConfigResponse::EventType
+            TEvFileStore::TEvUpdateConfigResponse::EventType,
         });
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
@@ -136,7 +136,8 @@ public:
         : OperationId(id)
     {
         IgnoreMessages(DebugHint(), {
-            TEvHive::TEvCreateTabletReply::EventType
+            TEvHive::TEvCreateTabletReply::EventType,
+            TEvFileStore::TEvUpdateConfigResponse::EventType
         });
     }
 

--- a/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
@@ -1,6 +1,7 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/filestore/core/filestore.h>
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
 #include <google/protobuf/text_format.h>
 
@@ -187,6 +188,54 @@ Y_UNIT_TEST_SUITE(TFileStoreWithReboots) {
                                 NLs::Finished,
                                 NLs::PathVersionEqual(3)});
         });
+    }
+
+    Y_UNIT_TEST(AlterHandlesDuplicateUpdateConfigResponse) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription vdescr;
+        auto& vc = InitCreateFileStoreConfig("FS", vdescr);
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", vdescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        InitAlterFileStoreConfig(vc);
+
+        // Intercept the first real UpdateConfigResponse from the fake filestore tablet
+        // so we can deliver it twice and emulate a late duplicate reply.
+        TVector<THolder<IEventHandle>> suppressed;
+        auto prevObserver = SetSuppressObserver(
+            runtime,
+            suppressed,
+            TEvFileStore::TEvUpdateConfigResponse::EventType);
+
+        const ui64 alterTxId = ++txId;
+        AsyncAlterFileStore(runtime, alterTxId, "/MyRoot", vdescr.DebugString());
+        TestModificationResult(runtime, alterTxId, NKikimrScheme::StatusAccepted);
+        WaitForSuppressed(runtime, suppressed, 1, prevObserver);
+
+        UNIT_ASSERT_VALUES_EQUAL(suppressed.size(), 1);
+
+        const TActorId recipient = suppressed.front()->Recipient;
+        const TActorId sender = suppressed.front()->Sender;
+
+        // Prepare an explicit duplicate with the same payload. The handler routes
+        // replies by tx id and origin tablet, both of which are stored in Record.
+        auto duplicate = MakeHolder<TEvFileStore::TEvUpdateConfigResponse>();
+        duplicate->Record.CopyFrom(suppressed.front()->Get<TEvFileStore::TEvUpdateConfigResponse>()->Record);
+
+        // First delivery advances alter-fs from ConfigureParts to Propose.
+        // The second delivery reproduces a late duplicate reply for the same op.
+        runtime.Send(suppressed.front().Release(), 0, true);
+        runtime.Send(new IEventHandle(recipient, sender, duplicate.Release()), 0, true);
+
+        env.TestWaitNotification(runtime, alterTxId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/FS"),
+                           {NLs::PathExist,
+                            NLs::Finished,
+                            NLs::PathVersionEqual(3)});
     }
 
     Y_UNIT_TEST(CreateAlterNoVersion) {


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Alter file store can receive a late duplicate TEvUpdateConfigResponse after ConfigureParts has already advanced the suboperation to Propose.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
