### PR TITLE
[CBO] Prevent accidental SE by changing the default ordering

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
@@ -824,10 +824,14 @@ template <typename TNodeSet> std::shared_ptr<IBaseOptimizerNode> TDPHypSolverShu
     if (!bestJoin.IsReversed) {
         auto tree = MakeJoinInternal(std::move(bestJoin.Stats), left, right, edge.LeftJoinKeys, edge.RightJoinKeys, edge.JoinKind, bestJoin.Algo, edge.LeftAny, edge.RightAny, left->Stats.LogicalOrderings);
         tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | right->Stats.LogicalOrderings.GetFDs());
+        tree->ShuffleLeftSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
+        tree->ShuffleRightSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         return tree;
     } else {
         auto tree = MakeJoinInternal(std::move(bestJoin.Stats), right, left, edge.RightJoinKeys, edge.LeftJoinKeys, edge.JoinKind, bestJoin.Algo, edge.RightAny, edge.LeftAny, left->Stats.LogicalOrderings);
         tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | right->Stats.LogicalOrderings.GetFDs());
+        tree->ShuffleRightSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
+        tree->ShuffleLeftSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         return tree;
     }
 }
@@ -866,10 +870,12 @@ template <typename TNodeSet> std::array<std::shared_ptr<IBaseOptimizerNode>, 2> 
             tree = MakeJoinInternal(std::move(shuffleLeftSideBestJoin.Stats), left, right, edge.LeftJoinKeys, edge.RightJoinKeys, edge.JoinKind, shuffleLeftSideBestJoin.Algo, edge.LeftAny, edge.RightAny, right->Stats.LogicalOrderings);
             tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | left->Stats.LogicalOrderings.GetFDs());
             tree->ShuffleLeftSideByOrderingIdx = edge.LeftJoinKeysShuffleOrderingIdx;
+            tree->ShuffleRightSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         } else {
             tree = MakeJoinInternal(std::move(shuffleLeftSideBestJoin.Stats), right, left, edge.RightJoinKeys, edge.LeftJoinKeys, edge.JoinKind, shuffleLeftSideBestJoin.Algo, edge.RightAny, edge.LeftAny, right->Stats.LogicalOrderings);
             tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | left->Stats.LogicalOrderings.GetFDs());
             tree->ShuffleRightSideByOrderingIdx = edge.LeftJoinKeysShuffleOrderingIdx;
+            tree->ShuffleLeftSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         }
     }
     trees[treeCount++] = std::move(tree);
@@ -911,10 +917,12 @@ template <typename TNodeSet> std::array<std::shared_ptr<IBaseOptimizerNode>, 2> 
             tree = MakeJoinInternal(std::move(shuffleRightSideBestJoin.Stats), left, right, edge.LeftJoinKeys, edge.RightJoinKeys, edge.JoinKind, shuffleRightSideBestJoin.Algo, edge.LeftAny, edge.RightAny, left->Stats.LogicalOrderings);
             tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | right->Stats.LogicalOrderings.GetFDs());
             tree->ShuffleRightSideByOrderingIdx = edge.RightJoinKeysShuffleOrderingIdx;
+            tree->ShuffleLeftSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         } else {
             tree = MakeJoinInternal(std::move(shuffleRightSideBestJoin.Stats), right, left, edge.RightJoinKeys, edge.LeftJoinKeys, edge.JoinKind, shuffleRightSideBestJoin.Algo, edge.RightAny, edge.LeftAny, left->Stats.LogicalOrderings);
             tree->Stats.LogicalOrderings.InduceNewOrderings(edge.FDs | right->Stats.LogicalOrderings.GetFDs());
             tree->ShuffleLeftSideByOrderingIdx = edge.RightJoinKeysShuffleOrderingIdx;
+            tree->ShuffleRightSideByOrderingIdx = TJoinOptimizerNodeInternal::DontShuffle;
         }
     }
     trees[treeCount++] = std::move(tree);

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -502,12 +502,10 @@ private:
                     }
                 }
 
