### PR TITLE
NBS-6778: add write request timeout; add hedging to write request wit…

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/config/config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config.cpp
@@ -11,7 +11,8 @@ namespace {
 
 const auto DefaultTraceSamplePeriod = TDuration::MicroSeconds(1000);
 const auto DefaultPBufferReplyTimeout = TDuration::MicroSeconds(50000);
-const auto DefaultHedgingDelay = TDuration::MilliSeconds(0);
+const auto DefaultHedgingDelay = TDuration::MicroSeconds(700);
+const auto DefaultWriteRequestTimeout = TDuration::MilliSeconds(10000);
 
 }   // namespace
 
@@ -141,12 +142,20 @@ TDuration TStorageConfig::GetTraceSamplePeriod() const
                : DefaultTraceSamplePeriod;
 }
 
-TDuration TStorageConfig::GetWriteHandoffDelay() const
+TDuration TStorageConfig::GetWriteHedgingDelay() const
 {
-    return StorageServiceConfig.HasWriteHandoffDelay()
+    return StorageServiceConfig.HasWriteHedgingDelay()
                ? TDuration::MicroSeconds(
-                     StorageServiceConfig.GetWriteHandoffDelay())
+                     StorageServiceConfig.GetWriteHedgingDelay())
                : DefaultHedgingDelay;
+}
+
+TDuration TStorageConfig::GetWriteRequestTimeout() const
+{
+    return StorageServiceConfig.HasWriteRequestTimeout()
+               ? TDuration::MilliSeconds(
+                     StorageServiceConfig.GetWriteRequestTimeout())
+               : DefaultWriteRequestTimeout;
 }
 
 TDuration TStorageConfig::GetPBufferReplyTimeout() const

--- a/ydb/core/nbs/cloud/blockstore/config/config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config.cpp
@@ -11,7 +11,7 @@ namespace {
 
 const auto DefaultTraceSamplePeriod = TDuration::MicroSeconds(1000);
 const auto DefaultPBufferReplyTimeout = TDuration::MicroSeconds(50000);
-const auto DefaultHedgingDelay = TDuration::MicroSeconds(700);
+const auto DefaultHedgingDelay = TDuration::MicroSeconds(1000);
 const auto DefaultWriteRequestTimeout = TDuration::MilliSeconds(10000);
 
 }   // namespace
@@ -27,7 +27,7 @@ TStorageConfig::TStorageConfig(
 
 // clang-format off
 #define BLOCKSTORE_STORAGE_CONFIG_RO(xxx)                                     \
-    xxx(SyncRequestsBatchSize,              ui32,     3                       )\
+    xxx(SyncRequestsBatchSize,              ui32,     10                      )\
     xxx(StripeSize,                         ui64,     512_KB                  )\
     xxx(DDiskPoolName,                      TString,  "ddp1"                  )\
     xxx(PersistentBufferDDiskPoolName,      TString,  "ddp1"                  )\

--- a/ydb/core/nbs/cloud/blockstore/config/config.h
+++ b/ydb/core/nbs/cloud/blockstore/config/config.h
@@ -29,7 +29,8 @@ public:
     [[nodiscard]] TDuration GetTraceSamplePeriod() const;
     [[nodiscard]] ui32 GetSyncRequestsBatchSize() const;
     [[nodiscard]] ui64 GetStripeSize() const;
-    [[nodiscard]] TDuration GetWriteHandoffDelay() const;
+    [[nodiscard]] TDuration GetWriteHedgingDelay() const;
+    [[nodiscard]] TDuration GetWriteRequestTimeout() const;
     [[nodiscard]] TString GetDDiskPoolName() const;
     [[nodiscard]] TString GetPersistentBufferDDiskPoolName() const;
     [[nodiscard]] NProto::EWriteMode GetWriteMode() const;

--- a/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
@@ -18,8 +18,8 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(3u, config.GetSyncRequestsBatchSize());
         UNIT_ASSERT_VALUES_EQUAL(524288u, config.GetStripeSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            TDuration::MicroSeconds(0),
-            config.GetWriteHandoffDelay());
+            TDuration::MicroSeconds(700),
+            config.GetWriteHedgingDelay());
         UNIT_ASSERT_VALUES_EQUAL("ddp1", config.GetDDiskPoolName());
         UNIT_ASSERT_VALUES_EQUAL(
             "ddp1",
@@ -33,7 +33,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         proto.SetTraceSamplePeriod(42);
         proto.SetSyncRequestsBatchSize(7);
         proto.SetStripeSize(8192);
-        proto.SetWriteHandoffDelay(99);
+        proto.SetWriteHedgingDelay(99);
         proto.SetVChunkSize(33554432);
 
         TStorageConfig config{std::move(proto)};
@@ -45,7 +45,7 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(8192u, config.GetStripeSize());
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MicroSeconds(99),
-            config.GetWriteHandoffDelay());
+            config.GetWriteHedgingDelay());
         UNIT_ASSERT_VALUES_EQUAL(33554432, config.GetVChunkSize());
     }
 
@@ -62,8 +62,8 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(3u, config.GetSyncRequestsBatchSize());
         UNIT_ASSERT_VALUES_EQUAL(2048u, config.GetStripeSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            TDuration::MicroSeconds(0),
-            config.GetWriteHandoffDelay());
+            TDuration::MicroSeconds(700),
+            config.GetWriteHedgingDelay());
         UNIT_ASSERT_VALUES_EQUAL(134217728, config.GetVChunkSize());
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/config/config_ut.cpp
@@ -15,10 +15,10 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MicroSeconds(1000),
             config.GetTraceSamplePeriod());
-        UNIT_ASSERT_VALUES_EQUAL(3u, config.GetSyncRequestsBatchSize());
+        UNIT_ASSERT_VALUES_EQUAL(10u, config.GetSyncRequestsBatchSize());
         UNIT_ASSERT_VALUES_EQUAL(524288u, config.GetStripeSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            TDuration::MicroSeconds(700),
+            TDuration::MicroSeconds(1000),
             config.GetWriteHedgingDelay());
         UNIT_ASSERT_VALUES_EQUAL("ddp1", config.GetDDiskPoolName());
         UNIT_ASSERT_VALUES_EQUAL(
@@ -59,10 +59,10 @@ Y_UNIT_TEST_SUITE(TStorageConfigTest)
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MicroSeconds(1000),
             config.GetTraceSamplePeriod());
