### PR TITLE
Fix Windows build: undef NO_ERROR macro before EErrorCode enum

### DIFF
--- a/ydb/library/actors/http/http2.h
+++ b/ydb/library/actors/http/http2.h
@@ -81,7 +81,7 @@ public:
     void RegisterUpgradeStream(TStringBuf path, TStringBuf authority);
 
     // Send GOAWAY and close
-    void SendGoaway(EErrorCode errorCode = EErrorCode::NO_ERROR, TStringBuf debugData = {});
+    void SendGoaway(EErrorCode errorCode = EErrorCode::NO_ERROR_CODE, TStringBuf debugData = {});
 
     // Returns true if session has been initialized (preface received/sent)
     bool IsReady() const { return PrefaceReceived; }
@@ -164,7 +164,7 @@ private:
     void ProcessContinuationFrame(const TFrameHeader& header, TStringBuf payload);
 
     void CompleteHeaderBlock(uint32_t streamId, TStream& stream, bool endStream);
-    void CloseStream(uint32_t streamId, EErrorCode errorCode = EErrorCode::NO_ERROR);
+    void CloseStream(uint32_t streamId, EErrorCode errorCode = EErrorCode::NO_ERROR_CODE);
 
     void ConnectionError(EErrorCode errorCode, TStringBuf message = {});
 };

--- a/ydb/library/actors/http/http2_frames.h
+++ b/ydb/library/actors/http/http2_frames.h
@@ -65,16 +65,10 @@ enum class ESettingsId : uint16_t {
 };
 
 // Error codes (RFC 7540 Section 7)