-                if (!lhsShuffled) {
-                    joinNode->ShuffleLeftSideByOrderingIdx = leftJoinKeysOrderingIdx;
-                }
-                if (!rhsShuffled) {
-                    joinNode->ShuffleRightSideByOrderingIdx = rightJoinKeysOrderingIdx;
-                }
+                joinNode->ShuffleLeftSideByOrderingIdx = lhsShuffled
+                    ? TJoinOptimizerNodeInternal::DontShuffle : leftJoinKeysOrderingIdx;
+                joinNode->ShuffleRightSideByOrderingIdx = rhsShuffled
+                    ? TJoinOptimizerNodeInternal::DontShuffle : rightJoinKeysOrderingIdx;
 
                 joinNode->Stats.LogicalOrderings.SetOrdering(leftJoinKeysOrderingIdx);
 

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.cpp
@@ -48,40 +48,40 @@ std::shared_ptr<TJoinOptimizerNode> ConvertFromInternal(
     auto newJoin = std::make_shared<TJoinOptimizerNode>(left, right, join->LeftJoinKeys, join->RightJoinKeys, join->JoinType, join->JoinAlgo, join->LeftAny, join->RightAny);
     newJoin->Stats = std::move(join->Stats);
 
-    if (
-        !enableShuffleElimination && join->JoinAlgo == EJoinAlgoType::GraceJoin ||
-        join->ShuffleLeftSideByOrderingIdx == TJoinOptimizerNodeInternal::NoOrdering
-    ) {
-        left->Stats.ShuffledByColumns =
-            TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
-                new TOptimizerStatistics::TShuffledByColumns(join->LeftJoinKeys)
-            );
-    } else if (join->ShuffleLeftSideByOrderingIdx >= 0 && fdStorage) {
-        auto shuffledBy = fdStorage->GetInterestingOrderingsColumnNamesByIdx(join->ShuffleLeftSideByOrderingIdx);
-
-        left->Stats.ShuffledByColumns =
-            TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
-                new TOptimizerStatistics::TShuffledByColumns(std::move(shuffledBy))
-            );
+    if (join->JoinAlgo == EJoinAlgoType::GraceJoin) {
+        if (!enableShuffleElimination || join->ShuffleLeftSideByOrderingIdx == TJoinOptimizerNodeInternal::NoOrdering) {
+            left->Stats.ShuffledByColumns =
+                TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
+                    new TOptimizerStatistics::TShuffledByColumns(join->LeftJoinKeys)
+                );
+        } else if (join->ShuffleLeftSideByOrderingIdx >= 0 && fdStorage) {
+            auto shuffledBy = fdStorage->GetInterestingOrderingsColumnNamesByIdx(join->ShuffleLeftSideByOrderingIdx);
+            left->Stats.ShuffledByColumns =
+                TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
+                    new TOptimizerStatistics::TShuffledByColumns(std::move(shuffledBy))
+                );
+        } else {
+            left->Stats.ShuffledByColumns = nullptr;
+        }
     } else {
         left->Stats.ShuffledByColumns = nullptr;
     }
 
-    if (
-        (!enableShuffleElimination && join->JoinAlgo == EJoinAlgoType::GraceJoin) ||
-        join->ShuffleRightSideByOrderingIdx == TJoinOptimizerNodeInternal::NoOrdering
-    ) {
-        right->Stats.ShuffledByColumns =
-            TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
-                new TOptimizerStatistics::TShuffledByColumns(join->RightJoinKeys)
-            );
-    } else if (join->ShuffleRightSideByOrderingIdx >= 0 && fdStorage) {
-        auto shuffledBy = fdStorage->GetInterestingOrderingsColumnNamesByIdx(join->ShuffleRightSideByOrderingIdx);
-
-        right->Stats.ShuffledByColumns =
-            TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
-                new TOptimizerStatistics::TShuffledByColumns(std::move(shuffledBy))
-            );
+    if (join->JoinAlgo == EJoinAlgoType::GraceJoin) {
+        if (!enableShuffleElimination || join->ShuffleRightSideByOrderingIdx == TJoinOptimizerNodeInternal::NoOrdering) {
+            right->Stats.ShuffledByColumns =
+                TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
+                    new TOptimizerStatistics::TShuffledByColumns(join->RightJoinKeys)
+                );
+        } else if (join->ShuffleRightSideByOrderingIdx >= 0 && fdStorage) {
+            auto shuffledBy = fdStorage->GetInterestingOrderingsColumnNamesByIdx(join->ShuffleRightSideByOrderingIdx);
+            right->Stats.ShuffledByColumns =
+                TIntrusivePtr<TOptimizerStatistics::TShuffledByColumns>(
+                    new TOptimizerStatistics::TShuffledByColumns(std::move(shuffledBy))
+                );
+        } else {
+            right->Stats.ShuffledByColumns = nullptr;
+        }
     } else {
         right->Stats.ShuffledByColumns = nullptr;
     }

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.h
@@ -104,8 +104,8 @@ struct TJoinOptimizerNodeInternal : public IBaseOptimizerNode {
     };
 
     // for interesting orderings framework
-    std::int64_t ShuffleLeftSideByOrderingIdx  = DontShuffle;
-    std::int64_t ShuffleRightSideByOrderingIdx = DontShuffle;
+    std::int64_t ShuffleLeftSideByOrderingIdx  = NoOrdering;
+    std::int64_t ShuffleRightSideByOrderingIdx = NoOrdering;
 };
 
 /**


### PR DESCRIPTION
`DPHyp` used to set `DontShuffle` as the default ordering. This is error prone because if you don't explicitly set the shuffle, it will be automatically eliminated. This PR changes the default to be NoOrdering, which is a much safer fallback.