### PR TITLE
Fix shutdown flag not setted LOGBROKER-10370

### DIFF
--- a/ydb/library/grpc/server/grpc_server.cpp
+++ b/ydb/library/grpc/server/grpc_server.cpp
@@ -21,6 +21,8 @@
 
 namespace NYdbGrpc {
 
+std::atomic<bool> GrpcDead = false;
+
 static void PullEvents(grpc::ServerCompletionQueue* cq, TIntrusivePtr<::NMonitoring::TDynamicCounters> counters) {
     TThread::SetCurrentThreadName("grpc_server");
     auto okCounter = counters->GetCounter("RequestExecuted", true);
@@ -273,7 +275,7 @@ void TGRpcServer::Start() {
 }
 
 void TGRpcServer::Stop() {
-    NYdbGrpc::GrpcDead = 1;
+    NYdbGrpc::GrpcDead = true;
     for (auto& service : Services_) {
         service->StopService();
     }

--- a/ydb/library/grpc/server/grpc_server.h
+++ b/ydb/library/grpc/server/grpc_server.h
@@ -25,7 +25,7 @@ namespace NMonitoring {
 
 namespace NYdbGrpc {
 
-static std::atomic<int> GrpcDead = 0;
+extern std::atomic<bool> GrpcDead;
 struct TSslData {
     TString Cert;
     TString Key;

--- a/ydb/library/grpc/server/grpc_server.h
+++ b/ydb/library/grpc/server/grpc_server.h
@@ -19,6 +19,8 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
+
 namespace NMonitoring {
     struct TDynamicCounters;
 } // NMonitoring


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Использование internal linkage (`static` или anonymous namespace) в заголовочных файлах — почти всегда ошибка.
В данном случае создаётся в каждом TU cвоя уникальная копия переменной, которая никак не связана с остальными. А в наследниках IQueueEvent будет ODR violation.
А установка флага grpc_server.cpp никогда не видна в grpc_pq_write.cpp или в grpc_pq_read.cpp

Также уменьшен размер  флага 

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