-// Windows' <winerror.h> defines NO_ERROR as a macro, which would otherwise
-// clash with the enumerator below. Save and restore the macro so downstream
-// code that relies on Win32's NO_ERROR is unaffected.
-#ifdef NO_ERROR
-#pragma push_macro("NO_ERROR")
-#undef NO_ERROR
-#define YDB_HTTP2_RESTORE_NO_ERROR
-#endif
+// Note: the RFC name "NO_ERROR" collides with a macro defined by Windows'
+// <winerror.h>, so we use NO_ERROR_CODE instead.
 enum class EErrorCode : uint32_t {
-    NO_ERROR            = 0x0,
+    NO_ERROR_CODE       = 0x0,
     PROTOCOL_ERROR      = 0x1,
     INTERNAL_ERROR      = 0x2,
     FLOW_CONTROL_ERROR  = 0x3,
@@ -89,10 +83,6 @@ enum class EErrorCode : uint32_t {
     INADEQUATE_SECURITY = 0xc,
     HTTP_1_1_REQUIRED   = 0xd,
 };
-#ifdef YDB_HTTP2_RESTORE_NO_ERROR
-#pragma pop_macro("NO_ERROR")
-#undef YDB_HTTP2_RESTORE_NO_ERROR
-#endif
 
 // Stream states (RFC 7540 Section 5.1)
 enum class EStreamState {

--- a/ydb/library/actors/http/http2_frames.h
+++ b/ydb/library/actors/http/http2_frames.h
@@ -65,6 +65,9 @@ enum class ESettingsId : uint16_t {
 };
 
 // Error codes (RFC 7540 Section 7)
+#ifdef NO_ERROR
+#undef NO_ERROR // windows.h pollution
+#endif
 enum class EErrorCode : uint32_t {
     NO_ERROR            = 0x0,
     PROTOCOL_ERROR      = 0x1,

--- a/ydb/library/actors/http/http2_frames.h
+++ b/ydb/library/actors/http/http2_frames.h
@@ -65,8 +65,13 @@ enum class ESettingsId : uint16_t {
 };
 
 // Error codes (RFC 7540 Section 7)
+// Windows' <winerror.h> defines NO_ERROR as a macro, which would otherwise
+// clash with the enumerator below. Save and restore the macro so downstream
+// code that relies on Win32's NO_ERROR is unaffected.
 #ifdef NO_ERROR
-#undef NO_ERROR // windows.h pollution
+#pragma push_macro("NO_ERROR")
+#undef NO_ERROR
+#define YDB_HTTP2_RESTORE_NO_ERROR
 #endif
 enum class EErrorCode : uint32_t {
     NO_ERROR            = 0x0,
@@ -84,6 +89,10 @@ enum class EErrorCode : uint32_t {
     INADEQUATE_SECURITY = 0xc,
     HTTP_1_1_REQUIRED   = 0xd,
 };
+#ifdef YDB_HTTP2_RESTORE_NO_ERROR
+#pragma pop_macro("NO_ERROR")
+#undef YDB_HTTP2_RESTORE_NO_ERROR
+#endif
 
 // Stream states (RFC 7540 Section 5.1)
 enum class EStreamState {

--- a/ydb/library/actors/http/http2_ut.cpp
+++ b/ydb/library/actors/http/http2_ut.cpp
@@ -265,7 +265,7 @@ Y_UNIT_TEST_SUITE(Http2FrameBuilder) {
 
     Y_UNIT_TEST(BuildGoaway) {
         TString debug = "test error";
-        TString frame = TFrameBuilder::BuildGoaway(3, EErrorCode::NO_ERROR, debug);
+        TString frame = TFrameBuilder::BuildGoaway(3, EErrorCode::NO_ERROR_CODE, debug);
 
         TFrameHeader hdr;
         hdr.Parse(frame.data());
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(Http2FrameBuilder) {
         uint32_t lastStreamId = ((p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3]) & 0x7FFFFFFF;
         UNIT_ASSERT_VALUES_EQUAL(lastStreamId, 3u);
         uint32_t errorCode = (p[4] << 24) | (p[5] << 16) | (p[6] << 8) | p[7];
-        UNIT_ASSERT_VALUES_EQUAL(errorCode, static_cast<uint32_t>(EErrorCode::NO_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(errorCode, static_cast<uint32_t>(EErrorCode::NO_ERROR_CODE));
 
         TStringBuf debugPayload(frame.data() + FRAME_HEADER_SIZE + 8, debug.size());
         UNIT_ASSERT_VALUES_EQUAL(debugPayload, debug);
@@ -860,7 +860,7 @@ Y_UNIT_TEST_SUITE(Http2Session) {
         TSessionPair pair;
         pair.Initialize();
 
-        pair.Client->SendGoaway(EErrorCode::NO_ERROR, "shutting down");
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR_CODE, "shutting down");
         pair.Pump();
 
         UNIT_ASSERT(pair.Client->IsGoaway());
@@ -871,7 +871,7 @@ Y_UNIT_TEST_SUITE(Http2Session) {
         TSessionPair pair;
         pair.Initialize();
 
-        pair.Server->SendGoaway(EErrorCode::NO_ERROR);
+        pair.Server->SendGoaway(EErrorCode::NO_ERROR_CODE);
         pair.Pump();
 
         UNIT_ASSERT(pair.Server->IsGoaway());
@@ -882,8 +882,8 @@ Y_UNIT_TEST_SUITE(Http2Session) {
         TSessionPair pair;
         pair.Initialize();
 
-        pair.Client->SendGoaway(EErrorCode::NO_ERROR);
-        pair.Client->SendGoaway(EErrorCode::NO_ERROR); // should be noop
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR_CODE);
+        pair.Client->SendGoaway(EErrorCode::NO_ERROR_CODE); // should be noop
         pair.Pump();
 
         UNIT_ASSERT(pair.Client->IsGoaway());
@@ -2696,7 +2696,7 @@ Y_UNIT_TEST_SUITE(Http2ErrorHandling) {
 
     Y_UNIT_TEST(GoawayValid) {
         TRawServerSession srv;
-        srv.Feed(TFrameBuilder::BuildGoaway(0, EErrorCode::NO_ERROR));
+        srv.Feed(TFrameBuilder::BuildGoaway(0, EErrorCode::NO_ERROR_CODE));
         UNIT_ASSERT(srv.Error.empty());
         UNIT_ASSERT(srv.GotGoaway);
     }


### PR DESCRIPTION
Windows `winerror.h` defines `NO_ERROR` as a macro, which conflicts with the `NHttp::NHttp2::EErrorCode::NO_ERROR` enumerator in `ydb/library/actors/http/http2_frames.h`, causing build failures:

```
http2_frames.h(69,5): error: expected identifier
   69 |     NO_ERROR            = 0x0,
http2.h(84,56): error: expected unqualified-id
   84 |     void SendGoaway(EErrorCode errorCode = EErrorCode::NO_ERROR, ...);
```

Undefine the macro before declaring the enum.