### PR TITLE
[CBO] Prevent hang inside DPHyp when both tables are OLTP

### DIFF
--- a/ydb/core/kqp/opt/cbo/cbo_interesting_orderings.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_interesting_orderings.cpp
@@ -678,6 +678,9 @@ bool TOrderingsStateMachine::TLogicalOrderings::IsInitialized() const {
 }
 
 bool TOrderingsStateMachine::TLogicalOrderings::IsSubsetOf(const TLogicalOrderings& logicalOrderings) {
+    if (!HasState() && !logicalOrderings.HasState()) {
+        return true; // empty isSubsetOf empty
+    }
     return HasState() && logicalOrderings.HasState() &&
            IsInitialized() && logicalOrderings.IsInitialized() &&
            Dfsm_ == logicalOrderings.Dfsm_ &&


### PR DESCRIPTION
When both tables are OLTP, DPHyp used to stop looking at costs and started populating DP table uncontrollably, leading to a hang. This PR introduces correct handling for the case when both tables don't have an initial shuffle.