-        UNIT_ASSERT_VALUES_EQUAL(3u, config.GetSyncRequestsBatchSize());
+        UNIT_ASSERT_VALUES_EQUAL(10u, config.GetSyncRequestsBatchSize());
         UNIT_ASSERT_VALUES_EQUAL(2048u, config.GetStripeSize());
         UNIT_ASSERT_VALUES_EQUAL(
-            TDuration::MicroSeconds(700),
+            TDuration::MicroSeconds(1000),
             config.GetWriteHedgingDelay());
         UNIT_ASSERT_VALUES_EQUAL(134217728, config.GetVChunkSize());
     }

--- a/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
@@ -85,7 +85,7 @@ message TStorageServiceConfig
     optional uint32 PBufferReplyTimeoutMicroseconds = 15;
 
     // Delay (in microseconds) before writing to handoff persistent buffers.
-    optional uint32 WriteHandoffDelay = 16;
+    optional uint32 WriteHedgingDelay = 16;
 
     // Size of VChunk (in bytes). Default is 128 MB.
     optional uint64 VChunkSize = 17;
@@ -95,4 +95,7 @@ message TStorageServiceConfig
 
     optional TDDiskConfig GlobalDDiskConfig = 19;
     optional TPBufferConfig GlobalPBufferConfig = 20;
+
+    // Timeout (in milliseconds) for write request handlers.
+    optional uint32 WriteRequestTimeout = 21;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.cpp
@@ -665,7 +665,7 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
         childSpan.get());
 
     auto promise = NewPromise<TDBGFlushResponse>();
-    auto result = promise.GetFuture();
+    auto flushFuture = promise.GetFuture();
 
     future.Subscribe(
         [weakSelf = weak_from_this(),
@@ -681,28 +681,56 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
         {
             // ActorSystem thread
 
-            const TEvSyncWithPersistentBufferResult& response = f.GetValue();
-            TDBGFlushResponse result;
-            if (response.GetStatus() ==
-                    NKikimrBlobStorage::NDDisk::TReplyStatus::OK &&
-                response.GetSegmentResults().size() ==
-                    static_cast<int>(segmentCount))
-            {
-                for (size_t i = 0; i < segmentCount; ++i) {
-                    const auto& segmentResult = response.GetSegmentResults(i);
-                    const bool ok =
-                        segmentResult.GetStatus() ==
-                            NKikimrBlobStorage::NDDisk::TReplyStatus::OK ||
-                        segmentResult.GetStatus() ==
-                            NKikimrBlobStorage::NDDisk::TReplyStatus::OUTDATED;
-                    result.Errors.push_back(MakeError(
-                        ok ? S_OK : E_FAIL,
-                        ok ? "" : segmentResult.GetErrorReason()));
-                }
-            } else {
-                for (size_t i = 0; i < segmentCount; ++i) {
-                    result.Errors.push_back(
-                        MakeError(E_FAIL, response.GetErrorReason()));
+            TDBGFlushResponse flushResponse;
+
+            if (auto self = weakSelf.lock()) {
+                const TEvSyncWithPersistentBufferResult& response =
+                    f.GetValue();
+                if (response.GetStatus() ==
+                        NKikimrBlobStorage::NDDisk::TReplyStatus::OK &&
+                    response.GetSegmentResults().size() ==
+                        static_cast<int>(segmentCount))
+                {
+                    for (size_t i = 0; i < segmentCount; ++i) {
+                        const auto& segmentResult =
+                            response.GetSegmentResults(i);
+                        const bool ok =
+                            segmentResult.GetStatus() ==
+                                NKikimrBlobStorage::NDDisk::TReplyStatus::OK ||
+                            segmentResult.GetStatus() ==
+                                NKikimrBlobStorage::NDDisk::TReplyStatus::
+                                    OUTDATED;
+                        flushResponse.Errors.push_back(MakeError(
+                            ok ? S_OK : E_FAIL,
+                            ok ? "" : segmentResult.GetErrorReason()));
+                    }
+                } else {
+                    LOG_ERROR(
+                        *self->ActorSystem,
+                        NKikimrServices::NBS_PARTITION,
+                        "SyncWithPBufferResult: %s, status: %d, error reason: "
+                        "%s",
+                        response.ShortUtf8DebugString().c_str(),
+                        response.GetStatus(),
+                        response.GetErrorReason().c_str());
+
+                    for (size_t i = 0; i < segmentCount; ++i) {
+                        LOG_ERROR(
+                            *self->ActorSystem,
+                            NKikimrServices::NBS_PARTITION,
+                            "SyncWithPBufferSegmentResult: %s, status: %d, "
+                            "error reason: %s",
+                            response.GetSegmentResults(i)
+                                .ShortUtf8DebugString()
+                                .c_str(),
+                            response.GetSegmentResults(i).GetStatus(),
+                            response.GetSegmentResults(i)
+                                .GetErrorReason()
+                                .c_str());
+
+                        flushResponse.Errors.push_back(
+                            MakeError(E_FAIL, response.GetErrorReason()));
+                    }
                 }
             }
 
@@ -713,7 +741,7 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
                  pbufferHostIndex,
                  ddiskHostIndex,
                  startAt,
-                 result = std::move(result),
+                 flushResponse = std::move(flushResponse),
                  threadChecker]   //
                 () mutable
                 {
@@ -724,14 +752,14 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
                             pbufferHostIndex,
                             ddiskHostIndex,
                             TMonotonic::Now() - startAt,
-                            result.Errors);
+                            flushResponse.Errors);
                     }
 
-                    promise.SetValue(std::move(result));
+                    promise.SetValue(std::move(flushResponse));
                 });
         });
 
