### PR TITLE
[NEW RBO] Switch IsJoinApplicable to whitelist

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_cbo.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_cbo.h
@@ -47,7 +47,7 @@ struct TRBOProviderContext : public TKqpProviderContext {
         NKqp::EJoinAlgoType joinAlgo,
         EJoinKind joinKind
     ) override {
-        if (joinAlgo == NKqp::EJoinAlgoType::LookupJoin || joinAlgo == NKqp::EJoinAlgoType::LookupJoinReverse) {
+        if (joinAlgo != NKqp::EJoinAlgoType::MapJoin && joinAlgo != NKqp::EJoinAlgoType::GraceJoin) {
             return false;
         }
         return TKqpProviderContext::IsJoinApplicable(left, right, leftJoinKeys, rightJoinKeys, joinAlgo, joinKind);


### PR DESCRIPTION
`IsJoinApplicable` used to just exclude `LookupJoin`, but this could lead to an error, when new `EJoinAlgoType` is added, like `ReverseBlockJoin` that was added recently. Instead this PR switches it to whitelist. If you want to include another join, you need to add it explicitly.