### PR TITLE
Fix heap-use-after-free in HTTP/2 session on stream erase

### DIFF
--- a/ydb/library/actors/http/http2.cpp
+++ b/ydb/library/actors/http/http2.cpp
@@ -271,7 +271,10 @@ void TSession::ProcessDataFrame(const TFrameHeader& header, TStringBuf payload) 
                 Callbacks.OnResponse(header.StreamId, *stream);
             }
         }
-        if (stream->State == EStreamState::Closed) {
+        // Callback may have sent a response and erased the stream,
+        // invalidating `stream`. Re-look up before further access.
+        stream = FindStream(header.StreamId);
+        if (stream && stream->State == EStreamState::Closed) {
             Streams.erase(header.StreamId);
         }
     }
@@ -550,7 +553,10 @@ void TSession::CompleteHeaderBlock(uint32_t streamId, TStream& stream, bool endS
         } else if (Role == ERole::Client && Callbacks.OnResponse) {
             Callbacks.OnResponse(streamId, stream);
         }
-        if (stream.State == EStreamState::Closed) {
+        // Callback may have sent a response and erased the stream,
+        // invalidating `stream`. Re-look up before further access.
+        TStream* reStream = FindStream(streamId);
+        if (reStream && reStream->State == EStreamState::Closed) {
             Streams.erase(streamId);
         }
     }


### PR DESCRIPTION
The `OnRequest`/`OnResponse` callback in `TSession::ProcessDataFrame` and `TSession::CompleteHeaderBlock` may synchronously send a response via `SendResponse`, which transitions the stream to `Closed` and erases it from the `Streams` `THashMap`. This invalidates the `stream` pointer/reference held by the caller, and the subsequent check of `stream->State` triggers a heap-use-after-free.

### Fix
Re-look up the stream via `FindStream(streamId)` after the callback returns and only erase it from `Streams` if it is still present and `Closed`.

### ASAN reports this fixes
- `Http2OutgoingIntegration::OutgoingH2cWithBody` — UAF at `http2.cpp:274` in `ProcessDataFrame`
- `Http2OutgoingIntegration::OutgoingH2cWithLargeResponseBody` — UAF at `http2.cpp:553` in `CompleteHeaderBlock`
- `Http2OutgoingIntegration::OutgoingH2cPriorKnowledge` — UAF at `http2.cpp:553` in `CompleteHeaderBlock`

### Verification
All three tests pass under ASAN after the fix.