### PR TITLE
[NEW RBO] Respect join algo selected by CBO

### DIFF
--- a/ydb/core/kqp/opt/rbo/rules/assign_stages.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/assign_stages.cpp
@@ -6,8 +6,7 @@ using namespace NKikimr;
 using namespace NKikimr::NKqp;
 
 void MaybeSetJoinAlgo(TPhysicalOpProps& props, const TRBOContext& rboCtx) {
-    // Currently we ingore cbo join type.
-    if (false && props.JoinAlgo.has_value()) {
+    if (props.JoinAlgo.has_value()) {
         return;
     }
 


### PR DESCRIPTION
New RBO used to always fallback to default join algo type, namely `GraceJoin` in `MaybeSetJoinAlgo`, after #38722 and #38796 it's probably safe to start using CBO-provided join algo instead.