### PR TITLE
MLP FIFO: prioritize read of the oldest records

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_consumer_split_ut.cpp
@@ -844,6 +844,13 @@ Y_UNIT_TEST(Order_NoneCommittedBeforeSplit) {
     });
 }
 
+Y_UNIT_TEST(Order_NoneCommittedBeforeSplitSmall) {
+    PartitionSplitWithMessageGroupOrdering({
+        {"group-A", {.Root = {.WriteCount = 2}, .LastSplit = {.WriteCount = 1}}},
+        {"group-B", {.Root = {.WriteCount = 1}, .LastSplit = {.WriteCount = 1}}},
+    });
+}
+
 // Case 3: All messages of group-A and group-B committed before split.
 //         None of group-C committed before split.
 // Expected: child messages for A and B available; C blocked until parent committed.

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
@@ -11,39 +11,34 @@ TMessageEnricherActor::TMessageEnricherActor(ui64 tabletId, ui32 partitionId, co
     , TabletId(tabletId)
     , PartitionId(partitionId)
     , ConsumerName(consumerName)
-    , Replies(std::make_move_iterator(replies.begin()), std::make_move_iterator(replies.end()))
+    , Replies(std::move(replies))
 {
+    size_t messagesCount = 0;
     PendingResponses.resize(Replies.size());
     for (size_t i = 0; i < Replies.size(); ++i) {
         auto& pr = PendingResponses[i];
-        pr.Sender = Replies[i].Sender;
-        pr.Cookie = Replies[i].Cookie;
         pr.TotalMessages = Replies[i].Messages.size();
         pr.EnrichedCount = 0;
         pr.Sent = false;
-    }
-    BuildSortedIndex();
-}
 
-void TMessageEnricherActor::BuildSortedIndex() {
-    for (size_t ri = 0; ri < Replies.size(); ++ri) {
-        auto& msgs = Replies[ri].Messages;
-        for (size_t mi = 0; mi < msgs.size(); ++mi) {
-            SortedEntries.push_back({msgs[mi].Offset, ri, mi, false});
+        messagesCount += pr.TotalMessages;
+    }
+
+    SortedEntries.reserve(messagesCount);
+    for (size_t replyIndex = 0; replyIndex < Replies.size(); ++replyIndex) {
+        auto& msgs = Replies[replyIndex].Messages;
+        for (size_t messageIndex = 0; messageIndex < msgs.size(); ++messageIndex) {
+            SortedEntries.push_back({msgs[messageIndex].Offset, replyIndex, messageIndex, false});
         }
     }
-    std::stable_sort(SortedEntries.begin(), SortedEntries.end(), [](const TOffsetEntry& a, const TOffsetEntry& b) { return a.Offset < b.Offset; });
+    SortBy(SortedEntries, [](const TOffsetEntry& item) { return item.Offset; });
 }
 
 void TMessageEnricherActor::Bootstrap() {
     Become(&TThis::StateWork);
 
     for (size_t i = 0; i < PendingResponses.size(); ++i) {
-        if (PendingResponses[i].TotalMessages == 0) {
-            Send(PendingResponses[i].Sender, new TEvPQ::TEvMLPReadResponse(), 0, PendingResponses[i].Cookie);
-            PendingResponses[i].Sent = true;
-            ++RepliesSent;
-        }
+        TrySendReplyImpl(i, true, true); // send empty results now
     }
 
     ProcessQueue();
@@ -51,39 +46,42 @@ void TMessageEnricherActor::Bootstrap() {
 
 void TMessageEnricherActor::PassAway() {
     LOG_D("PassAway");
-    for (auto& pr : PendingResponses) {
-        if (!pr.Sent) {
-            Send(pr.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, pr.Cookie);
-            pr.Sent = true;
+    for (size_t i = 0; i < PendingResponses.size(); ++i) {
+        if (!PendingResponses[i].Sent) {
+            const TReadResult& reply = Replies[i];
+            Send(reply.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, reply.Cookie);
+            PendingResponses[i].Sent = true;
+            ++RepliesSent;
         }
     }
-
     Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
     TBase::PassAway();
 }
 
-void TMessageEnricherActor::EnsureResponse(size_t replyIndex) {
-    auto& pr = PendingResponses[replyIndex];
-    if (!pr.Response) {
-        pr.Response = std::make_unique<TEvPQ::TEvMLPReadResponse>();
-    }
-}
-
-void TMessageEnricherActor::TrySendReply(size_t replyIndex) {
+void TMessageEnricherActor::TrySendReplyImpl(size_t replyIndex, bool waitForCompletion, bool allowEmpty) {
     auto& pr = PendingResponses[replyIndex];
     if (pr.Sent) {
         return;
     }
-    if (!pr.IsComplete()) {
+    if (!pr.IsComplete() && waitForCompletion) {
         return;
     }
-    if (pr.EnrichedCount > 0) {
-        Send(pr.Sender, pr.Response.release(), 0, pr.Cookie);
+    const TReadResult& reply = Replies[replyIndex];
+    if (pr.EnrichedCount > 0 || allowEmpty) {
+        Send(reply.Sender, pr.Response.release(), 0, reply.Cookie);
     } else {
-        Send(pr.Sender, std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages was not found").release(), 0, pr.Cookie);
+        Send(reply.Sender, std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages were not found").release(), 0, reply.Cookie);
     }
     pr.Sent = true;
     ++RepliesSent;
+}
+
+void TMessageEnricherActor::TrySendReplyIfComplete(size_t replyIndex) {
+    return TrySendReplyImpl(replyIndex, true, false);
+}
+
+void TMessageEnricherActor::SendPartialReply(size_t replyIndex) {
+    return TrySendReplyImpl(replyIndex, false, false);
 }
 
 void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
@@ -101,8 +99,8 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     }
 
     auto& results = response.GetPartitionResponse().GetCmdReadResult().GetResult();
-    size_t ei = NextEntryIdx;
-    int ri = 0;
+    size_t& entryIndex = NextEntryIdx;
+    int resultIndex = 0;
     int resultsSize = results.size();
     ui64 maxReturnedOffset = 0;
 
@@ -111,25 +109,33 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     }
 
     // Two-pointer: both SortedEntries and results are sorted by offset
-    while (ei < SortedEntries.size() && ri < resultsSize) {
-        auto& entry = SortedEntries[ei];
+    while (entryIndex < SortedEntries.size() && resultIndex < resultsSize) {
+        auto& entry = SortedEntries[entryIndex];
         if (entry.Processed) {
-            ++ei;
+            ++entryIndex;
             continue;
         }
 
-        auto resultOffset = results[ri].GetOffset();
+        auto resultOffset = results[resultIndex].GetOffset();
 
         if (entry.Offset < resultOffset) {
             entry.Processed = true;
             --PendingResponses[entry.ReplyIndex].TotalMessages;
-            ++ei;
-        } else if (entry.Offset == resultOffset) {
-            auto& result = results[ri];
+            TrySendReplyIfComplete(entry.ReplyIndex);
+            ++entryIndex;
+        } else if (entry.Offset > resultOffset) {
+            // unneeded Offset — advance result pointer
+            ++resultIndex;
+        } else if (PendingResponses[entry.ReplyIndex].Sent) {
+            Y_VERIFY_DEBUG(false, "Response already processed");
+            entry.Processed = true;
+            ++entryIndex;
+        } else {
+            auto& result = results[resultIndex];
             auto& msg = Replies[entry.ReplyIndex].Messages[entry.MessageIndex];
 
-            EnsureResponse(entry.ReplyIndex);
-            auto* message = PendingResponses[entry.ReplyIndex].Response->Record.AddMessage();
+            TEvPQ::TEvMLPReadResponse* readResponse = PendingResponses[entry.ReplyIndex].Response.get();
+            auto* message = readResponse->Record.AddMessage();
             message->MutableId()->SetPartitionId(PartitionId);
             message->MutableId()->SetOffset(entry.Offset);
             message->SetData(result.GetData());
@@ -140,39 +146,28 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
 
             entry.Processed = true;
             ++PendingResponses[entry.ReplyIndex].EnrichedCount;
-            ++ei;
+            TrySendReplyIfComplete(entry.ReplyIndex);
+            ++entryIndex;
 
-            // Don't advance ri yet — there may be more entries with the same offset (duplicates across replies)
-            if (ei < SortedEntries.size() && SortedEntries[ei].Offset == resultOffset) {
+            // Don't advance resultIndex yet — there may be more entries with the same offset (duplicates across replies)
+            if (entryIndex < SortedEntries.size() && SortedEntries[entryIndex].Offset == resultOffset) [[unlikely]] {
                 continue;
             }
-            ++ri;
-        } else {
-            // entry.Offset > resultOffset — advance result pointer
-            ++ri;
+            ++resultIndex;
         }
     }
 
     // Mark remaining entries whose offsets are <= maxReturnedOffset as missing
     if (resultsSize > 0) {
-        while (ei < SortedEntries.size() && SortedEntries[ei].Offset <= maxReturnedOffset) {
-            auto& entry = SortedEntries[ei];
+        while (entryIndex < SortedEntries.size() && SortedEntries[entryIndex].Offset <= maxReturnedOffset) {
+            auto& entry = SortedEntries[entryIndex];
             if (!entry.Processed) {
                 entry.Processed = true;
                 --PendingResponses[entry.ReplyIndex].TotalMessages;
+                TrySendReplyIfComplete(entry.ReplyIndex);
             }
-            ++ei;
+            ++entryIndex;
         }
-    }
-
-    // Advance NextEntryIdx past all processed entries
-    while (NextEntryIdx < SortedEntries.size() && SortedEntries[NextEntryIdx].Processed) {
-        ++NextEntryIdx;
-    }
-
-    // Try to send completed replies
-    for (size_t i = 0; i < PendingResponses.size(); ++i) {
-        TrySendReply(i);
     }
 
     if (RepliesSent == PendingResponses.size()) {
@@ -201,12 +196,9 @@ void TMessageEnricherActor::ProcessQueue() {
     if (NextEntryIdx >= SortedEntries.size()) {
         // All entries processed — send any remaining unsent replies
         for (size_t i = 0; i < PendingResponses.size(); ++i) {
-            TrySendReply(i);
+            SendPartialReply(i);
         }
-        if (RepliesSent == PendingResponses.size()) {
-            return PassAway();
-        }
-        return;
+        return PassAway();
     }
 
     auto minOffset = SortedEntries[NextEntryIdx].Offset;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
@@ -2,6 +2,8 @@
 
 #include <ydb/core/protos/pqdata_mlp.pb.h>
 
+#include <algorithm>
+
 namespace NKikimr::NPQ::NMLP {
 
 TMessageEnricherActor::TMessageEnricherActor(ui64 tabletId, ui32 partitionId, const TString& consumerName, std::deque<TReadResult>&& replies)
@@ -9,25 +11,79 @@ TMessageEnricherActor::TMessageEnricherActor(ui64 tabletId, ui32 partitionId, co
     , TabletId(tabletId)
     , PartitionId(partitionId)
     , ConsumerName(consumerName)
-    , Queue(std::move(replies))
-    , PendingResponse(std::make_unique<TEvPQ::TEvMLPReadResponse>())
+    , Replies(std::make_move_iterator(replies.begin()), std::make_move_iterator(replies.end()))
 {
+    PendingResponses.resize(Replies.size());
+    for (size_t i = 0; i < Replies.size(); ++i) {
+        auto& pr = PendingResponses[i];
+        pr.Sender = Replies[i].Sender;
+        pr.Cookie = Replies[i].Cookie;
+        pr.TotalMessages = Replies[i].Messages.size();
+        pr.EnrichedCount = 0;
+        pr.Sent = false;
+    }
+    BuildSortedIndex();
+}
+
+void TMessageEnricherActor::BuildSortedIndex() {
+    for (size_t ri = 0; ri < Replies.size(); ++ri) {
+        auto& msgs = Replies[ri].Messages;
+        for (size_t mi = 0; mi < msgs.size(); ++mi) {
+            SortedEntries.push_back({msgs[mi].Offset, ri, mi, false});
+        }
+    }
+    std::stable_sort(SortedEntries.begin(), SortedEntries.end(), [](const TOffsetEntry& a, const TOffsetEntry& b) { return a.Offset < b.Offset; });
 }
 
 void TMessageEnricherActor::Bootstrap() {
     Become(&TThis::StateWork);
+
+    for (size_t i = 0; i < PendingResponses.size(); ++i) {
+        if (PendingResponses[i].TotalMessages == 0) {
+            Send(PendingResponses[i].Sender, new TEvPQ::TEvMLPReadResponse(), 0, PendingResponses[i].Cookie);
+            PendingResponses[i].Sent = true;
+            ++RepliesSent;
+        }
+    }
+
     ProcessQueue();
 }
 
 void TMessageEnricherActor::PassAway() {
     LOG_D("PassAway");
-    for (auto& reply : Queue) {
-        Send(reply.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, reply.Cookie);
+    for (auto& pr : PendingResponses) {
+        if (!pr.Sent) {
+            Send(pr.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, pr.Cookie);
+            pr.Sent = true;
+        }
     }
 
     Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
-
     TBase::PassAway();
+}
+
+void TMessageEnricherActor::EnsureResponse(size_t replyIndex) {
+    auto& pr = PendingResponses[replyIndex];
+    if (!pr.Response) {
+        pr.Response = std::make_unique<TEvPQ::TEvMLPReadResponse>();
+    }
+}
+
+void TMessageEnricherActor::TrySendReply(size_t replyIndex) {
+    auto& pr = PendingResponses[replyIndex];
+    if (pr.Sent) {
+        return;
+    }
+    if (!pr.IsComplete()) {
+        return;
+    }
+    if (pr.EnrichedCount > 0) {
+        Send(pr.Sender, pr.Response.release(), 0, pr.Cookie);
+    } else {
+        Send(pr.Sender, std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages was not found").release(), 0, pr.Cookie);
+    }
+    pr.Sent = true;
+    ++RepliesSent;
 }
 
 void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
@@ -39,46 +95,87 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     }
 
     auto& response = ev->Get()->Record;
-    if (response.GetPartitionResponse().HasCmdReadResult()) {
-        for (auto& result : response.GetPartitionResponse().GetCmdReadResult().GetResult()) {
-            auto offset = result.GetOffset();
+    if (!response.GetPartitionResponse().HasCmdReadResult()) {
+        ProcessQueue();
+        return;
+    }
 
-            while(!Queue.empty()) {
-                auto& reply = Queue.front();
-                if (offset < reply.Messages.front().Offset) {
-                    break;
-                }
-                while (!reply.Messages.empty() && offset > reply.Messages.front().Offset) {
-                    reply.Messages.pop_front();
-                }
-                if (!reply.Messages.empty() && offset == reply.Messages.front().Offset) {
-                    auto* message = PendingResponse->Record.AddMessage();
-                    message->MutableId()->SetPartitionId(PartitionId);
-                    message->MutableId()->SetOffset(offset);
-                    message->SetData(result.GetData());
-                    message->MutableMessageMeta()->SetMessageGroupId(result.GetSourceId());
-                    message->MutableMessageMeta()->SetSentTimestampMilliseconds(result.GetWriteTimestampMS());
-                    message->MutableMessageMeta()->SetApproximateReceiveCount(reply.Messages.front().ApproximateReceiveCount);
-                    message->MutableMessageMeta()->SetApproximateFirstReceiveTimestampMilliseconds(reply.Messages.front().ApproximateFirstReceiveTimestamp.MilliSeconds());
+    auto& results = response.GetPartitionResponse().GetCmdReadResult().GetResult();
+    size_t ei = NextEntryIdx;
+    int ri = 0;
+    int resultsSize = results.size();
+    ui64 maxReturnedOffset = 0;
 
-                    reply.Messages.pop_front();
-                }
-                if (reply.Messages.empty()) {
-                    if (PendingResponse->Record.MessageSize() > 0) {
-                        Send(reply.Sender, PendingResponse.release(), 0, reply.Cookie);
-                    } else {
-                        auto r = std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages was not found");
-                        Send(reply.Sender, std::move(r), 0, reply.Cookie);
-                    }
-                    PendingResponse = std::make_unique<TEvPQ::TEvMLPReadResponse>();
-                    Queue.pop_front();
-                    continue;
-                }
+    if (resultsSize > 0) {
+        maxReturnedOffset = results[resultsSize - 1].GetOffset();
+    }
+
+    // Two-pointer: both SortedEntries and results are sorted by offset
+    while (ei < SortedEntries.size() && ri < resultsSize) {
+        auto& entry = SortedEntries[ei];
+        if (entry.Processed) {
+            ++ei;
+            continue;
+        }
+
+        auto resultOffset = results[ri].GetOffset();
+
+        if (entry.Offset < resultOffset) {
+            entry.Processed = true;
+            --PendingResponses[entry.ReplyIndex].TotalMessages;
+            ++ei;
+        } else if (entry.Offset == resultOffset) {
+            auto& result = results[ri];
+            auto& msg = Replies[entry.ReplyIndex].Messages[entry.MessageIndex];
+
+            EnsureResponse(entry.ReplyIndex);
+            auto* message = PendingResponses[entry.ReplyIndex].Response->Record.AddMessage();
+            message->MutableId()->SetPartitionId(PartitionId);
+            message->MutableId()->SetOffset(entry.Offset);
+            message->SetData(result.GetData());
+            message->MutableMessageMeta()->SetMessageGroupId(result.GetSourceId());
+            message->MutableMessageMeta()->SetSentTimestampMilliseconds(result.GetWriteTimestampMS());
+            message->MutableMessageMeta()->SetApproximateReceiveCount(msg.ApproximateReceiveCount);
+            message->MutableMessageMeta()->SetApproximateFirstReceiveTimestampMilliseconds(msg.ApproximateFirstReceiveTimestamp.MilliSeconds());
+
+            entry.Processed = true;
+            ++PendingResponses[entry.ReplyIndex].EnrichedCount;
+            ++ei;
+
+            // Don't advance ri yet — there may be more entries with the same offset (duplicates across replies)
+            if (ei < SortedEntries.size() && SortedEntries[ei].Offset == resultOffset) {
+                continue;
             }
+            ++ri;
+        } else {
+            // entry.Offset > resultOffset — advance result pointer
+            ++ri;
         }
     }
 
-    if (Queue.empty()) {
+    // Mark remaining entries whose offsets are <= maxReturnedOffset as missing
+    if (resultsSize > 0) {
+        while (ei < SortedEntries.size() && SortedEntries[ei].Offset <= maxReturnedOffset) {
+            auto& entry = SortedEntries[ei];
+            if (!entry.Processed) {
+                entry.Processed = true;
+                --PendingResponses[entry.ReplyIndex].TotalMessages;
+            }
+            ++ei;
+        }
+    }
+
+    // Advance NextEntryIdx past all processed entries
+    while (NextEntryIdx < SortedEntries.size() && SortedEntries[NextEntryIdx].Processed) {
+        ++NextEntryIdx;
+    }
+
+    // Try to send completed replies
+    for (size_t i = 0; i < PendingResponses.size(); ++i) {
+        TrySendReply(i);
+    }
+
+    if (RepliesSent == PendingResponses.size()) {
         return PassAway();
     }
 
@@ -101,25 +198,21 @@ STFUNC(TMessageEnricherActor::StateWork) {
 }
 
 void TMessageEnricherActor::ProcessQueue() {
-    while(!Queue.empty()) {
-        auto& reply = Queue.front();
-        if (reply.Messages.empty()) {
-            Send(reply.Sender, new TEvPQ::TEvMLPReadResponse(), 0, reply.Cookie);
-
-            Queue.pop_front();
-            continue;
+    if (NextEntryIdx >= SortedEntries.size()) {
+        // All entries processed — send any remaining unsent replies
+        for (size_t i = 0; i < PendingResponses.size(); ++i) {
+            TrySendReply(i);
         }
-
-        auto firstOffset = reply.Messages.front().Offset;
-        LOG_D("Fetching from offset " << firstOffset << " from " << TabletId);
-        SendToPQTablet(MakeEvPQRead(ConsumerName, PartitionId, firstOffset, 1));
-
+        if (RepliesSent == PendingResponses.size()) {
+            return PassAway();
+        }
         return;
     }
 
-    if (Queue.empty()) {
-        return PassAway();
-    }
+    auto minOffset = SortedEntries[NextEntryIdx].Offset;
+    auto count = 1;
+    LOG_D("Fetching from offset " << minOffset << " count " << count << " from " << TabletId);
+    SendToPQTablet(MakeEvPQRead(ConsumerName, PartitionId, minOffset, count));
 }
 
 void TMessageEnricherActor::SendToPQTablet(std::unique_ptr<IEventBase> ev) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
@@ -2,8 +2,6 @@
 
 #include <ydb/core/protos/pqdata_mlp.pb.h>
 
-#include <algorithm>
-
 namespace NKikimr::NPQ::NMLP {
 
 TMessageEnricherActor::TMessageEnricherActor(ui64 tabletId, ui32 partitionId, const TString& consumerName, std::deque<TReadResult>&& replies)
@@ -11,79 +9,25 @@ TMessageEnricherActor::TMessageEnricherActor(ui64 tabletId, ui32 partitionId, co
     , TabletId(tabletId)
     , PartitionId(partitionId)
     , ConsumerName(consumerName)
-    , Replies(std::make_move_iterator(replies.begin()), std::make_move_iterator(replies.end()))
+    , Queue(std::move(replies))
+    , PendingResponse(std::make_unique<TEvPQ::TEvMLPReadResponse>())
 {
-    PendingResponses.resize(Replies.size());
-    for (size_t i = 0; i < Replies.size(); ++i) {
-        auto& pr = PendingResponses[i];
-        pr.Sender = Replies[i].Sender;
-        pr.Cookie = Replies[i].Cookie;
-        pr.TotalMessages = Replies[i].Messages.size();
-        pr.EnrichedCount = 0;
-        pr.Sent = false;
-    }
-    BuildSortedIndex();
-}
-
-void TMessageEnricherActor::BuildSortedIndex() {
-    for (size_t ri = 0; ri < Replies.size(); ++ri) {
-        auto& msgs = Replies[ri].Messages;
-        for (size_t mi = 0; mi < msgs.size(); ++mi) {
-            SortedEntries.push_back({msgs[mi].Offset, ri, mi, false});
-        }
-    }
-    std::stable_sort(SortedEntries.begin(), SortedEntries.end(), [](const TOffsetEntry& a, const TOffsetEntry& b) { return a.Offset < b.Offset; });
 }
 
 void TMessageEnricherActor::Bootstrap() {
     Become(&TThis::StateWork);
-
-    for (size_t i = 0; i < PendingResponses.size(); ++i) {
-        if (PendingResponses[i].TotalMessages == 0) {
-            Send(PendingResponses[i].Sender, new TEvPQ::TEvMLPReadResponse(), 0, PendingResponses[i].Cookie);
-            PendingResponses[i].Sent = true;
-            ++RepliesSent;
-        }
-    }
-
     ProcessQueue();
 }
 
 void TMessageEnricherActor::PassAway() {
     LOG_D("PassAway");
-    for (auto& pr : PendingResponses) {
-        if (!pr.Sent) {
-            Send(pr.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, pr.Cookie);
-            pr.Sent = true;
-        }
+    for (auto& reply : Queue) {
+        Send(reply.Sender, new TEvPQ::TEvMLPErrorResponse(PartitionId, Ydb::StatusIds::SCHEME_ERROR, "Shutdown"), 0, reply.Cookie);
     }
 
     Send(MakePipePerNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
+
     TBase::PassAway();
-}
-
-void TMessageEnricherActor::EnsureResponse(size_t replyIndex) {
-    auto& pr = PendingResponses[replyIndex];
-    if (!pr.Response) {
-        pr.Response = std::make_unique<TEvPQ::TEvMLPReadResponse>();
-    }
-}
-
-void TMessageEnricherActor::TrySendReply(size_t replyIndex) {
-    auto& pr = PendingResponses[replyIndex];
-    if (pr.Sent) {
-        return;
-    }
-    if (!pr.IsComplete()) {
-        return;
-    }
-    if (pr.EnrichedCount > 0) {
-        Send(pr.Sender, pr.Response.release(), 0, pr.Cookie);
-    } else {
-        Send(pr.Sender, std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages was not found").release(), 0, pr.Cookie);
-    }
-    pr.Sent = true;
-    ++RepliesSent;
 }
 
 void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
@@ -95,87 +39,46 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     }
 
     auto& response = ev->Get()->Record;
-    if (!response.GetPartitionResponse().HasCmdReadResult()) {
-        ProcessQueue();
-        return;
-    }
+    if (response.GetPartitionResponse().HasCmdReadResult()) {
+        for (auto& result : response.GetPartitionResponse().GetCmdReadResult().GetResult()) {
+            auto offset = result.GetOffset();
 
-    auto& results = response.GetPartitionResponse().GetCmdReadResult().GetResult();
-    size_t ei = NextEntryIdx;
-    int ri = 0;
-    int resultsSize = results.size();
-    ui64 maxReturnedOffset = 0;
+            while(!Queue.empty()) {
+                auto& reply = Queue.front();
+                if (offset < reply.Messages.front().Offset) {
+                    break;
+                }
+                while (!reply.Messages.empty() && offset > reply.Messages.front().Offset) {
+                    reply.Messages.pop_front();
+                }
+                if (!reply.Messages.empty() && offset == reply.Messages.front().Offset) {
+                    auto* message = PendingResponse->Record.AddMessage();
+                    message->MutableId()->SetPartitionId(PartitionId);
+                    message->MutableId()->SetOffset(offset);
+                    message->SetData(result.GetData());
+                    message->MutableMessageMeta()->SetMessageGroupId(result.GetSourceId());
+                    message->MutableMessageMeta()->SetSentTimestampMilliseconds(result.GetWriteTimestampMS());
+                    message->MutableMessageMeta()->SetApproximateReceiveCount(reply.Messages.front().ApproximateReceiveCount);
+                    message->MutableMessageMeta()->SetApproximateFirstReceiveTimestampMilliseconds(reply.Messages.front().ApproximateFirstReceiveTimestamp.MilliSeconds());
 
-    if (resultsSize > 0) {
-        maxReturnedOffset = results[resultsSize - 1].GetOffset();
-    }
-
-    // Two-pointer: both SortedEntries and results are sorted by offset
-    while (ei < SortedEntries.size() && ri < resultsSize) {
-        auto& entry = SortedEntries[ei];
-        if (entry.Processed) {
-            ++ei;
-            continue;
-        }
-
-        auto resultOffset = results[ri].GetOffset();
-
-        if (entry.Offset < resultOffset) {
-            entry.Processed = true;
-            --PendingResponses[entry.ReplyIndex].TotalMessages;
-            ++ei;
-        } else if (entry.Offset == resultOffset) {
-            auto& result = results[ri];
-            auto& msg = Replies[entry.ReplyIndex].Messages[entry.MessageIndex];
-
-            EnsureResponse(entry.ReplyIndex);
-            auto* message = PendingResponses[entry.ReplyIndex].Response->Record.AddMessage();
-            message->MutableId()->SetPartitionId(PartitionId);
-            message->MutableId()->SetOffset(entry.Offset);
-            message->SetData(result.GetData());
-            message->MutableMessageMeta()->SetMessageGroupId(result.GetSourceId());
-            message->MutableMessageMeta()->SetSentTimestampMilliseconds(result.GetWriteTimestampMS());
-            message->MutableMessageMeta()->SetApproximateReceiveCount(msg.ApproximateReceiveCount);
-            message->MutableMessageMeta()->SetApproximateFirstReceiveTimestampMilliseconds(msg.ApproximateFirstReceiveTimestamp.MilliSeconds());
-
-            entry.Processed = true;
-            ++PendingResponses[entry.ReplyIndex].EnrichedCount;
-            ++ei;
-
-            // Don't advance ri yet — there may be more entries with the same offset (duplicates across replies)
-            if (ei < SortedEntries.size() && SortedEntries[ei].Offset == resultOffset) {
-                continue;
+                    reply.Messages.pop_front();
+                }
+                if (reply.Messages.empty()) {
+                    if (PendingResponse->Record.MessageSize() > 0) {
+                        Send(reply.Sender, PendingResponse.release(), 0, reply.Cookie);
+                    } else {
+                        auto r = std::make_unique<TEvPQ::TEvMLPErrorResponse>(PartitionId, Ydb::StatusIds::INTERNAL_ERROR, "Messages was not found");
+                        Send(reply.Sender, std::move(r), 0, reply.Cookie);
+                    }
+                    PendingResponse = std::make_unique<TEvPQ::TEvMLPReadResponse>();
+                    Queue.pop_front();
+                    continue;
+                }
             }
-            ++ri;
-        } else {
-            // entry.Offset > resultOffset — advance result pointer
-            ++ri;
         }
     }
 
-    // Mark remaining entries whose offsets are <= maxReturnedOffset as missing
-    if (resultsSize > 0) {
-        while (ei < SortedEntries.size() && SortedEntries[ei].Offset <= maxReturnedOffset) {
-            auto& entry = SortedEntries[ei];
-            if (!entry.Processed) {
-                entry.Processed = true;
-                --PendingResponses[entry.ReplyIndex].TotalMessages;
-            }
-            ++ei;
-        }
-    }
-
-    // Advance NextEntryIdx past all processed entries
-    while (NextEntryIdx < SortedEntries.size() && SortedEntries[NextEntryIdx].Processed) {
-        ++NextEntryIdx;
-    }
-
-    // Try to send completed replies
-    for (size_t i = 0; i < PendingResponses.size(); ++i) {
-        TrySendReply(i);
-    }
-
-    if (RepliesSent == PendingResponses.size()) {
+    if (Queue.empty()) {
         return PassAway();
     }
 
@@ -198,21 +101,25 @@ STFUNC(TMessageEnricherActor::StateWork) {
 }
 
 void TMessageEnricherActor::ProcessQueue() {
-    if (NextEntryIdx >= SortedEntries.size()) {
-        // All entries processed — send any remaining unsent replies
-        for (size_t i = 0; i < PendingResponses.size(); ++i) {
-            TrySendReply(i);
+    while(!Queue.empty()) {
+        auto& reply = Queue.front();
+        if (reply.Messages.empty()) {
+            Send(reply.Sender, new TEvPQ::TEvMLPReadResponse(), 0, reply.Cookie);
+
+            Queue.pop_front();
+            continue;
         }
-        if (RepliesSent == PendingResponses.size()) {
-            return PassAway();
-        }
+
+        auto firstOffset = reply.Messages.front().Offset;
+        LOG_D("Fetching from offset " << firstOffset << " from " << TabletId);
+        SendToPQTablet(MakeEvPQRead(ConsumerName, PartitionId, firstOffset, 1));
+
         return;
     }
 
-    auto minOffset = SortedEntries[NextEntryIdx].Offset;
-    auto count = 1;
-    LOG_D("Fetching from offset " << minOffset << " count " << count << " from " << TabletId);
-    SendToPQTablet(MakeEvPQRead(ConsumerName, PartitionId, minOffset, count));
+    if (Queue.empty()) {
+        return PassAway();
+    }
 }
 
 void TMessageEnricherActor::SendToPQTablet(std::unique_ptr<IEventBase> ev) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
@@ -101,12 +101,15 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     auto& results = response.GetPartitionResponse().GetCmdReadResult().GetResult();
     size_t& entryIndex = NextEntryIdx;
     int resultIndex = 0;
-    int resultsSize = results.size();
-    ui64 maxReturnedOffset = 0;
+    const int resultsSize = results.size();
 
-    if (resultsSize > 0) {
-        maxReturnedOffset = results[resultsSize - 1].GetOffset();
+    if (resultsSize <= 0) {
+        ++entryIndex;
+        ProcessQueue();
+        return;
     }
+
+    const ui64 maxReturnedOffset = results[resultsSize - 1].GetOffset();
 
     // Two-pointer: both SortedEntries and results are sorted by offset
     while (entryIndex < SortedEntries.size() && resultIndex < resultsSize) {
@@ -158,16 +161,14 @@ void TMessageEnricherActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
     }
 
     // Mark remaining entries whose offsets are <= maxReturnedOffset as missing
-    if (resultsSize > 0) {
-        while (entryIndex < SortedEntries.size() && SortedEntries[entryIndex].Offset <= maxReturnedOffset) {
-            auto& entry = SortedEntries[entryIndex];
-            if (!entry.Processed) {
-                entry.Processed = true;
-                --PendingResponses[entry.ReplyIndex].TotalMessages;
-                TrySendReplyIfComplete(entry.ReplyIndex);
-            }
-            ++entryIndex;
+    while (entryIndex < SortedEntries.size() && SortedEntries[entryIndex].Offset <= maxReturnedOffset) {
+        auto& entry = SortedEntries[entryIndex];
+        if (!entry.Processed) {
+            entry.Processed = true;
+            --PendingResponses[entry.ReplyIndex].TotalMessages;
+            TrySendReplyIfComplete(entry.ReplyIndex);
         }
+        ++entryIndex;
     }
 
     if (RepliesSent == PendingResponses.size()) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.cpp
@@ -2,7 +2,7 @@
 
 #include <ydb/core/protos/pqdata_mlp.pb.h>
 
-#include <algorithm>
+#include <util/generic/algorithm.h>
 
 namespace NKikimr::NPQ::NMLP {
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -23,11 +23,32 @@ public:
     void PassAway() override;
 
 private:
+    struct TOffsetEntry {
+        ui64 Offset;
+        size_t ReplyIndex;
+        size_t MessageIndex;
+        bool Processed = false;
+    };
+
+    struct TPendingResponse {
+        NActors::TActorId Sender;
+        ui64 Cookie;
+        std::unique_ptr<TEvPQ::TEvMLPReadResponse> Response;
+        size_t TotalMessages = 0;
+        size_t EnrichedCount = 0;
+        bool Sent = false;
+
+        bool IsComplete() const { return EnrichedCount == TotalMessages; }
+    };
+
     void Handle(TEvPersQueue::TEvResponse::TPtr&);
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&);
 
     STFUNC(StateWork);
 
+    void BuildSortedIndex();
+    void EnsureResponse(size_t replyIndex);
+    void TrySendReply(size_t replyIndex);
     void ProcessQueue();
     void SendToPQTablet(std::unique_ptr<IEventBase> ev);
 
@@ -35,8 +56,11 @@ private:
     const ui64 TabletId;
     const ui32 PartitionId;
     const TString ConsumerName;
-    std::deque<TReadResult> Queue;
-    std::unique_ptr<TEvPQ::TEvMLPReadResponse> PendingResponse;
+    std::vector<TReadResult> Replies;
+    std::vector<TPendingResponse> PendingResponses;
+    std::vector<TOffsetEntry> SortedEntries;
+    size_t NextEntryIdx = 0;
+    size_t RepliesSent = 0;
 
     bool FirstRequest = true;
 };

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -23,32 +23,11 @@ public:
     void PassAway() override;
 
 private:
-    struct TOffsetEntry {
-        ui64 Offset;
-        size_t ReplyIndex;
-        size_t MessageIndex;
-        bool Processed = false;
-    };
-
-    struct TPendingResponse {
-        NActors::TActorId Sender;
-        ui64 Cookie;
-        std::unique_ptr<TEvPQ::TEvMLPReadResponse> Response;
-        size_t TotalMessages = 0;
-        size_t EnrichedCount = 0;
-        bool Sent = false;
-
-        bool IsComplete() const { return EnrichedCount == TotalMessages; }
-    };
-
     void Handle(TEvPersQueue::TEvResponse::TPtr&);
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&);
 
     STFUNC(StateWork);
 
-    void BuildSortedIndex();
-    void EnsureResponse(size_t replyIndex);
-    void TrySendReply(size_t replyIndex);
     void ProcessQueue();
     void SendToPQTablet(std::unique_ptr<IEventBase> ev);
 
@@ -56,11 +35,8 @@ private:
     const ui64 TabletId;
     const ui32 PartitionId;
     const TString ConsumerName;
-    std::vector<TReadResult> Replies;
-    std::vector<TPendingResponse> PendingResponses;
-    std::vector<TOffsetEntry> SortedEntries;
-    size_t NextEntryIdx = 0;
-    size_t RepliesSent = 0;
+    std::deque<TReadResult> Queue;
+    std::unique_ptr<TEvPQ::TEvMLPReadResponse> PendingResponse;
 
     bool FirstRequest = true;
 };

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_message_enricher.h
@@ -31,11 +31,9 @@ private:
     };
 
     struct TPendingResponse {
-        NActors::TActorId Sender;
-        ui64 Cookie;
-        std::unique_ptr<TEvPQ::TEvMLPReadResponse> Response;
-        size_t TotalMessages = 0;
-        size_t EnrichedCount = 0;
+        std::unique_ptr<TEvPQ::TEvMLPReadResponse> Response = std::make_unique<TEvPQ::TEvMLPReadResponse>();
+        ui32 TotalMessages = 0;
+        ui32 EnrichedCount = 0;
         bool Sent = false;
 
         bool IsComplete() const { return EnrichedCount == TotalMessages; }
@@ -46,9 +44,9 @@ private:
 
     STFUNC(StateWork);
 
-    void BuildSortedIndex();
-    void EnsureResponse(size_t replyIndex);
-    void TrySendReply(size_t replyIndex);
+    void TrySendReplyIfComplete(size_t replyIndex);
+    void SendPartialReply(size_t replyIndex);
+    void TrySendReplyImpl(size_t replyIndex, bool waitForCompletion, bool allowEmpty);
     void ProcessQueue();
     void SendToPQTablet(std::unique_ptr<IEventBase> ev);
 
@@ -56,7 +54,7 @@ private:
     const ui64 TabletId;
     const ui32 PartitionId;
     const TString ConsumerName;
-    std::vector<TReadResult> Replies;
+    std::deque<TReadResult> Replies;
     std::vector<TPendingResponse> PendingResponses;
     std::vector<TOffsetEntry> SortedEntries;
     size_t NextEntryIdx = 0;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -152,7 +152,77 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     return MessageGroups.UnlockedMessageGroupsId.contains(messageGroupIdHash);
 }
 
+void TStorage::ValidateNextOffsets() const {
+    // Build actual set by scanning all messages
+    absl::flat_hash_set<ui64> actualOffsets;
+    absl::flat_hash_set<ui32> seenGroupHashes;
+
+    auto processMessage = [&](ui64 offset, const TMessage& message) {
+        if (message.GetStatus() != EMessageStatus::Unprocessed) {
+            return;
+        }
+        if (!message.HasMessageGroupId) {
+            actualOffsets.insert(offset);
+            return;
+        }
+        if (!CanReadMessageGroupIdHash(message.MessageGroupIdHash)) {
+            return;
+        }
+        if (seenGroupHashes.insert(message.MessageGroupIdHash).second) {
+            actualOffsets.insert(offset);
+        }
+    };
+    IterateAllMessagesInOrder(processMessage);
+
+    // Build expected set from MessageGroups index
+    absl::flat_hash_set<ui64> expectedOffsets(MessageGroups.UnorderedOffsets.begin(), MessageGroups.UnorderedOffsets.end());
+    for (ui32 groupHash : MessageGroups.UnlockedMessageGroupsId) {
+        const auto* group = MapFindPtr(MessageGroups.Groups, groupHash);
+        AFL_ENSURE(group != nullptr)("groupHash", groupHash);
+        expectedOffsets.insert(group->FirstOffset);
+    }
+
+    if (actualOffsets == expectedOffsets) {
+        return;
+    }
+
+    TStringBuilder sb;
+    sb << "ValidateNextOffsets MISMATCH: actual.size=" << actualOffsets.size() << " expected.size=" << expectedOffsets.size() << "\n";
+
+    TVector<ui64> allOffsets(Reserve(GetMessageCount() + actualOffsets.size() + expectedOffsets.size()));
+    IterateAllMessagesInOrder([&](ui64 offset, const TMessage&) { allOffsets.push_back(offset); });
+    allOffsets.insert(allOffsets.end(), actualOffsets.begin(), actualOffsets.end());
+    allOffsets.insert(allOffsets.end(), expectedOffsets.begin(), expectedOffsets.end());
+    SortUnique(allOffsets);
+
+    for (ui64 offset : allOffsets) {
+        auto [msg, slowZone] = GetMessageInt(offset);
+        sb << "  offset=" << offset;
+        sb << " zone=" << (slowZone ? 's' : 'f');
+        sb << " mismatch=" << (actualOffsets.contains(offset) != expectedOffsets.contains(offset));
+        sb << " inActual=" << actualOffsets.contains(offset);
+        sb << " inExpected=" << expectedOffsets.contains(offset);
+        sb << " inUnorderedOffsets=" << MessageGroups.UnorderedOffsets.contains(offset);
+        if (msg) {
+            sb << " status=" << static_cast<int>(msg->GetStatus());
+            sb << " hasGroup=" << (bool)msg->HasMessageGroupId;
+            if (msg->HasMessageGroupId) {
+                sb << " groupHash=" << msg->MessageGroupIdHash;
+                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsId.contains(msg->MessageGroupIdHash);
+            }
+        } else {
+            sb << " NOT_FOUND";
+        }
+        sb << "\n";
+    }
+
+    Y_ABORT("%s", sb.c_str());
+}
+
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
+    if (KeepMessageOrder) {
+        ValidateNextOffsets();
+    }
     std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -171,19 +171,44 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
         };
     };
 
-    auto isMessageGroupLocked = [&](TMessage& message) {
-        return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
-    };
+    if (KeepMessageOrder) {
+        auto isMessageGroupSkipped = [&](TMessage& message) {
+            return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
+        };
+        auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
+            const auto& [message, _] = GetMessageInt(offset);
+            AFL_ENSURE(message != nullptr)("offset", offset)("case", desc);
+            AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", desc);
+            if (retentionExpired(*message)) {
+                return std::nullopt;
+            }
+            if (isMessageGroupSkipped(*message)) {
+                return std::nullopt;
+            }
+            DoLock(offset, *message, deadline);
+            return asResult(offset, *message);
+        };
+        for (ui32 groupId : MessageGroups.UnlockedMessageGroupsId) {
+            auto* group = MapFindPtr(MessageGroups.Groups, groupId);
+            AFL_ENSURE(group != nullptr)("groupId", groupId);
+            ui64 offset = group->FirstOffset;
+            if (auto result = tryReturn(offset, "unblocked")) {
+                return result;
+            }
+        }
+        for (ui64 offset : MessageGroups.UnorderedOffsets) {
+            if (auto result = tryReturn(offset, "unordered")) {
+                return result;
+            }
+        }
+        return std::nullopt;
+    }
 
     for(; position.SlowPosition != SlowMessages.end(); ++position.SlowPosition.value()) {
         auto offset = position.SlowPosition.value()->first;
         auto& message = position.SlowPosition.value()->second;
         if (message.GetStatus() == EMessageStatus::Unprocessed) {
             if (retentionExpired(message)) {
-                continue;
-            }
-
-            if (isMessageGroupLocked(message)) {
                 continue;
             }
 
@@ -200,11 +225,6 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
                 if (moveUnlockedOffset) {
                     ++FirstUnlockedOffset;
                 }
-                continue;
-            }
-
-            if (isMessageGroupLocked(message)) {
-                moveUnlockedOffset = false;
                 continue;
             }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -172,7 +172,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
     };
 
     if (KeepMessageOrder) {
-        auto isMessageGroupSkipped = [&](TMessage& message) {
+        auto isMessageGroupSkipped = [&](const TMessage& message) {
             return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
         };
         auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -149,7 +149,7 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     if (!KeepMessageOrder) {
         return true;
     }
-    return MessageGroups.UnlockedMessageGroupsId.contains(messageGroupIdHash);
+    return MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(messageGroupIdHash);
 }
 
 void TStorage::ValidateNextOffsets() const {
@@ -176,7 +176,7 @@ void TStorage::ValidateNextOffsets() const {
 
     // Build expected set from MessageGroups index
     absl::flat_hash_set<ui64> expectedOffsets(MessageGroups.UnorderedOffsets.begin(), MessageGroups.UnorderedOffsets.end());
-    for (ui32 groupHash : MessageGroups.UnlockedMessageGroupsId) {
+    for (ui32 groupHash : MessageGroups.UnlockedMessageGroupsId.IterateMessageGroups()) {
         const auto* group = MapFindPtr(MessageGroups.Groups, groupHash);
         AFL_ENSURE(group != nullptr)("groupHash", groupHash);
         expectedOffsets.insert(group->FirstOffset);
@@ -208,7 +208,7 @@ void TStorage::ValidateNextOffsets() const {
             sb << " hasGroup=" << (bool)msg->HasMessageGroupId;
             if (msg->HasMessageGroupId) {
                 sb << " groupHash=" << msg->MessageGroupIdHash;
-                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsId.contains(msg->MessageGroupIdHash);
+                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(msg->MessageGroupIdHash);
             }
         } else {
             sb << " NOT_FOUND";
@@ -258,7 +258,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
             DoLock(offset, *message, deadline);
             return asResult(offset, *message);
         };
-        for (ui32 groupId : MessageGroups.UnlockedMessageGroupsId) {
+        for (ui32 groupId : MessageGroups.UnlockedMessageGroupsId.IterateMessageGroups()) {
             auto* group = MapFindPtr(MessageGroups.Groups, groupId);
             AFL_ENSURE(group != nullptr)("groupId", groupId);
             ui64 offset = group->FirstOffset;
@@ -588,12 +588,12 @@ static bool TrackMessageStatusInLockedGroups(const TStorage::TMessage& message) 
     return TrackMessageStatusInLockedGroups(message.GetStatus());
 }
 
-static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash) {
+static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash, ui64 offset) {
     if (locked.IsAccessible()) {
-        messageGroups.UnlockedMessageGroupsId.insert(messageGroupIdHash);
+        messageGroups.UnlockedMessageGroupsId.InsertOrAssign(messageGroupIdHash, offset);
         messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
     } else {
-        messageGroups.UnlockedMessageGroupsId.erase(messageGroupIdHash);
+        messageGroups.UnlockedMessageGroupsId.EraseIfExist(messageGroupIdHash, offset);
         if (locked.LockedSelf) {
             messageGroups.LockedMessageGroupsId.insert(messageGroupIdHash);
         } else {
@@ -609,7 +609,7 @@ void TStorage::UpdateMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& c
             return;
         }
         group.Locked.LockedParent = newLockedParent;
-        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash);
+        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash, group.FirstOffset);
     };
     bool updateAll = currLocked.size() + prevLocked.size() >= MessageGroups.Groups.size();
     if (modeChanged || updateAll) {
@@ -654,7 +654,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     if (nextOffset.Empty()) {
         MessageGroups.Groups.erase(messageGroupIterator);
         MessageGroups.LockedMessageGroupsId.erase(message.MessageGroupIdHash);
-        MessageGroups.UnlockedMessageGroupsId.erase(message.MessageGroupIdHash);
+        MessageGroups.UnlockedMessageGroupsId.EraseExist(message.MessageGroupIdHash, offset);
         AFL_ENSURE(Metrics.InflightMessageGroupCount > 0);
         --Metrics.InflightMessageGroupCount;
         return;
@@ -663,7 +663,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     auto [nextMessage, _] = GetMessageInt(*nextOffset);
     AFL_ENSURE(nextMessage != nullptr);
     ptr->Locked.FillFromStatus(nextMessage->GetStatus());
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash, *nextOffset);
 }
 
 void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus) {
@@ -693,7 +693,7 @@ void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessa
     TSingleMessageGroupIdInfo* ptr = MapFindPtr(MessageGroups.Groups, message.MessageGroupIdHash);
     AFL_ENSURE(ptr != nullptr)("offset", offset)("messageGroupIdHash", message.MessageGroupIdHash);
     ptr->Locked.FillFromStatus(newStatus);
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash, offset);
 }
 
 void TStorage::UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message) {
@@ -764,7 +764,7 @@ void TStorage::UpdateMessageGroupForNewMessage(ui64 offset, TMessage& message) {
     if (firstReadableMessageInGroup) {
         group.Locked.LockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
         group.Locked.FillFromStatus(message.GetStatus());
-        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash);
+        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash, offset);
     }
 }
 
@@ -1588,7 +1588,7 @@ TStorage::TMessageWrapper TStorage::TMessageIterator::operator*() const {
         .WriteTimestamp = Storage.BaseWriteTimestamp + TDuration::Seconds(message->WriteTimestampDelta),
         .LockingTimestamp = Storage.GetMessageLockingTime(*message),
         .MessageGroupIdHash = message->HasMessageGroupId ? std::optional<ui32>(message->MessageGroupIdHash) : std::nullopt,
-        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.contains(message->MessageGroupIdHash),
+        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(message->MessageGroupIdHash),
     };
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -152,7 +152,7 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     return MessageGroups.UnlockedMessageGroupsIdContains(messageGroupIdHash);
 }
 
-TReadMessage TStorage::ConvertoToReadMessage(ui64 offset, const TMessage& message) const {
+TReadMessage TStorage::ConvertToReadMessage(ui64 offset, const TMessage& message) const {
     return TReadMessage{
         .Offset = offset,
         .ApproximateReceiveCount = message.ProcessingCount,
@@ -162,7 +162,7 @@ TReadMessage TStorage::ConvertoToReadMessage(ui64 offset, const TMessage& messag
 
 static bool RetentionExpired(const TStorage::TMessage& message, const std::optional<ui32> retentionDeadlineDelta) {
     return retentionDeadlineDelta && message.WriteTimestampDelta <= retentionDeadlineDelta.value();
-};
+}
 
 bool TStorage::IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const {
     return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
@@ -250,7 +250,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
                 unlockedList.Append(std::move(cut));
             }
             DoLock(nextMessage.Offset, *nextMessage.Message, deadline);
-            return ConvertoToReadMessage(nextMessage.Offset, *nextMessage.Message);
+            return ConvertToReadMessage(nextMessage.Offset, *nextMessage.Message);
         }
 
         auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
@@ -259,7 +259,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
                 return std::nullopt;
             }
             DoLock(offset, *result.Message, deadline);
-            return ConvertoToReadMessage(offset, *result.Message);
+            return ConvertToReadMessage(offset, *result.Message);
         };
 
         for (ui64 offset : MessageGroups.UnorderedOffsets) [[unlikely]] {
@@ -283,7 +283,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
             }
 
             DoLock(offset, message, deadline);
-            return ConvertoToReadMessage(offset, message);
+            return ConvertToReadMessage(offset, message);
         }
     }
 
@@ -311,7 +311,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
             position.FastPosition = offset + 1;
 
             DoLock(offset, message, deadline);
-            return ConvertoToReadMessage(offset, message);
+            return ConvertToReadMessage(offset, message);
         } else if (moveUnlockedOffset) {
             ++FirstUnlockedOffset;
         }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -100,7 +100,7 @@ bool TStorage::HasUnlockedMessageGroupsId() const {
     if (ReadWithKeepOrder() == NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL) {
         return false;
     }
-    if (MessageGroups.UnlockedMessageGroupsId.size() > 0) {
+    if (MessageGroups.UnlockedMessageGroupsIdSize() > 0) {
         return true;
     }
     return MessageGroups.UnorderedOffsets.size() > 0;
@@ -149,7 +149,7 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     if (!KeepMessageOrder) {
         return true;
     }
-    return MessageGroups.UnlockedMessageGroupsId.contains(messageGroupIdHash);
+    return MessageGroups.UnlockedMessageGroupsIdContains(messageGroupIdHash);
 }
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
@@ -498,16 +498,21 @@ static bool TrackMessageStatusInLockedGroups(const TStorage::TMessage& message) 
     return TrackMessageStatusInLockedGroups(message.GetStatus());
 }
 
-static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash) {
+void TStorage::TMessageGroups::UpdateLockedMaps(const TLockedGroup& locked, ui32 messageGroupIdHash) {
     if (locked.IsAccessible()) {
-        messageGroups.UnlockedMessageGroupsId.insert(messageGroupIdHash);
-        messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
+        auto [uIt, uIns] = UnlockedMessageGroupsId.insert(messageGroupIdHash);
+        if (uIns) {
+            const TIntrusiveListItem<TOrderedMessageGroupIdHash>& pc = *uIt;
+            TIntrusiveListItem<TOrderedMessageGroupIdHash>& p = const_cast<TIntrusiveListItem<TOrderedMessageGroupIdHash>&>(pc);
+            UnlockedMessageGroupsIdViewOrder.PushBack(&p);
+        }
+        LockedMessageGroupsId.erase(messageGroupIdHash);
     } else {
-        messageGroups.UnlockedMessageGroupsId.erase(messageGroupIdHash);
+        UnlockedMessageGroupsIdErase(messageGroupIdHash);
         if (locked.LockedSelf) {
-            messageGroups.LockedMessageGroupsId.insert(messageGroupIdHash);
+            LockedMessageGroupsId.insert(messageGroupIdHash);
         } else {
-            messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
+            LockedMessageGroupsId.erase(messageGroupIdHash);
         }
     }
 }
@@ -519,7 +524,7 @@ void TStorage::UpdateMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& c
             return;
         }
         group.Locked.LockedParent = newLockedParent;
-        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash);
+        MessageGroups.UpdateLockedMaps(group.Locked, messageGroupIdHash);
     };
     bool updateAll = currLocked.size() + prevLocked.size() >= MessageGroups.Groups.size();
     if (modeChanged || updateAll) {
@@ -564,7 +569,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     if (nextOffset.Empty()) {
         MessageGroups.Groups.erase(messageGroupIterator);
         MessageGroups.LockedMessageGroupsId.erase(message.MessageGroupIdHash);
-        MessageGroups.UnlockedMessageGroupsId.erase(message.MessageGroupIdHash);
+        MessageGroups.UnlockedMessageGroupsIdErase(message.MessageGroupIdHash);
         AFL_ENSURE(Metrics.InflightMessageGroupCount > 0);
         --Metrics.InflightMessageGroupCount;
         return;
@@ -573,7 +578,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     auto [nextMessage, _] = GetMessageInt(*nextOffset);
     AFL_ENSURE(nextMessage != nullptr);
     ptr->Locked.FillFromStatus(nextMessage->GetStatus());
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+    MessageGroups.UpdateLockedMaps(ptr->Locked, message.MessageGroupIdHash);
 }
 
 void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus) {
@@ -603,7 +608,7 @@ void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessa
     TSingleMessageGroupIdInfo* ptr = MapFindPtr(MessageGroups.Groups, message.MessageGroupIdHash);
     AFL_ENSURE(ptr != nullptr)("offset", offset)("messageGroupIdHash", message.MessageGroupIdHash);
     ptr->Locked.FillFromStatus(newStatus);
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
+    MessageGroups.UpdateLockedMaps(ptr->Locked, message.MessageGroupIdHash);
 }
 
 void TStorage::UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message) {
@@ -674,7 +679,7 @@ void TStorage::UpdateMessageGroupForNewMessage(ui64 offset, TMessage& message) {
     if (firstReadableMessageInGroup) {
         group.Locked.LockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
         group.Locked.FillFromStatus(message.GetStatus());
-        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash);
+        MessageGroups.UpdateLockedMaps(group.Locked, message.MessageGroupIdHash);
     }
 }
 
@@ -1498,7 +1503,7 @@ TStorage::TMessageWrapper TStorage::TMessageIterator::operator*() const {
         .WriteTimestamp = Storage.BaseWriteTimestamp + TDuration::Seconds(message->WriteTimestampDelta),
         .LockingTimestamp = Storage.GetMessageLockingTime(*message),
         .MessageGroupIdHash = message->HasMessageGroupId ? std::optional<ui32>(message->MessageGroupIdHash) : std::nullopt,
-        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.contains(message->MessageGroupIdHash),
+        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsIdContains(message->MessageGroupIdHash),
     };
 }
 
@@ -1555,6 +1560,7 @@ void TStorage::TMessageGroups::Clear() {
     UnlockedMessageGroupsId.clear();
     LockedMessageGroupsId.clear();
     UnorderedOffsets.clear();
+    UnlockedMessageGroupsIdViewOrder.Clear();
 }
 
 void TStorage::IterateMessageGroupsIdExclusiveFromParent(const std::function<void(ui32)>& callback) const {
@@ -1593,5 +1599,50 @@ size_t TStorage::GetEstimatedLockedMessageGroupsIdSizeFromSelfAndParents() const
     }
     return n;
 }
+
+/* implicit */ TOrderedMessageGroupIdHash::TOrderedMessageGroupIdHash(ui32 groupIdHash)
+    : GroupIdHash(groupIdHash)
+{
+}
+
+TOrderedMessageGroupIdHash::TOrderedMessageGroupIdHash(TOrderedMessageGroupIdHash&& other)
+    : GroupIdHash(other.GroupIdHash)
+{
+    TIntrusiveListItem<TOrderedMessageGroupIdHash>& lhs = *this;
+    TIntrusiveListItem<TOrderedMessageGroupIdHash>& rhs = other;
+    if (rhs.Empty()) {
+        return;
+    }
+    lhs.SetNext(rhs.Next());
+    lhs.SetPrev(rhs.Prev());
+    rhs.Next()->SetPrev(&lhs);
+    rhs.Prev()->SetNext(&lhs);
+    rhs.ResetItem();
+}
+
+bool TOrderedMessageGroupIdHash::operator==(const TOrderedMessageGroupIdHash& other) const {
+    return GroupIdHash == other.GroupIdHash;
+}
+
+TOrderedMessageGroupIdHash::operator ui32() const {
+    return GroupIdHash;
+}
+
+bool TStorage::TMessageGroups::UnlockedMessageGroupsIdContains(const ui32 messageGroupIdHash) const {
+    return UnlockedMessageGroupsId.contains(messageGroupIdHash);
+}
+size_t TStorage::TMessageGroups::UnlockedMessageGroupsIdSize() const {
+    return UnlockedMessageGroupsId.size();
+}
+
+bool TStorage::TMessageGroups::UnlockedMessageGroupsIdErase(const ui32 messageGroupIdHash) {
+    size_t viewOrderSz0 = Y_IS_DEBUG_BUILD ? UnlockedMessageGroupsIdViewOrder.Size() : 0;
+    size_t n = UnlockedMessageGroupsId.erase(messageGroupIdHash);
+    size_t viewOrderSz1 = Y_IS_DEBUG_BUILD ? UnlockedMessageGroupsIdViewOrder.Size() : 0;
+    Y_ASSERT(Y_IS_DEBUG_BUILD && (viewOrderSz0 == viewOrderSz1 + n));
+    return n > 0;
+}
+
+TStorage::TMessageGroups::~TMessageGroups() = default;
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -598,6 +598,7 @@ void TStorage::TMessageGroups::UpdateLockedMaps(const TLockedGroup& locked, ui32
         auto [uIt, uIns] = UnlockedMessageGroupsId.insert(messageGroupIdHash);
         if (uIns) {
             const TIntrusiveListItem<TOrderedMessageGroupIdHash>& pc = *uIt;
+            // the base class cannot be declared as mutable
             TIntrusiveListItem<TOrderedMessageGroupIdHash>& p = const_cast<TIntrusiveListItem<TOrderedMessageGroupIdHash>&>(pc);
             UnlockedMessageGroupsIdViewOrder.PushBack(&p);
         }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -185,7 +185,7 @@ TStorage::TTryGetMessageResult TStorage::TryGetMessage(ui64 offset, const std::o
     }
     if (isMessageGroupSkipped(*message)) {
         return TTryGetMessageResult{
-            .Message = nullptr,
+            .Message = message,
             .TryNextInGroup = false,
             .Usable = false,
         };

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -152,86 +152,110 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     return MessageGroups.UnlockedMessageGroupsIdContains(messageGroupIdHash);
 }
 
+TReadMessage TStorage::ConvertoToReadMessage(ui64 offset, const TMessage& message) const {
+    return TReadMessage{
+        .Offset = offset,
+        .ApproximateReceiveCount = message.ProcessingCount,
+        .ApproximateFirstReceiveTimestamp = TimeProvider->Now(), // TODO: replace with persisted first-receive timestamp
+    };
+}
+
+static bool RetentionExpired(const TStorage::TMessage& message, const std::optional<ui32> retentionDeadlineDelta) {
+    return retentionDeadlineDelta && message.WriteTimestampDelta <= retentionDeadlineDelta.value();
+};
+
+bool TStorage::IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const {
+    return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
+};
+
+TStorage::TTryGetMessageResult TStorage::TryGetMessage(ui64 offset, const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups, const char* caseDescription) {
+    auto isMessageGroupSkipped = [&](const TMessage& message) {
+        return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
+    };
+    // checks if message is eligible for return: it is not expired or skipped
+    const auto& [message, _] = GetMessageInt(offset);
+    AFL_ENSURE(message != nullptr)("offset", offset)("case", caseDescription);
+    AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", caseDescription);
+    if (RetentionExpired(*message, retentionDeadlineDelta)) {
+        return TTryGetMessageResult{
+            .Message = nullptr,
+            .TryNextInGroup = true,
+        };
+    }
+    if (isMessageGroupSkipped(*message)) {
+        return TTryGetMessageResult{
+            .Message = nullptr,
+            .TryNextInGroup = false,
+        };
+    }
+    return TTryGetMessageResult{
+        .Message = message,
+        .TryNextInGroup = false,
+    };
+}
+TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups) {
+    auto& unlockedList = MessageGroups.GetUnlockedMessageGroupsIdViewOrder();
+    for (auto firstIt = unlockedList.begin(); firstIt != unlockedList.end(); ++firstIt) {
+        const ui32 groupId{*firstIt};
+        auto* group = MapFindPtr(MessageGroups.Groups, groupId);
+        AFL_ENSURE(group != nullptr)("groupId", groupId);
+        ui64 offset = group->FirstOffset;
+
+        while (true) {
+            TTryGetMessageResult result = TryGetMessage(offset, retentionDeadlineDelta, skipMessageGroups, "unlocked");
+            if (result.Message) {
+                return TNextMessageResult{
+                    .Message = result.Message,
+                    .Offset = offset,
+                    .OrderIterator = firstIt,
+                };
+            }
+            if (!result.TryNextInGroup) {
+                // TODO: hop inside group
+                break;
+            }
+            break;
+        }
+    }
+    return TNextMessageResult{
+        .Message = nullptr,
+        .Offset = Max<ui64>(),
+        .OrderIterator = unlockedList.end(),
+    };
+};
+
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
-    std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
+    const std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {
         position.SlowPosition = SlowMessages.begin();
     }
 
-    auto retentionExpired = [&](const auto& message) {
-        return retentionDeadlineDelta && message.WriteTimestampDelta <= retentionDeadlineDelta.value();
-    };
-
-    auto asResult = [&](auto offset, auto& message) {
-        return TReadMessage{
-            .Offset = offset,
-            .ApproximateReceiveCount = message.ProcessingCount,
-            .ApproximateFirstReceiveTimestamp = TimeProvider->Now(), // TODO: replace with persisted first-receive timestamp
-        };
-    };
-
-    auto isMessageGroupLocked = [&](TMessage& message) {
-        return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
-    };
-
     if (KeepMessageOrder) {
-        auto isMessageGroupSkipped = [&](const TMessage& message) {
-            return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
-        };
-
-        auto tryGetMessage = [&](ui64 offset, const char* desc) -> TMessage* {
-            // checks if message is eligible for return: it is not expired or skipped
-            const auto& [message, _] = GetMessageInt(offset);
-            AFL_ENSURE(message != nullptr)("offset", offset)("case", desc);
-            AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", desc);
-            if (retentionExpired(*message)) {
-                return nullptr;
-            }
-            if (isMessageGroupSkipped(*message)) {
-                return nullptr;
-            }
-            return message;
-        };
-
-        auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
-            auto* message = tryGetMessage(offset, desc);
-            if (!message) {
-                return std::nullopt;
-            }
-            DoLock(offset, *message, deadline);
-            return asResult(offset, *message);
-        };
-
-        auto& unlockedList = MessageGroups.GetUnlockedMessageGroupsIdViewOrder();
-        auto searchForEligibleMessage = [&]() -> std::tuple<TMessage*, ui64, TIntrusiveList<TOrderedMessageGroupIdHash>::iterator> {
-            for (auto firstIt = unlockedList.begin(); firstIt != unlockedList.end(); ++firstIt) {
-                const ui32 groupId{*firstIt};
-                auto* group = MapFindPtr(MessageGroups.Groups, groupId);
-                AFL_ENSURE(group != nullptr)("groupId", groupId);
-                ui64 offset = group->FirstOffset;
-                TMessage* message = tryGetMessage(offset, "unlocked");
-                if (message) {
-                    return std::make_tuple(message, offset, firstIt);
-                }
-            }
-            return std::make_tuple(nullptr, -1, unlockedList.end());
-        };
-
-        auto [message, offset, firstIt] = searchForEligibleMessage();
-        if (message) {
-            if (unlockedList.begin() != firstIt) [[unlikely]] {
+        TNextMessageResult nextMessage = SearchForEligibleMessage(retentionDeadlineDelta, skipMessageGroups);
+        if (nextMessage.Message) {
+            auto& unlockedList = MessageGroups.GetUnlockedMessageGroupsIdViewOrder();
+            if (unlockedList.begin() != nextMessage.OrderIterator) [[unlikely]] {
                 if constexpr (0) {
                     // rotate
                     // move skipped messaged to the end of queue, so they won't be rechecked on the next iteration
                     TIntrusiveList<TOrderedMessageGroupIdHash> cut;
-                    unlockedList.Cut(unlockedList.begin(), firstIt, cut.end());
+                    unlockedList.Cut(unlockedList.begin(), nextMessage.OrderIterator, cut.end());
                     unlockedList.Append(std::move(cut));
                 }
             }
-            DoLock(offset, *message, deadline);
-            return asResult(offset, *message);
+            DoLock(nextMessage.Offset, *nextMessage.Message, deadline);
+            return ConvertoToReadMessage(nextMessage.Offset, *nextMessage.Message);
         }
+
+        auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
+            TTryGetMessageResult result = TryGetMessage(offset, retentionDeadlineDelta, skipMessageGroups, desc);
+            if (!result.Message) {
+                return std::nullopt;
+            }
+            DoLock(offset, *result.Message, deadline);
+            return ConvertoToReadMessage(offset, *result.Message);
+        };
 
         for (ui64 offset : MessageGroups.UnorderedOffsets) [[unlikely]] {
             if (auto result = tryReturn(offset, "unordered")) {
@@ -245,16 +269,16 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
         auto offset = position.SlowPosition.value()->first;
         auto& message = position.SlowPosition.value()->second;
         if (message.GetStatus() == EMessageStatus::Unprocessed) {
-            if (retentionExpired(message)) {
+            if (RetentionExpired(message, retentionDeadlineDelta)) {
                 continue;
             }
 
-            if (isMessageGroupLocked(message)) {
+            if (IsMessageGroupLocked(message, skipMessageGroups)) {
                 continue;
             }
 
             DoLock(offset, message, deadline);
-            return asResult(offset, message);
+            return ConvertoToReadMessage(offset, message);
         }
     }
 
@@ -262,14 +286,14 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
     for (size_t i = std::max(position.FastPosition, FirstUnlockedOffset) - FirstOffset; i < Messages.size(); ++i) {
         auto& message = Messages[i];
         if (message.GetStatus() == EMessageStatus::Unprocessed) {
-            if (retentionExpired(message)) {
+            if (RetentionExpired(message, retentionDeadlineDelta)) {
                 if (moveUnlockedOffset) {
                     ++FirstUnlockedOffset;
                 }
                 continue;
             }
 
-            if (isMessageGroupLocked(message)) {
+            if (IsMessageGroupLocked(message, skipMessageGroups)) {
                 moveUnlockedOffset = false;
                 continue;
             }
@@ -282,7 +306,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
             position.FastPosition = offset + 1;
 
             DoLock(offset, message, deadline);
-            return asResult(offset, message);
+            return ConvertoToReadMessage(offset, message);
         } else if (moveUnlockedOffset) {
             ++FirstUnlockedOffset;
         }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -232,9 +232,6 @@ TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optio
 };
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
-    if (KeepMessageOrder) {
-        ValidateNextOffsets();
-    }
     const std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {
@@ -605,11 +602,6 @@ void TStorage::TMessageGroups::UpdateLockedMaps(const TLockedGroup& locked, ui32
             const TIntrusiveListItem<TOrderedMessageGroupIdHash>& pc = *uIt;
             TIntrusiveListItem<TOrderedMessageGroupIdHash>& p = const_cast<TIntrusiveListItem<TOrderedMessageGroupIdHash>&>(pc);
             UnlockedMessageGroupsIdViewOrder.PushBack(&p);
-        }
-        if constexpr (Y_IS_DEBUG_BUILD) {
-            if (UnlockedMessageGroupsId.size() < 300) {
-                Y_ASSERT(UnlockedMessageGroupsId.size() == UnlockedMessageGroupsIdViewOrder.Size());
-            }
         }
         LockedMessageGroupsId.erase(messageGroupIdHash);
     } else {
@@ -1757,73 +1749,5 @@ TIntrusiveList<TOrderedMessageGroupIdHash>& TStorage::TMessageGroups::GetUnlocke
 }
 
 TStorage::TMessageGroups::~TMessageGroups() = default;
-
-void TStorage::ValidateNextOffsets() const {
-    // Build actual set by scanning all messages
-    absl::flat_hash_set<ui64> actualOffsets;
-    absl::flat_hash_set<ui32> seenGroupHashes;
-
-    auto processMessage = [&](ui64 offset, const TMessage& message) {
-        if (message.GetStatus() != EMessageStatus::Unprocessed) {
-            return;
-        }
-        if (!message.HasMessageGroupId) {
-            actualOffsets.insert(offset);
-            return;
-        }
-        if (!CanReadMessageGroupIdHash(message.MessageGroupIdHash)) {
-            return;
-        }
-        if (seenGroupHashes.insert(message.MessageGroupIdHash).second) {
-            actualOffsets.insert(offset);
-        }
-    };
-    IterateAllMessagesInOrder(processMessage);
-
-    // Build expected set from MessageGroups index
-    absl::flat_hash_set<ui64> expectedOffsets(MessageGroups.UnorderedOffsets.begin(), MessageGroups.UnorderedOffsets.end());
-    for (const auto& g : MessageGroups.UnlockedMessageGroupsIdIterate()) {
-        ui32 groupHash{g};
-        const auto* group = MapFindPtr(MessageGroups.Groups, groupHash);
-        AFL_ENSURE(group != nullptr)("groupHash", groupHash);
-        expectedOffsets.insert(group->FirstOffset);
-    }
-
-    if (actualOffsets == expectedOffsets) {
-        return;
-    }
-
-    TStringBuilder sb;
-    sb << "ValidateNextOffsets MISMATCH: actual.size=" << actualOffsets.size() << " expected.size=" << expectedOffsets.size() << "\n";
-
-    TVector<ui64> allOffsets(Reserve(GetMessageCount() + actualOffsets.size() + expectedOffsets.size()));
-    IterateAllMessagesInOrder([&](ui64 offset, const TMessage&) { allOffsets.push_back(offset); });
-    allOffsets.insert(allOffsets.end(), actualOffsets.begin(), actualOffsets.end());
-    allOffsets.insert(allOffsets.end(), expectedOffsets.begin(), expectedOffsets.end());
-    SortUnique(allOffsets);
-
-    for (ui64 offset : allOffsets) {
-        auto [msg, slowZone] = GetMessageInt(offset);
-        sb << "  offset=" << offset;
-        sb << " zone=" << (slowZone ? 's' : 'f');
-        sb << " mismatch=" << (actualOffsets.contains(offset) != expectedOffsets.contains(offset));
-        sb << " inActual=" << actualOffsets.contains(offset);
-        sb << " inExpected=" << expectedOffsets.contains(offset);
-        sb << " inUnorderedOffsets=" << MessageGroups.UnorderedOffsets.contains(offset);
-        if (msg) {
-            sb << " status=" << static_cast<int>(msg->GetStatus());
-            sb << " hasGroup=" << (bool)msg->HasMessageGroupId;
-            if (msg->HasMessageGroupId) {
-                sb << " groupHash=" << msg->MessageGroupIdHash;
-                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsIdContains(msg->MessageGroupIdHash);
-            }
-        } else {
-            sb << " NOT_FOUND";
-        }
-        sb << "\n";
-    }
-
-    Y_ABORT("%s", sb.c_str());
- }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -178,19 +178,22 @@ TStorage::TTryGetMessageResult TStorage::TryGetMessage(ui64 offset, const std::o
     AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", caseDescription);
     if (RetentionExpired(*message, retentionDeadlineDelta)) {
         return TTryGetMessageResult{
-            .Message = nullptr,
+            .Message = message,
             .TryNextInGroup = true,
+            .Usable = false,
         };
     }
     if (isMessageGroupSkipped(*message)) {
         return TTryGetMessageResult{
             .Message = nullptr,
             .TryNextInGroup = false,
+            .Usable = false,
         };
     }
     return TTryGetMessageResult{
         .Message = message,
         .TryNextInGroup = false,
+        .Usable = true,
     };
 }
 TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups) {
@@ -203,7 +206,7 @@ TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optio
 
         while (true) {
             TTryGetMessageResult result = TryGetMessage(offset, retentionDeadlineDelta, skipMessageGroups, "unlocked");
-            if (result.Message) {
+            if (result.Usable) {
                 return TNextMessageResult{
                     .Message = result.Message,
                     .Offset = offset,
@@ -211,10 +214,14 @@ TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optio
                 };
             }
             if (!result.TryNextInGroup) {
-                // TODO: hop inside group
                 break;
             }
-            break;
+            // The head of the group contains expired messages. Try to look in the tail of the same group.
+            auto nextOffset = result.Message->NextMessageGroupIdOffset();
+            if (nextOffset.Empty()) {
+                break;
+            }
+            offset = *nextOffset;
         }
     }
     return TNextMessageResult{
@@ -250,7 +257,7 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
 
         auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
             TTryGetMessageResult result = TryGetMessage(offset, retentionDeadlineDelta, skipMessageGroups, desc);
-            if (!result.Message) {
+            if (!result.Usable) {
                 return std::nullopt;
             }
             DoLock(offset, *result.Message, deadline);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -175,6 +175,72 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
         return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
     };
 
+    if (KeepMessageOrder) {
+        auto isMessageGroupSkipped = [&](const TMessage& message) {
+            return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
+        };
+
+        auto tryGetMessage = [&](ui64 offset, const char* desc) -> TMessage* {
+            // checks if message is eligible for return: it is not expired or skipped
+            const auto& [message, _] = GetMessageInt(offset);
+            AFL_ENSURE(message != nullptr)("offset", offset)("case", desc);
+            AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", desc);
+            if (retentionExpired(*message)) {
+                return nullptr;
+            }
+            if (isMessageGroupSkipped(*message)) {
+                return nullptr;
+            }
+            return message;
+        };
+
+        auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
+            auto* message = tryGetMessage(offset, desc);
+            if (!message) {
+                return std::nullopt;
+            }
+            DoLock(offset, *message, deadline);
+            return asResult(offset, *message);
+        };
+
+        auto& unlockedList = MessageGroups.GetUnlockedMessageGroupsIdViewOrder();
+        auto searchForEligibleMessage = [&]() -> std::tuple<TMessage*, ui64, TIntrusiveList<TOrderedMessageGroupIdHash>::iterator> {
+            for (auto firstIt = unlockedList.begin(); firstIt != unlockedList.end(); ++firstIt) {
+                const ui32 groupId{*firstIt};
+                auto* group = MapFindPtr(MessageGroups.Groups, groupId);
+                AFL_ENSURE(group != nullptr)("groupId", groupId);
+                ui64 offset = group->FirstOffset;
+                TMessage* message = tryGetMessage(offset, "unlocked");
+                if (message) {
+                    return std::make_tuple(message, offset, firstIt);
+                }
+            }
+            return std::make_tuple(nullptr, -1, unlockedList.end());
+        };
+
+        auto [message, offset, firstIt] = searchForEligibleMessage();
+        if (message) {
+            if (unlockedList.begin() != firstIt) [[unlikely]] {
+                if constexpr (0) {
+                    // rotate
+                    // move skipped messaged to the end of queue, so they won't be rechecked on the next iteration
+                    TIntrusiveList<TOrderedMessageGroupIdHash> cut;
+                    unlockedList.Cut(unlockedList.begin(), firstIt, cut.end());
+                    unlockedList.Append(std::move(cut));
+                }
+            }
+            DoLock(offset, *message, deadline);
+            return asResult(offset, *message);
+        }
+
+        for (ui64 offset : MessageGroups.UnorderedOffsets) [[unlikely]] {
+            if (auto result = tryReturn(offset, "unordered")) {
+                return result;
+            }
+        }
+        return std::nullopt;
+    }
+
     for(; position.SlowPosition != SlowMessages.end(); ++position.SlowPosition.value()) {
         auto offset = position.SlowPosition.value()->first;
         auto& message = position.SlowPosition.value()->second;
@@ -1641,6 +1707,14 @@ bool TStorage::TMessageGroups::UnlockedMessageGroupsIdErase(const ui32 messageGr
     size_t viewOrderSz1 = Y_IS_DEBUG_BUILD ? UnlockedMessageGroupsIdViewOrder.Size() : 0;
     Y_ASSERT(Y_IS_DEBUG_BUILD && (viewOrderSz0 == viewOrderSz1 + n));
     return n > 0;
+}
+
+const TIntrusiveList<TOrderedMessageGroupIdHash>& TStorage::TMessageGroups::GetUnlockedMessageGroupsIdViewOrder() const {
+    return UnlockedMessageGroupsIdViewOrder;
+}
+
+TIntrusiveList<TOrderedMessageGroupIdHash>& TStorage::TMessageGroups::GetUnlockedMessageGroupsIdViewOrder() {
+    return UnlockedMessageGroupsIdViewOrder;
 }
 
 TStorage::TMessageGroups::~TMessageGroups() = default;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -232,7 +232,7 @@ TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optio
 };
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
-    const std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
+    const std::optional<ui32> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {
         position.SlowPosition = SlowMessages.begin();

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -243,13 +243,11 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
         if (nextMessage.Message) {
             auto& unlockedList = MessageGroups.GetUnlockedMessageGroupsIdViewOrder();
             if (unlockedList.begin() != nextMessage.OrderIterator) [[unlikely]] {
-                if constexpr (0) {
-                    // rotate
-                    // move skipped messaged to the end of queue, so they won't be rechecked on the next iteration
-                    TIntrusiveList<TOrderedMessageGroupIdHash> cut;
-                    unlockedList.Cut(unlockedList.begin(), nextMessage.OrderIterator, cut.end());
-                    unlockedList.Append(std::move(cut));
-                }
+                // rotate
+                // move skipped messaged to the end of queue, so they won't be rechecked on the next iteration
+                TIntrusiveList<TOrderedMessageGroupIdHash> cut;
+                unlockedList.Cut(unlockedList.begin(), nextMessage.OrderIterator, cut.end());
+                unlockedList.Append(std::move(cut));
             }
             DoLock(nextMessage.Offset, *nextMessage.Message, deadline);
             return ConvertoToReadMessage(nextMessage.Offset, *nextMessage.Message);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -149,80 +149,10 @@ bool TStorage::CanReadMessageGroupIdHash(const ui32 messageGroupIdHash) const {
     if (!KeepMessageOrder) {
         return true;
     }
-    return MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(messageGroupIdHash);
-}
-
-void TStorage::ValidateNextOffsets() const {
-    // Build actual set by scanning all messages
-    absl::flat_hash_set<ui64> actualOffsets;
-    absl::flat_hash_set<ui32> seenGroupHashes;
-
-    auto processMessage = [&](ui64 offset, const TMessage& message) {
-        if (message.GetStatus() != EMessageStatus::Unprocessed) {
-            return;
-        }
-        if (!message.HasMessageGroupId) {
-            actualOffsets.insert(offset);
-            return;
-        }
-        if (!CanReadMessageGroupIdHash(message.MessageGroupIdHash)) {
-            return;
-        }
-        if (seenGroupHashes.insert(message.MessageGroupIdHash).second) {
-            actualOffsets.insert(offset);
-        }
-    };
-    IterateAllMessagesInOrder(processMessage);
-
-    // Build expected set from MessageGroups index
-    absl::flat_hash_set<ui64> expectedOffsets(MessageGroups.UnorderedOffsets.begin(), MessageGroups.UnorderedOffsets.end());
-    for (ui32 groupHash : MessageGroups.UnlockedMessageGroupsId.IterateMessageGroups()) {
-        const auto* group = MapFindPtr(MessageGroups.Groups, groupHash);
-        AFL_ENSURE(group != nullptr)("groupHash", groupHash);
-        expectedOffsets.insert(group->FirstOffset);
-    }
-
-    if (actualOffsets == expectedOffsets) {
-        return;
-    }
-
-    TStringBuilder sb;
-    sb << "ValidateNextOffsets MISMATCH: actual.size=" << actualOffsets.size() << " expected.size=" << expectedOffsets.size() << "\n";
-
-    TVector<ui64> allOffsets(Reserve(GetMessageCount() + actualOffsets.size() + expectedOffsets.size()));
-    IterateAllMessagesInOrder([&](ui64 offset, const TMessage&) { allOffsets.push_back(offset); });
-    allOffsets.insert(allOffsets.end(), actualOffsets.begin(), actualOffsets.end());
-    allOffsets.insert(allOffsets.end(), expectedOffsets.begin(), expectedOffsets.end());
-    SortUnique(allOffsets);
-
-    for (ui64 offset : allOffsets) {
-        auto [msg, slowZone] = GetMessageInt(offset);
-        sb << "  offset=" << offset;
-        sb << " zone=" << (slowZone ? 's' : 'f');
-        sb << " mismatch=" << (actualOffsets.contains(offset) != expectedOffsets.contains(offset));
-        sb << " inActual=" << actualOffsets.contains(offset);
-        sb << " inExpected=" << expectedOffsets.contains(offset);
-        sb << " inUnorderedOffsets=" << MessageGroups.UnorderedOffsets.contains(offset);
-        if (msg) {
-            sb << " status=" << static_cast<int>(msg->GetStatus());
-            sb << " hasGroup=" << (bool)msg->HasMessageGroupId;
-            if (msg->HasMessageGroupId) {
-                sb << " groupHash=" << msg->MessageGroupIdHash;
-                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(msg->MessageGroupIdHash);
-            }
-        } else {
-            sb << " NOT_FOUND";
-        }
-        sb << "\n";
-    }
-
-    Y_ABORT("%s", sb.c_str());
+    return MessageGroups.UnlockedMessageGroupsId.contains(messageGroupIdHash);
 }
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
-    if (KeepMessageOrder) {
-        ValidateNextOffsets();
-    }
     std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {
@@ -241,44 +171,19 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
         };
     };
 
-    if (KeepMessageOrder) {
-        auto isMessageGroupSkipped = [&](const TMessage& message) {
-            return message.HasMessageGroupId && skipMessageGroups.contains(message.MessageGroupIdHash);
-        };
-        auto tryReturn = [&](ui64 offset, const char* desc) -> std::optional<TReadMessage> {
-            const auto& [message, _] = GetMessageInt(offset);
-            AFL_ENSURE(message != nullptr)("offset", offset)("case", desc);
-            AFL_ENSURE(message->GetStatus() == EMessageStatus::Unprocessed)("status", message->GetStatus())("offset", offset)("case", desc);
-            if (retentionExpired(*message)) {
-                return std::nullopt;
-            }
-            if (isMessageGroupSkipped(*message)) {
-                return std::nullopt;
-            }
-            DoLock(offset, *message, deadline);
-            return asResult(offset, *message);
-        };
-        for (ui32 groupId : MessageGroups.UnlockedMessageGroupsId.IterateMessageGroups()) {
-            auto* group = MapFindPtr(MessageGroups.Groups, groupId);
-            AFL_ENSURE(group != nullptr)("groupId", groupId);
-            ui64 offset = group->FirstOffset;
-            if (auto result = tryReturn(offset, "unblocked")) {
-                return result;
-            }
-        }
-        for (ui64 offset : MessageGroups.UnorderedOffsets) {
-            if (auto result = tryReturn(offset, "unordered")) {
-                return result;
-            }
-        }
-        return std::nullopt;
-    }
+    auto isMessageGroupLocked = [&](TMessage& message) {
+        return message.HasMessageGroupId && (!CanReadMessageGroupIdHash(message.MessageGroupIdHash) || skipMessageGroups.contains(message.MessageGroupIdHash));
+    };
 
     for(; position.SlowPosition != SlowMessages.end(); ++position.SlowPosition.value()) {
         auto offset = position.SlowPosition.value()->first;
         auto& message = position.SlowPosition.value()->second;
         if (message.GetStatus() == EMessageStatus::Unprocessed) {
             if (retentionExpired(message)) {
+                continue;
+            }
+
+            if (isMessageGroupLocked(message)) {
                 continue;
             }
 
@@ -295,6 +200,11 @@ std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& positio
                 if (moveUnlockedOffset) {
                     ++FirstUnlockedOffset;
                 }
+                continue;
+            }
+
+            if (isMessageGroupLocked(message)) {
+                moveUnlockedOffset = false;
                 continue;
             }
 
@@ -588,12 +498,12 @@ static bool TrackMessageStatusInLockedGroups(const TStorage::TMessage& message) 
     return TrackMessageStatusInLockedGroups(message.GetStatus());
 }
 
-static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash, ui64 offset) {
+static void UpdateLockedMaps(auto& messageGroups, const auto& locked, ui32 messageGroupIdHash) {
     if (locked.IsAccessible()) {
-        messageGroups.UnlockedMessageGroupsId.InsertOrAssign(messageGroupIdHash, offset);
+        messageGroups.UnlockedMessageGroupsId.insert(messageGroupIdHash);
         messageGroups.LockedMessageGroupsId.erase(messageGroupIdHash);
     } else {
-        messageGroups.UnlockedMessageGroupsId.EraseIfExist(messageGroupIdHash, offset);
+        messageGroups.UnlockedMessageGroupsId.erase(messageGroupIdHash);
         if (locked.LockedSelf) {
             messageGroups.LockedMessageGroupsId.insert(messageGroupIdHash);
         } else {
@@ -609,7 +519,7 @@ void TStorage::UpdateMessageGroupsParentLocks(const absl::flat_hash_set<ui32>& c
             return;
         }
         group.Locked.LockedParent = newLockedParent;
-        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash, group.FirstOffset);
+        UpdateLockedMaps(MessageGroups, group.Locked, messageGroupIdHash);
     };
     bool updateAll = currLocked.size() + prevLocked.size() >= MessageGroups.Groups.size();
     if (modeChanged || updateAll) {
@@ -654,7 +564,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     if (nextOffset.Empty()) {
         MessageGroups.Groups.erase(messageGroupIterator);
         MessageGroups.LockedMessageGroupsId.erase(message.MessageGroupIdHash);
-        MessageGroups.UnlockedMessageGroupsId.EraseExist(message.MessageGroupIdHash, offset);
+        MessageGroups.UnlockedMessageGroupsId.erase(message.MessageGroupIdHash);
         AFL_ENSURE(Metrics.InflightMessageGroupCount > 0);
         --Metrics.InflightMessageGroupCount;
         return;
@@ -663,7 +573,7 @@ void TStorage::UpdateMessageGroupToNextMessage(ui64 offset, const TMessage& mess
     auto [nextMessage, _] = GetMessageInt(*nextOffset);
     AFL_ENSURE(nextMessage != nullptr);
     ptr->Locked.FillFromStatus(nextMessage->GetStatus());
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash, *nextOffset);
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
 }
 
 void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessage& message, EMessageStatus newStatus) {
@@ -693,7 +603,7 @@ void TStorage::UpdateMessageGroupOnMessageStatusChange(ui64 offset, const TMessa
     TSingleMessageGroupIdInfo* ptr = MapFindPtr(MessageGroups.Groups, message.MessageGroupIdHash);
     AFL_ENSURE(ptr != nullptr)("offset", offset)("messageGroupIdHash", message.MessageGroupIdHash);
     ptr->Locked.FillFromStatus(newStatus);
-    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash, offset);
+    UpdateLockedMaps(MessageGroups, ptr->Locked, message.MessageGroupIdHash);
 }
 
 void TStorage::UpdateMessageGroupForRemovedMessage(ui64 offset, const TMessage& message) {
@@ -764,7 +674,7 @@ void TStorage::UpdateMessageGroupForNewMessage(ui64 offset, TMessage& message) {
     if (firstReadableMessageInGroup) {
         group.Locked.LockedParent = !CanReadMessageGroupIdHashFromParentPartition(messageGroupIdHash);
         group.Locked.FillFromStatus(message.GetStatus());
-        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash, offset);
+        UpdateLockedMaps(MessageGroups, group.Locked, message.MessageGroupIdHash);
     }
 }
 
@@ -1588,7 +1498,7 @@ TStorage::TMessageWrapper TStorage::TMessageIterator::operator*() const {
         .WriteTimestamp = Storage.BaseWriteTimestamp + TDuration::Seconds(message->WriteTimestampDelta),
         .LockingTimestamp = Storage.GetMessageLockingTime(*message),
         .MessageGroupIdHash = message->HasMessageGroupId ? std::optional<ui32>(message->MessageGroupIdHash) : std::nullopt,
-        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.ContainsMessageGroupId(message->MessageGroupIdHash),
+        .MessageGroupIsLocked = Storage.KeepMessageOrder && message->HasMessageGroupId && !Storage.MessageGroups.UnlockedMessageGroupsId.contains(message->MessageGroupIdHash),
     };
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.cpp
@@ -232,6 +232,9 @@ TStorage::TNextMessageResult TStorage::SearchForEligibleMessage(const std::optio
 };
 
 std::optional<TReadMessage> TStorage::Next(TInstant deadline, TPosition& position, const absl::flat_hash_set<ui32>& skipMessageGroups) {
+    if (KeepMessageOrder) {
+        ValidateNextOffsets();
+    }
     const std::optional<ui64> retentionDeadlineDelta = GetRetentionDeadlineDelta();
 
     if (!position.SlowPosition) {
@@ -602,6 +605,11 @@ void TStorage::TMessageGroups::UpdateLockedMaps(const TLockedGroup& locked, ui32
             const TIntrusiveListItem<TOrderedMessageGroupIdHash>& pc = *uIt;
             TIntrusiveListItem<TOrderedMessageGroupIdHash>& p = const_cast<TIntrusiveListItem<TOrderedMessageGroupIdHash>&>(pc);
             UnlockedMessageGroupsIdViewOrder.PushBack(&p);
+        }
+        if constexpr (Y_IS_DEBUG_BUILD) {
+            if (UnlockedMessageGroupsId.size() < 300) {
+                Y_ASSERT(UnlockedMessageGroupsId.size() == UnlockedMessageGroupsIdViewOrder.Size());
+            }
         }
         LockedMessageGroupsId.erase(messageGroupIdHash);
     } else {
@@ -1749,5 +1757,73 @@ TIntrusiveList<TOrderedMessageGroupIdHash>& TStorage::TMessageGroups::GetUnlocke
 }
 
 TStorage::TMessageGroups::~TMessageGroups() = default;
+
+void TStorage::ValidateNextOffsets() const {
+    // Build actual set by scanning all messages
+    absl::flat_hash_set<ui64> actualOffsets;
+    absl::flat_hash_set<ui32> seenGroupHashes;
+
+    auto processMessage = [&](ui64 offset, const TMessage& message) {
+        if (message.GetStatus() != EMessageStatus::Unprocessed) {
+            return;
+        }
+        if (!message.HasMessageGroupId) {
+            actualOffsets.insert(offset);
+            return;
+        }
+        if (!CanReadMessageGroupIdHash(message.MessageGroupIdHash)) {
+            return;
+        }
+        if (seenGroupHashes.insert(message.MessageGroupIdHash).second) {
+            actualOffsets.insert(offset);
+        }
+    };
+    IterateAllMessagesInOrder(processMessage);
+
+    // Build expected set from MessageGroups index
+    absl::flat_hash_set<ui64> expectedOffsets(MessageGroups.UnorderedOffsets.begin(), MessageGroups.UnorderedOffsets.end());
+    for (const auto& g : MessageGroups.UnlockedMessageGroupsIdIterate()) {
+        ui32 groupHash{g};
+        const auto* group = MapFindPtr(MessageGroups.Groups, groupHash);
+        AFL_ENSURE(group != nullptr)("groupHash", groupHash);
+        expectedOffsets.insert(group->FirstOffset);
+    }
+
+    if (actualOffsets == expectedOffsets) {
+        return;
+    }
+
+    TStringBuilder sb;
+    sb << "ValidateNextOffsets MISMATCH: actual.size=" << actualOffsets.size() << " expected.size=" << expectedOffsets.size() << "\n";
+
+    TVector<ui64> allOffsets(Reserve(GetMessageCount() + actualOffsets.size() + expectedOffsets.size()));
+    IterateAllMessagesInOrder([&](ui64 offset, const TMessage&) { allOffsets.push_back(offset); });
+    allOffsets.insert(allOffsets.end(), actualOffsets.begin(), actualOffsets.end());
+    allOffsets.insert(allOffsets.end(), expectedOffsets.begin(), expectedOffsets.end());
+    SortUnique(allOffsets);
+
+    for (ui64 offset : allOffsets) {
+        auto [msg, slowZone] = GetMessageInt(offset);
+        sb << "  offset=" << offset;
+        sb << " zone=" << (slowZone ? 's' : 'f');
+        sb << " mismatch=" << (actualOffsets.contains(offset) != expectedOffsets.contains(offset));
+        sb << " inActual=" << actualOffsets.contains(offset);
+        sb << " inExpected=" << expectedOffsets.contains(offset);
+        sb << " inUnorderedOffsets=" << MessageGroups.UnorderedOffsets.contains(offset);
+        if (msg) {
+            sb << " status=" << static_cast<int>(msg->GetStatus());
+            sb << " hasGroup=" << (bool)msg->HasMessageGroupId;
+            if (msg->HasMessageGroupId) {
+                sb << " groupHash=" << msg->MessageGroupIdHash;
+                sb << " inUnlockedGroups=" << MessageGroups.UnlockedMessageGroupsIdContains(msg->MessageGroupIdHash);
+            }
+        } else {
+            sb << " NOT_FOUND";
+        }
+        sb << "\n";
+    }
+
+    Y_ABORT("%s", sb.c_str());
+ }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -362,9 +362,152 @@ private:
         ui64 LastOffset;
     };
 
+    class TOrderedMessageGroups: TNonCopyable {
+    public:
+        using TOffsetToMessageGroupIdMap = TMap<ui64, ui32>;
+
+        void InsertOrAssign(ui32 messageGroupId, ui64 offset) {
+            auto [mit, newMessageGroupid] = MessageGroupId.try_emplace(messageGroupId, TOffsetToMessageGroupIdMap::iterator());
+            if (newMessageGroupid) {
+                auto oit  = InsertNewOffset(offset, messageGroupId);
+                mit->second = oit;
+                return;
+            }
+            if (offset == mit->second->first) {
+                return;
+            }
+            auto nh = OffsetToMessageGroupId.extract(mit->second);
+            Y_ASSERT(nh);
+            nh.key() = offset;
+            nh.mapped() = messageGroupId;
+            auto ins = OffsetToMessageGroupId.insert(std::move(nh));
+            Y_ASSERT(ins.inserted);
+            mit->second = ins.position;
+        }
+
+
+        void InsertUnique(ui32 messageGroupId, ui64 offset) {
+            auto oit = InsertNewOffset(offset, messageGroupId);
+            auto [_, unqiueMessageGroupId] = MessageGroupId.insert_or_assign(messageGroupId, oit);
+            Y_ASSERT(unqiueMessageGroupId);
+        }
+
+
+        bool EraseIfExist(ui32 messageGroupId, ui64 offset) {
+            return EraseImpl(messageGroupId, offset, false);
+        }
+
+        bool EraseExist(ui32 messageGroupId, ui64 offset) {
+            return EraseImpl(messageGroupId, offset, true);
+        }
+            /*
+        void EraseIfExist(TOffsetToMessageGroupIdMap::const_iterator it) {
+            const ui32 messageGroupId = it->second;
+            auto mit = MessageGroupId.find(messageGroupId);
+            Y_ASSERT(mit != MessageGroupId.end());
+            if (mit != MessageGroupId.end()) {
+                Y_ASSERT(mit->second == it);
+                MessageGroupId.erase(mit);
+            }
+            OffsetToMessageGroupId.extract(it).swap(NextNode);
+        }
+            */
+
+        bool EraseImpl(ui32 messageGroupId, ui64 offset, bool assumeExitst) {
+            auto oit = OffsetToMessageGroupId.find(offset);
+            bool hasOffset = oit != OffsetToMessageGroupId.end();
+            auto mit = MessageGroupId.find(messageGroupId);
+            bool hasMessageGroupId = mit != MessageGroupId.end();
+            if (assumeExitst) {
+                if (!hasOffset || !hasMessageGroupId) {
+                    TStringBuilder sb;
+                    sb << "EraseIfExist: " << messageGroupId << " " << offset << " " << hasOffset << " " << hasMessageGroupId << '\n';
+                    for (auto& [offset, messageGroupId] : OffsetToMessageGroupId) {
+                        sb << " O: " << offset << " " << messageGroupId << '\n';
+                    }
+                    for (auto& [messageGroupId, it] : MessageGroupId) {
+                        sb << " M: " << messageGroupId << " " << it->first << "->" << it->second << '\n';
+                    }
+                    Y_ABORT("%s", sb.c_str());
+                }
+
+            }
+            Y_ASSERT(hasOffset || !assumeExitst);
+            Y_ASSERT(hasMessageGroupId || !assumeExitst);
+            Y_ASSERT(hasMessageGroupId == hasOffset);
+            if (hasMessageGroupId) {
+                Y_ASSERT(mit->second == oit);
+                MessageGroupId.erase(mit);
+            }
+            if (hasOffset) {
+                auto nh = OffsetToMessageGroupId.extract(oit);
+                if (!NextNode) {
+                    NextNode = std::move(nh);
+                }
+            }
+            return hasMessageGroupId;
+        }
+
+
+        bool ContainsMessageGroupId(ui32 messageGroupId) const {
+            return MessageGroupId.contains(messageGroupId);
+        }
+        bool ContainsOffset(ui64 offset) const {
+            return OffsetToMessageGroupId.contains(offset);
+        }
+        /*
+        auto begin() const {
+            return OffsetToMessageGroupId.begin();
+        }
+        auto end() const {
+            return OffsetToMessageGroupId.end();
+        }
+            */
+
+        auto IterateOffsets() const {
+            return TIteratorRange(OffsetToMessageGroupId.begin(), OffsetToMessageGroupId.end());
+        }
+
+        auto IterateMessageGroups() const {
+            return IterateKeys(MessageGroupId);
+        }
+
+        void clear() {
+            OffsetToMessageGroupId.clear();
+            MessageGroupId.clear();
+        }
+
+        size_t size() const {
+            Y_ASSERT(OffsetToMessageGroupId.size() == MessageGroupId.size());
+            return OffsetToMessageGroupId.size();
+        }
+    private:
+        TOffsetToMessageGroupIdMap::iterator InsertNewOffset(ui64 offset, ui32 messageGroupId) {
+             if (NextNode) {
+                NextNode.key() = offset;
+                NextNode.mapped() = messageGroupId;
+                auto i = OffsetToMessageGroupId.insert(std::move(NextNode));
+                Y_ASSERT(i.inserted);
+                if (!i.inserted) {
+                    i.position->second = messageGroupId;
+                }
+                return i.position;
+            } else {
+                auto [it, inserted] = OffsetToMessageGroupId.insert_or_assign(offset, messageGroupId);
+                Y_ASSERT(inserted);
+                return it;
+            }
+        }
+
+    private:
+        TOffsetToMessageGroupIdMap OffsetToMessageGroupId;
+        absl::flat_hash_map<ui32, TOffsetToMessageGroupIdMap::iterator> MessageGroupId;
+        TOffsetToMessageGroupIdMap::node_type NextNode;
+    };
+
     struct TMessageGroups {
         absl::flat_hash_map<ui32, TSingleMessageGroupIdInfo> Groups;
-        absl::flat_hash_set<ui32> UnlockedMessageGroupsId; // without parents
+        TOrderedMessageGroups UnlockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui32> LockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui64> UnorderedOffsets; // Groupless
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -284,6 +284,7 @@ private:
     TUpdateExternalLockedMessageGroupsResult DoUpdateExternalLockedMessageGroupsId(const NKikimrPQ::TExternalLockedMessageGroupsId&, bool loadState);
     bool CanReadMessageGroupIdHash(ui32 messageGroupIdHash) const;
     bool CanReadMessageGroupIdHashFromParentPartition(const ui32 messageGroupIdHash) const;
+    void ValidateNextOffsets() const;
 
 
     void UpdateFirstUncommittedOffset();
@@ -310,6 +311,8 @@ private:
 
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
+    template <class Fn>
+    void IterateAllMessagesInOrder(Fn&& fn) const;
 
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
@@ -390,6 +393,16 @@ private:
 
 inline auto TStorage::GetMessageGroupsIdFromSelf() const {
     return IterateKeys(MessageGroups.Groups);
+}
+
+template <class Fn>
+inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) const {
+    for (auto& [offset, m] : SlowMessages) {
+        fn(offset, m);
+    }
+    for (size_t i = 0; i < Messages.size(); ++i) {
+        fn(FirstOffset + i, Messages[i]);
+    }
 }
 
 template <class Fn>

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -334,6 +334,10 @@ private:
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
 
+    template <class Fn>
+    void IterateAllMessagesInOrder(Fn&& fn) const;
+
+
     TReadMessage ConvertoToReadMessage(ui64 offset, const TMessage& message) const;
     bool IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const;
 
@@ -351,6 +355,8 @@ private:
 
     TTryGetMessageResult TryGetMessage(ui64 offset, const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups, const char* caseDescription);
     TNextMessageResult SearchForEligibleMessage(const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups);
+
+    void ValidateNextOffsets() const;
 
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
@@ -406,6 +412,9 @@ private:
         size_t UnlockedMessageGroupsIdSize() const;
         bool UnlockedMessageGroupsIdErase(const ui32 messageGroupIdHash);
         void UpdateLockedMaps(const TLockedGroup& locked, ui32 messageGroupIdHash);
+        const auto& UnlockedMessageGroupsIdIterate() const {
+            return UnlockedMessageGroupsId;
+        }
         const TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder() const;
         TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder();
         void Clear();
@@ -456,4 +465,14 @@ inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) {
     }
 }
 
+
+template <class Fn>
+inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) const {
+    for (auto& [offset, m] : SlowMessages) {
+        fn(offset, m);
+    }
+    for (size_t i = 0; i < Messages.size(); ++i) {
+        fn(FirstOffset + i, Messages[i]);
+    }
+}
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -20,6 +20,29 @@
 
 namespace NKikimr::NPQ::NMLP {
 
+    class TOrderedMessageGroupIdHash: public TIntrusiveListItem<TOrderedMessageGroupIdHash> {
+        ui32 GroupIdHash;
+
+    public:
+
+        /* implicit */ TOrderedMessageGroupIdHash(ui32 groupIdHash);
+
+        explicit operator ui32() const;
+
+        TOrderedMessageGroupIdHash(const TOrderedMessageGroupIdHash& other) = delete;
+        TOrderedMessageGroupIdHash(TOrderedMessageGroupIdHash&& other);
+        TOrderedMessageGroupIdHash& operator=(const TOrderedMessageGroupIdHash& other) = delete;
+        TOrderedMessageGroupIdHash& operator=(TOrderedMessageGroupIdHash&& other) = delete;
+
+        bool operator==(const TOrderedMessageGroupIdHash& other) const;
+
+        template <typename H>
+        friend H AbslHashValue(H h, const TOrderedMessageGroupIdHash& c) {
+            return H::combine(std::move(h), c.GroupIdHash);
+        }
+    };
+
+
 class TStorage {
     static constexpr size_t MAX_MESSAGES = 120000;
     static constexpr size_t MIN_MESSAGES = 100;
@@ -359,14 +382,25 @@ private:
         ui64 LastOffset;
     };
 
-    struct TMessageGroups {
+    class TMessageGroups {
+    public:
+        bool UnlockedMessageGroupsIdContains(const ui32 messageGroupIdHash) const;
+        size_t UnlockedMessageGroupsIdSize() const;
+        bool UnlockedMessageGroupsIdErase(const ui32 messageGroupIdHash);
+        void UpdateLockedMaps(const TLockedGroup& locked, ui32 messageGroupIdHash);
+        void Clear();
+        ~TMessageGroups();
+
+    public:
         absl::flat_hash_map<ui32, TSingleMessageGroupIdInfo> Groups;
-        absl::flat_hash_set<ui32> UnlockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui32> LockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui64> UnorderedOffsets; // Groupless
 
-        void Clear();
+    private:
+        absl::flat_hash_set<TOrderedMessageGroupIdHash> UnlockedMessageGroupsId; // without parents
+        TIntrusiveList<TOrderedMessageGroupIdHash> UnlockedMessageGroupsIdViewOrder;
     };
+
     TMessageGroups MessageGroups;
 
     std::deque<TDLQMessage> DLQQueue;

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -334,6 +334,23 @@ private:
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
 
+    TReadMessage ConvertoToReadMessage(ui64 offset, const TMessage& message) const;
+    bool IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const;
+
+    struct TNextMessageResult {
+        TMessage* Message; // nullable
+        ui64 Offset;
+        TIntrusiveList<TOrderedMessageGroupIdHash>::iterator OrderIterator;
+    };
+
+    struct TTryGetMessageResult {
+        TMessage* Message; // nullable
+        bool TryNextInGroup;
+    };
+
+    TTryGetMessageResult TryGetMessage(ui64 offset, const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups, const char* caseDescription);
+    TNextMessageResult SearchForEligibleMessage(const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups);
+
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -334,10 +334,6 @@ private:
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
 
-    template <class Fn>
-    void IterateAllMessagesInOrder(Fn&& fn) const;
-
-
     TReadMessage ConvertoToReadMessage(ui64 offset, const TMessage& message) const;
     bool IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const;
 
@@ -355,8 +351,6 @@ private:
 
     TTryGetMessageResult TryGetMessage(ui64 offset, const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups, const char* caseDescription);
     TNextMessageResult SearchForEligibleMessage(const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups);
-
-    void ValidateNextOffsets() const;
 
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
@@ -412,9 +406,6 @@ private:
         size_t UnlockedMessageGroupsIdSize() const;
         bool UnlockedMessageGroupsIdErase(const ui32 messageGroupIdHash);
         void UpdateLockedMaps(const TLockedGroup& locked, ui32 messageGroupIdHash);
-        const auto& UnlockedMessageGroupsIdIterate() const {
-            return UnlockedMessageGroupsId;
-        }
         const TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder() const;
         TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder();
         void Clear();
@@ -465,14 +456,4 @@ inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) {
     }
 }
 
-
-template <class Fn>
-inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) const {
-    for (auto& [offset, m] : SlowMessages) {
-        fn(offset, m);
-    }
-    for (size_t i = 0; i < Messages.size(); ++i) {
-        fn(FirstOffset + i, Messages[i]);
-    }
-}
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -284,7 +284,6 @@ private:
     TUpdateExternalLockedMessageGroupsResult DoUpdateExternalLockedMessageGroupsId(const NKikimrPQ::TExternalLockedMessageGroupsId&, bool loadState);
     bool CanReadMessageGroupIdHash(ui32 messageGroupIdHash) const;
     bool CanReadMessageGroupIdHashFromParentPartition(const ui32 messageGroupIdHash) const;
-    void ValidateNextOffsets() const;
 
 
     void UpdateFirstUncommittedOffset();
@@ -311,8 +310,6 @@ private:
 
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
-    template <class Fn>
-    void IterateAllMessagesInOrder(Fn&& fn) const;
 
 private:
     const TIntrusivePtr<ITimeProvider> TimeProvider;
@@ -362,152 +359,9 @@ private:
         ui64 LastOffset;
     };
 
-    class TOrderedMessageGroups: TNonCopyable {
-    public:
-        using TOffsetToMessageGroupIdMap = TMap<ui64, ui32>;
-
-        void InsertOrAssign(ui32 messageGroupId, ui64 offset) {
-            auto [mit, newMessageGroupid] = MessageGroupId.try_emplace(messageGroupId, TOffsetToMessageGroupIdMap::iterator());
-            if (newMessageGroupid) {
-                auto oit  = InsertNewOffset(offset, messageGroupId);
-                mit->second = oit;
-                return;
-            }
-            if (offset == mit->second->first) {
-                return;
-            }
-            auto nh = OffsetToMessageGroupId.extract(mit->second);
-            Y_ASSERT(nh);
-            nh.key() = offset;
-            nh.mapped() = messageGroupId;
-            auto ins = OffsetToMessageGroupId.insert(std::move(nh));
-            Y_ASSERT(ins.inserted);
-            mit->second = ins.position;
-        }
-
-
-        void InsertUnique(ui32 messageGroupId, ui64 offset) {
-            auto oit = InsertNewOffset(offset, messageGroupId);
-            auto [_, unqiueMessageGroupId] = MessageGroupId.insert_or_assign(messageGroupId, oit);
-            Y_ASSERT(unqiueMessageGroupId);
-        }
-
-
-        bool EraseIfExist(ui32 messageGroupId, ui64 offset) {
-            return EraseImpl(messageGroupId, offset, false);
-        }
-
-        bool EraseExist(ui32 messageGroupId, ui64 offset) {
-            return EraseImpl(messageGroupId, offset, true);
-        }
-            /*
-        void EraseIfExist(TOffsetToMessageGroupIdMap::const_iterator it) {
-            const ui32 messageGroupId = it->second;
-            auto mit = MessageGroupId.find(messageGroupId);
-            Y_ASSERT(mit != MessageGroupId.end());
-            if (mit != MessageGroupId.end()) {
-                Y_ASSERT(mit->second == it);
-                MessageGroupId.erase(mit);
-            }
-            OffsetToMessageGroupId.extract(it).swap(NextNode);
-        }
-            */
-
-        bool EraseImpl(ui32 messageGroupId, ui64 offset, bool assumeExitst) {
-            auto oit = OffsetToMessageGroupId.find(offset);
-            bool hasOffset = oit != OffsetToMessageGroupId.end();
-            auto mit = MessageGroupId.find(messageGroupId);
-            bool hasMessageGroupId = mit != MessageGroupId.end();
-            if (assumeExitst) {
-                if (!hasOffset || !hasMessageGroupId) {
-                    TStringBuilder sb;
-                    sb << "EraseIfExist: " << messageGroupId << " " << offset << " " << hasOffset << " " << hasMessageGroupId << '\n';
-                    for (auto& [offset, messageGroupId] : OffsetToMessageGroupId) {
-                        sb << " O: " << offset << " " << messageGroupId << '\n';
-                    }
-                    for (auto& [messageGroupId, it] : MessageGroupId) {
-                        sb << " M: " << messageGroupId << " " << it->first << "->" << it->second << '\n';
-                    }
-                    Y_ABORT("%s", sb.c_str());
-                }
-
-            }
-            Y_ASSERT(hasOffset || !assumeExitst);
-            Y_ASSERT(hasMessageGroupId || !assumeExitst);
-            Y_ASSERT(hasMessageGroupId == hasOffset);
-            if (hasMessageGroupId) {
-                Y_ASSERT(mit->second == oit);
-                MessageGroupId.erase(mit);
-            }
-            if (hasOffset) {
-                auto nh = OffsetToMessageGroupId.extract(oit);
-                if (!NextNode) {
-                    NextNode = std::move(nh);
-                }
-            }
-            return hasMessageGroupId;
-        }
-
-
-        bool ContainsMessageGroupId(ui32 messageGroupId) const {
-            return MessageGroupId.contains(messageGroupId);
-        }
-        bool ContainsOffset(ui64 offset) const {
-            return OffsetToMessageGroupId.contains(offset);
-        }
-        /*
-        auto begin() const {
-            return OffsetToMessageGroupId.begin();
-        }
-        auto end() const {
-            return OffsetToMessageGroupId.end();
-        }
-            */
-
-        auto IterateOffsets() const {
-            return TIteratorRange(OffsetToMessageGroupId.begin(), OffsetToMessageGroupId.end());
-        }
-
-        auto IterateMessageGroups() const {
-            return IterateKeys(MessageGroupId);
-        }
-
-        void clear() {
-            OffsetToMessageGroupId.clear();
-            MessageGroupId.clear();
-        }
-
-        size_t size() const {
-            Y_ASSERT(OffsetToMessageGroupId.size() == MessageGroupId.size());
-            return OffsetToMessageGroupId.size();
-        }
-    private:
-        TOffsetToMessageGroupIdMap::iterator InsertNewOffset(ui64 offset, ui32 messageGroupId) {
-             if (NextNode) {
-                NextNode.key() = offset;
-                NextNode.mapped() = messageGroupId;
-                auto i = OffsetToMessageGroupId.insert(std::move(NextNode));
-                Y_ASSERT(i.inserted);
-                if (!i.inserted) {
-                    i.position->second = messageGroupId;
-                }
-                return i.position;
-            } else {
-                auto [it, inserted] = OffsetToMessageGroupId.insert_or_assign(offset, messageGroupId);
-                Y_ASSERT(inserted);
-                return it;
-            }
-        }
-
-    private:
-        TOffsetToMessageGroupIdMap OffsetToMessageGroupId;
-        absl::flat_hash_map<ui32, TOffsetToMessageGroupIdMap::iterator> MessageGroupId;
-        TOffsetToMessageGroupIdMap::node_type NextNode;
-    };
-
     struct TMessageGroups {
         absl::flat_hash_map<ui32, TSingleMessageGroupIdInfo> Groups;
-        TOrderedMessageGroups UnlockedMessageGroupsId; // without parents
+        absl::flat_hash_set<ui32> UnlockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui32> LockedMessageGroupsId; // without parents
         absl::flat_hash_set<ui64> UnorderedOffsets; // Groupless
 
@@ -536,16 +390,6 @@ private:
 
 inline auto TStorage::GetMessageGroupsIdFromSelf() const {
     return IterateKeys(MessageGroups.Groups);
-}
-
-template <class Fn>
-inline void TStorage::IterateAllMessagesInOrder(Fn&& fn) const {
-    for (auto& [offset, m] : SlowMessages) {
-        fn(offset, m);
-    }
-    for (size_t i = 0; i < Messages.size(); ++i) {
-        fn(FirstOffset + i, Messages[i]);
-    }
 }
 
 template <class Fn>

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -388,6 +388,8 @@ private:
         size_t UnlockedMessageGroupsIdSize() const;
         bool UnlockedMessageGroupsIdErase(const ui32 messageGroupIdHash);
         void UpdateLockedMaps(const TLockedGroup& locked, ui32 messageGroupIdHash);
+        const TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder() const;
+        TIntrusiveList<TOrderedMessageGroupIdHash>& GetUnlockedMessageGroupsIdViewOrder();
         void Clear();
         ~TMessageGroups();
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -344,8 +344,9 @@ private:
     };
 
     struct TTryGetMessageResult {
-        TMessage* Message; // nullable
+        TMessage* Message; // not null
         bool TryNextInGroup;
+        bool Usable;
     };
 
     TTryGetMessageResult TryGetMessage(ui64 offset, const std::optional<ui32> retentionDeadlineDelta, const absl::flat_hash_set<ui32>& skipMessageGroups, const char* caseDescription);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage.h
@@ -334,7 +334,7 @@ private:
     template <class Fn>
     void IterateAllMessagesInOrder(Fn&& fn);
 
-    TReadMessage ConvertoToReadMessage(ui64 offset, const TMessage& message) const;
+    TReadMessage ConvertToReadMessage(ui64 offset, const TMessage& message) const;
     bool IsMessageGroupLocked(const TMessage& message, const absl::flat_hash_set<ui32>& skipMessageGroups) const;
 
     struct TNextMessageResult {

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -3207,21 +3207,17 @@ Y_UNIT_TEST(NextWithFairnessInterleavedUnlock) {
 }
 
 Y_UNIT_TEST(FairnessNormalInterleaved) {
-    // Mix of a hot shared group (0) and unique groups, drained with Next/Commit issued in interleaved and then
-    // batched orders. The model asserts fairness and FIFO after every operation.
     TFairnessModel model;
     const int n = 30;
     for (int i = 0; i < n; ++i) {
         model.AddMessage((i % 3 == 0) ? 0 : (i % 3 == 1) ? 1 : i);
     }
 
-    // Interleaved: one Next, immediately commit it.
     for (int i = 0; i < n / 2; ++i) {
         for (auto& m : model.Next(1)) {
             model.Commit(m.Offset);
         }
     }
-    // Batched: pull several, then commit them all.
     for (int i = 0; i < n; ++i) {
         auto v = model.Next(4);
         for (auto& m : v) {
@@ -3231,16 +3227,13 @@ Y_UNIT_TEST(FairnessNormalInterleaved) {
 }
 
 Y_UNIT_TEST(FairnessGrouplessAlwaysAvailable) {
-    // Groupless messages must always be returnable while Unprocessed, even when every grouped message is in
-    // flight and blocked. The model treats each groupless offset as an always-eligible unique group.
     TFairnessModel model;
-    // Layout: g0 groupless, g1 group A, g2 groupless, g3 group A, g4 group B, g5 groupless.
-    model.AddMessage(1000, /*hasGroup*/ false); // 0
-    model.AddMessage(1, /*hasGroup*/ true);     // 1
-    model.AddMessage(2000, /*hasGroup*/ false); // 2
-    model.AddMessage(1, /*hasGroup*/ true);     // 3
-    model.AddMessage(2, /*hasGroup*/ true);     // 4
-    model.AddMessage(3000, /*hasGroup*/ false); // 5
+    model.AddMessage(0, /*hasGroup*/ false); // 0
+    model.AddMessage(1, /*hasGroup*/ true);  // 1
+    model.AddMessage(0, /*hasGroup*/ false); // 2
+    model.AddMessage(1, /*hasGroup*/ true);  // 3
+    model.AddMessage(2, /*hasGroup*/ true);  // 4
+    model.AddMessage(0, /*hasGroup*/ false); // 5
 
     // Lock the heads of both grouped groups; their second messages become blocked.
     auto v = model.Next(2);
@@ -3288,8 +3281,6 @@ static TSet<ui64> ProbeCandidates(TStorage& storage, const absl::flat_hash_set<u
 }
 
 Y_UNIT_TEST(FairnessWithRetention) {
-    // The head of a group can expire by retention; Next must skip expired offsets and serve the next
-    // non-expired message of that group, while still honoring fairness across groups.
     auto timeProvider = TIntrusivePtr<MockTimeProvider>(new MockTimeProvider());
     TStorage storage(timeProvider, TStorage::TStorageSettings{.KeepMessageOrder = true});
     storage.SetRetentionPeriod(TDuration::Seconds(5));
@@ -3301,7 +3292,6 @@ Y_UNIT_TEST(FairnessWithRetention) {
 
     timeProvider->Tick(TDuration::Seconds(6)); // offset 0 is now expired
 
-    // The expired head (0) must never be returned; eligible heads are {1, 2}.
     {
         auto candidates = ProbeCandidates(storage);
         UNIT_ASSERT_C(!candidates.contains(0), "expired offset 0 must be skipped");
@@ -3310,7 +3300,6 @@ Y_UNIT_TEST(FairnessWithRetention) {
         UNIT_ASSERT(candidates.contains(2));
     }
 
-    // Physically remove the expired head so group A's head advances to offset 1.
     storage.Compact();
     {
         auto candidates = ProbeCandidates(storage);
@@ -3320,7 +3309,6 @@ Y_UNIT_TEST(FairnessWithRetention) {
         UNIT_ASSERT(candidates.contains(2));
     }
 
-    // Drain both groups; offset 0 must never appear.
     TSet<ui64> seen;
     for (int i = 0; i < 2; ++i) {
         TStorage::TPosition position;
@@ -3335,18 +3323,14 @@ Y_UNIT_TEST(FairnessWithRetention) {
 }
 
 Y_UNIT_TEST(FairnessWithDlq) {
-    // When a group's head is moved to DLQ, that group stays blocked (WaitDLQ) until the DLQ message is
-    // committed; other groups keep being served fairly meanwhile.
     TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
     storage.SetMaxMessageProcessingCount(1);
     storage.SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
 
-    // Group A (hash 1): offsets 0, 1. Group B (hash 2): offset 2.
     storage.AddMessage(0, true, 1, TInstant::Now());
     storage.AddMessage(1, true, 1, TInstant::Now());
     storage.AddMessage(2, true, 2, TInstant::Now());
 
-    // Take the head of group A and push it to DLQ via Unlock (ProcessingCount reaches the max).
     {
         TStorage::TPosition position;
         auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
@@ -3381,13 +3365,11 @@ Y_UNIT_TEST(FairnessWithSkipMessageGroups) {
     // served respecting FIFO. When all eligible groups are skipped, Next returns nothing.
     TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
 
-    // Groups: A=1 {0,1}, B=2 {2}, C=3 {3}.
     storage.AddMessage(0, true, 1, TInstant::Now());
     storage.AddMessage(1, true, 1, TInstant::Now());
     storage.AddMessage(2, true, 2, TInstant::Now());
     storage.AddMessage(3, true, 3, TInstant::Now());
 
-    // Skip groups A and B: only group C's head (offset 3) is eligible.
     {
         auto candidates = ProbeCandidates(storage, {1, 2});
         UNIT_ASSERT_VALUES_EQUAL(candidates.size(), 1);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -2920,6 +2920,15 @@ Y_UNIT_TEST(NextFromBlacklistedStorage) {
         UNIT_ASSERT(!result.has_value());
     }
 }
+
+Y_UNIT_TEST(TOrderedMessageGroupIdHash) {
+    TOrderedMessageGroupIdHash a(500);
+    TOrderedMessageGroupIdHash b(500);
+    TOrderedMessageGroupIdHash c(600);
+    UNIT_ASSERT_EQUAL(a, b);
+    UNIT_ASSERT_UNEQUAL(a, c);
+    UNIT_ASSERT_UNEQUAL(b, c);
+}
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -3438,6 +3438,107 @@ Y_UNIT_TEST(FairnessSkipThenNoSkip) {
     UNIT_ASSERT_C(remaining.empty(), "all previously-skipped messages must be returned");
 }
 
+static void DrainWithCommit(TFairnessModel& model, size_t readSize = 3) {
+    for (int guard = 0; guard < 200; ++guard) {
+        auto batch = model.Next(readSize);
+        if (batch.empty()) {
+            break;
+        }
+        for (auto& m : batch) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+Y_UNIT_TEST(FairnessAddMessageAfterNext_SameGroup) {
+    TFairnessModel model;
+    model.AddMessage(1);
+    model.AddMessage(2);
+
+    auto first = model.Next(1);
+    UNIT_ASSERT_VALUES_EQUAL(first.size(), 1);
+
+    model.AddMessage(first[0].Group);
+
+    DrainWithCommit(model);
+    model.Commit(first[0].Offset);
+    DrainWithCommit(model);
+
+    UNIT_ASSERT_VALUES_EQUAL(model.Committed.size(), model.Offset);
+}
+
+Y_UNIT_TEST(FairnessAddMessageAfterNext_DifferentGroup) {
+    TFairnessModel model;
+    model.AddMessage(1);
+    model.AddMessage(1);
+    model.AddMessage(2);
+
+    auto first = model.Next(1);
+    UNIT_ASSERT_VALUES_EQUAL(first.size(), 1);
+
+    model.AddMessage(999);
+
+    DrainWithCommit(model);
+    model.Commit(first[0].Offset);
+    DrainWithCommit(model);
+
+    UNIT_ASSERT_VALUES_EQUAL(model.Committed.size(), model.Offset);
+}
+
+Y_UNIT_TEST(FairnessAddMessageAfterCommit_SameGroup) {
+    TFairnessModel model;
+    model.AddMessage(1);
+    model.AddMessage(2);
+
+    auto first = model.Next(1);
+    UNIT_ASSERT_VALUES_EQUAL(first.size(), 1);
+    model.Commit(first[0].Offset);
+
+    model.AddMessage(first[0].Group);
+
+    DrainWithCommit(model);
+    UNIT_ASSERT_VALUES_EQUAL(model.Committed.size(), model.Offset);
+}
+
+Y_UNIT_TEST(FairnessAddMessageAfterCommit_DifferentGroup) {
+    TFairnessModel model;
+    model.AddMessage(1);
+    model.AddMessage(1);
+    model.AddMessage(2);
+
+    auto first = model.Next(1);
+    UNIT_ASSERT_VALUES_EQUAL(first.size(), 1);
+    model.Commit(first[0].Offset);
+
+    model.AddMessage(500);
+    model.AddMessage(500);
+
+    DrainWithCommit(model);
+    UNIT_ASSERT_VALUES_EQUAL(model.Committed.size(), model.Offset);
+}
+
+Y_UNIT_TEST(FairnessAddMessageDuringReadMixed) {
+    TFairnessModel model;
+    for (int i = 0; i < 6; ++i) {
+        model.AddMessage(i % 3);
+    }
+
+    ui32 newGroup = 100;
+    for (int round = 0; round < 20; ++round) {
+        auto batch = model.Next(1);
+        if (batch.empty()) {
+            continue;
+        }
+        model.AddMessage(batch[0].Group);
+        model.AddMessage(newGroup++);
+        model.AddMessage(newGroup++, /*hasGroup*/ false);
+        model.Commit(batch[0].Offset);
+    }
+
+    DrainWithCommit(model);
+    UNIT_ASSERT_VALUES_EQUAL(model.Committed.size(), model.Offset);
+}
+
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -2798,6 +2798,76 @@ Y_UNIT_TEST(NextFromLockedStorage) {
     }
 }
 
+void NextFromLockedWithSequenceOfUnlocksImpl(bool initiatialBlockAll) {
+    TStorage storage(CreateDefaultTimeProvider(), {.KeepMessageOrder = true, .ParentPartitionId = {0}});
+
+    auto sendUpdate = [&, step = 10](NKikimrPQ::EReadWithKeepOrder mode, TConstArrayRef<ui32> blacklist) mutable {
+        NKikimrPQ::TExternalLockedMessageGroupsId unlock;
+        unlock.SetParentPartitionId(0);
+        unlock.SetGeneration(1);
+        unlock.SetConsumerGeneration(1);
+        unlock.SetStep(step);
+        unlock.SetMode(mode);
+        for (ui32 h : blacklist) {
+            unlock.MutableFullBlacklist()->AddParentLockedMessageGroupsIdHash(h);
+        }
+        storage.UpdateExternalLockedMessageGroupsId(unlock);
+        ++step;
+    };
+
+    constexpr ui32 A = 0xAAAA;
+    constexpr ui32 B = 0xBBBB;
+
+    storage.AddMessage(0, true, A, TInstant::Now());
+    storage.AddMessage(1, true, B, TInstant::Now());
+    UNIT_ASSERT_VALUES_EQUAL(storage.GetFirstOffset(), 0);
+    UNIT_ASSERT_VALUES_EQUAL(storage.GetLastOffset(), 2);
+    {   // all locked
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now(), position);
+        UNIT_ASSERT(!result.has_value());
+    }
+
+    if (initiatialBlockAll)  {
+        sendUpdate(NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLOCK_ALL, {});
+    } else {
+        sendUpdate(NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST, {A, B});
+    }
+    {   // still all locked
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now(), position);
+        UNIT_ASSERT(!result.has_value());
+    }
+
+    sendUpdate(NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_BLACKLIST, {A});
+    sendUpdate(NKikimrPQ::EReadWithKeepOrder::READ_WITH_KEEP_ORDER_ALLOW_ALL, {});
+
+    {   // all unlocked
+        TSet<ui32> offsets;
+        TStorage::TPosition position;
+
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT(result.has_value());
+        offsets.insert(result->Offset);
+
+        result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT(result.has_value());
+        offsets.insert(result->Offset);
+
+        result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+
+        UNIT_ASSERT_EQUAL_C(offsets, TSet<ui32>({0, 1}), '[' + JoinSeq(",", offsets) + ']');
+    }
+}
+
+Y_UNIT_TEST(NextFromLockedWithSequenceOfUnlocksBlockStart) {
+    NextFromLockedWithSequenceOfUnlocksImpl(true);
+}
+
+Y_UNIT_TEST(NextFromLockedWithSequenceOfUnlocksBlacklistStart) {
+    NextFromLockedWithSequenceOfUnlocksImpl(false);
+}
+
 Y_UNIT_TEST(LockedStorageGeneration) {
     TStorage storage(CreateDefaultTimeProvider(), {.KeepMessageOrder = true, .ParentPartitionId = {4}});
 

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -2929,6 +2929,218 @@ Y_UNIT_TEST(TOrderedMessageGroupIdHash) {
     UNIT_ASSERT_UNEQUAL(a, c);
     UNIT_ASSERT_UNEQUAL(b, c);
 }
+
+struct TFairnessModel {
+    TStorage Storage = TStorage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+    ui64 Offset = 0;
+    TSet<ui64> Infly;
+    TSet<ui64> Committed;
+    TMap<ui64, ui32> Hashes;
+    TMap<ui32, ui32> LastReadTime;
+    ui32 ReadTime = 1;
+
+    TSet<ui64> GetAvailalableOffsets() const {
+        TSet<ui32> visited;
+        for (ui32 o : Infly) {
+            auto [_, ins] = visited.insert(Hashes.at(o));
+            Y_ASSERT(ins);
+        }
+
+        TSet<ui64> res;
+        ui32 OldestRecordTime = -1;
+        for (auto [o, h] : Hashes) {
+            if (Committed.contains(o)) {
+                continue;
+            }
+            if (Infly.contains(o)) {
+                continue;
+            }
+            if (visited.contains(h)) {
+                continue;
+            }
+            if (auto lrt = LastReadTime.Value(h, 0); lrt > OldestRecordTime) {
+                continue;
+            } else if (lrt < OldestRecordTime) {
+                OldestRecordTime = lrt;
+                res.clear();
+            }
+            visited.insert(h);
+            res.insert(o);
+        }
+        return res;
+
+    }
+
+    void AddMessage(ui32 group) {
+        Cerr << "Add message " << LabeledOutput(Offset, group) << "\n";
+        Storage.AddMessage(Offset, true, group, TInstant::Now());
+        Hashes[Offset] = group;
+        ++Offset;
+    }
+
+    struct TMessage {
+        ui64 Offset;
+        ui32 Group;
+    };
+
+    std::vector<TMessage> Next(size_t count) {
+        std::vector<TMessage> res;
+        TStorage::TPosition position;
+        for (size_t i = 0; i < count; ++i) {
+            auto result = Storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+            const auto available = GetAvailalableOffsets();
+
+            Cerr << "Next message " << (i + 1) << '/' << count << ": ";
+
+
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.has_value(), !available.empty(), i);
+
+            if (result.has_value()) {
+                ui64 offset = result->Offset;
+                ui32 hash = Hashes.at(result->Offset);
+                TString availableStr = "{" + JoinSeq(", ", available) + "}";
+                Cerr << LabeledOutput(offset, hash, availableStr) << "\n";
+                UNIT_ASSERT_C(available.contains(result->Offset), i);
+                Infly.insert(offset);
+                res.push_back(TMessage{.Offset =offset, .Group = hash});
+                LastReadTime[hash] = ReadTime;
+            } else {
+                Cerr << "none\n";
+            }
+        }
+        ++ReadTime;
+        return res;
+    }
+
+    void Commit(ui64 offset) {
+        Y_ASSERT(Infly.contains(offset));
+        Y_ASSERT(!Committed.contains(offset));
+        Infly.erase(offset);
+        Committed.insert(offset);
+
+        const auto available = GetAvailalableOffsets();
+        TString availableStr = "{" + JoinSeq(", ", available) + "}";
+        Cerr << "Commit message " << LabeledOutput(offset, Hashes.at(offset), availableStr) << "\n";
+
+        Storage.Commit(offset);
+    }
+
+};
+
+Y_UNIT_TEST(NextWithFairness3) {
+    TFairnessModel model;
+    const int n = 25;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = (i % 2 == 0) ? 0 : i;
+        model.AddMessage(hash);
+    }
+
+    for (int i = 0; i < n; ++i) {
+        auto v = model.Next(1);
+        for (auto& m : v) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+
+Y_UNIT_TEST(NextWithFairness4) {
+    TFairnessModel model;
+    const int n = 25;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = (i % 2 == 0) ? 0 : i;
+        model.AddMessage(hash);
+    }
+
+    for (int i = 0; i < n; ++i) {
+        auto v = model.Next(3);
+        for (auto& m : v) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+
+Y_UNIT_TEST(NextWithFairness5) {
+    TFairnessModel model;
+    const int n = 25;
+    const int groupsSize = 6;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = i / groupsSize;
+        model.AddMessage(hash);
+    }
+
+    for (int i = 0; i < n; ++i) {
+        auto v = model.Next(1);
+        for (auto& m : v) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+
+Y_UNIT_TEST(NextWithFairness6) {
+    TFairnessModel model;
+    const int n = 25;
+    const int groupsSize = 6;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = i / groupsSize;
+        model.AddMessage(hash);
+    }
+
+    for (int i = 0; i < n; ++i) {
+        auto v = model.Next(3);
+        for (auto& m : v) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+
+Y_UNIT_TEST(NextWithFairness1) {
+    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+
+    TMap<ui64, ui32> groupIds;
+    const int n = 25;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = (i % 2 == 0) ? 0 : IntHash(i);
+        storage.AddMessage(i, true, hash, TInstant::Now());
+        groupIds[i] = hash;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT_C(result.has_value(), LabeledOutput(i));
+        Cerr << LabeledOutput(i, result->Offset, groupIds.at(result->Offset)) << "\n";
+        bool commit = storage.Commit(result->Offset);
+        UNIT_ASSERT_C(commit, LabeledOutput(i));
+    }
+}
+
+Y_UNIT_TEST(NextWithFairness2) {
+    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+
+    TMap<ui64, ui32> groupIds;
+    const int n = 25;
+    const int groupsSize = 6;
+    for (int i = 0; i < n; ++i) {
+        ui32 hash = i / groupsSize;
+        storage.AddMessage(i, true, hash, TInstant::Now());
+        groupIds[i] = hash;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT_C(result.has_value(), LabeledOutput(i));
+        Cerr << LabeledOutput(i, result->Offset, groupIds.at(result->Offset)) << "\n";
+        bool commit = storage.Commit(result->Offset);
+        UNIT_ASSERT_C(commit, LabeledOutput(i));
+    }
+}
+
 }
 
 } // namespace NKikimr::NPQ::NMLP

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -3000,9 +3000,6 @@ Y_UNIT_TEST(TOrderedMessageGroupIdHash) {
     UNIT_ASSERT_UNEQUAL(b, c);
 }
 
-// Oracle for the KeepMessageOrder round-robin fairness invariant. It intentionally models ONLY
-// FIFO-per-group ordering, round-robin fairness across groups and groupless messages. It does NOT
-// model DLQ / retention / skipMessageGroups semantics - those are verified by dedicated direct tests.
 struct TFairnessModel {
     TStorage Storage = TStorage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
     ui64 Offset = 0;
@@ -3013,19 +3010,14 @@ struct TFairnessModel {
     TMap<ui32, ui32> LastReadTime;
     ui32 ReadTime = 1;
 
-    // Returns the set of offsets that Next is currently allowed to return. Grouped offsets obey FIFO-per-group
-    // plus round-robin (only heads of the least-recently-served group). Groupless offsets are always eligible
-    // while Unprocessed and bypass round-robin entirely.
+    // Returns the set of offsets that Next is currently allowed to return
     TSet<ui64> GetAvailalableOffsets() const {
-        // Groupless messages are always eligible while Unprocessed, independent of round-robin.
         TSet<ui64> res;
         for (ui64 o : Groupless) {
             if (!Committed.contains(o) && !Infly.contains(o)) {
                 res.insert(o);
             }
         }
-
-        // Grouped messages: only the head of each group whose group is least-recently-served is eligible.
         TSet<ui32> visited;
         for (ui64 o : Infly) {
             if (!Groupless.contains(o)) {
@@ -3040,10 +3032,13 @@ struct TFairnessModel {
             if (Committed.contains(o) || Infly.contains(o) || Groupless.contains(o) || visited.contains(h)) {
                 continue;
             }
-            if (auto lrt = LastReadTime.Value(h, 0); lrt > oldestReadTime) {
+            if (auto* lastReadTime = LastReadTime.FindPtr(h); lastReadTime == nullptr) {
+                res.insert(o);
+                visited.insert(h);
+            } else if (*lastReadTime > oldestReadTime) {
                 continue;
-            } else if (lrt < oldestReadTime) {
-                oldestReadTime = lrt;
+            } else if (*lastReadTime < oldestReadTime) {
+                oldestReadTime = *lastReadTime;
                 grouped.clear();
             }
             visited.insert(h);

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -3000,50 +3000,67 @@ Y_UNIT_TEST(TOrderedMessageGroupIdHash) {
     UNIT_ASSERT_UNEQUAL(b, c);
 }
 
+// Oracle for the KeepMessageOrder round-robin fairness invariant. It intentionally models ONLY
+// FIFO-per-group ordering, round-robin fairness across groups and groupless messages. It does NOT
+// model DLQ / retention / skipMessageGroups semantics - those are verified by dedicated direct tests.
 struct TFairnessModel {
     TStorage Storage = TStorage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
     ui64 Offset = 0;
     TSet<ui64> Infly;
     TSet<ui64> Committed;
     TMap<ui64, ui32> Hashes;
+    TSet<ui64> Groupless;
     TMap<ui32, ui32> LastReadTime;
     ui32 ReadTime = 1;
 
+    // Returns the set of offsets that Next is currently allowed to return. Grouped offsets obey FIFO-per-group
+    // plus round-robin (only heads of the least-recently-served group). Groupless offsets are always eligible
+    // while Unprocessed and bypass round-robin entirely.
     TSet<ui64> GetAvailalableOffsets() const {
-        TSet<ui32> visited;
-        for (ui32 o : Infly) {
-            auto [_, ins] = visited.insert(Hashes.at(o));
-            Y_ASSERT(ins);
+        // Groupless messages are always eligible while Unprocessed, independent of round-robin.
+        TSet<ui64> res;
+        for (ui64 o : Groupless) {
+            if (!Committed.contains(o) && !Infly.contains(o)) {
+                res.insert(o);
+            }
         }
 
-        TSet<ui64> res;
-        ui32 OldestRecordTime = -1;
+        // Grouped messages: only the head of each group whose group is least-recently-served is eligible.
+        TSet<ui32> visited;
+        for (ui64 o : Infly) {
+            if (!Groupless.contains(o)) {
+                auto [_, ins] = visited.insert(Hashes.at(o));
+                Y_ASSERT(ins);
+            }
+        }
+
+        TSet<ui64> grouped;
+        ui32 oldestReadTime = -1;
         for (auto [o, h] : Hashes) {
-            if (Committed.contains(o)) {
+            if (Committed.contains(o) || Infly.contains(o) || Groupless.contains(o) || visited.contains(h)) {
                 continue;
             }
-            if (Infly.contains(o)) {
+            if (auto lrt = LastReadTime.Value(h, 0); lrt > oldestReadTime) {
                 continue;
-            }
-            if (visited.contains(h)) {
-                continue;
-            }
-            if (auto lrt = LastReadTime.Value(h, 0); lrt > OldestRecordTime) {
-                continue;
-            } else if (lrt < OldestRecordTime) {
-                OldestRecordTime = lrt;
-                res.clear();
+            } else if (lrt < oldestReadTime) {
+                oldestReadTime = lrt;
+                grouped.clear();
             }
             visited.insert(h);
-            res.insert(o);
+            grouped.insert(o);
         }
+
+        res.insert(grouped.begin(), grouped.end());
         return res;
     }
 
-    void AddMessage(ui32 group) {
-        Cerr << "Add message " << LabeledOutput(Offset, group) << "\n";
-        Storage.AddMessage(Offset, true, group, TInstant::Now());
+    void AddMessage(ui32 group, bool hasGroup = true) {
+        Cerr << "Add message " << LabeledOutput(Offset, group, hasGroup) << "\n";
+        Storage.AddMessage(Offset, hasGroup, group, TInstant::Now());
         Hashes[Offset] = group;
+        if (!hasGroup) {
+            Groupless.insert(Offset);
+        }
         ++Offset;
     }
 
@@ -3068,7 +3085,9 @@ struct TFairnessModel {
                 UNIT_ASSERT_C(available.contains(result->Offset), i);
                 Infly.insert(offset);
                 res.push_back(TMessage{.Offset = offset, .Group = hash});
-                LastReadTime[hash] = ReadTime;
+                if (!Groupless.contains(offset)) {
+                    LastReadTime[hash] = ReadTime;
+                }
             } else {
                 Cerr << "none\n";
             }
@@ -3089,72 +3108,30 @@ struct TFairnessModel {
 
         Storage.Commit(offset);
     }
+
+    void Unlock(ui64 offset) {
+        Y_ASSERT(Infly.contains(offset));
+        Y_ASSERT(!Committed.contains(offset));
+        Infly.erase(offset);
+
+        const auto available = GetAvailalableOffsets();
+        TString availableStr = "{" + JoinSeq(", ", available) + "}";
+        Cerr << "Unlock message " << LabeledOutput(offset, Hashes.at(offset), availableStr) << "\n";
+
+        Storage.Unlock(offset);
+    }
 };
 
-Y_UNIT_TEST(NextWithFairness3) {
+
+void NextWithFairnessBasicImpl(TConstArrayRef<ui32> groups, size_t readSize) {
     TFairnessModel model;
-    const int n = 25;
-    for (int i = 0; i < n; ++i) {
-        ui32 hash = (i % 2 == 0) ? 0 : i;
-        model.AddMessage(hash);
+    const size_t n = groups.size();
+    for (ui32 g : groups) {
+        model.AddMessage(g);
     }
 
-    for (int i = 0; i < n; ++i) {
-        auto v = model.Next(1);
-        for (auto& m : v) {
-            model.Commit(m.Offset);
-        }
-    }
-}
-
-
-Y_UNIT_TEST(NextWithFairness4) {
-    TFairnessModel model;
-    const int n = 25;
-    for (int i = 0; i < n; ++i) {
-        ui32 hash = (i % 2 == 0) ? 0 : i;
-        model.AddMessage(hash);
-    }
-
-    for (int i = 0; i < n; ++i) {
-        auto v = model.Next(3);
-        for (auto& m : v) {
-            model.Commit(m.Offset);
-        }
-    }
-}
-
-
-Y_UNIT_TEST(NextWithFairness5) {
-    TFairnessModel model;
-    const int n = 25;
-    const int groupsSize = 6;
-    for (int i = 0; i < n; ++i) {
-        ui32 hash = i / groupsSize;
-        model.AddMessage(hash);
-    }
-
-    for (int i = 0; i < n; ++i) {
-        auto v = model.Next(1);
-        for (auto& m : v) {
-            model.Commit(m.Offset);
-        }
-    }
-}
-
-
-Y_UNIT_TEST(NextWithFairness6) {
-    TFairnessModel model;
-    const int n = 25;
-    const int groupsSize = 6;
-    for (int i = 0; i < n; ++i) {
-        ui32 hash = i / groupsSize;
-        model.AddMessage(hash);
-    }
-
-    for (int i = 0; i < n; ++i) {
-        auto v = model.Next(3);
-        for (auto& m : v) {
+    for (size_t i = 0; i < n / readSize + 2; ++i) {
+        for (auto& m : model.Next(readSize)) {
             model.Commit(m.Offset);
         }
     }
@@ -3162,46 +3139,326 @@ Y_UNIT_TEST(NextWithFairness6) {
 
 
 Y_UNIT_TEST(NextWithFairness1) {
-    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
-
-    TMap<ui64, ui32> groupIds;
-    const int n = 25;
-    for (int i = 0; i < n; ++i) {
-        ui32 hash = (i % 2 == 0) ? 0 : IntHash(i);
-        storage.AddMessage(i, true, hash, TInstant::Now());
-        groupIds[i] = hash;
-    }
-
-    for (int i = 0; i < n; ++i) {
-        TStorage::TPosition position;
-        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
-        UNIT_ASSERT_C(result.has_value(), LabeledOutput(i));
-        Cerr << LabeledOutput(i, result->Offset, groupIds.at(result->Offset)) << "\n";
-        bool commit = storage.Commit(result->Offset);
-        UNIT_ASSERT_C(commit, LabeledOutput(i));
-    }
+    NextWithFairnessBasicImpl({0, 1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0, 17, 0, 19, 0, 21, 0, 23, 0}, 1);
 }
 
 Y_UNIT_TEST(NextWithFairness2) {
-    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+    NextWithFairnessBasicImpl({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4}, 1);
+}
 
-    TMap<ui64, ui32> groupIds;
+Y_UNIT_TEST(NextWithFairness3) {
+    NextWithFairnessBasicImpl({0, 1, 0, 3, 0, 5, 0, 7, 0, 9, 0, 11, 0, 13, 0, 15, 0, 17, 0, 19, 0, 21, 0, 23, 0}, 3);
+}
+
+Y_UNIT_TEST(NextWithFairness4) {
+    NextWithFairnessBasicImpl({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4}, 3);
+}
+
+Y_UNIT_TEST(NextWithFairnessInterleavedCommit) {
+    // Interleave Next and Commit: pull a batch, commit only part of it, keep the rest in flight so following
+    // Next calls must respect that those groups are still busy.
+    TFairnessModel model;
+    const int n = 25;
+    for (int i = 0; i < n; ++i) {
+        model.AddMessage((i % 2 == 0) ? 0 : i);
+    }
+
+    std::vector<ui64> inflight;
+    for (int i = 0; i < 2 * n; ++i) {
+        for (auto& m : model.Next(3)) {
+            inflight.push_back(m.Offset);
+        }
+        if (!inflight.empty()) {
+            model.Commit(inflight.front());
+            inflight.erase(inflight.begin());
+        }
+    }
+    for (ui64 offset : inflight) {
+        model.Commit(offset);
+    }
+}
+
+Y_UNIT_TEST(NextWithFairnessInterleavedUnlock) {
+    // Interleave Next, Unlock and Commit: unlocked messages must become eligible for their group again while
+    // still obeying round-robin ordering.
+    TFairnessModel model;
     const int n = 25;
     const int groupsSize = 6;
     for (int i = 0; i < n; ++i) {
-        ui32 hash = i / groupsSize;
-        storage.AddMessage(i, true, hash, TInstant::Now());
-        groupIds[i] = hash;
+        model.AddMessage(i / groupsSize);
     }
 
     for (int i = 0; i < n; ++i) {
+        auto v = model.Next(2);
+        for (size_t j = 0; j < v.size(); ++j) {
+            if (j % 2 == 0) {
+                model.Commit(v[j].Offset);
+            } else {
+                model.Unlock(v[j].Offset);
+            }
+        }
+    }
+    // Drain whatever remains.
+    for (int i = 0; i < n; ++i) {
+        for (auto& m : model.Next(1)) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+Y_UNIT_TEST(FairnessNormalInterleaved) {
+    // Mix of a hot shared group (0) and unique groups, drained with Next/Commit issued in interleaved and then
+    // batched orders. The model asserts fairness and FIFO after every operation.
+    TFairnessModel model;
+    const int n = 30;
+    for (int i = 0; i < n; ++i) {
+        model.AddMessage((i % 3 == 0) ? 0 : (i % 3 == 1) ? 1 : i);
+    }
+
+    // Interleaved: one Next, immediately commit it.
+    for (int i = 0; i < n / 2; ++i) {
+        for (auto& m : model.Next(1)) {
+            model.Commit(m.Offset);
+        }
+    }
+    // Batched: pull several, then commit them all.
+    for (int i = 0; i < n; ++i) {
+        auto v = model.Next(4);
+        for (auto& m : v) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+Y_UNIT_TEST(FairnessGrouplessAlwaysAvailable) {
+    // Groupless messages must always be returnable while Unprocessed, even when every grouped message is in
+    // flight and blocked. The model treats each groupless offset as an always-eligible unique group.
+    TFairnessModel model;
+    // Layout: g0 groupless, g1 group A, g2 groupless, g3 group A, g4 group B, g5 groupless.
+    model.AddMessage(1000, /*hasGroup*/ false); // 0
+    model.AddMessage(1, /*hasGroup*/ true);     // 1
+    model.AddMessage(2000, /*hasGroup*/ false); // 2
+    model.AddMessage(1, /*hasGroup*/ true);     // 3
+    model.AddMessage(2, /*hasGroup*/ true);     // 4
+    model.AddMessage(3000, /*hasGroup*/ false); // 5
+
+    // Lock the heads of both grouped groups; their second messages become blocked.
+    auto v = model.Next(2);
+    UNIT_ASSERT_VALUES_EQUAL(v.size(), 2);
+
+    // Even though groups A and B are busy, all three groupless messages must still be drainable now.
+    auto g = model.Next(3);
+    UNIT_ASSERT_VALUES_EQUAL_C(g.size(), 3, "all groupless messages must be available while grouped ones are busy");
+    for (auto& m : g) {
+        UNIT_ASSERT_C(m.Offset == 0 || m.Offset == 2 || m.Offset == 5, LabeledOutput(m.Offset));
+    }
+
+    // Commit everything drained so far, then finish the remaining grouped tails.
+    for (auto& m : v) {
+        model.Commit(m.Offset);
+    }
+    for (auto& m : g) {
+        model.Commit(m.Offset);
+    }
+    for (int i = 0; i < 4; ++i) {
+        for (auto& m : model.Next(1)) {
+            model.Commit(m.Offset);
+        }
+    }
+}
+
+// Collects the set of offsets that Next may return in the current storage state by repeatedly locking heads and
+// then unlocking them, so the returned messages can be treated as an unordered candidate set.
+static TSet<ui64> ProbeCandidates(TStorage& storage, const absl::flat_hash_set<ui32>& skip = {}) {
+    TSet<ui64> res;
+    std::vector<ui64> locked;
+    while (true) {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position, skip);
+        if (!result.has_value()) {
+            break;
+        }
+        res.insert(result->Offset);
+        locked.push_back(result->Offset);
+    }
+    for (ui64 offset : locked) {
+        storage.Unlock(offset);
+    }
+    return res;
+}
+
+Y_UNIT_TEST(FairnessWithRetention) {
+    // The head of a group can expire by retention; Next must skip expired offsets and serve the next
+    // non-expired message of that group, while still honoring fairness across groups.
+    auto timeProvider = TIntrusivePtr<MockTimeProvider>(new MockTimeProvider());
+    TStorage storage(timeProvider, TStorage::TStorageSettings{.KeepMessageOrder = true});
+    storage.SetRetentionPeriod(TDuration::Seconds(5));
+
+    // Group A (hash 1): offset 0 old (will expire), offset 1 fresh. Group B (hash 2): offset 2 fresh.
+    storage.AddMessage(0, true, 1, timeProvider->Now());
+    storage.AddMessage(1, true, 1, timeProvider->Now() + TDuration::Seconds(20));
+    storage.AddMessage(2, true, 2, timeProvider->Now() + TDuration::Seconds(20));
+
+    timeProvider->Tick(TDuration::Seconds(6)); // offset 0 is now expired
+
+    // The expired head (0) must never be returned; eligible heads are {1, 2}.
+    {
+        auto candidates = ProbeCandidates(storage);
+        UNIT_ASSERT_C(!candidates.contains(0), "expired offset 0 must be skipped");
+        UNIT_ASSERT_VALUES_EQUAL(candidates.size(), 2);
+        UNIT_ASSERT(candidates.contains(1));
+        UNIT_ASSERT(candidates.contains(2));
+    }
+
+    // Physically remove the expired head so group A's head advances to offset 1.
+    storage.Compact();
+    {
+        auto candidates = ProbeCandidates(storage);
+        UNIT_ASSERT_C(!candidates.contains(0), "expired offset 0 must be gone after compaction");
+        UNIT_ASSERT_VALUES_EQUAL(candidates.size(), 2);
+        UNIT_ASSERT(candidates.contains(1));
+        UNIT_ASSERT(candidates.contains(2));
+    }
+
+    // Drain both groups; offset 0 must never appear.
+    TSet<ui64> seen;
+    for (int i = 0; i < 2; ++i) {
+        TStorage::TPosition position;
+        auto result = storage.Next(timeProvider->Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT_C(result.has_value(), LabeledOutput(i));
+        UNIT_ASSERT_C(result->Offset != 0, "expired offset 0 must never be returned");
+        seen.insert(result->Offset);
+        UNIT_ASSERT(storage.Commit(result->Offset));
+    }
+    UNIT_ASSERT_VALUES_EQUAL(seen.size(), 2);
+    UNIT_ASSERT(seen.contains(1) && seen.contains(2));
+}
+
+Y_UNIT_TEST(FairnessWithDlq) {
+    // When a group's head is moved to DLQ, that group stays blocked (WaitDLQ) until the DLQ message is
+    // committed; other groups keep being served fairly meanwhile.
+    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+    storage.SetMaxMessageProcessingCount(1);
+    storage.SetDeadLetterPolicy(NKikimrPQ::TPQTabletConfig::DEAD_LETTER_POLICY_MOVE);
+
+    // Group A (hash 1): offsets 0, 1. Group B (hash 2): offset 2.
+    storage.AddMessage(0, true, 1, TInstant::Now());
+    storage.AddMessage(1, true, 1, TInstant::Now());
+    storage.AddMessage(2, true, 2, TInstant::Now());
+
+    // Take the head of group A and push it to DLQ via Unlock (ProcessingCount reaches the max).
+    {
         TStorage::TPosition position;
         auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
-        UNIT_ASSERT_C(result.has_value(), LabeledOutput(i));
-        Cerr << LabeledOutput(i, result->Offset, groupIds.at(result->Offset)) << "\n";
-        bool commit = storage.Commit(result->Offset);
-        UNIT_ASSERT_C(commit, LabeledOutput(i));
+        UNIT_ASSERT(result.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(result->Offset, 0);
+        storage.Unlock(0);
     }
+    {
+        auto [message, _] = storage.GetMessage(0);
+        UNIT_ASSERT_VALUES_EQUAL(message->GetStatus(), TStorage::EMessageStatus::DLQ);
+    }
+
+    // While offset 0 is a DLQ head, group A is blocked: only group B's offset 2 is eligible, and offset 1 must
+    // not be returned.
+    {
+        auto candidates = ProbeCandidates(storage);
+        UNIT_ASSERT_C(!candidates.contains(1), "group A is blocked by its DLQ head");
+        UNIT_ASSERT_VALUES_EQUAL(candidates.size(), 1);
+        UNIT_ASSERT(candidates.contains(2));
+    }
+
+    // Commit the DLQ head; group A unblocks and its next message (offset 1) becomes eligible.
+    UNIT_ASSERT(storage.Commit(0));
+    {
+        auto candidates = ProbeCandidates(storage);
+        UNIT_ASSERT_C(candidates.contains(1), "group A must be eligible after DLQ head committed");
+    }
+}
+
+Y_UNIT_TEST(FairnessWithSkipMessageGroups) {
+    // Groups listed in skipMessageGroups must never be returned by that Next call, while other groups are still
+    // served respecting FIFO. When all eligible groups are skipped, Next returns nothing.
+    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+
+    // Groups: A=1 {0,1}, B=2 {2}, C=3 {3}.
+    storage.AddMessage(0, true, 1, TInstant::Now());
+    storage.AddMessage(1, true, 1, TInstant::Now());
+    storage.AddMessage(2, true, 2, TInstant::Now());
+    storage.AddMessage(3, true, 3, TInstant::Now());
+
+    // Skip groups A and B: only group C's head (offset 3) is eligible.
+    {
+        auto candidates = ProbeCandidates(storage, {1, 2});
+        UNIT_ASSERT_VALUES_EQUAL(candidates.size(), 1);
+        UNIT_ASSERT(candidates.contains(3));
+    }
+
+    // Skipping every group yields nothing.
+    {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position, {1, 2, 3});
+        UNIT_ASSERT_C(!result.has_value(), "all eligible groups skipped");
+    }
+
+    // Skipping only A leaves heads of B and C eligible; the skipped-group offsets 0/1 must not appear.
+    {
+        auto candidates = ProbeCandidates(storage, {1});
+        UNIT_ASSERT_C(!candidates.contains(0) && !candidates.contains(1), "skipped group A must not be returned");
+        UNIT_ASSERT(candidates.contains(2));
+        UNIT_ASSERT(candidates.contains(3));
+    }
+}
+
+Y_UNIT_TEST(FairnessSkipThenNoSkip) {
+    // Groups skipped in earlier Next calls must eventually be returnable once Next is called with an empty skip
+    // set (not necessarily on the first such call), preserving FIFO within each group and losing no message.
+    TStorage storage(CreateDefaultTimeProvider(), TStorage::TStorageSettings{.KeepMessageOrder = true});
+
+    // Groups: A=1 {0,1}, B=2 {2,3}, C=3 {4}.
+    storage.AddMessage(0, true, 1, TInstant::Now());
+    storage.AddMessage(1, true, 1, TInstant::Now());
+    storage.AddMessage(2, true, 2, TInstant::Now());
+    storage.AddMessage(3, true, 2, TInstant::Now());
+    storage.AddMessage(4, true, 3, TInstant::Now());
+
+    TMap<ui64, ui32> group = {{0, 1}, {1, 1}, {2, 2}, {3, 2}, {4, 3}};
+    TMap<ui32, ui64> nextExpectedInGroup = {{1, 0}, {2, 2}, {3, 4}};
+
+    auto consume = [&](ui64 offset) {
+        ui32 g = group.at(offset);
+        UNIT_ASSERT_VALUES_EQUAL_C(offset, nextExpectedInGroup.at(g), "FIFO within group violated");
+        ++nextExpectedInGroup[g];
+        UNIT_ASSERT(storage.Commit(offset));
+    };
+
+    // Phase 1: skip groups A and B, so only group C is served.
+    {
+        const absl::flat_hash_set<ui32> skip = {1, 2};
+        while (true) {
+            TStorage::TPosition position;
+            auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position, skip);
+            if (!result.has_value()) {
+                break;
+            }
+            ui32 g = group.at(result->Offset);
+            UNIT_ASSERT_C(g != 1 && g != 2, "skipped group must not be returned");
+            consume(result->Offset);
+        }
+    }
+    UNIT_ASSERT_VALUES_EQUAL_C(nextExpectedInGroup.at(3), 5, "group C fully drained in phase 1");
+
+    // Phase 2: no skip. The previously-skipped groups A and B must all be returned eventually, FIFO preserved.
+    TSet<ui64> remaining = {0, 1, 2, 3};
+    for (int guard = 0; guard < 100 && !remaining.empty(); ++guard) {
+        TStorage::TPosition position;
+        auto result = storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
+        UNIT_ASSERT_C(result.has_value(), "remaining messages must eventually be returned with empty skip");
+        UNIT_ASSERT_C(remaining.contains(result->Offset), LabeledOutput(result->Offset));
+        remaining.erase(result->Offset);
+        consume(result->Offset);
+    }
+    UNIT_ASSERT_C(remaining.empty(), "all previously-skipped messages must be returned");
 }
 
 }

--- a/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mlp/mlp_storage_ut.cpp
@@ -3038,7 +3038,6 @@ struct TFairnessModel {
             res.insert(o);
         }
         return res;
-
     }
 
     void AddMessage(ui32 group) {
@@ -3059,13 +3058,8 @@ struct TFairnessModel {
         for (size_t i = 0; i < count; ++i) {
             auto result = Storage.Next(TInstant::Now() + TDuration::Seconds(1), position);
             const auto available = GetAvailalableOffsets();
-
             Cerr << "Next message " << (i + 1) << '/' << count << ": ";
-
-
-
             UNIT_ASSERT_VALUES_EQUAL_C(result.has_value(), !available.empty(), i);
-
             if (result.has_value()) {
                 ui64 offset = result->Offset;
                 ui32 hash = Hashes.at(result->Offset);
@@ -3073,7 +3067,7 @@ struct TFairnessModel {
                 Cerr << LabeledOutput(offset, hash, availableStr) << "\n";
                 UNIT_ASSERT_C(available.contains(result->Offset), i);
                 Infly.insert(offset);
-                res.push_back(TMessage{.Offset =offset, .Group = hash});
+                res.push_back(TMessage{.Offset = offset, .Group = hash});
                 LastReadTime[hash] = ReadTime;
             } else {
                 Cerr << "none\n";
@@ -3095,7 +3089,6 @@ struct TFairnessModel {
 
         Storage.Commit(offset);
     }
-
 };
 
 Y_UNIT_TEST(NextWithFairness3) {


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. добавлен intrusive list, задающий порядок, в котором TStorage::Next отдаёт сообщения;
2. после разблокировки группы она добавлется в конец списка;
3. исправлен message_enricher: поддержка пересекающихся диапазонов в запросах.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


LOGBROKER-10487
