### PR TITLE
[NEW RBO] Fallback JoinAlgo gracefully if CBO timeouted or didn't start

### DIFF
--- a/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
@@ -125,7 +125,13 @@ TIntrusivePtr<IOperator> ConvertOptimizedTree(std::shared_ptr<IBaseOptimizerNode
         auto joinKind = ConvertToJoinString(join->JoinType);
 
         auto res = MakeIntrusive<TOpJoin>(leftArg, rightArg, pos, joinKind, joinKeys);
-        res->Props.JoinAlgo = join->JoinAlgo;
+
+        // JoinAlgo is optional, set it only if CBO ran and decided on an algo.
+        // Otherwise MaybeSetJoinAlgo can see that it's std::nullopt and set it to the default.
+        if (join->JoinAlgo != NKikimr::NKqp::EJoinAlgoType::Undefined) {
+            res->Props.JoinAlgo = join->JoinAlgo;
+        }
+
         return res;
     }
 }


### PR DESCRIPTION
Before this PR, if CBO didn't start or reached a timeout, the tree would keep the initial `EJoinAlgoType::Undefined`, which are then propagated to the RBO and cause a failure. This PR checks for `Undefined` and doesn't pass them further, allowing `MaybeSetAlgoJoin` to gracefully fallback.