### PR TITLE
Handle OUT_OF_SPACE for huge writes

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/out_of_space.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/out_of_space.cpp
@@ -1,0 +1,52 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/util/lz4_data_generator.h>
+
+Y_UNIT_TEST_SUITE(OutOfSpace) {
+
+    Y_UNIT_TEST(HugeBlobWriteError) {
+        TEnvironmentSetup env{{
+            .NodeCount = 1,
+            .Erasure = TBlobStorageGroupType::ErasureNone,
+            .PDiskSize = 2_GB,
+        }};
+        auto& runtime = env.Runtime;
+
+        env.CreateBoxAndPool(1, 1, 1, NKikimrBlobStorage::EPDiskType::NVME, std::nullopt);
+        env.Sim(TDuration::Seconds(30));
+
+        const ui32 groupId = env.GetGroups().front();
+
+        const TActorId edge = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+        size_t size = 65536;
+        size_t index = 0;
+        std::vector<TLogoBlobID> success;
+        while (size <= 10_MB) {
+            Cerr << size << Endl;
+            TString buffer = FastGenDataForLZ4(size);
+            TLogoBlobID id(1, 1, 1, 0, size, 0);
+            runtime->WrapInActorContext(edge, [&] {
+                SendToBSProxy(edge, groupId, new TEvBlobStorage::TEvPut(id, buffer, TInstant::Max()));
+            });
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(edge, false);
+            if (index < 17) {
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+                success.push_back(id);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
+            }
+            size = size * 9 / 8;
+            ++index;
+        }
+        for (const TLogoBlobID& id : success) {
+            runtime->WrapInActorContext(edge, [&] {
+                SendToBSProxy(edge, groupId, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(), NKikimrBlobStorage::FastRead));
+            });
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(edge, false);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Responses[0].Status, NKikimrProto::OK);
+            UNIT_ASSERT_EQUAL(res->Get()->Responses[0].Buffer.ConvertToString(), FastGenDataForLZ4(id.BlobSize()));
+        }
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ut_oos/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_oos/ya.make
@@ -1,0 +1,16 @@
+UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
+
+    FORK_SUBTESTS()
+
+    SIZE(MEDIUM)
+    REQUIREMENTS(cpu:2)
+
+    SRCS(
+        out_of_space.cpp
+    )
+
+    PEERDIR(
+        ydb/core/blobstorage/ut_blobstorage/lib
+    )
+
+END()

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -92,4 +92,5 @@ RECURSE_FOR_TESTS(
     ut_cluster_balancing
     ut_move_pdisk
     ut_vdisk_internals
+    ut_oos
 )

--- a/ydb/core/blobstorage/vdisk/common/vdisk_context.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_context.h
@@ -124,7 +124,6 @@ namespace NKikimr {
                         OutOfSpaceState.UpdateLocalLog(ev.StatusFlags);
                     }
                     return true;
-                case NKikimrProto::ERROR:
                 case NKikimrProto::INVALID_OWNER:
                 case NKikimrProto::INVALID_ROUND:
                     // BlobStorage group reconfiguration, just return false and wait until
@@ -134,6 +133,7 @@ namespace NKikimr {
                                 "CheckPDiskResponse: Group Reconfiguration: %s",
                                 FormatMessage(ev.Status, ev.ErrorReason, ev.StatusFlags, message).data()));
                     return false;
