### PR TITLE
fix use after move warning in the TMonitoringProxy CLOUD-247389

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl_app.cpp
@@ -43,14 +43,14 @@ public:
     }
 
     TMonitoringProxy(ui64 tabletId, const TActorId& tabletActorId, const TActorId& sender, const TString& query,
-        const TMap<ui32, TActorId>&& partitions, const TActorId& cache, const TString& topicName, ui32 inflight,
+        TMap<ui32, TActorId> partitions, const TActorId& cache, const TString& topicName, ui32 inflight,
         TString&& config, std::vector<TTransactionSnapshot>&& transactions)
     : TBaseTabletActor(tabletId, tabletActorId, NKikimrServices::PERSQUEUE)
     , Sender(sender)
     , Query(query)
     , Partitions(std::move(partitions))
     , Cache(cache)
-    , TotalRequests(partitions.size() + 1)
+    , TotalRequests(Partitions.size() + 1)
     , TopicName(topicName)
     , Inflight(inflight)
     , Config(std::move(config))


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

не уязвимость, т.к. в TMap нет перемещения для `const&&`, и вызывается контруктор копирование для случая `const&`. Но дефект производительности

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
