### PR TITLE
[JI] JSON_* predicate extraction with AND/OR support

### DIFF
--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -36,8 +36,11 @@ NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
 
 // Keys may contain binary data (e.g. a zero byte), so we prefix each key with its
 // varint-encoded length (LEB128). This allows unambiguous prefix-scan queries.
+// Key lengths are encoded as (actual_length + 1) so that the encoded length byte is never
+// zero. This reserves \x00 exclusively for the literal separator used in AppendJsonIndexLiteral,
+// preventing ambiguity between an empty-key path component and the start of a literal suffix
 void AppendKey(TString& prefix, TStringBuf key) {
-    size_t size = key.size();
+    size_t size = key.size() + 1;
     do {
         if (size < 0x80) {
             prefix.push_back((ui8)size);
@@ -82,6 +85,56 @@ bool IsPredicateType(EJsonPathItemType type) {
     }
 }
 
+// Remove redundant tokens based on prefix (ancestor/descendant) relationships
+//
+// OR  -> keep roots (minimal tokens): if token A is a prefix of token B, B is redundant
+//        because any match for B also matches A (ancestor covers descendant)
+//
+// AND -> keep leaves (maximal tokens): if token A is a prefix of token B, A is redundant
+//        because requiring both A and B is satisfied by B alone (descendant implies ancestor)
+//
+// String prefix check is unambiguous because:
+//   1. AppendKey encodes key lengths as (actual_length + 1), so no key-length byte is ever \x00
+//   2. AppendJsonIndexLiteral always starts the literal suffix with \x00
+// Therefore \x00 can only appear at the start of a literal suffix, never inside the path portion
+// A token B whose content after position A.size() starts with \x00 has the SAME path as A but
+// carries a value constraint - still a valid ancestor/descendant relationship for pruning.
+void PruneRedundantTokens(TCollectResult::TTokens& tokens, TCollectResult::ETokensMode mode) {
+    if (tokens.size() <= 1 || mode == TCollectResult::ETokensMode::NotSet) {
+        return;
+    }
+
+    TCollectResult::TTokens result;
+    for (const auto& token : tokens) {
+        bool redundant = false;
+        for (const auto& other : tokens) {
+            if (other == token) {
+                continue;
+            }
+
+            if (mode == TCollectResult::ETokensMode::Or) {
+                // token is redundant if some shorter other is its prefix (other covers token)
+                if (other.size() < token.size() && token.StartsWith(other)) {
+                    redundant = true;
+                    break;
+                }
+            } else {
+                // AND: token is redundant if some longer other starts with it (other implies token)
+                if (other.size() > token.size() && other.StartsWith(token)) {
+                    redundant = true;
+                    break;
+                }
+            }
+        }
+
+        if (!redundant) {
+            result.insert(token);
+        }
+    }
+
+    tokens = std::move(result);
+}
+
 TCollectResult MergeBooleanOperands(TCollectResult left, TCollectResult right,
     TCollectResult::ETokensMode incompatibleMode, TCollectResult::ETokensMode combinedMode)
 {
@@ -104,7 +157,9 @@ TCollectResult MergeBooleanOperands(TCollectResult left, TCollectResult right,
 
     leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
-        left.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : combinedMode);
+        auto finalMode = hasMix ? TCollectResult::ETokensMode::Or : combinedMode;
+        left.SetTokensMode(finalMode);
+        PruneRedundantTokens(leftTokens, finalMode);
     }
     return left;
 }

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -105,30 +105,26 @@ void PruneRedundantTokens(TCollectResult::TTokens& tokens, TCollectResult::EToke
     }
 
     TCollectResult::TTokens result;
-    for (const auto& token : tokens) {
-        bool redundant = false;
-        for (const auto& other : tokens) {
-            if (other == token) {
+    std::optional<TString> lastKept;
+
+    if (mode == TCollectResult::ETokensMode::Or) {
+        // OR: keep minimal tokens (roots). Token is redundant if a shorter prefix is already kept
+        for (const auto& token : tokens) {
+            if (lastKept.has_value() && token.StartsWith(*lastKept)) {
                 continue;
             }
-
-            if (mode == TCollectResult::ETokensMode::Or) {
-                // token is redundant if some shorter other is its prefix (other covers token)
-                if (other.size() < token.size() && token.StartsWith(other)) {
-                    redundant = true;
-                    break;
-                }
-            } else {
-                // AND: token is redundant if some longer other starts with it (other implies token)
-                if (other.size() > token.size() && other.StartsWith(token)) {
-                    redundant = true;
-                    break;
-                }
-            }
-        }
-
-        if (!redundant) {
             result.insert(token);
+            lastKept = token;
+        }
+    } else {
+        // AND: keep maximal tokens (leaves). Token is redundant if a longer token that starts with it is already kept
+        for (auto it = tokens.rbegin(); it != tokens.rend(); ++it) {
+            const auto& token = *it;
+            if (lastKept.has_value() && lastKept->StartsWith(token)) {
+                continue;
+            }
+            result.insert(token);
+            lastKept = token;
         }
     }
 

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -723,7 +723,18 @@ TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error) {
 }
 
 TCollectResult CollectJsonPath(const TJsonPathPtr path, ECallableType callableType) {
-    return TQueryCollector(path, callableType).Collect();
+    auto result = TQueryCollector(path, callableType).Collect();
+    if (!result.IsError()) {
+        if (result.GetTokens().empty()) {
+            result = TCollectResult(TIssue("Cannot collect tokens for the given JSON path"));
+        }
+
+        if (callableType != ECallableType::JsonValue) {
+            result.StopCollecting();
+        }
+    }
+
+    return result;
 }
 
 TCollectResult MergeAnd(TCollectResult left, TCollectResult right) {

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -102,8 +102,7 @@ TCollectResult MergeBooleanOperands(TCollectResult left, TCollectResult right,
         }
     }
 
-    leftTokens.reserve(leftTokens.size() + rightTokens.size());
-    leftTokens.insert(leftTokens.end(), rightTokens.begin(), rightTokens.end());
+    leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
         left.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : combinedMode);
     }
@@ -129,8 +128,7 @@ TCollectResult MergeComparisonPathResults(TCollectResult left, TCollectResult ri
         }
     }
 
-    leftTokens.reserve(leftTokens.size() + rightTokens.size());
-    leftTokens.insert(leftTokens.end(), rightTokens.begin(), rightTokens.end());
+    leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
         left.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : TCollectResult::ETokensMode::And);
     }
@@ -314,8 +312,10 @@ TCollectResult TQueryCollector::MemberAccess(const TJsonPathItem& item, EMode mo
         return result;
     }
 
-    auto& token = result.GetTokens().front();
-    AppendKey(token, item.GetString());
+    auto& tokens = result.GetTokens();
+    auto node = tokens.extract(tokens.begin());
+    AppendKey(node.value(), item.GetString());
+    tokens.insert(std::move(node));
     return result;
 }
 
@@ -379,8 +379,7 @@ TCollectResult TQueryCollector::BinaryArithmeticOp(const TJsonPathItem& item, EM
         }
     }
 
-    leftTokens.reserve(leftTokens.size() + rightTokens.size());
-    leftTokens.insert(leftTokens.end(), rightTokens.begin(), rightTokens.end());
+    leftTokens.insert(rightTokens.begin(), rightTokens.end());
     if (leftTokens.size() > 1) {
         leftCollectResult.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : TCollectResult::ETokensMode::And);
     }
@@ -471,7 +470,7 @@ TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode
         return inputCollectResult;
     }
 
-    FilterObjectPrefixes.push_back(tokens.front());
+    FilterObjectPrefixes.push_back(*tokens.begin());
     const auto& predicateItem = Reader.ReadFilterPredicate(item);
     auto predicateResult = Collect(predicateItem, EMode::Filter);
     FilterObjectPrefixes.pop_back();
@@ -517,7 +516,9 @@ TCollectResult TQueryCollector::CollectEqualOperands(const TJsonPathItem& leftIt
     auto& pathTokens = pathResult.GetTokens();
     auto& literalTokens = literalResult.GetTokens();
     if (pathResult.CanCollect() && literalTokens.size() == 1) {
-        pathTokens.front() += literalTokens.front();
+        auto node = pathTokens.extract(pathTokens.begin());
+        node.value() += *literalTokens.begin();
+        pathTokens.insert(std::move(node));
     }
 
     pathResult.StopCollecting();
@@ -655,9 +656,10 @@ TCollectResult::TCollectResult(TTokens&& tokens)
 {
 }
 
-TCollectResult::TCollectResult(TString&& token)
-    : Result(TTokens{std::move(token)})
-{
+TCollectResult::TCollectResult(TString&& token) {
+    TTokens tokens;
+    tokens.insert(std::move(token));
+    Result = std::move(tokens);
 }
 
 TCollectResult::TCollectResult(TCollectResult::TError&& issue)

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -134,7 +134,7 @@ TCollectResult MergeComparisonPathResults(TCollectResult left, TCollectResult ri
     if (leftTokens.size() > 1) {
         left.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : TCollectResult::ETokensMode::And);
     }
-    left.Finish();
+    left.StopCollecting();
     return left;
 }
 
@@ -310,26 +310,18 @@ TCollectResult TQueryCollector::ContextObject(EMode mode) {
 
 TCollectResult TQueryCollector::MemberAccess(const TJsonPathItem& item, EMode mode) {
     auto result = Collect(Reader.ReadInput(item), mode);
-    if (result.IsError() || result.IsFinished()) {
+    if (!result.CanCollect()) {
         return result;
     }
 
-    auto& tokens = result.GetTokens();
-    Y_ENSURE(tokens.size() <= 1, "Expected at most one result, but got " << tokens.size());
-
-    // There is no context or filter object, so we can't collect any more
-    if (tokens.empty()) {
-        return {};
-    }
-
-    auto& token = tokens.front();
+    auto& token = result.GetTokens().front();
     AppendKey(token, item.GetString());
     return result;
 }
 
 TCollectResult TQueryCollector::WildcardMemberAccess(const TJsonPathItem& item, EMode mode) {
     auto result = Collect(Reader.ReadInput(item), mode);
-    result.Finish();
+    result.StopCollecting();
     if (!result.IsError() && result.GetTokens().size() > 1) {
         return TCollectResult(TIssue("Expected at most one result, but got " + std::to_string(result.GetTokens().size())));
     }
@@ -358,7 +350,7 @@ TCollectResult TQueryCollector::UnaryArithmeticOp(const TJsonPathItem& item, EMo
     }
 
     auto result = Collect(Reader.ReadInput(item), mode);
-    result.Finish();
+    result.StopCollecting();
     return result;
 }
 
@@ -392,7 +384,7 @@ TCollectResult TQueryCollector::BinaryArithmeticOp(const TJsonPathItem& item, EM
     if (leftTokens.size() > 1) {
         leftCollectResult.SetTokensMode(hasMix ? TCollectResult::ETokensMode::Or : TCollectResult::ETokensMode::And);
     }
-    leftCollectResult.Finish();
+    leftCollectResult.StopCollecting();
     return leftCollectResult;
 }
 
@@ -465,18 +457,18 @@ TCollectResult TQueryCollector::FilterObject(const TJsonPathItem& item, EMode mo
 }
 
 TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode mode) {
-    auto inpuTCollectResult = Collect(Reader.ReadInput(item), mode);
-    if (inpuTCollectResult.IsError()) {
-        return inpuTCollectResult;
+    auto inputCollectResult = Collect(Reader.ReadInput(item), mode);
+    if (inputCollectResult.IsError()) {
+        return inputCollectResult;
     }
 
-    const auto& tokens = inpuTCollectResult.GetTokens();
+    const auto& tokens = inputCollectResult.GetTokens();
 
-    // If input path is already finished (e.g. $.a.*) or has multiple tokens,
+    // If input path is already stopped (e.g. $.a.*) or has multiple tokens,
     // we can't apply the filter to narrow down
-    if (inpuTCollectResult.IsFinished() || tokens.size() != 1) {
-        inpuTCollectResult.Finish();
-        return inpuTCollectResult;
+    if (!inputCollectResult.CanCollect()) {
+        inputCollectResult.StopCollecting();
+        return inputCollectResult;
     }
 
     FilterObjectPrefixes.push_back(tokens.front());
@@ -488,13 +480,13 @@ TCollectResult TQueryCollector::FilterPredicate(const TJsonPathItem& item, EMode
         return predicateResult;
     }
 
-    predicateResult.Finish();
+    predicateResult.StopCollecting();
     return predicateResult;
 }
 
 TCollectResult TQueryCollector::Methods(const TJsonPathItem& item, EMode mode) {
     auto result = Collect(Reader.ReadInput(item), mode);
-    result.Finish();
+    result.StopCollecting();
     if (!result.IsError() && result.GetTokens().size() > 1) {
         return TCollectResult(TIssue("Expected at most one result, but got " + std::to_string(result.GetTokens().size())));
     }
@@ -507,7 +499,7 @@ TCollectResult TQueryCollector::Predicates(const TJsonPathItem& item, EMode mode
     }
 
     auto result = Collect(Reader.ReadInput(item), EMode::Predicate);
-    result.Finish();
+    result.StopCollecting();
     return result;
 }
 
@@ -524,11 +516,11 @@ TCollectResult TQueryCollector::CollectEqualOperands(const TJsonPathItem& leftIt
 
     auto& pathTokens = pathResult.GetTokens();
     auto& literalTokens = literalResult.GetTokens();
-    if (!pathResult.IsFinished() && pathTokens.size() == 1 && literalTokens.size() == 1) {
+    if (pathResult.CanCollect() && literalTokens.size() == 1) {
         pathTokens.front() += literalTokens.front();
     }
 
-    pathResult.Finish();
+    pathResult.StopCollecting();
     return pathResult;
 }
 
@@ -658,11 +650,6 @@ void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringB
     }
 }
 
-TCollectResult::TCollectResult()
-    : Result(TTokens{})
-{
-}
-
 TCollectResult::TCollectResult(TTokens&& tokens)
     : Result(std::move(tokens))
 {
@@ -697,12 +684,12 @@ bool TCollectResult::IsError() const {
     return std::holds_alternative<TCollectResult::TError>(Result);
 }
 
-bool TCollectResult::IsFinished() const {
-    return Finished;
+void TCollectResult::StopCollecting() {
+    Stopped = true;
 }
 
-void TCollectResult::Finish() {
-    Finished = true;
+bool TCollectResult::CanCollect() const {
+    return !IsError() && !Stopped && GetTokens().size() == 1;
 }
 
 TCollectResult::ETokensMode TCollectResult::GetTokensMode() const {

--- a/ydb/core/base/json_index.cpp
+++ b/ydb/core/base/json_index.cpp
@@ -12,7 +12,6 @@ namespace NJsonIndex {
 using NYql::TIssue;
 using NYql::TIssues;
 using namespace NYql::NJsonPath;
-
 namespace {
 
 NBinaryJson::EEntryType GetEntryType(const TJsonPathItem& item) {
@@ -48,30 +47,6 @@ void AppendKey(TString& prefix, TStringBuf key) {
         size >>= 7;
     } while (size > 0);
     prefix += key;
-}
-
-// Appends NUL, binary JSON entry type byte, and scalar payload (matches index token layout).
-void AppendLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload = {},
-    const double* numberPayload = nullptr)
-{
-    out.push_back(0);
-    out.push_back(static_cast<char>(type));
-    switch (type) {
-        case NBinaryJson::EEntryType::String:
-            out += stringPayload;
-            break;
-        case NBinaryJson::EEntryType::Number:
-            Y_ENSURE(numberPayload, "Number payload required");
-            out += TStringBuf(reinterpret_cast<const char*>(numberPayload), sizeof(double));
-            break;
-        case NBinaryJson::EEntryType::BoolFalse:
-        case NBinaryJson::EEntryType::BoolTrue:
-        case NBinaryJson::EEntryType::Null:
-            Y_ENSURE(!numberPayload, "No number payload for bool/null literal");
-            break;
-        case NBinaryJson::EEntryType::Container:
-            Y_ENSURE(false, "Container is not a scalar literal");
-    }
 }
 
 bool IsLiteralType(EJsonPathItemType type) {
@@ -310,16 +285,16 @@ TCollectResult TQueryCollector::Literal(const TJsonPathItem& item, EMode mode) {
     TString value;
     switch (item.Type) {
         case EJsonPathItemType::StringLiteral:
-            AppendLiteral(value, GetEntryType(item), item.GetString(), nullptr);
+            AppendJsonIndexLiteral(value, GetEntryType(item), item.GetString(), nullptr);
             break;
         case EJsonPathItemType::NumberLiteral: {
             double number = item.GetNumber();
-            AppendLiteral(value, GetEntryType(item), {}, &number);
+            AppendJsonIndexLiteral(value, GetEntryType(item), {}, &number);
             break;
         }
         case EJsonPathItemType::BooleanLiteral:
         case EJsonPathItemType::NullLiteral:
-            AppendLiteral(value, GetEntryType(item), {}, nullptr);
+            AppendJsonIndexLiteral(value, GetEntryType(item), {}, nullptr);
             break;
         default:
             return TCollectResult(TIssue("Expected a literal expression"));
@@ -335,7 +310,7 @@ TCollectResult TQueryCollector::ContextObject(EMode mode) {
 
 TCollectResult TQueryCollector::MemberAccess(const TJsonPathItem& item, EMode mode) {
     auto result = Collect(Reader.ReadInput(item), mode);
-    if (!result.CanCollect()) {
+    if (result.IsError() || result.IsFinished()) {
         return result;
     }
 
@@ -378,7 +353,7 @@ TCollectResult TQueryCollector::UnaryArithmeticOp(const TJsonPathItem& item, EMo
 
         TString value;
         double number = *val;
-        AppendLiteral(value, NBinaryJson::EEntryType::Number, {}, &number);
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &number);
         return TCollectResult(std::move(value));
     }
 
@@ -610,17 +585,17 @@ void TokenizeBinaryJson(NBinaryJson::TEntryCursor element, const TString& prefix
     TString token = prefix;
     switch (element.GetType()) {
     case NBinaryJson::EEntryType::String:
-        AppendLiteral(token, element.GetType(), element.GetString(), nullptr);
+        AppendJsonIndexLiteral(token, element.GetType(), element.GetString(), nullptr);
         break;
     case NBinaryJson::EEntryType::Number: {
         double number = element.GetNumber();
-        AppendLiteral(token, element.GetType(), {}, &number);
+        AppendJsonIndexLiteral(token, element.GetType(), {}, &number);
         break;
     }
     case NBinaryJson::EEntryType::BoolFalse:
     case NBinaryJson::EEntryType::BoolTrue:
     case NBinaryJson::EEntryType::Null:
-        AppendLiteral(token, element.GetType(), {}, nullptr);
+        AppendJsonIndexLiteral(token, element.GetType(), {}, nullptr);
         break;
     case NBinaryJson::EEntryType::Container:
         Y_ENSURE(false, "Unreachable");
@@ -659,6 +634,29 @@ void TokenizeBinaryJson(const NBinaryJson::TContainerCursor& root, const TString
 }
 
 }  // namespace
+
+void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload,
+    const double* numberPayload)
+{
+    out.push_back(0);
+    out.push_back(static_cast<char>(type));
+    switch (type) {
+        case NBinaryJson::EEntryType::String:
+            out += stringPayload;
+            break;
+        case NBinaryJson::EEntryType::Number:
+            Y_ENSURE(numberPayload, "Number payload required");
+            out += TStringBuf(reinterpret_cast<const char*>(numberPayload), sizeof(double));
+            break;
+        case NBinaryJson::EEntryType::BoolFalse:
+        case NBinaryJson::EEntryType::BoolTrue:
+        case NBinaryJson::EEntryType::Null:
+            Y_ENSURE(!numberPayload, "No number payload for bool/null literal");
+            break;
+        case NBinaryJson::EEntryType::Container:
+            Y_ENSURE(false, "Container is not a scalar literal");
+    }
+}
 
 TCollectResult::TCollectResult()
     : Result(TTokens{})
@@ -703,10 +701,6 @@ bool TCollectResult::IsFinished() const {
     return Finished;
 }
 
-bool TCollectResult::CanCollect() const {
-    return !IsError() && !IsFinished();
-}
-
 void TCollectResult::Finish() {
     Finished = true;
 }
@@ -743,6 +737,16 @@ TVector<TString> TokenizeJson(const TStringBuf jsonStr, TString& error) {
 
 TCollectResult CollectJsonPath(const TJsonPathPtr path, ECallableType callableType) {
     return TQueryCollector(path, callableType).Collect();
+}
+
+TCollectResult MergeAnd(TCollectResult left, TCollectResult right) {
+    return MergeBooleanOperands(std::move(left), std::move(right),
+        TCollectResult::ETokensMode::Or, TCollectResult::ETokensMode::And);
+}
+
+TCollectResult MergeOr(TCollectResult left, TCollectResult right) {
+    return MergeBooleanOperands(std::move(left), std::move(right),
+        TCollectResult::ETokensMode::And, TCollectResult::ETokensMode::Or);
 }
 
 }  // namespace NJsonIndex

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -4,6 +4,7 @@
 #include <yql/essentials/minikql/jsonpath/parser/parser.h>
 #include <yql/essentials/types/binary_json/format.h>
 
+#include <set>
 #include <variant>
 
 namespace NKikimr {
@@ -14,7 +15,7 @@ namespace NJsonIndex {
 // Contains tokens for the JSON index or an error if the collection process failed
 class TCollectResult {
 public:
-    using TTokens = TVector<TString>;
+    using TTokens = std::set<TString>;
     using TError = NYql::TIssue;
 
     enum class ETokensMode {

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -2,6 +2,7 @@
 
 #include <yql/essentials/public/issue/yql_issue.h>
 #include <yql/essentials/minikql/jsonpath/parser/parser.h>
+#include <yql/essentials/types/binary_json/format.h>
 
 #include <variant>
 
@@ -41,8 +42,6 @@ public:
 
     bool IsFinished() const;
 
-    bool CanCollect() const;
-
     void Finish();
 
     ETokensMode GetTokensMode() const;
@@ -75,6 +74,15 @@ TVector<TString> TokenizeBinaryJson(const TStringBuf text);
 // The tokens are used for searching in the JSON index
 TCollectResult CollectJsonPath(const NYql::NJsonPath::TJsonPathPtr path, ECallableType callableType);
 
+// Merges two collect results with AND semantics (all tokens must match)
+TCollectResult MergeAnd(TCollectResult left, TCollectResult right);
+
+// Merges two collect results with OR semantics (any token must match)
+TCollectResult MergeOr(TCollectResult left, TCollectResult right);
+
+// Appends NULL, binary JSON entry type byte, and scalar payload (the index token layout)
+void AppendJsonIndexLiteral(TString& out, NBinaryJson::EEntryType type, TStringBuf stringPayload = {},
+    const double* numberPayload = nullptr);
 
 }  // namespace NJsonIndex
 

--- a/ydb/core/base/json_index.h
+++ b/ydb/core/base/json_index.h
@@ -24,34 +24,47 @@ public:
     };
 
 public:
-    TCollectResult();
-
+    // Constructs a collect result with the given tokens
     TCollectResult(TTokens&& tokens);
 
+    // Constructs a collect result with the given token
     TCollectResult(TString&& token);
 
+    // Constructs a collect result with the given error
     TCollectResult(TError&& issue);
 
+    // Returns the collected tokens for the JSON index
     const TTokens& GetTokens() const;
 
+    // Returns the collected tokens for the JSON index for modification
     TTokens& GetTokens();
 
+    // Returns the error if the collection process failed
     const TError& GetError() const;
 
+    // Returns true if the collection process failed
     bool IsError() const;
 
-    bool IsFinished() const;
+    // Returns true if the collection process can be continued
+    // If it is true, the result token can be extended with the next token (e.g. literal)
+    // It does not affect collecting multiple tokens (AND, OR, etc.)
+    bool CanCollect() const;
 
-    void Finish();
+    // Stops the collection process
+    // It means that the result token is completed and cannot be extended
+    // It does not affect collecting multiple tokens (AND, OR, etc.)
+    void StopCollecting();
 
+    // Returns the tokens mode
     ETokensMode GetTokensMode() const;
 
+    // Sets the tokens mode
     void SetTokensMode(ETokensMode mode);
 
 private:
     std::variant<TTokens, TError> Result;
     ETokensMode TokensMode = ETokensMode::NotSet;
-    bool Finished = false;
+    bool Stopped = false;
 };
 
 // Type of the callable function that is used for the JSON index collection

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -49,7 +49,7 @@ void ValidateQueries(const TString& jsonPath, TVector<TString> expectedQueries, 
     auto result = ParseAndCollect(jsonPath, callableType, tokensMode);
 
     TVector<TString> resultVector;
-    std::move(result.begin(), result.end(), std::back_inserter(resultVector));
+    std::copy(result.begin(), result.end(), std::back_inserter(resultVector));
 
     std::sort(resultVector.begin(), resultVector.end());
     std::sort(expectedQueries.begin(), expectedQueries.end());
@@ -1875,6 +1875,71 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         CheckMerge(
             MergeOr(MakeTokens({first}), MakeTokens({second})),
             {first, second}, EMode::Or);
+    }
+
+    // The empty string token ("") represents the root context object ($)
+    Y_UNIT_TEST(MergeAndOr_EmptyPathToken) {
+        const TString root = "";
+        const TString a = "\2a";
+        const TString ab = "\2a\2b";
+        const TString b = "\2b";
+
+        // OR: root token covers any other token -> only root survives
+        CheckMerge(
+            MergeOr(MakeTokens({root}), MakeTokens({a})),
+            {root}, EMode::Or);
+
+        CheckMerge(
+            MergeOr(MakeTokens({a}), MakeTokens({root})),
+            {root}, EMode::Or);
+
+        // OR: root in a multi-token set — all others pruned
+        CheckMerge(
+            MergeOr(MakeTokens({root, a}, EMode::Or), MakeTokens({ab, b}, EMode::Or)),
+            {root}, EMode::Or);
+
+        // AND: root is more general than any other token -> root is pruned
+        CheckMerge(
+            MergeAnd(MakeTokens({root}), MakeTokens({a})),
+            {a}, EMode::And);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({a}), MakeTokens({root})),
+            {a}, EMode::And);
+
+        // AND: root with multiple non-empty tokens -> root pruned, others kept
+        CheckMerge(
+            MergeAnd(MakeTokens({root, a}, EMode::And), MakeTokens({ab, b}, EMode::And)),
+            {ab, b}, EMode::And);
+
+        // Root on both sides: deduplication leaves a single token -> NotSet mode, no pruning
+        CheckMerge(
+            MergeOr(MakeTokens({root}), MakeTokens({root})),
+            {root}, EMode::NotSet);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({root}), MakeTokens({root})),
+            {root}, EMode::NotSet);
+
+        // Root with a literal-suffixed token (path + value): root is still a prefix -> same rules
+        const TString aNum = a + numSuffix(1.0);
+        CheckMerge(
+            MergeOr(MakeTokens({root}), MakeTokens({aNum})),
+            {root}, EMode::Or);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({root}), MakeTokens({aNum})),
+            {aNum}, EMode::And);
+
+        // Root with a sibling pair: both siblings extend root, so root covers both in OR
+        CheckMerge(
+            MergeOr(MakeTokens({root}), MakeTokens({a, b}, EMode::Or)),
+            {root}, EMode::Or);
+
+        // AND: root with siblings -> root pruned, siblings kept
+        CheckMerge(
+            MergeAnd(MakeTokens({root}), MakeTokens({a, b}, EMode::And)),
+            {a, b}, EMode::And);
     }
 
     Y_UNIT_TEST(TokenizeJson) {

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -87,6 +87,7 @@ const TString compError = "Comparison is not allowed between literals on both si
 const TString varError = "Variables are not supported at the moment";
 const TString predError = "Predicates are not allowed in this context";
 const TString filterError = "'@' is only allowed inside filters";
+const TString emptyError = "Cannot collect tokens for the given JSON path";
 
 }  // namespace
 
@@ -370,8 +371,8 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateQueries("$.a.b - (-$.c.d)", {"\1a\1b", "\1c\1d"});
 
         // Both operands are literals - no path to collect
-        ValidateQueries("1 + 2", {});
-        ValidateQueries("(+(-1.5)) * 2.0", {});
+        ValidateError("1 + 2", emptyError);
+        ValidateError("(+(-1.5)) * 2.0", emptyError);
 
         // Wildcard on left, path on right - both collected
         ValidateJsonExists("$.a.* + $.b", {"\1a", "\1b"});
@@ -704,10 +705,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonValue("$ <= $.a", {"", "\1a"});
         ValidateJsonValue("$.a >= $", {"\1a", ""});
 
-        // Both sides are literals - both dropped, empty result
-        ValidateJsonValue("1 < 2", {});
-        ValidateJsonValue("1.5 >= -2.0", {});
-        ValidateJsonValue("true != false", {});
+        // Both sides are literals - error
+        ValidateError("1 < 2", emptyError, ECallableType::JsonValue);
+        ValidateError("1.5 >= -2.0", emptyError, ECallableType::JsonValue);
+        ValidateError("true != false", emptyError, ECallableType::JsonValue);
 
         // Arithmetic expression as operand (same as BinaryArithmeticOp behavior)
         // $.a + $.b produces mode=And, comparison also sets And - compatible

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -9,7 +9,7 @@ using namespace NYql::NJsonPath;
 
 namespace {
 
-TVector<TString> ParseAndCollect(const TString& jsonPath, ECallableType callableType = ECallableType::JsonExists,
+std::set<TString> ParseAndCollect(const TString& jsonPath, ECallableType callableType = ECallableType::JsonExists,
     std::optional<TCollectResult::ETokensMode> tokensMode = std::nullopt)
 {
     NYql::TIssues issues;
@@ -43,10 +43,18 @@ void ValidateError(const TString& jsonPath, const TString& errorMessage, ECallab
     }
 }
 
-void ValidateQueries(const TString& jsonPath, const TVector<TString>& expectedQueries, ECallableType callableType = ECallableType::JsonExists,
+void ValidateQueries(const TString& jsonPath, TVector<TString> expectedQueries, ECallableType callableType = ECallableType::JsonExists,
     std::optional<TCollectResult::ETokensMode> tokensMode = std::nullopt)
 {
-    UNIT_ASSERT_VALUES_EQUAL_C(ParseAndCollect(jsonPath, callableType, tokensMode), expectedQueries, "for path = " << jsonPath);
+    auto result = ParseAndCollect(jsonPath, callableType, tokensMode);
+
+    TVector<TString> resultVector;
+    std::move(result.begin(), result.end(), std::back_inserter(resultVector));
+
+    std::sort(resultVector.begin(), resultVector.end());
+    std::sort(expectedQueries.begin(), expectedQueries.end());
+
+    UNIT_ASSERT_VALUES_EQUAL_C(resultVector, expectedQueries, "for path = " << jsonPath);
 }
 
 void ValidateJsonExists(const TString& jsonPath, const TVector<TString>& expectedQueries,
@@ -384,10 +392,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonExists("$.a.b + $.*", {"\1a\1b", ""});
 
         // Wildcard on both sides - two wildcard tokens collected
-        ValidateJsonExists("$.* + $.*", {"", ""});
+        ValidateJsonExists("$.* + $.*", {""});
         ValidateJsonExists("$.a.* + $.*", {"\1a", ""});
         ValidateJsonExists("$.* + $.a.*", {"", "\1a"});
-        ValidateJsonExists("$.a.b.*.c + $.a.b.*.d", {"\1a\1b", "\1a\1b"});
+        ValidateJsonExists("$.a.b.*.c + $.a.b.*.d", {"\1a\1b"});
 
         // Error on left - propagated immediately, right not collected
         ValidateError("$var + $.b", varError);
@@ -616,7 +624,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         // Both operands are paths: merge index tokens with AND (same as comparison ops)
         ValidateJsonValue("$.a == $.b", {"\1a", "\1b"});
         ValidateJsonValue("$.key == $", {"\3key", ""});
-        ValidateJsonValue("$ == $", {"", ""});
+        ValidateJsonValue("$ == $", {""});
         ValidateJsonValue("$.a.b == $.c.d", {"\1a\1b", "\1c\1d"});
 
         // Literals only
@@ -811,7 +819,7 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Comparison in AND inside filter
         ValidateJsonExists("$.a ? (@.b < +10 && @.c == 1)", {"\1a\1b", "\1a\1c" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (@.b > 0 && @.b < 100)", {"\1a\1b", "\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b > 0 && @.b < 100)", {"\1a\1b"});
         ValidateJsonExists("$.a ? (@.b != 5 && @.c >= 0 && @.d <= -10)", {"\1a\1b", "\1a\1c", "\1a\1d"});
 
         // Comparison in OR inside filter

--- a/ydb/core/base/ut/json_index_ut.cpp
+++ b/ydb/core/base/ut/json_index_ut.cpp
@@ -95,7 +95,27 @@ const TString compError = "Comparison is not allowed between literals on both si
 const TString varError = "Variables are not supported at the moment";
 const TString predError = "Predicates are not allowed in this context";
 const TString filterError = "'@' is only allowed inside filters";
-const TString emptyError = "Cannot collect tokens for the given JSON path";
+const TString emptyError = "Cannot collect tokens for the given JSON path"; 
+
+using EMode = TCollectResult::ETokensMode;
+
+TCollectResult MakeTokens(std::initializer_list<TString> tokens, EMode mode = EMode::NotSet) {
+    TCollectResult::TTokens tokenSet(tokens);
+    TCollectResult result(std::move(tokenSet));
+    result.SetTokensMode(mode);
+    return result;
+}
+
+TCollectResult MakeError(const TString& message) {
+    return TCollectResult(NYql::TIssue(message));
+}
+
+void CheckMerge(const TCollectResult& result, std::initializer_list<TString> expectedTokens, EMode expectedMode) {
+    UNIT_ASSERT(!result.IsError());
+    const TCollectResult::TTokens expected(expectedTokens);
+    UNIT_ASSERT(result.GetTokens() == expected);
+    UNIT_ASSERT(result.GetTokensMode() == expectedMode);
+}
 
 }  // namespace
 
@@ -111,13 +131,13 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     }
 
     Y_UNIT_TEST(CollectPath_MemberAccess) {
-        ValidateJsonExists("$.a", {"\1a"});
-        ValidateJsonExists("$.a.b.c", {"\1a\1b\1c"});
-        ValidateJsonExists("$.aba.\"caba\"", {"\3aba\4caba"});
-        ValidateJsonExists("$.\"\".abc", {TString("\0\3abc", 5)});
+        ValidateJsonExists("$.a", {"\2a"});
+        ValidateJsonExists("$.a.b.c", {"\2a\2b\2c"});
+        ValidateJsonExists("$.aba.\"caba\"", {"\4aba\5caba"});
+        ValidateJsonExists("$.\"\".abc", {TString("\1\4abc", 5)});
         ValidateJsonExists("$.*", {""});
-        ValidateJsonExists("$.a.*", {"\1a"});
-        ValidateJsonExists("$.a.*.c", {"\1a"});
+        ValidateJsonExists("$.a.*", {"\2a"});
+        ValidateJsonExists("$.a.*.c", {"\2a"});
     }
 
     Y_UNIT_TEST(CollectPath_ArrayAccess) {
@@ -126,12 +146,12 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonExists("$[1 to 3]", {""});
         ValidateJsonExists("$[last]", {""});
         ValidateJsonExists("$[0, 2 to last]", {""});
-        ValidateJsonExists("$[0 to 1].key", {"\3key"});
-        ValidateJsonExists("$.key[0]", {"\3key"});
-        ValidateJsonExists("$.key1[last].key2", {"\4key1\4key2"});
-        ValidateJsonExists("$.arr[2 to last]", {"\3arr"});
+        ValidateJsonExists("$[0 to 1].key", {"\4key"});
+        ValidateJsonExists("$.key[0]", {"\4key"});
+        ValidateJsonExists("$.key1[last].key2", {"\5key1\5key2"});
+        ValidateJsonExists("$.arr[2 to last]", {"\4arr"});
         ValidateJsonExists("$.*[2 to last].key", {""});
-        ValidateJsonExists("$.key[0].*", {"\3key"});
+        ValidateJsonExists("$.key[0].*", {"\4key"});
     }
 
     // Methods stop further path extraction: operand path only
@@ -139,16 +159,16 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonExists("$.abs()", {""});
         ValidateJsonExists("$.*.floor()", {""});
         ValidateJsonExists("$[1, 2, 3].ceiling()", {""});
-        ValidateJsonExists("$.key.abs()", {"\3key"});
-        ValidateJsonExists("$.key.floor()", {"\3key"});
-        ValidateJsonExists("$.key.ceiling()", {"\3key"});
-        ValidateJsonExists("$.key.double()", {"\3key"});
-        ValidateJsonExists("$.key.type()", {"\3key"});
-        ValidateJsonExists("$.key.size()", {"\3key"});
-        ValidateJsonExists("$.key.keyvalue()", {"\3key"});
+        ValidateJsonExists("$.key.abs()", {"\4key"});
+        ValidateJsonExists("$.key.floor()", {"\4key"});
+        ValidateJsonExists("$.key.ceiling()", {"\4key"});
+        ValidateJsonExists("$.key.double()", {"\4key"});
+        ValidateJsonExists("$.key.type()", {"\4key"});
+        ValidateJsonExists("$.key.size()", {"\4key"});
+        ValidateJsonExists("$.key.keyvalue()", {"\4key"});
         ValidateJsonExists("$.*.keyvalue()", {""});
-        ValidateJsonExists("$.key[1, 2, 3].value.size().floor()", {"\3key\5value"});
-        ValidateJsonExists("$.key.keyvalue().name", {"\3key"});
+        ValidateJsonExists("$.key[1, 2, 3].value.size().floor()", {"\4key\6value"});
+        ValidateJsonExists("$.key.keyvalue().name", {"\4key"});
     }
 
     // StartsWith predicates stop further path extraction: operand path only
@@ -156,11 +176,11 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonValue("$ starts with \"lol\"", {""});
         ValidateJsonValue("$[1 to last] starts with \"lol\"", {""});
         ValidateJsonValue("$[*] starts with \"lol\"", {""});
-        ValidateJsonValue("$.key starts with \"abc\"", {"\3key"});
-        ValidateJsonValue("$.a.b.c[1, 2, 3] starts with \"abc\"", {"\1a\1b\1c"});
-        ValidateJsonValue("$.key.type().name starts with \"abc\"", {"\3key"});
+        ValidateJsonValue("$.key starts with \"abc\"", {"\4key"});
+        ValidateJsonValue("$.a.b.c[1, 2, 3] starts with \"abc\"", {"\2a\2b\2c"});
+        ValidateJsonValue("$.key.type().name starts with \"abc\"", {"\4key"});
         ValidateJsonValue("$.* starts with \"abc\"", {""});
-        ValidateJsonValue("$.a.*.c[1, 2, 3] starts with \"abc\"", {"\1a"});
+        ValidateJsonValue("$.a.*.c[1, 2, 3] starts with \"abc\"", {"\2a"});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("$.key starts with \"lol\"", "Predicates are not allowed in this context", ECallableType::JsonExists);
@@ -171,12 +191,12 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonValue("$ like_regex \"abc\"", {""});
         ValidateJsonValue("$[1 to 2] like_regex \"abc\"", {""});
         ValidateJsonValue("$[*] like_regex \"abc\"", {""});
-        ValidateJsonValue("$.key like_regex \"abc\"", {"\3key"});
+        ValidateJsonValue("$.key like_regex \"abc\"", {"\4key"});
         ValidateJsonValue("$.* like_regex \"abc\"", {""});
-        ValidateJsonValue("$.key[1, 2, 3] like_regex \"abc\"", {"\3key"});
-        ValidateJsonValue("$.key.keyvalue() like_regex \"abc\"", {"\3key"});
-        ValidateJsonValue("$.key like_regex \"a.c\"", {"\3key"});
-        ValidateJsonValue("$.key like_regex \".*\"", {"\3key"});
+        ValidateJsonValue("$.key[1, 2, 3] like_regex \"abc\"", {"\4key"});
+        ValidateJsonValue("$.key.keyvalue() like_regex \"abc\"", {"\4key"});
+        ValidateJsonValue("$.key like_regex \"a.c\"", {"\4key"});
+        ValidateJsonValue("$.key like_regex \".*\"", {"\4key"});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("$.key like_regex \"abc\"", "Predicates are not allowed in this context", ECallableType::JsonExists);
@@ -185,10 +205,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Exists predicates stop further path extraction: operand path only
     Y_UNIT_TEST(CollectPath_ExistsPredicate) {
         ValidateJsonValue("exists($)", {""});
-        ValidateJsonValue("exists($.key)", {"\3key"});
-        ValidateJsonValue("exists($.key[1, 2, 3])", {"\3key"});
+        ValidateJsonValue("exists($.key)", {"\4key"});
+        ValidateJsonValue("exists($.key[1, 2, 3])", {"\4key"});
         ValidateJsonValue("exists($[*].size())", {""});
-        ValidateJsonValue("exists($.key.keyvalue().name)", {"\3key"});
+        ValidateJsonValue("exists($.key.keyvalue().name)", {"\4key"});
 
         // For JSON_EXISTS, the result is always true even if the path does not exist
         ValidateError("exists($)", "Predicates are not allowed in this context", ECallableType::JsonExists);
@@ -297,33 +317,33 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     // Unary +/- stop further path extraction (same as methods): operand path only
     Y_UNIT_TEST(CollectPath_UnaryPlusMinus) {
-        ValidateJsonExists("-$.key", {"\3key"});
-        ValidateJsonExists("+$.key", {"\3key"});
+        ValidateJsonExists("-$.key", {"\4key"});
+        ValidateJsonExists("+$.key", {"\4key"});
 
         ValidateJsonExists("-$", {""});
         ValidateJsonExists("+$", {""});
 
-        ValidateJsonExists("-$.a.b.c", {"\1a\1b\1c"});
-        ValidateJsonExists("+$.a.b.c", {"\1a\1b\1c"});
+        ValidateJsonExists("-$.a.b.c", {"\2a\2b\2c"});
+        ValidateJsonExists("+$.a.b.c", {"\2a\2b\2c"});
 
         ValidateJsonExists("-$.*", {""});
         ValidateJsonExists("+$.*", {""});
-        ValidateJsonExists("-$.a.*", {"\1a"});
-        ValidateJsonExists("+$.a.*", {"\1a"});
+        ValidateJsonExists("-$.a.*", {"\2a"});
+        ValidateJsonExists("+$.a.*", {"\2a"});
 
-        ValidateJsonExists("-$.key[0]", {"\3key"});
-        ValidateJsonExists("+$.key[last]", {"\3key"});
+        ValidateJsonExists("-$.key[0]", {"\4key"});
+        ValidateJsonExists("+$.key[last]", {"\4key"});
 
-        ValidateJsonExists("-$.key.abs()", {"\3key"});
-        ValidateJsonExists("+$.key.type()", {"\3key"});
+        ValidateJsonExists("-$.key.abs()", {"\4key"});
+        ValidateJsonExists("+$.key.type()", {"\4key"});
 
-        ValidateJsonExists("-(-$.key)", {"\3key"});
-        ValidateJsonExists("-(+$.key)", {"\3key"});
-        ValidateJsonExists("+(-$.key)", {"\3key"});
-        ValidateJsonExists("+(+$.key)", {"\3key"});
+        ValidateJsonExists("-(-$.key)", {"\4key"});
+        ValidateJsonExists("-(+$.key)", {"\4key"});
+        ValidateJsonExists("+(-$.key)", {"\4key"});
+        ValidateJsonExists("+(+$.key)", {"\4key"});
 
-        ValidateJsonValue("exists(-$.a.b)", {"\1a\1b"});
-        ValidateJsonValue("exists(+$.a.b)", {"\1a\1b"});
+        ValidateJsonValue("exists(-$.a.b)", {"\2a\2b"});
+        ValidateJsonValue("exists(+$.a.b)", {"\2a\2b"});
 
         ValidateJsonValue("-($.double())", {""});
         ValidateJsonValue("+($.double())", {""});
@@ -342,60 +362,60 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Binary arithmetic operators extract tokens from both operands and finish
     Y_UNIT_TEST(CollectPath_BinaryArithmetic) {
         // Path on the left, literal on the right - only left token
-        ValidateQueries("$.key + 1", {"\3key"});
-        ValidateQueries("$.key - 1", {"\3key"});
-        ValidateQueries("$.key - (-1)", {"\3key"});
-        ValidateQueries("$.key * 2", {"\3key"});
-        ValidateQueries("$.key / 2", {"\3key"});
-        ValidateQueries("$.key % 2", {"\3key"});
+        ValidateQueries("$.key + 1", {"\4key"});
+        ValidateQueries("$.key - 1", {"\4key"});
+        ValidateQueries("$.key - (-1)", {"\4key"});
+        ValidateQueries("$.key * 2", {"\4key"});
+        ValidateQueries("$.key / 2", {"\4key"});
+        ValidateQueries("$.key % 2", {"\4key"});
 
         // Literal on the left, path on the right - only right token
-        ValidateQueries("1 + $.key", {"\3key"});
-        ValidateQueries("-1 - $.key", {"\3key"});
-        ValidateQueries("1 * $.key", {"\3key"});
-        ValidateQueries("(+(-1)) / $.key", {"\3key"});
-        ValidateQueries("1 % $.key", {"\3key"});
+        ValidateQueries("1 + $.key", {"\4key"});
+        ValidateQueries("-1 - $.key", {"\4key"});
+        ValidateQueries("1 * $.key", {"\4key"});
+        ValidateQueries("(+(-1)) / $.key", {"\4key"});
+        ValidateQueries("1 % $.key", {"\4key"});
 
         // Context object on the left
         ValidateQueries("$ + 1", {""});
         ValidateQueries("$ * 2", {""});
 
         // Deeper paths as left operand
-        ValidateQueries("$.a.b.c + 1", {"\1a\1b\1c"});
-        ValidateQueries("$.a.b - 1", {"\1a\1b"});
+        ValidateQueries("$.a.b.c + 1", {"\2a\2b\2c"});
+        ValidateQueries("$.a.b - 1", {"\2a\2b"});
 
         // Array access on the left operand
-        ValidateQueries("$.key[0] + 1", {"\3key"});
-        ValidateQueries("$.arr[last] * 2", {"\3arr"});
+        ValidateQueries("$.key[0] + 1", {"\4key"});
+        ValidateQueries("$.arr[last] * 2", {"\4arr"});
 
         // Wildcard on the left - collection already finished by wildcard
         ValidateQueries("$.* + 1", {""});
         ValidateQueries("$.* + (-1)", {""});
-        ValidateQueries("$.a.* - 1", {"\1a"});
+        ValidateQueries("$.a.* - 1", {"\2a"});
 
         // Both operands are paths - tokens from both are collected (AND)
-        ValidateQueries("$.a + $.b", {"\1a", "\1b"});
-        ValidateQueries("$.a.b - $.c.d", {"\1a\1b", "\1c\1d"});
-        ValidateQueries("$.a.b - (-$.c.d)", {"\1a\1b", "\1c\1d"});
+        ValidateQueries("$.a + $.b", {"\2a", "\2b"});
+        ValidateQueries("$.a.b - $.c.d", {"\2a\2b", "\2c\2d"});
+        ValidateQueries("$.a.b - (-$.c.d)", {"\2a\2b", "\2c\2d"});
 
         // Both operands are literals - no path to collect
         ValidateError("1 + 2", emptyError);
         ValidateError("(+(-1.5)) * 2.0", emptyError);
 
         // Wildcard on left, path on right - both collected
-        ValidateJsonExists("$.a.* + $.b", {"\1a", "\1b"});
-        ValidateJsonExists("$.* + $.b", {"", "\1b"});
-        ValidateJsonExists("$.* - $.a.b", {"", "\1a\1b"});
+        ValidateJsonExists("$.a.* + $.b", {"\2a", "\2b"});
+        ValidateJsonExists("$.* + $.b", {"", "\2b"});
+        ValidateJsonExists("$.* - $.a.b", {"", "\2a\2b"});
 
         // Path on left, wildcard on right
-        ValidateJsonExists("$.a + $.*", {"\1a", ""});
-        ValidateJsonExists("$.a.b + $.*", {"\1a\1b", ""});
+        ValidateJsonExists("$.a + $.*", {"\2a", ""});
+        ValidateJsonExists("$.a.b + $.*", {"\2a\2b", ""});
 
         // Wildcard on both sides - two wildcard tokens collected
         ValidateJsonExists("$.* + $.*", {""});
-        ValidateJsonExists("$.a.* + $.*", {"\1a", ""});
-        ValidateJsonExists("$.* + $.a.*", {"", "\1a"});
-        ValidateJsonExists("$.a.b.*.c + $.a.b.*.d", {"\1a\1b"});
+        ValidateJsonExists("$.a.* + $.*", {"\2a", ""});
+        ValidateJsonExists("$.* + $.a.*", {"", "\2a"});
+        ValidateJsonExists("$.a.b.*.c + $.a.b.*.d", {"\2a\2b"});
 
         // Error on left - propagated immediately, right not collected
         ValidateError("$var + $.b", varError);
@@ -419,129 +439,129 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Non-trivial combinations of unary and binary arithmetic operators
     Y_UNIT_TEST(CollectPath_ArithmeticCombinations) {
         // Unary applied to binary: tokens from both binary operands, then Finish
-        ValidateQueries("-($.a + 1)", {"\1a"});
-        ValidateQueries("+($.a - 1)", {"\1a"});
-        ValidateQueries("-($.a * $.b)", {"\1a", "\1b"});
-        ValidateQueries("-(1 + $.b)", {"\1b"});
+        ValidateQueries("-($.a + 1)", {"\2a"});
+        ValidateQueries("+($.a - 1)", {"\2a"});
+        ValidateQueries("-($.a * $.b)", {"\2a", "\2b"});
+        ValidateQueries("-(1 + $.b)", {"\2b"});
 
         // Binary with unary left operand
-        ValidateQueries("-$.a + $.b", {"\1a", "\1b"});
-        ValidateQueries("+$.a - $.b", {"\1a", "\1b"});
-        ValidateQueries("-$.key + 1", {"\3key"});
-        ValidateQueries("+$.key * 2", {"\3key"});
+        ValidateQueries("-$.a + $.b", {"\2a", "\2b"});
+        ValidateQueries("+$.a - $.b", {"\2a", "\2b"});
+        ValidateQueries("-$.key + 1", {"\4key"});
+        ValidateQueries("+$.key * 2", {"\4key"});
 
         // Binary with unary right operand - right token still collected
-        ValidateQueries("$.a + (-$.b)", {"\1a", "\1b"});
-        ValidateQueries("$.a * (+$.b)", {"\1a", "\1b"});
-        ValidateQueries("1 + (-$.b)", {"\1b"});
+        ValidateQueries("$.a + (-$.b)", {"\2a", "\2b"});
+        ValidateQueries("$.a * (+$.b)", {"\2a", "\2b"});
+        ValidateQueries("1 + (-$.b)", {"\2b"});
 
         // Chained binary (left-associative): all three path tokens collected
-        ValidateQueries("$.a + $.b + $.c", {"\1a", "\1b", "\1c"});
-        ValidateQueries("$.a - $.b - $.c", {"\1a", "\1b", "\1c"});
-        ValidateQueries("$.a * $.b * $.c", {"\1a", "\1b", "\1c"});
+        ValidateQueries("$.a + $.b + $.c", {"\2a", "\2b", "\2c"});
+        ValidateQueries("$.a - $.b - $.c", {"\2a", "\2b", "\2c"});
+        ValidateQueries("$.a * $.b * $.c", {"\2a", "\2b", "\2c"});
 
         // Mixed precedence: * binds tighter than +, but all paths still collected
-        ValidateQueries("$.a + $.b * $.c", {"\1a", "\1b", "\1c"});
-        ValidateQueries("$.a * $.b + $.c", {"\1a", "\1b", "\1c"});
+        ValidateQueries("$.a + $.b * $.c", {"\2a", "\2b", "\2c"});
+        ValidateQueries("$.a * $.b + $.c", {"\2a", "\2b", "\2c"});
 
         // Double unary combined with binary
-        ValidateQueries("-(-$.a) + $.b", {"\1a", "\1b"});
-        ValidateQueries("-(+$.a) * 2", {"\1a"});
+        ValidateQueries("-(-$.a) + $.b", {"\2a", "\2b"});
+        ValidateQueries("-(+$.a) * 2", {"\2a"});
 
         // Longer paths on both sides
-        ValidateQueries("$.a.b.c + $.x.y.z", {"\1a\1b\1c", "\1x\1y\1z"});
-        ValidateQueries("-($.a.*.c) + $.x.y.*", {"\1a", "\1x\1y"});
-        ValidateQueries("$.a.b.c * 3.14", {"\1a\1b\1c"});
+        ValidateQueries("$.a.b.c + $.x.y.z", {"\2a\2b\2c", "\2x\2y\2z"});
+        ValidateQueries("-($.a.*.c) + $.x.y.*", {"\2a", "\2x\2y"});
+        ValidateQueries("$.a.b.c * 3.14", {"\2a\2b\2c"});
 
         // Method result used as operand of binary - method finishes, but token still collected
-        ValidateQueries("$.key.size() + 1", {"\3key"});
-        ValidateQueries("$.key.abs() * 2", {"\3key"});
-        ValidateQueries("$.a.size() + $.b.floor()", {"\1a", "\1b"});
+        ValidateQueries("$.key.size() + 1", {"\4key"});
+        ValidateQueries("$.key.abs() * 2", {"\4key"});
+        ValidateQueries("$.a.size() + $.b.floor()", {"\2a", "\2b"});
     }
 
     // Arithmetic operators (two-path operands produce And mode) combined with && and ||
     Y_UNIT_TEST(CollectPath_ArithmeticWithBooleanOps) {
         // Two-path arithmetic result (And mode) in AND chain: stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a - $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a * $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a / $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a % $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\1c" + numSuffix(1), "\1a", "\1b"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a - $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a * $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a / $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a % $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"}, TCollectResult::ETokensMode::And);
 
         // Two arithmetic results combined via AND: stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\")", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a - $.b == \"x\") && ($.c * $.d == \"y\") && ($.e == 1)", {"\1a", "\1b", "\1c", "\1d", "\1e" + numSuffix(1)},
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a - $.b == \"x\") && ($.c * $.d == \"y\") && ($.e == 1)", {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)},
             TCollectResult::ETokensMode::And);
 
         // Two-path arithmetic result (And mode) in OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\1c" + numSuffix(1), "\1a", "\1b"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"}, TCollectResult::ETokensMode::Or);
 
         // Two arithmetic results combined via OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c + $.d == \"y\")", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c * $.d == \"y\")", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c % $.d == \"y\")", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c + $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a - $.b == \"x\") || ($.c * $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a / $.b == \"x\") || ($.c % $.d == \"y\")", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
 
         // Three-way OR of arithmetic results: all become OR
         ValidateJsonValue("($.a + $.b == \"x\") || ($.c + $.d == \"y\") || ($.e == 1)",
-            {"\1a", "\1b", "\1c", "\1d", "\1e" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
+            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)}, TCollectResult::ETokensMode::Or);
 
         // Arithmetic result with comparison (single-path, NotSet) via AND: compatible, stays And
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c < 5)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.c < 5) && ($.a + $.b == \"x\")", {"\1c", "\1a", "\1b"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c < 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.c < 5) && ($.a + $.b == \"x\")", {"\2c", "\2a", "\2b"}, TCollectResult::ETokensMode::And);
 
         // Arithmetic result with comparison via OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c < 5)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.c < 5) || ($.a + $.b == \"x\")", {"\1c", "\1a", "\1b"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c < 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.c < 5) || ($.a + $.b == \"x\")", {"\2c", "\2a", "\2b"}, TCollectResult::ETokensMode::Or);
 
         // Arithmetic result with starts with / like_regex / exists in AND: compatible
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c starts with \"abc\")", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c like_regex \".*\")", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a + $.b == \"x\") && exists($.c)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c starts with \"abc\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c like_regex \".*\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a + $.b == \"x\") && exists($.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
 
         // Arithmetic result with starts with / like_regex / exists in OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c starts with \"abc\")", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c like_regex \".*\")", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a + $.b == \"x\") || exists($.c)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c starts with \"abc\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c like_regex \".*\")", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a + $.b == \"x\") || exists($.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
 
         // Deeper paths in arithmetic operands
-        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") && ($.key == 1)", {"\1a\1b\1c", "\1x\1y\1z", "\3key" + numSuffix(1)},
+        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") && ($.key == 1)", {"\2a\2b\2c", "\2x\2y\2z", "\4key" + numSuffix(1)},
             TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") || ($.key == 1)", {"\1a\1b\1c", "\1x\1y\1z", "\3key" + numSuffix(1)},
+        ValidateJsonValue("($.a.b.c + $.x.y.z == \"val\") || ($.key == 1)", {"\2a\2b\2c", "\2x\2y\2z", "\4key" + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
 
         // Filter: arithmetic with two paths combined via OR with plain path
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c == 1)", {"\3key\1a", "\3key\1b", "\3key\1c" + numSuffix(1)},
+        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c == 1)", {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
         // Filter: two arithmetic results in OR
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c + @.d == 3)", {"\3key\1a", "\3key\1b", "\3key\1c", "\3key\1d"},
+        ValidateJsonExists("$.key ? (@.a + @.b == 5 || @.c + @.d == 3)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"},
             TCollectResult::ETokensMode::Or);
         // Filter: AND chain with OR appended - OR wins
         ValidateJsonExists("$.key ? (@.a + @.b == 5 && @.c == 1 || @.d == 2)",
-            {"\3key\1a", "\3key\1b", "\3key\1c" + numSuffix(1), "\3key\1d" + numSuffix(2)}, TCollectResult::ETokensMode::Or);
+            {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1), "\4key\2d" + numSuffix(2)}, TCollectResult::ETokensMode::Or);
     }
 
     Y_UNIT_TEST(CollectPath_EqualityOperator) {
         // Path == literal, all literal types
-        ValidateJsonValue("$.key == \"hello\"", {"\3key" + strSuffix("hello")});
-        ValidateJsonValue("$.key == \"\"", {"\3key" + strSuffix("")});
-        ValidateJsonValue("$.key == 42", {"\3key" + numSuffix(42)});
-        ValidateJsonValue("$.key == 0", {"\3key" + numSuffix(0)});
-        ValidateJsonValue("$.key == 3.14", {"\3key" + numSuffix(3.14)});
-        ValidateJsonValue("$.key == true", {"\3key" + boolTrueSuffix});
-        ValidateJsonValue("$.key == false", {"\3key" + boolFalseSuffix});
-        ValidateJsonValue("$.key == null", {"\3key" + nullSuffix});
+        ValidateJsonValue("$.key == \"hello\"", {"\4key" + strSuffix("hello")});
+        ValidateJsonValue("$.key == \"\"", {"\4key" + strSuffix("")});
+        ValidateJsonValue("$.key == 42", {"\4key" + numSuffix(42)});
+        ValidateJsonValue("$.key == 0", {"\4key" + numSuffix(0)});
+        ValidateJsonValue("$.key == 3.14", {"\4key" + numSuffix(3.14)});
+        ValidateJsonValue("$.key == true", {"\4key" + boolTrueSuffix});
+        ValidateJsonValue("$.key == false", {"\4key" + boolFalseSuffix});
+        ValidateJsonValue("$.key == null", {"\4key" + nullSuffix});
 
         // Reversed order: literal == path (identical result)
-        ValidateJsonValue("\"hello\" == $.key", {"\3key" + strSuffix("hello")});
-        ValidateJsonValue("42 == $.key", {"\3key" + numSuffix(42)});
-        ValidateJsonValue("true == $.key", {"\3key" + boolTrueSuffix});
-        ValidateJsonValue("null == $.key", {"\3key" + nullSuffix});
+        ValidateJsonValue("\"hello\" == $.key", {"\4key" + strSuffix("hello")});
+        ValidateJsonValue("42 == $.key", {"\4key" + numSuffix(42)});
+        ValidateJsonValue("true == $.key", {"\4key" + boolTrueSuffix});
+        ValidateJsonValue("null == $.key", {"\4key" + nullSuffix});
 
         // Context object as path (empty prefix)
         ValidateJsonValue("$ == \"hello\"", {strSuffix("hello")});
@@ -551,62 +571,62 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonValue("\"hello\" == $", {strSuffix("hello")});
 
         // Deeper paths
-        ValidateJsonValue("$.a.b == \"x\"", {"\1a\1b" + strSuffix("x")});
-        ValidateJsonValue("$.a.b.c == null", {"\1a\1b\1c" + nullSuffix});
-        ValidateJsonValue("\"x\" == $.a.b.c", {"\1a\1b\1c" + strSuffix("x")});
-        ValidateJsonValue("$.aba.\"caba\" == true", {"\3aba\4caba" + boolTrueSuffix});
-        ValidateJsonValue("$.a.b.c.d == 0", {"\1a\1b\1c\1d" + numSuffix(0)});
-        ValidateJsonValue("$.\"\".\"\" == 0", {TString("\0\0", 2) + numSuffix(0)});
+        ValidateJsonValue("$.a.b == \"x\"", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonValue("$.a.b.c == null", {"\2a\2b\2c" + nullSuffix});
+        ValidateJsonValue("\"x\" == $.a.b.c", {"\2a\2b\2c" + strSuffix("x")});
+        ValidateJsonValue("$.aba.\"caba\" == true", {"\4aba\5caba" + boolTrueSuffix});
+        ValidateJsonValue("$.a.b.c.d == 0", {"\2a\2b\2c\2d" + numSuffix(0)});
+        ValidateJsonValue("$.\"\".\"\" == 0", {TString("\1\1", 2) + numSuffix(0)});
 
         // Array subscript
-        ValidateJsonValue("$.key[0] == \"x\"", {"\3key" + strSuffix("x")});
-        ValidateJsonValue("$.key[last] == true", {"\3key" + boolTrueSuffix});
-        ValidateJsonValue("$.key[1, 2, 3] == null", {"\3key" + nullSuffix});
-        ValidateJsonValue("$.key[0 to last] == 42", {"\3key" + numSuffix(42)});
-        ValidateJsonValue("$.key[0].sub == \"x\"", {"\3key\3sub" + strSuffix("x")});
-        ValidateJsonValue("$.a.b[0].c == \"x\"", {"\1a\1b\1c" + strSuffix("x")});
-        ValidateJsonValue("$.key[*] == \"x\"", {"\3key" + strSuffix("x")});
+        ValidateJsonValue("$.key[0] == \"x\"", {"\4key" + strSuffix("x")});
+        ValidateJsonValue("$.key[last] == true", {"\4key" + boolTrueSuffix});
+        ValidateJsonValue("$.key[1, 2, 3] == null", {"\4key" + nullSuffix});
+        ValidateJsonValue("$.key[0 to last] == 42", {"\4key" + numSuffix(42)});
+        ValidateJsonValue("$.key[0].sub == \"x\"", {"\4key\4sub" + strSuffix("x")});
+        ValidateJsonValue("$.a.b[0].c == \"x\"", {"\2a\2b\2c" + strSuffix("x")});
+        ValidateJsonValue("$.key[*] == \"x\"", {"\4key" + strSuffix("x")});
 
         // Wildcard member access finishes the path
         ValidateJsonValue("$.* == \"x\"", {""});
-        ValidateJsonValue("$.a.* == \"x\"", {"\1a"});
-        ValidateJsonValue("$.a.b.* == \"x\"", {"\1a\1b"});
+        ValidateJsonValue("$.a.* == \"x\"", {"\2a"});
+        ValidateJsonValue("$.a.b.* == \"x\"", {"\2a\2b"});
         ValidateJsonValue("\"x\" == $.*", {""});
-        ValidateJsonValue("\"x\" == $.a.*", {"\1a"});
+        ValidateJsonValue("\"x\" == $.a.*", {"\2a"});
 
         // Methods finish the path
-        ValidateJsonValue("$.key.size() == 3", {"\3key"});
-        ValidateJsonValue("$.key.abs() == 1", {"\3key"});
-        ValidateJsonValue("$.key.type() == \"number\"", {"\3key"});
-        ValidateJsonValue("$.a.b.floor() == 0", {"\1a\1b"});
-        ValidateJsonValue("$.key.keyvalue().name == \"x\"", {"\3key"});
+        ValidateJsonValue("$.key.size() == 3", {"\4key"});
+        ValidateJsonValue("$.key.abs() == 1", {"\4key"});
+        ValidateJsonValue("$.key.type() == \"number\"", {"\4key"});
+        ValidateJsonValue("$.a.b.floor() == 0", {"\2a\2b"});
+        ValidateJsonValue("$.key.keyvalue().name == \"x\"", {"\4key"});
 
         // Unary arithmetic on path finishes the path
-        ValidateJsonValue("-$.key == 1", {"\3key"});
-        ValidateJsonValue("+$.key == 1", {"\3key"});
-        ValidateJsonValue("-$.a.b == null", {"\1a\1b"});
+        ValidateJsonValue("-$.key == 1", {"\4key"});
+        ValidateJsonValue("+$.key == 1", {"\4key"});
+        ValidateJsonValue("-$.a.b == null", {"\2a\2b"});
 
         // Literal numeric value folded from unary + / - (same suffix as a plain number literal)
-        ValidateJsonValue("$.a == -10", {"\1a" + numSuffix(-10)});
-        ValidateJsonValue("$.k == +(-(+(-3)))", {"\1k" + numSuffix(3)});
-        ValidateJsonValue("$.key == +42", {"\3key" + numSuffix(42)});
-        ValidateJsonValue("$.key == -(-42)", {"\3key" + numSuffix(42)});
-        ValidateJsonValue("$.key == +(-15)", {"\3key" + numSuffix(-15)});
-        ValidateJsonValue("$.a.b == -(-(-2))", {"\1a\1b" + numSuffix(-2)});
+        ValidateJsonValue("$.a == -10", {"\2a" + numSuffix(-10)});
+        ValidateJsonValue("$.k == +(-(+(-3)))", {"\2k" + numSuffix(3)});
+        ValidateJsonValue("$.key == +42", {"\4key" + numSuffix(42)});
+        ValidateJsonValue("$.key == -(-42)", {"\4key" + numSuffix(42)});
+        ValidateJsonValue("$.key == +(-15)", {"\4key" + numSuffix(-15)});
+        ValidateJsonValue("$.a.b == -(-(-2))", {"\2a\2b" + numSuffix(-2)});
         ValidateJsonValue("$ == +(-(-7))", {numSuffix(7)});
-        ValidateJsonValue("-10 == $.a", {"\1a" + numSuffix(-10)});
-        ValidateJsonValue("+(-(+(-3))) == $.k", {"\1k" + numSuffix(3)});
+        ValidateJsonValue("-10 == $.a", {"\2a" + numSuffix(-10)});
+        ValidateJsonValue("+(-(+(-3))) == $.k", {"\2k" + numSuffix(3)});
 
         // Arithmetic produces multiple tokens
-        ValidateJsonValue("($.a + $.b) == \"x\"", {"\1a", "\1b"});
-        ValidateJsonValue("\"x\" == ($.a + $.b)", {"\1a", "\1b"});
-        ValidateJsonValue("$.key + 1 == \"x\"", {"\3key"});
-        ValidateJsonValue("1 + $.key == \"x\"", {"\3key"});
+        ValidateJsonValue("($.a + $.b) == \"x\"", {"\2a", "\2b"});
+        ValidateJsonValue("\"x\" == ($.a + $.b)", {"\2a", "\2b"});
+        ValidateJsonValue("$.key + 1 == \"x\"", {"\4key"});
+        ValidateJsonValue("1 + $.key == \"x\"", {"\4key"});
 
         // Parenthesized path - no effect
-        ValidateJsonValue("($.a.b) == \"x\"", {"\1a\1b" + strSuffix("x")});
-        ValidateJsonValue("\"x\" == ($.a.b)", {"\1a\1b" + strSuffix("x")});
-        ValidateJsonValue("(((((($).a).b))) == (\"x\"))", {"\1a\1b" + strSuffix("x")});
+        ValidateJsonValue("($.a.b) == \"x\"", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonValue("\"x\" == ($.a.b)", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonValue("(((((($).a).b))) == (\"x\"))", {"\2a\2b" + strSuffix("x")});
 
         // Predicates with equality operator -> nested predicates are not allowed
         ValidateError("exists($.key) == true", predError, ECallableType::JsonValue);
@@ -622,10 +642,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("false == ($.key == 10)", "Predicates are not allowed in this context", ECallableType::JsonExists);
 
         // Both operands are paths: merge index tokens with AND (same as comparison ops)
-        ValidateJsonValue("$.a == $.b", {"\1a", "\1b"});
-        ValidateJsonValue("$.key == $", {"\3key", ""});
+        ValidateJsonValue("$.a == $.b", {"\2a", "\2b"});
+        ValidateJsonValue("$.key == $", {"\4key", ""});
         ValidateJsonValue("$ == $", {""});
-        ValidateJsonValue("$.a.b == $.c.d", {"\1a\1b", "\1c\1d"});
+        ValidateJsonValue("$.a.b == $.c.d", {"\2a\2b", "\2c\2d"});
 
         // Literals only
         ValidateError("\"x\" == \"y\"", compError, ECallableType::JsonValue);
@@ -648,27 +668,27 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Mode is set to And only when more than one token is collected (same rule as BinaryArithmeticOp).
     Y_UNIT_TEST(CollectPath_ComparisonOperators) {
         // Literal on the right is dropped, only the path token is returned.
-        ValidateJsonValue("$.key < 10", {"\3key"});
-        ValidateJsonValue("$.key <= 10", {"\3key"});
-        ValidateJsonValue("$.key > 10", {"\3key"});
-        ValidateJsonValue("$.key >= 10", {"\3key"});
-        ValidateJsonValue("$.key != 10", {"\3key"});
-        ValidateJsonValue("$.key != -10", {"\3key"});
-        ValidateJsonValue("$.key >= -(+(-10))", {"\3key"});
-        ValidateJsonValue("$.key < \"hello\"", {"\3key"});
-        ValidateJsonValue("$.key != \"\"", {"\3key"});
-        ValidateJsonValue("$.key > 3.14", {"\3key"});
-        ValidateJsonValue("$.key >= true", {"\3key"});
-        ValidateJsonValue("$.key < null", {"\3key"});
+        ValidateJsonValue("$.key < 10", {"\4key"});
+        ValidateJsonValue("$.key <= 10", {"\4key"});
+        ValidateJsonValue("$.key > 10", {"\4key"});
+        ValidateJsonValue("$.key >= 10", {"\4key"});
+        ValidateJsonValue("$.key != 10", {"\4key"});
+        ValidateJsonValue("$.key != -10", {"\4key"});
+        ValidateJsonValue("$.key >= -(+(-10))", {"\4key"});
+        ValidateJsonValue("$.key < \"hello\"", {"\4key"});
+        ValidateJsonValue("$.key != \"\"", {"\4key"});
+        ValidateJsonValue("$.key > 3.14", {"\4key"});
+        ValidateJsonValue("$.key >= true", {"\4key"});
+        ValidateJsonValue("$.key < null", {"\4key"});
 
         // Literal on the left, path on the right - literal dropped, path token returned
-        ValidateJsonValue("10 < $.key", {"\3key"});
-        ValidateJsonValue("10 <= $.key", {"\3key"});
-        ValidateJsonValue("10 > $.key", {"\3key"});
-        ValidateJsonValue("10 >= $.key", {"\3key"});
-        ValidateJsonValue("10 != $.key", {"\3key"});
-        ValidateJsonValue("-10 != $.key", {"\3key"});
-        ValidateJsonValue("-(+(-10)) != $.key", {"\3key"});
+        ValidateJsonValue("10 < $.key", {"\4key"});
+        ValidateJsonValue("10 <= $.key", {"\4key"});
+        ValidateJsonValue("10 > $.key", {"\4key"});
+        ValidateJsonValue("10 >= $.key", {"\4key"});
+        ValidateJsonValue("10 != $.key", {"\4key"});
+        ValidateJsonValue("-10 != $.key", {"\4key"});
+        ValidateJsonValue("-(+(-10)) != $.key", {"\4key"});
 
         // Context object as path (empty prefix)
         ValidateJsonValue("$ < 5", {""});
@@ -676,42 +696,42 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateJsonValue("$ != null", {""});
 
         // Deeper member access paths
-        ValidateJsonValue("$.a.b.c < 42", {"\1a\1b\1c"});
-        ValidateJsonValue("$.a.b > -1", {"\1a\1b"});
-        ValidateJsonValue("$.aba.\"caba\" != false", {"\3aba\4caba"});
-        ValidateJsonValue("$.a.b.c.d >= 0", {"\1a\1b\1c\1d"});
+        ValidateJsonValue("$.a.b.c < 42", {"\2a\2b\2c"});
+        ValidateJsonValue("$.a.b > -1", {"\2a\2b"});
+        ValidateJsonValue("$.aba.\"caba\" != false", {"\4aba\5caba"});
+        ValidateJsonValue("$.a.b.c.d >= 0", {"\2a\2b\2c\2d"});
 
         // Array access
-        ValidateJsonValue("$.key[0] < 5", {"\3key"});
-        ValidateJsonValue("$.key[last] > true", {"\3key"});
-        ValidateJsonValue("$.key[1, 2, 3] != null", {"\3key"});
-        ValidateJsonValue("$.key[0 to last] >= 1", {"\3key"});
-        ValidateJsonValue("$.a.b[0].c <= \"x\"", {"\1a\1b\1c"});
+        ValidateJsonValue("$.key[0] < 5", {"\4key"});
+        ValidateJsonValue("$.key[last] > true", {"\4key"});
+        ValidateJsonValue("$.key[1, 2, 3] != null", {"\4key"});
+        ValidateJsonValue("$.key[0 to last] >= 1", {"\4key"});
+        ValidateJsonValue("$.a.b[0].c <= \"x\"", {"\2a\2b\2c"});
 
         // Wildcard member access finishes the path (literal not appended, but still dropped)
         ValidateJsonValue("$.* < 5", {""});
-        ValidateJsonValue("$.a.* > 1", {"\1a"});
-        ValidateJsonValue("$.a.b.* != \"x\"", {"\1a\1b"});
+        ValidateJsonValue("$.a.* > 1", {"\2a"});
+        ValidateJsonValue("$.a.b.* != \"x\"", {"\2a\2b"});
 
         // Wildcard array access
-        ValidateJsonValue("$.key[*] < 5", {"\3key"});
+        ValidateJsonValue("$.key[*] < 5", {"\4key"});
 
         // Methods finish the path
-        ValidateJsonValue("$.key.size() < -3", {"\3key"});
-        ValidateJsonValue("$.key.abs() >= 1", {"\3key"});
-        ValidateJsonValue("$.a.b.floor() != 0", {"\1a\1b"});
-        ValidateJsonValue("$.key.keyvalue().name > \"x\"", {"\3key"});
+        ValidateJsonValue("$.key.size() < -3", {"\4key"});
+        ValidateJsonValue("$.key.abs() >= 1", {"\4key"});
+        ValidateJsonValue("$.a.b.floor() != 0", {"\2a\2b"});
+        ValidateJsonValue("$.key.keyvalue().name > \"x\"", {"\4key"});
 
         // Unary arithmetic on path finishes the path
-        ValidateJsonValue("-$.key < 1", {"\3key"});
-        ValidateJsonValue("+$.key >= 0", {"\3key"});
+        ValidateJsonValue("-$.key < 1", {"\4key"});
+        ValidateJsonValue("+$.key >= 0", {"\4key"});
 
         // Both sides are paths - tokens from both collected (mode=And)
-        ValidateJsonValue("$.a < $.b", {"\1a", "\1b"});
-        ValidateJsonValue("$.a.b > $.c.d", {"\1a\1b", "\1c\1d"});
-        ValidateJsonValue("$.key != $.other", {"\3key", "\5other"});
-        ValidateJsonValue("$ <= $.a", {"", "\1a"});
-        ValidateJsonValue("$.a >= $", {"\1a", ""});
+        ValidateJsonValue("$.a < $.b", {"\2a", "\2b"});
+        ValidateJsonValue("$.a.b > $.c.d", {"\2a\2b", "\2c\2d"});
+        ValidateJsonValue("$.key != $.other", {"\4key", "\6other"});
+        ValidateJsonValue("$ <= $.a", {"", "\2a"});
+        ValidateJsonValue("$.a >= $", {"\2a", ""});
 
         // Both sides are literals - error
         ValidateError("1 < 2", emptyError, ECallableType::JsonValue);
@@ -720,10 +740,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
         // Arithmetic expression as operand (same as BinaryArithmeticOp behavior)
         // $.a + $.b produces mode=And, comparison also sets And - compatible
-        ValidateJsonValue("$.a + $.b < -5", {"\1a", "\1b"});
-        ValidateJsonValue("1 < $.a + $.b", {"\1a", "\1b"});
-        ValidateJsonValue("$.key + 1 >= 5", {"\3key"});
-        ValidateJsonValue("$.a.size() + $.b.abs() != 0", {"\1a", "\1b"});
+        ValidateJsonValue("$.a + $.b < -5", {"\2a", "\2b"});
+        ValidateJsonValue("1 < $.a + $.b", {"\2a", "\2b"});
+        ValidateJsonValue("$.key + 1 >= 5", {"\4key"});
+        ValidateJsonValue("$.a.size() + $.b.abs() != 0", {"\2a", "\2b"});
 
         // Comparison predicate nested inside another comparison
         ValidateError("($.a == -10) < -5", predError, ECallableType::JsonValue);
@@ -749,23 +769,23 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$.key != -10", predError, ECallableType::JsonExists);
 
         // Single-path comparison produces 1 token, NotSet mode, can appear in AND or OR
-        ValidateJsonValue("($.a < 5) && ($.b > 1)", {"\1a", "\1b"});
-        ValidateJsonValue("($.a <= 5) && ($.b >= 1)", {"\1a", "\1b"});
-        ValidateJsonValue("($.a != 5) && ($.b == 1)", {"\1a", "\1b" + numSuffix(1)});
-        ValidateJsonValue("($.a < 5) && ($.b > 1) && ($.c != 3)", {"\1a", "\1b", "\1c"});
+        ValidateJsonValue("($.a < 5) && ($.b > 1)", {"\2a", "\2b"});
+        ValidateJsonValue("($.a <= 5) && ($.b >= 1)", {"\2a", "\2b"});
+        ValidateJsonValue("($.a != 5) && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("($.a < 5) && ($.b > 1) && ($.c != 3)", {"\2a", "\2b", "\2c"});
 
-        ValidateJsonValue("($.a < 5) || ($.b > 1)", {"\1a", "\1b"});
-        ValidateJsonValue("($.a >= 5) || ($.b != -1)", {"\1a", "\1b"});
-        ValidateJsonValue("($.a != 5) || ($.b == 1)", {"\1a", "\1b" + numSuffix(1)});
-        ValidateJsonValue("($.a < -5) || ($.b > 1) || ($.c != 3)", {"\1a", "\1b", "\1c"});
+        ValidateJsonValue("($.a < 5) || ($.b > 1)", {"\2a", "\2b"});
+        ValidateJsonValue("($.a >= 5) || ($.b != -1)", {"\2a", "\2b"});
+        ValidateJsonValue("($.a != 5) || ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("($.a < -5) || ($.b > 1) || ($.c != 3)", {"\2a", "\2b", "\2c"});
 
         // Two-path comparison (And mode) mixed with OR: OR wins
-        ValidateJsonValue("($.a < $.b) || ($.c > 1)", {"\1a", "\1b", "\1c"});
-        ValidateJsonValue("($.a != $.b) || ($.c == -1)", {"\1a", "\1b", "\1c" + numSuffix(-1)});
+        ValidateJsonValue("($.a < $.b) || ($.c > 1)", {"\2a", "\2b", "\2c"});
+        ValidateJsonValue("($.a != $.b) || ($.c == -1)", {"\2a", "\2b", "\2c" + numSuffix(-1)});
 
         // AND chain with OR: OR wins, all tokens become OR
-        ValidateJsonValue("($.a < -5) && ($.b == 1) || ($.c > 2)", {"\1a", "\1b" + numSuffix(1), "\1c"});
-        ValidateJsonValue("($.a < -5) && ($.b > -1) || ($.c != 3)", {"\1a", "\1b", "\1c"});
+        ValidateJsonValue("($.a < -5) && ($.b == 1) || ($.c > 2)", {"\2a", "\2b" + numSuffix(1), "\2c"});
+        ValidateJsonValue("($.a < -5) && ($.b > -1) || ($.c != 3)", {"\2a", "\2b", "\2c"});
 
         // Variables
         ValidateError("$var < 5", varError, ECallableType::JsonValue);
@@ -776,59 +796,59 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Comparison operators inside filter predicates (EMode::Filter allows predicates)
     Y_UNIT_TEST(CollectPath_ComparisonOperators_InFilter) {
         // Basic filter with each comparison op
-        ValidateJsonExists("$.a ? (@.b < 10)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b <= -10)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b > 10)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b >= +10)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b != 10)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b < 10)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b <= -10)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b > 10)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b >= +10)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b != 10)", {"\2a\2b"});
 
         // All literal types as right operand (dropped)
-        ValidateJsonExists("$.a ? (@.b < \"hello\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b > -3.14)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b != true)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b >= null)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b < \"hello\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b > -3.14)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b != true)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b >= null)", {"\2a\2b"});
 
         // Literal on the left, @ path on the right
-        ValidateJsonExists("$.a ? (10 < @.b)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (\"x\" != @.b)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (10 < @.b)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (\"x\" != @.b)", {"\2a\2b"});
 
         // @ itself (filter object) as operand
-        ValidateJsonExists("$.a ? (@ < 10)", {"\1a"});
-        ValidateJsonExists("$.a ? (@ != \"x\")", {"\1a"});
-        ValidateJsonExists("$.a.b ? (@ > 0)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@ < 10)", {"\2a"});
+        ValidateJsonExists("$.a ? (@ != \"x\")", {"\2a"});
+        ValidateJsonExists("$.a.b ? (@ > 0)", {"\2a\2b"});
 
         // Deeper filter-object paths
-        ValidateJsonExists("$.a ? (@.b.c < -(+(-5)))", {"\1a\1b\1c"});
-        ValidateJsonExists("$.a.b ? (@.c.d != null)", {"\1a\1b\1c\1d"});
+        ValidateJsonExists("$.a ? (@.b.c < -(+(-5)))", {"\2a\2b\2c"});
+        ValidateJsonExists("$.a.b ? (@.c.d != null)", {"\2a\2b\2c\2d"});
 
         // Method on filter-object path (finishes, literal dropped)
-        ValidateJsonExists("$.a ? (@.b.size() < -3)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.abs() >= 0)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b.size() < -3)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.abs() >= 0)", {"\2a\2b"});
 
         // Unary on filter-object path (finishes, literal dropped)
-        ValidateJsonExists("$.a ? (-@.b < 5)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (+@.b >= 0)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (-@.b < 5)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (+@.b >= 0)", {"\2a\2b"});
 
         // Both operands are @-paths (both tokens collected)
-        ValidateJsonExists("$.key ? (@.a < @.b)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.x != @.y)", {"\3key\1x", "\3key\1y"});
+        ValidateJsonExists("$.key ? (@.a < @.b)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.x != @.y)", {"\4key\2x", "\4key\2y"});
 
         // Wildcard on filter-object path
-        ValidateJsonExists("$.a ? (@.* < 5)", {"\1a"});
-        ValidateJsonExists("$.a ? (@.b.* != 1)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.* < 5)", {"\2a"});
+        ValidateJsonExists("$.a ? (@.b.* != 1)", {"\2a\2b"});
 
         // Comparison in AND inside filter
-        ValidateJsonExists("$.a ? (@.b < +10 && @.c == 1)", {"\1a\1b", "\1a\1c" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (@.b > 0 && @.b < 100)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b != 5 && @.c >= 0 && @.d <= -10)", {"\1a\1b", "\1a\1c", "\1a\1d"});
+        ValidateJsonExists("$.a ? (@.b < +10 && @.c == 1)", {"\2a\2b", "\2a\2c" + numSuffix(1)});
+        ValidateJsonExists("$.a ? (@.b > 0 && @.b < 100)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b != 5 && @.c >= 0 && @.d <= -10)", {"\2a\2b", "\2a\2c", "\2a\2d"});
 
         // Comparison in OR inside filter
-        ValidateJsonExists("$.a ? ((@.b < 5) || (@.c > 10))", {"\1a\1b", "\1a\1c"});
-        ValidateJsonExists("$.a ? ((@.b != 1) || (@.c != 2))", {"\1a\1b", "\1a\1c"});
+        ValidateJsonExists("$.a ? ((@.b < 5) || (@.c > 10))", {"\2a\2b", "\2a\2c"});
+        ValidateJsonExists("$.a ? ((@.b != 1) || (@.c != 2))", {"\2a\2b", "\2a\2c"});
 
         // Mixing AND and OR inside filter: OR wins
-        ValidateJsonExists("$.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2)))", {"\1a\1b", "\1a\1c", "\1a\1d"});
-        ValidateJsonExists("$.a ? (((@.b < 5) || (@.c > 1)) && @.d > 2)", {"\1a\1b", "\1a\1c", "\1a\1d"});
+        ValidateJsonExists("$.a ? ((@.b < 5) && ((@.c > 1) || (@.d > 2)))", {"\2a\2b", "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("$.a ? (((@.b < 5) || (@.c > 1)) && @.d > 2)", {"\2a\2b", "\2a\2c", "\2a\2d"});
 
         // Nested predicate in filter operand is blocked (EMode::Predicate on operand)
         ValidateError("$.a ? (($.b == 1) < 5)", predError, ECallableType::JsonExists);
@@ -841,146 +861,146 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$.a ? ((@.b != 1) is unknown)", predError, ECallableType::JsonExists);
 
         // Arithmetic expression as comparison operand in filter
-        ValidateJsonExists("$.key ? (@.a + @.b < +5)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.a * 2 != 0)", {"\3key\1a"});
+        ValidateJsonExists("$.key ? (@.a + @.b < +5)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.a * 2 != 0)", {"\4key\2a"});
 
         // JsonValue also supports comparison in filter
-        ValidateJsonValue("$.a ? (@.b < -10)", {"\1a\1b"});
-        ValidateJsonValue("$.a ? (@.b != null && @.c >= 1)", {"\1a\1b", "\1a\1c"});
+        ValidateJsonValue("$.a ? (@.b < -10)", {"\2a\2b"});
+        ValidateJsonValue("$.a ? (@.b != null && @.c >= 1)", {"\2a\2b", "\2a\2c"});
     }
 
     // Comparison operators (path vs path produce And mode) combined with && and ||
     Y_UNIT_TEST(CollectPath_ComparisonWithBooleanOps) {
         // Two-path comparison (And mode) in AND chain: compatible, stays And
-        ValidateJsonValue("($.a < $.b) && ($.c > $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a <= $.b) && ($.c >= $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a != $.b) && ($.c == $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a == $.b) && ($.c < $.d) && ($.e > $.f)", {"\1a", "\1b", "\1c", "\1d", "\1e", "\1f"},
+        ValidateJsonValue("($.a < $.b) && ($.c > $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a <= $.b) && ($.c >= $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a != $.b) && ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a == $.b) && ($.c < $.d) && ($.e > $.f)", {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"},
             TCollectResult::ETokensMode::And);
 
         // Two-path comparison (And mode) in OR: OR wins
-        ValidateJsonValue("($.a < $.b) || ($.c > $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a <= $.b) || ($.c >= $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a != $.b) || ($.c == $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < $.b) || ($.c > $.d) || ($.e != $.f)", {"\1a", "\1b", "\1c", "\1d", "\1e", "\1f"},
+        ValidateJsonValue("($.a < $.b) || ($.c > $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a <= $.b) || ($.c >= $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a != $.b) || ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a < $.b) || ($.c > $.d) || ($.e != $.f)", {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"},
             TCollectResult::ETokensMode::Or);
 
         // Single-path comparison (NotSet mode) in AND chain
-        ValidateJsonValue("($.a < 5) && ($.b > 3) && ($.c <= 10)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a > 0) && ($.b >= 1) && ($.c != 0) && ($.d == 2)", {"\1a", "\1b", "\1c", "\1d" + numSuffix(2)},
+        ValidateJsonValue("($.a < 5) && ($.b > 3) && ($.c <= 10)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a > 0) && ($.b >= 1) && ($.c != 0) && ($.d == 2)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(2)},
             TCollectResult::ETokensMode::And);
 
         // Single-path comparison in OR chain
-        ValidateJsonValue("($.a < 5) || ($.b > 3) || ($.c <= 10)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a > 0) || ($.b >= 1) || ($.c != 0) || ($.d == 2)", {"\1a", "\1b", "\1c", "\1d" + numSuffix(2)}, 
+        ValidateJsonValue("($.a < 5) || ($.b > 3) || ($.c <= 10)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a > 0) || ($.b >= 1) || ($.c != 0) || ($.d == 2)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(2)}, 
             TCollectResult::ETokensMode::Or);
 
         // Mix of single-path and two-path comparisons in AND: compatible (neither has Or)
-        ValidateJsonValue("($.a < 5) && ($.b > $.c)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a < $.b) && ($.c > 5)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a < 5) && ($.b > $.c) && ($.d == 1)", {"\1a", "\1b", "\1c", "\1d" + numSuffix(1)}, 
+        ValidateJsonValue("($.a < 5) && ($.b > $.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a < $.b) && ($.c > 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a < 5) && ($.b > $.c) && ($.d == 1)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(1)}, 
             TCollectResult::ETokensMode::And);
 
         // Mix of single-path and two-path comparisons in OR: OR wins
-        ValidateJsonValue("($.a < 5) || ($.b > $.c)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < $.b) || ($.c > 5)", {"\1a", "\1b", "\1c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a < 5) || ($.b > $.c)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a < $.b) || ($.c > 5)", {"\2a", "\2b", "\2c"}, TCollectResult::ETokensMode::Or);
 
         // AND chain then OR: OR wins
-        ValidateJsonValue("($.a < $.b) && ($.c > 1) || ($.d != 0)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonValue("($.a < 5) && ($.b > $.c) || ($.d == 1)", {"\1a", "\1b", "\1c", "\1d" + numSuffix(1)},
+        ValidateJsonValue("($.a < $.b) && ($.c > 1) || ($.d != 0)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a < 5) && ($.b > $.c) || ($.d == 1)", {"\2a", "\2b", "\2c", "\2d" + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
 
         // Two-path equality combined via AND and OR
-        ValidateJsonValue("($.a == $.b) && ($.c == $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonValue("($.a == $.b) || ($.c == $.d)", {"\1a", "\1b", "\1c", "\1d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonValue("($.a == $.b) && ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonValue("($.a == $.b) || ($.c == $.d)", {"\2a", "\2b", "\2c", "\2d"}, TCollectResult::ETokensMode::Or);
 
         // Filter: two-path comparison combined with AND/OR
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > 1)", {"\3key\1a", "\3key\1b", "\3key\1c"}, TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.key ? (@.a < @.b || @.c > 1)", {"\3key\1a", "\3key\1b", "\3key\1c"}, TCollectResult::ETokensMode::Or);
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d)", {"\3key\1a", "\3key\1b", "\3key\1c", "\3key\1d"}, TCollectResult::ETokensMode::And);
-        ValidateJsonExists("$.key ? (@.a < @.b || @.c > @.d)", {"\3key\1a", "\3key\1b", "\3key\1c", "\3key\1d"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonExists("$.key ? (@.a < @.b && @.c > 1)", {"\4key\2a", "\4key\2b", "\4key\2c"}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("$.key ? (@.a < @.b || @.c > 1)", {"\4key\2a", "\4key\2b", "\4key\2c"}, TCollectResult::ETokensMode::Or);
+        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"}, TCollectResult::ETokensMode::And);
+        ValidateJsonExists("$.key ? (@.a < @.b || @.c > @.d)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d"}, TCollectResult::ETokensMode::Or);
 
         // Filter: AND chain with OR - OR wins
-        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d || @.e == 1)", {"\3key\1a", "\3key\1b", "\3key\1c", "\3key\1d", "\3key\1e" + numSuffix(1)},
+        ValidateJsonExists("$.key ? (@.a < @.b && @.c > @.d || @.e == 1)", {"\4key\2a", "\4key\2b", "\4key\2c", "\4key\2d", "\4key\2e" + numSuffix(1)},
             TCollectResult::ETokensMode::Or);
     }
 
     Y_UNIT_TEST(CollectPath_BinaryAnd) {
         // Basic equality on both sides, all literal types
-        ValidateJsonValue("($.a == 10) && ($.b == \"hello\")", {"\1a" + numSuffix(10), "\1b" + strSuffix("hello")});
-        ValidateJsonValue("(42 == $.key) && ($.val == true)", {"\3key" + numSuffix(42), "\3val" + boolTrueSuffix});
-        ValidateJsonValue("($.x == null) && ($.y == false)", {"\1x" + nullSuffix, "\1y" + boolFalseSuffix});
-        ValidateJsonValue("($.a == 0) && ($.b == 3.14)", {"\1a" + numSuffix(0), "\1b" + numSuffix(3.14)});
-        ValidateJsonValue("(\"hello\" == $.a) && (null == $.b)", {"\1a" + strSuffix("hello"), "\1b" + nullSuffix});
+        ValidateJsonValue("($.a == 10) && ($.b == \"hello\")", {"\2a" + numSuffix(10), "\2b" + strSuffix("hello")});
+        ValidateJsonValue("(42 == $.key) && ($.val == true)", {"\4key" + numSuffix(42), "\4val" + boolTrueSuffix});
+        ValidateJsonValue("($.x == null) && ($.y == false)", {"\2x" + nullSuffix, "\2y" + boolFalseSuffix});
+        ValidateJsonValue("($.a == 0) && ($.b == 3.14)", {"\2a" + numSuffix(0), "\2b" + numSuffix(3.14)});
+        ValidateJsonValue("(\"hello\" == $.a) && (null == $.b)", {"\2a" + strSuffix("hello"), "\2b" + nullSuffix});
 
         // Deeper member access paths
-        ValidateJsonValue("($.a.b.c == 1) && ($.x.y == \"z\")", {"\1a\1b\1c" + numSuffix(1), "\1x\1y" + strSuffix("z")});
-        ValidateJsonValue("($.aba.\"caba\" == true) && ($.d.e.f == 0)", {"\3aba\4caba" + boolTrueSuffix, "\1d\1e\1f" + numSuffix(0)});
-        ValidateJsonValue("($.a.b.c.d == 0) && ($.p.q == null)", {"\1a\1b\1c\1d" + numSuffix(0), "\1p\1q" + nullSuffix});
+        ValidateJsonValue("($.a.b.c == 1) && ($.x.y == \"z\")", {"\2a\2b\2c" + numSuffix(1), "\2x\2y" + strSuffix("z")});
+        ValidateJsonValue("($.aba.\"caba\" == true) && ($.d.e.f == 0)", {"\4aba\5caba" + boolTrueSuffix, "\2d\2e\2f" + numSuffix(0)});
+        ValidateJsonValue("($.a.b.c.d == 0) && ($.p.q == null)", {"\2a\2b\2c\2d" + numSuffix(0), "\2p\2q" + nullSuffix});
 
         // Context object as path (empty prefix)
-        ValidateJsonValue("($ == \"root\") && ($.b == 2)", {strSuffix("root"), "\1b" + numSuffix(2)});
+        ValidateJsonValue("($ == \"root\") && ($.b == 2)", {strSuffix("root"), "\2b" + numSuffix(2)});
         ValidateJsonValue("($ == null) && ($ == 42)", {nullSuffix, numSuffix(42)});
 
         // Array access
-        ValidateJsonValue("($.key[0] == 1) && ($.arr[last] == true)", {"\3key" + numSuffix(1), "\3arr" + boolTrueSuffix});
-        ValidateJsonValue("($.key[1, 2, 3] == null) && ($.b[0 to last] == \"x\")", {"\3key" + nullSuffix, "\1b" + strSuffix("x")});
-        ValidateJsonValue("($.a.b[0].c == \"x\") && ($.d.e == false)", {"\1a\1b\1c" + strSuffix("x"), "\1d\1e" + boolFalseSuffix});
-        ValidateJsonValue("($.key[0].sub == \"x\") && ($.v == 1)", {"\3key\3sub" + strSuffix("x"), "\1v" + numSuffix(1)});
+        ValidateJsonValue("($.key[0] == 1) && ($.arr[last] == true)", {"\4key" + numSuffix(1), "\4arr" + boolTrueSuffix});
+        ValidateJsonValue("($.key[1, 2, 3] == null) && ($.b[0 to last] == \"x\")", {"\4key" + nullSuffix, "\2b" + strSuffix("x")});
+        ValidateJsonValue("($.a.b[0].c == \"x\") && ($.d.e == false)", {"\2a\2b\2c" + strSuffix("x"), "\2d\2e" + boolFalseSuffix});
+        ValidateJsonValue("($.key[0].sub == \"x\") && ($.v == 1)", {"\4key\4sub" + strSuffix("x"), "\2v" + numSuffix(1)});
 
         // Wildcard member access (finishes collection, no literal suffix appended)
-        ValidateJsonValue("($.a.* == \"x\") && ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.* == \"x\") && ($.b == 2)", {"", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && ($.b.* == \"z\")", {"\1a" + numSuffix(1), "\1b"});
-        ValidateJsonValue("($.a.b.* == true) && ($.c.* == null)", {"\1a\1b", "\1c"});
+        ValidateJsonValue("($.a.* == \"x\") && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.* == \"x\") && ($.b == 2)", {"\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) && ($.b.* == \"z\")", {"\2a" + numSuffix(1), "\2b"});
+        ValidateJsonValue("($.a.b.* == true) && ($.c.* == null)", {"\2a\2b", "\2c"});
 
         // Wildcard array access
-        ValidateJsonValue("($.key[*] == \"x\") && ($.b == 2)", {"\3key" + strSuffix("x"), "\1b" + numSuffix(2)});
+        ValidateJsonValue("($.key[*] == \"x\") && ($.b == 2)", {"\4key" + strSuffix("x"), "\2b" + numSuffix(2)});
 
         // Methods (finish the path, no literal suffix appended)
-        ValidateJsonValue("($.key.size() == 3) && ($.val == 1)", {"\3key", "\3val" + numSuffix(1)});
-        ValidateJsonValue("($.a == \"x\") && ($.key.abs() == 2)", {"\1a" + strSuffix("x"), "\3key"});
-        ValidateJsonValue("($.a.floor() == 0) && ($.b.type() == \"number\")", {"\1a", "\1b"});
-        ValidateJsonValue("($.key.keyvalue().name == \"x\") && ($.v == true)", {"\3key", "\1v" + boolTrueSuffix});
-        ValidateJsonValue("($.a.size() == 5) && ($.b.ceiling() == 3)", {"\1a", "\1b"});
+        ValidateJsonValue("($.key.size() == 3) && ($.val == 1)", {"\4key", "\4val" + numSuffix(1)});
+        ValidateJsonValue("($.a == \"x\") && ($.key.abs() == 2)", {"\2a" + strSuffix("x"), "\4key"});
+        ValidateJsonValue("($.a.floor() == 0) && ($.b.type() == \"number\")", {"\2a", "\2b"});
+        ValidateJsonValue("($.key.keyvalue().name == \"x\") && ($.v == true)", {"\4key", "\2v" + boolTrueSuffix});
+        ValidateJsonValue("($.a.size() == 5) && ($.b.ceiling() == 3)", {"\2a", "\2b"});
 
         // StartsWith predicate on left and right
-        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1)", {"\1a", "\1b" + numSuffix(1)});
-        ValidateJsonValue("($.a == 1) && ($.b starts with \"y\")", {"\1a" + numSuffix(1), "\1b"});
-        ValidateJsonValue("($.a.b.c starts with \"abc\") && ($.d[0] == null)", {"\1a\1b\1c", "\1d" + nullSuffix});
-        ValidateJsonValue("($.a starts with \"x\") && ($.b starts with \"y\")", {"\1a", "\1b"});
-        ValidateJsonValue("($.a.* starts with \"x\") && ($.b == 1)", {"\1a", "\1b" + numSuffix(1)});
+        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("($.a == 1) && ($.b starts with \"y\")", {"\2a" + numSuffix(1), "\2b"});
+        ValidateJsonValue("($.a.b.c starts with \"abc\") && ($.d[0] == null)", {"\2a\2b\2c", "\2d" + nullSuffix});
+        ValidateJsonValue("($.a starts with \"x\") && ($.b starts with \"y\")", {"\2a", "\2b"});
+        ValidateJsonValue("($.a.* starts with \"x\") && ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
 
         // LikeRegex predicate on left and right
-        ValidateJsonValue("($.a like_regex \".*\") && ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == \"x\") && ($.b like_regex \"[a-z]+\")", {"\1a" + strSuffix("x"), "\1b"});
-        ValidateJsonValue("($.a like_regex \"x.*\") && ($.b like_regex \"y.*\")", {"\1a", "\1b"});
+        ValidateJsonValue("($.a like_regex \".*\") && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == \"x\") && ($.b like_regex \"[a-z]+\")", {"\2a" + strSuffix("x"), "\2b"});
+        ValidateJsonValue("($.a like_regex \"x.*\") && ($.b like_regex \"y.*\")", {"\2a", "\2b"});
 
         // Exists predicate on left and right
-        ValidateJsonValue("exists($.a) && ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && exists($.b.c)", {"\1a" + numSuffix(1), "\1b\1c"});
-        ValidateJsonValue("exists($.a.b[0]) && exists($.c.*)", {"\1a\1b", "\1c"});
-        ValidateJsonValue("exists($.a.key.size()) && ($.b == true)", {"\1a\3key", "\1b" + boolTrueSuffix});
+        ValidateJsonValue("exists($.a) && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) && exists($.b.c)", {"\2a" + numSuffix(1), "\2b\2c"});
+        ValidateJsonValue("exists($.a.b[0]) && exists($.c.*)", {"\2a\2b", "\2c"});
+        ValidateJsonValue("exists($.a.key.size()) && ($.b == true)", {"\2a\4key", "\2b" + boolTrueSuffix});
 
         // Unary arithmetic operand (finishes, no literal suffix)
-        ValidateJsonValue("(-$.a == 1) && ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) && (+$.b.c == 0)", {"\1a" + numSuffix(1), "\1b\1c"});
-        ValidateJsonValue("(-$.a.b.* == 1) && ($.c == 2)", {"\1a\1b", "\1c" + numSuffix(2)});
+        ValidateJsonValue("(-$.a == 1) && ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) && (+$.b.c == 0)", {"\2a" + numSuffix(1), "\2b\2c"});
+        ValidateJsonValue("(-$.a.b.* == 1) && ($.c == 2)", {"\2a\2b", "\2c" + numSuffix(2)});
 
         // Binary arithmetic with two paths as AND operand (two path tokens, And mode, compatible with AND)
         // $.a + $.b == "x" is parsed as ($.a + $.b) == "x", arithmetic finishes, literal not appended
-        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\1c" + numSuffix(1), "\1a", "\1b"});
-        ValidateJsonValue("($.a.size() + $.b.abs() == 5) && ($.c == null)", {"\1a", "\1b", "\1c" + nullSuffix});
+        ValidateJsonValue("($.a + $.b == \"x\") && ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.c == 1) && ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"});
+        ValidateJsonValue("($.a.size() + $.b.abs() == 5) && ($.c == null)", {"\2a", "\2b", "\2c" + nullSuffix});
 
         // Chained AND (left-associative)
-        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3) && ($.d == 4)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
-        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1) && exists($.c.d)", {"\1a", "\1b" + numSuffix(1), "\1c\1d"});
-        ValidateJsonValue("($.a like_regex \".*\") && ($.b.* == 2) && ($.c.size() == 3) && exists($.d)", {"\1a", "\1b", "\1c", "\1d"});
+        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3) && ($.d == 4)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("($.a starts with \"x\") && ($.b == 1) && exists($.c.d)", {"\2a", "\2b" + numSuffix(1), "\2c\2d"});
+        ValidateJsonValue("($.a like_regex \".*\") && ($.b.* == 2) && ($.c.size() == 3) && exists($.d)", {"\2a", "\2b", "\2c", "\2d"});
 
         // Same path on both sides (two different equality conditions)
-        ValidateJsonValue("($.a == 1) && ($.a == 2)", {"\1a" + numSuffix(1), "\1a" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) && ($.a == 2)", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
 
         // Variables are not supported
         ValidateError("($var == 1) && ($.b == 2)", varError, ECallableType::JsonValue);
@@ -993,10 +1013,10 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("exists($.a) && exists($.b)", predError, ECallableType::JsonExists);
 
         // Mixing AND and OR: OR wins, all tokens become OR
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
+        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
 
         // Nested predicates: AND appears in predicate position (inside exists / is unknown / == literal)
         // BinaryAnd inherits EMode::Predicate and its operands (==, starts with, like_regex, exists) are blocked
@@ -1010,58 +1030,58 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
 
     Y_UNIT_TEST(CollectPath_BinaryOr) {
         // Basic equality on both sides, all literal types
-        ValidateJsonValue("($.a == 10) || ($.b == \"hello\")", {"\1a" + numSuffix(10), "\1b" + strSuffix("hello")});
-        ValidateJsonValue("(42 == $.key) || ($.val == true)", {"\3key" + numSuffix(42), "\3val" + boolTrueSuffix});
-        ValidateJsonValue("($.x == null) || ($.y == false)", {"\1x" + nullSuffix, "\1y" + boolFalseSuffix});
-        ValidateJsonValue("($.a == 0) || ($.b == 3.14)", {"\1a" + numSuffix(0), "\1b" + numSuffix(3.14)});
-        ValidateJsonValue("($ == \"root\") || ($.b == 2)", {strSuffix("root"), "\1b" + numSuffix(2)});
+        ValidateJsonValue("($.a == 10) || ($.b == \"hello\")", {"\2a" + numSuffix(10), "\2b" + strSuffix("hello")});
+        ValidateJsonValue("(42 == $.key) || ($.val == true)", {"\4key" + numSuffix(42), "\4val" + boolTrueSuffix});
+        ValidateJsonValue("($.x == null) || ($.y == false)", {"\2x" + nullSuffix, "\2y" + boolFalseSuffix});
+        ValidateJsonValue("($.a == 0) || ($.b == 3.14)", {"\2a" + numSuffix(0), "\2b" + numSuffix(3.14)});
+        ValidateJsonValue("($ == \"root\") || ($.b == 2)", {strSuffix("root"), "\2b" + numSuffix(2)});
 
         // Deeper member access paths
-        ValidateJsonValue("($.a.b.c == 1) || ($.x.y == \"z\")", {"\1a\1b\1c" + numSuffix(1), "\1x\1y" + strSuffix("z")});
-        ValidateJsonValue("($.aba.\"caba\" == true) || ($.d.e.f == 0)", {"\3aba\4caba" + boolTrueSuffix, "\1d\1e\1f" + numSuffix(0)});
+        ValidateJsonValue("($.a.b.c == 1) || ($.x.y == \"z\")", {"\2a\2b\2c" + numSuffix(1), "\2x\2y" + strSuffix("z")});
+        ValidateJsonValue("($.aba.\"caba\" == true) || ($.d.e.f == 0)", {"\4aba\5caba" + boolTrueSuffix, "\2d\2e\2f" + numSuffix(0)});
 
         // Array access
-        ValidateJsonValue("($.key[0] == 1) || ($.arr[last] == true)", {"\3key" + numSuffix(1), "\3arr" + boolTrueSuffix});
-        ValidateJsonValue("($.key[1, 2, 3] == null) || ($.b[0 to last] == \"x\")", {"\3key" + nullSuffix, "\1b" + strSuffix("x")});
-        ValidateJsonValue("($.a.b[0].c == \"x\") || ($.d.e == false)", {"\1a\1b\1c" + strSuffix("x"), "\1d\1e" + boolFalseSuffix});
+        ValidateJsonValue("($.key[0] == 1) || ($.arr[last] == true)", {"\4key" + numSuffix(1), "\4arr" + boolTrueSuffix});
+        ValidateJsonValue("($.key[1, 2, 3] == null) || ($.b[0 to last] == \"x\")", {"\4key" + nullSuffix, "\2b" + strSuffix("x")});
+        ValidateJsonValue("($.a.b[0].c == \"x\") || ($.d.e == false)", {"\2a\2b\2c" + strSuffix("x"), "\2d\2e" + boolFalseSuffix});
 
         // Wildcard member and array access (finishes, no literal suffix)
-        ValidateJsonValue("($.a.* == \"x\") || ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.* == \"x\") || ($.b == 2)", {"", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) || ($.b.* == \"z\")", {"\1a" + numSuffix(1), "\1b"});
-        ValidateJsonValue("($.key[*] == \"x\") || ($.b == 2)", {"\3key" + strSuffix("x"), "\1b" + numSuffix(2)});
+        ValidateJsonValue("($.a.* == \"x\") || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.* == \"x\") || ($.b == 2)", {""});
+        ValidateJsonValue("($.a == 1) || ($.b.* == \"z\")", {"\2a" + numSuffix(1), "\2b"});
+        ValidateJsonValue("($.key[*] == \"x\") || ($.b == 2)", {"\4key" + strSuffix("x"), "\2b" + numSuffix(2)});
 
         // Methods (finish the path, no literal suffix)
-        ValidateJsonValue("($.key.size() == 3) || ($.val == 1)", {"\3key", "\3val" + numSuffix(1)});
-        ValidateJsonValue("($.a == \"x\") || ($.key.abs() == 2)", {"\1a" + strSuffix("x"), "\3key"});
-        ValidateJsonValue("($.a.floor() == 0) || ($.b.type() == \"number\")", {"\1a", "\1b"});
-        ValidateJsonValue("($.key.keyvalue().name == \"x\") || ($.v == true)", {"\3key", "\1v" + boolTrueSuffix});
+        ValidateJsonValue("($.key.size() == 3) || ($.val == 1)", {"\4key", "\4val" + numSuffix(1)});
+        ValidateJsonValue("($.a == \"x\") || ($.key.abs() == 2)", {"\2a" + strSuffix("x"), "\4key"});
+        ValidateJsonValue("($.a.floor() == 0) || ($.b.type() == \"number\")", {"\2a", "\2b"});
+        ValidateJsonValue("($.key.keyvalue().name == \"x\") || ($.v == true)", {"\4key", "\2v" + boolTrueSuffix});
 
         // StartsWith predicate
-        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1)", {"\1a", "\1b" + numSuffix(1)});
-        ValidateJsonValue("($.a == 1) || ($.b starts with \"y\")", {"\1a" + numSuffix(1), "\1b"});
-        ValidateJsonValue("($.a starts with \"x\") || ($.b starts with \"y\")", {"\1a", "\1b"});
-        ValidateJsonValue("($.a.* starts with \"x\") || ($.b[0] == 1)", {"\1a", "\1b" + numSuffix(1)});
+        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1)", {"\2a", "\2b" + numSuffix(1)});
+        ValidateJsonValue("($.a == 1) || ($.b starts with \"y\")", {"\2a" + numSuffix(1), "\2b"});
+        ValidateJsonValue("($.a starts with \"x\") || ($.b starts with \"y\")", {"\2a", "\2b"});
+        ValidateJsonValue("($.a.* starts with \"x\") || ($.b[0] == 1)", {"\2a", "\2b" + numSuffix(1)});
 
         // LikeRegex predicate
-        ValidateJsonValue("($.a like_regex \".*\") || ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == \"x\") || ($.b like_regex \"[a-z]+\")", {"\1a" + strSuffix("x"), "\1b"});
-        ValidateJsonValue("($.a like_regex \"x.*\") || ($.b like_regex \"y.*\")", {"\1a", "\1b"});
+        ValidateJsonValue("($.a like_regex \".*\") || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == \"x\") || ($.b like_regex \"[a-z]+\")", {"\2a" + strSuffix("x"), "\2b"});
+        ValidateJsonValue("($.a like_regex \"x.*\") || ($.b like_regex \"y.*\")", {"\2a", "\2b"});
 
         // Exists predicate
-        ValidateJsonValue("exists($.a) || ($.b == 2)", {"\1a", "\1b" + numSuffix(2)});
-        ValidateJsonValue("($.a == 1) || exists($.b.c)", {"\1a" + numSuffix(1), "\1b\1c"});
-        ValidateJsonValue("exists($.a.b[0]) || exists($.c.*)", {"\1a\1b", "\1c"});
+        ValidateJsonValue("exists($.a) || ($.b == 2)", {"\2a", "\2b" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) || exists($.b.c)", {"\2a" + numSuffix(1), "\2b\2c"});
+        ValidateJsonValue("exists($.a.b[0]) || exists($.c.*)", {"\2a\2b", "\2c"});
 
         // Same path on both sides, different values
-        ValidateJsonValue("($.a == 1) || ($.a == 2)", {"\1a" + numSuffix(1), "\1a" + numSuffix(2)});
+        ValidateJsonValue("($.a == 1) || ($.a == 2)", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
         ValidateJsonValue("($.key == \"a\") || ($.key == \"b\") || ($.key == \"c\")",
-            {"\3key" + strSuffix("a"), "\3key" + strSuffix("b"), "\3key" + strSuffix("c")});
+            {"\4key" + strSuffix("a"), "\4key" + strSuffix("b"), "\4key" + strSuffix("c")});
 
         // Chained OR (left-associative)
-        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3)",{"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3) || ($.d == 4)",{"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
-        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1) || exists($.c.d)",{"\1a", "\1b" + numSuffix(1), "\1c\1d"});
+        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3)",{"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3) || ($.d == 4)",{"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
+        ValidateJsonValue("($.a starts with \"x\") || ($.b == 1) || exists($.c.d)",{"\2a", "\2b" + numSuffix(1), "\2c\2d"});
 
         // Variable on left or right side
         ValidateError("($var == 1) || ($.b == 2)", varError, ECallableType::JsonValue);
@@ -1074,15 +1094,15 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("exists($.a) || exists($.b)", predError, ECallableType::JsonExists);
 
         // Arithmetic with multiple paths (And mode) mixed with OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\1c" + numSuffix(1), "\1a", "\1b"});
-        ValidateJsonValue("($.a.size() + $.b.abs() == 5) || ($.c == null)", {"\1a", "\1b", "\1c" + nullSuffix});
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.c == 1) || ($.a + $.b == \"x\")", {"\2c" + numSuffix(1), "\2a", "\2b"});
+        ValidateJsonValue("($.a.size() + $.b.abs() == 5) || ($.c == null)", {"\2a", "\2b", "\2c" + nullSuffix});
 
         // Mixing AND and OR: OR wins
-        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
-        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3)});
+        ValidateJsonValue("(($.a == 1) && ($.b == 2)) || ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) || (($.b == 2) && ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("($.a == 1) && (($.b == 2) || ($.c == 3))", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
+        ValidateJsonValue("(($.a == 1) || ($.b == 2)) && ($.c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3)});
 
         // Nested predicates: OR appears in predicate position (inside exists / is unknown / == literal)
         ValidateError("exists(($.a == 1) || ($.b == 2))", predError, ECallableType::JsonValue);
@@ -1098,326 +1118,326 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     Y_UNIT_TEST(CollectPath_ModePropagation) {
         // ((A && B) && (C && D)) - And+And combined at top level
         ValidateJsonValue("(($.a == 1) && ($.b == 2)) && (($.c == 3) && ($.d == 4))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // ((A || B) || (C || D)) - Or+Or combined at top level
         ValidateJsonValue("(($.a == 1) || ($.b == 2)) || (($.c == 3) || ($.d == 4))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A && (B && (C && D))
         ValidateJsonValue("($.a == 1) && (($.b == 2) && (($.c == 3) && ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A || (B || (C || D))
         ValidateJsonValue("($.a == 1) || (($.b == 2) || (($.c == 3) || ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
 
         // Arithmetic with two paths (mode=And) is compatible with AND chains
         // Two arithmetic operands inside AND: ($.a+$.b == "x") && ($.c+$.d == "y")
         ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\")",
-            {"\1a", "\1b", "\1c", "\1d"});
+            {"\2a", "\2b", "\2c", "\2d"});
         ValidateJsonValue("($.a + $.b == \"x\") && ($.c + $.d == \"y\") && ($.e == 1)",
-            {"\1a", "\1b", "\1c", "\1d", "\1e" + numSuffix(1)});
+            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)});
 
         // (A && B) || (C && D): OR wins, all tokens become OR
         ValidateJsonValue("(($.a == 1) && ($.b == 2)) || (($.c == 3) && ($.d == 4))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // (A || B) && (C || D): OR wins, all tokens become OR
         ValidateJsonValue("(($.a == 1) || ($.b == 2)) && (($.c == 3) || ($.d == 4))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
 
         // A && (B || (C || D)): OR wins
         ValidateJsonValue("($.a == 1) && (($.b == 2) || (($.c == 3) || ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A && (B && (C || D)): OR wins
         ValidateJsonValue("($.a == 1) && (($.b == 2) && (($.c == 3) || ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
 
         // A || (B && (C && D)): OR wins
         ValidateJsonValue("($.a == 1) || (($.b == 2) && (($.c == 3) && ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A || (B || (C && D)): OR wins
         ValidateJsonValue("($.a == 1) || (($.b == 2) || (($.c == 3) && ($.d == 4)))",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
 
         // && binds tighter than ||
         // A && B && C || D  =>  ((A && B) && C) || D: OR wins
         ValidateJsonValue("($.a == 1) && ($.b == 2) && ($.c == 3) || ($.d == 4)",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A || B || C && D  =>  (A || B) || (C && D): OR wins
         ValidateJsonValue("($.a == 1) || ($.b == 2) || ($.c == 3) && ($.d == 4)",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
         // A || B && C || D  =>  A || (B && C) || D  =>  (A || (B && C)) || D: OR wins
         ValidateJsonValue("($.a == 1) || ($.b == 2) && ($.c == 3) || ($.d == 4)",
-            {"\1a" + numSuffix(1), "\1b" + numSuffix(2), "\1c" + numSuffix(3), "\1d" + numSuffix(4)});
+            {"\2a" + numSuffix(1), "\2b" + numSuffix(2), "\2c" + numSuffix(3), "\2d" + numSuffix(4)});
 
         // ($.a + $.b == "x") has mode=And, nested as part of OR: OR wins
         ValidateJsonValue("(($.a + $.b == \"x\") || ($.c == 1)) && ($.d == 2)",
-            {"\1a", "\1b", "\1c" + numSuffix(1), "\1d" + numSuffix(2)});
+            {"\2a", "\2b", "\2c" + numSuffix(1), "\2d" + numSuffix(2)});
         ValidateJsonValue("($.d == 2) && (($.a + $.b == \"x\") || ($.c == 1))",
-            {"\1d" + numSuffix(2), "\1a", "\1b", "\1c" + numSuffix(1)});
+            {"\2d" + numSuffix(2), "\2a", "\2b", "\2c" + numSuffix(1)});
 
         // ($.a[0].b == 1) && ((-$.c.d == 2) && ($.e.* starts with "x"))
-        // -$.c.d == 2: unary makes path Finished, no literal appended, token "\1c\1d"
-        // $.e.* starts with "x": wildcard makes path Finished, token "\1e"
+        // -$.c.d == 2: unary makes path Finished, no literal appended, token "\2c\2d"
+        // $.e.* starts with "x": wildcard makes path Finished, token "\2e"
         ValidateJsonValue("($.a[0].b == 1) && ((-$.c.d == 2) && ($.e.* starts with \"x\"))",
-            {"\1a\1b" + numSuffix(1), "\1c\1d", "\1e"});
+            {"\2a\2b" + numSuffix(1), "\2c\2d", "\2e"});
 
         // ($.a.b.c starts with "x") && ($.d.size() == 3) && ($.e[0] + $.f.abs() == 5)
         // $.e[0] + $.f.abs(): both sub-paths collected, mode=And, arithmetic Finished, no literal appended
         ValidateJsonValue("($.a.b.c starts with \"x\") && ($.d.size() == 3) && ($.e[0] + $.f.abs() == 5)",
-            {"\1a\1b\1c", "\1d", "\1e", "\1f"});
+            {"\2a\2b\2c", "\2d", "\2e", "\2f"});
 
         // (exists($.a.b[0]) && ($.c.d == "x")) && (($.e like_regex ".*") && (+$.f.g.h == 0))
-        // +$.f.g.h == 0: unary makes path Finished, no literal appended, token "\1f\1g\1h"
+        // +$.f.g.h == 0: unary makes path Finished, no literal appended, token "\2f\2g\2h"
         ValidateJsonValue("(exists($.a.b[0]) && ($.c.d == \"x\")) && (($.e like_regex \".*\") && (+$.f.g.h == 0))",
-            {"\1a\1b", "\1c\1d" + strSuffix("x"), "\1e", "\1f\1g\1h"});
+            {"\2a\2b", "\2c\2d" + strSuffix("x"), "\2e", "\2f\2g\2h"});
 
         // All five binary arithmetic ops as AND operands - each produces mode=And, all compatible
         ValidateJsonValue("($.a + $.b == \"x\") && ($.c - $.d == \"y\") && ($.e * $.f == \"z\")",
-            {"\1a", "\1b", "\1c", "\1d", "\1e", "\1f"});
+            {"\2a", "\2b", "\2c", "\2d", "\2e", "\2f"});
         ValidateJsonValue("($.a / $.b == \"x\") && ($.c % $.d == \"y\") && ($.e == 1)",
-            {"\1a", "\1b", "\1c", "\1d", "\1e" + numSuffix(1)});
+            {"\2a", "\2b", "\2c", "\2d", "\2e" + numSuffix(1)});
 
         // Unary on both sides of AND - each makes path Finished, literal not appended
         ValidateJsonValue("(-$.a.b == 1) && (+$.c.d.e == 2) && (-$.f[0] == 3)",
-            {"\1a\1b", "\1c\1d\1e", "\1f"});
+            {"\2a\2b", "\2c\2d\2e", "\2f"});
 
         // ($.a.size() == 3) || (($.b[0] == "x") || (-$.c.d.e == 1))
         // Right inner OR: two NotSet operands, Or, outer OR: left=NotSet, right=Or, Or
         ValidateJsonValue("($.a.size() == 3) || (($.b[0] == \"x\") || (-$.c.d.e == 1))",
-            {"\1a", "\1b" + strSuffix("x"), "\1c\1d\1e"});
+            {"\2a", "\2b" + strSuffix("x"), "\2c\2d\2e"});
 
         // ($.a starts with "x") || ($.b.* == "y") || exists($.c.d[0])
-        // $.b.* == "y": wildcard Finished, no literal, token "\1b"
+        // $.b.* == "y": wildcard Finished, no literal, token "\2b"
         ValidateJsonValue("($.a starts with \"x\") || ($.b.* == \"y\") || exists($.c.d[0])",
-            {"\1a", "\1b", "\1c\1d"});
+            {"\2a", "\2b", "\2c\2d"});
 
         // ($.a[1 to 3].b like_regex ".*") || ((-$.c == 0) || ($.d.e.keyvalue() == "f"))
-        // $.d.e.keyvalue() == "f": method Finished, no literal, token "\1d\1e"
+        // $.d.e.keyvalue() == "f": method Finished, no literal, token "\2d\2e"
         ValidateJsonValue("($.a[1 to 3].b like_regex \".*\") || ((-$.c == 0) || ($.d.e.keyvalue() == \"f\"))",
-            {"\1a\1b", "\1c", "\1d\1e"});
+            {"\2a\2b", "\2c", "\2d\2e"});
 
         // Unary on both sides of OR
         ValidateJsonValue("(-$.a.b == 1) || (+$.c.d == 2) || (-$.e.f.g == 3)",
-            {"\1a\1b", "\1c\1d", "\1e\1f\1g"});
+            {"\2a\2b", "\2c\2d", "\2e\2f\2g"});
 
         // ((-$.a.b == 1) && ($.c.size() == 2)) || (exists($.d) && ($.e starts with "x")): OR wins
         ValidateJsonValue("((-$.a.b == 1) && ($.c.size() == 2)) || (exists($.d) && ($.e starts with \"x\"))",
-            {"\1a\1b", "\1c", "\1d", "\1e"});
+            {"\2a\2b", "\2c", "\2d", "\2e"});
 
         // ($.a like_regex "x.*") || (($.b.abs() == 1) && ($.c[0] starts with "y")): OR wins
         ValidateJsonValue("($.a like_regex \"x.*\") || ($.b.abs() == 1) && ($.c[0] starts with \"y\")",
-            {"\1a", "\1b", "\1c"});
+            {"\2a", "\2b", "\2c"});
 
         // (($.a + $.b == "x") && (-$.c.d == 1)) || ($.e.f == 2): OR wins
         ValidateJsonValue("($.a + $.b == \"x\") && (-$.c.d == 1) || ($.e.f == 2)",
-            {"\1a", "\1b", "\1c\1d", "\1e\1f" + numSuffix(2)});
+            {"\2a", "\2b", "\2c\2d", "\2e\2f" + numSuffix(2)});
 
         // ($.a[0] starts with "x") || (($.b.c + $.d.e == 3) && exists($.f.g.*)): OR wins
         ValidateJsonValue("($.a[0] starts with \"x\") || ($.b.c + $.d.e == 3) && exists($.f.g.*)",
-            {"\1a", "\1b\1c", "\1d\1e", "\1f\1g"});
+            {"\2a", "\2b\2c", "\2d\2e", "\2f\2g"});
 
         // (($.a.b[0].c == 1) && ($.d.* starts with "x")) || (-$.e.f.g == 2): OR wins
         ValidateJsonValue("($.a.b[0].c == 1) && ($.d.* starts with \"x\") || (-$.e.f.g == 2)",
-            {"\1a\1b\1c" + numSuffix(1), "\1d", "\1e\1f\1g"});
+            {"\2a\2b\2c" + numSuffix(1), "\2d", "\2e\2f\2g"});
 
         // (($.a like_regex ".*") && ($.b.size() == 0) && ($.c[last] == true)) || ($.d.floor() == 0): OR wins
         ValidateJsonValue("($.a like_regex \".*\") && ($.b.size() == 0) && ($.c[last] == true) || ($.d.floor() == 0)",
-            {"\1a", "\1b", "\1c" + boolTrueSuffix, "\1d"});
+            {"\2a", "\2b", "\2c" + boolTrueSuffix, "\2d"});
 
         // ($.a == 1) || ((-$.b.c.d == 2) && ($.e.size() == 3)): OR wins
         ValidateJsonValue("($.a == 1) || ((-$.b.c.d == 2) && ($.e.size() == 3))",
-            {"\1a" + numSuffix(1), "\1b\1c\1d", "\1e"});
+            {"\2a" + numSuffix(1), "\2b\2c\2d", "\2e"});
 
         // All five arithmetic ops with two paths inside OR: OR wins
-        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
-        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\1a", "\1b", "\1c" + numSuffix(1)});
+        ValidateJsonValue("($.a + $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.a - $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.a * $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.a / $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
+        ValidateJsonValue("($.a % $.b == \"x\") || ($.c == 1)", {"\2a", "\2b", "\2c" + numSuffix(1)});
     }
 
     // Filter predicates allow the collector to use predicate constraints for path narrowing
-    // $.a ? (@.b == 10)  =>  ["\1a\1b" + numSuffix(10)]
+    // $.a ? (@.b == 10)  =>  ["\2a\2b" + numSuffix(10)]
     Y_UNIT_TEST(CollectPath_FilterPredicate) {
         // Basic: simple path before ?, simple equality predicate
-        ValidateJsonExists("$.a ? (@.b == 10)", {"\1a\1b" + numSuffix(10)});
-        ValidateJsonExists("$.a ? (@.b == -(+10))", {"\1a\1b" + numSuffix(-10)});
-        ValidateJsonExists("$.a ? (@.b == \"hello\")", {"\1a\1b" + strSuffix("hello")});
-        ValidateJsonExists("$.a ? (@.b == true)", {"\1a\1b" + boolTrueSuffix});
-        ValidateJsonExists("$.a ? (@.b == false)", {"\1a\1b" + boolFalseSuffix});
-        ValidateJsonExists("$.a ? (@.b == null)", {"\1a\1b" + nullSuffix});
-        ValidateJsonExists("$.a ? (-10 == @.b)", {"\1a\1b" + numSuffix(-10)});
-        ValidateJsonExists("$.a ? (\"hello\" == @.b)", {"\1a\1b" + strSuffix("hello")});
-        ValidateJsonExists("$ ? (@.a == 1)", {"\1a" + numSuffix(1)});
-        ValidateJsonExists("$ ? (@.key == \"x\")", {"\3key" + strSuffix("x")});
+        ValidateJsonExists("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
+        ValidateJsonExists("$.a ? (@.b == -(+10))", {"\2a\2b" + numSuffix(-10)});
+        ValidateJsonExists("$.a ? (@.b == \"hello\")", {"\2a\2b" + strSuffix("hello")});
+        ValidateJsonExists("$.a ? (@.b == true)", {"\2a\2b" + boolTrueSuffix});
+        ValidateJsonExists("$.a ? (@.b == false)", {"\2a\2b" + boolFalseSuffix});
+        ValidateJsonExists("$.a ? (@.b == null)", {"\2a\2b" + nullSuffix});
+        ValidateJsonExists("$.a ? (-10 == @.b)", {"\2a\2b" + numSuffix(-10)});
+        ValidateJsonExists("$.a ? (\"hello\" == @.b)", {"\2a\2b" + strSuffix("hello")});
+        ValidateJsonExists("$ ? (@.a == 1)", {"\2a" + numSuffix(1)});
+        ValidateJsonExists("$ ? (@.key == \"x\")", {"\4key" + strSuffix("x")});
 
         // @ == literal: equality on the filter object itself, prefix becomes the full token
-        ValidateJsonExists("$.a ? (@ == \"hello\")", {"\1a" + strSuffix("hello")});
-        ValidateJsonExists("$.a ? (@ == -42)", {"\1a" + numSuffix(-42)});
-        ValidateJsonExists("$.a ? (@ == true)", {"\1a" + boolTrueSuffix});
-        ValidateJsonExists("$.a ? (@ == null)", {"\1a" + nullSuffix});
-        ValidateJsonExists("$.a.b ? (@ == \"x\")", {"\1a\1b" + strSuffix("x")});
+        ValidateJsonExists("$.a ? (@ == \"hello\")", {"\2a" + strSuffix("hello")});
+        ValidateJsonExists("$.a ? (@ == -42)", {"\2a" + numSuffix(-42)});
+        ValidateJsonExists("$.a ? (@ == true)", {"\2a" + boolTrueSuffix});
+        ValidateJsonExists("$.a ? (@ == null)", {"\2a" + nullSuffix});
+        ValidateJsonExists("$.a.b ? (@ == \"x\")", {"\2a\2b" + strSuffix("x")});
         ValidateJsonExists("$ ? (@ == 0)", {numSuffix(0)});
 
         // @ starts with / like_regex: predicate on the filter object itself
-        ValidateJsonExists("$.a ? (@ starts with \"x\")", {"\1a"});
-        ValidateJsonExists("$.a.b ? (@ starts with \"hello\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@ like_regex \"[a-z]+\")", {"\1a"});
-        ValidateJsonExists("$.a.b.c ? (@ like_regex \".*\")", {"\1a\1b\1c"});
+        ValidateJsonExists("$.a ? (@ starts with \"x\")", {"\2a"});
+        ValidateJsonExists("$.a.b ? (@ starts with \"hello\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@ like_regex \"[a-z]+\")", {"\2a"});
+        ValidateJsonExists("$.a.b.c ? (@ like_regex \".*\")", {"\2a\2b\2c"});
 
         // exists(@): filter predicate is exists on the filter object
-        ValidateJsonExists("$.a ? (exists(@))", {"\1a"});
-        ValidateJsonExists("$.a.b ? (exists(@))", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (exists(@))", {"\2a"});
+        ValidateJsonExists("$.a.b ? (exists(@))", {"\2a\2b"});
 
         // @[0].b: array subscript on filter object, then member access
-        ValidateJsonExists("$.a ? (@[0].b == 1)", {"\1a\1b" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (@[last].b == \"x\")", {"\1a\1b" + strSuffix("x")});
-        ValidateJsonExists("$.a ? (@[*].b == true)", {"\1a\1b" + boolTrueSuffix});
+        ValidateJsonExists("$.a ? (@[0].b == 1)", {"\2a\2b" + numSuffix(1)});
+        ValidateJsonExists("$.a ? (@[last].b == \"x\")", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonExists("$.a ? (@[*].b == true)", {"\2a\2b" + boolTrueSuffix});
 
         // FilterObject via wildcard member access, finishes the path, so literal is not appended
-        ValidateJsonExists("$.a ? (@.* == \"x\")", {"\1a"});
-        ValidateJsonExists("$.a ? (@.b.* starts with \"x\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.* == 1)", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.* == \"x\")", {"\2a"});
+        ValidateJsonExists("$.a ? (@.b.* starts with \"x\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.* == 1)", {"\2a\2b"});
 
         // Methods finish the path, so literal is not appended
-        ValidateJsonExists("$.a ? (@.b.size() == 3)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.abs() == 1)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.floor() == 0)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.ceiling() == 5)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.type() == \"number\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.double() == 1)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.keyvalue() == \"x\")", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b.size() == 3)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.abs() == 1)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.floor() == 0)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.ceiling() == 5)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.type() == \"number\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.double() == 1)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.keyvalue() == \"x\")", {"\2a\2b"});
         // method result checked in AND: both paths collected
-        ValidateJsonExists("$.a ? (@.b.size() == +3 && @.c == -1)", {"\1a\1b", "\1a\1c" + numSuffix(-1)});
+        ValidateJsonExists("$.a ? (@.b.size() == +3 && @.c == -1)", {"\2a\2b", "\2a\2c" + numSuffix(-1)});
 
         // Unary finishes the path, so literal is not appended
-        ValidateJsonExists("$.a ? (-@.b == 5)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (+@.b == 5)", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (-@.b.c.d == 0)", {"\1a\1b\1c\1d"});
-        ValidateJsonExists("$.a ? (-@.b == 5 && @.c == 1)", {"\1a\1b", "\1a\1c" + numSuffix(1)});
-        ValidateJsonExists("$.a ? (-@.b == 5 || +@.c == 2)", {"\1a\1b", "\1a\1c"});
+        ValidateJsonExists("$.a ? (-@.b == 5)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (+@.b == 5)", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (-@.b.c.d == 0)", {"\2a\2b\2c\2d"});
+        ValidateJsonExists("$.a ? (-@.b == 5 && @.c == 1)", {"\2a\2b", "\2a\2c" + numSuffix(1)});
+        ValidateJsonExists("$.a ? (-@.b == 5 || +@.c == 2)", {"\2a\2b", "\2a\2c"});
 
         // All five arithmetic operators: path + path, both tokens, no literal suffix
-        ValidateJsonExists("$.key ? (@.a + @.b == +5)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.a - @.b == 0)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.a * @.b == 10)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.a / @.b == 2)", {"\3key\1a", "\3key\1b"});
-        ValidateJsonExists("$.key ? (@.a % @.b == 1)", {"\3key\1a", "\3key\1b"});
+        ValidateJsonExists("$.key ? (@.a + @.b == +5)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.a - @.b == 0)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.a * @.b == 10)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.a / @.b == 2)", {"\4key\2a", "\4key\2b"});
+        ValidateJsonExists("$.key ? (@.a % @.b == 1)", {"\4key\2a", "\4key\2b"});
         // path + literal: literal side dropped by CollectArithmeticOperand, only path token
-        ValidateJsonExists("$.key ? (@.a + 1 == 5)", {"\3key\1a"});
-        ValidateJsonExists("$.key ? (1 - @.a == 5)", {"\3key\1a"});
-        ValidateJsonExists("$.key ? (@.a * (-2) == -10)", {"\3key\1a"});
+        ValidateJsonExists("$.key ? (@.a + 1 == 5)", {"\4key\2a"});
+        ValidateJsonExists("$.key ? (1 - @.a == 5)", {"\4key\2a"});
+        ValidateJsonExists("$.key ? (@.a * (-2) == -10)", {"\4key\2a"});
         // three paths via chained arithmetic
-        ValidateJsonExists("$.key ? (@.a + @.b + @.c == 0)", {"\3key\1a", "\3key\1b", "\3key\1c"});
+        ValidateJsonExists("$.key ? (@.a + @.b + @.c == 0)", {"\4key\2a", "\4key\2b", "\4key\2c"});
         // arithmetic with deeper filter object paths
-        ValidateJsonExists("$.x ? (@.a.b + @.c.d == 0)", {"\1x\1a\1b", "\1x\1c\1d"});
+        ValidateJsonExists("$.x ? (@.a.b + @.c.d == 0)", {"\2x\2a\2b", "\2x\2c\2d"});
         // arithmetic with two paths produces mode=And, compatible with AND
-        ValidateJsonExists("$.key ? (@.a + @.b == 5 && @.c == 1)", {"\3key\1a", "\3key\1b", "\3key\1c" + numSuffix(1)});
+        ValidateJsonExists("$.key ? (@.a + @.b == 5 && @.c == 1)", {"\4key\2a", "\4key\2b", "\4key\2c" + numSuffix(1)});
 
         // StartsWith finishes the path
-        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\1a\1b"});
-        ValidateJsonExists("$.a.b.c ? (@.d starts with \"abc\")", {"\1a\1b\1c\1d"});
-        ValidateJsonValue("$.a ? (@.b starts with \"x\")", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
+        ValidateJsonExists("$.a.b.c ? (@.d starts with \"abc\")", {"\2a\2b\2c\2d"});
+        ValidateJsonValue("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
 
         // LikeRegex finishes the path
-        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b.c like_regex \"[0-9]+\")", {"\1a\1b\1c"});
-        ValidateJsonValue("$.a ? (@.b like_regex \"[a-z]+\")", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b.c like_regex \"[0-9]+\")", {"\2a\2b\2c"});
+        ValidateJsonValue("$.a ? (@.b like_regex \"[a-z]+\")", {"\2a\2b"});
 
         // Exists finishes the path
-        ValidateJsonExists("$.a ? (exists(@.b))", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (exists(@.b.c.d))", {"\1a\1b\1c\1d"});
-        ValidateJsonExists("$.a ? (exists(@.b[0]))", {"\1a\1b"});
-        ValidateJsonValue("$.a ? (exists(@.b))", {"\1a\1b"});
+        ValidateJsonExists("$.a ? (exists(@.b))", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (exists(@.b.c.d))", {"\2a\2b\2c\2d"});
+        ValidateJsonExists("$.a ? (exists(@.b[0]))", {"\2a\2b"});
+        ValidateJsonValue("$.a ? (exists(@.b))", {"\2a\2b"});
 
         // Deeper paths before and inside filter
-        ValidateJsonExists("$.a.b ? (@.c == \"x\")", {"\1a\1b\1c" + strSuffix("x")});
-        ValidateJsonExists("$.a ? (@.b.c == true)", {"\1a\1b\1c" + boolTrueSuffix});
-        ValidateJsonExists("$.a.b.c ? (@.d.e == null)", {"\1a\1b\1c\1d\1e" + nullSuffix});
-        ValidateJsonExists("$.a ? (@.b.c.d == 3.14)", {"\1a\1b\1c\1d" + numSuffix(3.14)});
+        ValidateJsonExists("$.a.b ? (@.c == \"x\")", {"\2a\2b\2c" + strSuffix("x")});
+        ValidateJsonExists("$.a ? (@.b.c == true)", {"\2a\2b\2c" + boolTrueSuffix});
+        ValidateJsonExists("$.a.b.c ? (@.d.e == null)", {"\2a\2b\2c\2d\2e" + nullSuffix});
+        ValidateJsonExists("$.a ? (@.b.c.d == 3.14)", {"\2a\2b\2c\2d" + numSuffix(3.14)});
 
         // Array access in the input path
-        ValidateJsonExists("$.a[0] ? (@.b == 1)", {"\1a\1b" + numSuffix(1)});
-        ValidateJsonExists("$.key[1, 2, 3] ? (@.sub == \"x\")", {"\3key\3sub" + strSuffix("x")});
-        ValidateJsonExists("$.a[0 to last] ? (@.b == true)", {"\1a\1b" + boolTrueSuffix});
+        ValidateJsonExists("$.a[0] ? (@.b == 1)", {"\2a\2b" + numSuffix(1)});
+        ValidateJsonExists("$.key[1, 2, 3] ? (@.sub == \"x\")", {"\4key\4sub" + strSuffix("x")});
+        ValidateJsonExists("$.a[0 to last] ? (@.b == true)", {"\2a\2b" + boolTrueSuffix});
 
 
         // AND: Two equality conditions
-        ValidateJsonExists("$.a ? (@.b == +10 && @.c == +13)", {"\1a\1b" + numSuffix(10), "\1a\1c" + numSuffix(13)});
-        ValidateJsonExists("$.a.b ? (@.c == \"x\" && @.d == 1)", {"\1a\1b\1c" + strSuffix("x"), "\1a\1b\1d" + numSuffix(1)});
-        ValidateJsonExists("$ ? (@.x == null && @.y == true)", {"\1x" + nullSuffix, "\1y" + boolTrueSuffix});
+        ValidateJsonExists("$.a ? (@.b == +10 && @.c == +13)", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
+        ValidateJsonExists("$.a.b ? (@.c == \"x\" && @.d == 1)", {"\2a\2b\2c" + strSuffix("x"), "\2a\2b\2d" + numSuffix(1)});
+        ValidateJsonExists("$ ? (@.x == null && @.y == true)", {"\2x" + nullSuffix, "\2y" + boolTrueSuffix});
 
         // AND: Three conditions chained with AND
-        ValidateJsonExists("$.key ? (@.a == 1 && @.b == -2 && @.c == 3)", {"\3key\1a" + numSuffix(1), "\3key\1b" + numSuffix(-2), "\3key\1c" + numSuffix(3)});
+        ValidateJsonExists("$.key ? (@.a == 1 && @.b == -2 && @.c == 3)", {"\4key\2a" + numSuffix(1), "\4key\2b" + numSuffix(-2), "\4key\2c" + numSuffix(3)});
 
         // AND: Four conditions chained with AND (two pairs)
         ValidateJsonExists("$.a ? ((@.b == 1 && @.c == 2) && (@.d == 3 && @.e == 4))",
-            {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2),
-             "\1a\1d" + numSuffix(3), "\1a\1e" + numSuffix(4)});
+            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2),
+             "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)});
 
         // AND: mixing predicate types
         ValidateJsonExists("$.a ? ((@.b == 1) && (@.c starts with \"x\") && (@.d like_regex \"y.*\") && exists(@.e))",
-            {"\1a\1b" + numSuffix(1), "\1a\1c", "\1a\1d", "\1a\1e"});
+            {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d", "\2a\2e"});
 
         // AND: mixing methods, unary, wildcard, equality
         ValidateJsonExists("$.key ? ((@.a == 1) && (@.b.size() == 3) && (-@.c == 0) && (@.d.* starts with \"x\"))",
-            {"\3key\1a" + numSuffix(1), "\3key\1b", "\3key\1c", "\3key\1d"});
+            {"\4key\2a" + numSuffix(1), "\4key\2b", "\4key\2c", "\4key\2d"});
 
         // OR: Two equality conditions
-        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c == 13))", {"\1a\1b" + numSuffix(10), "\1a\1c" + numSuffix(13)});
-        ValidateJsonExists("$.key ? ((@.x == \"a\") || (@.y == \"b\"))", {"\3key\1x" + strSuffix("a"), "\3key\1y" + strSuffix("b")});
+        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c == 13))", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
+        ValidateJsonExists("$.key ? ((@.x == \"a\") || (@.y == \"b\"))", {"\4key\2x" + strSuffix("a"), "\4key\2y" + strSuffix("b")});
 
         // OR: Three conditions chained with OR
-        ValidateJsonExists("$.a ? ((@.b == 1) || (@.c == 2) || (@.d == 3))", {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2), "\1a\1d" + numSuffix(3)});
+        ValidateJsonExists("$.a ? ((@.b == 1) || (@.c == 2) || (@.d == 3))", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
 
         // OR: Four conditions chained with OR (two pairs)
         ValidateJsonExists("$.a ? ((@.b == 1 || @.c == 2) || (@.d == 3 || @.e == 4))",
-            {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2),
-             "\1a\1d" + numSuffix(3), "\1a\1e" + numSuffix(4)});
+            {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2),
+             "\2a\2d" + numSuffix(3), "\2a\2e" + numSuffix(4)});
 
         // OR: mixing predicate types
         ValidateJsonExists("$.a ? ((@.b == 1) || (@.c starts with \"x\") || (@.d like_regex \"y.*\") || exists(@.e))",
-            {"\1a\1b" + numSuffix(1), "\1a\1c", "\1a\1d", "\1a\1e"});
+            {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d", "\2a\2e"});
 
         // AND on left of OR: OR wins
-        ValidateJsonExists("$.a ? ((@.b == 1 && @.c == 2) || @.d == 3)", {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2), "\1a\1d" + numSuffix(3)});
+        ValidateJsonExists("$.a ? ((@.b == 1 && @.c == 2) || @.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
         // OR on right of AND: OR wins
-        ValidateJsonExists("$.a ? (@.b == 1 && ((@.c == 2) || (@.d == 3)))", {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2), "\1a\1d" + numSuffix(3)});
+        ValidateJsonExists("$.a ? (@.b == 1 && ((@.c == 2) || (@.d == 3)))", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
         // Arithmetic with two paths (mode=And) on left of OR: OR wins
-        ValidateJsonExists("$.a ? ((@.b + @.c == 5) || @.d == 3)", {"\1a\1b", "\1a\1c", "\1a\1d" + numSuffix(3)});
+        ValidateJsonExists("$.a ? ((@.b + @.c == 5) || @.d == 3)", {"\2a\2b", "\2a\2c", "\2a\2d" + numSuffix(3)});
         // Arithmetic with two paths (mode=And) on right of OR: OR wins
-        ValidateJsonExists("$.a ? (@.b == 1 || (@.c + @.d == 5))", {"\1a\1b" + numSuffix(1), "\1a\1c", "\1a\1d"});
+        ValidateJsonExists("$.a ? (@.b == 1 || (@.c + @.d == 5))", {"\2a\2b" + numSuffix(1), "\2a\2c", "\2a\2d"});
         // (A || B) inside AND chain: OR wins
-        ValidateJsonExists("$.a ? (((@.b == 1) || (@.c == 2)) && @.d == 3)", {"\1a\1b" + numSuffix(1), "\1a\1c" + numSuffix(2), "\1a\1d" + numSuffix(3)});
+        ValidateJsonExists("$.a ? (((@.b == 1) || (@.c == 2)) && @.d == 3)", {"\2a\2b" + numSuffix(1), "\2a\2c" + numSuffix(2), "\2a\2d" + numSuffix(3)});
 
         // Finished input path (wildcard/method) - filter predicate can't narrow
         ValidateJsonExists("$.* ? (@.b == 1)", {""});
-        ValidateJsonExists("$.a.* ? (@.b == 1)", {"\1a"});
-        ValidateJsonExists("$.a.b.* ? (@.c == \"x\")", {"\1a\1b"});
+        ValidateJsonExists("$.a.* ? (@.b == 1)", {"\2a"});
+        ValidateJsonExists("$.a.b.* ? (@.c == \"x\")", {"\2a\2b"});
 
         // Filter is Finished - further member access is dropped
-        ValidateJsonExists("$.a ? (@.b == 10) .c", {"\1a\1b" + numSuffix(10)});
+        ValidateJsonExists("$.a ? (@.b == 10) .c", {"\2a\2b" + numSuffix(10)});
 
         // JsonExists explicitly: filter allows all predicate types even though
-        ValidateJsonExists("$.a ? (@.b == 10)", {"\1a\1b" + numSuffix(10)});
-        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (exists(@.b))", {"\1a\1b"});
-        ValidateJsonExists("$.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {"\1a\1b" + numSuffix(10), "\1a\1c", "\1a\1d"});
-        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c starts with \"x\") || exists(@.d))", {"\1a\1b" + numSuffix(10), "\1a\1c", "\1a\1d"});
-        ValidateJsonExists("$.a ? (@.b + @.c == 5)", {"\1a\1b", "\1a\1c"});
+        ValidateJsonExists("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
+        ValidateJsonExists("$.a ? (@.b starts with \"x\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b like_regex \".*\")", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (exists(@.b))", {"\2a\2b"});
+        ValidateJsonExists("$.a ? (@.b == 10 && @.c starts with \"x\" && exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("$.a ? ((@.b == 10) || (@.c starts with \"x\") || exists(@.d))", {"\2a\2b" + numSuffix(10), "\2a\2c", "\2a\2d"});
+        ValidateJsonExists("$.a ? (@.b + @.c == 5)", {"\2a\2b", "\2a\2c"});
 
         // JsonValue also works (filter allowed predicates in both callable types)
-        ValidateJsonValue("$.a ? (@.b == 10)", {"\1a\1b" + numSuffix(10)});
-        ValidateJsonValue("$.a ? (@.b == 10 && @.c == 13)", {"\1a\1b" + numSuffix(10), "\1a\1c" + numSuffix(13)});
-        ValidateJsonValue("$.a ? ((@.b == 10) || (@.c == 13))", {"\1a\1b" + numSuffix(10), "\1a\1c" + numSuffix(13)});
-        ValidateJsonValue("$.a ? (@.b + @.c == 5)", {"\1a\1b", "\1a\1c"});
-        ValidateJsonValue("$.a ? (@.b == @.c)", {"\1a\1b", "\1a\1c"});
-        ValidateJsonValue("$.a ? (@.b == $.c)", {"\1a\1b", "\1c"});
-        ValidateJsonValue("$.a ? (@ == @.b)", {"\1a", "\1a\1b"});
+        ValidateJsonValue("$.a ? (@.b == 10)", {"\2a\2b" + numSuffix(10)});
+        ValidateJsonValue("$.a ? (@.b == 10 && @.c == 13)", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
+        ValidateJsonValue("$.a ? ((@.b == 10) || (@.c == 13))", {"\2a\2b" + numSuffix(10), "\2a\2c" + numSuffix(13)});
+        ValidateJsonValue("$.a ? (@.b + @.c == 5)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonValue("$.a ? (@.b == @.c)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonValue("$.a ? (@.b == $.c)", {"\2a\2b", "\2c"});
+        ValidateJsonValue("$.a ? (@ == @.b)", {"\2a", "\2a\2b"});
 
         // Nested filter: exists(@.b ? (@.c == 1)) inside an outer filter
-        ValidateJsonExists("$.a ? (exists(@.b ? (@.c == 1)))", {"\1a\1b\1c" + numSuffix(1)});
-        ValidateJsonExists("$.key ? (exists(@.sub ? (@.val == \"x\")))", {"\3key\3sub\3val" + strSuffix("x")});
+        ValidateJsonExists("$.a ? (exists(@.b ? (@.c == 1)))", {"\2a\2b\2c" + numSuffix(1)});
+        ValidateJsonExists("$.key ? (exists(@.sub ? (@.val == \"x\")))", {"\4key\4sub\4val" + strSuffix("x")});
 
         // @ outside filter context is an error
         ValidateError("@", filterError);
@@ -1427,9 +1447,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("@ starts with \"x\"", filterError, ECallableType::JsonValue);
 
         // Both sides of == are paths: AND-merge of filter-relative paths
-        ValidateJsonExists("$.a ? (@.b == @.c)", {"\1a\1b", "\1a\1c"});
-        ValidateJsonExists("$.a ? (@.b == $.c)", {"\1a\1b", "\1c"});
-        ValidateJsonExists("$.a ? (@ == @.b)", {"\1a", "\1a\1b"});
+        ValidateJsonExists("$.a ? (@.b == @.c)", {"\2a\2b", "\2a\2c"});
+        ValidateJsonExists("$.a ? (@.b == $.c)", {"\2a\2b", "\2c"});
+        ValidateJsonExists("$.a ? (@ == @.b)", {"\2a", "\2a\2b"});
         // Both sides are literals
         ValidateError("$.a ? (1 == 2)", compError, ECallableType::JsonExists);
         ValidateError("$.a ? (\"x\" == \"y\")", compError, ECallableType::JsonExists);
@@ -1491,67 +1511,67 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
     // Nested filter: (@ ? (predicate)).member == value
     Y_UNIT_TEST(CollectPath_NestedFilter) {
         // Basic: inner == predicate, outer comparison dropped
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1)).b == 2)", {"\1a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (@.a == \"x\")).b == \"y\")", {"\1a" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (@.a == true)).b == false)", {"\1a" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == false)).b == true)", {"\1a" + boolFalseSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == null)).b == null)", {"\1a" + nullSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == -3.14)).b == 0)", {"\1a" + numSuffix(-3.14)});
+        ValidateJsonExists("$ ? ((@ ? (@.a == 1)).b == 2)", {"\2a" + numSuffix(1)});
+        ValidateJsonExists("$ ? ((@ ? (@.a == \"x\")).b == \"y\")", {"\2a" + strSuffix("x")});
+        ValidateJsonExists("$ ? ((@ ? (@.a == true)).b == false)", {"\2a" + boolTrueSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a == false)).b == true)", {"\2a" + boolFalseSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a == null)).b == null)", {"\2a" + nullSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a == -3.14)).b == 0)", {"\2a" + numSuffix(-3.14)});
 
         // Reversed literal in inner predicate (literal == @.path)
-        ValidateJsonExists("$ ? ((@ ? (1 == @.a)).b == 2)", {"\1a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (\"x\" == @.a)).b == \"y\")", {"\1a" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (null == @.a)).b == 0)", {"\1a" + nullSuffix});
+        ValidateJsonExists("$ ? ((@ ? (1 == @.a)).b == 2)", {"\2a" + numSuffix(1)});
+        ValidateJsonExists("$ ? ((@ ? (\"x\" == @.a)).b == \"y\")", {"\2a" + strSuffix("x")});
+        ValidateJsonExists("$ ? ((@ ? (null == @.a)).b == 0)", {"\2a" + nullSuffix});
 
         // Outer path contributes to the index prefix
-        ValidateJsonExists("$.key ? ((@ ? (@.sub == \"x\")).other == \"y\")", {"\3key\3sub" + strSuffix("x")});
-        ValidateJsonExists("$.a.b ? ((@ ? (@.c == true)).d == false)", {"\1a\1b\1c" + boolTrueSuffix});
-        ValidateJsonExists("$.arr ? ((@ ? (@.id == 9)).name == \"x\")", {"\3arr\2id" + numSuffix(9)});
-        ValidateJsonExists("$.items ? ((@ ? (@.type == null)).value > 0)", {"\5items\4type" + nullSuffix});
+        ValidateJsonExists("$.key ? ((@ ? (@.sub == \"x\")).other == \"y\")", {"\4key\4sub" + strSuffix("x")});
+        ValidateJsonExists("$.a.b ? ((@ ? (@.c == true)).d == false)", {"\2a\2b\2c" + boolTrueSuffix});
+        ValidateJsonExists("$.arr ? ((@ ? (@.id == 9)).name == \"x\")", {"\4arr\3id" + numSuffix(9)});
+        ValidateJsonExists("$.items ? ((@ ? (@.type == null)).value > 0)", {"\6items\5type" + nullSuffix});
 
         // Comparison operators != == in inner predicate: literal not appended, only path
-        ValidateJsonExists("$ ? ((@ ? (@.n < 10)).label == \"x\")", {"\1n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n > 0)).label == \"x\")", {"\1n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n != 0)).label == \"x\")", {"\1n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n >= 0)).label == \"x\")", {"\1n"});
-        ValidateJsonExists("$ ? ((@ ? (@.n <= 100)).label == \"x\")", {"\1n"});
-        ValidateJsonExists("$.arr ? ((@ ? (@.score >= 5)).rank == 1)", {"\3arr\5score"});
+        ValidateJsonExists("$ ? ((@ ? (@.n < 10)).label == \"x\")", {"\2n"});
+        ValidateJsonExists("$ ? ((@ ? (@.n > 0)).label == \"x\")", {"\2n"});
+        ValidateJsonExists("$ ? ((@ ? (@.n != 0)).label == \"x\")", {"\2n"});
+        ValidateJsonExists("$ ? ((@ ? (@.n >= 0)).label == \"x\")", {"\2n"});
+        ValidateJsonExists("$ ? ((@ ? (@.n <= 100)).label == \"x\")", {"\2n"});
+        ValidateJsonExists("$.arr ? ((@ ? (@.score >= 5)).rank == 1)", {"\4arr\6score"});
 
         // Deeper inner path
-        ValidateJsonExists("$ ? ((@ ? (@.a.b == 1)).c == 2)", {"\1a\1b" + numSuffix(1)});
-        ValidateJsonExists("$.key ? ((@ ? (@.a.b.c == \"x\")).d == \"y\")", {"\3key\1a\1b\1c" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? (@.x.y == null)).z == true)", {"\1x\1y" + nullSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a.b == 1)).c == 2)", {"\2a\2b" + numSuffix(1)});
+        ValidateJsonExists("$.key ? ((@ ? (@.a.b.c == \"x\")).d == \"y\")", {"\4key\2a\2b\2c" + strSuffix("x")});
+        ValidateJsonExists("$ ? ((@ ? (@.x.y == null)).z == true)", {"\2x\2y" + nullSuffix});
 
         // Array subscript in inner predicate path: subscript is dropped for the index
-        ValidateJsonExists("$ ? ((@ ? (@.a[0] == 1)).b == 2)", {"\1a" + numSuffix(1)});
-        ValidateJsonExists("$ ? ((@ ? (@.a[last] == true)).b == null)", {"\1a" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a[0].b == \"x\")).c == 1)", {"\1a\1b" + strSuffix("x")});
+        ValidateJsonExists("$ ? ((@ ? (@.a[0] == 1)).b == 2)", {"\2a" + numSuffix(1)});
+        ValidateJsonExists("$ ? ((@ ? (@.a[last] == true)).b == null)", {"\2a" + boolTrueSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a[0].b == \"x\")).c == 1)", {"\2a\2b" + strSuffix("x")});
 
         // Array subscript on @ before inner filter: subscript is dropped for the index
-        ValidateJsonExists("$ ? ((@[0] ? (@.id == 9)).name == \"x\")", {"\2id" + numSuffix(9)});
-        ValidateJsonExists("$ ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\3tag" + strSuffix("foo")});
-        ValidateJsonExists("$.items ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\5items\3tag" + strSuffix("foo")});
-        ValidateJsonExists("$.k ? ((@[1] ? (@.x == true)).y == false)", {"\1k\1x" + boolTrueSuffix});
+        ValidateJsonExists("$ ? ((@[0] ? (@.id == 9)).name == \"x\")", {"\3id" + numSuffix(9)});
+        ValidateJsonExists("$ ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\4tag" + strSuffix("foo")});
+        ValidateJsonExists("$.items ? ((@[*] ? (@.tag == \"foo\")).value > 0)", {"\6items\4tag" + strSuffix("foo")});
+        ValidateJsonExists("$.k ? ((@[1] ? (@.x == true)).y == false)", {"\2k\2x" + boolTrueSuffix});
 
         // Wildcard in inner predicate: path finishes, literal not appended
         ValidateJsonExists("$ ? ((@ ? (@.* == 1)).x == 2)", {""});
-        ValidateJsonExists("$.key ? ((@ ? (@.* == \"x\")).y == 1)", {"\3key"});
-        ValidateJsonExists("$ ? ((@ ? (@.a.* == null)).b == 1)", {"\1a"});
+        ValidateJsonExists("$.key ? ((@ ? (@.* == \"x\")).y == 1)", {"\4key"});
+        ValidateJsonExists("$ ? ((@ ? (@.a.* == null)).b == 1)", {"\2a"});
 
         // Inner AND: both tokens propagate (filter result has multiple tokens)
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1 && @.b == 2)).c == 3)", {"\1a" + numSuffix(1), "\1b" + numSuffix(2)});
-        ValidateJsonExists("$.key ? ((@ ? (@.x == \"v\" && @.y == true)).z == null)", {"\3key\1x" + strSuffix("v"), "\3key\1y" + boolTrueSuffix});
-        ValidateJsonExists("$ ? ((@ ? (@.a == null && @.b == false)).c == 1)", {"\1a" + nullSuffix, "\1b" + boolFalseSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a == 1 && @.b == 2)).c == 3)", {"\2a" + numSuffix(1), "\2b" + numSuffix(2)});
+        ValidateJsonExists("$.key ? ((@ ? (@.x == \"v\" && @.y == true)).z == null)", {"\4key\2x" + strSuffix("v"), "\4key\2y" + boolTrueSuffix});
+        ValidateJsonExists("$ ? ((@ ? (@.a == null && @.b == false)).c == 1)", {"\2a" + nullSuffix, "\2b" + boolFalseSuffix});
 
         // Inner OR: both tokens propagate
-        ValidateJsonExists("$ ? ((@ ? (@.a == 1 || @.a == 2)).b == \"x\")", {"\1a" + numSuffix(1), "\1a" + numSuffix(2)});
-        ValidateJsonExists("$ ? ((@ ? (@.tag == \"foo\" || @.tag == \"bar\")).value == 0)", {"\3tag" + strSuffix("foo"), "\3tag" + strSuffix("bar")});
-        ValidateJsonExists("$.arr ? ((@ ? (@.id == 1 || @.id == 2)).val == true)", {"\3arr\2id" + numSuffix(1), "\3arr\2id" + numSuffix(2)});
+        ValidateJsonExists("$ ? ((@ ? (@.a == 1 || @.a == 2)).b == \"x\")", {"\2a" + numSuffix(1), "\2a" + numSuffix(2)});
+        ValidateJsonExists("$ ? ((@ ? (@.tag == \"foo\" || @.tag == \"bar\")).value == 0)", {"\4tag" + strSuffix("foo"), "\4tag" + strSuffix("bar")});
+        ValidateJsonExists("$.arr ? ((@ ? (@.id == 1 || @.id == 2)).val == true)", {"\4arr\3id" + numSuffix(1), "\4arr\3id" + numSuffix(2)});
 
         // Double nesting: only deepest (innermost) inner filter determines the tokens
-        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.z == 1)).w == 2)).val == 3)", {"\1z" + numSuffix(1)});
-        ValidateJsonExists("$.a ? ((@ ? ((@ ? (@.b == \"x\")).c == \"y\")).d == \"z\")", {"\1a\1b" + strSuffix("x")});
-        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.p == null)).q == true)).r == false)", {"\1p" + nullSuffix});
+        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.z == 1)).w == 2)).val == 3)", {"\2z" + numSuffix(1)});
+        ValidateJsonExists("$.a ? ((@ ? ((@ ? (@.b == \"x\")).c == \"y\")).d == \"z\")", {"\2a\2b" + strSuffix("x")});
+        ValidateJsonExists("$ ? ((@ ? ((@ ? (@.p == null)).q == true)).r == false)", {"\2p" + nullSuffix});
     }
 
     // Variables are not supported now
@@ -1561,6 +1581,300 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         ValidateError("$var", errorMessage);
         ValidateError("$var.key", errorMessage);
         ValidateError("$var[1, 2, 3]", errorMessage);
+    }
+
+    // Tokens with no ancestor–descendant relation survive both AND and OR merge intact.
+    Y_UNIT_TEST(MergeAndOr_DisjointPaths) {
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2c\2d"})),
+            {"\2a\2b", "\2c\2d"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2c\2d"})),
+            {"\2a\2b", "\2c\2d"}, EMode::Or);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a", "\2b"}, EMode::And), MakeTokens({"\2c"})),
+            {"\2a", "\2b", "\2c"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a", "\2b"}, EMode::Or), MakeTokens({"\2c"})),
+            {"\2a", "\2b", "\2c"}, EMode::Or);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b", "\2c\2d"}, EMode::And),
+                     MakeTokens({"\2e\2f", "\2g\2h"}, EMode::And)),
+            {"\2a\2b", "\2c\2d", "\2e\2f", "\2g\2h"}, EMode::And);
+
+    }
+
+    // AND keeps the deepest descendant (leaf); OR keeps the shallowest ancestor (root).
+    Y_UNIT_TEST(MergeAndOr_DirectAncestorDescendant) {
+        // parent in left operand
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b\2c"})),
+            {"\2a\2b\2c"}, EMode::And);
+
+        // parent in right operand
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b\2c"}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b\2c"}, EMode::And);
+
+        // grandparent pruned (two levels up)
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a"}), MakeTokens({"\2a\2b\2c"})),
+            {"\2a\2b\2c"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b\2c"})),
+            {"\2a\2b"}, EMode::Or);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b\2c"}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b"}, EMode::Or);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a"}), MakeTokens({"\2a\2b\2c"})),
+            {"\2a"}, EMode::Or);
+    }
+
+    // Identical tokens collapse to a single entry; equal tokens are NOT each other's prefix.
+    Y_UNIT_TEST(MergeAndOr_IdenticalTokens) {
+        // single-token sets: set deduplication leaves 1 token -> mode stays NotSet
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        // multi-token sets: deduplication, no pruning (b and c are siblings, not prefix-related)
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b", "\2c"}, EMode::And),
+                     MakeTokens({"\2a\2b", "\2c"}, EMode::And)),
+            {"\2a\2b", "\2c"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b", "\2c"}, EMode::Or),
+                    MakeTokens({"\2a\2b", "\2c"}, EMode::Or)),
+            {"\2a\2b", "\2c"}, EMode::Or);
+    }
+
+    // The five-term example from the task description.
+    // Terms: a.b, a.b.c, a.d, a.b.c.e, e.f
+    //
+    // Tree:
+    //   a               e
+    //  / \              |
+    // b   d             f
+    // |
+    // c
+    // |
+    // e
+    //
+    // AND -> leaves: a.b.c.e, a.d, e.f
+    // OR  -> roots:  a.b,     a.d, e.f
+    Y_UNIT_TEST(MergeAndOr_FullExample) {
+        auto left = MakeTokens({"\2a\2b", "\2a\2b\2c", "\2a\2d"}, EMode::And);
+        auto right = MakeTokens({"\2a\2b\2c\2e", "\2e\2f"}, EMode::And);
+        CheckMerge(
+            MergeAnd(std::move(left), std::move(right)),
+            {"\2a\2b\2c\2e", "\2a\2d", "\2e\2f"}, EMode::And);
+
+        left = MakeTokens({"\2a\2b", "\2a\2b\2c", "\2a\2d"}, EMode::Or);
+        right = MakeTokens({"\2a\2b\2c\2e", "\2e\2f"}, EMode::Or);
+        CheckMerge(
+            MergeOr(std::move(left), std::move(right)),
+            {"\2a\2b", "\2a\2d", "\2e\2f"}, EMode::Or);
+    }
+
+    // Two completely independent subtrees each with an ancestor–descendant pair.
+    Y_UNIT_TEST(MergeAndOr_MultipleBranches) {
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::And),
+                     MakeTokens({"\2x\2y", "\2x\2y\2z"}, EMode::And)),
+            {"\2a\2b\2c", "\2x\2y\2z"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::Or),
+                    MakeTokens({"\2x\2y", "\2x\2y\2z"}, EMode::Or)),
+            {"\2a\2b", "\2x\2y"}, EMode::Or);
+    }
+
+    // A path-only token is a string prefix of a path+literal token for the same field.
+    // AND should keep the value-specific (longer) token; OR should keep the path-only (shorter).
+    Y_UNIT_TEST(MergeAndOr_LiteralSuffix) {
+        const TString ab = "\2a\2b";
+        const TString abNum = ab + numSuffix(5.0);
+        const TString abNum2 = ab + numSuffix(7.0);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({ab}), MakeTokens({abNum})),
+            {abNum}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({ab}), MakeTokens({abNum})),
+            {ab}, EMode::Or);
+
+        // Two different values for the same path: neither is a prefix of the other -> both kept
+        CheckMerge(
+            MergeOr(MakeTokens({abNum}), MakeTokens({abNum2})),
+            {abNum, abNum2}, EMode::Or);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({abNum}), MakeTokens({abNum2})),
+            {abNum, abNum2}, EMode::And);
+    }
+
+    // When one operand carries an incompatible mode, the merge falls back to OR mode,
+    // so OR pruning (keep roots) is applied even inside MergeAnd.
+    Y_UNIT_TEST(MergeAnd_ModeMixAppliesOrPruning) {
+        // Left has Or mode -> hasMix -> final mode Or -> OR pruning keeps the shorter token
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}, EMode::Or),
+                     MakeTokens({"\2a\2b\2c"}, EMode::And)),
+            {"\2a\2b"}, EMode::Or);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b\2c"}, EMode::And),
+                     MakeTokens({"\2a\2b"}, EMode::Or)),
+            {"\2a\2b"}, EMode::Or);
+    }
+
+    // A chain of three levels (grandparent -> parent -> child) in a single merge call.
+    Y_UNIT_TEST(MergeAndOr_DeepChain) {
+        // AND: grandparent and parent are both prefixes of child -> only child survives
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a", "\2a\2b"}, EMode::And),
+                     MakeTokens({"\2a\2b\2c"})),
+            {"\2a\2b\2c"}, EMode::And);
+
+        // OR: root covers all -> only root survives
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a"}),
+                    MakeTokens({"\2a\2b", "\2a\2b\2c"}, EMode::Or)),
+            {"\2a"}, EMode::Or);
+    }
+
+    // Hierarchical tokens mixed with completely unrelated tokens.
+    Y_UNIT_TEST(MergeAndOr_MixedHierarchyAndDisjoint) {
+        // {a.b, a.b.c, x} AND {a.b.c.d, y} -> {a.b.c.d, x, y}
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b", "\2a\2b\2c", "\2x"}, EMode::And),
+                     MakeTokens({"\2a\2b\2c\2d", "\2y"}, EMode::And)),
+            {"\2a\2b\2c\2d", "\2x", "\2y"}, EMode::And);
+
+        // {a, a.b, x} OR {a.b.c, y} -> {a, x, y}
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a", "\2a\2b", "\2x"}, EMode::Or),
+                    MakeTokens({"\2a\2b\2c", "\2y"}, EMode::Or)),
+            {"\2a", "\2x", "\2y"}, EMode::Or);
+    }
+
+    Y_UNIT_TEST(MergeAndOr_EmptyOperands) {
+        // One operand is empty: result is the other operand's single token, NotSet mode
+        CheckMerge(
+            MergeAnd(MakeTokens({}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        CheckMerge(
+            MergeAnd(MakeTokens({}), MakeTokens({})),
+            {}, EMode::NotSet);
+
+        CheckMerge(
+            MergeOr(MakeTokens({}), MakeTokens({"\2a\2b"})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({})),
+            {"\2a\2b"}, EMode::NotSet);
+
+        CheckMerge(
+            MergeOr(MakeTokens({}), MakeTokens({})),
+            {}, EMode::NotSet);
+    }
+
+    Y_UNIT_TEST(MergeAndOr_ErrorPropagation) {
+        {
+            auto r = MergeAnd(MakeError("left error"), MakeTokens({"\2a\2b"}));
+            UNIT_ASSERT_C(r.IsError(), "AND: expected error from left");
+            UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "left error");
+        }
+        {
+            auto r = MergeAnd(MakeTokens({"\2a\2b"}), MakeError("right error"));
+            UNIT_ASSERT_C(r.IsError(), "AND: expected error from right");
+            UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "right error");
+        }
+        {
+            auto r = MergeOr(MakeError("left error"), MakeTokens({"\2a\2b"}));
+            UNIT_ASSERT_C(r.IsError(), "OR: expected error from left");
+            UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "left error");
+        }
+        {
+            auto r = MergeOr(MakeTokens({"\2a\2b"}), MakeError("right error"));
+            UNIT_ASSERT_C(r.IsError(), "OR: expected error from right");
+            UNIT_ASSERT_STRING_CONTAINS(r.GetError().GetMessage(), "right error");
+        }
+    }
+
+    // Sibling paths sharing only a common ancestor but not a prefix relation between themselves.
+    Y_UNIT_TEST(MergeAndOr_Siblings) {
+        // a.b and a.c share ancestor a but neither is a prefix of the other
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2c"})),
+            {"\2a\2b", "\2a\2c"}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b"}), MakeTokens({"\2a\2c"})),
+            {"\2a\2b", "\2a\2c"}, EMode::Or);
+
+        // Mix: one sibling has a deeper descendant
+        // {a.b, a.c} AND {a.b.d, a.c} -> AND: a.b.d covers a.b; a.c deduplicates -> {a.b.d, a.c}
+        CheckMerge(
+            MergeAnd(MakeTokens({"\2a\2b", "\2a\2c"}, EMode::And),
+                     MakeTokens({"\2a\2b\2d", "\2a\2c"}, EMode::And)),
+            {"\2a\2b\2d", "\2a\2c"}, EMode::And);
+
+        // {a.b, a.c} OR {a.b.d, a.c} -> OR: a.b covers a.b.d; a.c deduplicates -> {a.b, a.c}
+        CheckMerge(
+            MergeOr(MakeTokens({"\2a\2b", "\2a\2c"}, EMode::Or),
+                    MakeTokens({"\2a\2b\2d", "\2a\2c"}, EMode::Or)),
+            {"\2a\2b", "\2a\2c"}, EMode::Or);
+    }
+
+    // Ensure different-length key names don't create false prefix matches.
+    // Key "ab" (2 bytes, length prefix \x02) must NOT match as a prefix for key "a" (\x01).
+    Y_UNIT_TEST(MergeAndOr_DifferentLengthKeys) {
+        // \2a\2b  = path $.a.b  (keys "a" and "b", each 1 char, encoded as 2)
+        // \3ab\2c = path $.ab.c (key "ab" is 2 chars, encoded as 3)
+        const TString pathAB  = "\2a\2b";
+        const TString pathABC = TString("\3ab\2c", 5);  // $.ab.c — unrelated to $.a.b
+
+        CheckMerge(
+            MergeAnd(MakeTokens({pathAB}), MakeTokens({pathABC})),
+            {pathAB, pathABC}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({pathAB}), MakeTokens({pathABC})),
+            {pathAB, pathABC}, EMode::Or);
+    }
+
+    Y_UNIT_TEST(MergeAndOr_ZeroPath) {
+        const TString first  = TString("\1", 1); // $.""
+        const TString second = boolTrueSuffix;
+
+        CheckMerge(
+            MergeAnd(MakeTokens({first}), MakeTokens({second})),
+            {first, second}, EMode::And);
+
+        CheckMerge(
+            MergeOr(MakeTokens({first}), MakeTokens({second})),
+            {first, second}, EMode::Or);
     }
 
     Y_UNIT_TEST(TokenizeJson) {
@@ -1578,36 +1892,36 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         std::sort(tokens.begin(), tokens.end());
         UNIT_ASSERT_VALUES_EQUAL(tokens, (TVector<TString>{
             TString(),
-            TString("\2id", 3),
-            TString("\2id\0\4\0\0\0\0@\x87\xE4@", 13),
-            TString("\5brand", 6),
-            TString("\5brand\0\3bricks", 14),
-            TString("\5parts", 6),
-            TString("\5parts\2id", 9),
-            TString("\5parts\2id", 9),
-            TString("\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@", 19),
-            TString("\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@", 19),
-            TString("\5parts\4name", 11),
-            TString("\5parts\4name", 11),
-            TString("\5parts\4name\0\0031x3", 16),
-            TString("\5parts\4name\0\0033x5", 16),
-            TString("\5parts\5count", 12),
-            TString("\5parts\5count", 12),
-            TString("\5parts\5count\0\4\0\0\0\0\0\0\x1C@", 22),
-            TString("\5parts\5count\0\4\0\0\0\0\0\0001@", 22),
-            TString("\5price", 6),
-            TString("\5price\0\2", 8),
-            TString("\npart_count", 11),
-            TString("\npart_count\0\4\0\0\0\0\0\xE4\x95@", 21)
+            TString("\3id", 3),
+            TString("\3id\0\4\0\0\0\0@\x87\xE4@", 13),
+            TString("\6brand", 6),
+            TString("\6brand\0\3bricks", 14),
+            TString("\6parts", 6),
+            TString("\6parts\3id", 9),
+            TString("\6parts\3id", 9),
+            TString("\6parts\3id\0\4\0\0\0\0\x80\xC3\xDF@", 19),
+            TString("\6parts\3id\0\4\0\0\0\0\xC0\xC2\xDF@", 19),
+            TString("\6parts\5name", 11),
+            TString("\6parts\5name", 11),
+            TString("\6parts\5name\0\0031x3", 16),
+            TString("\6parts\5name\0\0033x5", 16),
+            TString("\6parts\6count", 12),
+            TString("\6parts\6count", 12),
+            TString("\6parts\6count\0\4\0\0\0\0\0\0\x1C@", 22),
+            TString("\6parts\6count\0\4\0\0\0\0\0\0001@", 22),
+            TString("\6price", 6),
+            TString("\6price\0\2", 8),
+            TString("\x0Bpart_count", 11),
+            TString("\x0Bpart_count\0\4\0\0\0\0\0\xE4\x95@", 21)
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
         TString emptyKeyObj = "{\"\":{\"a\":\"b\"}}";
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(emptyKeyObj, error), (TVector<TString>{
             TString(),
-            TString("\0", 1),
-            TString("\0\1a", 3),
-            TString("\0\1a\0\3b", 6)
+            TString("\1", 1),
+            TString("\1\2a", 3),
+            TString("\1\2a\0\3b", 6)
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
 
@@ -1618,9 +1932,9 @@ Y_UNIT_TEST_SUITE(NJsonIndex) {
         TString longKeyObj = "{\"" + longKey + "\":{\"short\":\"b\"}}";
         UNIT_ASSERT_VALUES_EQUAL(TokenizeJson(longKeyObj, error), (TVector<TString>{
             TString(),
-            TString("\xE8\7") + longKey,
-            TString("\xE8\7") + longKey + TString("\5short", 6),
-            TString("\xE8\7") + longKey + TString("\5short\0\3b", 9)
+            TString("\xE9\7") + longKey,
+            TString("\xE9\7") + longKey + TString("\6short", 6),
+            TString("\xE9\7") + longKey + TString("\6short\0\3b", 9)
         }));
         UNIT_ASSERT_VALUES_EQUAL(error, "");
     }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -1874,6 +1874,7 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverFullTextMatch(const NYql::NNodes::TEx
         .Done();
     return res;
 }
+
 TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
     if (!node.Maybe<TCoFlatMap>()) {
         return node;

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -1,6 +1,6 @@
-#include <ydb/core/base/json_index.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
+#include <ydb/core/kqp/opt/logical/kqp_opt_log_json_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 
@@ -1874,52 +1874,12 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverFullTextMatch(const NYql::NNodes::TEx
         .Done();
     return res;
 }
-
-// Parses jsonPathStr, collects search tokens via CollectJsonPath and builds TKqpReadTableFullTextIndexSettings
-std::optional<TKqpReadTableFullTextIndexSettings> BuildFullTextSettingsFromJsonPath(const TString& jsonPathStr, const TExprBase& node, TExprContext& ctx) {
-    NYql::TIssues parseIssues;
-    const auto jsonPath = NYql::NJsonPath::ParseJsonPath(jsonPathStr, parseIssues, 1);
-    if (!parseIssues.Empty()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Failed to parse jsonpath expression: " << parseIssues.ToOneLineString()));
-        return std::nullopt;
-    }
-
-    auto collectResult = NJsonIndex::CollectJsonPath(jsonPath, NJsonIndex::ECallableType::JsonExists);
-    if (collectResult.IsError()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Failed to extract search terms from jsonpath expression: " << collectResult.GetError().GetMessage()));
-        return std::nullopt;
-    }
-
-    if (collectResult.GetTokens().empty()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Failed to extract search terms from jsonpath expression, no tokens found"));
-        return std::nullopt;
-    }
-
-    TVector<TExprNode::TPtr> tokenNodes;
-    tokenNodes.reserve(collectResult.GetTokens().size());
-    for (const auto& token : collectResult.GetTokens()) {
-        tokenNodes.push_back(Build<TCoString>(ctx, node.Pos()).Literal().Build(token).Done().Ptr());
-    }
-
-    TStringBuf defaultOperator = collectResult.GetTokensMode() == NJsonIndex::TCollectResult::ETokensMode::Or ? "or" : "and";
-
-    auto settings = TKqpReadTableFullTextIndexSettings{};
-    settings.SetDefaultOperator(Build<TCoString>(ctx, node.Pos()).Literal().Build(defaultOperator).Done().Ptr());
-    settings.SetMinimumShouldMatch(Build<TCoString>(ctx, node.Pos()).Literal().Build("").Done().Ptr());
-    settings.SetTokens(ctx.NewList(node.Pos(), std::move(tokenNodes)));
-    return settings;
-}
-
 TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
     if (!node.Maybe<TCoFlatMap>()) {
         return node;
     }
 
     auto flatMap = node.Maybe<TCoFlatMap>().Cast();
-
     auto read = TReadMatch::MatchJsonRead(flatMap.Input(), kqpCtx);
     if (!read) {
         return node;
@@ -1927,64 +1887,19 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBas
 
     const auto& tableDesc = GetTableData(*kqpCtx.Tables, kqpCtx.Cluster, read.Table().Path());
     YQL_ENSURE(tableDesc.Metadata);
+
     auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
     if (indexDesc->Type != TIndexDescription::EType::GlobalJson) {
         return {};
     }
 
-    auto body = flatMap.Lambda().Body();
-    if (!body.Maybe<TCoOptionalIf>()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Expected OptionalIf in lambda body"));
-        return {};
-    }
-
-    auto optionalIf = body.Maybe<TCoOptionalIf>().Cast();
-    if (!optionalIf.Predicate().Maybe<TCoCoalesce>()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Expected Coalesce in predicate"));
-        return {};
-    }
-
-    auto coalesce = optionalIf.Predicate().Maybe<TCoCoalesce>().Cast();
-    if (!coalesce.Predicate().Maybe<TCoJsonExists>()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Expected JsonExists in predicate"));
-        return {};
-    }
-
-    auto jsonExists = coalesce.Predicate().Maybe<TCoJsonExists>().Cast();
-
-    if (!jsonExists.Json().Maybe<TCoMember>()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Expected Member in Json"));
-        return {};
-    }
-
-    if (!jsonExists.JsonPath().Maybe<TCoUtf8>()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Expected Utf8 in JsonPath"));
-        return {};
-    }
-
-    auto jsonColumnName = jsonExists.Json().Maybe<TCoMember>().Cast().Name().StringValue();
-    auto jsonPathStr = jsonExists.JsonPath().Maybe<TCoUtf8>().Cast().Literal().StringValue();
-
-    const auto& variables = jsonExists.Variables().Ref();
-    if (!variables.GetTypeAnn() || variables.GetTypeAnn()->GetKind() != ETypeAnnotationKind::EmptyDict) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()),
-            TStringBuilder() << "Variables are not supported at the moment"));
-        return {};
-    }
-
-    // Compile jsonpath to search tokens at query compile time to surface parse errors
-    auto settings = BuildFullTextSettingsFromJsonPath(jsonPathStr, node, ctx);
-    if (!settings) {
+    auto jsonIndexSettings = CollectJsonIndexPredicate(flatMap.Lambda().Body(), node, ctx);
+    if (!jsonIndexSettings) {
         return {};
     }
 
     auto searchColumns = Build<TCoAtomList>(ctx, node.Pos())
-        .Add(Build<TCoAtom>(ctx, node.Pos()).Value(jsonColumnName).Done())
+        .Add(Build<TCoAtom>(ctx, node.Pos()).Value(jsonIndexSettings->ColumnName).Done())
         .Done();
 
     auto newInput = Build<TKqlReadTableFullTextIndex>(ctx, node.Pos())
@@ -1993,7 +1908,7 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBas
         .Columns(read.Columns())
         .Query<TExprList>().Build()
         .QueryColumns(searchColumns.Ptr())
-        .Settings(settings->BuildNode(ctx, node.Pos()))
+        .Settings(jsonIndexSettings->Settings.BuildNode(ctx, node.Pos()))
         .Done();
 
     return Build<TCoFlatMap>(ctx, read.Pos())

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
+#include <yql/essentials/core/sql_types/yql_atom_enums.h>
 
 namespace NKikimr::NKqp::NOpt {
 
@@ -74,9 +75,32 @@ std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& js
         return std::unexpected("Expected empty dict as variables");
     }
 
+    if (jsonNode.Maybe<TCoJsonExists>()) {
+        const auto jsonExists = jsonNode.Cast<TCoJsonExists>();
+        if (jsonExists.OnError() && jsonExists.OnError().Maybe<TCoJust>()) {
+            const auto arg = jsonExists.OnError().Cast<TCoJust>().Input();
+            if (arg.Maybe<TCoBool>() && FromString<bool>(arg.Cast<TCoBool>().Literal().Value())) {
+                return std::unexpected("JSON_EXISTS with ON ERROR TRUE is not supported by JSON index");
+            }
+        }
+    }
+
     std::optional<EDataSlot> returningType;
     if (jsonNode.Maybe<TCoJsonValue>()) {
-        auto jsonValue = jsonNode.Cast<TCoJsonValue>();
+        const auto jsonValue = jsonNode.Cast<TCoJsonValue>();
+
+        const auto onEmptyMode = FromString<EJsonValueHandlerMode>(jsonValue.OnEmptyMode().Ref().Content());
+        const auto onEmptyValue = jsonValue.OnEmpty();
+        if (onEmptyMode == EJsonValueHandlerMode::DefaultValue && !onEmptyValue.Maybe<TCoNull>()) {
+            return std::unexpected("DEFAULT ON EMPTY in JSON_VALUE must be NULL");
+        }
+
+        const auto onErrorMode = FromString<EJsonValueHandlerMode>(jsonValue.OnErrorMode().Ref().Content());
+        const auto onErrorValue = jsonValue.OnError();
+        if (onErrorMode == EJsonValueHandlerMode::DefaultValue && !onErrorValue.Maybe<TCoNull>()) {
+            return std::unexpected("DEFAULT ON ERROR in JSON_VALUE must be NULL");
+        }
+
         if (jsonValue.ReturningType()) {
             const auto* returningTypeAnn = jsonValue.ReturningType().Ref()
                 .GetTypeAnn()->Cast<TTypeExprType>()->GetType();

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -72,13 +72,6 @@ ECallableType NodeToCallableType(const TExprBase& node) {
     return ECallableType::JsonExists;
 }
 
-bool IsCoalesceWithTrueDefault(const TCoCoalesce& coalesce) {
-    if (!coalesce.Value().Maybe<TCoBool>()) {
-        return false;
-    }
-    return FromString<bool>(coalesce.Value().Cast<TCoBool>().Literal().Value());
-}
-
 std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& jsonNode) {
     if (!jsonNode.Json().Maybe<TCoMember>()) {
         return std::unexpected("Nested JSON_* functions are not supported");
@@ -340,15 +333,6 @@ std::optional<TPredicateCollectResult> VisitJsonUnaryOperator(const TCoUnaryArit
 }
 
 std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TExprContext& ctx) {
-    if (auto exists = node.Maybe<TCoExists>()) {
-        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
-        if (inner.Maybe<TCoJsonExists>()) {
-            return VisitJsonExists(inner, ctx);
-        }
-
-        return std::nullopt;
-    }
-
     if (node.Maybe<TCoJsonExists>()) {
         auto params = VisitJsonNode(node.Cast<TCoJsonExists>());
         if (!params) {
@@ -377,42 +361,6 @@ std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TEx
         return VisitJsonUnaryOperator(unaryArithmetic.Cast(), ctx);
     }
 
-    if (auto exists = node.Maybe<TCoExists>()) {
-        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
-        if (inner.Maybe<TCoJsonValue>()) {
-            auto params = VisitJsonNode(inner.Cast<TCoJsonValue>());
-            if (!params) {
-                return MakeCollectError(ctx, node.Pos(), params.error());
-            }
-
-            return ParseAndCollectJson(params->ColumnName, params->JsonPath,
-                ECallableType::JsonValue, std::nullopt, ctx, node.Pos());
-        }
-
-        return std::nullopt;
-    }
-
-    if (auto notNode = node.Maybe<TCoNot>()) {
-        const auto inner = notNode.Cast().Value();
-        if (auto exists = inner.Maybe<TCoExists>()) {
-            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
-            if (opt.Maybe<TCoJsonValue>()) {
-                return MakeCollectError(ctx, node.Pos(), "JSON_VALUE IS NULL is not supported by JSON index");
-            }
-
-            return std::nullopt;
-        }
-
-        if (auto coal = inner.Maybe<TCoCoalesce>()) {
-            auto coalesce = coal.Cast();
-            if (coalesce.Predicate().Maybe<TCoJsonValue>() && IsCoalesceWithTrueDefault(coalesce)) {
-                return MakeCollectError(ctx, node.Pos(), "Negated JSON_VALUE is not supported by JSON index");
-            }
-        }
-
-        return std::nullopt;
-    }
-
     if (node.Maybe<TCoJsonValue>()) {
         auto jsonValue = node.Cast<TCoJsonValue>();
         auto params = VisitJsonNode(jsonValue);
@@ -433,40 +381,8 @@ std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TEx
 }
 
 std::optional<TPredicateCollectResult> VisitJsonQuery(const TExprBase& node, TExprContext& ctx) {
-    if (auto exists = node.Maybe<TCoExists>()) {
-        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
-        if (inner.Maybe<TCoJsonQuery>()) {
-            auto params = VisitJsonNode(inner.Cast<TCoJsonQuery>());
-            if (!params) {
-                return MakeCollectError(ctx, node.Pos(), params.error());
-            }
-
-            return ParseAndCollectJson(params->ColumnName, params->JsonPath, ECallableType::JsonQuery, std::nullopt, ctx, node.Pos());
-        }
-
-        return std::nullopt;
-    }
-
-    if (auto notNode = node.Maybe<TCoNot>()) {
-        auto inner = notNode.Cast().Value();
-        if (auto exists = inner.Maybe<TCoExists>()) {
-            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
-            if (opt.Maybe<TCoJsonQuery>()) {
-                return MakeCollectError(ctx, node.Pos(), "JSON_QUERY IS NULL is not supported by JSON index");
-            }
-        }
-
-        return std::nullopt;
-    }
-
     if (node.Maybe<TCoJsonQuery>()) {
-        auto params = VisitJsonNode(node.Cast<TCoJsonQuery>());
-        if (!params) {
-            return MakeCollectError(ctx, node.Pos(), params.error());
-        }
-
-        return ParseAndCollectJson(params->ColumnName, params->JsonPath,
-            ECallableType::JsonQuery, std::nullopt, ctx, node.Pos());
+        return MakeCollectError(ctx, node.Pos(), "JSON_QUERY is not supported by JSON index");
     }
 
     return std::nullopt;

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -1,5 +1,7 @@
 #include "kqp_opt_log_json_index.h"
 
+#include <type_traits>
+
 #include <ydb/core/base/json_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
@@ -18,13 +20,48 @@ struct TPredicateCollectResult {
     TCollectResult Collect;
 };
 
-struct TExtractJsonResult {
+struct TJsonNodeParams {
     TString ColumnName;
     TString JsonPath;
     std::optional<EDataSlot> ReturningType;
 };
 
-ECallableType JsonCallableType(const TExprBase& node) {
+TPredicateCollectResult MakeCollectError(TExprContext& ctx, TPositionHandle pos, TStringBuf message) {
+    return TPredicateCollectResult{"", TCollectResult(
+        TIssue(ctx.GetPosition(pos), TString{message}))};
+}
+
+bool IsJsonValueReturningNonIndexable(std::optional<EDataSlot> slot) {
+    if (!slot) {
+        return false;
+    }
+
+    switch (*slot) {
+        case EDataSlot::Date:
+        case EDataSlot::Datetime:
+        case EDataSlot::Timestamp:
+            return true;
+        default:
+            return false;
+    }
+}
+
+TExprBase UnwrapOptionalNodes(TExprBase node) {
+    while (true) {
+        if (auto just = node.Maybe<TCoJust>()) {
+            node = just.Cast().Input();
+        } else if (auto coalesce = node.Maybe<TCoCoalesce>()) {
+            node = coalesce.Cast().Predicate();
+        } else if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
+            node = optionalIf.Cast().Predicate();
+        } else {
+            break;
+        }
+    }
+    return node;
+}
+
+ECallableType NodeToCallableType(const TExprBase& node) {
     if (node.Maybe<TCoJsonValue>()) {
         return ECallableType::JsonValue;
     } else if (node.Maybe<TCoJsonExists>()) {
@@ -32,49 +69,69 @@ ECallableType JsonCallableType(const TExprBase& node) {
     } else if (node.Maybe<TCoJsonQuery>()) {
         return ECallableType::JsonQuery;
     }
-
     YQL_ENSURE(false, "Unsupported JSON_* function: " << node.Ref().Content());
     return ECallableType::JsonExists;
 }
 
-std::optional<TExtractJsonResult> ExtractJsonQueryBase(const TExprBase& node) {
-    if (!node.Maybe<TCoJsonQueryBase>()) {
-        return std::nullopt;
+bool IsCoalesceWithTrueDefault(const TCoCoalesce& coalesce) {
+    if (!coalesce.Value().Maybe<TCoBool>()) {
+        return false;
+    }
+    return FromString<bool>(coalesce.Value().Cast<TCoBool>().Literal().Value());
+}
+
+std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& jsonNode) {
+    if (!jsonNode.Json().Maybe<TCoMember>()) {
+        return std::unexpected("Nested JSON_* functions are not supported");
     }
 
-    auto jsonNode = node.Cast<TCoJsonQueryBase>();
-    if (!jsonNode.Json().template Maybe<TCoMember>()) {
-        return std::nullopt;
-    }
-    if (!jsonNode.JsonPath().template Maybe<TCoUtf8>()) {
-        return std::nullopt;
+    if (!jsonNode.JsonPath().Maybe<TCoUtf8>()) {
+        return std::unexpected("Expected JSON path as a string literal");
     }
 
     const auto& variables = jsonNode.Variables().Ref();
     if (!variables.GetTypeAnn() || variables.GetTypeAnn()->GetKind() != ETypeAnnotationKind::EmptyDict) {
-        return std::nullopt;
+        return std::unexpected("Expected empty dict as variables");
     }
 
     std::optional<EDataSlot> returningType;
-    if (node.Maybe<TCoJsonValue>()) {
-        auto jsonValue = node.Cast<TCoJsonValue>();
+    if (jsonNode.Maybe<TCoJsonValue>()) {
+        auto jsonValue = jsonNode.Cast<TCoJsonValue>();
         if (jsonValue.ReturningType()) {
-            const auto* returningTypeAnn = jsonValue.ReturningType().Ref().GetTypeAnn()->Cast<TTypeExprType>()->GetType();
+            const auto* returningTypeAnn = jsonValue.ReturningType().Ref()
+                .GetTypeAnn()->Cast<TTypeExprType>()->GetType();
             returningType = returningTypeAnn->Cast<TDataExprType>()->GetSlot();
         }
     }
 
-    return TExtractJsonResult{
-        .ColumnName = jsonNode.Json().template Cast<TCoMember>().Name().StringValue(),
-        .JsonPath = jsonNode.JsonPath().template Cast<TCoUtf8>().Literal().StringValue(),
+    return TJsonNodeParams{
+        .ColumnName = jsonNode.Json().Cast<TCoMember>().Name().StringValue(),
+        .JsonPath = jsonNode.JsonPath().Cast<TCoUtf8>().Literal().StringValue(),
         .ReturningType = returningType
     };
 }
 
-template <typename TLiteral, typename TNode>
-void AppendNumberToJsonPath(const TExprBase& node, TString& value) {
-    double literalValue = static_cast<double>(FromString<TLiteral>(node.Cast<TNode>().Literal().Value()));
-    AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPredicateCollectResult> left,
+    std::optional<TPredicateCollectResult> right, TCollectResult::ETokensMode mode, TExprContext& ctx, TPositionHandle pos)
+{
+    if ((left.has_value() && left->Collect.IsError()) || !right.has_value()) {
+        return left;
+    }
+
+    if ((right.has_value() && right->Collect.IsError()) || !left.has_value()) {
+        return right;
+    }
+
+    if (left->ColumnName != right->ColumnName) {
+        auto error = TCollectResult(TIssue(ctx.GetPosition(pos),
+            TStringBuilder() << "Cross-column predicates are not supported"));
+        return TPredicateCollectResult{"", std::move(error)};
+    }
+
+    auto merged = (mode == TCollectResult::ETokensMode::And)
+        ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
+        : MergeOr(std::move(left->Collect), std::move(right->Collect));
+    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged)};
 }
 
 std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
@@ -87,7 +144,9 @@ std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
 
     if (node.Maybe<TCoBool>()) {
         auto boolValue = FromString<bool>(node.Cast<TCoBool>().Literal().Value());
-        AppendJsonIndexLiteral(value, boolValue ? NBinaryJson::EEntryType::BoolTrue : NBinaryJson::EEntryType::BoolFalse);
+        AppendJsonIndexLiteral(value, boolValue
+            ? NBinaryJson::EEntryType::BoolTrue
+            : NBinaryJson::EEntryType::BoolFalse);
         return value;
     }
 
@@ -166,13 +225,14 @@ std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
     return std::nullopt;
 }
 
-std::optional<TPredicateCollectResult> CollectFromJsonCallable(const TString& columnName, const TString& jsonPath,
+TPredicateCollectResult ParseAndCollectJson(const TString& columnName, const TString& jsonPath,
     ECallableType callableType, std::optional<TExprBase> comparisonValue, TExprContext& ctx, TPositionHandle pos)
 {
     NYql::TIssues parseIssues;
     const auto path = NYql::NJsonPath::ParseJsonPath(jsonPath, parseIssues, 1);
     if (!parseIssues.Empty()) {
-        auto error = TCollectResult(TIssue(ctx.GetPosition(pos), TStringBuilder() << "Failed to parse jsonpath expression: " << parseIssues.ToOneLineString()));
+        auto error = TCollectResult(TIssue(ctx.GetPosition(pos), TStringBuilder()
+            << "Failed to parse JSON path expression: " << parseIssues.ToOneLineString()));
         return TPredicateCollectResult{"", std::move(error)};
     }
 
@@ -182,60 +242,328 @@ std::optional<TPredicateCollectResult> CollectFromJsonCallable(const TString& co
     }
 
     auto& tokens = collectResult.GetTokens();
-    if (comparisonValue && collectResult.CanCollect()) {
+    if (collectResult.CanCollect() && comparisonValue.has_value()) {
+        YQL_ENSURE(tokens.size() == 1, "Expected exactly one token");
+
         if (auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
             tokens.front() += *encodedValue;
+            collectResult.StopCollecting();
         }
     }
 
     return TPredicateCollectResult{columnName, std::move(collectResult)};
 }
 
-std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPredicateCollectResult> left,
-    std::optional<TPredicateCollectResult> right, TCollectResult::ETokensMode mode)
-{
-    if (left && left->Collect.IsError()) {
-        return left;
+template<typename TJsonNode>
+std::optional<std::pair<TExprBase, TExprBase>> NormalizeBinaryJsonOperands(TExprBase left, TExprBase right) {
+    left = UnwrapOptionalNodes(left);
+    right = UnwrapOptionalNodes(right);
+    if (!left.Maybe<TJsonNode>()) {
+        if (!right.Maybe<TJsonNode>()) {
+            return std::nullopt;
+        }
+        std::swap(left, right);
     }
-    if (right && right->Collect.IsError()) {
-        return right;
+    return std::pair{std::move(left), std::move(right)};
+}
+
+std::optional<TPredicateCollectResult> MergeWithRightJsonIfPresent(std::optional<TPredicateCollectResult> leftResult,
+    const TExprBase& right, TExprContext& ctx)
+{
+    if (!right.Maybe<TCoJsonQueryBase>()) {
+        return leftResult;
     }
 
-    if (!left || !right || left->ColumnName != right->ColumnName) {
+    auto rightParams = VisitJsonNode(right.Cast<TCoJsonQueryBase>());
+    if (!rightParams) {
+        return MakeCollectError(ctx, right.Pos(), rightParams.error());
+    }
+
+    auto rightResult = ParseAndCollectJson(rightParams->ColumnName, rightParams->JsonPath,
+        NodeToCallableType(right), std::nullopt, ctx, right.Pos());
+    return MergePredicateResults(std::move(leftResult), std::move(rightResult),
+        TCollectResult::ETokensMode::And, ctx, right.Pos());
+}
+
+template<typename TJsonNode>
+std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& node, TExprBase left, TExprBase right,
+    bool isCompare, bool useEqualComparison, TExprContext& ctx)
+{
+    static_assert(std::is_same_v<TJsonNode, TCoJsonExists> || std::is_same_v<TJsonNode, TCoJsonValue>);
+
+    auto normalized = NormalizeBinaryJsonOperands<TJsonNode>(std::move(left), std::move(right));
+    if (!normalized) {
         return std::nullopt;
     }
 
-    auto merged = (mode == TCollectResult::ETokensMode::And)
-        ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
-        : MergeOr(std::move(left->Collect), std::move(right->Collect));
-    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged)};
+    auto [jsonSide, otherSide] = *normalized;
+    auto leftParams = VisitJsonNode(jsonSide.template Cast<TCoJsonQueryBase>());
+    if (!leftParams) {
+        return MakeCollectError(ctx, left.Pos(), leftParams.error());
+    }
+
+    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
+        if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
+            return MakeCollectError(ctx, left.Pos(),
+                "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
+        }
+    }
+
+    if constexpr (std::is_same_v<TJsonNode, TCoJsonExists>) {
+        if (isCompare && otherSide.template Maybe<TCoBool>()) {
+            const auto boolValue = FromString<bool>(otherSide.template Cast<TCoBool>().Literal().Value());
+            if (node.Maybe<TCoCmpEqual>() && !boolValue) {
+                return MakeCollectError(ctx, otherSide.Pos(),
+                    "Negated JSON_EXISTS is not supported by JSON index");
+            }
+        }
+    }
+
+    std::optional<TExprBase> comparisonValue;
+    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
+        if (useEqualComparison && node.Maybe<TCoCmpEqual>() && otherSide.template Maybe<TCoDataCtor>()) {
+            comparisonValue = otherSide;
+        }
+    }
+
+    constexpr ECallableType callable = std::is_same_v<TJsonNode, TCoJsonValue>
+        ? ECallableType::JsonValue
+        : ECallableType::JsonExists;
+
+    auto leftResult = ParseAndCollectJson(leftParams->ColumnName, leftParams->JsonPath,
+        callable, comparisonValue, ctx, left.Pos());
+    return MergeWithRightJsonIfPresent(std::move(leftResult), otherSide, ctx);
 }
 
-std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node, TExprContext& ctx, TPositionHandle pos) {
-    if (auto just = node.Maybe<TCoJust>()) {
-        return VisitJsonPredicate(just.Cast().Input(), ctx, pos);
-    }
-    if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
-        return VisitJsonPredicate(optionalIf.Cast().Predicate(), ctx, pos);
-    }
-    if (auto coalesce = node.Maybe<TCoCoalesce>()) {
-        return VisitJsonPredicate(coalesce.Cast().Predicate(), ctx, pos);
+template<typename TJsonNode>
+std::optional<TPredicateCollectResult> VisitJsonUnaryOperator(const TCoUnaryArithmetic& unary, TExprContext& ctx) {
+    static_assert(std::is_same_v<TJsonNode, TCoJsonExists> || std::is_same_v<TJsonNode, TCoJsonValue>);
+
+    TExprBase arg = UnwrapOptionalNodes(unary.Arg());
+    if (!arg.Maybe<TJsonNode>()) {
+        return std::nullopt;
     }
 
-    auto createError = [&](const TString& message) -> TPredicateCollectResult {
-        return TPredicateCollectResult{"", TCollectResult(TIssue(ctx.GetPosition(pos), message))};
-    };
+    auto params = VisitJsonNode(arg.Cast<TCoJsonQueryBase>());
+    if (!params) {
+        return MakeCollectError(ctx, arg.Pos(), params.error());
+    }
+
+    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
+        if (IsJsonValueReturningNonIndexable(params->ReturningType)) {
+            return MakeCollectError(ctx, arg.Pos(),
+                "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
+        }
+    }
+
+    constexpr ECallableType callable = std::is_same_v<TJsonNode, TCoJsonValue>
+        ? ECallableType::JsonValue
+        : ECallableType::JsonExists;
+
+    return ParseAndCollectJson(params->ColumnName, params->JsonPath,
+        callable, std::nullopt, ctx, arg.Pos());
+}
+
+std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TExprContext& ctx) {
+    if (auto cmp = node.Maybe<TCoCompare>()) {
+        return VisitJsonBinaryOperator<TCoJsonExists>(node, cmp.Cast().Left(),
+            cmp.Cast().Right(), /* isCompare */ true, /* useEqualComparison */ false, ctx);
+    }
+
+    if (auto binary = node.Maybe<TCoBinaryArithmetic>()) {
+        return VisitJsonBinaryOperator<TCoJsonExists>(node, binary.Cast().Left(),
+            binary.Cast().Right(), /* isCompare */ false, /* useEqualComparison */ false, ctx);
+    }
+
+    if (auto unary = node.Maybe<TCoUnaryArithmetic>()) {
+        return VisitJsonUnaryOperator<TCoJsonExists>(unary.Cast(), ctx);
+    }
+
+    if (auto exists = node.Maybe<TCoExists>()) {
+        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
+        if (inner.Maybe<TCoJsonExists>()) {
+            return VisitJsonExists(inner, ctx);
+        }
+
+        return std::nullopt;
+    }
+
+    if (auto notNode = node.Maybe<TCoNot>()) {
+        const auto inner = notNode.Cast().Value();
+        if (auto exists = inner.Maybe<TCoExists>()) {
+            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
+            if (opt.Maybe<TCoJsonExists>()) {
+                return MakeCollectError(ctx, node.Pos(), "JSON_EXISTS IS NULL is not supported by JSON index");
+            }
+
+            return std::nullopt;
+        }
+
+        if (auto coal = inner.Maybe<TCoCoalesce>()) {
+            auto coalesce = coal.Cast();
+            if (coalesce.Predicate().Maybe<TCoJsonExists>() && IsCoalesceWithTrueDefault(coalesce)) {
+                return MakeCollectError(ctx, node.Pos(), "Negated JSON_EXISTS is not supported by JSON index");
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    if (node.Maybe<TCoJsonExists>()) {
+        auto params = VisitJsonNode(node.Cast<TCoJsonExists>());
+        if (!params) {
+            return MakeCollectError(ctx, node.Pos(), params.error());
+        }
+
+        return ParseAndCollectJson(params->ColumnName, params->JsonPath,
+            ECallableType::JsonExists, std::nullopt, ctx, node.Pos());
+    }
+
+    return std::nullopt;
+}
+
+std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TExprContext& ctx) {
+    if (auto cmp = node.Maybe<TCoCompare>()) {
+        return VisitJsonBinaryOperator<TCoJsonValue>(node, cmp.Cast().Left(),
+            cmp.Cast().Right(), /* isCompare */ true, /* useEqualComparison */ true, ctx);
+    }
+
+    if (auto binary = node.Maybe<TCoBinaryArithmetic>()) {
+        return VisitJsonBinaryOperator<TCoJsonValue>(node, binary.Cast().Left(),
+            binary.Cast().Right(), /* isCompare */ false, /* useEqualComparison */ false, ctx);
+    }
+
+    if (auto unaryArithmetic = node.Maybe<TCoUnaryArithmetic>()) {
+        return VisitJsonUnaryOperator<TCoJsonValue>(unaryArithmetic.Cast(), ctx);
+    }
+
+    if (auto exists = node.Maybe<TCoExists>()) {
+        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
+        if (inner.Maybe<TCoJsonValue>()) {
+            auto params = VisitJsonNode(inner.Cast<TCoJsonValue>());
+            if (!params) {
+                return MakeCollectError(ctx, node.Pos(), params.error());
+            }
+
+            return ParseAndCollectJson(params->ColumnName, params->JsonPath,
+                ECallableType::JsonValue, std::nullopt, ctx, node.Pos());
+        }
+
+        return std::nullopt;
+    }
+
+    if (auto notNode = node.Maybe<TCoNot>()) {
+        const auto inner = notNode.Cast().Value();
+        if (auto exists = inner.Maybe<TCoExists>()) {
+            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
+            if (opt.Maybe<TCoJsonValue>()) {
+                return MakeCollectError(ctx, node.Pos(), "JSON_VALUE IS NULL is not supported by JSON index");
+            }
+
+            return std::nullopt;
+        }
+
+        if (auto coal = inner.Maybe<TCoCoalesce>()) {
+            auto coalesce = coal.Cast();
+            if (coalesce.Predicate().Maybe<TCoJsonValue>() && IsCoalesceWithTrueDefault(coalesce)) {
+                return MakeCollectError(ctx, node.Pos(), "Negated JSON_VALUE is not supported by JSON index");
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    if (node.Maybe<TCoJsonValue>()) {
+        auto jsonValue = node.Cast<TCoJsonValue>();
+        auto params = VisitJsonNode(jsonValue);
+        if (!params) {
+            return MakeCollectError(ctx, node.Pos(), params.error());
+        }
+
+        std::optional<TExprBase> comparisonValue;
+        if (params->ReturningType && *params->ReturningType == EDataSlot::Bool) {
+            comparisonValue = TExprBase(Build<TCoBool>(ctx, node.Pos()).Literal().Build(true).Done().Ptr());
+        }
+
+        return ParseAndCollectJson(params->ColumnName, params->JsonPath,
+            ECallableType::JsonValue, comparisonValue, ctx, node.Pos());
+    }
+
+    return std::nullopt;
+}
+
+std::optional<TPredicateCollectResult> VisitJsonQuery(const TExprBase& node, TExprContext& ctx) {
+    if (auto exists = node.Maybe<TCoExists>()) {
+        auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
+        if (inner.Maybe<TCoJsonQuery>()) {
+            auto params = VisitJsonNode(inner.Cast<TCoJsonQuery>());
+            if (!params) {
+                return MakeCollectError(ctx, node.Pos(), params.error());
+            }
+
+            return ParseAndCollectJson(params->ColumnName, params->JsonPath, ECallableType::JsonQuery, std::nullopt, ctx, node.Pos());
+        }
+
+        return std::nullopt;
+    }
+
+    if (auto notNode = node.Maybe<TCoNot>()) {
+        auto inner = notNode.Cast().Value();
+        if (auto exists = inner.Maybe<TCoExists>()) {
+            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
+            if (opt.Maybe<TCoJsonQuery>()) {
+                return MakeCollectError(ctx, node.Pos(), "JSON_QUERY IS NULL is not supported by JSON index");
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    if (node.Maybe<TCoJsonQuery>()) {
+        auto params = VisitJsonNode(node.Cast<TCoJsonQuery>());
+        if (!params) {
+            return MakeCollectError(ctx, node.Pos(), params.error());
+        }
+
+        return ParseAndCollectJson(params->ColumnName, params->JsonPath,
+            ECallableType::JsonQuery, std::nullopt, ctx, node.Pos());
+    }
+
+    return std::nullopt;
+}
+
+std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node, TExprContext& ctx) {
+    if (auto just = node.Maybe<TCoJust>()) {
+        return VisitJsonPredicate(just.Cast().Input(), ctx);
+    }
+
+    if (auto coalesce = node.Maybe<TCoCoalesce>()) {
+        return VisitJsonPredicate(coalesce.Cast().Predicate(), ctx);
+    }
+
+    if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
+        return VisitJsonPredicate(optionalIf.Cast().Predicate(), ctx);
+    }
 
     if (auto maybeAnd = node.Maybe<TCoAnd>()) {
         auto andNode = maybeAnd.Cast();
         if (andNode.ArgCount() == 0) {
             return std::nullopt;
         }
-        auto result = VisitJsonPredicate(andNode.Arg(0), ctx, pos);
+
+        auto result = VisitJsonPredicate(andNode.Arg(0), ctx);
         for (size_t i = 1; i < andNode.ArgCount(); ++i) {
-            auto next = VisitJsonPredicate(andNode.Arg(i), ctx, pos);
-            result = MergePredicateResults(std::move(result), std::move(next), TCollectResult::ETokensMode::And);
+            auto nextNode = andNode.Arg(i);
+            auto nextResult = VisitJsonPredicate(nextNode, ctx);
+
+            result = MergePredicateResults(std::move(result), std::move(nextResult),
+                TCollectResult::ETokensMode::And, ctx, nextNode.Pos());
+
+            if (result.has_value() && result->Collect.IsError()) {
+                return result;
+            }
         }
+
         return result;
     }
 
@@ -244,97 +572,45 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         if (orNode.ArgCount() == 0) {
             return std::nullopt;
         }
-        auto result = VisitJsonPredicate(orNode.Arg(0), ctx, pos);
+
+        auto result = VisitJsonPredicate(orNode.Arg(0), ctx);
         for (size_t i = 1; i < orNode.ArgCount(); ++i) {
-            auto next = VisitJsonPredicate(orNode.Arg(i), ctx, pos);
-            result = MergePredicateResults(std::move(result), std::move(next), TCollectResult::ETokensMode::Or);
+            auto nextNode = orNode.Arg(i);
+            auto nextResult = VisitJsonPredicate(nextNode, ctx);
+
+            result = MergePredicateResults(std::move(result), std::move(nextResult),
+                TCollectResult::ETokensMode::Or, ctx, nextNode.Pos());
+
+            if (result.has_value() && result->Collect.IsError()) {
+                return result;
+            }
         }
+
         return result;
     }
 
-    if (auto maybeNot = node.Maybe<TCoNot>()) {
-        auto notNode = maybeNot.Cast();
-        if (auto maybeCoalesce = notNode.Value().Maybe<TCoCoalesce>()) {
-            auto coalesceNode = maybeCoalesce.Cast();
-            if (!coalesceNode.Predicate().Maybe<TCoJsonValue>()) {
-                return std::nullopt;
-            }
-
-            auto extracted = ExtractJsonQueryBase(coalesceNode.Predicate().Cast<TCoJsonValue>());
-            if (!extracted) {
-                return createError("Failed to extract JSON_VALUE from predicate");
-            }
-
-            std::optional<TExprBase> comparisonValue;
-            if (extracted->ReturningType && extracted->ReturningType == EDataSlot::Bool) {
-                comparisonValue = TExprBase(Build<TCoBool>(ctx, pos).Literal().Build(false).Done().Ptr());
-            }
-
-            return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
-                ECallableType::JsonValue, comparisonValue, ctx, pos);
-        }
-
-        return std::nullopt;
+    if (auto existsResult = VisitJsonExists(node, ctx)) {
+        return existsResult;
     }
 
-    if (auto maybeExists = node.Maybe<TCoExists>()) {
-        return VisitJsonPredicate(maybeExists.Cast().Optional(), ctx, pos);
+    if (auto valueResult = VisitJsonValue(node, ctx)) {
+        return valueResult;
     }
 
-    if (auto maybeCmp = node.Maybe<TCoCompare>()) {
-        auto cmp = maybeCmp.Cast();
-        TExprBase jsonSide = cmp.Left();
-        TExprBase otherSide = cmp.Right();
-
-        if (!jsonSide.Maybe<TCoJsonQueryBase>()) {
-            if (!otherSide.Maybe<TCoJsonQueryBase>()) {
-                return std::nullopt;
-            }
-            std::swap(jsonSide, otherSide);
-        }
-
-        if (!jsonSide.Maybe<TCoJsonValue>()) {
-            return createError("Expected JSON_VALUE on the left side of comparison");
-        }
-        if (!otherSide.Maybe<TCoDataCtor>()) {
-            return createError("Expected a literal in comparison");
-        }
-
-        auto extracted = ExtractJsonQueryBase(jsonSide.Cast<TCoJsonValue>());
-        if (!extracted) {
-            return createError("Failed to extract JSON_VALUE from comparison");
-        }
-
-        auto comparisonValue = (node.Maybe<TCoCmpEqual>()) ? std::make_optional(otherSide) : std::nullopt;
-        return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
-            ECallableType::JsonValue, comparisonValue, ctx, pos);
+    if (auto queryResult = VisitJsonQuery(node, ctx)) {
+        return queryResult;
     }
 
-    if (auto maybeJson = node.Maybe<TCoJsonQueryBase>()) {
-        auto extracted = ExtractJsonQueryBase(maybeJson.Cast());
-        if (!extracted) {
-            return createError("Failed to extract JSON_* function");
-        }
-
-        std::optional<TExprBase> comparisonValue;
-        if (extracted->ReturningType && extracted->ReturningType == EDataSlot::Bool) {
-            comparisonValue = TExprBase(Build<TCoBool>(ctx, pos).Literal().Build(true).Done().Ptr());
-        }
-
-        return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
-            JsonCallableType(node), comparisonValue, ctx, pos);
-    }
-
-    return createError("Unsupported predicate node: " + TString(node.Ref().Content()));
+    return std::nullopt;
 }
 
 } // namespace
 
 std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& body, const TExprBase& node, TExprContext& ctx) {
-    auto result = VisitJsonPredicate(body, ctx, node.Pos());
+    auto result = VisitJsonPredicate(body, ctx);
     if (!result) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: Predicate is not supported"));
+            << "Failed to extract search terms from predicate: nothing to extract"));
         return std::nullopt;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -304,9 +304,9 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
             "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
     }
 
-    if (isCompare && otherSide.template Maybe<TCoBool>()) {
+    if (isCompare && leftParams->ReturningType && *leftParams->ReturningType == EDataSlot::Bool) {
         return MakeCollectError(ctx, otherSide.Pos(),
-            "Negated JSON_VALUE is not supported by JSON index");
+            "Comparison with JSON_VALUE RETURNING Bool is not supported by JSON index");
     }
 
     std::optional<TExprBase> comparisonValue;

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -17,7 +17,6 @@ namespace {
 struct TPredicateCollectResult {
     TString ColumnName;
     TCollectResult Collect;
-    size_t ProcessedJsonNodes = 0;
 };
 
 struct TJsonNodeParams {
@@ -93,7 +92,7 @@ std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& js
         if (jsonExists.OnError() && jsonExists.OnError().Maybe<TCoJust>()) {
             const auto arg = jsonExists.OnError().Cast<TCoJust>().Input();
             if (arg.Maybe<TCoBool>() && FromString<bool>(arg.Cast<TCoBool>().Literal().Value())) {
-                return std::unexpected("JSON_EXISTS with ON ERROR TRUE is not supported by JSON index");
+                return std::unexpected("JSON_EXISTS with ON ERROR TRUE is not supported");
             }
         }
     }
@@ -131,25 +130,55 @@ std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& js
 std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPredicateCollectResult> left,
     std::optional<TPredicateCollectResult> right, TCollectResult::ETokensMode mode, TExprContext& ctx, TPositionHandle pos)
 {
-    if ((left.has_value() && left->Collect.IsError()) || !right.has_value()) {
-        return left;
+    const bool leftValid  = left.has_value()  && !left->Collect.IsError();
+    const bool rightValid = right.has_value() && !right->Collect.IsError();
+
+    if (leftValid && rightValid) {
+        if (left->ColumnName != right->ColumnName) {
+            return MakeCollectError(ctx, pos, "Cross-column predicates are not supported");
+        }
+
+        auto merged = (mode == TCollectResult::ETokensMode::And)
+            ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
+            : MergeOr(std::move(left->Collect), std::move(right->Collect));
+        return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged)};
     }
 
-    if ((right.has_value() && right->Collect.IsError()) || !left.has_value()) {
-        return right;
+    // AND semantics: one of the operands must be valid
+    if (mode == TCollectResult::ETokensMode::And) {
+        if (leftValid) {
+            return left;
+        }
+
+        if (rightValid) {
+            return right;
+        }
+
+        if (left.has_value() && left->Collect.IsError()) {
+            return left;
+        }
+
+        if (right.has_value() && right->Collect.IsError()) {
+            return right;
+        }
+
+        return std::nullopt;
     }
 
-    if (left->ColumnName != right->ColumnName) {
-        auto error = TCollectResult(TIssue(ctx.GetPosition(pos),
-            TStringBuilder() << "Cross-column predicates are not supported"));
-        return TPredicateCollectResult{"", std::move(error)};
+    // OR semantics: both operands must be valid
+    if (mode == TCollectResult::ETokensMode::Or) {
+        if (left.has_value() && left->Collect.IsError()) {
+            return left;
+        }
+
+        if (right.has_value() && right->Collect.IsError()) {
+            return right;
+        }
+
+        return std::nullopt;
     }
 
-    size_t totalProcessed = left->ProcessedJsonNodes + right->ProcessedJsonNodes;
-    auto merged = (mode == TCollectResult::ETokensMode::And)
-        ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
-        : MergeOr(std::move(left->Collect), std::move(right->Collect));
-    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged), totalProcessed};
+    Y_UNREACHABLE();
 }
 
 std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
@@ -249,9 +278,7 @@ TPredicateCollectResult ParseAndCollectJson(const TString& columnName, const TSt
     NYql::TIssues parseIssues;
     const auto path = NYql::NJsonPath::ParseJsonPath(jsonPath, parseIssues, 1);
     if (!parseIssues.Empty()) {
-        auto error = TCollectResult(TIssue(ctx.GetPosition(pos), TStringBuilder()
-            << "Failed to parse JSON path expression: " << parseIssues.ToOneLineString()));
-        return TPredicateCollectResult{"", std::move(error)};
+        return MakeCollectError(ctx, pos, "Failed to parse JSON path expression: " + parseIssues.ToOneLineString());
     }
 
     auto collectResult = CollectJsonPath(path, callableType);
@@ -269,7 +296,7 @@ TPredicateCollectResult ParseAndCollectJson(const TString& columnName, const TSt
         }
     }
 
-    return TPredicateCollectResult{columnName, std::move(collectResult), 1};
+    return TPredicateCollectResult{columnName, std::move(collectResult)};
 }
 
 template<typename TJsonNode>
@@ -298,12 +325,11 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
     }
 
     if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
-        return std::nullopt;
+        return MakeCollectError(ctx, jsonSide.Pos(), "Date/time types in RETURNING clause are not supported");
     }
 
     if (leftParams->ReturningType.has_value() && *leftParams->ReturningType == EDataSlot::Bool) {
-        return MakeCollectError(ctx, otherSide.Pos(),
-            "Comparison with JSON_VALUE RETURNING Bool is not supported by JSON index");
+        return MakeCollectError(ctx, jsonSide.Pos(), "Comparison JSON_VALUE with RETURNING Bool is not supported");
     }
 
     std::optional<TExprBase> comparisonValue;
@@ -393,10 +419,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
 
             result = MergePredicateResults(std::move(result), std::move(nextResult),
                 TCollectResult::ETokensMode::And, ctx, nextNode.Pos());
-
-            if (result.has_value() && result->Collect.IsError()) {
-                return result;
-            }
         }
 
         return result;
@@ -423,10 +445,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
 
             result = MergePredicateResults(std::move(result), std::move(nextResult),
                 TCollectResult::ETokensMode::Or, ctx, nextNode.Pos());
-
-            if (result.has_value() && result->Collect.IsError()) {
-                return result;
-            }
         }
 
         return result;
@@ -464,7 +482,7 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
 
     if (hasJsonQuery) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: JSON_QUERY is not supported by JSON index"));
+            << "Failed to extract search terms from predicate: JSON_QUERY is not supported"));
         return std::nullopt;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -1,7 +1,5 @@
 #include "kqp_opt_log_json_index.h"
 
-#include <type_traits>
-
 #include <ydb/core/base/json_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
@@ -18,6 +16,7 @@ namespace {
 struct TPredicateCollectResult {
     TString ColumnName;
     TCollectResult Collect;
+    size_t ProcessedJsonNodes = 0;
 };
 
 struct TJsonNodeParams {
@@ -128,10 +127,11 @@ std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPred
         return TPredicateCollectResult{"", std::move(error)};
     }
 
+    size_t totalProcessed = left->ProcessedJsonNodes + right->ProcessedJsonNodes;
     auto merged = (mode == TCollectResult::ETokensMode::And)
         ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
         : MergeOr(std::move(left->Collect), std::move(right->Collect));
-    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged)};
+    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged), totalProcessed};
 }
 
 std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
@@ -251,7 +251,7 @@ TPredicateCollectResult ParseAndCollectJson(const TString& columnName, const TSt
         }
     }
 
-    return TPredicateCollectResult{columnName, std::move(collectResult)};
+    return TPredicateCollectResult{columnName, std::move(collectResult), 1};
 }
 
 template<typename TJsonNode>
@@ -285,13 +285,10 @@ std::optional<TPredicateCollectResult> MergeWithRightJsonIfPresent(std::optional
         TCollectResult::ETokensMode::And, ctx, right.Pos());
 }
 
-template<typename TJsonNode>
-std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& node, TExprBase left, TExprBase right,
-    bool isCompare, bool useEqualComparison, TExprContext& ctx)
+std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& node, TExprBase left,
+    TExprBase right, bool isCompare, bool useEqualComparison, TExprContext& ctx)
 {
-    static_assert(std::is_same_v<TJsonNode, TCoJsonExists> || std::is_same_v<TJsonNode, TCoJsonValue>);
-
-    auto normalized = NormalizeBinaryJsonOperands<TJsonNode>(std::move(left), std::move(right));
+    auto normalized = NormalizeBinaryJsonOperands<TCoJsonValue>(std::move(left), std::move(right));
     if (!normalized) {
         return std::nullopt;
     }
@@ -302,45 +299,29 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
         return MakeCollectError(ctx, left.Pos(), leftParams.error());
     }
 
-    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
-        if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
-            return MakeCollectError(ctx, left.Pos(),
-                "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
-        }
+    if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
+        return MakeCollectError(ctx, left.Pos(),
+            "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
     }
 
-    if constexpr (std::is_same_v<TJsonNode, TCoJsonExists>) {
-        if (isCompare && otherSide.template Maybe<TCoBool>()) {
-            const auto boolValue = FromString<bool>(otherSide.template Cast<TCoBool>().Literal().Value());
-            if (node.Maybe<TCoCmpEqual>() && !boolValue) {
-                return MakeCollectError(ctx, otherSide.Pos(),
-                    "Negated JSON_EXISTS is not supported by JSON index");
-            }
-        }
+    if (isCompare && otherSide.template Maybe<TCoBool>()) {
+        return MakeCollectError(ctx, otherSide.Pos(),
+            "Negated JSON_VALUE is not supported by JSON index");
     }
 
     std::optional<TExprBase> comparisonValue;
-    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
-        if (useEqualComparison && node.Maybe<TCoCmpEqual>() && otherSide.template Maybe<TCoDataCtor>()) {
-            comparisonValue = otherSide;
-        }
+    if (useEqualComparison && node.Maybe<TCoCmpEqual>() && otherSide.template Maybe<TCoDataCtor>()) {
+        comparisonValue = otherSide;
     }
 
-    constexpr ECallableType callable = std::is_same_v<TJsonNode, TCoJsonValue>
-        ? ECallableType::JsonValue
-        : ECallableType::JsonExists;
-
     auto leftResult = ParseAndCollectJson(leftParams->ColumnName, leftParams->JsonPath,
-        callable, comparisonValue, ctx, left.Pos());
+        ECallableType::JsonValue, comparisonValue, ctx, left.Pos());
     return MergeWithRightJsonIfPresent(std::move(leftResult), otherSide, ctx);
 }
 
-template<typename TJsonNode>
 std::optional<TPredicateCollectResult> VisitJsonUnaryOperator(const TCoUnaryArithmetic& unary, TExprContext& ctx) {
-    static_assert(std::is_same_v<TJsonNode, TCoJsonExists> || std::is_same_v<TJsonNode, TCoJsonValue>);
-
     TExprBase arg = UnwrapOptionalNodes(unary.Arg());
-    if (!arg.Maybe<TJsonNode>()) {
+    if (!arg.Maybe<TCoJsonValue>()) {
         return std::nullopt;
     }
 
@@ -349,61 +330,20 @@ std::optional<TPredicateCollectResult> VisitJsonUnaryOperator(const TCoUnaryArit
         return MakeCollectError(ctx, arg.Pos(), params.error());
     }
 
-    if constexpr (std::is_same_v<TJsonNode, TCoJsonValue>) {
-        if (IsJsonValueReturningNonIndexable(params->ReturningType)) {
-            return MakeCollectError(ctx, arg.Pos(),
-                "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
-        }
+    if (IsJsonValueReturningNonIndexable(params->ReturningType)) {
+        return MakeCollectError(ctx, arg.Pos(),
+            "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
     }
 
-    constexpr ECallableType callable = std::is_same_v<TJsonNode, TCoJsonValue>
-        ? ECallableType::JsonValue
-        : ECallableType::JsonExists;
-
     return ParseAndCollectJson(params->ColumnName, params->JsonPath,
-        callable, std::nullopt, ctx, arg.Pos());
+        ECallableType::JsonValue, std::nullopt, ctx, arg.Pos());
 }
 
 std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TExprContext& ctx) {
-    if (auto cmp = node.Maybe<TCoCompare>()) {
-        return VisitJsonBinaryOperator<TCoJsonExists>(node, cmp.Cast().Left(),
-            cmp.Cast().Right(), /* isCompare */ true, /* useEqualComparison */ false, ctx);
-    }
-
-    if (auto binary = node.Maybe<TCoBinaryArithmetic>()) {
-        return VisitJsonBinaryOperator<TCoJsonExists>(node, binary.Cast().Left(),
-            binary.Cast().Right(), /* isCompare */ false, /* useEqualComparison */ false, ctx);
-    }
-
-    if (auto unary = node.Maybe<TCoUnaryArithmetic>()) {
-        return VisitJsonUnaryOperator<TCoJsonExists>(unary.Cast(), ctx);
-    }
-
     if (auto exists = node.Maybe<TCoExists>()) {
         auto inner = UnwrapOptionalNodes(exists.Cast().Optional());
         if (inner.Maybe<TCoJsonExists>()) {
             return VisitJsonExists(inner, ctx);
-        }
-
-        return std::nullopt;
-    }
-
-    if (auto notNode = node.Maybe<TCoNot>()) {
-        const auto inner = notNode.Cast().Value();
-        if (auto exists = inner.Maybe<TCoExists>()) {
-            auto opt = UnwrapOptionalNodes(exists.Cast().Optional());
-            if (opt.Maybe<TCoJsonExists>()) {
-                return MakeCollectError(ctx, node.Pos(), "JSON_EXISTS IS NULL is not supported by JSON index");
-            }
-
-            return std::nullopt;
-        }
-
-        if (auto coal = inner.Maybe<TCoCoalesce>()) {
-            auto coalesce = coal.Cast();
-            if (coalesce.Predicate().Maybe<TCoJsonExists>() && IsCoalesceWithTrueDefault(coalesce)) {
-                return MakeCollectError(ctx, node.Pos(), "Negated JSON_EXISTS is not supported by JSON index");
-            }
         }
 
         return std::nullopt;
@@ -424,17 +364,17 @@ std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TE
 
 std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TExprContext& ctx) {
     if (auto cmp = node.Maybe<TCoCompare>()) {
-        return VisitJsonBinaryOperator<TCoJsonValue>(node, cmp.Cast().Left(),
+        return VisitJsonBinaryOperator(node, cmp.Cast().Left(),
             cmp.Cast().Right(), /* isCompare */ true, /* useEqualComparison */ true, ctx);
     }
 
     if (auto binary = node.Maybe<TCoBinaryArithmetic>()) {
-        return VisitJsonBinaryOperator<TCoJsonValue>(node, binary.Cast().Left(),
+        return VisitJsonBinaryOperator(node, binary.Cast().Left(),
             binary.Cast().Right(), /* isCompare */ false, /* useEqualComparison */ false, ctx);
     }
 
     if (auto unaryArithmetic = node.Maybe<TCoUnaryArithmetic>()) {
-        return VisitJsonUnaryOperator<TCoJsonValue>(unaryArithmetic.Cast(), ctx);
+        return VisitJsonUnaryOperator(unaryArithmetic.Cast(), ctx);
     }
 
     if (auto exists = node.Maybe<TCoExists>()) {
@@ -624,6 +564,26 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
     if (collectResult.GetTokens().empty()) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
             << "Failed to extract search terms from predicate: Empty result"));
+        return std::nullopt;
+    }
+
+    size_t totalJsonNodes = 0;
+    std::function<void(const TExprNode::TPtr&)> countJsonNodes = [&](const TExprNode::TPtr& expr) {
+        if (TExprBase(expr).Maybe<TCoJsonQueryBase>()) {
+            totalJsonNodes++;
+            return;
+        }
+        for (const auto& child : expr->Children()) {
+            countJsonNodes(child);
+        }
+    };
+
+    // VisitExpr only visits unique nodes
+    countJsonNodes(body.Ptr());
+
+    if (result->ProcessedJsonNodes != totalJsonNodes) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: not all JSON_* functions could be used for index lookup"));
         return std::nullopt;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -291,7 +291,9 @@ TPredicateCollectResult ParseAndCollectJson(const TString& columnName, const TSt
         YQL_ENSURE(tokens.size() == 1, "Expected exactly one token");
 
         if (auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
-            tokens.front() += *encodedValue;
+            auto node = tokens.extract(tokens.begin());
+            node.value() += *encodedValue;
+            tokens.insert(std::move(node));
             collectResult.StopCollecting();
         }
     }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -60,18 +60,6 @@ TExprBase UnwrapOptionalNodes(TExprBase node) {
     return node;
 }
 
-ECallableType NodeToCallableType(const TExprBase& node) {
-    if (node.Maybe<TCoJsonValue>()) {
-        return ECallableType::JsonValue;
-    } else if (node.Maybe<TCoJsonExists>()) {
-        return ECallableType::JsonExists;
-    } else if (node.Maybe<TCoJsonQuery>()) {
-        return ECallableType::JsonQuery;
-    }
-    YQL_ENSURE(false, "Unsupported JSON_* function: " << node.Ref().Content());
-    return ECallableType::JsonExists;
-}
-
 std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& jsonNode) {
     if (!jsonNode.Json().Maybe<TCoMember>()) {
         return std::unexpected("Nested JSON_* functions are not supported");
@@ -260,35 +248,15 @@ std::optional<std::pair<TExprBase, TExprBase>> NormalizeBinaryJsonOperands(TExpr
     return std::pair{std::move(left), std::move(right)};
 }
 
-std::optional<TPredicateCollectResult> MergeWithRightJsonIfPresent(std::optional<TPredicateCollectResult> leftResult,
-    const TExprBase& right, TExprContext& ctx)
-{
-    if (!right.Maybe<TCoJsonQueryBase>()) {
-        return leftResult;
-    }
-
-    auto rightParams = VisitJsonNode(right.Cast<TCoJsonQueryBase>());
-    if (!rightParams) {
-        return MakeCollectError(ctx, right.Pos(), rightParams.error());
-    }
-
-    auto rightResult = ParseAndCollectJson(rightParams->ColumnName, rightParams->JsonPath,
-        NodeToCallableType(right), std::nullopt, ctx, right.Pos());
-    return MergePredicateResults(std::move(leftResult), std::move(rightResult),
-        TCollectResult::ETokensMode::And, ctx, right.Pos());
-}
-
-std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& node, TExprBase left,
-    TExprBase right, bool isCompare, bool useEqualComparison, TExprContext& ctx)
-{
+std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& node, TExprBase left, TExprBase right, TExprContext& ctx) {
     auto normalized = NormalizeBinaryJsonOperands<TCoJsonValue>(std::move(left), std::move(right));
     if (!normalized) {
         return std::nullopt;
     }
 
     auto [jsonSide, otherSide] = *normalized;
-    auto leftParams = VisitJsonNode(jsonSide.template Cast<TCoJsonQueryBase>());
-    if (!leftParams) {
+    auto leftParams = VisitJsonNode(jsonSide.Cast<TCoJsonValue>());
+    if (!leftParams.has_value()) {
         return MakeCollectError(ctx, jsonSide.Pos(), leftParams.error());
     }
 
@@ -297,39 +265,32 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
             "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
     }
 
-    if (isCompare && leftParams->ReturningType && *leftParams->ReturningType == EDataSlot::Bool) {
+    if (leftParams->ReturningType.has_value() && *leftParams->ReturningType == EDataSlot::Bool) {
         return MakeCollectError(ctx, otherSide.Pos(),
             "Comparison with JSON_VALUE RETURNING Bool is not supported by JSON index");
     }
 
     std::optional<TExprBase> comparisonValue;
-    if (useEqualComparison && node.Maybe<TCoCmpEqual>() && otherSide.template Maybe<TCoDataCtor>()) {
+    if (node.Maybe<TCoCmpEqual>() && otherSide.Maybe<TCoDataCtor>()) {
         comparisonValue = otherSide;
     }
 
     auto leftResult = ParseAndCollectJson(leftParams->ColumnName, leftParams->JsonPath,
         ECallableType::JsonValue, comparisonValue, ctx, left.Pos());
-    return MergeWithRightJsonIfPresent(std::move(leftResult), otherSide, ctx);
-}
 
-std::optional<TPredicateCollectResult> VisitJsonUnaryOperator(const TCoUnaryArithmetic& unary, TExprContext& ctx) {
-    TExprBase arg = UnwrapOptionalNodes(unary.Arg());
-    if (!arg.Maybe<TCoJsonValue>()) {
-        return std::nullopt;
+    if (otherSide.Maybe<TCoJsonValue>()) {
+        auto rightParams = VisitJsonNode(otherSide.Cast<TCoJsonValue>());
+        if (!rightParams.has_value()) {
+            return MakeCollectError(ctx, otherSide.Pos(), rightParams.error());
+        }
+
+        auto rightResult = ParseAndCollectJson(rightParams->ColumnName, rightParams->JsonPath,
+            ECallableType::JsonValue, std::nullopt, ctx, otherSide.Pos());
+        return MergePredicateResults(std::move(leftResult), std::move(rightResult),
+            TCollectResult::ETokensMode::And, ctx, otherSide.Pos());
     }
 
-    auto params = VisitJsonNode(arg.Cast<TCoJsonQueryBase>());
-    if (!params) {
-        return MakeCollectError(ctx, arg.Pos(), params.error());
-    }
-
-    if (IsJsonValueReturningNonIndexable(params->ReturningType)) {
-        return MakeCollectError(ctx, arg.Pos(),
-            "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
-    }
-
-    return ParseAndCollectJson(params->ColumnName, params->JsonPath,
-        ECallableType::JsonValue, std::nullopt, ctx, arg.Pos());
+    return leftResult;
 }
 
 std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TExprContext& ctx) {
@@ -348,17 +309,7 @@ std::optional<TPredicateCollectResult> VisitJsonExists(const TExprBase& node, TE
 
 std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TExprContext& ctx) {
     if (auto cmp = node.Maybe<TCoCompare>()) {
-        return VisitJsonBinaryOperator(node, cmp.Cast().Left(),
-            cmp.Cast().Right(), /* isCompare */ true, /* useEqualComparison */ true, ctx);
-    }
-
-    if (auto binary = node.Maybe<TCoBinaryArithmetic>()) {
-        return VisitJsonBinaryOperator(node, binary.Cast().Left(),
-            binary.Cast().Right(), /* isCompare */ false, /* useEqualComparison */ false, ctx);
-    }
-
-    if (auto unaryArithmetic = node.Maybe<TCoUnaryArithmetic>()) {
-        return VisitJsonUnaryOperator(unaryArithmetic.Cast(), ctx);
+        return VisitJsonBinaryOperator(node, cmp.Cast().Left(), cmp.Cast().Right(), ctx);
     }
 
     if (node.Maybe<TCoJsonValue>()) {
@@ -380,25 +331,17 @@ std::optional<TPredicateCollectResult> VisitJsonValue(const TExprBase& node, TEx
     return std::nullopt;
 }
 
-std::optional<TPredicateCollectResult> VisitJsonQuery(const TExprBase& node, TExprContext& ctx) {
-    if (node.Maybe<TCoJsonQuery>()) {
-        return MakeCollectError(ctx, node.Pos(), "JSON_QUERY is not supported by JSON index");
-    }
-
-    return std::nullopt;
-}
-
 std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node, TExprContext& ctx) {
-    if (auto just = node.Maybe<TCoJust>()) {
-        return VisitJsonPredicate(just.Cast().Input(), ctx);
+    if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
+        return VisitJsonPredicate(optionalIf.Cast().Predicate(), ctx);
     }
 
     if (auto coalesce = node.Maybe<TCoCoalesce>()) {
         return VisitJsonPredicate(coalesce.Cast().Predicate(), ctx);
     }
 
-    if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
-        return VisitJsonPredicate(optionalIf.Cast().Predicate(), ctx);
+    if (auto just = node.Maybe<TCoJust>()) {
+        return VisitJsonPredicate(just.Cast().Input(), ctx);
     }
 
     if (auto maybeAnd = node.Maybe<TCoAnd>()) {
@@ -461,10 +404,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         return valueResult;
     }
 
-    if (auto queryResult = VisitJsonQuery(node, ctx)) {
-        return queryResult;
-    }
-
     return std::nullopt;
 }
 
@@ -492,9 +431,12 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
     }
 
     size_t totalJsonNodes = 0;
+    bool hasJsonQuery = false;
+
     std::function<void(const TExprNode::TPtr&)> countJsonNodes = [&](const TExprNode::TPtr& expr) {
         if (TExprBase(expr).Maybe<TCoJsonQueryBase>()) {
             totalJsonNodes++;
+            hasJsonQuery |= static_cast<bool>(TExprBase(expr).Maybe<TCoJsonQuery>());
             return;
         }
         for (const auto& child : expr->Children()) {
@@ -503,6 +445,12 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
     };
 
     countJsonNodes(body.Ptr());
+
+    if (hasJsonQuery) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: JSON_QUERY is not supported by JSON index"));
+        return std::nullopt;
+    }
 
     if (result->ProcessedJsonNodes != totalJsonNodes) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -37,12 +37,22 @@ bool IsJsonValueReturningNonIndexable(std::optional<EDataSlot> slot) {
     }
 
     switch (*slot) {
-        case EDataSlot::Date:
-        case EDataSlot::Datetime:
-        case EDataSlot::Timestamp:
-            return true;
-        default:
+        case EDataSlot::Int8:
+        case EDataSlot::Int16:
+        case EDataSlot::Int32:
+        case EDataSlot::Int64:
+        case EDataSlot::Uint8:
+        case EDataSlot::Uint16:
+        case EDataSlot::Uint32:
+        case EDataSlot::Uint64:
+        case EDataSlot::Float:
+        case EDataSlot::Double:
+        case EDataSlot::String:
+        case EDataSlot::Utf8:
+        case EDataSlot::Bool:
             return false;
+        default:
+            return true;
     }
 }
 
@@ -63,7 +73,10 @@ TExprBase UnwrapOptionalNodes(TExprBase node) {
 
 std::expected<TJsonNodeParams, TString> VisitJsonNode(const TCoJsonQueryBase& jsonNode) {
     if (!jsonNode.Json().Maybe<TCoMember>()) {
-        return std::unexpected("Nested JSON_* functions are not supported");
+        if (jsonNode.Json().Maybe<TCoJsonQueryBase>()) {
+            return std::unexpected("Nested JSON_* functions are not supported");
+        }
+        return std::unexpected("JSON source must be a column reference");
     }
 
     if (!jsonNode.JsonPath().Maybe<TCoUtf8>()) {
@@ -285,8 +298,7 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
     }
 
     if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
-        return MakeCollectError(ctx, jsonSide.Pos(),
-            "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
+        return std::nullopt;
     }
 
     if (leftParams->ReturningType.has_value() && *leftParams->ReturningType == EDataSlot::Bool) {
@@ -434,26 +446,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
 } // namespace
 
 std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& body, const TExprBase& node, TExprContext& ctx) {
-    auto result = VisitJsonPredicate(body, ctx);
-    if (!result) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: nothing to extract"));
-        return std::nullopt;
-    }
-
-    auto& collectResult = result->Collect;
-    if (collectResult.IsError()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: " << collectResult.GetError().GetMessage()));
-        return std::nullopt;
-    }
-
-    if (collectResult.GetTokens().empty()) {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: Empty result"));
-        return std::nullopt;
-    }
-
     size_t totalJsonNodes = 0;
     bool hasJsonQuery = false;
 
@@ -476,9 +468,29 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
         return std::nullopt;
     }
 
-    if (result->ProcessedJsonNodes != totalJsonNodes) {
+    if (totalJsonNodes == 0) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "Failed to extract search terms from predicate: not all JSON_* functions could be used for index lookup"));
+            << "Failed to extract search terms from predicate: no JSON_* functions found"));
+        return std::nullopt;
+    }
+
+    auto result = VisitJsonPredicate(body, ctx);
+    if (!result.has_value()) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: nothing to extract"));
+        return std::nullopt;
+    }
+
+    auto& collectResult = result->Collect;
+    if (collectResult.IsError()) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: " << collectResult.GetError().GetMessage()));
+        return std::nullopt;
+    }
+
+    if (collectResult.GetTokens().empty()) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: Empty result"));
         return std::nullopt;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -289,11 +289,11 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
     auto [jsonSide, otherSide] = *normalized;
     auto leftParams = VisitJsonNode(jsonSide.template Cast<TCoJsonQueryBase>());
     if (!leftParams) {
-        return MakeCollectError(ctx, left.Pos(), leftParams.error());
+        return MakeCollectError(ctx, jsonSide.Pos(), leftParams.error());
     }
 
     if (IsJsonValueReturningNonIndexable(leftParams->ReturningType)) {
-        return MakeCollectError(ctx, left.Pos(),
+        return MakeCollectError(ctx, jsonSide.Pos(),
             "JSON_VALUE with Date/DateTime/Timestamp RETURNING is not supported by JSON index");
     }
 
@@ -408,25 +408,9 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         }
 
         auto result = VisitJsonPredicate(andNode.Arg(0), ctx);
-        if (result.has_value() && result->Collect.GetTokensMode() == TCollectResult::ETokensMode::NotSet) {
-            result->Collect.SetTokensMode(TCollectResult::ETokensMode::And);
-        }
-
         for (size_t i = 1; i < andNode.ArgCount(); ++i) {
             auto nextNode = andNode.Arg(i);
             auto nextResult = VisitJsonPredicate(nextNode, ctx);
-
-            if (result.has_value() && result->Collect.GetTokensMode() == TCollectResult::ETokensMode::Or) {
-                if (!nextResult.has_value()) {
-                    return MakeCollectError(ctx, nextNode.Pos(), "JSON index does not support mixed AND/OR with non-indexable predicates");
-                }
-            }
-
-            if (nextResult.has_value() && nextResult->Collect.GetTokensMode() == TCollectResult::ETokensMode::Or) {
-                if (!result.has_value()) {
-                    return MakeCollectError(ctx, nextNode.Pos(), "JSON index does not support mixed AND/OR with non-indexable predicates");
-                }
-            }
 
             result = MergePredicateResults(std::move(result), std::move(nextResult),
                 TCollectResult::ETokensMode::And, ctx, nextNode.Pos());
@@ -448,10 +432,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         auto result = VisitJsonPredicate(orNode.Arg(0), ctx);
         if (!result.has_value()) {
             return MakeCollectError(ctx, orNode.Arg(0).Pos(), "JSON index does not support OR with non-indexable predicates");
-        }
-
-        if (result->Collect.GetTokensMode() == TCollectResult::ETokensMode::NotSet) {
-            result->Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
         }
 
         for (size_t i = 1; i < orNode.ArgCount(); ++i) {
@@ -522,7 +502,6 @@ std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& bod
         }
     };
 
-    // VisitExpr only visits unique nodes
     countJsonNodes(body.Ptr());
 
     if (result->ProcessedJsonNodes != totalJsonNodes) {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -492,9 +492,25 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         }
 
         auto result = VisitJsonPredicate(andNode.Arg(0), ctx);
+        if (result.has_value() && result->Collect.GetTokensMode() == TCollectResult::ETokensMode::NotSet) {
+            result->Collect.SetTokensMode(TCollectResult::ETokensMode::And);
+        }
+
         for (size_t i = 1; i < andNode.ArgCount(); ++i) {
             auto nextNode = andNode.Arg(i);
             auto nextResult = VisitJsonPredicate(nextNode, ctx);
+
+            if (result.has_value() && result->Collect.GetTokensMode() == TCollectResult::ETokensMode::Or) {
+                if (!nextResult.has_value()) {
+                    return MakeCollectError(ctx, nextNode.Pos(), "JSON index does not support mixed AND/OR with non-indexable predicates");
+                }
+            }
+
+            if (nextResult.has_value() && nextResult->Collect.GetTokensMode() == TCollectResult::ETokensMode::Or) {
+                if (!result.has_value()) {
+                    return MakeCollectError(ctx, nextNode.Pos(), "JSON index does not support mixed AND/OR with non-indexable predicates");
+                }
+            }
 
             result = MergePredicateResults(std::move(result), std::move(nextResult),
                 TCollectResult::ETokensMode::And, ctx, nextNode.Pos());
@@ -514,9 +530,21 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
         }
 
         auto result = VisitJsonPredicate(orNode.Arg(0), ctx);
+        if (!result.has_value()) {
+            return MakeCollectError(ctx, orNode.Arg(0).Pos(), "JSON index does not support OR with non-indexable predicates");
+        }
+
+        if (result->Collect.GetTokensMode() == TCollectResult::ETokensMode::NotSet) {
+            result->Collect.SetTokensMode(TCollectResult::ETokensMode::Or);
+        }
+
         for (size_t i = 1; i < orNode.ArgCount(); ++i) {
             auto nextNode = orNode.Arg(i);
             auto nextResult = VisitJsonPredicate(nextNode, ctx);
+
+            if (!nextResult.has_value()) {
+                return MakeCollectError(ctx, nextNode.Pos(), "JSON index does not support OR with non-indexable predicates");
+            }
 
             result = MergePredicateResults(std::move(result), std::move(nextResult),
                 TCollectResult::ETokensMode::Or, ctx, nextNode.Pos());

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -185,6 +185,7 @@ std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPred
 }
 
 std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
+    static constexpr i64 maxSupportedInt = 9007199254740992;
     TString value;
 
     if (node.Maybe<TCoNull>()) {
@@ -243,7 +244,12 @@ std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
     }
 
     if (node.Maybe<TCoInt64>()) {
-        double literalValue = static_cast<double>(FromString<i64>(node.Cast<TCoInt64>().Literal().Value()));
+        auto intValue = FromString<i64>(node.Cast<TCoInt64>().Literal().Value());
+        if (intValue > maxSupportedInt || intValue < -maxSupportedInt) {
+            return std::nullopt;
+        }
+
+        double literalValue = static_cast<double>(intValue);
         AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
         return value;
     }
@@ -267,7 +273,12 @@ std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
     }
 
     if (node.Maybe<TCoUint64>()) {
-        double literalValue = static_cast<double>(FromString<ui64>(node.Cast<TCoUint64>().Literal().Value()));
+        auto uintValue = FromString<ui64>(node.Cast<TCoUint64>().Literal().Value());
+        if (uintValue > static_cast<ui64>(maxSupportedInt)) {
+            return std::nullopt;
+        }
+
+        double literalValue = static_cast<double>(uintValue);
         AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
         return value;
     }
@@ -349,6 +360,14 @@ std::optional<TPredicateCollectResult> VisitJsonBinaryOperator(const TExprBase& 
         auto rightParams = VisitJsonNode(otherSide.Cast<TCoJsonValue>());
         if (!rightParams.has_value()) {
             return MakeCollectError(ctx, otherSide.Pos(), rightParams.error());
+        }
+
+        if (IsJsonValueReturningNonIndexable(rightParams->ReturningType)) {
+            return MakeCollectError(ctx, jsonSide.Pos(), "Date/time types in RETURNING clause are not supported");
+        }
+
+        if (rightParams->ReturningType.has_value() && *rightParams->ReturningType == EDataSlot::Bool) {
+            return MakeCollectError(ctx, jsonSide.Pos(), "Comparison JSON_VALUE with RETURNING Bool is not supported");
         }
 
         auto rightResult = ParseAndCollectJson(rightParams->ColumnName, rightParams->JsonPath,

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -1,5 +1,8 @@
 #include "kqp_opt_log_json_index.h"
 
+#include <expected>
+#include <functional>
+
 #include <ydb/core/base/json_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -182,7 +182,7 @@ std::optional<TPredicateCollectResult> CollectFromJsonCallable(const TString& co
     }
 
     auto& tokens = collectResult.GetTokens();
-    if (comparisonValue && !collectResult.IsFinished() && tokens.size() == 1) {
+    if (comparisonValue && collectResult.CanCollect()) {
         if (auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
             tokens.front() += *encodedValue;
         }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -331,8 +331,6 @@ std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node,
 } // namespace
 
 std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& body, const TExprBase& node, TExprContext& ctx) {
-    Cout << NYql::NCommon::ExprToPrettyString(ctx, body.Ref()) << Endl;
-
     auto result = VisitJsonPredicate(body, ctx, node.Pos());
     if (!result) {
         ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.cpp
@@ -1,0 +1,372 @@
+#include "kqp_opt_log_json_index.h"
+
+#include <ydb/core/base/json_index.h>
+#include <ydb/core/kqp/common/kqp_yql.h>
+#include <ydb/core/kqp/opt/kqp_opt_impl.h>
+#include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
+
+namespace NKikimr::NKqp::NOpt {
+
+using namespace NYql;
+using namespace NYql::NNodes;
+using namespace NJsonIndex;
+
+namespace {
+
+struct TPredicateCollectResult {
+    TString ColumnName;
+    TCollectResult Collect;
+};
+
+struct TExtractJsonResult {
+    TString ColumnName;
+    TString JsonPath;
+    std::optional<EDataSlot> ReturningType;
+};
+
+ECallableType JsonCallableType(const TExprBase& node) {
+    if (node.Maybe<TCoJsonValue>()) {
+        return ECallableType::JsonValue;
+    } else if (node.Maybe<TCoJsonExists>()) {
+        return ECallableType::JsonExists;
+    } else if (node.Maybe<TCoJsonQuery>()) {
+        return ECallableType::JsonQuery;
+    }
+
+    YQL_ENSURE(false, "Unsupported JSON_* function: " << node.Ref().Content());
+    return ECallableType::JsonExists;
+}
+
+std::optional<TExtractJsonResult> ExtractJsonQueryBase(const TExprBase& node) {
+    if (!node.Maybe<TCoJsonQueryBase>()) {
+        return std::nullopt;
+    }
+
+    auto jsonNode = node.Cast<TCoJsonQueryBase>();
+    if (!jsonNode.Json().template Maybe<TCoMember>()) {
+        return std::nullopt;
+    }
+    if (!jsonNode.JsonPath().template Maybe<TCoUtf8>()) {
+        return std::nullopt;
+    }
+
+    const auto& variables = jsonNode.Variables().Ref();
+    if (!variables.GetTypeAnn() || variables.GetTypeAnn()->GetKind() != ETypeAnnotationKind::EmptyDict) {
+        return std::nullopt;
+    }
+
+    std::optional<EDataSlot> returningType;
+    if (node.Maybe<TCoJsonValue>()) {
+        auto jsonValue = node.Cast<TCoJsonValue>();
+        if (jsonValue.ReturningType()) {
+            const auto* returningTypeAnn = jsonValue.ReturningType().Ref().GetTypeAnn()->Cast<TTypeExprType>()->GetType();
+            returningType = returningTypeAnn->Cast<TDataExprType>()->GetSlot();
+        }
+    }
+
+    return TExtractJsonResult{
+        .ColumnName = jsonNode.Json().template Cast<TCoMember>().Name().StringValue(),
+        .JsonPath = jsonNode.JsonPath().template Cast<TCoUtf8>().Literal().StringValue(),
+        .ReturningType = returningType
+    };
+}
+
+template <typename TLiteral, typename TNode>
+void AppendNumberToJsonPath(const TExprBase& node, TString& value) {
+    double literalValue = static_cast<double>(FromString<TLiteral>(node.Cast<TNode>().Literal().Value()));
+    AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+}
+
+std::optional<TString> EncodeValueToJsonPath(const TExprBase& node) {
+    TString value;
+
+    if (node.Maybe<TCoNull>()) {
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Null);
+        return value;
+    }
+
+    if (node.Maybe<TCoBool>()) {
+        auto boolValue = FromString<bool>(node.Cast<TCoBool>().Literal().Value());
+        AppendJsonIndexLiteral(value, boolValue ? NBinaryJson::EEntryType::BoolTrue : NBinaryJson::EEntryType::BoolFalse);
+        return value;
+    }
+
+    if (node.Maybe<TCoString>()) {
+        auto stringValue = node.Cast<TCoString>().Literal().Value();
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::String, stringValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoUtf8>()) {
+        auto utf8Value = node.Cast<TCoUtf8>().Literal().Value();
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::String, utf8Value);
+        return value;
+    }
+
+    if (node.Maybe<TCoFloat>()) {
+        double literalValue = static_cast<double>(FromString<float>(node.Cast<TCoFloat>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoDouble>()) {
+        double literalValue = static_cast<double>(FromString<double>(node.Cast<TCoDouble>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoInt8>()) {
+        double literalValue = static_cast<double>(FromString<i8>(node.Cast<TCoInt8>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoInt16>()) {
+        double literalValue = static_cast<double>(FromString<i16>(node.Cast<TCoInt16>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoInt32>()) {
+        double literalValue = static_cast<double>(FromString<i32>(node.Cast<TCoInt32>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoInt64>()) {
+        double literalValue = static_cast<double>(FromString<i64>(node.Cast<TCoInt64>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoUint8>()) {
+        double literalValue = static_cast<double>(FromString<ui8>(node.Cast<TCoUint8>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoUint16>()) {
+        double literalValue = static_cast<double>(FromString<ui16>(node.Cast<TCoUint16>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoUint32>()) {
+        double literalValue = static_cast<double>(FromString<ui32>(node.Cast<TCoUint32>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    if (node.Maybe<TCoUint64>()) {
+        double literalValue = static_cast<double>(FromString<ui64>(node.Cast<TCoUint64>().Literal().Value()));
+        AppendJsonIndexLiteral(value, NBinaryJson::EEntryType::Number, {}, &literalValue);
+        return value;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<TPredicateCollectResult> CollectFromJsonCallable(const TString& columnName, const TString& jsonPath,
+    ECallableType callableType, std::optional<TExprBase> comparisonValue, TExprContext& ctx, TPositionHandle pos)
+{
+    NYql::TIssues parseIssues;
+    const auto path = NYql::NJsonPath::ParseJsonPath(jsonPath, parseIssues, 1);
+    if (!parseIssues.Empty()) {
+        auto error = TCollectResult(TIssue(ctx.GetPosition(pos), TStringBuilder() << "Failed to parse jsonpath expression: " << parseIssues.ToOneLineString()));
+        return TPredicateCollectResult{"", std::move(error)};
+    }
+
+    auto collectResult = CollectJsonPath(path, callableType);
+    if (collectResult.IsError()) {
+        return TPredicateCollectResult{"", std::move(collectResult)};
+    }
+
+    auto& tokens = collectResult.GetTokens();
+    if (comparisonValue && !collectResult.IsFinished() && tokens.size() == 1) {
+        if (auto encodedValue = EncodeValueToJsonPath(*comparisonValue)) {
+            tokens.front() += *encodedValue;
+        }
+    }
+
+    return TPredicateCollectResult{columnName, std::move(collectResult)};
+}
+
+std::optional<TPredicateCollectResult> MergePredicateResults(std::optional<TPredicateCollectResult> left,
+    std::optional<TPredicateCollectResult> right, TCollectResult::ETokensMode mode)
+{
+    if (left && left->Collect.IsError()) {
+        return left;
+    }
+    if (right && right->Collect.IsError()) {
+        return right;
+    }
+
+    if (!left || !right || left->ColumnName != right->ColumnName) {
+        return std::nullopt;
+    }
+
+    auto merged = (mode == TCollectResult::ETokensMode::And)
+        ? MergeAnd(std::move(left->Collect), std::move(right->Collect))
+        : MergeOr(std::move(left->Collect), std::move(right->Collect));
+    return TPredicateCollectResult{std::move(left->ColumnName), std::move(merged)};
+}
+
+std::optional<TPredicateCollectResult> VisitJsonPredicate(const TExprBase& node, TExprContext& ctx, TPositionHandle pos) {
+    if (auto just = node.Maybe<TCoJust>()) {
+        return VisitJsonPredicate(just.Cast().Input(), ctx, pos);
+    }
+    if (auto optionalIf = node.Maybe<TCoOptionalIf>()) {
+        return VisitJsonPredicate(optionalIf.Cast().Predicate(), ctx, pos);
+    }
+    if (auto coalesce = node.Maybe<TCoCoalesce>()) {
+        return VisitJsonPredicate(coalesce.Cast().Predicate(), ctx, pos);
+    }
+
+    auto createError = [&](const TString& message) -> TPredicateCollectResult {
+        return TPredicateCollectResult{"", TCollectResult(TIssue(ctx.GetPosition(pos), message))};
+    };
+
+    if (auto maybeAnd = node.Maybe<TCoAnd>()) {
+        auto andNode = maybeAnd.Cast();
+        if (andNode.ArgCount() == 0) {
+            return std::nullopt;
+        }
+        auto result = VisitJsonPredicate(andNode.Arg(0), ctx, pos);
+        for (size_t i = 1; i < andNode.ArgCount(); ++i) {
+            auto next = VisitJsonPredicate(andNode.Arg(i), ctx, pos);
+            result = MergePredicateResults(std::move(result), std::move(next), TCollectResult::ETokensMode::And);
+        }
+        return result;
+    }
+
+    if (auto maybeOr = node.Maybe<TCoOr>()) {
+        auto orNode = maybeOr.Cast();
+        if (orNode.ArgCount() == 0) {
+            return std::nullopt;
+        }
+        auto result = VisitJsonPredicate(orNode.Arg(0), ctx, pos);
+        for (size_t i = 1; i < orNode.ArgCount(); ++i) {
+            auto next = VisitJsonPredicate(orNode.Arg(i), ctx, pos);
+            result = MergePredicateResults(std::move(result), std::move(next), TCollectResult::ETokensMode::Or);
+        }
+        return result;
+    }
+
+    if (auto maybeNot = node.Maybe<TCoNot>()) {
+        auto notNode = maybeNot.Cast();
+        if (auto maybeCoalesce = notNode.Value().Maybe<TCoCoalesce>()) {
+            auto coalesceNode = maybeCoalesce.Cast();
+            if (!coalesceNode.Predicate().Maybe<TCoJsonValue>()) {
+                return std::nullopt;
+            }
+
+            auto extracted = ExtractJsonQueryBase(coalesceNode.Predicate().Cast<TCoJsonValue>());
+            if (!extracted) {
+                return createError("Failed to extract JSON_VALUE from predicate");
+            }
+
+            std::optional<TExprBase> comparisonValue;
+            if (extracted->ReturningType && extracted->ReturningType == EDataSlot::Bool) {
+                comparisonValue = TExprBase(Build<TCoBool>(ctx, pos).Literal().Build(false).Done().Ptr());
+            }
+
+            return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
+                ECallableType::JsonValue, comparisonValue, ctx, pos);
+        }
+
+        return std::nullopt;
+    }
+
+    if (auto maybeExists = node.Maybe<TCoExists>()) {
+        return VisitJsonPredicate(maybeExists.Cast().Optional(), ctx, pos);
+    }
+
+    if (auto maybeCmp = node.Maybe<TCoCompare>()) {
+        auto cmp = maybeCmp.Cast();
+        TExprBase jsonSide = cmp.Left();
+        TExprBase otherSide = cmp.Right();
+
+        if (!jsonSide.Maybe<TCoJsonQueryBase>()) {
+            if (!otherSide.Maybe<TCoJsonQueryBase>()) {
+                return std::nullopt;
+            }
+            std::swap(jsonSide, otherSide);
+        }
+
+        if (!jsonSide.Maybe<TCoJsonValue>()) {
+            return createError("Expected JSON_VALUE on the left side of comparison");
+        }
+        if (!otherSide.Maybe<TCoDataCtor>()) {
+            return createError("Expected a literal in comparison");
+        }
+
+        auto extracted = ExtractJsonQueryBase(jsonSide.Cast<TCoJsonValue>());
+        if (!extracted) {
+            return createError("Failed to extract JSON_VALUE from comparison");
+        }
+
+        auto comparisonValue = (node.Maybe<TCoCmpEqual>()) ? std::make_optional(otherSide) : std::nullopt;
+        return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
+            ECallableType::JsonValue, comparisonValue, ctx, pos);
+    }
+
+    if (auto maybeJson = node.Maybe<TCoJsonQueryBase>()) {
+        auto extracted = ExtractJsonQueryBase(maybeJson.Cast());
+        if (!extracted) {
+            return createError("Failed to extract JSON_* function");
+        }
+
+        std::optional<TExprBase> comparisonValue;
+        if (extracted->ReturningType && extracted->ReturningType == EDataSlot::Bool) {
+            comparisonValue = TExprBase(Build<TCoBool>(ctx, pos).Literal().Build(true).Done().Ptr());
+        }
+
+        return CollectFromJsonCallable(extracted->ColumnName, extracted->JsonPath,
+            JsonCallableType(node), comparisonValue, ctx, pos);
+    }
+
+    return createError("Unsupported predicate node: " + TString(node.Ref().Content()));
+}
+
+} // namespace
+
+std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const TExprBase& body, const TExprBase& node, TExprContext& ctx) {
+    Cout << NYql::NCommon::ExprToPrettyString(ctx, body.Ref()) << Endl;
+
+    auto result = VisitJsonPredicate(body, ctx, node.Pos());
+    if (!result) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: Predicate is not supported"));
+        return std::nullopt;
+    }
+
+    auto& collectResult = result->Collect;
+    if (collectResult.IsError()) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: " << collectResult.GetError().GetMessage()));
+        return std::nullopt;
+    }
+
+    if (collectResult.GetTokens().empty()) {
+        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
+            << "Failed to extract search terms from predicate: Empty result"));
+        return std::nullopt;
+    }
+
+    TVector<TExprNode::TPtr> tokenNodes;
+    tokenNodes.reserve(collectResult.GetTokens().size());
+    for (const auto& token : collectResult.GetTokens()) {
+        tokenNodes.push_back(Build<TCoString>(ctx, node.Pos()).Literal().Build(token).Done().Ptr());
+    }
+
+    TStringBuf defaultOperator = collectResult.GetTokensMode() == TCollectResult::ETokensMode::Or ? "or" : "and";
+
+    auto settings = TKqpReadTableFullTextIndexSettings{};
+    settings.SetDefaultOperator(Build<TCoString>(ctx, node.Pos()).Literal().Build(defaultOperator).Done().Ptr());
+    settings.SetMinimumShouldMatch(Build<TCoString>(ctx, node.Pos()).Literal().Build("").Done().Ptr());
+    settings.SetTokens(ctx.NewList(node.Pos(), std::move(tokenNodes)));
+
+    return TJsonIndexSettings{std::move(result->ColumnName), std::move(settings)};
+}
+
+} // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_json_index.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <ydb/core/kqp/common/kqp_yql.h>
+#include <yql/essentials/ast/yql_expr.h>
+
+namespace NKikimr::NKqp::NOpt {
+
+struct TJsonIndexSettings {
+    TString ColumnName;
+    NYql::TKqpReadTableFullTextIndexSettings Settings;
+};
+
+std::optional<TJsonIndexSettings> CollectJsonIndexPredicate(const NYql::NNodes::TExprBase& body, const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx);
+
+} // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/logical/ya.make
+++ b/ydb/core/kqp/opt/logical/ya.make
@@ -6,6 +6,7 @@ SRCS(
     kqp_opt_log_helpers.cpp
     kqp_opt_log_join.cpp
     kqp_opt_log_indexes.cpp
+    kqp_opt_log_json_index.cpp
     kqp_opt_log_ranges.cpp
     kqp_opt_log_ranges_predext.cpp
     kqp_opt_log_sort.cpp

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2070,6 +2070,46 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\2k1"});
 
+            // JSON_VALUE op JSON_VALUE - both collectable
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k2' RETURNING Int32) == JSON_VALUE(Text, '$.k1' RETURNING Int32))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+
+            // JSON_VALUE RETURNING Bool comparison is not supported
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) >= JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) < JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) <= JSON_VALUE(Text, '$.k2' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k2' RETURNING Bool) == JSON_VALUE(Text, '$.k1' RETURNING Bool))");
+            ValidateError(db, R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool)))");
+            ValidateError(db, R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) > JSON_VALUE(Text, '$.k2' RETURNING Bool)))");
+
             // For some nodes inside the path, the collected result cannot be combined with == operator
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"') == "true")", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\2k1"});

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2078,6 +2078,12 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$ ? (@.k1 == 1 && @.k2 == 2)') == true)");
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b'))");
+
+            // JSON_EXISTS with TRUE ON ERROR is negation
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.key' TRUE ON ERROR))");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' FALSE ON ERROR))", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' ERROR ON ERROR))", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' UNKNOWN ON ERROR))", {"\3key"});
         });
     }
 
@@ -2321,6 +2327,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e' RETURNING Int32) == 1)");
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")");
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u OR JSON_VALUE(Text, '$.b') == "w")");
+
+            // DEFAULT ON EMPTY with non-NULL value is negation
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY) > 10)");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON EMPTY) > 10)", {"\3key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON EMPTY) > 10)", {"\3key"});
+
+            // DEFAULT ON ERROR with non-NULL value is negation
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON ERROR) > 10)");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON ERROR) > 10)", {"\3key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON ERROR) > 10)", {"\3key"});
+
+            // Both DEFAULT ON EMPTY and DEFAULT ON ERROR with non-NULL value are negation too
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10)");
         });
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -230,18 +230,19 @@ void FillTestTable(TQueryClient& db, const std::string& tableName, const std::st
 }
 
 void ValidatePredicate(TQueryClient& db, const std::string& predicate) {
-    static constexpr const char* Table = "TestTable";
-    static constexpr const char* IndexTable = "json_idx";
+    static constexpr const char* table = "TestTable";
+    static constexpr const char* indexTable = "json_idx";
+
     auto query = [&](const std::string& indexPart, const std::string& pred) {
         return std::format(R"(
             SELECT Key, Text FROM {} {} WHERE {} ORDER BY Key;
-        )", Table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
+        )", table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
     };
 
     auto mainResult = db.ExecuteQuery(query("", predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(mainResult.IsSuccess(), mainResult.GetIssues().ToString());
 
-    auto indexResult = db.ExecuteQuery(query(IndexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    auto indexResult = db.ExecuteQuery(query(indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(indexResult.IsSuccess(), indexResult.GetIssues().ToString());
 
     // Cerr << "MAIN: " << Endl << FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
@@ -252,15 +253,16 @@ void ValidatePredicate(TQueryClient& db, const std::string& predicate) {
 }
 
 void ValidateError(TQueryClient& db, const std::string& predicate) {
-    static constexpr const char* Table = "TestTable";
-    static constexpr const char* IndexTable = "json_idx";
+    static constexpr const char* table = "TestTable";
+    static constexpr const char* indexTable = "json_idx";
+
     auto query = [&](const std::string& indexPart, const std::string& pred) {
         return std::format(R"(
             SELECT * FROM {} {} WHERE {} ORDER BY Key;
-        )", Table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
+        )", table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
     };
 
-    auto result = db.ExecuteQuery(query(IndexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    auto result = db.ExecuteQuery(query(indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(!result.IsSuccess(), "Predicate: " + predicate + ", issues: " + result.GetIssues().ToString());
     UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Failed to extract search terms from predicate", "for predicate = " << predicate);
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 
+#include <optional>
+
 namespace NKikimr::NKqp {
 
 using namespace NYdb::NQuery;
@@ -263,7 +265,7 @@ void ValidateError(TQueryClient& db, const std::string& predicate) {
     UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Failed to extract search terms from predicate", "for predicate = " << predicate);
 }
 
-void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
+void TestSelectJsonWithIndex(const std::string& jsonType, const std::optional<bool>& jsonExistsStrict,
     const std::function<void(TQueryClient&, const std::function<std::string(const std::string&)>&)>& body)
 {
     auto kikimr = Kikimr();
@@ -272,10 +274,15 @@ void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
     kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
     kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
 
-    const std::string jsonType = isJsonDocument ? "JsonDocument" : "Json";
-    const auto jsonExists = [&](const std::string& predicate) {
-        return std::format("JSON_EXISTS(Text, '{}')", (isStrict ? "strict " : "lax ") + predicate);
-    };
+    std::function<std::string(const std::string&)> jsonExists;
+    if (jsonExistsStrict.has_value()) {
+        const bool isStrict = jsonExistsStrict.value();
+        jsonExists = [isStrict](const std::string& predicate) {
+            return std::format("JSON_EXISTS(Text, '{}')", (isStrict ? "strict " : "lax ") + predicate);
+        };
+    } else {
+        jsonExists = [](const std::string&) { return std::string{}; };
+    }
 
     CreateTestTable(db, jsonType, /* withIndex */ false);
     FillTestTable(db, "TestTable", jsonType);
@@ -332,28 +339,6 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, std::vector<
     std::sort(expected.begin(), expected.end());
 
     UNIT_ASSERT_VALUES_EQUAL_C(actual, expected, "for predicate = " << predicate);
-}
-
-void TestSelectJsonTokens(const std::function<void(TQueryClient&)>& body) {
-    auto kikimr = Kikimr();
-    auto db = kikimr.GetQueryClient();
-
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-
-    const std::string jsonType = "JsonDocument";
-    CreateTestTable(db, jsonType, /* withIndex */ false);
-    FillTestTable(db, "TestTable", jsonType);
-
-    {
-        auto query = R"(
-            ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (Text)
-        )";
-        auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-    }
-
-    body(db);
 }
 
 TExecuteQueryResult WriteJsonIndexWithKeys(TQueryClient& db, const std::string& stmt, const std::string& tableName,
@@ -1281,13 +1266,13 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_ContextObject, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$"));
         });
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_MemberAccess, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$.k1"));
             ValidatePredicate(db, jsonExists("$.k2"));
             ValidatePredicate(db, jsonExists("$.k3"));
@@ -1326,7 +1311,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_ArrayAccess, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$[0]"));
             ValidatePredicate(db, jsonExists("$[0, 3]"));
             ValidatePredicate(db, jsonExists("$[1 to 3]"));
@@ -1352,7 +1337,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_Methods, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             auto validateMethod = [&](const std::string& method) {
                 ValidatePredicate(db, jsonExists(std::format("$.{}", method)));
                 ValidatePredicate(db, jsonExists(std::format("$.k1.{}", method)));
@@ -1382,7 +1367,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // All 6 literal types with == inside a filter, plus @ itself (not a sub-member)
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterEqual, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             // @.field == literal, all literal types
             ValidatePredicate(db, jsonExists("$ ? (@.k1 == 1)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k2 == -1.5)"));
@@ -1405,7 +1390,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // All comparison operators in a filter
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterComparisonOps, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 < 10)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 <= -1)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 > 0)"));
@@ -1421,7 +1406,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // AND and OR boolean operators inside filter predicates
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterLogicalOps, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k4 == true && @.k5 == null)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 > 0 && @.k1 < 100)"));
@@ -1434,7 +1419,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Corner cases for the filter context path: deep nesting, array subscript, empty key
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterPaths, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1[0] == 1)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k6[2] == false)"));
@@ -1446,7 +1431,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Predicates and boolean operators inside filter
     Y_UNIT_TEST_QUAD(SelectJsonExists_Predicates, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             // Predicates are not allowed in JsonExists without a filter
             ValidateError(db, jsonExists("exists($.k1)"));
             ValidateError(db, jsonExists("$.k1 starts with \"abc\""));
@@ -1491,7 +1476,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_Literals, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidateError(db, jsonExists("null"));
             ValidateError(db, jsonExists("1"));
             ValidateError(db, jsonExists("\"str\""));
@@ -1502,7 +1487,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Filter with != (inequality) and range comparisons (<, <=, >, >=)
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterInequality, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 != 1)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k3 != \"text\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k5 != null)"));
@@ -1526,7 +1511,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Three-way AND/OR and mixed (AND+OR) filter predicates
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterAndOrComplex, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k4 == true)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 == \"1\" && @.k2 == \"22\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k2 == false)"));
@@ -1553,7 +1538,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Filter with arithmetic operators combined with && and ||: OR dominance
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterArithmeticWithBooleanOps, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 == \"text\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 - @.k2 > 0 || @.k4 == true)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 * @.k2 != 0 || @.k5 == null)"));
@@ -1579,7 +1564,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Filter with path-vs-path comparison operators combined with && and ||: OR dominance
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterComparisonWithBooleanOps, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 || @.k3 == \"text\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 > @.k2 || @.k4 == true)"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1 <= @.k2 || @.k5 == null)"));
@@ -1608,7 +1593,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Filter with paths: deep nesting, array subscripts inside filter, empty key
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterPathsDeep, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
             ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"2\")"));
 
@@ -1640,7 +1625,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Combined key access + array subscript + method with filter
     Y_UNIT_TEST_QUAD(SelectJsonExists_PathArrayMethodWithFilter, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$.k1[*] ? (@.k1 == 10)"));
             ValidatePredicate(db, jsonExists("$.k1[0] ? (@.k1 == 10)"));
             ValidatePredicate(db, jsonExists("$.k1[last] ? (@.k1 == 20)"));
@@ -1665,7 +1650,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Nested filter: result of an inner filter (@ ? (pred)) is accessed as an object
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilter, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k2 == -1.5)"));
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k3 == \"text\")"));
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k4 == false)"));
@@ -1700,7 +1685,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Nested filter where the inner predicate uses AND or OR
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilterAndOr, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k5 == null)"));
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k3 == \"text\")).k4 == true)"));
             ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == false)).k5 == null)"));
@@ -1723,7 +1708,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Nested filter combined with other path constructs: array subscript, wildcards, double nesting
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilterPaths, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$ ? ((@[0] ? (@.k1 == \"1\")).k2 == \"22\")"));
             ValidatePredicate(db, jsonExists("$.k1 ? ((@[0] ? (@.k1 == 10)).k1 == 10)"));
             ValidatePredicate(db, jsonExists("$.k1 ? ((@[last] ? (@.k1 == 20)).k1 == 20)"));
@@ -1748,7 +1733,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     // Combined key access + array subscript + methods + predicates + filters + literals + nested filter + AND/OR
     Y_UNIT_TEST_QUAD(SelectJsonExists_Mix, IsJsonDocument, IsStrict) {
-        TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
+        TestSelectJsonWithIndex(IsJsonDocument ? "JsonDocument" : "Json", std::make_optional(IsStrict), [](TQueryClient& db, const auto& jsonExists) {
             ValidatePredicate(db, jsonExists("$.k1[*] ? (exists(@.k1 ? (@.type() starts with \"s\")))"));
             ValidatePredicate(db, jsonExists("$.k1 ? (@.k2[*].k3 != null && -@.k1.floor() > +3)"));
 
@@ -1781,7 +1766,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST(JsonExistsTokens) {
-        TestSelectJsonTokens([](TQueryClient& db) {
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Basic path exists cases
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\3key"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\2k1\2k2" + numSuffix(2)});
@@ -1866,7 +1851,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')))");
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))");
 
-            // Filter equality: covers every literal type; the token carries the value suffix
+            // Filter equality - covers every literal type, the token carries the value suffix
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\2k1\2k2" + nullSuffix});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\2k1\2k2" + trueSuffix});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\2k1\2k2" + falseSuffix});
@@ -1876,7 +1861,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\2k1\2k2" + numSuffix(2)});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\2k1\2k2" + strSuffix("s")});
 
-            // Filter inequality / range: path only, no value suffix
+            // Filter inequality / range - path only, no value suffix
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\2k1\2k2"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\2k1\2k2"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\2k1\2k2"});
@@ -1889,7 +1874,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\2k1\2k2"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\2k1\2k2"});
 
-            // Filter path-vs-path comparisons: two tokens, AND mode (value suffix dropped)
+            // Filter path-vs-path comparisons - two tokens, AND mode (value suffix dropped)
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\2k1", "\2k2"}, "and");
@@ -1897,7 +1882,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\2k1", "\2k2"}, "and");
 
-            // Filter arithmetic (path vs literal): path only, no value suffix
+            // Filter arithmetic (path vs literal) - path only, no value suffix
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\2k1"});
@@ -1906,14 +1891,14 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\2k1"});
 
-            // Filter arithmetic (path vs path): two tokens, AND mode
+            // Filter arithmetic (path vs path) - two tokens, AND mode
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\2k1", "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\2k1", "\2k2"}, "and");
 
-            // Filter unary operators: path only
+            // Filter unary operators - path only
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\2k1"});
@@ -1925,7 +1910,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\2k1"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\2k1", "\2k2"}, "and");
 
-            // && / || inside jsonpath: mode propagates from inner operator
+            // && / || inside jsonpath - mode propagates from inner operator
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 != 2)'))",
                 {"\2k1" + numSuffix(1), "\2k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 != 2)'))",
@@ -1974,14 +1959,14 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
                 {"\2k1", "\2k2", "\2k3"}, "and");
 
             // Outer range comparison with bool literal (non-equality): errors
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > true)");
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= false)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true)");
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < false)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < true)");
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= false)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= false)");
 
             // Flipped side (literal op JSON_EXISTS)
             ValidateError(db, R"(true > JSON_EXISTS(Text, '$.k1'))");
@@ -2028,7 +2013,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST(JsonValueTokens) {
-        TestSelectJsonTokens([](TQueryClient& db) {
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported RETURNING types
             ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)"); // negation
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)", {"\3key"});
@@ -2055,22 +2040,37 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "1")", {"\2k1" + strSuffix("1")});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "string")", {"\2k1" + strSuffix("string")});
 
-            // Bool comparison with true
+            // JSON_VALUE comparison with true rewrites to JSON_VALUE without boolean comparison
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
+            ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\2k1" + trueSuffix});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
 
-            // Bool comparison with false (negation)
+            // JSON_VALUE comparison with false rewrites to NOT JSON_VALUE
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
+            ValidateError(db, R"(false == JSON_VALUE(Text, '$.k1' RETURNING Bool))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != true)");
             ValidateError(db, R"(NOT JSON_VALUE(Text, '$.k1' RETURNING Bool))");
 
+            // JSON_VALUE RETURNING Bool with range comparisons - not extractable
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > true)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) >= true)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) < true)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) <= true)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > false)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) >= false)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) < false)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) <= false)");
+
             // Comparison with other literals
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 10)", {"\2k1" + numSuffix(10)});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\2k1"});
 
-            // For some nodes inside the path, it cannot be combined with == operator
+            // For some nodes inside the path, the collected result cannot be combined with == operator
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"') == "true")", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\2k1"});
@@ -2078,7 +2078,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\2k1" + numSuffix(2)});
 
-            // BETWEEN clause
+            // BETWEEN clause (replaces with JSON_VALUE >= 1 AND JSON_VALUE <= 10)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\2k1", "\2k1"});
 
             // AND/OR combinations - numeric equality
@@ -2148,21 +2148,21 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
             ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
 
-            // STARTS WITH
+            // STARTS WITH - path only token
             ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix"))", {"\2k1"});
             ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix") AND JSON_VALUE(Text, '$.k1') == "a")", {"\2k1", "\2k1" + strSuffix("a")});
 
-            // ENDS WITH: not extractable
+            // ENDS WITH - path only token
             ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1'), "suffix"))", {"\2k1"});
 
-            // LIKE / ILIKE: not extractable
+            // LIKE - path only token / ILIKE - not extractable (Re2)
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') LIKE "pattern%")", {"\2k1"});
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1') ILIKE "pattern%")"); // udf
 
-            // REGEXP: not extractable
+            // REGEXP - not extractable (Re2)
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1') REGEXP "^pattern$")"); // udf
 
-            // String concatenation (||) in a comparison: not extractable
+            // String concatenation (||) in a comparison - not extractable
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix")");
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")");
         });

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -117,24 +117,24 @@ void TestAddJsonIndex(const std::string& type, bool nullable, bool covered) {
             [["d1"];[10u];"\0\3literal string"];
             [["array data 6"];[15u];"\0\4\0\0\0\0\0\200F@"];
             [["data 2"];[11u];"\0\4\xB0rh\x91\xED|\xBF?"];
-            [["object data 7"];[16u];"\2id"];
-            [["object data 7"];[16u];"\2id\0\4\0\0\0\0@\x87\xE4@"];
-            [["object data 7"];[16u];"\5brand"];
-            [["object data 7"];[16u];"\5brand\0\3bricks"];
-            [["object data 7"];[16u];"\5parts"];
-            [["object data 7"];[16u];"\5parts\2id"];
-            [["object data 7"];[16u];"\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@"];
-            [["object data 7"];[16u];"\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@"];
-            [["object data 7"];[16u];"\5parts\4name"];
-            [["object data 7"];[16u];"\5parts\4name\0\0031x3"];
-            [["object data 7"];[16u];"\5parts\4name\0\0033x5"];
-            [["object data 7"];[16u];"\5parts\5count"];
-            [["object data 7"];[16u];"\5parts\5count\0\4\0\0\0\0\0\0\x1C@"];
-            [["object data 7"];[16u];"\5parts\5count\0\4\0\0\0\0\0\0001@"];
-            [["object data 7"];[16u];"\5price"];
-            [["object data 7"];[16u];"\5price\0\2"];
-            [["object data 7"];[16u];"\npart_count"];
-            [["object data 7"];[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
+            [["object data 7"];[16u];"\3id"];
+            [["object data 7"];[16u];"\3id\0\4\0\0\0\0@\x87\xE4@"];
+            [["object data 7"];[16u];"\6brand"];
+            [["object data 7"];[16u];"\6brand\0\3bricks"];
+            [["object data 7"];[16u];"\6parts"];
+            [["object data 7"];[16u];"\6parts\3id"];
+            [["object data 7"];[16u];"\6parts\3id\0\4\0\0\0\0\x80\xC3\xDF@"];
+            [["object data 7"];[16u];"\6parts\3id\0\4\0\0\0\0\xC0\xC2\xDF@"];
+            [["object data 7"];[16u];"\6parts\5name"];
+            [["object data 7"];[16u];"\6parts\5name\0\0031x3"];
+            [["object data 7"];[16u];"\6parts\5name\0\0033x5"];
+            [["object data 7"];[16u];"\6parts\6count"];
+            [["object data 7"];[16u];"\6parts\6count\0\4\0\0\0\0\0\0\x1C@"];
+            [["object data 7"];[16u];"\6parts\6count\0\4\0\0\0\0\0\0001@"];
+            [["object data 7"];[16u];"\6price"];
+            [["object data 7"];[16u];"\6price\0\2"];
+            [["object data 7"];[16u];"\x0bpart_count"];
+            [["object data 7"];[16u];"\x0bpart_count\0\4\0\0\0\0\0\xE4\x95@"]
         ])", FormatResultSetYson(index));
     } else {
         CompareYson(R"([
@@ -153,24 +153,24 @@ void TestAddJsonIndex(const std::string& type, bool nullable, bool covered) {
             [[10u];"\0\3literal string"];
             [[15u];"\0\4\0\0\0\0\0\200F@"];
             [[11u];"\0\4\xB0rh\x91\xED|\xBF?"];
-            [[16u];"\2id"];
-            [[16u];"\2id\0\4\0\0\0\0@\x87\xE4@"];
-            [[16u];"\5brand"];
-            [[16u];"\5brand\0\3bricks"];
-            [[16u];"\5parts"];
-            [[16u];"\5parts\2id"];
-            [[16u];"\5parts\2id\0\4\0\0\0\0\x80\xC3\xDF@"];
-            [[16u];"\5parts\2id\0\4\0\0\0\0\xC0\xC2\xDF@"];
-            [[16u];"\5parts\4name"];
-            [[16u];"\5parts\4name\0\0031x3"];
-            [[16u];"\5parts\4name\0\0033x5"];
-            [[16u];"\5parts\5count"];
-            [[16u];"\5parts\5count\0\4\0\0\0\0\0\0\x1C@"];
-            [[16u];"\5parts\5count\0\4\0\0\0\0\0\0001@"];
-            [[16u];"\5price"];
-            [[16u];"\5price\0\2"];
-            [[16u];"\npart_count"];
-            [[16u];"\npart_count\0\4\0\0\0\0\0\xE4\x95@"]
+            [[16u];"\3id"];
+            [[16u];"\3id\0\4\0\0\0\0@\x87\xE4@"];
+            [[16u];"\6brand"];
+            [[16u];"\6brand\0\3bricks"];
+            [[16u];"\6parts"];
+            [[16u];"\6parts\3id"];
+            [[16u];"\6parts\3id\0\4\0\0\0\0\x80\xC3\xDF@"];
+            [[16u];"\6parts\3id\0\4\0\0\0\0\xC0\xC2\xDF@"];
+            [[16u];"\6parts\5name"];
+            [[16u];"\6parts\5name\0\0031x3"];
+            [[16u];"\6parts\5name\0\0033x5"];
+            [[16u];"\6parts\6count"];
+            [[16u];"\6parts\6count\0\4\0\0\0\0\0\0\x1C@"];
+            [[16u];"\6parts\6count\0\4\0\0\0\0\0\0001@"];
+            [[16u];"\6price"];
+            [[16u];"\6price\0\2"];
+            [[16u];"\x0bpart_count"];
+            [[16u];"\x0bpart_count\0\4\0\0\0\0\0\xE4\x95@"]
         ])", FormatResultSetYson(index));
     }
 }
@@ -603,25 +603,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[3u];""];
-                [[3u];"\2k3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -655,31 +655,31 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 
             CompareYson(R"([
-                [[1u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[1u];"\2k3\0\3v3"];
-                [[1u];"\2k3\0\0"];
-                [[1u];"\2k3"];
+                [[1u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[1u];"\3k3\0\3v3"];
+                [[1u];"\3k3\0\0"];
+                [[1u];"\3k3"];
                 [[1u];""];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[3u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[3u];"\2k2\0\3v2"];
-                [[3u];"\2k2\0\1"];
-                [[3u];"\2k2"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[3u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];"\3k2\0\3v2"];
+                [[3u];"\3k2\0\1"];
+                [[3u];"\3k2"];
                 [[3u];""];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"];
                 [[5u];""];
-                [[5u];"\2k5"];
-                [[5u];"\2k5\0\0"];
-                [[5u];"\2k5\0\3v5"];
-                [[5u];"\2k5\0\4\0\0\0\0\0\0\x14@"]
+                [[5u];"\3k5"];
+                [[5u];"\3k5\0\0"];
+                [[5u];"\3k5\0\3v5"];
+                [[5u];"\3k5\0\4\0\0\0\0\0\0\x14@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
@@ -732,25 +732,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[3u];""];
-                [[3u];"\2k3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -784,31 +784,31 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 
             CompareYson(R"([
-                [[1u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[1u];"\2k3\0\3v3"];
-                [[1u];"\2k3\0\0"];
-                [[1u];"\2k3"];
+                [[1u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[1u];"\3k3\0\3v3"];
+                [[1u];"\3k3\0\0"];
+                [[1u];"\3k3"];
                 [[1u];""];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[3u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[3u];"\2k2\0\3v2"];
-                [[3u];"\2k2\0\1"];
-                [[3u];"\2k2"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[3u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[3u];"\3k2\0\3v2"];
+                [[3u];"\3k2\0\1"];
+                [[3u];"\3k2"];
                 [[3u];""];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"];
                 [[5u];""];
-                [[5u];"\2k5"];
-                [[5u];"\2k5\0\0"];
-                [[5u];"\2k5\0\3v5"];
-                [[5u];"\2k5\0\4\0\0\0\0\0\0\x14@"]
+                [[5u];"\3k5"];
+                [[5u];"\3k5\0\0"];
+                [[5u];"\3k5\0\3v5"];
+                [[5u];"\3k5\0\4\0\0\0\0\0\0\x14@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
@@ -861,25 +861,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[3u];""];
-                [[3u];"\2k3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -911,35 +911,35 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[2u];"\2k2\0\3v2"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2\0\3v2"];
                 [[3u];""];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[5u];"\2k3"];
-                [[5u];"\2k3\0\0"];
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[5u];"\3k3"];
+                [[5u];"\3k3\0\0"];
                 [[5u];""];
-                [[5u];"\2k3\0\3v3"];
-                [[5u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[6u];"\2k2\0\1"];
-                [[6u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[6u];"\2k2"];
+                [[5u];"\3k3\0\3v3"];
+                [[5u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[6u];"\3k2\0\1"];
+                [[6u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[6u];"\3k2"];
                 [[6u];""];
-                [[6u];"\2k2\0\3v2"]
+                [[6u];"\3k2\0\3v2"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -957,35 +957,35 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[2u];"\2k2\0\3v2"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2\0\3v2"];
                 [[3u];""];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[5u];"\2k3"];
-                [[5u];"\2k3\0\0"];
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[5u];"\3k3"];
+                [[5u];"\3k3\0\0"];
                 [[5u];""];
-                [[5u];"\2k3\0\3v3"];
-                [[5u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
-                [[6u];"\2k2\0\1"];
-                [[6u];"\2k2\0\4\0\0\0\0\0\0\0@"];
-                [[6u];"\2k2"];
+                [[5u];"\3k3\0\3v3"];
+                [[5u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
+                [[6u];"\3k2\0\1"];
+                [[6u];"\3k2\0\4\0\0\0\0\0\0\0@"];
+                [[6u];"\3k2"];
                 [[6u];""];
-                [[6u];"\2k2\0\3v2"]
+                [[6u];"\3k2\0\3v2"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
@@ -1020,25 +1020,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\2k2"];
-                [[2u];"\2k2\0\1"];
-                [[2u];"\2k2\0\3v2"];
-                [[2u];"\2k2\0\4\0\0\0\0\0\0\0@"];
+                [[2u];"\3k2"];
+                [[2u];"\3k2\0\1"];
+                [[2u];"\3k2\0\3v2"];
+                [[2u];"\3k2\0\4\0\0\0\0\0\0\0@"];
                 [[3u];""];
-                [[3u];"\2k3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -1079,25 +1079,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[2u];""];
-                [[2u];"\3k10"];
-                [[2u];"\3k10\0\1"];
-                [[2u];"\3k10\0\3v10"];
-                [[2u];"\3k10\0\4\0\0\0\0\0\0$@"];
+                [[2u];"\4k10"];
+                [[2u];"\4k10\0\1"];
+                [[2u];"\4k10\0\3v10"];
+                [[2u];"\4k10\0\4\0\0\0\0\0\0$@"];
                 [[3u];""];
-                [[3u];"\3k10"];
-                [[3u];"\3k10\0\1"];
-                [[3u];"\3k10\0\3v10"];
-                [[3u];"\3k10\0\4\0\0\0\0\0\0$@"];
+                [[3u];"\4k10"];
+                [[3u];"\4k10\0\1"];
+                [[3u];"\4k10\0\3v10"];
+                [[3u];"\4k10\0\4\0\0\0\0\0\0$@"];
                 [[4u];""];
-                [[4u];"\2k4"];
-                [[4u];"\2k4\0\1"];
-                [[4u];"\2k4\0\3v4"];
-                [[4u];"\2k4\0\4\0\0\0\0\0\0\x10@"]
+                [[4u];"\3k4"];
+                [[4u];"\3k4\0\1"];
+                [[4u];"\3k4\0\3v4"];
+                [[4u];"\3k4\0\4\0\0\0\0\0\0\x10@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -1141,25 +1141,25 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\4k100"];
-                [[1u];"\4k100\0\0"];
-                [[1u];"\4k100\0\3v100"];
-                [[1u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[1u];"\5k100"];
+                [[1u];"\5k100\0\0"];
+                [[1u];"\5k100\0\3v100"];
+                [[1u];"\5k100\0\4\0\0\0\0\0\0Y@"];
                 [[2u];""];
-                [[2u];"\4k100"];
-                [[2u];"\4k100\0\0"];
-                [[2u];"\4k100\0\3v100"];
-                [[2u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[2u];"\5k100"];
+                [[2u];"\5k100\0\0"];
+                [[2u];"\5k100\0\3v100"];
+                [[2u];"\5k100\0\4\0\0\0\0\0\0Y@"];
                 [[3u];""];
-                [[3u];"\4k100"];
-                [[3u];"\4k100\0\0"];
-                [[3u];"\4k100\0\3v100"];
-                [[3u];"\4k100\0\4\0\0\0\0\0\0Y@"];
+                [[3u];"\5k100"];
+                [[3u];"\5k100\0\0"];
+                [[3u];"\5k100\0\3v100"];
+                [[3u];"\5k100\0\4\0\0\0\0\0\0Y@"];
                 [[4u];""];
-                [[4u];"\4k100"];
-                [[4u];"\4k100\0\0"];
-                [[4u];"\4k100\0\3v100"];
-                [[4u];"\4k100\0\4\0\0\0\0\0\0Y@"]
+                [[4u];"\5k100"];
+                [[4u];"\5k100\0\0"];
+                [[4u];"\5k100\0\3v100"];
+                [[4u];"\5k100\0\4\0\0\0\0\0\0Y@"]
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
     }
@@ -1219,15 +1219,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             CompareYson(R"([
                 [[1u];""];
-                [[1u];"\2k1"];
-                [[1u];"\2k1\0\0"];
-                [[1u];"\2k1\0\3v1"];
-                [[1u];"\2k1\0\4\0\0\0\0\0\0\xF0?"];
+                [[1u];"\3k1"];
+                [[1u];"\3k1\0\0"];
+                [[1u];"\3k1\0\3v1"];
+                [[1u];"\3k1\0\4\0\0\0\0\0\0\xF0?"];
                 [[3u];""];
-                [[3u];"\2k3"];
-                [[3u];"\2k3\0\0"];
-                [[3u];"\2k3\0\3v3"];
-                [[3u];"\2k3\0\4\0\0\0\0\0\0\x08@"];
+                [[3u];"\3k3"];
+                [[3u];"\3k3\0\0"];
+                [[3u];"\3k3\0\3v3"];
+                [[3u];"\3k3\0\4\0\0\0\0\0\0\x08@"];
             ])", FormatResultSetYson(result.GetResultSet(0)));
         }
 
@@ -1770,11 +1770,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST(JsonExistsTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Basic path exists cases
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\3key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\2k1\2k2" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\2k1" + trueSuffix, "\2k2" + falseSuffix}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\2k1" + nullSuffix, "\2k2" + strSuffix("str")}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\3k1\3k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\3k1" + trueSuffix, "\3k2" + falseSuffix}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\3k1" + nullSuffix, "\3k2" + strSuffix("str")}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\4key"});
 
             // Negated JSON_EXISTS is not supported by JSON index
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key') == false)");
@@ -1785,97 +1785,97 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // AND combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "and");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
 
             // OR combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
+                {"\3k1" + nullSuffix, "\3k2" + strSuffix("str"), "\3k3" + trueSuffix, "\3k4" + falseSuffix}, "or");
 
             // Mixed combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "or");
+                {"\3k1", "\3k2", "\3k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "or");
+                {"\3k1", "\3k2", "\3k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "or");
+                {"\3k1", "\3k2", "\3k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND (JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') AND JSON_EXISTS(Text, '$.k4')))",
-                {"\2k1", "\2k2", "\2k3", "\2k4"}, "and");
+                {"\3k1", "\3k2", "\3k3", "\3k4"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "or");
+                {"\3k1", "\3k2", "\3k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')))",
-                {"\2k1", "\2k2", "\2k3"}, "or");
+                {"\3k1", "\3k2", "\3k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') OR JSON_EXISTS(Text, '$.k4')))",
-                {"\2k1", "\2k2", "\2k3", "\2k4"}, "or");
+                {"\3k1", "\3k2", "\3k3", "\3k4"}, "or");
 
             // AND with non-indexable predicate
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1")",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1'))",
-                {"\2k1"}, "and");
+                {"\3k1"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1")",
-                {"\2k1"}, "and");
+                {"\3k1"}, "and");
             ValidateTokens(db,
                 R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1" AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3') AND Data = "d1")",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
 
             // OR with non-indexable predicate - not extractable
             ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
@@ -1895,10 +1895,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" OR JSON_EXISTS(Text, '$.k2'))");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\2k1", "\2k2"}, "or");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND Data = "d1")", {"\2k1", "\2k2"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND Data = "d1")", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
 
             // NOT JSON_EXISTS and wrapped-NOT forms fall through to "nothing to extract"
             ValidateError(db, R"(NOT JSON_EXISTS(Text, '$.k1'))");
@@ -1906,111 +1906,111 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))");
 
             // Filter equality - covers every literal type, the token carries the value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\2k1\2k2" + nullSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\2k1\2k2" + trueSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\2k1\2k2" + falseSuffix});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == "abc")'))", {"\2k1\2k2" + strSuffix("abc")});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 42)'))", {"\2k1\2k2" + numSuffix(42)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -1.5)'))", {"\2k1\2k2" + numSuffix(-1.5)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\2k1\2k2" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\2k1\2k2" + strSuffix("s")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\3k1\3k2" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\3k1\3k2" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\3k1\3k2" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == "abc")'))", {"\3k1\3k2" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 42)'))", {"\3k1\3k2" + numSuffix(42)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -1.5)'))", {"\3k1\3k2" + numSuffix(-1.5)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\3k1\3k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\3k1\3k2" + strSuffix("s")});
 
             // Filter inequality / range - path only, no value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= 2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= 2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != null)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != "abc")'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 > @.k2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 < @.k2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\2k1\2k2"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= 2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= 2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != null)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != "abc")'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 > @.k2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 < @.k2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\3k1\3k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\3k1\3k2"});
 
             // Filter path-vs-path comparisons - two tokens, AND mode (value suffix dropped)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 < @.k2)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 < @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\3k1", "\3k2"}, "and");
 
             // Filter arithmetic (path vs literal) - path only, no value suffix
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / 2 == 1)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % 2 == 0)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / 2 == 1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % 2 == 0)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\3k1"});
 
             // Filter arithmetic (path vs path) - two tokens, AND mode
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\3k1", "\3k2"}, "and");
 
             // Filter unary operators - path only
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() > 5)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() == 3)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() > 0)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\2k1"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() > 5)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() == 3)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() > 0)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\3k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\3k1", "\3k2"}, "and");
 
             // && / || inside jsonpath - mode propagates from inner operator
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 != 2)'))",
-                {"\2k1" + numSuffix(1), "\2k2"}, "and");
+                {"\3k1" + numSuffix(1), "\3k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 != 2)'))",
-                {"\2k1" + numSuffix(1), "\2k2"}, "or");
+                {"\3k1" + numSuffix(1), "\3k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 && @.k2 < 10)'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 || @.k2 < 10)'))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 && @.k2 * 2 == 4)'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 || @.k2 * 2 == 4)'))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1 && @.k2.size() > 0)'))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1 || @.k2 % 2 == 0)'))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
 
             // Three-way && / || inside jsonpath
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2 && @.k3 == 3)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "and");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2 || @.k3 == 3)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
 
             // Mixed && and || inside jsonpath
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 == 1 && @.k2 == 2) || @.k3 == 3)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || (@.k2 == 2 && @.k3 == 3))'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 > 0 && @.k2 != null) || @.k3 == "text")'))",
-                {"\2k1", "\2k2", "\2k3" + strSuffix("text")}, "or");
+                {"\3k1", "\3k2", "\3k3" + strSuffix("text")}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5 && @.k3 == "text" || @.k4 == null)'))",
-                {"\2k1", "\2k2", "\2k3" + strSuffix("text"), "\2k4" + nullSuffix}, "or");
+                {"\3k1", "\3k2", "\3k3" + strSuffix("text"), "\3k4" + nullSuffix}, "or");
 
             // Outer SQL AND/OR over filters with &&/|| inside
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "and");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') OR JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)') AND JSON_EXISTS(Text, '$ ? (-@.k3 == -3)'))",
-                {"\2k1", "\2k2", "\2k3"}, "and");
+                {"\3k1", "\3k2", "\3k3"}, "and");
 
             // Outer range comparison with bool literal (non-equality): errors
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > true)");
@@ -2029,8 +2029,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(true != JSON_EXISTS(Text, '$.k1'))");
 
             // JSON_EXISTS comparison with true rewrites to JSON_EXISTS without boolean comparison
-            ValidateTokens(db, R"(true == JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
-            ValidateTokens(db, R"(false != JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"(true == JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"(false != JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
 
             // JSON_EXISTS comparison with false rewrites to NOT JSON_EXISTS
             ValidateError(db, R"(false == JSON_EXISTS(Text, '$.k1'))");
@@ -2048,12 +2048,12 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2') <= true)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false OR JSON_EXISTS(Text, '$.k2') < true)");
             // AND: non-indexable range cmp on k1, but standalone JE($.k2) IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))", {"\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))", {"\3k2"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true OR JSON_EXISTS(Text, '$.k2') == true)");
 
             // Outer AND/OR over cross JSON_EXISTS comparisons
             // AND: JE1 > JE2 not indexable, but standalone JE($.k3) IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k3"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k3"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') != JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') >= JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') <= JSON_EXISTS(Text, '$.k4')))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') != JSON_EXISTS(Text, '$.k4')))");
@@ -2080,15 +2080,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$ ? (@.k1 == 1 && @.k2 == 2)') == true)");
 
             // AND: JE in JSON_QUERY + indexable JE -> extract indexable
-            ValidateTokens(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k2"});
             // OR: indexable JE + JE in JSON_QUERY -> error
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b'))");
 
             // JSON_EXISTS with TRUE ON ERROR is negation
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key' TRUE ON ERROR))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' FALSE ON ERROR))", {"\3key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' ERROR ON ERROR))", {"\3key"});
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' UNKNOWN ON ERROR))", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' FALSE ON ERROR))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' ERROR ON ERROR))", {"\4key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key' UNKNOWN ON ERROR))", {"\4key"});
         });
     }
 
@@ -2125,19 +2125,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST(JsonValueTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported RETURNING types
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == 1us)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == 1u)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 1ul)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == 1.0f)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\2k1" + numSuffix(1)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "value"s)", {"\2k1" + strSuffix("value")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "value"u)", {"\2k1" + strSuffix("value")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == 1us)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == 1u)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 1ul)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == 1.0f)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\3k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "value"s)", {"\3k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "value"u)", {"\3k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\3k1" + trueSuffix});
 
             // Not supported RETURNING types
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))");
@@ -2145,18 +2145,18 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Timestamp) == Timestamp("2021-01-01T00:00:00Z"))");
 
             // Default RETURNING type is Utf8
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "1")", {"\2k1" + strSuffix("1")});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "string")", {"\2k1" + strSuffix("string")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "1")", {"\3k1" + strSuffix("1")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "string")", {"\3k1" + strSuffix("string")});
 
             // Negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)");
             ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)"); 
 
             // JV(...) == true is equivalent to standalone JV(...) - collects trueSuffix token
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
-            ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\2k1" + trueSuffix});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\3k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\3k1" + trueSuffix});
 
             // JV comparison with false rewrites to NOT JSON_VALUE
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
@@ -2175,41 +2175,41 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) <= false)");
 
             // Comparison with other literals
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 10)", {"\2k1" + numSuffix(10)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 10)", {"\3k1" + numSuffix(10)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\3k1"});
 
             // JV op JV - both collectable
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= JSON_VALUE(Text, '$.k2' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Int32) == JSON_VALUE(Text, '$.k1' RETURNING Int32))",
-                {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= JSON_VALUE(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= JSON_VALUE(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
 
             // JSON_VALUE RETURNING Bool comparison is not supported
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))");
@@ -2223,92 +2223,92 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) > JSON_VALUE(Text, '$.k2' RETURNING Bool)))");
 
             // For some nodes inside the path, the collected result cannot be combined with == operator
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"') == "true")", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 2)", {"\2k1" + numSuffix(2)});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\2k1" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"') == "true")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 2)", {"\3k1" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\3k1" + numSuffix(2)});
 
             // BETWEEN clause (replaces with JSON_VALUE >= 1 AND JSON_VALUE <= 10)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\3k1"});
 
             // AND/OR combinations - numeric equality
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "and");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "or");
 
             // AND/OR combinations - string equality
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1') == "a" AND JSON_VALUE(Text, '$.k2') == "b")",
-                {"\2k1" + strSuffix("a"), "\2k2" + strSuffix("b")}, "and");
+                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1') == "a" OR JSON_VALUE(Text, '$.k2') == "b")",
-                {"\2k1" + strSuffix("a"), "\2k2" + strSuffix("b")}, "or");
+                {"\3k1" + strSuffix("a"), "\3k2" + strSuffix("b")}, "or");
 
             // AND/OR with range comparisons - path-only tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
-                {"\2k1", "\2k2"}, "and");
+                {"\3k1", "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
 
             // AND/OR mixing equality and range
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1') == "a" AND JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
-                {"\2k1" + strSuffix("a"), "\2k2"}, "and");
+                {"\3k1" + strSuffix("a"), "\3k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1') == "a" OR JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
-                {"\2k1" + strSuffix("a"), "\2k2"}, "or");
+                {"\3k1" + strSuffix("a"), "\3k2"}, "or");
 
             // Three-way AND/OR
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "and");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "and");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
 
             // Mixed AND/OR (AND binds tighter): both cases produce "or"
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
 
             // Comparison operators with strings - path-only token (no value suffix for non-equality)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > "abc")", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < "xyz")", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= "abc")", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= "xyz")", {"\2k1"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != "abc")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > "abc")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < "xyz")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= "abc")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= "xyz")", {"\3k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != "abc")", {"\3k1"});
 
             // Flipped operand order - string comparisons
-            ValidateTokens(db, R"("abc" < JSON_VALUE(Text, '$.k1'))", {"\2k1"});
-            ValidateTokens(db, R"("abc" > JSON_VALUE(Text, '$.k1'))", {"\2k1"});
-            ValidateTokens(db, R"("abc" != JSON_VALUE(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"("abc" < JSON_VALUE(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"("abc" > JSON_VALUE(Text, '$.k1'))", {"\3k1"});
+            ValidateTokens(db, R"("abc" != JSON_VALUE(Text, '$.k1'))", {"\3k1"});
 
             // Flipped operand order - numeric comparisons
-            ValidateTokens(db, R"(10 < JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
-            ValidateTokens(db, R"(10 > JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
-            ValidateTokens(db, R"(10 >= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
-            ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
-            ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+            ValidateTokens(db, R"(10 < JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
+            ValidateTokens(db, R"(10 > JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
+            ValidateTokens(db, R"(10 >= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
+            ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
+            ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\3k1"});
 
             // STARTS WITH - path only token
-            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix"))", {"\2k1"});
-            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix") AND JSON_VALUE(Text, '$.k1') == "a")", {"\2k1", "\2k1" + strSuffix("a")});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix"))", {"\3k1"});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix") AND JSON_VALUE(Text, '$.k1') == "a")", {"\3k1" + strSuffix("a")});
 
             // ENDS WITH - path only token
-            ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1'), "suffix"))", {"\2k1"});
+            ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1'), "suffix"))", {"\3k1"});
 
             // LIKE - path only token / ILIKE - not extractable (Re2)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') LIKE "pattern%")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') LIKE "pattern%")", {"\3k1"});
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1') ILIKE "pattern%")"); // udf
 
             // REGEXP - not extractable (Re2)
@@ -2318,7 +2318,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // If JV1 is the only JSON node - nothing to extract
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix")");
             // AND: JV1 inside concat is non-indexable, but JV2 == "b" IS indexable - post-filter applies
-            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")", {"\2k2" + strSuffix("b")});
+            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")", {"\3k2" + strSuffix("b")});
 
             // Nested JSON_QUERY as JSON source for JSON_VALUE - not extractable
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER), '$.k2' RETURNING Int32) == 1)");
@@ -2333,19 +2333,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e' RETURNING Int32) == 1)");
 
             // AND: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter applies
-            ValidateTokens(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")", {"\1b" + strSuffix("w")});
+            ValidateTokens(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")", {"\2b" + strSuffix("w")});
             // OR: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter does not apply
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u OR JSON_VALUE(Text, '$.b') == "w")");
 
             // DEFAULT ON EMPTY with non-NULL value is negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY) > 10)");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON EMPTY) > 10)", {"\3key"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON EMPTY) > 10)", {"\3key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON EMPTY) > 10)", {"\4key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON EMPTY) > 10)", {"\4key"});
 
             // DEFAULT ON ERROR with non-NULL value is negation
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON ERROR) > 10)");
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON ERROR) > 10)", {"\3key"});
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON ERROR) > 10)", {"\3key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int ERROR ON ERROR) > 10)", {"\4key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int NULL ON ERROR) > 10)", {"\4key"});
 
             // Both DEFAULT ON EMPTY and DEFAULT ON ERROR with non-NULL value are negation too
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10)");
@@ -2359,10 +2359,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"((Data = "a"u) OR (Data = "b"u))");
 
             // JSON_* only (tokens in explain are successful)
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
 
             // JSON_* together with a non-JSON column
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u)))", {"\2k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u)))", {"\3k1"});
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))");
 
             // JSONPath that cannot be parsed for index extraction
@@ -2370,46 +2370,46 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             // OR: an indexable branch and a non-indexable branch (JSON_VALUE in an arithmetic expression)
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))", {"\3k1"});
 
             ValidateError(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) OR JSON_EXISTS(Text, '$.k1'))");
-            ValidateTokens(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"});
 
             // AND: indexable JSON with unsupported JSON (RETURNING Date) - collect error
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))", {"\2k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))", {"\3k1"});
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))");
 
             // OR: one disjunct is indexable, the other is not
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))");
             ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))",
-                {"\2k1" + numSuffix(1)}, "and");
+                {"\3k1" + numSuffix(1)}, "and");
 
             // AND: several indexable JSON_* in one filter
             ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)))",
-                {"\2k1" + numSuffix(1), "\2k1"});
+                {"\3k1" + numSuffix(1)});
             ValidateTokens(db, R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)))",
-                {"\1a", "\1b" + numSuffix(0)});
+                {"\2a", "\2b" + numSuffix(0)});
 
             // OR: only JSON_*; three-way
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) OR (JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2), "\3k3" + numSuffix(3)}, "or");
 
             // OR: a non-JSON disjunct
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\2k1" + numSuffix(1), "\2k1"}, "or");
-            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\2k1" + numSuffix(1), "\2k1"}, "and");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\3k1"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\3k1" + numSuffix(1)}, "and");
 
             // (indexable subexpression) OR (indexable) - "or" mode for tokens
             ValidateTokens(db,
                 R"(((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)) OR (JSON_EXISTS(Text, '$.c'))))",
-                {"\1a", "\1b" + numSuffix(0), "\1c"}, "or");
+                {"\2a", "\2b" + numSuffix(0), "\2c"}, "or");
 
             // AND: three indexable JSON_* in one filter
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0) AND (JSON_VALUE(Text, '$.c') == "z"u)))",
-                {"\1a", "\1b" + numSuffix(0), "\1c" + strSuffix("z")}, "and");
+                {"\2a", "\2b" + numSuffix(0), "\2c" + strSuffix("z")}, "and");
 
             // AND with JSON_QUERY in the same predicate
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))");
@@ -2418,27 +2418,27 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // Case 1: non-indexable is arithmetic JSON_VALUE
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             // Case 2: symmetric (non-indexable first)
             ValidateTokens(db,
                 R"(((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0) AND (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             // Case 3: non-indexable is RETURNING Date (treated as post-filter)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             // Case 4: OR branch contains (indexable AND non-indexable)
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             // Case 5: symmetric (non-indexable-AND first)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)) OR JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"}, "or");
+                {"\3k1", "\3k2"}, "or");
             // Case 6: OR of two indexable JV comparisons AND a non-indexable RETURNING Date JV
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
-                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "or");
+                {"\3k1" + numSuffix(1), "\3k2" + numSuffix(2)}, "or");
 
             // Non-indexable RETURNING types now caught by whitelist (Date, Datetime, Timestamp already tested above)
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) > Date("2021-01-01"))");
@@ -2451,184 +2451,184 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // JSON_EXISTS TRUE ON ERROR + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             // Symmetric: error operand on right -> JE tokens
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))",
-                {"\1a"});
+                {"\2a"});
 
             // JSON_VALUE DEFAULT 12 ON EMPTY + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10 AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10)",
-                {"\1a"});
+                {"\2a"});
 
             // JSON_VALUE DEFAULT 12 ON ERROR + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10 AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10)",
-                {"\1a"});
+                {"\2a"});
 
             // Both ON EMPTY and ON ERROR with non-NULL DEFAULT
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10))",
-                {"\1a"});
+                {"\2a"});
 
             // Multiple non-indexable JV forms AND'd with a single JPRED
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                     AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
                    AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
-                {"\1a"});
+                {"\2a"});
 
             // JV(... RETURNING Bool) == literal + JE -> JE tokens
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)",
-                {"\1a"});
+                {"\2a"});
 
             // Range comparison on Bool + JE
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > true AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) > true)",
-                {"\1a"});
+                {"\2a"});
 
             // JV(Bool) compared with another JV(Bool) + JE
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))",
-                {"\1a"});
+                {"\2a"});
 
             // both error-producing returning types should behave identically inside AND
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
                    AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
-                {"\2k1" + trueSuffix, "\1a"});
+                {"\3k1" + trueSuffix, "\2a"});
 
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a", "\2k1" + trueSuffix});
+                {"\2a", "\3k1" + trueSuffix});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
-                {"\1a", "\2k1" + trueSuffix});
+                {"\2a", "\3k1" + trueSuffix});
 
             ValidateTokens(db,
                 R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a", "\2k1" + trueSuffix});
+                {"\2a", "\3k1" + trueSuffix});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
-                {"\1a", "\2k1" + trueSuffix});
+                {"\2a", "\3k1" + trueSuffix});
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
-                {"\1a"});
+                {"\2a"});
 
             // Same shape but with a comparison form that is supported alone -
             // proves that NOT does not change tokens regardless of inner form
             ValidateTokens(db,
                 R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1))",
-                {"\1a"});
+                {"\2a"});
 
             // Inner OR: JE OR (non-JSON column predicate)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             // Inner OR: JE OR (arithmetic JV - nullopt branch)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             // Inner OR: JE OR (RETURNING Bool comparison - error branch)
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k2' RETURNING Bool) != true))
                    AND JSON_EXISTS(Text, '$.a'))",
-                {"\1a"});
+                {"\2a"});
             // Symmetric: outer AND has the bad OR on the right
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.a')
                    AND (JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))",
-                {"\1a"});
+                {"\2a"});
             // Two valid JPREDs combined with the bad OR: tokens of both JPREDs
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
                    AND JSON_EXISTS(Text, '$.a')
                    AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0))",
-                {"\1a", "\1b" + numSuffix(0)});
+                {"\2a", "\2b" + numSuffix(0)});
 
             // Same forms alone 
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
@@ -2675,7 +2675,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             */
 
             // J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // P -> ERROR
             ValidateError(db, R"((Data = "d1"u))");
             // PJ -> ERROR
@@ -2685,15 +2685,15 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // OR rule: all sides must be indexable
 
             // J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
             // J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
             // P AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
             // PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // P AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u))");
             // P AND PJ -> ERROR
@@ -2704,7 +2704,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
 
             // J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // P OR J -> ERROR
@@ -2723,79 +2723,79 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
 
             // J AND J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "and");
             // J AND J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\3k1", "\3k2"}, "and");
             // J AND J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1", "\3k2"}, "and");
             // J AND P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
             // J AND P AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND (Data = "d1"u))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND (Data = "d1"u))", {"\3k1"}, "and");
             // J AND P AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
             // J AND PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
             // J AND PJ AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))", {"\3k1"}, "and");
             // J AND PJ AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
             // P AND J AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
             // P AND J AND P -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
             // P AND J AND PJ -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
             // P AND P AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // P AND P AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND (Data = "d1"u))");
             // P AND P AND PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // P AND PJ AND J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // P AND PJ AND P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // P AND PJ AND PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "and");
             // PJ AND J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\3k1"}, "and");
             // PJ AND J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1"}, "and");
             // PJ AND P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // PJ AND P AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND (Data = "d1"u))");
             // PJ AND P AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\3k1"}, "and");
             // PJ AND PJ AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // PJ AND PJ AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
             // J AND J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
             // J AND J OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND P OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // J AND P OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR (Data = "d1"u))");
             // J AND P OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J AND PJ OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // J AND PJ OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
             // J AND PJ OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // P AND J OR J -> OK
-            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // P AND J OR P -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // P AND J OR PJ -> ERROR
@@ -2813,7 +2813,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // P AND PJ OR PJ -> ERROR
             ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // PJ AND J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // PJ AND J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
             // PJ AND J OR PJ -> ERROR
@@ -2831,19 +2831,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // PJ AND PJ OR PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR J AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
             // J OR J AND P -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\3k1", "\3k2"}, "or");
             // J OR J AND PJ -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\3k1", "\3k2"}, "or");
             // J OR P AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // J OR P AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND (Data = "d1"u))");
             // J OR P AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR PJ AND J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\3k1", "\3k2"}, "or");
             // J OR PJ AND P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
             // J OR PJ AND PJ -> ERROR
@@ -2885,7 +2885,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // PJ OR PJ AND PJ -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
             // J OR J OR J -> OK
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\3k1", "\3k2", "\3k3"}, "or");
             // J OR J OR P -> ERROR
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
             // J OR J OR PJ -> ERROR

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -1894,6 +1894,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND Data = "d1")", {"\2k1", "\2k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
 

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2352,6 +2352,46 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         });
     }
 
+    Y_UNIT_TEST(JsonValueLargeIntegerPrecisionLoss) {
+        // Int64/Uint64 values outside [-2^53, 2^53] lose precision when cast to double
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
+            constexpr double rounded = 9007199254740992.0;
+
+            // Positive side: supported 2^53 - 1 / 2^53 and rounded 2^53 + 1
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740991l)",
+                {"\3k1" + numSuffix(rounded - 1.0)});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740991ul)",
+                {"\3k1" + numSuffix(rounded - 1.0)});
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740992l)",
+                {"\3k1" + numSuffix(rounded)});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740992ul)",
+                {"\3k1" + numSuffix(rounded)});
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 9007199254740993l)",
+                {"\3k1"});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 9007199254740993ul)",
+                {"\3k1"});
+
+            // Negative side: supported -(2^53 - 1) / -2^53 and rounded -(2^53 + 1)
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740991l)",
+                {"\3k1" + numSuffix(-rounded + 1.0)});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740992l)",
+                {"\3k1" + numSuffix(-rounded)});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == -9007199254740993l)",
+                {"\3k1"});
+        });
+    }
+
     Y_UNIT_TEST(JsonCombinationsTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // No JSON_* in the filter - "no JSON_* functions found"

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2066,6 +2066,37 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         });
     }
 
+    // JSON index does not support JSON_QUERY, every predicate that references it should fail term extraction
+    // No comments ;)
+    Y_UNIT_TEST(JsonQueryTokens) {
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1') IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, 'lax $.k1' WITHOUT ARRAY WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, 'strict $.k1' WITHOUT ARRAY WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, 'strict $.k1' WITHOUT ARRAY WRAPPER NULL ON EMPTY) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, 'strict $.k1' WITHOUT ARRAY WRAPPER NULL ON ERROR) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1' WITH UNCONDITIONAL WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1' WITH CONDITIONAL WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1' WITH UNCONDITIONAL ARRAY WRAPPER) IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$ ? (@.k1 == 1)') IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1.*') IS NOT NULL)");
+            ValidateError(db, R"(JSON_QUERY(Text, '$.k1[0]') IS NOT NULL)");
+            ValidateError(db, R"(NOT (JSON_QUERY(Text, '$.k1') IS NOT NULL))");
+            ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NULL))");
+
+            ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NOT NULL) AND (JSON_QUERY(Text, '$.k2') IS NOT NULL))");
+            ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NOT NULL) OR (JSON_QUERY(Text, '$.k2') IS NOT NULL))");
+            ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NOT NULL) OR (JSON_QUERY(Text, '$.k2') IS NOT NULL) AND (JSON_QUERY(Text, '$.k3') IS NOT NULL))");
+            ValidateError(db, R"((JSON_QUERY(Text, '$.k1') IS NOT NULL) AND (JSON_QUERY(Text, '$.k2') IS NOT NULL) OR (JSON_QUERY(Text, '$.k3') IS NOT NULL))");
+            ValidateError(db, R"(((JSON_QUERY(Text, '$.k1') IS NOT NULL) AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)) OR (JSON_QUERY(Text, '$.k3') IS NOT NULL))");
+
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))");
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_QUERY(Text, '$.k2') IS NOT NULL)))");
+            ValidateError(db, R"((JSON_VALUE(Text, '$.k1') = "1") AND (JSON_QUERY(Text, '$.k2') IS NOT NULL))");
+        });
+    }
+
     Y_UNIT_TEST(JsonValueTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported RETURNING types

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -291,7 +291,7 @@ void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
     body(db, jsonExists);
 }
 
-void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::vector<std::string>& expected,
+void ValidateTokens(TQueryClient& db, const std::string& predicate, std::vector<std::string> expected,
     const std::string& defaultOperator = "and")
 {
     auto settings = TExecuteQuerySettings().ExecMode(EExecMode::Explain);
@@ -306,11 +306,11 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::v
     auto plan = result.GetStats()->GetPlan();
     UNIT_ASSERT_C(plan, "Plan is empty");
 
-    Cerr << "PREDICATE: " << predicate << Endl;
-    auto ast = result.GetStats()->GetAst();
-    UNIT_ASSERT_C(ast, "AST is empty");
-    Cout << "AST: " << Endl << *ast << Endl;
-    Cout << "PLAN: " << Endl << *plan << Endl;
+    // Cerr << "PREDICATE: " << predicate << Endl;
+    // auto ast = result.GetStats()->GetAst();
+    // UNIT_ASSERT_C(ast, "AST is empty");
+    // Cout << "AST: " << Endl << *ast << Endl;
+    // Cout << "PLAN: " << Endl << *plan << Endl;
 
     NJson::TJsonValue planJson;
     auto success = NJson::ReadJsonTree(*plan, &planJson, true);
@@ -323,12 +323,15 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::v
     auto tokens = SplitString(splitTokens, ", ");
     UNIT_ASSERT_VALUES_EQUAL_C(tokens.size(), expected.size(), "for predicate = " << predicate);
 
+    std::vector<std::string> actual;
     for (const auto& token : tokens) {
-        auto decoded = HexDecode(token);
-        if (std::find(expected.begin(), expected.end(), decoded) == expected.end()) {
-            UNIT_FAIL("Unexpected token: " << decoded);
-        }
+        actual.push_back(HexDecode(token));
     }
+
+    std::sort(actual.begin(), actual.end());
+    std::sort(expected.begin(), expected.end());
+
+    UNIT_ASSERT_VALUES_EQUAL_C(actual, expected, "for predicate = " << predicate);
 }
 
 void TestSelectJsonTokens(const std::function<void(TQueryClient&)>& body) {

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2078,7 +2078,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d'))");
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e'))");
             ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$ ? (@.k1 == 1 && @.k2 == 2)') == true)");
-            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))");
+
+            // AND: JE in JSON_QUERY + indexable JE -> extract indexable
+            ValidateTokens(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k2"});
+            // OR: indexable JE + JE in JSON_QUERY -> error
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b'))");
 
             // JSON_EXISTS with TRUE ON ERROR is negation
@@ -2090,7 +2093,6 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     // JSON index does not support JSON_QUERY, every predicate that references it should fail term extraction
-    // No comments ;)
     Y_UNIT_TEST(JsonQueryTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             ValidateError(db, R"(JSON_QUERY(Text, '$.k1') IS NOT NULL)");
@@ -2150,19 +2152,19 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)");
             ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)"); 
 
-            // JSON_VALUE comparison with true rewrites to JSON_VALUE without boolean comparison
+            // JV(...) == true is equivalent to standalone JV(...) - collects trueSuffix token
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
             ValidateTokens(db, R"(true == JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)", {"\2k1" + trueSuffix});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
 
-            // JSON_VALUE comparison with false rewrites to NOT JSON_VALUE
+            // JV comparison with false rewrites to NOT JSON_VALUE
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
             ValidateError(db, R"(false == JSON_VALUE(Text, '$.k1' RETURNING Bool))");
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) != true)");
             ValidateError(db, R"(NOT JSON_VALUE(Text, '$.k1' RETURNING Bool))");
 
-            // JSON_VALUE RETURNING Bool with range comparisons - not extractable
+            // JV RETURNING Bool with range comparisons - not extractable
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > true)");
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) >= true)");
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) < true)");
@@ -2180,7 +2182,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\2k1"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\2k1"});
 
-            // JSON_VALUE op JSON_VALUE - both collectable
+            // JV op JV - both collectable
             ValidateTokens(db,
                 R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == JSON_VALUE(Text, '$.k2' RETURNING Int32))",
                 {"\2k1", "\2k2"}, "and");
@@ -2329,7 +2331,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' RETURNING Int32) == 1)");
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d') == "1")");
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e' RETURNING Int32) == 1)");
-            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")");
+
+            // AND: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter applies
+            ValidateTokens(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")", {"\1b" + strSuffix("w")});
+            // OR: JV1 inside JSON_QUERY is non-indexable, but JV2 == "w" IS indexable - post-filter does not apply
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u OR JSON_VALUE(Text, '$.b') == "w")");
 
             // DEFAULT ON EMPTY with non-NULL value is negation
@@ -2347,8 +2352,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         });
     }
 
-    // CollectJsonIndexPredicate: no JSON_*, only JSON, JSON with non-JSON column, OR rules, path parse, mixed support
-    Y_UNIT_TEST(JsonCombinations) {
+    // CollectJsonIndexPredicate: without JSON_*, only JSON, JSON with non-JSON column, AND rules, OR rules, path parse, mixed support
+    Y_UNIT_TEST(JsonCombinationsTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // No JSON_* in the filter - "no JSON_* functions found"
             ValidateError(db, R"(Key = 1ul)");
@@ -2443,6 +2448,222 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             // Nested JSON_* functions as source - specific error message
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1'), '$.k2') == "1")", "Nested JSON_* functions are not supported");
+
+            // JSON_EXISTS TRUE ON ERROR + JE -> JE tokens
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            // Symmetric: error operand on right -> JE tokens
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))",
+                {"\1a"});
+
+            // JSON_VALUE DEFAULT 12 ON EMPTY + JE -> JE tokens
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10 AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY) > 10)",
+                {"\1a"});
+
+            // JSON_VALUE DEFAULT 12 ON ERROR + JE -> JE tokens
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10 AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10)",
+                {"\1a"});
+
+            // Both ON EMPTY and ON ERROR with non-NULL DEFAULT
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND (JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10))",
+                {"\1a"});
+
+            // Multiple non-indexable JV forms AND'd with a single JPRED
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
+                   AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
+                   AND JSON_EXISTS(Text, '$.a')
+                   AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                    AND JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
+                   AND JSON_EXISTS(Text, '$.k2' TRUE ON ERROR))",
+                {"\1a"});
+
+            // JV(... RETURNING Bool) == literal + JE -> JE tokens
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)",
+                {"\1a"});
+
+            // Range comparison on Bool + JE
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) > true AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a') AND JSON_VALUE(Text, '$.k1' RETURNING Bool) > true)",
+                {"\1a"});
+
+            // JV(Bool) compared with another JV(Bool) + JE
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == JSON_VALUE(Text, '$.k2' RETURNING Bool))",
+                {"\1a"});
+
+            // both error-producing returning types should behave identically inside AND
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\2k1" + trueSuffix, "\1a"});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
+                   AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\2k1" + trueSuffix, "\1a"});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
+                   AND JSON_EXISTS(Text, '$.a')
+                   AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
+                {"\2k1" + trueSuffix, "\1a"});
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
+                   AND JSON_EXISTS(Text, '$.a')
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
+                {"\2k1" + trueSuffix, "\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01"))",
+                {"\2k1" + trueSuffix, "\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Date) == Date("2021-01-01")
+                   AND JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
+                {"\2k1" + trueSuffix, "\1a"});
+
+            ValidateTokens(db,
+                R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a", "\2k1" + trueSuffix});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) == false))",
+                {"\1a", "\2k1" + trueSuffix});
+
+            ValidateTokens(db,
+                R"((JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a", "\2k1" + trueSuffix});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
+                {"\1a", "\2k1" + trueSuffix});
+            ValidateTokens(db,
+                R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Bool) != false))",
+                {"\1a"});
+
+            // Same shape but with a comparison form that is supported alone -
+            // proves that NOT does not change tokens regardless of inner form
+            ValidateTokens(db,
+                R"(NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND NOT (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1))",
+                {"\1a"});
+
+            // Inner OR: JE OR (non-JSON column predicate)
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            // Inner OR: JE OR (arithmetic JV - nullopt branch)
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            // Inner OR: JE OR (RETURNING Bool comparison - error branch)
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k2' RETURNING Bool) != true))
+                   AND JSON_EXISTS(Text, '$.a'))",
+                {"\1a"});
+            // Symmetric: outer AND has the bad OR on the right
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.a')
+                   AND (JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))",
+                {"\1a"});
+            // Two valid JPREDs combined with the bad OR: tokens of both JPREDs
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))
+                   AND JSON_EXISTS(Text, '$.a')
+                   AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0))",
+                {"\1a", "\1b" + numSuffix(0)});
+
+            // Same forms alone 
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
+
+            // Same forms inside OR with another JPRED -> error
+            ValidateError(db,
+                R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.a'))");
+            ValidateError(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
+                   OR JSON_EXISTS(Text, '$.a'))");
+            ValidateError(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false
+                   OR JSON_EXISTS(Text, '$.a'))");
+
+            // (JE OR PRED) at top level - error
+            ValidateError(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            ValidateError(db,
+                R"(JSON_EXISTS(Text, '$.k1')
+                   OR (JSON_VALUE(Text, '$.k2' RETURNING Bool) >= true))");
+
+            // AND of multiple error-producing forms with no JPRED at all -> error
+            ValidateError(db,
+                R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR)
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Bool) == false)");
+            ValidateError(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int DEFAULT 12 ON ERROR) > 10
+                   AND JSON_VALUE(Text, '$.k2' RETURNING Bool) == false)");
+
+            // Error AND non-recognised PRED (no JPRED either) -> error
+            ValidateError(db,
+                R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND Data = "d1"u)");
         });
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -324,7 +324,7 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, std::vector<
     UNIT_ASSERT_C(success, "Failed to read plan as JSON");
 
     auto op = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["DefaultOperator"].GetString();
-    UNIT_ASSERT_VALUES_EQUAL(op, '"' + defaultOperator + '"');
+    UNIT_ASSERT_VALUES_EQUAL_C(op, '"' + defaultOperator + '"', "for predicate = " << predicate);
 
     auto splitTokens = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["Tokens"].GetString();
     auto tokens = SplitString(splitTokens, ", ");
@@ -1845,6 +1845,57 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') OR JSON_EXISTS(Text, '$.k4')))",
                 {"\2k1", "\2k2", "\2k3", "\2k4"}, "or");
+
+            // AND with non-indexable predicate
+            ValidateTokens(db,
+                R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2'))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1")",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1'))",
+                {"\2k1"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1")",
+                {"\2k1"}, "and");
+            ValidateTokens(db,
+                R"(Data = "d1" AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND Data = "d1" AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3') AND Data = "d1")",
+                {"\2k1", "\2k2", "\2k3"}, "and");
+
+            // OR with non-indexable predicate - not extractable
+            ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" OR JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
+            ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1")");
+            ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1" OR JSON_EXISTS(Text, '$.k3'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3') OR Data = "d1")");
+
+            // Mixed AND/OR with Data - not extractable if the non-indexable predicate is on the OR branch
+            ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1")");
+            ValidateError(db, R"(Data = "d1" OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" OR JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR Data = "d1")");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND Data = "d1")", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR Data = "d1" AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND Data = "d1" OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
 
             // NOT JSON_EXISTS and wrapped-NOT forms fall through to "nothing to extract"
             ValidateError(db, R"(NOT JSON_EXISTS(Text, '$.k1'))");

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2231,7 +2231,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\2k1" + numSuffix(2)});
 
             // BETWEEN clause (replaces with JSON_VALUE >= 1 AND JSON_VALUE <= 10)
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\2k1", "\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\2k1"});
 
             // AND/OR combinations - numeric equality
             ValidateTokens(db,
@@ -2352,7 +2352,6 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
         });
     }
 
-    // CollectJsonIndexPredicate: without JSON_*, only JSON, JSON with non-JSON column, AND rules, OR rules, path parse, mixed support
     Y_UNIT_TEST(JsonCombinationsTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // No JSON_* in the filter - "no JSON_* functions found"
@@ -2666,6 +2665,280 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
                 R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND Data = "d1"u)");
         });
     }
-}
 
+    Y_UNIT_TEST(JsonErrorsTokens) {
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
+            /*
+                J - indexable predicate (let J = JSON_EXISTS(Text, '$.k1'))
+                P - non-indexable predicate (let P = Data = "d1"u)
+                PJ - non-indexable predicate with JSON_* (let PJ = JSON_EXISTS(Text, '$.k1' TRUE ON ERROR)))
+            */
+
+            // J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // P -> ERROR
+            ValidateError(db, R"((Data = "d1"u))");
+            // PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+
+            // AND rule: at least one of the sides must be indexable
+            // OR rule: all sides must be indexable
+
+            // J AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            // J AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            // P AND J -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // J AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            // PJ AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // P AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u))");
+            // P AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // PJ AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+
+            // J OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // J OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            // P OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1'))");
+            // J OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1'))");
+            // P OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u))");
+            // P OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // PJ OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+
+            // J AND J AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "and");
+            // J AND J AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\2k1", "\2k2"}, "and");
+            // J AND J AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1", "\2k2"}, "and");
+            // J AND P AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            // J AND P AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND (Data = "d1"u))", {"\2k1"}, "and");
+            // J AND P AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            // J AND PJ AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            // J AND PJ AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))", {"\2k1"}, "and");
+            // J AND PJ AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            // P AND J AND J -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            // P AND J AND P -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            // P AND J AND PJ -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            // P AND P AND J -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // P AND P AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND (Data = "d1"u))");
+            // P AND P AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P AND PJ AND J -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // P AND PJ AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // P AND PJ AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND J AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "and");
+            // PJ AND J AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))", {"\2k1"}, "and");
+            // PJ AND J AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1"}, "and");
+            // PJ AND P AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // PJ AND P AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND (Data = "d1"u))");
+            // PJ AND P AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND PJ AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"}, "and");
+            // PJ AND PJ AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // PJ AND PJ AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J AND J OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            // J AND J OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
+            // J AND J OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J AND P OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // J AND P OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR (Data = "d1"u))");
+            // J AND P OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J AND PJ OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // J AND PJ OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // J AND PJ OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P AND J OR J -> OK
+            ValidateTokens(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // P AND J OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            // P AND J OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P AND P OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1'))");
+            // P AND P OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) OR (Data = "d1"u))");
+            // P AND P OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P AND PJ OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1'))");
+            // P AND PJ OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // P AND PJ OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND J OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // PJ AND J OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            // PJ AND J OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND P OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1'))");
+            // PJ AND P OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) OR (Data = "d1"u))");
+            // PJ AND P OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ AND PJ OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1'))");
+            // PJ AND PJ OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // PJ AND PJ OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J OR J AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            // J OR J AND P -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND (Data = "d1"u))", {"\2k1", "\2k2"}, "or");
+            // J OR J AND PJ -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))", {"\2k1", "\2k2"}, "or");
+            // J OR P AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // J OR P AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND (Data = "d1"u))");
+            // J OR P AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J OR PJ AND J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k2'))", {"\2k1", "\2k2"}, "or");
+            // J OR PJ AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // J OR PJ AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR J AND J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))");
+            // P OR J AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))");
+            // P OR J AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR P AND J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))");
+            // P OR P AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) AND (Data = "d1"u))");
+            // P OR P AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR PJ AND J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))");
+            // P OR PJ AND P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // P OR PJ AND PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR J AND J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))");
+            // PJ OR J AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u))");
+            // PJ OR J AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR P AND J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1'))");
+            // PJ OR P AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) AND (Data = "d1"u))");
+            // PJ OR P AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR PJ AND J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1'))");
+            // PJ OR PJ AND P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND (Data = "d1"u))");
+            // PJ OR PJ AND PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) AND JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J OR J OR J -> OK
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))", {"\2k1", "\2k2", "\2k3"}, "or");
+            // J OR J OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR (Data = "d1"u))");
+            // J OR J OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J OR P OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k2'))");
+            // J OR P OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) OR (Data = "d1"u))");
+            // J OR P OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // J OR PJ OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k2'))");
+            // J OR PJ OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // J OR PJ OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR J OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
+            // P OR J OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            // P OR J OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR P OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1'))");
+            // P OR P OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) OR (Data = "d1"u))");
+            // P OR P OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // P OR PJ OR J -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1'))");
+            // P OR PJ OR P -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // P OR PJ OR PJ -> ERROR
+            ValidateError(db, R"((Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR J OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))");
+            // PJ OR J OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u))");
+            // PJ OR J OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR P OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1'))");
+            // PJ OR P OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) OR (Data = "d1"u))");
+            // PJ OR P OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+            // PJ OR PJ OR J -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1'))");
+            // PJ OR PJ OR P -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR (Data = "d1"u))");
+            // PJ OR PJ OR PJ -> ERROR
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR) OR JSON_EXISTS(Text, '$.k1' TRUE ON ERROR))");
+        });
+    }
+}
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -1772,13 +1772,13 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\2k1\2k2" + numSuffix(2)});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\2k1" + trueSuffix, "\2k2" + falseSuffix}, "and");
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\2k1" + nullSuffix, "\2k2" + strSuffix("str")}, "or");
-            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') IS NOT NULL)", {"\3key"});
             ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\3key"});
 
             // Negated JSON_EXISTS is not supported by JSON index
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key') == false)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key') != true)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.key') IS NULL)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.key') IS NOT NULL)"); // returns false != null -> exists
 
             // AND combinations
             ValidateTokens(db,
@@ -2066,8 +2066,6 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST(JsonValueTokens) {
         TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
             // Supported RETURNING types
-            ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)"); // negation
-            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)", {"\3key"});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\2k1" + numSuffix(1)});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\2k1" + numSuffix(1)});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\2k1" + numSuffix(1)});
@@ -2090,6 +2088,10 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // Default RETURNING type is Utf8
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "1")", {"\2k1" + strSuffix("1")});
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "string")", {"\2k1" + strSuffix("string")});
+
+            // Negation
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)"); 
 
             // JSON_VALUE comparison with true rewrites to JSON_VALUE without boolean comparison
             ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -227,36 +227,40 @@ void FillTestTable(TQueryClient& db, const std::string& tableName, const std::st
     UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 }
 
-void ValidatePredicate(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
-    auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
+void ValidatePredicate(TQueryClient& db, const std::string& predicate) {
+    static constexpr const char* Table = "TestTable";
+    static constexpr const char* IndexTable = "json_idx";
+    auto query = [&](const std::string& indexPart, const std::string& pred) {
         return std::format(R"(
             SELECT Key, Text FROM {} {} WHERE {} ORDER BY Key;
-        )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
+        )", Table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
     };
 
-    auto mainResult = db.ExecuteQuery(query(table, "", predicate), TTxControl::NoTx()).ExtractValueSync();
+    auto mainResult = db.ExecuteQuery(query("", predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(mainResult.IsSuccess(), mainResult.GetIssues().ToString());
 
-    auto indexResult = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    auto indexResult = db.ExecuteQuery(query(IndexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(indexResult.IsSuccess(), indexResult.GetIssues().ToString());
 
     // Cerr << "MAIN: " << Endl << FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
     // Cerr << "INDEX: " << Endl << FormatResultSetYson(indexResult.GetResultSet(0)) << Endl;
-    // Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
 
+    Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
     CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
-void ValidateError(TQueryClient& db, const std::string& table, const std::string& indexTable, const std::string& predicate) {
-    auto query = [&](const std::string& table, const std::string& indexTable, const std::string& predicate) {
+void ValidateError(TQueryClient& db, const std::string& predicate) {
+    static constexpr const char* Table = "TestTable";
+    static constexpr const char* IndexTable = "json_idx";
+    auto query = [&](const std::string& indexPart, const std::string& pred) {
         return std::format(R"(
             SELECT * FROM {} {} WHERE {} ORDER BY Key;
-        )", table, (indexTable.empty() ? "" : "VIEW  " + indexTable), predicate);
+        )", Table, (indexPart.empty() ? "" : "VIEW  " + indexPart), pred);
     };
 
-    auto result = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
-    UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
-    UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Failed to extract search terms from predicate");
+    auto result = db.ExecuteQuery(query(IndexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_C(!result.IsSuccess(), "Predicate: " + predicate + ", issues: " + result.GetIssues().ToString());
+    UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Failed to extract search terms from predicate", "for predicate = " << predicate);
 }
 
 void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
@@ -296,17 +300,17 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::v
     )", predicate);
 
     auto result = db.ExecuteQuery(query, TTxControl::NoTx(), settings).ExtractValueSync();
-    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    UNIT_ASSERT_C(result.IsSuccess(), "Predicate: " + predicate + ", error: " + result.GetIssues().ToString());
     UNIT_ASSERT_C(result.GetStats(), "Stats are empty");
 
     auto plan = result.GetStats()->GetPlan();
     UNIT_ASSERT_C(plan, "Plan is empty");
 
-    // Cerr << "PREDICATE: " << predicate << Endl;
-    // auto ast = result.GetStats()->GetAst();
-    // UNIT_ASSERT_C(ast, "AST is empty");
-    // Cout << "AST: " << Endl << *ast << Endl;
-    // Cout << "PLAN: " << Endl << *plan << Endl;
+    Cerr << "PREDICATE: " << predicate << Endl;
+    auto ast = result.GetStats()->GetAst();
+    UNIT_ASSERT_C(ast, "AST is empty");
+    Cout << "AST: " << Endl << *ast << Endl;
+    Cout << "PLAN: " << Endl << *plan << Endl;
 
     NJson::TJsonValue planJson;
     auto success = NJson::ReadJsonTree(*plan, &planJson, true);
@@ -317,7 +321,7 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::v
 
     auto splitTokens = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["Tokens"].GetString();
     auto tokens = SplitString(splitTokens, ", ");
-    UNIT_ASSERT_VALUES_EQUAL(tokens.size(), expected.size());
+    UNIT_ASSERT_VALUES_EQUAL_C(tokens.size(), expected.size(), "for predicate = " << predicate);
 
     for (const auto& token : tokens) {
         auto decoded = HexDecode(token);
@@ -1275,83 +1279,83 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_ContextObject, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$"));
+            ValidatePredicate(db, jsonExists("$"));
         });
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_MemberAccess, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k4"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k5"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k6"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k7"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k8"));
+            ValidatePredicate(db, jsonExists("$.k1"));
+            ValidatePredicate(db, jsonExists("$.k2"));
+            ValidatePredicate(db, jsonExists("$.k3"));
+            ValidatePredicate(db, jsonExists("$.k4"));
+            ValidatePredicate(db, jsonExists("$.k5"));
+            ValidatePredicate(db, jsonExists("$.k6"));
+            ValidatePredicate(db, jsonExists("$.k7"));
+            ValidatePredicate(db, jsonExists("$.k8"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k3"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k4"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k5"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k2"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k3"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k4"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.k5"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k3.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k4.k1"));
+            ValidatePredicate(db, jsonExists("$.k1.k1"));
+            ValidatePredicate(db, jsonExists("$.k1.k2"));
+            ValidatePredicate(db, jsonExists("$.k1.k3"));
+            ValidatePredicate(db, jsonExists("$.k1.k4"));
+            ValidatePredicate(db, jsonExists("$.k1.k5"));
+            ValidatePredicate(db, jsonExists("$.k2.k1"));
+            ValidatePredicate(db, jsonExists("$.k2.k2"));
+            ValidatePredicate(db, jsonExists("$.k2.k3"));
+            ValidatePredicate(db, jsonExists("$.k2.k4"));
+            ValidatePredicate(db, jsonExists("$.k2.k5"));
+            ValidatePredicate(db, jsonExists("$.k3.k1"));
+            ValidatePredicate(db, jsonExists("$.k4.k1"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\""));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\""));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\""));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\""));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.\"\".\"\".\"\".\"\".\"\""));
+            ValidatePredicate(db, jsonExists("$.\"\""));
+            ValidatePredicate(db, jsonExists("$.\"\".\"\""));
+            ValidatePredicate(db, jsonExists("$.\"\".\"\".\"\""));
+            ValidatePredicate(db, jsonExists("$.\"\".\"\".\"\".\"\""));
+            ValidatePredicate(db, jsonExists("$.\"\".\"\".\"\".\"\".\"\""));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2.*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k1.*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.*.*"));
+            ValidatePredicate(db, jsonExists("$.*"));
+            ValidatePredicate(db, jsonExists("$.k1.*"));
+            ValidatePredicate(db, jsonExists("$.k2.*"));
+            ValidatePredicate(db, jsonExists("$.k1.k1.*"));
+            ValidatePredicate(db, jsonExists("$.k1.*.k1"));
+            ValidatePredicate(db, jsonExists("$.k1.*.*"));
         });
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_ArrayAccess, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0][0][0]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0, 3].k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[1 to 3].k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[last].k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].k1"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0].*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*].*"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0, 3]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[1 to 3]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0 to last]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[0]"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.*[*]"));
+            ValidatePredicate(db, jsonExists("$[0]"));
+            ValidatePredicate(db, jsonExists("$[0, 3]"));
+            ValidatePredicate(db, jsonExists("$[1 to 3]"));
+            ValidatePredicate(db, jsonExists("$[last]"));
+            ValidatePredicate(db, jsonExists("$[*]"));
+            ValidatePredicate(db, jsonExists("$[0][0][0]"));
+            ValidatePredicate(db, jsonExists("$[0].k1"));
+            ValidatePredicate(db, jsonExists("$[0, 3].k1"));
+            ValidatePredicate(db, jsonExists("$[1 to 3].k1"));
+            ValidatePredicate(db, jsonExists("$[last].k1"));
+            ValidatePredicate(db, jsonExists("$[*].k1"));
+            ValidatePredicate(db, jsonExists("$[0].*"));
+            ValidatePredicate(db, jsonExists("$[*].*"));
+            ValidatePredicate(db, jsonExists("$.k1[0]"));
+            ValidatePredicate(db, jsonExists("$.k1[0, 3]"));
+            ValidatePredicate(db, jsonExists("$.k1[1 to 3]"));
+            ValidatePredicate(db, jsonExists("$.k1[last]"));
+            ValidatePredicate(db, jsonExists("$.k1[0 to last]"));
+            ValidatePredicate(db, jsonExists("$.k1[*]"));
+            ValidatePredicate(db, jsonExists("$.*[0]"));
+            ValidatePredicate(db, jsonExists("$.*[*]"));
         });
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_Methods, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             auto validateMethod = [&](const std::string& method) {
-                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.{}", method)));
-                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.k1.{}", method)));
-                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$.*.{}", method)));
-                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$[0].{}", method)));
-                ValidatePredicate(db, "TestTable", "json_idx", jsonExists(std::format("$[*].{}", method)));
+                ValidatePredicate(db, jsonExists(std::format("$.{}", method)));
+                ValidatePredicate(db, jsonExists(std::format("$.k1.{}", method)));
+                ValidatePredicate(db, jsonExists(std::format("$.*.{}", method)));
+                ValidatePredicate(db, jsonExists(std::format("$[0].{}", method)));
+                ValidatePredicate(db, jsonExists(std::format("$[*].{}", method)));
             };
 
             validateMethod("type()");
@@ -1377,63 +1381,63 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterEqual, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             // @.field == literal, all literal types
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k2 == -1.5)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k2 == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k2 == -1.5)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k2 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k5 == null)"));
             // Both sides are paths (index terms merged with AND)
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == @.k1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k3 == @.k4)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == @.k1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k3 == @.k4)"));
             // @ itself as the filter path (not a sub-member), all literal types
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == -1.5)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == null)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == 1)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == -1.5)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == \"1\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == true)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == false)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == null)"));
         });
     }
 
     // All comparison operators in a filter
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterComparisonOps, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 <= -1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 >= -2)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 != 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 <= -1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 >= -2)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 != 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (+1 == @.k1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (-(+(-10)) > @.k1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (\"text\" == @.k3)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (null == @.k5)"));
+            ValidatePredicate(db, jsonExists("$ ? (+1 == @.k1)"));
+            ValidatePredicate(db, jsonExists("$ ? (-(+(-10)) > @.k1)"));
+            ValidatePredicate(db, jsonExists("$ ? (\"text\" == @.k3)"));
+            ValidatePredicate(db, jsonExists("$ ? (null == @.k5)"));
         });
     }
 
     // AND and OR boolean operators inside filter predicates
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterLogicalOps, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k4 == true && @.k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > 0 && @.k1 < 100)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k4 == true && @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > 0 && @.k1 < 100)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k1 == 1) || (@.k1 == 0))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k4 == true) || (@.k2 == false))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@.k1 == 10) || (@.k1 == 20))"));
+            ValidatePredicate(db, jsonExists("$ ? ((@.k1 == 1) || (@.k1 == 0))"));
+            ValidatePredicate(db, jsonExists("$ ? ((@.k4 == true) || (@.k2 == false))"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@.k1 == 10) || (@.k1 == 20))"));
         });
     }
 
     // Corner cases for the filter context path: deep nesting, array subscript, empty key
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterPaths, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1[0] == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[2] == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1[0] == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[2] == false)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == 1)"));
         });
     }
 
@@ -1441,580 +1445,725 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST_QUAD(SelectJsonExists_Predicates, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
             // Predicates are not allowed in JsonExists without a filter
-            ValidateError(db, "TestTable", "json_idx", jsonExists("exists($.k1)"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 starts with \"abc\""));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 like_regex \"abc\""));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("($.k1 == 10) is unknown"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 == 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 != 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 > 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 < 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 >= 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 <= 10"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("!($.k1 == 10)"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 == 10 && $.k2 == 20"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$.k1 == 10 || $.k2 == 20"));
+            ValidateError(db, jsonExists("exists($.k1)"));
+            ValidateError(db, jsonExists("$.k1 starts with \"abc\""));
+            ValidateError(db, jsonExists("$.k1 like_regex \"abc\""));
+            ValidateError(db, jsonExists("($.k1 == 10) is unknown"));
+            ValidateError(db, jsonExists("$.k1 == 10"));
+            ValidateError(db, jsonExists("$.k1 != 10"));
+            ValidateError(db, jsonExists("$.k1 > 10"));
+            ValidateError(db, jsonExists("$.k1 < 10"));
+            ValidateError(db, jsonExists("$.k1 >= 10"));
+            ValidateError(db, jsonExists("$.k1 <= 10"));
+            ValidateError(db, jsonExists("!($.k1 == 10)"));
+            ValidateError(db, jsonExists("$.k1 == 10 && $.k2 == 20"));
+            ValidateError(db, jsonExists("$.k1 == 10 || $.k2 == 20"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (exists(@.k1))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 starts with \"abc\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 like_regex \"abc\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 != 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 >= 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 <= 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 10 && @.k2 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 10 || @.k2 == 20)"));
+            ValidatePredicate(db, jsonExists("$ ? (exists(@.k1))"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 starts with \"abc\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 like_regex \"abc\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 != 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 >= 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 <= 10)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 10 && @.k2 == 20)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 10 || @.k2 == 20)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (exists(@))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ starts with \"abc\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ like_regex \"abc\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ != 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ > 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ < 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ >= 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ <= 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (exists(@))"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ starts with \"abc\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ like_regex \"abc\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ != 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ > 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ < 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ >= 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ <= 10)"));
 
             // Nested predicates are not allowed even in a filter
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k1 == 10) is unknown)"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("$ ? (!(@.k1 == 10))"));
+            ValidateError(db, jsonExists("$ ? ((@.k1 == 10) is unknown)"));
+            ValidateError(db, jsonExists("$ ? (!(@.k1 == 10))"));
         });
     }
 
     Y_UNIT_TEST_QUAD(SelectJsonExists_Literals, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidateError(db, "TestTable", "json_idx", jsonExists("null"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("1"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("\"str\""));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("true"));
-            ValidateError(db, "TestTable", "json_idx", jsonExists("false"));
+            ValidateError(db, jsonExists("null"));
+            ValidateError(db, jsonExists("1"));
+            ValidateError(db, jsonExists("\"str\""));
+            ValidateError(db, jsonExists("true"));
+            ValidateError(db, jsonExists("false"));
         });
     }
 
     // Filter with != (inequality) and range comparisons (<, <=, >, >=)
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterInequality, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 != 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k3 != \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k5 != null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k4 != false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 != 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k3 != \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k5 != null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k4 != false)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ != 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ != null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@ != \"1\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ != 1)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ != null)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@ != \"1\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 <= 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 >= 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k2 < 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (0 < @.k1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (0 >= @.k2)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > 999)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k99 != 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 <= 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 >= 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k2 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (0 < @.k1)"));
+            ValidatePredicate(db, jsonExists("$ ? (0 >= @.k2)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > 999)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k99 != 1)"));
         });
     }
 
     // Three-way AND/OR and mixed (AND+OR) filter predicates
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterAndOrComplex, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 && @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == \"1\" && @.k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 && @.k2 == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 >= 0 && @.k1 <= 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k4 == true && @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == \"1\" && @.k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k2 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 >= 0 && @.k1 <= 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k4 == true && @.k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 || @.k1 == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k4 == true || @.k2 == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == \"1\" || @.k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k99 == 1 || @.k98 == 2)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 || @.k1 == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k4 == true || @.k2 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == \"1\" || @.k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k99 == 1 || @.k98 == 2)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\" && @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\" && @.k4 == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 || @.k1 == 1 || @.k1 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\" && @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 && @.k3 == \"text\" && @.k4 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 || @.k1 == 1 || @.k1 == \"1\")"));
 
             // Mixing AND and OR inside filter: OR wins, index search uses OR semantics
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k1 == 0 && @.k4 == true) || @.k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 1 || (@.k1 == \"1\" && @.k2 == \"22\"))"));
+            ValidatePredicate(db, jsonExists("$ ? ((@.k1 == 0 && @.k4 == true) || @.k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 1 || (@.k1 == \"1\" && @.k2 == \"22\"))"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 == 10 || @.k1 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? (@.k1 == 2 && @.k2 == true)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 == 10 || @.k1 == 20)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? (@.k1 == 2 && @.k2 == true)"));
         });
     }
 
     // Filter with arithmetic operators combined with && and ||: OR dominance
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterArithmeticWithBooleanOps, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 - @.k2 > 0 || @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 * @.k2 != 0 || @.k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 / @.k2 < 1 || @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 % @.k2 == 0 || @.k4 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 - @.k2 > 0 || @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 * @.k2 != 0 || @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 / @.k2 < 1 || @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 % @.k2 == 0 || @.k4 == false)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 + @.k2 == 5 && @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 - @.k2 > 0 && @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 * @.k2 != 0 && @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 && @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 - @.k2 > 0 && @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 * @.k2 != 0 && @.k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 + @.k4 == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 - @.k2 > 0 || @.k3 - @.k4 < 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 + @.k2 == 5 && @.k3 + @.k4 == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 - @.k4 < 0 || @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 + @.k4 == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 - @.k2 > 0 || @.k3 - @.k4 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 && @.k3 + @.k4 == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 + @.k2 == 5 || @.k3 - @.k4 < 0 || @.k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k1 + @.k2 == 5 && @.k3 == \"text\") || @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 || (@.k1 + @.k2 == 5 && @.k3 == \"text\"))"));
+            ValidatePredicate(db, jsonExists("$ ? ((@.k1 + @.k2 == 5 && @.k3 == \"text\") || @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 || (@.k1 + @.k2 == 5 && @.k3 == \"text\"))"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 + @.k2 == 5 || @.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 - @.k2 > 0 && @.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 + @.k2 == 5 || @.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 - @.k2 > 0 && @.k1 == 10)"));
         });
     }
 
     // Filter with path-vs-path comparison operators combined with && and ||: OR dominance
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterComparisonWithBooleanOps, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 || @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > @.k2 || @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 <= @.k2 || @.k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 >= @.k2 || @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == @.k2 || @.k4 == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 != @.k2 || @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 || @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > @.k2 || @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 <= @.k2 || @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 >= @.k2 || @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == @.k2 || @.k4 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 != @.k2 || @.k3 == \"text\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 && @.k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 > @.k2 && @.k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 != @.k2 && @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 && @.k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 > @.k2 && @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 != @.k2 && @.k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 || @.k3 > @.k4)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == @.k2 || @.k3 != @.k4)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 && @.k3 > @.k4)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 && @.k3 > @.k4 || @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 || @.k3 > @.k4)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == @.k2 || @.k3 != @.k4)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 && @.k3 > @.k4)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 && @.k3 > @.k4 || @.k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 || @.k2 < @.k3)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 < @.k2 || @.k3 == \"text\" || @.k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 || @.k2 < @.k3)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 < @.k2 || @.k3 == \"text\" || @.k4 == true)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@.k1 < @.k2 && @.k3 > @.k4) || @.k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 == 0 || (@.k2 < @.k3 && @.k4 == true))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 < @.k2 || @.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 > @.k2 && @.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@.k1 < @.k2 && @.k3 > @.k4) || @.k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 == 0 || (@.k2 < @.k3 && @.k4 == true))"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 < @.k2 || @.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 > @.k2 && @.k1 == 10)"));
         });
     }
 
     // Filter with paths: deep nesting, array subscripts inside filter, empty key
     Y_UNIT_TEST_QUAD(SelectJsonExists_FilterPathsDeep, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1.k2.k3.k4 == \"2\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1.k2.k3.k4 == \"2\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[0] == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[1] == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[2] == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[0] == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k6[123] == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[0] == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[1] == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[2] == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[0] == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k6[123] == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1[0] == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1[1] == 2)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1[2] == 3)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1[0] == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1[1] == 2)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1[2] == 3)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1 == 999)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 == 20)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1 == 999)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? (@.k1 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[0] ? (@.k1 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? (@.\"\" == \"\")"));
+            ValidatePredicate(db, jsonExists("$[*] ? (@.k1 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$[0] ? (@.k1 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$[*] ? (@.\"\" == \"\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == false)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.\"\" == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == null)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == 1)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == false)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.\"\" == \"1\")"));
         });
     }
 
     // Combined key access + array subscript + method with filter
     Y_UNIT_TEST_QUAD(SelectJsonExists_PathArrayMethodWithFilter, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*] ? (@.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0] ? (@.k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last] ? (@.k1 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*] ? (@.k1 == 999)"));
+            ValidatePredicate(db, jsonExists("$.k1[*] ? (@.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1[0] ? (@.k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1[last] ? (@.k1 == 20)"));
+            ValidatePredicate(db, jsonExists("$.k1[*] ? (@.k1 == 999)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* ? (@ == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* ? (@ == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* ? (@ == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* ? (@ == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.* ? (@ == 42)"));
+            ValidatePredicate(db, jsonExists("$.* ? (@ == 1)"));
+            ValidatePredicate(db, jsonExists("$.* ? (@ == \"1\")"));
+            ValidatePredicate(db, jsonExists("$.* ? (@ == true)"));
+            ValidatePredicate(db, jsonExists("$.* ? (@ == null)"));
+            ValidatePredicate(db, jsonExists("$.* ? (@ == 42)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.size() ? (@ == 3)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.size() ? (@ > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.size() == 3)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.size() > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k2.k3 != null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? (@.k1 == 2 && @.k2 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? (@.k1 == 2 || @.k2.type() == \"boolean\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@.k1.abs() - @.k2.abs()) == 0)"));
+            ValidatePredicate(db, jsonExists("$.k1.size() ? (@ == 3)"));
+            ValidatePredicate(db, jsonExists("$.k1.size() ? (@ > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.size() == 3)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.size() > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k2.k3 != null)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? (@.k1 == 2 && @.k2 == true)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? (@.k1 == 2 || @.k2.type() == \"boolean\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@.k1.abs() - @.k2.abs()) == 0)"));
         });
     }
 
     // Nested filter: result of an inner filter (@ ? (pred)) is accessed as an object
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilter, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0)).k2 == -1.5)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0)).k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0)).k4 == false)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k2 == -1.5)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0)).k4 == false)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? ((@ ? (@.k1 == 2)).k2 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? ((@ ? (@.k1 == 2)).k2 == false)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? ((@ ? (@.k1 == 2)).k2 == true)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? ((@ ? (@.k1 == 2)).k2 == false)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 10)).k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 20)).k1 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 99)).k1 == 99)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 10)).k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 20)).k1 == 20)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 99)).k1 == 99)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? ((@ ? (@.k1 == \"1\")).k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? ((@ ? (@.k1 == \"x\")).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$[*] ? ((@ ? (@.k1 == \"1\")).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$[*] ? ((@ ? (@.k1 == \"x\")).k2 == \"22\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k2 == \"b\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k1 == \"b\")"));
+            ValidatePredicate(db, jsonExists("$.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k2 == \"b\")"));
+            ValidatePredicate(db, jsonExists("$.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k1 == \"b\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 != 0)).k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 > 0)).k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k2 < 0)).k1 == 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 >= 10)).k1 > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 <= 10)).k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 != 0)).k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 > 0)).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k2 < 0)).k1 == 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 >= 10)).k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 <= 10)).k1 == 10)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (0 == @.k1)).k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (\"1\" == @.k1)).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (0 == @.k1)).k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (\"1\" == @.k1)).k2 == \"22\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.\"\" == null)).\"\" == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.\"\" == 1)).\"\" == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? ((@ ? (@.\"\" == \"\")).\"\" == \"\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.\"\" == null)).\"\" == null)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.\"\" == 1)).\"\" == 1)"));
+            ValidatePredicate(db, jsonExists("$[*] ? ((@ ? (@.\"\" == \"\")).\"\" == \"\")"));
         });
     }
 
     // Nested filter where the inner predicate uses AND or OR
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilterAndOr, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k3 == \"text\")).k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == false)).k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k5 == null)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k3 == \"text\")).k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == false)).k5 == null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == \"1\" && @.k2 == \"22\")).k1 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == \"1\" && @.k2 == \"99\")).k1 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == \"1\" && @.k2 == \"22\")).k1 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == \"1\" && @.k2 == \"99\")).k1 == \"1\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? ((@ ? (@.k1 == 2 && @.k2 == true)).k2 == true)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? ((@ ? (@.k1 == 2 && @.k2 == true)).k2 == true)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 || @.k1 == 1)).k3 == \"text\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 || @.k1 == 1)).k4 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == \"1\" || @.k2 == \"22\")).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 || @.k1 == 1)).k3 == \"text\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 || @.k1 == 1)).k4 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == \"1\" || @.k2 == \"22\")).k2 == \"22\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k4 == true || @.k5 == null)).k1 == 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k99 == 1 || @.k98 == 2)).k1 == 0)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k4 == true || @.k5 == null)).k1 == 0)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k99 == 1 || @.k98 == 2)).k1 == 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 > 0)"));
         });
     }
 
     // Nested filter combined with other path constructs: array subscript, wildcards, double nesting
     Y_UNIT_TEST_QUAD(SelectJsonExists_NestedFilterPaths, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@[0] ? (@.k1 == \"1\")).k2 == \"22\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@[0] ? (@.k1 == 10)).k1 == 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@[last] ? (@.k1 == 20)).k1 == 20)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@[0] ? (@.k1 == 99)).k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@[0] ? (@.k1 == \"1\")).k2 == \"22\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@[0] ? (@.k1 == 10)).k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@[last] ? (@.k1 == 20)).k1 == 20)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@[0] ? (@.k1 == 99)).k1 == 10)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$[*] ? ((@[*] ? (@.k1 == 1)).k1 == 1)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@[*] ? (@.k1 == 10)).k1 == 10)"));
+            ValidatePredicate(db, jsonExists("$[*] ? ((@[*] ? (@.k1 == 1)).k1 == 1)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@[*] ? (@.k1 == 10)).k1 == 10)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k2.k3.k4 == \"1\")).k2.k3.k4 == \"1\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2 ? ((@ ? (@.k4[0] == 0)).k3[0].k1 == \"a\")"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k2.k3.k4 == \"1\")).k2.k3.k4 == \"1\")"));
+            ValidatePredicate(db, jsonExists("$.k1.k2 ? ((@ ? (@.k4[0] == 0)).k3[0].k1 == \"a\")"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? ((@ ? (@.k1 == 0)).k4 == true)).k5 == null)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? ((@ ? (@.k1 == 10)).k1 == 10)).k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? ((@ ? (@.k1 == 0)).k4 == true)).k5 == null)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? ((@ ? (@.k1 == 10)).k1 == 10)).k1 > 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (exists($.k1 ? ((@ ? (@.k1 == 10)).k1 > 0)))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (exists($.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k2 == \"b\")))"));
+            ValidatePredicate(db, jsonExists("$ ? (exists($.k1 ? ((@ ? (@.k1 == 10)).k1 > 0)))"));
+            ValidatePredicate(db, jsonExists("$ ? (exists($.k1.k2.k3 ? ((@ ? (@.k2 == \"b\")).k2 == \"b\")))"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3 ? ((@ ? (@.k1 == \"a\")).k1 starts with \"a\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k3 == \"text\")).k3 starts with \"tex\")"));
+            ValidatePredicate(db, jsonExists("$.k1.k2.k3 ? ((@ ? (@.k1 == \"a\")).k1 starts with \"a\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k3 == \"text\")).k3 starts with \"tex\")"));
         });
     }
 
     // Combined key access + array subscript + methods + predicates + filters + literals + nested filter + AND/OR
     Y_UNIT_TEST_QUAD(SelectJsonExists_Mix, IsJsonDocument, IsStrict) {
         TestSelectJsonExists(IsJsonDocument, IsStrict, [](TQueryClient& db, const auto& jsonExists) {
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[*] ? (exists(@.k1 ? (@.type() starts with \"s\")))"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k2[*].k3 != null && -@.k1.floor() > +3)"));
+            ValidatePredicate(db, jsonExists("$.k1[*] ? (exists(@.k1 ? (@.type() starts with \"s\")))"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k2[*].k3 != null && -@.k1.floor() > +3)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 > 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 <= 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 < 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 <= 10)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? ((@ ? (@.k1 == 10 || @.k1 == 20)).k1 < 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 < 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 >= -2)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k3 != \"blah\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 > -1)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 >= -2)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k3 != \"blah\")"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k1 == 0 && @.k4 == true)).k2 > -1)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0] ? ((@ ? (@.k1 == 10)).k1 >= 10)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[last] ? ((@ ? (@.k1 == 20)).k1 > 15)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1[0] ? ((@ ? (@.k1 == 10)).k1 < 5)"));
+            ValidatePredicate(db, jsonExists("$.k1[0] ? ((@ ? (@.k1 == 10)).k1 >= 10)"));
+            ValidatePredicate(db, jsonExists("$.k1[last] ? ((@ ? (@.k1 == 20)).k1 > 15)"));
+            ValidatePredicate(db, jsonExists("$.k1[0] ? ((@ ? (@.k1 == 10)).k1 < 5)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k2 ? (-@.k1 < 0 && @.k2 == true)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (@.k1 <= 1 && @.k2 < 0)"));
+            ValidatePredicate(db, jsonExists("$.k2 ? (-@.k1 < 0 && @.k2 == true)"));
+            ValidatePredicate(db, jsonExists("$ ? (@.k1 <= 1 && @.k2 < 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1 ? (@.k1.abs() > 5 && @.k1 != null)"));
+            ValidatePredicate(db, jsonExists("$.k1 ? (@.k1.abs() > 5 && @.k1 != null)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? (exists(@.k1) && @.k2 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? (exists(@.k1) && @.k2 < 0)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k3 starts with \"te\")).k2 < 0)"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$ ? ((@ ? (@.k3 starts with \"te\")).k1 != 99)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k3 starts with \"te\")).k2 < 0)"));
+            ValidatePredicate(db, jsonExists("$ ? ((@ ? (@.k3 starts with \"te\")).k1 != 99)"));
 
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k3[*] ? ((@ ? (@.k1 == \"a\")).k1 > \"\")"));
-            ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k4[*] ? (@ != null && @ > 0)"));
+            ValidatePredicate(db, jsonExists("$.k1.k2.k3[*] ? ((@ ? (@.k1 == \"a\")).k1 > \"\")"));
+            ValidatePredicate(db, jsonExists("$.k1.k2.k4[*] ? (@ != null && @ > 0)"));
         });
     }
 
     Y_UNIT_TEST(JsonExistsTokens) {
         TestSelectJsonTokens([](TQueryClient& db) {
-            ValidateTokens(db,
-                R"(JSON_EXISTS(Text, '$.key'))",
-                {"\3key"},
-                "and"
-            );
-            ValidateTokens(db,
-                R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))",
-                {"\2k1\2k2" + numSuffix(2)},
-                "and"
-            );
+            // Basic path exists cases
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key'))", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))", {"\2k1\2k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))", {"\2k1" + trueSuffix, "\2k2" + falseSuffix}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))", {"\2k1" + nullSuffix, "\2k2" + strSuffix("str")}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') IS NOT NULL)", {"\3key"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.key') == true)", {"\3key"});
 
-            ValidateTokens(db,
-                R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))",
-                {"\2k1" + trueSuffix, "\2k2" + falseSuffix},
-                "and"
-            );
-            ValidateTokens(db,
-                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str")},
-                "or"
-            );
+            // Negated JSON_EXISTS is not supported by JSON index
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.key') == false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.key') != true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.key') IS NULL)");
 
+            // AND combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"},
-                "and"
-            );
+                {"\2k1", "\2k2"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "and"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
 
+            // OR combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))",
-                {"\2k1", "\2k2"},
-                "or"
-            );
+                {"\2k1", "\2k2"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
-                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
-                "or"
-            );
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix}, "or");
 
+            // Mixed combinations
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "and"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "or"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "or"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "or"
-            );
-
+                {"\2k1", "\2k2", "\2k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "and"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "and");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') AND (JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')))",
-                {"\2k1", "\2k2", "\2k3"},
-                "and"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') AND JSON_EXISTS(Text, '$.k4')))",
-                {"\2k1", "\2k2", "\2k3", "\2k4"},
-                "and"
-            );
-
+                {"\2k1", "\2k2", "\2k3", "\2k4"}, "and");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR JSON_EXISTS(Text, '$.k3'))",
-                {"\2k1", "\2k2", "\2k3"},
-                "or"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "or");
             ValidateTokens(db,
                 R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')))",
-                {"\2k1", "\2k2", "\2k3"},
-                "or"
-            );
+                {"\2k1", "\2k2", "\2k3"}, "or");
             ValidateTokens(db,
                 R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') OR JSON_EXISTS(Text, '$.k4')))",
-                {"\2k1", "\2k2", "\2k3", "\2k4"},
-                "or"
-            );
+                {"\2k1", "\2k2", "\2k3", "\2k4"}, "or");
 
+            // NOT JSON_EXISTS and wrapped-NOT forms fall through to "nothing to extract"
+            ValidateError(db, R"(NOT JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))");
+
+            // Filter equality: covers every literal type; the token carries the value suffix
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == null)'))", {"\2k1\2k2" + nullSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == true)'))", {"\2k1\2k2" + trueSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == false)'))", {"\2k1\2k2" + falseSuffix});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == "abc")'))", {"\2k1\2k2" + strSuffix("abc")});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 42)'))", {"\2k1\2k2" + numSuffix(42)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == -1.5)'))", {"\2k1\2k2" + numSuffix(-1.5)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 == @.k2)'))", {"\2k1\2k2" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? ("s" == @.k2)'))", {"\2k1\2k2" + strSuffix("s")});
+
+            // Filter inequality / range: path only, no value suffix
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != 2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 > 2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 < 2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 >= 2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 <= 2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != null)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 != "abc")'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 > @.k2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 < @.k2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 >= @.k2)'))", {"\2k1\2k2"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1 ? (2 <= @.k2)'))", {"\2k1\2k2"});
+
+            // Filter path-vs-path comparisons: two tokens, AND mode (value suffix dropped)
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 != @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 < @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 >= @.k2)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 <= @.k2)'))", {"\2k1", "\2k2"}, "and");
+
+            // Filter arithmetic (path vs literal): path only, no value suffix
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - 1 == 0)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 == 4)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / 2 == 1)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % 2 == 0)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 > 2)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * 2 != 4)'))", {"\2k1"});
+
+            // Filter arithmetic (path vs path): two tokens, AND mode
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 - @.k2 > 0)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 * @.k2 < 10)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 / @.k2 >= 1)'))", {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 % @.k2 != 0)'))", {"\2k1", "\2k2"}, "and");
+
+            // Filter unary operators: path only
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (+@.k1 == 1)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 > 0)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() > 5)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() == 3)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.size() > 0)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1.size() ? (@ == 3)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1.abs() == -1)'))", {"\2k1"});
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() - @.k2.abs() == 0)'))", {"\2k1", "\2k2"}, "and");
+
+            // && / || inside jsonpath: mode propagates from inner operator
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 != 2)'))",
+                {"\2k1" + numSuffix(1), "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 != 2)'))",
+                {"\2k1" + numSuffix(1), "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 && @.k2 < 10)'))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 > 0 || @.k2 < 10)'))",
+                {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 && @.k2 * 2 == 4)'))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + 1 == 2 || @.k2 * 2 == 4)'))",
+                {"\2k1", "\2k2"}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1.abs() == 1 && @.k2.size() > 0)'))",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (-@.k1 == -1 || @.k2 % 2 == 0)'))",
+                {"\2k1", "\2k2"}, "or");
+
+            // Three-way && / || inside jsonpath
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2 && @.k3 == 3)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "and");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2 || @.k3 == 3)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+
+            // Mixed && and || inside jsonpath
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 == 1 && @.k2 == 2) || @.k3 == 3)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || (@.k2 == 2 && @.k3 == 3))'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? ((@.k1 > 0 && @.k2 != null) || @.k3 == "text")'))",
+                {"\2k1", "\2k2", "\2k3" + strSuffix("text")}, "or");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5 && @.k3 == "text" || @.k4 == null)'))",
+                {"\2k1", "\2k2", "\2k3" + strSuffix("text"), "\2k4" + nullSuffix}, "or");
+
+            // Outer SQL AND/OR over filters with &&/|| inside
             ValidateTokens(db,
-                R"(JSON_EXISTS(Text, '$.key') IS NOT NULL)",
-                {"\3key"},
-                "and"
-            );
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "and");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 || @.k2 == 2)') AND JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "or");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == 1 && @.k2 == 2)') OR JSON_EXISTS(Text, '$ ? (@.k3 > 0)'))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3"}, "or");
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 + @.k2 == 5)') AND JSON_EXISTS(Text, '$ ? (-@.k3 == -3)'))",
+                {"\2k1", "\2k2", "\2k3"}, "and");
+
+            // Outer range comparison with bool literal (non-equality): errors
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= false)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= true)");
+
+            // Flipped side (literal op JSON_EXISTS)
+            ValidateError(db, R"(true > JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(false >= JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(false == JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(true != JSON_EXISTS(Text, '$.k1'))");
+
+            // JSON_EXISTS comparison with true rewrites to JSON_EXISTS without boolean comparison
+            ValidateTokens(db, R"(true == JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"(false != JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+
+            // JSON_EXISTS comparison with false rewrites to NOT JSON_EXISTS
+            ValidateError(db, R"(false == JSON_EXISTS(Text, '$.k1'))");
+            ValidateError(db, R"(true != JSON_EXISTS(Text, '$.k1'))");
+
+            // Outer comparison between two JSON_EXISTS: errors
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') != JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') < JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') <= JSON_EXISTS(Text, '$.k2'))");
+
+            // Outer AND/OR over range comparisons with bool literal
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2') <= true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false OR JSON_EXISTS(Text, '$.k2') < true)");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true OR JSON_EXISTS(Text, '$.k2') == true)");
+
+            // Outer AND/OR over cross JSON_EXISTS comparisons
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') != JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') >= JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') <= JSON_EXISTS(Text, '$.k4')))");
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') != JSON_EXISTS(Text, '$.k4')))");
+
+            // NOT of these outer comparisons falls through to "nothing to extract"
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') > true))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') >= false))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') < true))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') <= false))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')))");
+            ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2')))");
         });
     }
 
     Y_UNIT_TEST(JsonValueTokens) {
         TestSelectJsonTokens([](TQueryClient& db) {
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.key') IS NOT NULL)",
-                {"\3key"},
-                "and"
-            );
+            // Supported RETURNING types
+            ValidateError(db, R"(JSON_VALUE(Text, '$.key') IS NULL)"); // negation
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.key') IS NOT NULL)", {"\3key"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int8) == 1t)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint8) == 1ut)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int16) == 1s)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint16) == 1us)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint32) == 1u)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int64) == 1l)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Uint64) == 1ul)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Float) == 1.0f)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Double) == 1.0)", {"\2k1" + numSuffix(1)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING String) == "value"s)", {"\2k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Utf8) == "value"u)", {"\2k1" + strSuffix("value")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
 
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)",
-                {"\2k1" + numSuffix(1)},
-                "and"
-            );
+            // Not supported RETURNING types
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Datetime) == Datetime("2021-01-01T00:00:00Z"))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Timestamp) == Timestamp("2021-01-01T00:00:00Z"))");
 
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1') == "1")",
-                {"\2k1" + strSuffix("1")},
-                "and"
-            );
+            // Default RETURNING type is Utf8
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "1")", {"\2k1" + strSuffix("1")});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') == "string")", {"\2k1" + strSuffix("string")});
 
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
-                {"\2k1" + trueSuffix},
-                "and"
-            );
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))",
-                {"\2k1" + trueSuffix},
-                "and"
-            );
+            // Bool comparison with true
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)", {"\2k1" + trueSuffix});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))", {"\2k1" + trueSuffix});
 
-            ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)",
-                {"\2k1" + falseSuffix},
-                "and"
-            );
-            ValidateTokens(db,
-                R"(NOT JSON_VALUE(Text, '$.k1' RETURNING Bool))",
-                {"\2k1" + falseSuffix},
-                "and"
-            );
+            // Bool comparison with false (negation)
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)");
+            ValidateError(db, R"(NOT JSON_VALUE(Text, '$.k1' RETURNING Bool))");
 
+            // Comparison with other literals
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)", {"\2k1"});
+
+            // For some nodes inside the path, it cannot be combined with == operator
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 starts with "1"') == "true")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.size()' RETURNING Int32) == 2)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1.*' RETURNING Int32) == 2)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1[*]' RETURNING Int32) == 2)", {"\2k1" + numSuffix(2)});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 + 1' RETURNING Int32) == 2)", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1 == 2' RETURNING Bool))", {"\2k1" + numSuffix(2)});
+
+            // BETWEEN clause
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) BETWEEN 1 AND 10)", {"\2k1", "\2k1"});
+
+            // AND/OR combinations - numeric equality
             ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)",
-                {"\2k1"},
-                "and"
-            );
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "and");
             ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)",
-                {"\2k1"},
-                "and"
-            );
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "or");
+
+            // AND/OR combinations - string equality
             ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)",
-                {"\2k1"},
-                "and"
-            );
+                R"(JSON_VALUE(Text, '$.k1') == "a" AND JSON_VALUE(Text, '$.k2') == "b")",
+                {"\2k1" + strSuffix("a"), "\2k2" + strSuffix("b")}, "and");
             ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)",
-                {"\2k1"},
-                "and"
-            );
+                R"(JSON_VALUE(Text, '$.k1') == "a" OR JSON_VALUE(Text, '$.k2') == "b")",
+                {"\2k1" + strSuffix("a"), "\2k2" + strSuffix("b")}, "or");
+
+            // AND/OR with range comparisons - path-only tokens
             ValidateTokens(db,
-                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)",
-                {"\2k1"},
-                "and"
-            );
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
+                {"\2k1", "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 5 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) < 10)",
+                {"\2k1", "\2k2"}, "or");
+
+            // AND/OR mixing equality and range
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1') == "a" AND JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
+                {"\2k1" + strSuffix("a"), "\2k2"}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1') == "a" OR JSON_VALUE(Text, '$.k2' RETURNING Int32) > 0)",
+                {"\2k1" + strSuffix("a"), "\2k2"}, "or");
+
+            // Three-way AND/OR
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "and");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+
+            // Mixed AND/OR (AND binds tighter): both cases produce "or"
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 OR JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2 AND JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3)",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+
+            // Comparison operators with strings - path-only token (no value suffix for non-equality)
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') > "abc")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') < "xyz")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') >= "abc")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') <= "xyz")", {"\2k1"});
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') != "abc")", {"\2k1"});
+
+            // Flipped operand order - string comparisons
+            ValidateTokens(db, R"("abc" < JSON_VALUE(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"("abc" > JSON_VALUE(Text, '$.k1'))", {"\2k1"});
+            ValidateTokens(db, R"("abc" != JSON_VALUE(Text, '$.k1'))", {"\2k1"});
+
+            // Flipped operand order - numeric comparisons
+            ValidateTokens(db, R"(10 < JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+            ValidateTokens(db, R"(10 > JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+            ValidateTokens(db, R"(10 >= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+            ValidateTokens(db, R"(10 <= JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+            ValidateTokens(db, R"(10 != JSON_VALUE(Text, '$.k1' RETURNING Int32))", {"\2k1"});
+
+            // STARTS WITH
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix"))", {"\2k1"});
+            ValidateTokens(db, R"(StartsWith(JSON_VALUE(Text, '$.k1'), "prefix") AND JSON_VALUE(Text, '$.k1') == "a")", {"\2k1", "\2k1" + strSuffix("a")});
+
+            // ENDS WITH: not extractable
+            ValidateTokens(db, R"(EndsWith(JSON_VALUE(Text, '$.k1'), "suffix"))", {"\2k1"});
+
+            // LIKE / ILIKE: not extractable
+            ValidateTokens(db, R"(JSON_VALUE(Text, '$.k1') LIKE "pattern%")", {"\2k1"});
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1') ILIKE "pattern%")"); // udf
+
+            // REGEXP: not extractable
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1') REGEXP "^pattern$")"); // udf
+
+            // String concatenation (||) in a comparison: not extractable
+            ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix")");
+            ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")");
         });
     }
-
-    // Y_UNIT_TEST(Tmp) {
-    //     TestSelectJsonExists(false, false, [](TQueryClient& db, const auto&) {
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "NOT JSON_EXISTS(Text, '$.k1')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "NOT JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') IS NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') IS NOT NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') = True");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') = False");
-
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "2 == JSON_VALUE(Text, '$.k1' RETURNING Int32)");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) != 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) > 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) < 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 2");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 AND JSON_EXISTS(Text, '$.k2')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 OR JSON_EXISTS(Text, '$.k2')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') IS NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Utf8) IS NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') == NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Bool) == NULL");
-
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') IS NOT NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Utf8) IS NOT NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') != NULL");
-    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Bool) != NULL");
-    //     });
-    // }
 }
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -2063,6 +2063,21 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') <= false))");
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')))");
             ValidateError(db, R"(NOT (JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2')))");
+
+            // Nested JSON_QUERY as JSON source for JSON_EXISTS - not extractable
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER), '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, 'lax $.a' WITHOUT ARRAY WRAPPER), 'lax $.b'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, 'strict $.a' WITHOUT ARRAY WRAPPER), 'strict $.b'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITH CONDITIONAL WRAPPER), '$.b'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITH UNCONDITIONAL WRAPPER), '$.b'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$ ? (@.x == 1)' WITHOUT ARRAY WRAPPER), '$.y'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a[0]' WITHOUT ARRAY WRAPPER), '$.b'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e'))");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$ ? (@.k1 == 1 && @.k2 == 2)') == true)");
+            ValidateError(db, R"(JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k1') AND JSON_EXISTS(Text, '$.k2'))");
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b'))");
         });
     }
 
@@ -2292,6 +2307,20 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // String concatenation (||) in a comparison - not extractable
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix")");
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")");
+
+            // Nested JSON_QUERY as JSON source for JSON_VALUE - not extractable
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER), '$.k2' RETURNING Int32) == 1)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, 'lax $.a' WITHOUT ARRAY WRAPPER), '$.b' RETURNING Utf8) == "1"u)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, 'strict $.a' WITHOUT ARRAY WRAPPER), '$.b' RETURNING Int64) == 1l)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITH CONDITIONAL WRAPPER), '$.b') == "x"u)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITH UNCONDITIONAL WRAPPER), '$.b' RETURNING String) == "s"s)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a[0]' WITHOUT ARRAY WRAPPER), '$.b' RETURNING Double) == 1.0)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$ ? (@.x == 1)' WITHOUT ARRAY WRAPPER), '$.y' RETURNING Bool) == true)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' RETURNING Int32) == 1)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d') == "1")");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(JSON_QUERY(JSON_QUERY(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.b' WITHOUT ARRAY WRAPPER), '$.c' WITHOUT ARRAY WRAPPER), '$.d' WITHOUT ARRAY WRAPPER), '$.e' RETURNING Int32) == 1)");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u AND JSON_VALUE(Text, '$.b') == "w")");
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.a' WITHOUT ARRAY WRAPPER), '$.k' RETURNING Utf8) == "v"u OR JSON_VALUE(Text, '$.b') == "w")");
         });
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -252,7 +252,7 @@ void ValidatePredicate(TQueryClient& db, const std::string& predicate) {
     CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
-void ValidateError(TQueryClient& db, const std::string& predicate) {
+void ValidateError(TQueryClient& db, const std::string& predicate, const std::string& errorMessage = "Failed to extract search terms from predicate") {
     static constexpr const char* table = "TestTable";
     static constexpr const char* indexTable = "json_idx";
 
@@ -264,7 +264,7 @@ void ValidateError(TQueryClient& db, const std::string& predicate) {
 
     auto result = db.ExecuteQuery(query(indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(!result.IsSuccess(), "Predicate: " + predicate + ", issues: " + result.GetIssues().ToString());
-    UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Failed to extract search terms from predicate", "for predicate = " << predicate);
+    UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), errorMessage, "for predicate = " << predicate);
 }
 
 void TestSelectJsonWithIndex(const std::string& jsonType, const std::optional<bool>& jsonExistsStrict,
@@ -2047,11 +2047,13 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // Outer AND/OR over range comparisons with bool literal
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2') <= true)");
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > false OR JSON_EXISTS(Text, '$.k2') < true)");
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))");
+            // AND: non-indexable range cmp on k1, but standalone JE($.k2) IS indexable - post-filter applies
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') >= true AND JSON_EXISTS(Text, '$.k2'))", {"\2k2"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') >= true OR JSON_EXISTS(Text, '$.k2') == true)");
 
             // Outer AND/OR over cross JSON_EXISTS comparisons
-            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))");
+            // AND: JE1 > JE2 not indexable, but standalone JE($.k3) IS indexable - post-filter applies
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') > JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))", {"\2k3"});
             ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') != JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') >= JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') <= JSON_EXISTS(Text, '$.k4')))");
             ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') == JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') != JSON_EXISTS(Text, '$.k4')))");
@@ -2310,9 +2312,11 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             // REGEXP - not extractable (Re2)
             ValidateError(db, R"(JSON_VALUE(Text, '$.k1') REGEXP "^pattern$")"); // udf
 
-            // String concatenation (||) in a comparison - not extractable
+            // String concatenation (||) in a comparison: JV1 inside concat is not indexable
+            // If JV1 is the only JSON node - nothing to extract
             ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix")");
-            ValidateError(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")");
+            // AND: JV1 inside concat is non-indexable, but JV2 == "b" IS indexable - post-filter applies
+            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1') || "suffix") == "value_suffix" AND JSON_VALUE(Text, '$.k2') == "b")", {"\2k2" + strSuffix("b")});
 
             // Nested JSON_QUERY as JSON source for JSON_VALUE - not extractable
             ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1' WITHOUT ARRAY WRAPPER), '$.k2' RETURNING Int32) == 1)");
@@ -2340,6 +2344,105 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
 
             // Both DEFAULT ON EMPTY and DEFAULT ON ERROR with non-NULL value are negation too
             ValidateError(db, R"(JSON_VALUE(Text, '$.key' RETURNING Int DEFAULT 12 ON EMPTY DEFAULT 12 ON ERROR) > 10)");
+        });
+    }
+
+    // CollectJsonIndexPredicate: no JSON_*, only JSON, JSON with non-JSON column, OR rules, path parse, mixed support
+    Y_UNIT_TEST(JsonCombinations) {
+        TestSelectJsonWithIndex("JsonDocument", std::nullopt, [](TQueryClient& db, const auto&) {
+            // No JSON_* in the filter - "no JSON_* functions found"
+            ValidateError(db, R"(Key = 1ul)");
+            ValidateError(db, R"((Data = "a"u) OR (Data = "b"u))");
+
+            // JSON_* only (tokens in explain are successful)
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+
+            // JSON_* together with a non-JSON column
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (Data = "d1"u)))", {"\2k1"});
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (Data = "d1"u)))");
+
+            // JSONPath that cannot be parsed for index extraction
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.[0'))", "Invalid json path");
+
+            // OR: an indexable branch and a non-indexable branch (JSON_VALUE in an arithmetic expression)
+            ValidateError(db, R"(JSON_EXISTS(Text, '$.k1') OR ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))");
+            ValidateTokens(db, R"(JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11))", {"\2k1"});
+
+            ValidateError(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) OR JSON_EXISTS(Text, '$.k1'))");
+            ValidateTokens(db, R"(((JSON_VALUE(Text, '$.k2' RETURNING Int32) + 10) > 11) AND JSON_EXISTS(Text, '$.k1'))", {"\2k1"});
+
+            // AND: indexable JSON with unsupported JSON (RETURNING Date) - collect error
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))", {"\2k1"});
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Date) == Date("2021-01-01"))))");
+
+            // OR: one disjunct is indexable, the other is not
+            ValidateError(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))");
+            ValidateTokens(db, R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 AND ((JSON_VALUE(Text, '$.k1' RETURNING Int32) + 10) > 11)))",
+                {"\2k1" + numSuffix(1)}, "and");
+
+            // AND: several indexable JSON_* in one filter
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)))",
+                {"\2k1" + numSuffix(1), "\2k1"});
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)))",
+                {"\1a", "\1b" + numSuffix(0)});
+
+            // OR: only JSON_*; three-way
+            ValidateTokens(db,
+                R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) OR (JSON_VALUE(Text, '$.k3' RETURNING Int32) == 3))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2), "\2k3" + numSuffix(3)}, "or");
+
+            // OR: a non-JSON disjunct
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) OR (Key = 1ul)))");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') OR (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\2k1" + numSuffix(1), "\2k1"}, "or");
+            ValidateTokens(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1) AND (Key = 1ul)))", {"\2k1" + numSuffix(1), "\2k1"}, "and");
+
+            // (indexable subexpression) OR (indexable) - "or" mode for tokens
+            ValidateTokens(db,
+                R"(((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0)) OR (JSON_EXISTS(Text, '$.c'))))",
+                {"\1a", "\1b" + numSuffix(0), "\1c"}, "or");
+
+            // AND: three indexable JSON_* in one filter
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.a') AND (JSON_VALUE(Text, '$.b' RETURNING Int32) == 0) AND (JSON_VALUE(Text, '$.c') == "z"u)))",
+                {"\1a", "\1b" + numSuffix(0), "\1c" + strSuffix("z")}, "and");
+
+            // AND with JSON_QUERY in the same predicate
+            ValidateError(db, R"((JSON_EXISTS(Text, '$.k1') AND (JSON_QUERY(Text, '$.k2') IS NOT NULL)))");
+
+            // (OR of indexable predicates) AND (non-indexable JSON predicate) - OR lookup + post-filter
+            // Case 1: non-indexable is arithmetic JSON_VALUE
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0))",
+                {"\2k1", "\2k2"}, "or");
+            // Case 2: symmetric (non-indexable first)
+            ValidateTokens(db,
+                R"(((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0) AND (JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')))",
+                {"\2k1", "\2k2"}, "or");
+            // Case 3: non-indexable is RETURNING Date (treated as post-filter)
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
+                {"\2k1", "\2k2"}, "or");
+            // Case 4: OR branch contains (indexable AND non-indexable)
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)))",
+                {"\2k1", "\2k2"}, "or");
+            // Case 5: symmetric (non-indexable-AND first)
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') AND ((JSON_VALUE(Text, '$.x' RETURNING Int32) + 1) > 0)) OR JSON_EXISTS(Text, '$.k2'))",
+                {"\2k1", "\2k2"}, "or");
+            // Case 6: OR of two indexable JV comparisons AND a non-indexable RETURNING Date JV
+            ValidateTokens(db,
+                R"((JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1 OR JSON_VALUE(Text, '$.k2' RETURNING Int32) == 2) AND (JSON_VALUE(Text, '$.k3' RETURNING Date) == Date("2021-01-01")))",
+                {"\2k1" + numSuffix(1), "\2k2" + numSuffix(2)}, "or");
+
+            // Non-indexable RETURNING types now caught by whitelist (Date, Datetime, Timestamp already tested above)
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Date) > Date("2021-01-01"))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Datetime) > Datetime("2021-01-01T00:00:00Z"))");
+            ValidateError(db, R"(JSON_VALUE(Text, '$.k1' RETURNING Timestamp) > Timestamp("2021-01-01T00:00:00Z"))");
+
+            // Nested JSON_* functions as source - specific error message
+            ValidateError(db, R"(JSON_VALUE(JSON_QUERY(Text, '$.k1'), '$.k2') == "1")", "Nested JSON_* functions are not supported");
         });
     }
 }

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -242,8 +242,8 @@ void ValidatePredicate(TQueryClient& db, const std::string& table, const std::st
 
     // Cerr << "MAIN: " << Endl << FormatResultSetYson(mainResult.GetResultSet(0)) << Endl;
     // Cerr << "INDEX: " << Endl << FormatResultSetYson(indexResult.GetResultSet(0)) << Endl;
+    // Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
 
-    Cerr << predicate << ", main size: " << mainResult.GetResultSet(0).RowsCount() << ", index size: " << indexResult.GetResultSet(0).RowsCount() << Endl;
     CompareYson(FormatResultSetYson(mainResult.GetResultSet(0)), FormatResultSetYson(indexResult.GetResultSet(0)));
 }
 
@@ -302,12 +302,11 @@ void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::v
     auto plan = result.GetStats()->GetPlan();
     UNIT_ASSERT_C(plan, "Plan is empty");
 
-    Cerr << "PREDICATE: " << predicate << Endl;
-
-    auto ast = result.GetStats()->GetAst();
-    UNIT_ASSERT_C(ast, "AST is empty");
-    Cout << "AST: " << Endl << *ast << Endl;
-    Cout << "PLAN: " << Endl << *plan << Endl;
+    // Cerr << "PREDICATE: " << predicate << Endl;
+    // auto ast = result.GetStats()->GetAst();
+    // UNIT_ASSERT_C(ast, "AST is empty");
+    // Cout << "AST: " << Endl << *ast << Endl;
+    // Cout << "PLAN: " << Endl << *plan << Endl;
 
     NJson::TJsonValue planJson;
     auto success = NJson::ReadJsonTree(*plan, &planJson, true);

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -7,6 +7,22 @@ using namespace NYdb;
 
 namespace {
 
+const auto strSuffix = [](const std::string& s) {
+    return std::string("\0\3", 2) + s;
+};
+
+const auto numSuffix = [](double v) {
+    std::string s;
+    s.push_back('\0');
+    s.push_back('\4');
+    s.append(reinterpret_cast<const char*>(&v), sizeof(double));
+    return s;
+};
+
+const std::string trueSuffix = std::string("\0\1", 2);
+const std::string falseSuffix = std::string("\0\0", 2);
+const std::string nullSuffix = std::string("\0\2", 2);
+
 TKikimrRunner Kikimr(bool enableJsonIndex = true) {
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableJsonIndex(enableJsonIndex);
@@ -240,7 +256,7 @@ void ValidateError(TQueryClient& db, const std::string& table, const std::string
 
     auto result = db.ExecuteQuery(query(table, indexTable, predicate), TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
-    UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Failed to extract search terms from jsonpath expression");
+    UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Failed to extract search terms from predicate");
 }
 
 void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
@@ -269,6 +285,69 @@ void TestSelectJsonExists(bool isJsonDocument, bool isStrict,
     }
 
     body(db, jsonExists);
+}
+
+void ValidateTokens(TQueryClient& db, const std::string& predicate, const std::vector<std::string>& expected,
+    const std::string& defaultOperator = "and")
+{
+    auto settings = TExecuteQuerySettings().ExecMode(EExecMode::Explain);
+    auto query = std::format(R"(
+        SELECT * FROM TestTable VIEW json_idx WHERE {};
+    )", predicate);
+
+    auto result = db.ExecuteQuery(query, TTxControl::NoTx(), settings).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    UNIT_ASSERT_C(result.GetStats(), "Stats are empty");
+
+    auto plan = result.GetStats()->GetPlan();
+    UNIT_ASSERT_C(plan, "Plan is empty");
+
+    Cerr << "PREDICATE: " << predicate << Endl;
+
+    auto ast = result.GetStats()->GetAst();
+    UNIT_ASSERT_C(ast, "AST is empty");
+    Cout << "AST: " << Endl << *ast << Endl;
+    Cout << "PLAN: " << Endl << *plan << Endl;
+
+    NJson::TJsonValue planJson;
+    auto success = NJson::ReadJsonTree(*plan, &planJson, true);
+    UNIT_ASSERT_C(success, "Failed to read plan as JSON");
+
+    auto op = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["DefaultOperator"].GetString();
+    UNIT_ASSERT_VALUES_EQUAL(op, '"' + defaultOperator + '"');
+
+    auto splitTokens = planJson["Plan"]["Plans"][0]["Plans"][0]["Plans"][0]["Operators"][0]["Tokens"].GetString();
+    auto tokens = SplitString(splitTokens, ", ");
+    UNIT_ASSERT_VALUES_EQUAL(tokens.size(), expected.size());
+
+    for (const auto& token : tokens) {
+        auto decoded = HexDecode(token);
+        if (std::find(expected.begin(), expected.end(), decoded) == expected.end()) {
+            UNIT_FAIL("Unexpected token: " << decoded);
+        }
+    }
+}
+
+void TestSelectJsonTokens(const std::function<void(TQueryClient&)>& body) {
+    auto kikimr = Kikimr();
+    auto db = kikimr.GetQueryClient();
+
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+    const std::string jsonType = "JsonDocument";
+    CreateTestTable(db, jsonType, /* withIndex */ false);
+    FillTestTable(db, "TestTable", jsonType);
+
+    {
+        auto query = R"(
+            ALTER TABLE TestTable ADD INDEX json_idx GLOBAL USING json ON (Text)
+        )";
+        auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    body(db);
 }
 
 TExecuteQueryResult WriteJsonIndexWithKeys(TQueryClient& db, const std::string& stmt, const std::string& tableName,
@@ -1694,6 +1773,249 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             ValidatePredicate(db, "TestTable", "json_idx", jsonExists("$.k1.k2.k4[*] ? (@ != null && @ > 0)"));
         });
     }
+
+    Y_UNIT_TEST(JsonExistsTokens) {
+        TestSelectJsonTokens([](TQueryClient& db) {
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.key'))",
+                {"\3key"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1 ? (@.k2 == 2)'))",
+                {"\2k1\2k2" + numSuffix(2)},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == true && @.k2 == false)'))",
+                {"\2k1" + trueSuffix, "\2k2" + falseSuffix},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str")},
+                "or"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2'))",
+                {"\2k1", "\2k2"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') AND JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2'))",
+                {"\2k1", "\2k2"},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true && @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null && @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$ ? (@.k1 == null || @.k2 == "str")') OR JSON_EXISTS(Text, '$ ? (@.k3 == true || @.k4 == false)'))",
+                {"\2k1" + nullSuffix, "\2k2" + strSuffix("str"), "\2k3" + trueSuffix, "\2k4" + falseSuffix},
+                "or"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "or"
+            );
+
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') AND (JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')))",
+                {"\2k1", "\2k2", "\2k3"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')) AND (JSON_EXISTS(Text, '$.k3') AND JSON_EXISTS(Text, '$.k4')))",
+                {"\2k1", "\2k2", "\2k3", "\2k4"},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR JSON_EXISTS(Text, '$.k3'))",
+                {"\2k1", "\2k2", "\2k3"},
+                "or"
+            );
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.k1') OR (JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')))",
+                {"\2k1", "\2k2", "\2k3"},
+                "or"
+            );
+            ValidateTokens(db,
+                R"((JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')) OR (JSON_EXISTS(Text, '$.k3') OR JSON_EXISTS(Text, '$.k4')))",
+                {"\2k1", "\2k2", "\2k3", "\2k4"},
+                "or"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_EXISTS(Text, '$.key') IS NOT NULL)",
+                {"\3key"},
+                "and"
+            );
+        });
+    }
+
+    Y_UNIT_TEST(JsonValueTokens) {
+        TestSelectJsonTokens([](TQueryClient& db) {
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.key') IS NOT NULL)",
+                {"\3key"},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) == 1)",
+                {"\2k1" + numSuffix(1)},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1') == "1")",
+                {"\2k1" + strSuffix("1")},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == true)",
+                {"\2k1" + trueSuffix},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool))",
+                {"\2k1" + trueSuffix},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Bool) == false)",
+                {"\2k1" + falseSuffix},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(NOT JSON_VALUE(Text, '$.k1' RETURNING Bool))",
+                {"\2k1" + falseSuffix},
+                "and"
+            );
+
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) > 10)",
+                {"\2k1"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) < 10)",
+                {"\2k1"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 10)",
+                {"\2k1"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 10)",
+                {"\2k1"},
+                "and"
+            );
+            ValidateTokens(db,
+                R"(JSON_VALUE(Text, '$.k1' RETURNING Int32) != 10)",
+                {"\2k1"},
+                "and"
+            );
+        });
+    }
+
+    // Y_UNIT_TEST(Tmp) {
+    //     TestSelectJsonExists(false, false, [](TQueryClient& db, const auto&) {
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') AND JSON_EXISTS(Text, '$.k3')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "NOT JSON_EXISTS(Text, '$.k1')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "NOT JSON_EXISTS(Text, '$.k1') OR JSON_EXISTS(Text, '$.k2')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') IS NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') IS NOT NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') = True");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_EXISTS(Text, '$.k1') = False");
+
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "2 == JSON_VALUE(Text, '$.k1' RETURNING Int32)");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) != 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) > 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) < 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) >= 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) <= 2");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 AND JSON_EXISTS(Text, '$.k2')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 OR JSON_EXISTS(Text, '$.k2')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Int32) == 2 AND JSON_EXISTS(Text, '$.k2') OR JSON_EXISTS(Text, '$.k3')");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') IS NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Utf8) IS NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') == NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Bool) == NULL");
+
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') IS NOT NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Utf8) IS NOT NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1') != NULL");
+    //         ValidatePredicate(db, "TestTable", "json_idx", "JSON_VALUE(Text, '$.k1' RETURNING Bool) != NULL");
+    //     });
+    // }
 }
 
 }  // namespace NKikimr::NKqp


### PR DESCRIPTION
### Changelog entry

Added KQP logical optimizer support for JSON index predicate extraction, including AND/OR predicate
  combinations, `JSON_VALUE` and `JSON_EXISTS` comparisons.

### Changelog category

* New feature

### Description for reviewers

**Core changes (`json_index.cpp/h`):**
- Changed `TCollectResult::TTokens` from `TVector<TString>` to `std::set<TString>` to deduplicate index tokens automatically
- Added `MergeAnd` / `MergeOr` free functions for combining two `TCollectResult`s with AND/OR semantics
- Added `AppendJsonIndexLiteral` helper to construct index token bytes (NULL prefix + entry type + scalar payload)
- Renamed `Finish`/`IsFinished` → `StopCollecting`/`CanCollect`; redundant tokens are pruned in merged results

**New optimizer pass (`kqp_opt_log_json_index.cpp/h`):**
- `CollectJsonIndexPredicate` — walks a filter predicate AST and extracts an index-compatible token set for a JSON column
- Supports `JSON_EXISTS`, `JSON_VALUE` (string/number/bool comparisons), and their AND/OR combinations
- Non-indexable predicates in an AND chain are allowed (index narrows candidates, residual filter applied on top); non-indexable predicates in an OR chain disable index use

**Integration (`kqp_opt_log_indexes.cpp`):**
- Wired `CollectJsonIndexPredicate` into the existing full-text / JSON index optimizer rule

**Tests:**
- Greatly expanded `json_index_ut.cpp` (token collection unit tests for AND/OR, error cases, type coverage)
- Greatly expanded `kqp_indexes_json_ut.cpp` (end-to-end query tests: simple predicates, AND/OR combos, nested JSON_*, error/empty behaviours)