### PR TITLE
FsyncParentDir & ReadBatchSize & ListFilesRecursive fixes for NFS backups

### DIFF
--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -1072,11 +1072,7 @@ public:
     static TSettings GetSettings(const NKikimrSchemeOp::TRestoreTask& task);
 
     static ui64 GetReadBatchSize(const NKikimrSchemeOp::TRestoreTask& task) {
-        if constexpr (std::is_same_v<TSettings, NKikimrSchemeOp::TS3Settings>) {
-            return GetSettings(task).GetLimits().GetReadBatchSize();
-        } else {
-            return 8388608; // Default 8MB for FS
-        }
+        return GetSettings(task).GetLimits().GetReadBatchSize();
     }
 
     explicit TS3Downloader(const TActorId& dataShard, ui64 txId, const NKikimrSchemeOp::TRestoreTask& task, const TTableInfo& tableInfo)

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -391,7 +391,8 @@ public:
     static constexpr int DefaultMaxListKeys = 1000;
 
     bool ListFilesRecursive(const TFsPath& dir, const TString& marker, int maxKeys,
-                            Aws::S3::Model::ListObjectsResult& result) {
+        Aws::S3::Model::ListObjectsResult& result)
+    {
         TVector<TString> children;
         dir.ListNames(children);
         Sort(children);

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -44,6 +44,7 @@ private:
             : Key(key)
             , File(key, OpenAlways | WrOnly | ForAppend)
         {
+            FsyncParentDir(key);
             File.Flock(LOCK_EX | LOCK_NB);
             File.Resize(0);
         }
@@ -247,7 +248,6 @@ public:
             TMultipartUploadSession session(key);
             session.File.Write(body.data(), body.size());
             session.File.Flush();
-            FsyncParentDir(fsPath);
             session.File.Close();
             ReplySuccess<TEvPutObjectResponse>(ev->Sender, key);
         } catch (const TSystemError& ex) {
@@ -397,11 +397,7 @@ public:
         Sort(children);
         for (const auto& name : children) {
             TFsPath child = dir / name;
-            if (child.IsDirectory()) {
-                if (ListFilesRecursive(child, marker, maxKeys, result)) {
-                    return true;
-                }
-            } else if (child.IsFile()) {
+            if (child.IsFile()) {
                 const TString& path = child.GetPath();
                 if (!marker.empty() && path <= marker) {
                     continue;
@@ -412,6 +408,10 @@ public:
                 Aws::S3::Model::Object obj;
                 obj.SetKey(Aws::String(path.data(), path.size()));
                 result.AddContents(std::move(obj));
+            } else if (child.IsDirectory()) {
+                if (ListFilesRecursive(child, marker, maxKeys, result)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- https://github.com/ydb-platform/ydb/pull/36901 - исправления из этого ревью (ListFilesRecursive)
- FsyncParentDir вызывается при создании новой сессии (файла) в конструкторе
- ReadBatchSize удалено захардкоженое значение
