### PR TITLE
[NEW RBO] Do not ignore table aliases in TOrderingStatesAssigner

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_hypergraph.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_hypergraph.h
@@ -563,10 +563,10 @@ class TOrderingStatesAssigner {
 public:
     TOrderingStatesAssigner(
         TJoinHypergraph<TNodeSet>& graph,
-        TTableAliasMap*
+        TTableAliasMap* tableAliases
     )
         : Graph_(graph)
-        , TableAliases_(nullptr)
+        , TableAliases_(tableAliases)
     {}
 
     void Assign(TOrderingsStateMachine& fsm) {


### PR DESCRIPTION
`TOrderingStatesAssigner` used to ignore passed to it `TTableAliasMap`. In the old RBO an identity map (maps table names to themselves) was passed (and subsequently ignored). In new RBO proper aliases derived from lineage are passed instead.

This PR stops ignoring the map. It doesn't change behavior in the old RBO (it passes identity map), while allowing us to use aliases in the new RBO.