### PR TITLE
State storage availability monitoring improvement

### DIFF
--- a/ydb/core/base/statestorage.cpp
+++ b/ydb/core/base/statestorage.cpp
@@ -249,6 +249,93 @@ bool operator!=(const TStateStorageInfo::TRingGroup& lhs, const TStateStorageInf
     return !operator==(lhs, rhs);
 }
 
+/*
+ * Calculate a conservative "effective number of unavailable rings" for a
+ * single state storage ring group: the maximum number of unavailable state
+ * storage replicas that may simultaneously belong to SelectReplicas for a
+ * single hash/tabletId, counted in ring units (at most one selected replica
+ * per ring).
+ *
+ * The input is not "which rings are broken", but per-replica availability for
+ * each ring. So the result is not a plain count of physically degraded rings,
+ * but the worst-case number of rings that may be unavailable for some hash.
+ *
+ * This distinction matters because ring unavailability depends on
+ * UseRingSpecificNodeSelection.
+ *
+ * 1. UseRingSpecificNodeSelection = true
+ *    Replica choice inside the ring depends on the ring itself, so different
+ *    hashes may hit different replicas of the same ring independently. If at
+ *    least one replica is unavailable, then there exists a set of hashes for
+ *    which this ring becomes unavailable. For this conservative model such a
+ *    ring contributes 1 to the result.
+ *
+ * 2. UseRingSpecificNodeSelection = false
+ *    Replica choice is shared between rings of the same size: hash % ring_size
+ *    picks the same column in every such ring. In this mode a failed replica
+ *    does not invalidate the whole ring for all hashes, it only affects its
+ *    column. Therefore we group rings by ring size, count unavailable replicas
+ *    per column, and take the worst column in each group. That value is the
+ *    effective number of unavailable rings for this group.
+ *
+ * The final result is the sum of contributions from:
+ * - all ring-specific rings, counted individually;
+ * - all shared-selection groups, counted by their worst column.
+ */
+ui32 CalculateEffectiveUnavailableRings(
+    const TStateStorageInfo::TRingGroup& ringGroup,
+    const TVector<TStateStorageRingAvailability>& ringAvailability)
+{
+    Y_ABORT_UNLESS(ringGroup.Rings.size() == ringAvailability.size());
+
+    ui32 effectiveUnavailable = 0;
+    THashMap<ui32, TVector<ui32>> columnUnavailableByRingSize;
+
+    for (ui32 ringIdx : xrange(ringGroup.Rings.size())) {
+        const auto& ring = ringGroup.Rings[ringIdx];
+        const auto& availability = ringAvailability[ringIdx];
+
+        Y_ABORT_UNLESS(ring.Replicas.size() == availability.AvailableReplicas.size());
+
+        if (ring.UseRingSpecificNodeSelection) {
+            // For ring-specific selection any unavailable replica makes the whole
+            // ring effectively unavailable for some hashes.
+            bool hasUnavailableReplica = false;
+            for (bool available : availability.AvailableReplicas) {
+                if (!available) {
+                    hasUnavailableReplica = true;
+                    break;
+                }
+            }
+
+            effectiveUnavailable += hasUnavailableReplica;
+            continue;
+        }
+
+        // Rings with shared replica selection are grouped by ring size and
+        // accounted by columns: the worst column contributes to the total.
+        auto& columnUnavailable = columnUnavailableByRingSize[ring.Replicas.size()];
+        if (columnUnavailable.empty()) {
+            columnUnavailable.resize(ring.Replicas.size(), 0);
+        } else {
+            Y_ABORT_UNLESS(columnUnavailable.size() == ring.Replicas.size());
+        }
+
+        for (ui32 replicaIdx : xrange(availability.AvailableReplicas.size())) {
+            if (!availability.AvailableReplicas[replicaIdx]) {
+                ++columnUnavailable[replicaIdx];
+            }
+        }
+    }
+
+    for (const auto& [ringSize, columnUnavailable] : columnUnavailableByRingSize) {
+        Y_UNUSED(ringSize);
+        effectiveUnavailable += *MaxElement(columnUnavailable.begin(), columnUnavailable.end());
+    }
+
+    return effectiveUnavailable;
+}
+
 static void CopyStateStorageRingInfo(
     const NKikimrConfig::TDomainsConfig::TStateStorage::TRing &source,
     TStateStorageInfo::TRingGroup& ringGroup,

--- a/ydb/core/base/statestorage.h
+++ b/ydb/core/base/statestorage.h
@@ -611,6 +611,16 @@ private:
     mutable ui64 Hash;
 };
 
+struct TStateStorageRingAvailability {
+    // Per-replica availability mask. true means the replica is available.
+    // A fully unavailable ring is represented by setting all replicas to false.
+    TVector<bool> AvailableReplicas;
+};
+
+ui32 CalculateEffectiveUnavailableRings(
+    const TStateStorageInfo::TRingGroup& ringGroup,
+    const TVector<TStateStorageRingAvailability>& ringAvailability);
+
 bool operator==(const TStateStorageInfo::TRing& lhs, const TStateStorageInfo::TRing& rhs);
 bool operator==(const TStateStorageInfo::TRingGroup& lhs, const TStateStorageInfo::TRingGroup& rhs);
 bool operator!=(const TStateStorageInfo::TRing& lhs, const TStateStorageInfo::TRing& rhs);

