### PR TITLE
[NEW RBO] Add missing fields to json plan

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -334,11 +334,15 @@ void TKqpNewRBOTransformer::AddPlans(std::optional<NJson::TJsonValue> execPlan, 
 
         auto planList = NJson::TJsonValue(NJson::EJsonValueType::JSON_ARRAY);
         auto planElement = NJson::TJsonValue(NJson::EJsonValueType::JSON_MAP);
+        planElement["Node Type"] = "Query";
+        planElement["PlanNodeType"] = "Query";
         planElement["Plans"] = planList;
         planJson["Plan"] = planElement;
 
         auto simplifiedPlanList = NJson::TJsonValue(NJson::EJsonValueType::JSON_ARRAY);
         auto simplifiedPlanElement = NJson::TJsonValue(NJson::EJsonValueType::JSON_MAP);
+        simplifiedPlanElement["Node Type"] = "Query";
+        simplifiedPlanElement["PlanNodeType"] = "Query";
         simplifiedPlanElement["Plans"] = simplifiedPlanList;
 
         planJson["SimplifiedPlan"] = simplifiedPlanElement;


### PR DESCRIPTION
New RBO didn't set some of the fields in the json plan, which lead to a SEGFAULT in `kqp_ut_common.cpp` `SimplifyPlan` - because it requires them.