+                case NKikimrProto::ERROR:
                 case NKikimrProto::CORRUPTED:
                 case NKikimrProto::OUT_OF_SPACE: {
                     // Device is out of order

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -785,8 +785,11 @@ namespace NKikimr {
             return ToString(Record);
         }
 
-        void UpdateStatus(const NKikimrProto::EReplyStatus status) {
+        void UpdateStatus(const NKikimrProto::EReplyStatus status, std::optional<TString> errorReason = std::nullopt) {
             Record.SetStatus(status);
+            if (errorReason) {
+                Record.SetErrorReason(*errorReason);
+            }
         }
 
         static TString ToString(const NKikimrBlobStorage::TEvVPutResult &record) {

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/blobstorage/base/utility.h>
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/blobstorage/vdisk/common/align.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_response.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_pdiskctx.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_lsnmngr.h>
@@ -108,19 +109,18 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
     ////////////////////////////////////////////////////////////////////////////
     // TEvHullHugeChunkAllocated
     ////////////////////////////////////////////////////////////////////////////
-    class TEvHullHugeChunkAllocated : public TEventLocal<TEvHullHugeChunkAllocated, TEvBlobStorage::EvHullHugeChunkAllocated> {
-    public:
-        const ui32 ChunkId;
+    struct TEvHullHugeChunkAllocated : TEventLocal<TEvHullHugeChunkAllocated, TEvBlobStorage::EvHullHugeChunkAllocated> {
         const ui32 SlotSize;
+        const bool Success;
 
-        explicit TEvHullHugeChunkAllocated(ui32 chunkId, ui32 slotSize)
-            : ChunkId(chunkId)
-            , SlotSize(slotSize)
+        TEvHullHugeChunkAllocated(ui32 slotSize, bool success)
+            : SlotSize(slotSize)
+            , Success(success)
         {}
 
         TString ToString() const {
             TStringStream str;
-            str << "{ChunkId# " << ChunkId << " SlotSize# " << SlotSize << "}";
+            str << "{SlotSize# " << SlotSize << " Success# " << Success << "}";
             return str.Str();
         }
     };
@@ -234,8 +234,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             }
             CHECK_PDISK_RESPONSE(HugeKeeperCtx->VCtx, ev, ctx);
             ctx.Send(NotifyID, new TEvHullHugeWritten(HugeSlot));
-            ctx.Send(HugeKeeperCtx->SkeletonId, new TEvHullLogHugeBlob(WriteId, Item->LogoBlobId, Item->Ingress, DiskAddr,
-                Item->IgnoreBlock, Item->IssueKeepFlag, Item->SenderId, Item->Cookie, Item->HandleClass,
+            ctx.Send(HugeKeeperCtx->SkeletonId, new TEvHullLogHugeBlob(WriteId, Item->LogoBlobId, Item->Ingress,
+                DiskAddr, Item->IgnoreBlock, Item->IssueKeepFlag, Item->SenderId, Item->Cookie, Item->HandleClass,
                 std::move(Item->Result), &Item->ExtraBlockChecks, Item->RewriteBlob), 0, 0, Span.GetTraceId());
             LOG_DEBUG(ctx, BS_HULLHUGE,
                       VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix,
@@ -310,6 +310,13 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
         }
 
         void Handle(NPDisk::TEvChunkReserveResult::TPtr &ev, const TActorContext &ctx) {
+            if (ev->Get()->Status == NKikimrProto::OUT_OF_SPACE) {
+                ctx.Send(ParentId, new TEvHullHugeChunkAllocated(SlotSize, false));
+                Die(ctx);
+                Span.EndOk();
+                return;
+            }
+
             CHECK_PDISK_RESPONSE(HugeKeeperCtx->VCtx, ev, ctx);
             Y_VERIFY_S(ev->Get()->ChunkIds.size() == 1, HugeKeeperCtx->VCtx->VDiskLogPrefix);
             ChunkId = ev->Get()->ChunkIds.front();
@@ -355,7 +362,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             LOG_DEBUG(ctx, BS_HULLHUGE, VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix, "ChunkAllocator: committed:"
                 " chunkId# %" PRIu32 " LsnSeg# %" PRIu64, ChunkId, Lsn));
 
-            ctx.Send(ParentId, new TEvHullHugeChunkAllocated(ChunkId, SlotSize));
+            ctx.Send(ParentId, new TEvHullHugeChunkAllocated(SlotSize, true));
             Die(ctx);
             Span.EndOk();
         }
@@ -699,8 +706,14 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                 std::move(item->TraceId), "VDisk.HullHugeKeeper.InWaitQueue"));
         }
 
+        enum class EProcessWriteReason {
+            INITIAL_PUT,
+            RECHECK,
+            OUT_OF_SPACE,
+        };
+
         bool ProcessWrite(std::unique_ptr<TEvHullWriteHugeBlob::THandle>& ev, const TActorContext& ctx,
-                NWilson::TTraceId traceId, bool putToQueue) {
+                NWilson::TTraceId traceId, EProcessWriteReason reason) {
             auto& msg = *ev->Get();
             NHuge::THugeSlot hugeSlot;
             ui32 slotSize;
@@ -715,22 +728,30 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                     std::unique_ptr<TEvHullWriteHugeBlob>(ev->Release().Release()), wId, std::move(traceId)));
                 ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
                 return true;
