### PR TITLE
schemeshard: fix altered migrated table indexes

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2970,7 +2970,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                              << ", at schemeshard: " << Self->TabletID());
 
             // See KIKIMR-25153
-            TVector<TPathId> migratedAlteredIndexes;
+            TVector<std::pair<TPathId, ui64>> migratedAlteredIndexes;
             for (auto& rec: indexes) {
                 TPathId pathId = std::get<0>(rec);
                 ui64 alterVersion = std::get<1>(rec);
@@ -2988,12 +2988,24 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     Self->Indexes[pathId] = new TTableIndexInfo(alterVersion, indexType, state, description);
                     Self->IncrementPathDbRefCount(pathId);
                 } else {
-                    migratedAlteredIndexes.push_back(pathId);
+                    migratedAlteredIndexes.emplace_back(pathId, alterVersion);
                 }
             }
 
-            for (const auto& pathId : migratedAlteredIndexes) {
-                db.Table<Schema::TableIndex>().Key(pathId.LocalPathId).Delete();
+            // KIKIMR-25153: fixup after altering migrated indexes.
+            // Move index version from Schema::TableIndex to Schema::MigratedTableIndex.
+            for (const auto& [pathId, alterVersion] : migratedAlteredIndexes) {
+                // proper path-id for migrated index has owner-id equal to root schemeshard tablet-id
+                TPathId migratedIndexPathId = TPathId(Self->ParentDomainId.OwnerId, pathId.LocalPathId);
+                if (Self->Indexes.contains(migratedIndexPathId)) {
+                    // update record in Schema::MigratedTableIndex and in memory
+                    db.Table<Schema::MigratedTableIndex>().Key(migratedIndexPathId.OwnerId, migratedIndexPathId.LocalPathId).Update(
+                        NIceDb::TUpdate<Schema::MigratedTableIndex::AlterVersion>(alterVersion)
+                    );
+                    Self->Indexes[migratedIndexPathId]->AlterVersion = alterVersion;
+                    // remove record from Schema::TableIndex
+                    db.Table<Schema::TableIndex>().Key(pathId.LocalPathId).Delete();
+                }
             }
             migratedAlteredIndexes.clear();
 

--- a/ydb/core/tx/schemeshard/ut_cdc_stream/ut_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/ut_cdc_stream/ut_cdc_stream.cpp
@@ -1697,10 +1697,30 @@ Y_UNIT_TEST_SUITE(TCdcStreamTests) {
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
+        // remember index schema-versions after the change and before reboot
+        auto getTableIndexSchemaVersion = [&](const auto& path) {
+            auto describe = DescribePath(runtime, tenantSchemeShard, path);
+            auto table = describe.GetPathDescription().GetTable();
+            UNIT_ASSERT_VALUES_EQUAL_C(table.TableIndexesSize(), 1, table.DebugString());
+            return table.GetTableIndexes(0).GetSchemaVersion();
+        };
+        auto getIndexSchemaVersion = [&](const auto& path) {
+            auto describe = DescribePath(runtime, tenantSchemeShard, path);
+            return describe.GetPathDescription().GetTableIndex().GetSchemaVersion();
+        };
+        const ui64 tableIndexSchemaVersion = getTableIndexSchemaVersion("/MyRoot/Tenant/Table");
+        const ui64 indexSchemaVersion = getIndexSchemaVersion("/MyRoot/Tenant/Table/Index");
+        UNIT_ASSERT_VALUES_EQUAL(tableIndexSchemaVersion, indexSchemaVersion);
+
         RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
+
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/Tenant/Table"), {
             NLs::PathExist,
         });
+
+        // check that index schema-versions after reboot are the same as before
+        UNIT_ASSERT_VALUES_EQUAL(getTableIndexSchemaVersion("/MyRoot/Tenant/Table"), tableIndexSchemaVersion);
+        UNIT_ASSERT_VALUES_EQUAL(getIndexSchemaVersion("/MyRoot/Tenant/Table/Index"), indexSchemaVersion);
     }
 
 } // TCdcStreamTests


### PR DESCRIPTION
Properly move updated migrated index version to the correct local table from the wrong one.

Close #38687.