-    return result;
+    return flushFuture;
 }
 
 NThreading::TFuture<TDBGEraseResponse> TDirectBlockGroup::EraseFromPBuffer(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/location.h
@@ -74,6 +74,11 @@ constexpr std::array<ELocation, 5> PBufferLocations{
     ELocation::HOPBuffer0,
     ELocation::HOPBuffer1};
 
+constexpr std::array<ELocation, 2> HandOffPBuffersLocations{
+    ELocation::HOPBuffer0,
+    ELocation::HOPBuffer1,
+};
+
 bool IsDDisk(ELocation location);
 bool IsPBuffer(ELocation location);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -61,7 +61,8 @@ TVector<std::shared_ptr<TRegion>> CreateRegions(
             directBlockGroups,
             storageConfig.GetSyncRequestsBatchSize(),
             storageConfig.GetVChunkSize(),
-            storageConfig.GetWriteHandoffDelay(),
+            storageConfig.GetWriteHedgingDelay(),
+            storageConfig.GetWriteRequestTimeout(),
             storageConfig.GetTraceSamplePeriod(),
             regionCounters);
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -46,7 +46,8 @@ struct TScopedNbsService: TDisableCopyMove
 
 [[nodiscard]] TScopedNbsService SetupStorage(
     TEnvironmentSetup& env,
-    EWriteMode writeMode)
+    EWriteMode writeMode,
+    TDuration writeHedgingDelay = TDuration::Seconds(1))
 {
     env.CreateBoxAndPool();
     env.Sim(TDuration::Seconds(30));
@@ -79,6 +80,7 @@ struct TScopedNbsService: TDisableCopyMove
         PersistentBufferDDiskPoolName);
     storageConfig->SetWriteMode(GetProtoWriteMode(writeMode));
     storageConfig->SetVChunkSize(DefaultVChunkSize);
+    storageConfig->SetWriteHedgingDelay(writeHedgingDelay.MicroSeconds());
 
     return TScopedNbsService(nbsConfig);
 }
@@ -779,12 +781,6 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
                 NDDisk::TEvWritePersistentBuffer::EventType)
             {
                 if (writeRequestsCount++ < 2) {
-                    runtime->Schedule(
-                        TDuration::Seconds(10),
-                        ev.release(),
-                        nullptr,
-                        nodeId);
-
                     return false;
                 }
             }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
@@ -27,7 +27,8 @@ TRegion::TRegion(
     TVector<IDirectBlockGroupPtr> directBlockGroups,
     ui32 syncRequestsBatchSize,
     ui64 vChunkSize,
-    TDuration writeHandoffDelay,
+    TDuration writeHedgingDelay,
+    TDuration writeRequestTimeout,
     TDuration traceSamplePeriod,
     NMonitoring::TDynamicCounterPtr counters)
     : ActorSystem(actorSystem)
@@ -49,7 +50,8 @@ TRegion::TRegion(
             directBlockGroups[dbgIndex],
             syncRequestsBatchSize,
             vChunkSize,
-            writeHandoffDelay,
+            writeHedgingDelay,
+            writeRequestTimeout,
             traceSamplePeriod,
             vChunkCounters);
         vChunk->Start();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
@@ -24,7 +24,8 @@ public:
         TVector<IDirectBlockGroupPtr> directBlockGroups,
         ui32 syncRequestsBatchSize,
         ui64 vChunkSize,
-        TDuration writeHandoffDelay,
+        TDuration writeHedgingDelay,
+        TDuration writeRequestTimeout,
         TDuration traceSamplePeriod,
         NMonitoring::TDynamicCounterPtr counters);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -34,7 +34,8 @@ TVChunk::TVChunk(
     IDirectBlockGroupPtr directBlockGroup,
     ui32 syncRequestsBatchSize,
     ui64 vChunkSize,
-    TDuration writeHandoffDelay,
+    TDuration writeHedgingDelay,
+    TDuration writeRequestTimeout,
     TDuration traceSamplePeriod,
     NMonitoring::TDynamicCounterPtr counters)
     : ActorSystem(actorSystem)
@@ -45,7 +46,8 @@ TVChunk::TVChunk(
     , BlockSize(DefaultBlockSize)
     , BlocksCount(vChunkSize / BlockSize)
     , SyncRequestsBatchSize(syncRequestsBatchSize)
-    , WriteHandoffDelay(writeHandoffDelay)
+    , WriteHedgingDelay(writeHedgingDelay)
+    , WriteRequestTimeout(writeRequestTimeout)
     , TraceSamplePeriod(traceSamplePeriod)
     , Counters(counters)
 {
@@ -366,7 +368,8 @@ void TVChunk::DoWriteBlocksLocal(
                     std::move(request),
                     lsn,
                     span->GetTraceId(),
-                    WriteHandoffDelay,
+                    WriteHedgingDelay,
+                    WriteRequestTimeout,
                     pbufferReplyTimeout);
             break;
         case EWriteMode::DirectPBuffersFilling:
@@ -380,7 +383,8 @@ void TVChunk::DoWriteBlocksLocal(
                     std::move(request),
                     lsn,
                     span->GetTraceId(),
-                    WriteHandoffDelay);
+                    WriteHedgingDelay,
+                    WriteRequestTimeout);
             break;
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -32,7 +32,8 @@ public:
         IDirectBlockGroupPtr directBlockGroup,
         ui32 syncRequestsBatchSize,
         ui64 vChunkSize,
-        TDuration writeHandoffDelay,
+        TDuration writeHedgingDelay,
+        TDuration writeRequestTimeout,
         TDuration traceSamplePeriod,
         NMonitoring::TDynamicCounterPtr counters);
 
@@ -97,7 +98,8 @@ private:
     const ui32 BlockSize;
     const ui64 BlocksCount;
     const ui32 SyncRequestsBatchSize;
-    const TDuration WriteHandoffDelay;
+    const TDuration WriteHedgingDelay;
+    const TDuration WriteRequestTimeout;
     const TDuration TraceSamplePeriod;
 
     TBlocksDirtyMap BlocksDirtyMap{BlockSize, BlocksCount};

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -16,7 +16,8 @@ TBaseWriteRequestExecutor::TBaseWriteRequestExecutor(
     std::shared_ptr<TWriteBlocksLocalRequest> request,
     ui64 lsn,
     NWilson::TTraceId traceId,
-    TDuration hedgingDelay)
+    TDuration hedgingDelay,
+    TDuration timeout)
     : ActorSystem(actorSystem)
     , VChunkConfig(vChunkConfig)
     , DirectBlockGroup(std::move(directBlockGroup))