--- a/ydb/core/base/statestorage_ut.cpp
+++ b/ydb/core/base/statestorage_ut.cpp
@@ -360,6 +360,30 @@ Y_UNIT_TEST_SUITE(TStateStorageConfig) {
         }
     }
 
+    TStateStorageInfo::TRing MakeRing(ui32 ringId, ui32 replicasInRing, bool useRingSpecificNodeSelection) {
+        TStateStorageInfo::TRing ring;
+        ring.IsDisabled = false;
+        ring.UseRingSpecificNodeSelection = useRingSpecificNodeSelection;
+        for (ui32 replicaIdx : xrange(replicasInRing)) {
+            const ui32 nodeId = ringId * 100 + replicaIdx + 1;
+            ring.Replicas.push_back(TActorId(nodeId, ringId, replicaIdx, ringId));
+        }
+        return ring;
+    }
+
+    TStateStorageInfo::TRingGroup MakeRingGroup(std::initializer_list<TStateStorageInfo::TRing> rings) {
+        TStateStorageInfo::TRingGroup group;
+        group.NToSelect = rings.size();
+        group.Rings.assign(rings.begin(), rings.end());
+        return group;
+    }
+
+    TStateStorageRingAvailability MakeRingAvailability(std::initializer_list<bool> availableReplicas) {
+        TStateStorageRingAvailability availability;
+        availability.AvailableReplicas.assign(availableReplicas.begin(), availableReplicas.end());
+        return availability;
+    }
+
     ui64 StabilityRun(ui32 replicas, ui32 nToSelect, ui32 replicasInRing, bool useRingSpecificNodeSelection) {
         ui64 retHash = 0;
 
@@ -432,6 +456,92 @@ Y_UNIT_TEST_SUITE(TStateStorageConfig) {
         UNIT_ASSERT_DOUBLES_EQUAL(UniqueCombinationsRun(113, 3, 5, true), 0.63673, 1e-7);
         UNIT_ASSERT_DOUBLES_EQUAL(UniqueCombinationsRun(113, 9, 1, true), 0.009237, 1e-7);
         UNIT_ASSERT_DOUBLES_EQUAL(UniqueCombinationsRun(113, 9, 8, true), 0.072514, 1e-7);
+    }
+
+    Y_UNIT_TEST(EffectiveUnavailableRingsForRingSpecificClass) {
+        const auto ringGroup = MakeRingGroup({
+            MakeRing(0, 3, true),
+            MakeRing(1, 2, true),
+            MakeRing(2, 4, true),
+            MakeRing(3, 2, true),
+        });
+
+        const TVector<TStateStorageRingAvailability> ringAvailability = {
+            MakeRingAvailability({false, true, true}),
+            MakeRingAvailability({true, true}),
+            MakeRingAvailability({false, false, false, false}),
+            MakeRingAvailability({true, false}),
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(CalculateEffectiveUnavailableRings(ringGroup, ringAvailability), 3);
+    }
+
+    Y_UNIT_TEST(EffectiveUnavailableRingsForColumnClass) {
+        const auto ringGroup = MakeRingGroup({
+            MakeRing(0, 2, false),
+            MakeRing(1, 2, false),
+            MakeRing(2, 2, false),
+            MakeRing(3, 2, false),
+        });
+
+        const TVector<TStateStorageRingAvailability> ringAvailability = {
+            MakeRingAvailability({false, true}),
+            MakeRingAvailability({true, false}),
+            MakeRingAvailability({false, true}),
+            MakeRingAvailability({true, true}),
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(CalculateEffectiveUnavailableRings(ringGroup, ringAvailability), 2);
+    }
+
+    Y_UNIT_TEST(FullyUnavailableRingAffectsAllColumns) {
+        const auto ringGroup = MakeRingGroup({
+            MakeRing(0, 2, false),
+            MakeRing(1, 2, false),
+            MakeRing(2, 2, false),
+        });
+
+        const TVector<TStateStorageRingAvailability> ringAvailability = {
+            MakeRingAvailability({false, false}),
+            MakeRingAvailability({true, false}),
+            MakeRingAvailability({false, true}),
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(CalculateEffectiveUnavailableRings(ringGroup, ringAvailability), 2);
+    }
+
+    Y_UNIT_TEST(EffectiveUnavailableRingsForMixedClasses) {
+        const auto ringGroup = MakeRingGroup({
+            MakeRing(0, 3, true),
+            MakeRing(1, 2, false),
+            MakeRing(2, 2, false),
+            MakeRing(3, 3, false),
+            MakeRing(4, 3, false),
+        });
+
+        const TVector<TStateStorageRingAvailability> ringAvailability = {
+            MakeRingAvailability({true, false, true}),
+            MakeRingAvailability({false, true}),
+            MakeRingAvailability({false, true}),
+            MakeRingAvailability({true, true, false}),
+            MakeRingAvailability({true, false, true}),
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(CalculateEffectiveUnavailableRings(ringGroup, ringAvailability), 4);
+    }
+
+    Y_UNIT_TEST(EffectiveUnavailableRingsIsConservativeAcrossDifferentRingSizes) {
+        const auto ringGroup = MakeRingGroup({
+            MakeRing(0, 2, false),
+            MakeRing(1, 4, false),
+        });
+
+        const TVector<TStateStorageRingAvailability> ringAvailability = {
+            MakeRingAvailability({true, false}),
+            MakeRingAvailability({true, true, false, true}),
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(CalculateEffectiveUnavailableRings(ringGroup, ringAvailability), 2);
     }
 
     double UniformityRun(ui32 replicas, ui32 nToSelect, ui32 replicasInRing, bool useRingSpecificNodeSelection) {

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -43,6 +43,13 @@ namespace {
 
 constexpr size_t MAX_ISSUES_TO_STORE = 100;
 
+struct TStateStorageAvailabilityStats {
+    TVector<TStateStorageRingAvailability> RingAvailability;
+    ui32 DisabledRings = 0;
+    bool CurrentRingDisabled = false;
+    bool HasRestartRingsByThisRequest = false;
+};
+
 TAction::TIssue ConvertIssue(const TReason& reason) {
     TAction::TIssue issue;
     switch (reason.GetType()) {
@@ -67,6 +74,71 @@ TAction::TIssue ConvertIssue(const TReason& reason) {
     }
     issue.SetMessage(reason.GetMessage());
     return issue;
+}
+
+TStateStorageAvailabilityStats BuildStateStorageAvailabilityStats(
+    const TStateStorageInfo::TRingGroup& ringGroup,
+    const TVector<TStateStorageRingInfoPtr>& ringInfos,
+    ui32 currentNodeId,
+    ui32 currentRingId,
+    TInstant now,
+    TDuration retryTime,
+    TDuration duration,
+    const TString& requestId)
+{
+    Y_ABORT_UNLESS(ringGroup.Rings.size() == ringInfos.size());
+
+    TStateStorageAvailabilityStats stats;
+    stats.RingAvailability.resize(ringInfos.size());
+
+    TErrorInfo unusedError;
+
+    for (const auto& ringInfo : ringInfos) {
+        const ui32 ringId = ringInfo->RingId;
+        Y_ABORT_UNLESS(ringId < ringGroup.Rings.size());
+
+        const auto& ring = ringGroup.Rings[ringId];
+        auto& availability = stats.RingAvailability[ringId];
+        availability.AvailableReplicas.reserve(ringInfo->Replicas.size());
+
+        Y_ABORT_UNLESS(ring.Replicas.size() == ringInfo->Replicas.size());
+
+        if (ringInfo->IsDisabled) {
+            if (ringId == currentRingId) {
+                stats.CurrentRingDisabled = true;
+            } else {
+                ++stats.DisabledRings;
+            }
+
+            availability.AvailableReplicas.resize(ringInfo->Replicas.size(), true);
+            continue;
+        }
+
+        for (const auto& replica : ringInfo->Replicas) {
+            bool available = true;
+            bool restartedByThisRequest = false;
+
+            if (replica->NodeId == currentNodeId) {
+                available = false;
+                restartedByThisRequest = replica->IsLockedByRequest(requestId);
+            } else {
+                const bool unavailableByRestart = replica->IsDown(unusedError, now + retryTime)
+                    || replica->IsLocked(unusedError, retryTime, now, duration);
+
+                if (unavailableByRestart) {
+                    available = false;
+                    restartedByThisRequest = replica->IsLockedByRequest(requestId);
+                } else if (now <= replica->StartTime + ringInfo->Timeout) {
+                    available = false;
+                }
+            }
+
+            stats.HasRestartRingsByThisRequest |= restartedByThisRequest;
+            availability.AvailableReplicas.push_back(available);
+        }
+    }
+
+    return stats;
 }
 
 } // anonymous namespace
@@ -756,58 +828,34 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
 
     const ui32 ringGroupId = node.PileId.GetOrElse(0);
     Y_ABORT_UNLESS(ringGroupId < ClusterInfo->StateStorageInfo->RingGroups.size());
-    const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId].NToSelect;
+    const auto& ringGroup = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId];
+    const ui32 nToSelect = ringGroup.NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
-    ui8 currentRingState = TStateStorageRingInfo::Unknown;
-    bool hasRestartRingsByThisRequest = false;
-    ui32 restartRings = 0;
-    ui32 lockedRings = 0;
-    ui32 disabledRings = 0;
     auto now = AppData(ctx)->TimeProvider->Now();
     TDuration duration = TDuration::MicroSeconds(action.GetDuration()) + opts.PermissionDuration;
-    for (auto ringInfo : ClusterInfo->StateStorageRings[ringGroupId]) {
-        auto state = ringInfo->CountState(now, State->Config.DefaultRetryTime, duration, opts.RequestId);
-        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Ring: " << ringInfo->RingId
-                                                                 << "; State: " << TStateStorageRingInfo::RingStateToString(state));
-        
-        if (state == TStateStorageRingInfo::RestartByThisRequest) {
-            hasRestartRingsByThisRequest = true;
-            state = TStateStorageRingInfo::Restart;
-        }
+    const auto availabilityStats = BuildStateStorageAvailabilityStats(
+        ringGroup,
+        ClusterInfo->StateStorageRings[ringGroupId],
+        node.NodeId,
+        currentRing,
+        now,
+        State->Config.DefaultRetryTime,
+        duration,
+        opts.RequestId);
 
-        if (ringInfo->RingId == currentRing) {
-            if (state == TStateStorageRingInfo::Disabled) {
-                return true;
-            }
-            currentRingState = state;
-            continue;
-        }
-        switch (state) {
-            case TStateStorageRingInfo::Ok:
-                break;
-            case TStateStorageRingInfo::Locked:
-                ++lockedRings;
-                break;
-            case TStateStorageRingInfo::Restart:
-                ++restartRings;
-                break;
-            case TStateStorageRingInfo::Disabled:
-                ++disabledRings;
-                break;
-            default:
-                break;
-        }
+    if (availabilityStats.CurrentRingDisabled) {
+        return true;
     }
-    Y_ABORT_UNLESS(currentRingState != TStateStorageRingInfo::Unknown);
 
-    // Add current ring to restart rings
-    ++restartRings;
+    const ui32 effectiveUnavailableRings = CalculateEffectiveUnavailableRings(
+        ringGroup,
+        availabilityStats.RingAvailability);
 
     const ui32 maxAvailabilityLimit = 1;
     const ui32 keepAvailableLimit = (nToSelect - 1) / 2;
 
-    const bool maxAvailabilityOk = restartRings + lockedRings <= maxAvailabilityLimit;
-    const bool keepAvailableOk = restartRings + lockedRings + disabledRings <= keepAvailableLimit;
+    const bool maxAvailabilityOk = effectiveUnavailableRings <= maxAvailabilityLimit;
+    const bool keepAvailableOk = effectiveUnavailableRings + availabilityStats.DisabledRings <= keepAvailableLimit;
 
     switch (opts.AvailabilityMode) {
         case MODE_MAX_AVAILABILITY:
@@ -815,10 +863,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
                 error.Code = TStatus::DISALLOW_TEMP;
                 error.Reason = TReason(
                     TStringBuilder() << "Too many unavailable state storage rings"
-                    << ". Restarting rings: "
-                    << (currentRingState == TStateStorageRingInfo::Restart ? restartRings : restartRings - 1)
-                    << ". Temporary (for a 2 minutes) locked rings: "
-                    << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
+                    << ". Effective unavailable rings after action: " << effectiveUnavailableRings
                     << ". Maximum allowed number of unavailable rings for this mode: " << maxAvailabilityLimit,
                     TReason::EType::TooManyUnavailableStateStorageRings
                 );
@@ -831,11 +876,8 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
                 error.Code = TStatus::DISALLOW_TEMP;
                 error.Reason = TReason(
                     TStringBuilder() << "Too many unavailable state storage rings"
-                    << ". Restarting rings: "
-                    << (currentRingState == TStateStorageRingInfo::Restart ? restartRings : restartRings - 1)
-                    << ". Temporary (for a 2 minutes) locked rings: "
-                    << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
-                    << ". Disabled rings: " << disabledRings
+                    << ". Effective unavailable rings after action: " << effectiveUnavailableRings
+                    << ". Disabled rings: " << availabilityStats.DisabledRings
                     << ". Maximum allowed number of unavailable rings for this mode: " << keepAvailableLimit,
                     TReason::EType::TooManyUnavailableStateStorageRings
                 );
@@ -851,7 +893,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
                 break;
             }
             
-            if (!hasRestartRingsByThisRequest) {
+            if (!availabilityStats.HasRestartRingsByThisRequest) {
                 limit = keepAvailableLimit;
                 if (keepAvailableOk) {
                     break;
@@ -861,10 +903,10 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
             error.Code = TStatus::DISALLOW_TEMP;
             error.Reason = TReason(
                 TStringBuilder() << "Too many unavailable state storage rings"
-                << ". Restarting rings: "
-                << (currentRingState == TStateStorageRingInfo::Restart ? restartRings : restartRings - 1)
-                << ". Temporary (for a 2 minutes) locked rings: "
-                << (currentRingState == TStateStorageRingInfo::Locked ? lockedRings + 1 : lockedRings)
+                << ". Effective unavailable rings after action: " << effectiveUnavailableRings
+                << (limit == keepAvailableLimit
+                    ? TStringBuilder() << ". Disabled rings: " << availabilityStats.DisabledRings
+                    : TStringBuilder())
                 << ". Maximum allowed number of unavailable rings for this mode: " << limit,
                 TReason::EType::TooManyUnavailableStateStorageRings
             );

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -1509,6 +1509,96 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
     }
 
+    Y_UNIT_TEST(StateStorageSharedReplicaSelectionMaxAvailability)
+    {
+        TTestEnvOpts options(10);
+        options.VDisks = 0;
+        options.NRings = 5;
+        options.RingSize = 2;
+        options.NToSelect = 5;
+        options.UseRingSpecificNodeSelection = false;
+
+        TCmsTestEnv env(options);
+
+        TFakeNodeWhiteboardService::Info[env.GetNodeId(0)].Connected = false;
+        env.RestartCms();
+
+        env.CheckPermissionRequest("user", false, true, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+
+        env.CheckPermissionRequest("user", false, true, false, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+    }
+
+    Y_UNIT_TEST(StateStorageSharedReplicaSelectionKeepAvailable)
+    {
+        TTestEnvOpts options(10);
+        options.VDisks = 0;
+        options.NRings = 5;
+        options.RingSize = 2;
+        options.NToSelect = 5;
+        options.UseRingSpecificNodeSelection = false;
+
+        TCmsTestEnv env(options);
+
+        TFakeNodeWhiteboardService::Info[env.GetNodeId(0)].Connected = false;
+        TFakeNodeWhiteboardService::Info[env.GetNodeId(3)].Connected = false;
+        env.RestartCms();
+
+        env.CheckPermissionRequest("user", false, true, false, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(4), 60000000, "storage"));
+    }
+
+    Y_UNIT_TEST(StateStorageSharedReplicaSelectionKeepAvailableLimit)
+    {
+        TTestEnvOpts options(10);
+        options.VDisks = 0;
+        options.NRings = 5;
+        options.RingSize = 2;
+        options.NToSelect = 5;
+        options.UseRingSpecificNodeSelection = false;
+
+        TCmsTestEnv env(options);
+
+        TFakeNodeWhiteboardService::Info[env.GetNodeId(0)].Connected = false;
+        TFakeNodeWhiteboardService::Info[env.GetNodeId(4)].Connected = false;
+        env.RestartCms();
+
+        env.CheckPermissionRequest("user", false, true, false, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(6), 60000000, "storage"));
+    }
+
+    Y_UNIT_TEST(StateStorageSharedReplicaSelectionDependsOnUseRingSpecificNodeSelection)
+    {
+        TTestEnvOpts options(10);
+        options.VDisks = 0;
+        options.NRings = 5;
+        options.RingSize = 2;
+        options.NToSelect = 5;
+
+        options.UseRingSpecificNodeSelection = false;
+        {
+            TCmsTestEnv env(options);
+
+            TFakeNodeWhiteboardService::Info[env.GetNodeId(0)].Connected = false;
+            env.RestartCms();
+
+            env.CheckPermissionRequest("user", false, true, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                       MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+        }
+
+        options.UseRingSpecificNodeSelection = true;
+        {
+            TCmsTestEnv env(options);
+
+            TFakeNodeWhiteboardService::Info[env.GetNodeId(0)].Connected = false;
+            env.RestartCms();
+
+            env.CheckPermissionRequest("user", false, true, false, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                       MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+        }
+    }
+
     Y_UNIT_TEST(StateStorageTwoBrokenRings)
     {
         TTestEnvOpts options(10);

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -719,7 +719,8 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
     } else {
         for (ui32 nodeIndex = 0; nodeIndex < GetNodeCount(); ++nodeIndex) {
             if (options.NRings > 1) {
-                SetupCustomStateStorage(*this, options.NToSelect, options.NRings, options.RingSize);
+                SetupCustomStateStorage(*this, options.NToSelect, options.NRings, options.RingSize, 1,
+                                        options.UseRingSpecificNodeSelection);
             } else {
                 SetupStateStorage(*this, nodeIndex);
             }

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -96,6 +96,7 @@ struct TTestEnvOpts {
     bool EnableDynamicGroups;
     bool IsBridgeMode;
     bool EnableSimpleStateStorageConfig;
+    bool UseRingSpecificNodeSelection;
     bool EnableCmsLocksPriority;
     bool EnableCmsSmartAvailabilityMode;
 
@@ -124,6 +125,7 @@ struct TTestEnvOpts {
         , EnableDynamicGroups(false)
         , IsBridgeMode(false)
         , EnableSimpleStateStorageConfig(false)
+        , UseRingSpecificNodeSelection(true)
         , EnableCmsLocksPriority(false)
         , EnableCmsSmartAvailabilityMode(false)
     {

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -3561,33 +3561,39 @@ public:
                 currentContext = &pileContext;
             }
             ui32 disabledRings = 0;
-            ui32 badRings = 0;
+            TVector<TStateStorageRingAvailability> ringAvailability;
+            ringAvailability.reserve(ringGroup.Rings.size());
             for (size_t ringIdx = 0; ringIdx < ringGroup.Rings.size(); ++ringIdx) {
                 const auto& ring = ringGroup.Rings[ringIdx];
+                auto& availability = ringAvailability.emplace_back();
+                availability.AvailableReplicas.reserve(ring.Replicas.size());
                 TSelfCheckContext ringContext(currentContext, TStringBuilder() << type << "_RING");
                 ringContext.Location.mutable_compute()->mutable_state_storage()->set_ring(ringIdx + 1);
                 if (ring.IsDisabled) {
                     ++disabledRings;
+                    // Disabled rings are accounted separately via disabledRings.
+                    // Keep this ring "available" for the helper to avoid double counting.
+                    availability.AvailableReplicas.resize(ring.Replicas.size(), true);
                     continue;
                 }
                 for (const auto& replica : ring.Replicas) {
                     const auto node = replica.NodeId();
-                    if (!NodeSystemState[node].IsOk()) {
+                    const bool available = NodeSystemState[node].IsOk();
+                    availability.AvailableReplicas.push_back(available);
+                    if (!available) {
                         TSelfCheckContext nodeContext(&ringContext, TStringBuilder() << type << "_NODE");
                         nodeContext.Location.mutable_compute()->mutable_state_storage()->mutable_node()->set_id(node);
                         nodeContext.ReportStatus(Ydb::Monitoring::StatusFlag::RED, "Node is not available", ETags::StateStorageNode);
                     }
                 }
                 ringContext.ReportWithMaxChildStatus("Ring has unavailable nodes", ETags::StateStorageRing, {ETags::StateStorageNode});
-                if (ringContext.GetOverallStatus() == Ydb::Monitoring::StatusFlag::RED) {
-                    ++badRings;
-                }
             }
-            if (disabledRings + badRings > (ringGroup.NToSelect - 1) / 2) {
+            const ui32 effectiveUnavailableRings = CalculateEffectiveUnavailableRings(ringGroup, ringAvailability);
+            if (disabledRings + effectiveUnavailableRings > (ringGroup.NToSelect - 1) / 2) {
                 currentContext->ReportStatus(Ydb::Monitoring::StatusFlag::RED, "There is not enough functional rings", ETags::StateStorage);
-            } else if (badRings > 1) {
+            } else if (effectiveUnavailableRings > 1) {
                 currentContext->ReportStatus(Ydb::Monitoring::StatusFlag::YELLOW, "Multiple rings have unavailable replicas", ETags::StateStorage);
-            } else if (badRings > 0) {
+            } else if (effectiveUnavailableRings > 0) {
                 currentContext->ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, "One ring has unavailable replicas", ETags::StateStorage);
             }
         }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -3008,12 +3008,67 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
     }
 
-    void TestStateStorage(ui32 deadNodes, std::optional<Ydb::Monitoring::StatusFlag::Status> expectedStatus) {
+    struct TStateStorageRingSpec {
+        TVector<ui32> NodeIndexes;
+        bool IsDisabled = false;
+        bool UseRingSpecificNodeSelection = true;
+    };
+
+    ui32 GetStateStorageNodeCount(const TVector<TStateStorageRingSpec>& ringSpecs,
+                                  const TVector<ui32>& deadNodeIndexes) {
+        ui32 maxNodeIndex = 0;
+        for (const auto& ringSpec : ringSpecs) {
+            for (ui32 nodeIndex : ringSpec.NodeIndexes) {
+                maxNodeIndex = Max(maxNodeIndex, nodeIndex);
+            }
+        }
+        for (ui32 nodeIndex : deadNodeIndexes) {
+            maxNodeIndex = Max(maxNodeIndex, nodeIndex);
+        }
+        return maxNodeIndex + 1;
+    }
+
+    TIntrusivePtr<TStateStorageInfo> MakeStateStorageInfo(TTestActorRuntime& runtime,
+                                                          ui32 nToSelect,
+                                                          const TVector<TStateStorageRingSpec>& ringSpecs) {
+        TIntrusivePtr<TStateStorageInfo> info = new TStateStorageInfo();
+        auto& ringGroup = info->RingGroups.emplace_back();
+        ringGroup.State = ERingGroupState::PRIMARY;
+        ringGroup.NToSelect = nToSelect;
+        ringGroup.Rings.reserve(ringSpecs.size());
+
+        for (const auto& ringSpec : ringSpecs) {
+            auto& ring = ringGroup.Rings.emplace_back();
+            ring.IsDisabled = ringSpec.IsDisabled;
+            ring.UseRingSpecificNodeSelection = ringSpec.UseRingSpecificNodeSelection;
+            for (ui32 nodeIdx : ringSpec.NodeIndexes) {
+                ring.Replicas.emplace_back(runtime.GetNodeId(nodeIdx), "FAKE");
+            }
+        }
+
+        return info;
+    }
+
+    void CheckStateStorageResult(const Ydb::Monitoring::SelfCheckResult& result,
+                                 std::optional<Ydb::Monitoring::StatusFlag::Status> expectedStatus) {
+        if (expectedStatus) {
+            CheckHcResultHasIssuesWithStatus(result, "STATE_STORAGE", *expectedStatus, 1);
+            CheckHcResultHasIssuesWithStatus(result, "SCHEME_BOARD", *expectedStatus, 1);
+            CheckHcResultHasIssuesWithStatus(result, "BOARD", *expectedStatus, 1);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
+        }
+    }
+
+    void TestStateStorage(const TVector<TStateStorageRingSpec>& ringSpecs,
+                          ui32 nToSelect,
+                          const TVector<ui32>& deadNodeIndexes,
+                          std::optional<Ydb::Monitoring::StatusFlag::Status> expectedStatus) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
         auto settings = TServerSettings(port)
-                .SetNodeCount(9)
+                .SetNodeCount(GetStateStorageNodeCount(ringSpecs, deadNodeIndexes))
                 .SetUseRealThreads(false)
                 .SetDomainName("Root");
         TServer server(settings);
@@ -3024,12 +3079,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         TActorId sender = runtime.AllocateEdgeActor();
         TAutoPtr<IEventHandle> handle;
 
-        TIntrusivePtr<TStateStorageInfo> info = new TStateStorageInfo();
-        info->RingGroups.push_back({ERingGroupState::PRIMARY, false, 9, {}, {}});
-        info->RingGroups.back().Rings.resize(9);
-        info->RingGroups.back().NToSelect = 9;
-        for (ui32 i = 0; i < 9; ++i) {
-            info->RingGroups.back().Rings[i].Replicas.emplace_back(runtime.GetNodeId(i), "FAKE");
+        auto info = MakeStateStorageInfo(runtime, nToSelect, ringSpecs);
+
+        TVector<ui32> deadNodeIds;
+        deadNodeIds.reserve(deadNodeIndexes.size());
+        for (ui32 nodeIdx : deadNodeIndexes) {
+            deadNodeIds.push_back(runtime.GetNodeId(nodeIdx));
         }
 
         auto ssObserver = runtime.AddObserver<TEvStateStorage::TEvListStateStorageResult>([&](auto&& ev) { ev->Get()->Info = info; });
@@ -3039,10 +3094,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         auto disconnectObserver = runtime.AddObserver<TEvWhiteboard::TEvSystemStateResponse>([&](auto&& ev) {
             auto actor = ev->Recipient;
             auto nodeId = ev->Sender.NodeId();
-            auto nodeIdx = nodeId - runtime.GetNodeId(0);
-            if (nodeIdx < deadNodes) {
-                runtime.Send(new IEventHandle(actor, actor, new TEvInterconnect::TEvNodeDisconnected(nodeId)), actor.NodeId() - runtime.GetNodeId(0));
-                ev.Reset();
+            for (ui32 deadNodeId : deadNodeIds) {
+                if (deadNodeId == nodeId) {
+                    runtime.Send(new IEventHandle(actor, actor, new TEvInterconnect::TEvNodeDisconnected(nodeId)), actor.NodeId() - runtime.GetNodeId(0));
+                    ev.Reset();
+                    break;
+                }
             }
         });
 
@@ -3051,13 +3108,22 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
         Cerr << result.ShortDebugString() << Endl;
-        if (expectedStatus) {
-            CheckHcResultHasIssuesWithStatus(result, "STATE_STORAGE", *expectedStatus, 1);
-            CheckHcResultHasIssuesWithStatus(result, "SCHEME_BOARD", *expectedStatus, 1);
-            CheckHcResultHasIssuesWithStatus(result, "BOARD", *expectedStatus, 1);
-        } else {
-            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
+        CheckStateStorageResult(result, expectedStatus);
+    }
+
+    void TestStateStorage(ui32 deadNodes, std::optional<Ydb::Monitoring::StatusFlag::Status> expectedStatus) {
+        TVector<TStateStorageRingSpec> ringSpecs;
+        TVector<ui32> deadNodeIndexes;
+        ringSpecs.reserve(9);
+        deadNodeIndexes.reserve(deadNodes);
+        for (ui32 nodeIdx = 0; nodeIdx < 9; ++nodeIdx) {
+            ringSpecs.push_back(TStateStorageRingSpec{.NodeIndexes = {nodeIdx}});
+            if (nodeIdx < deadNodes) {
+                deadNodeIndexes.push_back(nodeIdx);
+            }
         }
+
+        TestStateStorage(ringSpecs, 9, deadNodeIndexes, expectedStatus);
     }
 
     Y_UNIT_TEST(TestStateStorageOk) {
@@ -3074,6 +3140,78 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
     Y_UNIT_TEST(TestStateStorageRed) {
         TestStateStorage(6, Ydb::Monitoring::StatusFlag::RED);
+    }
+
+    Y_UNIT_TEST(TestStateStorageSharedReplicaSelectionBlue) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {6, 7}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {8, 9}, .UseRingSpecificNodeSelection = false},
+        };
+
+        TestStateStorage(ringSpecs, 4, {0, 3}, Ydb::Monitoring::StatusFlag::BLUE);
+    }
+
+    Y_UNIT_TEST(TestStateStorageSharedReplicaSelectionYellow) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {6, 7}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {8, 9}, .UseRingSpecificNodeSelection = false},
+        };
+
+        TestStateStorage(ringSpecs, 5, {0, 3, 4}, Ydb::Monitoring::StatusFlag::YELLOW);
+    }
+
+    Y_UNIT_TEST(TestStateStorageSharedReplicaSelectionRed) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {6, 7}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {8, 9}, .UseRingSpecificNodeSelection = false},
+        };
+
+        TestStateStorage(ringSpecs, 5, {0, 2, 4}, Ydb::Monitoring::StatusFlag::RED);
+    }
+
+    Y_UNIT_TEST(TestStateStorageDisabledRingIsNotDoubleCounted) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .IsDisabled = true, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {6, 7}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {8, 9}, .UseRingSpecificNodeSelection = false},
+        };
+
+        TestStateStorage(ringSpecs, 5, {2}, Ydb::Monitoring::StatusFlag::BLUE);
+    }
+
+    Y_UNIT_TEST(TestStateStorageSharedReplicaSelectionDifferentRingSizes) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5, 6}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {7, 8, 9}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {10}, .UseRingSpecificNodeSelection = false},
+        };
+
+        TestStateStorage(ringSpecs, 5, {0, 5}, Ydb::Monitoring::StatusFlag::YELLOW);
+    }
+
+    Y_UNIT_TEST(TestStateStorageMixedReplicaSelectionModes) {
+        const TVector<TStateStorageRingSpec> ringSpecs = {
+            TStateStorageRingSpec{.NodeIndexes = {0, 1}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {2, 3}, .UseRingSpecificNodeSelection = false},
+            TStateStorageRingSpec{.NodeIndexes = {4, 5}},
+            TStateStorageRingSpec{.NodeIndexes = {6, 7}},
+            TStateStorageRingSpec{.NodeIndexes = {8, 9}},
+        };
+
+        TestStateStorage(ringSpecs, 5, {0, 3, 4}, Ydb::Monitoring::StatusFlag::YELLOW);
     }
 
     Y_UNIT_TEST(CLusterNotBootstrapped) {

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -44,7 +44,8 @@ namespace NFake {
 
     void SetupStateStorage(TTestActorRuntime& runtime, ui32 nodeIndex,
                            bool replicasOnFirstNode = false);
-    void SetupCustomStateStorage(TTestActorRuntime &runtime, ui32 NToSelect, ui32 nrings, ui32 ringSize, ui32 ringGroups = 1);
+    void SetupCustomStateStorage(TTestActorRuntime &runtime, ui32 NToSelect, ui32 nrings, ui32 ringSize,
+                                 ui32 ringGroups = 1, bool useRingSpecificNodeSelection = true);
     TStateStorageSetupper CreateCustomStateStorageSetupper(const TVector<TStateStorageInfo::TRingGroup>& ringGroups, int replicasInRingGroup);
     TStateStorageSetupper CreateCustomStateStorageSetupper(const TVector<TStateStorageInfo::TRingGroup>& ringGroups,
                                                            const THashMap<ui32, TVector<ui32>>& pileIdToNodeIds);

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -207,7 +207,12 @@ namespace NKikimr {
         return info;
     }
 
-    static TIntrusivePtr<TStateStorageInfo> GenerateStateStorageInfo(const TVector<TActorId> &replicas, ui32 NToSelect, ui32 nrings, ui32 ringSize, ui32 ringGroups = 1)
+    static TIntrusivePtr<TStateStorageInfo> GenerateStateStorageInfo(const TVector<TActorId> &replicas,
+                                                                    ui32 NToSelect,
+                                                                    ui32 nrings,
+                                                                    ui32 ringSize,
+                                                                    ui32 ringGroups = 1,
+                                                                    bool useRingSpecificNodeSelection = true)
     {
         Y_ABORT_UNLESS(replicas.size() >= ringGroups * nrings * ringSize);
         Y_ABORT_UNLESS(NToSelect <= nrings);
@@ -221,6 +226,7 @@ namespace NKikimr {
             group.Rings.resize(nrings);
 
             for (size_t i = 0; i < nrings; ++i) {
+                group.Rings[i].UseRingSpecificNodeSelection = useRingSpecificNodeSelection;
                 for (size_t j = 0; j < ringSize; ++j) {
                     group.Rings[i].Replicas.push_back(replicas[inode++]);
                 }
@@ -242,7 +248,8 @@ namespace NKikimr {
         ui32 NToSelect,
         ui32 nrings,
         ui32 ringSize,
-        ui32 ringGroups)
+        ui32 ringGroups,
+        bool useRingSpecificNodeSelection)
     {
         TVector<TActorId> ssreplicas;
         for (size_t i = 0; i < ringGroups * nrings * ringSize; ++i) {
@@ -261,9 +268,9 @@ namespace NKikimr {
 
         const TActorId ssproxy = MakeStateStorageProxyID();
 
-        auto ssInfo = GenerateStateStorageInfo(ssreplicas, NToSelect, nrings, ringSize, ringGroups);
-        auto sbInfo = GenerateStateStorageInfo(sbreplicas, NToSelect, nrings, ringSize, ringGroups);
-        auto bInfo = GenerateStateStorageInfo(breplicas, NToSelect, nrings, ringSize, ringGroups);
+        auto ssInfo = GenerateStateStorageInfo(ssreplicas, NToSelect, nrings, ringSize, ringGroups, useRingSpecificNodeSelection);
+        auto sbInfo = GenerateStateStorageInfo(sbreplicas, NToSelect, nrings, ringSize, ringGroups, useRingSpecificNodeSelection);
+        auto bInfo = GenerateStateStorageInfo(breplicas, NToSelect, nrings, ringSize, ringGroups, useRingSpecificNodeSelection);
 
 
         for (ui32 ssIndex = 0; ssIndex < ringGroups * nrings * ringSize; ++ssIndex) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improved state storage availability checks for configurations that use `use_ring_specific_node_selection: false`

### Changelog category <!-- remove all except one -->

* Improvement
### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR improves state storage availability checks for configurations that use `use_ring_specific_node_selection: false`.

It adds a shared helper for calculating `effective unavailable rings` and switches both health check and CMS to use it instead of plain ring-level counting. For `use_ring_specific_node_selection=false`, availability is now evaluated more accurately by grouping rings by size and counting failures by column, which removes unnecessary pessimism in common topologies.

The change also adds unit tests for the shared helper, health check, and CMS, and extends test helpers so `UseRingSpecificNodeSelection` can be configured explicitly in tests.