+            } else if (reason == EProcessWriteReason::OUT_OF_SPACE) {
+                // cancel this item because we have no space left to allocate a chunk
+                msg.Result->UpdateStatus(NKikimrProto::ERROR, "out of space");
+                SendVDiskResponse(ctx, msg.SenderId, msg.Result.release(), msg.Cookie, HugeKeeperCtx->VCtx, msg.HandleClass);
+                return true;
             } else if (AllocatingChunkPerSlotSize.insert(slotSize).second) {
                 LWTRACK(HugeBlobChunkAllocatorStart, ev->Get()->Orbit);
                 auto aid = ctx.RegisterWithSameMailbox(new THullHugeBlobChunkAllocator(HugeKeeperCtx, State.Pers,
                     std::move(traceId), slotSize));
                 ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
             }
-            if (putToQueue) {
-                PutToWaitQueue(slotSize, std::move(ev));
+            if (reason == EProcessWriteReason::INITIAL_PUT) {
+                PutToWaitQueue(slotSize, std::move(ev)); // otherwise this item is already in put queue
             }
             return false;
         }
 
-        void ProcessQueue(ui32 slotSize, const TActorContext &ctx) {
+        void ProcessQueue(ui32 slotSize, bool success, const TActorContext &ctx) {
             auto& queue = State.WaitQueue[slotSize];
             auto it = queue.begin();
-            while (it != queue.end() && ProcessWrite(it->Item, ctx, it->Span.GetTraceId(), false)) {
+            const auto reason = success
+                ? EProcessWriteReason::RECHECK
+                : EProcessWriteReason::OUT_OF_SPACE;
+            while (it != queue.end() && ProcessWrite(it->Item, ctx, it->Span.GetTraceId(), reason)) {
                 it->Span.EndOk();
                 ++it;
             }
@@ -874,7 +895,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                 "THullHugeKeeper: TEvHullWriteHugeBlob: %s", std::data(ev->Get()->ToString())));
             LWTRACK(HugeKeeperWriteHugeBlobReceived, ev->Get()->Orbit);
             std::unique_ptr<TEvHullWriteHugeBlob::THandle> item(ev.Release());
-            ProcessWrite(item, ctx, item->TraceId.Clone(), true);
+            ProcessWrite(item, ctx, item->TraceId.Clone(), EProcessWriteReason::INITIAL_PUT);
         }
 
         void Handle(TEvHullHugeChunkAllocated::TPtr &ev, const TActorContext &ctx) {
@@ -885,7 +906,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             Y_VERIFY_S(numErased == 1, HugeKeeperCtx->VCtx->VDiskLogPrefix);
             ActiveActors.Erase(ev->Sender);
             ProcessAllocateSlotTasks(msg->SlotSize, ctx);
-            ProcessQueue(msg->SlotSize, ctx);
+            ProcessQueue(msg->SlotSize, msg->Success, ctx);
         }
 
         void Handle(TEvHullFreeHugeSlots::TPtr &ev, const TActorContext &ctx) {
@@ -899,10 +920,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                     VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix,
                             "THullHugeKeeper: TEvHullFreeHugeSlots: %s", msg->ToString().data()));
 
-            THashSet<ui32> slotSizes;
-
             for (const auto &x : msg->HugeBlobs) {
-                slotSizes.insert(State.Pers->Heap->SlotSizeOfThisSize(x.Size));
                 State.Pers->Heap->Free(x);
                 State.Pers->DeleteChunkSize(State.Pers->Heap->ConvertDiskPartToHugeSlot(x));
                 LOG_DEBUG(ctx, BS_HULLHUGE,
@@ -934,9 +952,6 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                 case TLogSignature::SignatureHullBarriersDB:
                 default:
                     Y_ABORT("Impossible case");
-            }
-            for (ui32 slotSize : slotSizes) {
-                ProcessQueue(slotSize, ctx);
             }
             FreeChunks(ctx);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Handle OUT\_OF\_SPACE for huge writes

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This allows to terminate huge blob write queries in out-of-space situation without turning VDisk into stone.