@@ -26,6 +27,7 @@ TBaseWriteRequestExecutor::TBaseWriteRequestExecutor(
     , TraceId(std::move(traceId))
     , Lsn(lsn)
     , HedgingDelay(hedgingDelay)
+    , RequestTimeout(timeout)
 {}
 
 TBaseWriteRequestExecutor::~TBaseWriteRequestExecutor()
@@ -59,6 +61,10 @@ void TBaseWriteRequestExecutor::Reply(NProto::TError error)
 
 void TBaseWriteRequestExecutor::SendWriteRequest(ELocation location)
 {
+    if (Promise.IsReady()) {
+        return;
+    }
+
     auto span =
         DirectBlockGroup->CreateChildSpan(TraceId, "TBaseWriteRequestExecutor");
     if (span) {
@@ -87,6 +93,10 @@ void TBaseWriteRequestExecutor::OnWriteResponse(
     const TDBGWriteBlocksResponse& response,
     std::shared_ptr<NWilson::TSpan> span)
 {
+    if (Promise.IsReady()) {
+        return;
+    }
+
     if (!HasError(response.Error)) {
         CompletedWrites.Set(location);
         if (CompletedWrites.Count() >= QuorumDirectBlockGroupHostCount) {
@@ -122,6 +132,49 @@ void TBaseWriteRequestExecutor::OnWriteResponse(
 
         auto ender = TEndSpanWithError(std::move(span), response.Error);
     }
+}
+
+void TBaseWriteRequestExecutor::ScheduleRequestTimeoutCallback()
+{
+    if (!RequestTimeout) {
+        return;
+    }
+
+    DirectBlockGroup->Schedule(
+        RequestTimeout,
+        [weakSelf = weak_from_this()]()
+        {
+            if (auto self = weakSelf.lock()) {
+                self->RequestTimeoutCallback();
+            }
+        });
+}
+
+void TBaseWriteRequestExecutor::RequestTimeoutCallback()
+{
+    LOG_WARN(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "TBaseWriteRequestExecutor. Write request timeout. %s %s",
+        Request->Headers.VolumeConfig->DiskId.Quote().c_str(),
+        Request->Headers.Range.Print().c_str());
+
+    Reply(MakeError(E_TIMEOUT, "Write request timeout"));
+}
+
+TVector<ELocation>
+TBaseWriteRequestExecutor::GetAvailableHandOffLocations() const
+{
+    TVector<ELocation> locations;
+    locations.reserve(2);
+    if (!RequestedWrites.Get(ELocation::HOPBuffer0)) {
+        locations.push_back(ELocation::HOPBuffer0);
+    }
+    if (!RequestedWrites.Get(ELocation::HOPBuffer1)) {
+        locations.push_back(ELocation::HOPBuffer1);
+    }
+
+    return locations;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.h
@@ -35,7 +35,8 @@ public:
         std::shared_ptr<TWriteBlocksLocalRequest> request,
         ui64 lsn,
         NWilson::TTraceId traceId,
-        TDuration hedgingDelay);
+        TDuration hedgingDelay,
+        TDuration timeout);
 
     virtual ~TBaseWriteRequestExecutor();
 
@@ -53,6 +54,13 @@ protected:
         const TDBGWriteBlocksResponse& response,
         std::shared_ptr<NWilson::TSpan> span);
 
+    void ScheduleRequestTimeoutCallback();
+    void RequestTimeoutCallback();
+
+    TVector<ELocation> GetAvailableHandOffLocations() const;
+
+    virtual void ScheduleHedging() = 0;
+
     NActors::TActorSystem* ActorSystem;
     const TVChunkConfig VChunkConfig;
     const IDirectBlockGroupPtr DirectBlockGroup;
@@ -62,6 +70,7 @@ protected:
     const NWilson::TTraceId TraceId;
     const ui64 Lsn;
     const TDuration HedgingDelay;
+    const TDuration RequestTimeout;
 
     NThreading::TPromise<TResponse> Promise =
         NThreading::NewPromise<TResponse>();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
@@ -2,6 +2,7 @@
 
 #include "base_test_fixture.h"
 #include "write_with_direct_replication_request.h"
+#include "write_with_pb_replication_request.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -9,6 +10,27 @@ using namespace NKikimr;
 using namespace NThreading;
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+namespace {
+
+TRequestHeaders MakeWriteTestRequestHeaders(
+    const TBlockRange64& range,
+    ui32 blockSize)
+{
+    auto volumeConfig = std::make_shared<TVolumeConfig>(TVolumeConfig{
+        .DiskId = "disk-1",
+        .BlockSize = blockSize,
+        .BlockCount = 65536,
+        .BlocksPerStripe = 1024,
+        .VChunkSize = DefaultVChunkSize});
+
+    return TRequestHeaders{
+        .VolumeConfig = std::move(volumeConfig),
+        .RequestId = 1,
+        .Range = range};
+}
+
+}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -19,15 +41,15 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         const ui64 userLsn = 123;
         const TBlockRange64 range = TBlockRange64::WithLength(10, 10);
         const auto hedgeDelay = TDuration::MilliSeconds(1000);
+        const auto timeout = TDuration::MilliSeconds(1000);
 
         Init();
 
-        TCallback hedgeCallback;
+        TVector<std::pair<TDuration, TCallback>> scheduled;
         DirectBlockGroup->ScheduleHandler =
             [&](TDuration delay, TCallback callback)
         {
-            UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, delay);
-            hedgeCallback = std::move(callback);
+            scheduled.emplace_back(delay, std::move(callback));
         };
 
         TMap<ui8, TPromise<TDBGWriteBlocksResponse>> writePBufferPromises;
@@ -58,7 +80,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
 
         auto callContext = MakeIntrusive<TCallContext>(static_cast<ui64>(0));
         auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
-            TRequestHeaders{.RequestId = 1, .Range = range});
+            MakeWriteTestRequestHeaders(range, BlockSize));
         originalRequest->Sglist = MakeSgList();
 
         auto writeRequest =
@@ -71,10 +93,14 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
                 std::move(originalRequest),
                 userLsn,
                 NWilson::TTraceId(),
-                hedgeDelay);
+                hedgeDelay,
+                timeout);
         auto future = writeRequest->GetFuture();
         writeRequest->Run();
         UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(2, scheduled.size());
+        UNIT_ASSERT_VALUES_EQUAL(timeout, scheduled[0].first);
+        UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, scheduled[1].first);
 
         UNIT_ASSERT_VALUES_EQUAL(3, writePBufferPromises.size());
         writePBufferPromises[0].SetValue({.Error = MakeError(S_OK)});
@@ -84,6 +110,404 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.Error.GetCode());
+    }
+
+    Y_UNIT_TEST_F(ShouldReturnErrorAfterTimeout, TBaseFixture)
+    {
+        const ui64 userLsn = 123;
+        const TBlockRange64 range = TBlockRange64::WithLength(10, 10);
+        const auto hedgeDelay = TDuration::MilliSeconds(1000);
+        const auto timeout = TDuration::MilliSeconds(1000);
+
+        Init();
+
+        TVector<std::pair<TDuration, TCallback>> scheduled;
+        DirectBlockGroup->ScheduleHandler =
+            [&](TDuration delay, TCallback callback)
+        {
+            scheduled.emplace_back(delay, std::move(callback));
+        };
+
+        TMap<ui8, TPromise<TDBGWriteBlocksResponse>> writePBufferPromises;
+        DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
+            (ui32 vChunkIndex,
+             ui8 hostIndex,
+             ui64 lsn,
+             TBlockRange64 range,
+             const TGuardedSgList& guardedSglist,
+             const NWilson::TTraceId& traceId)
+        {
+            Y_UNUSED(traceId);
+            Y_UNUSED(guardedSglist);
+
+            UNIT_ASSERT_C(userLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
+
+            writePBufferPromises.emplace(
+                hostIndex,
+                NewPromise<TDBGWriteBlocksResponse>());
+
+            return writePBufferPromises[hostIndex].GetFuture();
+        };
+
+        ExpectedRange = range;
+        RangeData = GenerateRandomString(BlockSize * range.Size());
+
+        auto callContext = MakeIntrusive<TCallContext>(static_cast<ui64>(0));
+        auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
+            MakeWriteTestRequestHeaders(range, BlockSize));
+        originalRequest->Sglist = MakeSgList();
+
+        auto writeRequest =
+            std::make_shared<TWriteWithDirectReplicationRequestExecutor>(
+                Runtime->GetActorSystem(0),
+                VChunkConfig,
+                DirectBlockGroup,
+                range,
+                std::move(callContext),
+                std::move(originalRequest),
+                userLsn,
+                NWilson::TTraceId(),
+                hedgeDelay,
+                timeout);
+        auto future = writeRequest->GetFuture();
+        writeRequest->Run();
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(2, scheduled.size());
+        UNIT_ASSERT_VALUES_EQUAL(timeout, scheduled[0].first);
+        UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, scheduled[1].first);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, writePBufferPromises.size());
+
+        // Run hedge callback.
+        scheduled[0].second();
+
+        UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
+        const auto& response = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL(E_TIMEOUT, response.Error.GetCode());
+        UNIT_ASSERT_VALUES_EQUAL(
+            TStringBuf("Write request timeout"),
+            response.Error.GetMessage());
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldSucceedWithHedgingWhenPrimariesHangAndHandoffsOkWithDirectReplication,
+        TBaseFixture)
+    {
+        const ui64 userLsn = 123;
+        const TBlockRange64 range = TBlockRange64::WithLength(10, 10);
+        const auto hedgeDelay = TDuration::MilliSeconds(1000);
+        const auto timeout = TDuration::MilliSeconds(1000);
+
+        Init();
+
+        TVector<std::pair<TDuration, TCallback>> scheduled;
+        DirectBlockGroup->ScheduleHandler =
+            [&](TDuration delay, TCallback callback)
+        {
+            scheduled.emplace_back(delay, std::move(callback));
+        };
+
+        TMap<ui8, TPromise<TDBGWriteBlocksResponse>> writePBufferPromises;
+        DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
+            (ui32 vChunkIndex,
+             ui8 hostIndex,
+             ui64 lsn,
+             TBlockRange64 range,
+             const TGuardedSgList& guardedSglist,
+             const NWilson::TTraceId& traceId)
+        {
+            Y_UNUSED(traceId);
+            Y_UNUSED(guardedSglist);
+
+            UNIT_ASSERT_C(userLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
+
+            writePBufferPromises.emplace(
+                hostIndex,
+                NewPromise<TDBGWriteBlocksResponse>());
+
+            return writePBufferPromises[hostIndex].GetFuture();
+        };
+
+        ExpectedRange = range;
+        RangeData = GenerateRandomString(BlockSize * range.Size());
+
+        auto callContext = MakeIntrusive<TCallContext>(static_cast<ui64>(0));
+        auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
+            MakeWriteTestRequestHeaders(range, BlockSize));
+        originalRequest->Sglist = MakeSgList();
+
+        auto writeRequest =
+            std::make_shared<TWriteWithDirectReplicationRequestExecutor>(
+                Runtime->GetActorSystem(0),
+                VChunkConfig,
+                DirectBlockGroup,
+                range,
+                std::move(callContext),
+                std::move(originalRequest),
+                userLsn,
+                NWilson::TTraceId(),
+                hedgeDelay,
+                timeout);
+        auto future = writeRequest->GetFuture();
+        writeRequest->Run();
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(2, scheduled.size());
+        UNIT_ASSERT_VALUES_EQUAL(timeout, scheduled[0].first);
+        UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, scheduled[1].first);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, writePBufferPromises.size());
+
+        // Run hedge callback.
+        scheduled[1].second();
+
+        UNIT_ASSERT_VALUES_EQUAL(5, writePBufferPromises.size());
+
+        writePBufferPromises[VChunkConfig.HandOffHost0].SetValue(
+            {.Error = MakeError(S_OK)});
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+
+        writePBufferPromises[VChunkConfig.HandOffHost1].SetValue(
+            {.Error = MakeError(S_OK)});
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+
+        writePBufferPromises[VChunkConfig.PrimaryHost2].SetValue(
+            {.Error = MakeError(S_OK)});
+
+        UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
+        const auto& response = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response.Error.GetCode());
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(true, true, true, true, true),
+            response.RequestedWrites);
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(false, false, true, true, true),
+            response.CompletedWrites);
+    }
+
+    Y_UNIT_TEST_F(ShouldNotSendWriteRequestAfterQuorumIsReached, TBaseFixture)
+    {
+        const ui64 userLsn = 123;
+        const TBlockRange64 range = TBlockRange64::WithLength(10, 10);
+        const auto hedgeDelay = TDuration::MilliSeconds(100);
+        const auto timeout = TDuration::MilliSeconds(10000);
+
+        Init();
+
+        TVector<std::pair<TDuration, TCallback>> scheduled;
+        DirectBlockGroup->ScheduleHandler =
+            [&](TDuration delay, TCallback callback)
+        {
+            scheduled.emplace_back(delay, std::move(callback));
+        };
+
+        TMap<ui8, TPromise<TDBGWriteBlocksResponse>> writePBufferPromises;
+        DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
+            (ui32 vChunkIndex,
+             ui8 hostIndex,
+             ui64 lsn,
+             TBlockRange64 range,
+             const TGuardedSgList& guardedSglist,
+             const NWilson::TTraceId& traceId)
+        {
+            Y_UNUSED(traceId);
+            Y_UNUSED(guardedSglist);
+
+            UNIT_ASSERT_C(userLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
+
+            writePBufferPromises.emplace(
+                hostIndex,
+                NewPromise<TDBGWriteBlocksResponse>());
+
+            return writePBufferPromises[hostIndex].GetFuture();
+        };
+
+        ExpectedRange = range;
+        RangeData = GenerateRandomString(BlockSize * range.Size());
+
+        auto callContext = MakeIntrusive<TCallContext>(static_cast<ui64>(0));
+        auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
+            MakeWriteTestRequestHeaders(range, BlockSize));
+        originalRequest->Sglist = MakeSgList();
+
+        auto writeRequest =
+            std::make_shared<TWriteWithDirectReplicationRequestExecutor>(
+                Runtime->GetActorSystem(0),
+                VChunkConfig,
+                DirectBlockGroup,
+                range,
+                std::move(callContext),
+                std::move(originalRequest),
+                userLsn,
+                NWilson::TTraceId(),
+                hedgeDelay,
+                timeout);
+        auto future = writeRequest->GetFuture();
+        writeRequest->Run();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, scheduled.size());
+        UNIT_ASSERT_VALUES_EQUAL(timeout, scheduled[0].first);
+        UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, scheduled[1].first);
+
+        UNIT_ASSERT_VALUES_EQUAL(3, writePBufferPromises.size());
+        writePBufferPromises[VChunkConfig.PrimaryHost0].SetValue(
+            {.Error = MakeError(S_OK)});
+        writePBufferPromises[VChunkConfig.PrimaryHost1].SetValue(
+            {.Error = MakeError(S_OK)});
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+
+        scheduled[1].second();
+        UNIT_ASSERT_VALUES_EQUAL(4, writePBufferPromises.size());
+        UNIT_ASSERT(!writePBufferPromises.contains(VChunkConfig.HandOffHost1));
+
+        writePBufferPromises[VChunkConfig.PrimaryHost2].SetValue(
+            {.Error = MakeError(S_OK)});
+
+        writePBufferPromises[VChunkConfig.HandOffHost0].SetValue(
+            {.Error = MakeError(E_FAIL, "hedged handoff failed")});
+
+        UNIT_ASSERT_VALUES_EQUAL(4, writePBufferPromises.size());
+        UNIT_ASSERT(!writePBufferPromises.contains(VChunkConfig.HandOffHost1));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
+        const auto& response = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response.Error.GetCode());
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(true, true, true, true, false),
+            response.RequestedWrites);
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(true, true, true, false, false),
+            response.CompletedWrites);
+    }
+
+    Y_UNIT_TEST_F(
+        ShouldSucceedWithHedgingWhenPrimariesHangAndHandoffsOkWithPbReplication,
+        TBaseFixture)
+    {
+        const ui64 userLsn = 123;
+        const TBlockRange64 range = TBlockRange64::WithLength(10, 10);
+        const auto hedgeDelay = TDuration::MilliSeconds(1000);
+        const auto timeout = TDuration::MilliSeconds(1000);
+        const auto pbufferReplyTimeout = TDuration::MilliSeconds(500);
+
+        Init();
+
+        TVector<std::pair<TDuration, TCallback>> scheduled;
+        DirectBlockGroup->ScheduleHandler =
+            [&](TDuration delay, TCallback callback)
+        {
+            scheduled.emplace_back(delay, std::move(callback));
+        };
+
+        TVector<TPromise<TDBGWriteBlocksToManyPBuffersResponse>>
+            manyPBufferBatchPromises;
+
+        DirectBlockGroup->WriteBlocksToManyPBuffersHandler =
+            [&](ui32 vChunkIndex,
+                std::vector<ui8> hostIndexes,
+                ui64 lsn,
+                TBlockRange64 range,
+                TDuration replyTimeout,
+                const TGuardedSgList& guardedSglist,
+                const NWilson::TTraceId& traceId)   //
+            -> TFuture<TDBGWriteBlocksToManyPBuffersResponse>
+        {
+            Y_UNUSED(traceId);
+            Y_UNUSED(guardedSglist);
+
+            UNIT_ASSERT_C(userLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
+            UNIT_ASSERT_VALUES_EQUAL(pbufferReplyTimeout, replyTimeout);
+
+            if (manyPBufferBatchPromises.empty()) {
+                UNIT_ASSERT_VALUES_EQUAL(3u, hostIndexes.size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.PrimaryHost0,
+                    hostIndexes[0]);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.PrimaryHost1,
+                    hostIndexes[1]);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.PrimaryHost2,
+                    hostIndexes[2]);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(3u, hostIndexes.size());
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.PrimaryHost2,
+                    hostIndexes[0]);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.HandOffHost0,
+                    hostIndexes[1]);
+                UNIT_ASSERT_VALUES_EQUAL(
+                    VChunkConfig.HandOffHost1,
+                    hostIndexes[2]);
+            }
+
+            auto promise = NewPromise<TDBGWriteBlocksToManyPBuffersResponse>();
+            manyPBufferBatchPromises.push_back(std::move(promise));
+            return manyPBufferBatchPromises.back().GetFuture();
+        };
+
+        ExpectedRange = range;
+        RangeData = GenerateRandomString(BlockSize * range.Size());
+
+        auto callContext = MakeIntrusive<TCallContext>(static_cast<ui64>(0));
+        auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
+            MakeWriteTestRequestHeaders(range, BlockSize));
+        originalRequest->Sglist = MakeSgList();
+
+        auto writeRequest =
+            std::make_shared<TWriteWithPbReplicationRequestExecutor>(
+                Runtime->GetActorSystem(0),
+                VChunkConfig,
+                DirectBlockGroup,
+                range,
+                std::move(callContext),
+                std::move(originalRequest),
+                userLsn,
+                NWilson::TTraceId(),
+                hedgeDelay,
+                timeout,
+                pbufferReplyTimeout);
+        auto future = writeRequest->GetFuture();
+        writeRequest->Run();
+        UNIT_ASSERT_VALUES_EQUAL(false, future.HasValue());
+        UNIT_ASSERT_VALUES_EQUAL(2, scheduled.size());
+        UNIT_ASSERT_VALUES_EQUAL(timeout, scheduled[0].first);
+        UNIT_ASSERT_VALUES_EQUAL(hedgeDelay, scheduled[1].first);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, manyPBufferBatchPromises.size());
+
+        scheduled[1].second();
+
+        UNIT_ASSERT_VALUES_EQUAL(2, manyPBufferBatchPromises.size());
+
+        TDBGWriteBlocksToManyPBuffersResponse hedgeOk;
+        hedgeOk.OverallError = MakeError(S_OK);
+        hedgeOk.Responses.push_back(
+            {.HostIndex = VChunkConfig.HandOffHost0, .Error = MakeError(S_OK)});
+        hedgeOk.Responses.push_back(
+            {.HostIndex = VChunkConfig.HandOffHost1, .Error = MakeError(S_OK)});
+        hedgeOk.Responses.push_back(
+            {.HostIndex = VChunkConfig.PrimaryHost2, .Error = MakeError(S_OK)});
+
+        manyPBufferBatchPromises[1].SetValue(std::move(hedgeOk));
+
+        UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
+        const auto& response = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL(S_OK, response.Error.GetCode());
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(true, true, true, true, true),
+            response.RequestedWrites);
+        UNIT_ASSERT_EQUAL(
+            TLocationMask::MakePBuffer(false, false, true, true, true),
+            response.CompletedWrites);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
@@ -16,7 +16,8 @@ TWriteWithDirectReplicationRequestExecutor::
         std::shared_ptr<TWriteBlocksLocalRequest> request,
         ui64 lsn,
         NWilson::TTraceId traceId,
-        TDuration hedgingDelay)
+        TDuration hedgingDelay,
+        TDuration timeout)
     : TBaseWriteRequestExecutor(
           actorSystem,
           vChunkConfig,
@@ -26,54 +27,62 @@ TWriteWithDirectReplicationRequestExecutor::
           std::move(request),
           lsn,
           std::move(traceId),
-          hedgingDelay)
+          hedgingDelay,
+          timeout)
 {}
 
 void TWriteWithDirectReplicationRequestExecutor::Run()
 {
+    ScheduleRequestTimeoutCallback();
+    ScheduleHedging();
     SendWriteRequest(ELocation::PBuffer0);
     SendWriteRequest(ELocation::PBuffer1);
     SendWriteRequest(ELocation::PBuffer2);
+}
 
-    if (HedgingDelay) {
-        DirectBlockGroup->Schedule(
-            HedgingDelay,
-            [weakSelf = weak_from_this()]()
-            {
-                if (auto self = weakSelf.lock()) {
-                    std::static_pointer_cast<
-                        TWriteWithDirectReplicationRequestExecutor>(self)
-                        ->SendWriteRequestsToHandoffPBuffers();
-                }
-            });
+void TWriteWithDirectReplicationRequestExecutor::ScheduleHedging()
+{
+    if (!HedgingDelay) {
+        return;
     }
+
+    DirectBlockGroup->Schedule(
+        HedgingDelay,
+        [weakSelf = weak_from_this()]()
+        {
+            if (auto self = std::static_pointer_cast<
+                    TWriteWithDirectReplicationRequestExecutor>(
+                    weakSelf.lock()))
+            {
+                self->SendWriteRequestsToHandoffPBuffers();
+            }
+        });
 }
 
 void TWriteWithDirectReplicationRequestExecutor::
     SendWriteRequestsToHandoffPBuffers()
 {
-    if (CompletedWrites.Count() <= QuorumDirectBlockGroupHostCount - 1) {
-        LOG_DEBUG(
-            *ActorSystem,
-            NKikimrServices::NBS_PARTITION,
-            "TWriteWithDirectReplicationRequestExecutor. Send write request to "
-            "HOPBuffer0 since we "
-            "have %lu completed writes",
-            CompletedWrites.Count());
-
-        SendWriteRequest(ELocation::HOPBuffer0);
+    if (Promise.IsReady()) {
+        return;
     }
 
-    if (CompletedWrites.Count() <= QuorumDirectBlockGroupHostCount - 2) {
+    const auto availableHandOffLocations = GetAvailableHandOffLocations();
+    const size_t neededHedgingRequestsCount = std::min(
+        QuorumDirectBlockGroupHostCount - CompletedWrites.Count(),
+        availableHandOffLocations.size());
+
+    for (size_t i = 0; i < neededHedgingRequestsCount; ++i) {
+        const auto& location = availableHandOffLocations[i];
         LOG_DEBUG(
             *ActorSystem,
             NKikimrServices::NBS_PARTITION,
             "TWriteWithDirectReplicationRequestExecutor. Send write request to "
-            "HOPBuffer1 since we "
+            "handoff buffer %lu since we "
             "have %lu completed writes",
+            GetLocationIndex(location),
             CompletedWrites.Count());
 
-        SendWriteRequest(ELocation::HOPBuffer1);
+        SendWriteRequest(location);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.h
@@ -19,7 +19,8 @@ public:
         std::shared_ptr<TWriteBlocksLocalRequest> request,
         ui64 lsn,
         NWilson::TTraceId traceId,
-        TDuration hedgingDelay);
+        TDuration hedgingDelay,
+        TDuration timeout);
 
     ~TWriteWithDirectReplicationRequestExecutor() override = default;
 
@@ -27,6 +28,8 @@ public:
 
 private:
     void SendWriteRequestsToHandoffPBuffers();
+
+    void ScheduleHedging() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.cpp
@@ -16,6 +16,7 @@ TWriteWithPbReplicationRequestExecutor::TWriteWithPbReplicationRequestExecutor(
     ui64 lsn,
     NWilson::TTraceId traceId,
     TDuration hedgingDelay,
+    TDuration timeout,
     TDuration pbufferReplyTimeout)
     : TBaseWriteRequestExecutor(
           actorSystem,
@@ -26,23 +27,50 @@ TWriteWithPbReplicationRequestExecutor::TWriteWithPbReplicationRequestExecutor(
           std::move(request),
           lsn,
           std::move(traceId),
-          hedgingDelay)
+          hedgingDelay,
+          timeout)
     , PbufferReplyTimeout(pbufferReplyTimeout)
 {}
 
 void TWriteWithPbReplicationRequestExecutor::Run()
 {
-    SendWriteRequestToManyPBuffers();
+    ScheduleRequestTimeoutCallback();
+    ScheduleHedging();
+    SendWriteRequestToManyPBuffers(
+        {ELocation::PBuffer0, ELocation::PBuffer1, ELocation::PBuffer2});
 }
 
-void TWriteWithPbReplicationRequestExecutor::SendWriteRequestToManyPBuffers()
+void TWriteWithPbReplicationRequestExecutor::ScheduleHedging()
 {
-    std::vector<ELocation> locations = {
-        ELocation::PBuffer0,
-        ELocation::PBuffer1,
-        ELocation::PBuffer2};
+    if (!HedgingDelay) {
+        return;
+    }
 
-    std::vector<ui8> hostsIndexes;
+    DirectBlockGroup->Schedule(
+        HedgingDelay,
+        [weakSelf = weak_from_this()]()
+        {
+            if (auto self = std::static_pointer_cast<
+                    TWriteWithPbReplicationRequestExecutor>(weakSelf.lock()))
+            {
+                if (!self->CompletedWrites.Count()) {
+                    self->SendWriteRequestToManyPBuffers(
+                        {ELocation::PBuffer2,
+                         ELocation::HOPBuffer0,
+                         ELocation::HOPBuffer1});
+                }
+            }
+        });
+}
+
+void TWriteWithPbReplicationRequestExecutor::SendWriteRequestToManyPBuffers(
+    TVector<ELocation> locations)
+{
+    if (Promise.IsReady()) {
+        return;
+    }
+
+    TVector<ui8> hostsIndexes;
     hostsIndexes.reserve(3);
     for (auto location: locations) {
         hostsIndexes.push_back(VChunkConfig.GetHostIndex(location));
@@ -98,9 +126,8 @@ void TWriteWithPbReplicationRequestExecutor::OnWriteToManyPBuffersResponse(
         return;
     }
 
-    std::vector<ELocation> handoffLocations(
-        {ELocation::HOPBuffer0, ELocation::HOPBuffer1});
-    if (CompletedWrites.Count() + handoffLocations.size() <
+    const auto availableHandOffLocations = GetAvailableHandOffLocations();
+    if (CompletedWrites.Count() + availableHandOffLocations.size() <
         QuorumDirectBlockGroupHostCount)
     {
         auto resultError =
@@ -125,7 +152,8 @@ void TWriteWithPbReplicationRequestExecutor::OnWriteToManyPBuffersResponse(
             NKikimrServices::NBS_PARTITION,
             "trying to send fallback writeRequest to %d handoff",
             i);
-        SendWriteRequest(handoffLocations[i]);
+
+        SendWriteRequest(availableHandOffLocations[i]);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.h
@@ -19,6 +19,7 @@ public:
         ui64 lsn,
         NWilson::TTraceId traceId,
         TDuration hedgingDelay,
+        TDuration timeout,
         TDuration pbufferReplyTimeout);
 
     ~TWriteWithPbReplicationRequestExecutor() override = default;
@@ -28,9 +29,11 @@ public:
 private:
     const TDuration PbufferReplyTimeout;
 
-    void SendWriteRequestToManyPBuffers();
+    void SendWriteRequestToManyPBuffers(TVector<ELocation> locations);
     void OnWriteToManyPBuffersResponse(
         const TDBGWriteBlocksToManyPBuffersResponse& response);
+
+    void ScheduleHedging() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
```
qemu@ubuntu:~$ sudo fio --name=randwrite --ioengine=libaio --iodepth=32 --rw=randwrite --bs=4k --direct=1 --numjobs=1 --group_reporting1
randwrite: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=32
fio-3.16
Starting 1 process
Jobs: 1 (f=1): [w(1)][100.0%][w=197MiB/s][w=50.4k IOPS][eta 00m:00s]
randwrite: (groupid=0, jobs=1): err= 0: pid=1077: Fri Apr 24 15:22:17 2026
  write: IOPS=50.6k, BW=198MiB/s (207MB/s)(11.6GiB/60001msec); 0 zone resets
    slat (usec): min=2, max=1068, avg= 7.01, stdev= 2.97
    clat (usec): min=199, max=3303, avg=624.32, stdev=186.33
     lat (usec): min=206, max=3311, avg=631.50, stdev=186.37
    clat percentiles (usec):
     |  1.00th=[  379],  5.00th=[  437], 10.00th=[  465], 20.00th=[  502],
     | 30.00th=[  529], 40.00th=[  553], 50.00th=[  578], 60.00th=[  611],
     | 70.00th=[  644], 80.00th=[  701], 90.00th=[  832], 95.00th=[  996],
     | 99.00th=[ 1336], 99.50th=[ 1516], 99.90th=[ 1991], 99.95th=[ 2212],
     | 99.99th=[ 2573]
   bw (  KiB/s): min=174576, max=215384, per=100.00%, avg=202469.97, stdev=8103.14, samples=120
   iops        : min=43644, max=53846, avg=50617.48, stdev=2025.76, samples=120
  lat (usec)   : 250=0.01%, 500=18.93%, 750=66.39%, 1000=9.74%
  lat (msec)   : 2=4.84%, 4=0.10%
  cpu          : usr=15.16%, sys=43.73%, ctx=1057521, majf=0, minf=11
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,3037229,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
  WRITE: bw=198MiB/s (207MB/s), 198MiB/s-198MiB/s (207MB/s-207MB/s), io=11.6GiB (12.4GB), run=60001-60001msec

Disk stats (read/write):
  vdb: ios=50/3031951, merge=0/0, ticks=30/1867888, in_queue=0, util=99.97%
```