### PR TITLE
EXT-2089 Free idle resources in quoter service

### DIFF
--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -486,9 +486,14 @@ private:
                         << "Connected: " << (Connected ? "true" : "false") << "\n"
                         << "DisconnectTime: " << DisconnectTime << "\n"
                         << "Resources:\n";
+                    bool firstRes = true;
                     for (auto& [name, res] : Resources) {
+                        if (firstRes) {
+                            firstRes = false;
+                        } else {
+                            str << "\n";
+                        }
                         str << "  Resource: " << name << "\n";
-
                         if (res) {
                             str << "  Id: " << res->ResId << "\n"
                                 << "  Available: " << res->Available << "\n"

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -929,7 +929,7 @@ private:
                         KESUS_PROXY_LOG_INFO("Initialized new session with resource \"" << resourcePaths[i] << "\"");
                         if (resState->ResId != Max<ui64>() && resState->ResId != resResult.GetResourceId()) { // Kesus was disconnected and then resource was recreated.
                             BreakResource(*resState, GetProxyUpdateEv());
-                            ResIndex.erase(resState->ResId);
+                            ResIndex[resState->ResId] = Resources.end();
                         }
                         resState->ResId = resResult.GetResourceId();
                         ResIndex[resState->ResId] = resourceIt;

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -347,8 +347,7 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
     THashMap<ui64, std::vector<TString>> CookieToResourcePath;
     ui64 NextCookie = 1;
 
-    TInstant LastReplicationReport = TInstant::Zero();
-    TDuration MinReplicationReportPeriod = TDuration::Max();
+    TInstant NextReplicationReport = TInstant::Max();
 
     THolder<NKesus::TEvKesus::TEvUpdateConsumptionState> UpdateEv;
     THolder<NKesus::TEvKesus::TEvAccountResources> AccountEv;
@@ -445,7 +444,9 @@ private:
 
     void SetResProps(TResourceState* resState, const NKikimrKesus::TStreamingQuoterResource& props) {
         resState->SetProps(props, ServerVersion);
-        MinReplicationReportPeriod = Min(resState->ReplicationReportPeriod, MinReplicationReportPeriod);
+        if (resState->ReplicationReportPeriod != TDuration::Max()) {
+            NextReplicationReport = Min(NextReplicationReport, TActivationContext::Now());
+        }
     }
 
     TResourceState* FindResource(ui64 id) {
@@ -647,7 +648,8 @@ private:
 
     void SendDeferredEvents() {
         const TInstant now = TActivationContext::Now();
-        if (MinReplicationReportPeriod != TDuration::Max() && LastReplicationReport + MinReplicationReportPeriod < now) {
+        if (NextReplicationReport != TInstant::Max() && now >= NextReplicationReport) {
+            NextReplicationReport = TInstant::Max();
             for (auto& [_, res] : Resources) {
                 if (res->ReplicationEnabled) {
                     CheckReplicationReport(*res, now);
@@ -903,7 +905,7 @@ private:
         ConnectToKesus(true);
         DisconnectTime = TActivationContext::Now();
         OfflineAllocationCookie = NextCookie++;
-        MinReplicationReportPeriod = TDuration::Max();
+        NextReplicationReport = TInstant::Max();
         MarkAllActiveResourcesForOfflineAllocation();
         if (Counters.Disconnects) {
             ++*Counters.Disconnects;
@@ -1128,14 +1130,15 @@ private:
     }
 
     void CheckReplicationReport(TResourceState& res, TInstant now) {
-        if (res.LastReplicationReport + res.ReplicationReportPeriod < now) {
+        Y_ASSERT(res.ReplicationReportPeriod < TDuration::Max());
+        if (res.LastReplicationReport + res.ReplicationReportPeriod <= now) {
             ReportReplicationSession(res);
             // `LastReplicationReport` must be aligned to send resources' stats in one message
             // in case they have the same `ReportPeriod`
-            Y_ASSERT(res.ReplicationReportPeriod < TDuration::Max());
             ui64 periodUs = res.ReplicationReportPeriod.MicroSeconds();
             res.LastReplicationReport = TInstant::MicroSeconds(now.MicroSeconds() / periodUs * periodUs);
         }
+        NextReplicationReport = Min(NextReplicationReport, res.LastReplicationReport + res.ReplicationReportPeriod);
     }
 
     static TString GetLogPrefix(const TVector<TString>& path) {

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -347,6 +347,9 @@ class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
     THashMap<ui64, std::vector<TString>> CookieToResourcePath;
     ui64 NextCookie = 1;
 
+    TInstant LastReplicationReport = TInstant::Zero();
+    TDuration MinReplicationReportPeriod = TDuration::Max();
+
     THolder<NKesus::TEvKesus::TEvUpdateConsumptionState> UpdateEv;
     THolder<NKesus::TEvKesus::TEvAccountResources> AccountEv;
     THolder<NKesus::TEvKesus::TEvReportResources> ReplicationEv;
@@ -440,6 +443,11 @@ private:
         }
     }
 
+    void SetResProps(TResourceState* resState, const NKikimrKesus::TStreamingQuoterResource& props) {
+        resState->SetProps(props, ServerVersion);
+        MinReplicationReportPeriod = Min(resState->ReplicationReportPeriod, MinReplicationReportPeriod);
+    }
+
     TResourceState* FindResource(ui64 id) {
         const auto indexIt = ResIndex.find(id);
         return indexIt != ResIndex.end() ? indexIt->second->second.Get() : nullptr;
@@ -514,17 +522,23 @@ private:
                                 << "  Props: " << res->Props.ShortDebugString() << "\n";
                         }
                     }
-                    str << "UpdateEv: " << (UpdateEv ? "" : "null") << "\n";
+                    str << "UpdateEv: ";
                     if (UpdateEv) {
-
+                        str << UpdateEv->Record.ResourcesInfoSize() << "\n";
+                    } else {
+                        str << "null" << "\n";
                     }
-                    str << "AccountEv: " << (AccountEv ? "" : "null") << "\n";
+                    str << "AccountEv: ";
                     if (AccountEv) {
-
+                        str << AccountEv->Record.ResourcesInfoSize() << "\n";
+                    } else {
+                        str << "null" << "\n";
                     }
-                    str << "ReplicationEv: " << (ReplicationEv ? "" : "null") << "\n";
+                    str << "ReplicationEv: ";
                     if (ReplicationEv) {
-
+                        str << ReplicationEv->Record.ResourcesInfoSize() << "\n";
+                    } else {
+                        str << "null" << "\n";
                     }
                 }
                 str << "</div>";
@@ -632,33 +646,39 @@ private:
     }
 
     void SendDeferredEvents() {
-        for (auto& [_, res] : Resources) {
-            if (res->ReplicationEnabled) {
-                CheckReplicationReport(*res, TActivationContext::Now());
+        const TInstant now = TActivationContext::Now();
+        if (MinReplicationReportPeriod != TDuration::Max() && LastReplicationReport + MinReplicationReportPeriod < now) {
+            for (auto& [_, res] : Resources) {
+                if (res->ReplicationEnabled) {
+                    CheckReplicationReport(*res, now);
+                }
             }
         }
 
-        if (Connected && UpdateEv) {
-            KESUS_PROXY_LOG_TRACE("UpdateConsumptionState(" << UpdateEv->Record << ")");
-            NTabletPipe::SendData(SelfId(), KesusPipeClient, UpdateEv.Release());
-        }
-        UpdateEv.Reset();
+        if (Connected) {
+            if (UpdateEv) {
+                KESUS_PROXY_LOG_TRACE("UpdateConsumptionState(" << UpdateEv->Record << ")");
+                NTabletPipe::SendData(SelfId(), KesusPipeClient, UpdateEv.Release());
+            }
 
-        if (Connected && AccountEv && AccountEv->Record.GetResourcesInfo().size() > 0) {
-            KESUS_PROXY_LOG_TRACE("AccountResources(" << AccountEv->Record << ")");
-            NTabletPipe::SendData(SelfId(), KesusPipeClient, AccountEv.Release());
-        }
-        AccountEv.Reset();
+            if (AccountEv && AccountEv->Record.GetResourcesInfo().size() > 0) {
+                KESUS_PROXY_LOG_TRACE("AccountResources(" << AccountEv->Record << ")");
+                NTabletPipe::SendData(SelfId(), KesusPipeClient, AccountEv.Release());
+            }
 
-        if (Connected && ReplicationEv && ReplicationEv->Record.GetResourcesInfo().size() > 0) {
-            KESUS_PROXY_LOG_TRACE("ReportResources(" << ReplicationEv->Record << ")");
-            NTabletPipe::SendData(SelfId(), KesusPipeClient, ReplicationEv.Release());
+            if (ReplicationEv && ReplicationEv->Record.GetResourcesInfo().size() > 0) {
+                KESUS_PROXY_LOG_TRACE("ReportResources(" << ReplicationEv->Record << ")");
+                NTabletPipe::SendData(SelfId(), KesusPipeClient, ReplicationEv.Release());
+            }
         }
-        ReplicationEv.Reset();
 
         if (ProxyUpdateEv && ProxyUpdateEv->Resources) {
             SendToService(std::move(ProxyUpdateEv));
         }
+
+        UpdateEv.Reset();
+        AccountEv.Reset();
+        ReplicationEv.Reset();
     }
 
     void ScheduleOfflineAllocation() {
@@ -770,7 +790,8 @@ private:
     }
 
     void ReportReplicationSession(TResourceState& res) {
-        if (Connected && res.ReplicationEnabled) {
+        if (Connected) {
+            Y_ASSERT(res.ReplicationEnabled);
             InitReplicationEv();
             auto* resInfo = ReplicationEv->Record.AddResourcesInfo();
             resInfo->SetResourceId(res.ResId);
@@ -882,6 +903,7 @@ private:
         ConnectToKesus(true);
         DisconnectTime = TActivationContext::Now();
         OfflineAllocationCookie = NextCookie++;
+        MinReplicationReportPeriod = TDuration::Max();
         MarkAllActiveResourcesForOfflineAllocation();
         if (Counters.Disconnects) {
             ++*Counters.Disconnects;
@@ -909,7 +931,7 @@ private:
                         }
                         resState->ResId = resResult.GetResourceId();
                         ResIndex[resState->ResId] = resourceIt;
-                        resourceIt->second->SetProps(resResult.GetEffectiveProps(), ServerVersion);
+                        SetResProps(resourceIt->second.Get(), resResult.GetEffectiveProps());
                         if (resourceIt->second->ReplicationEnabled) { // use initial availiable only in replicated mode
                             resourceIt->second->SetAvailable(resResult.GetInitialAvailable());
                         }
@@ -938,7 +960,7 @@ private:
                 const auto amount = allocatedInfo.GetAmount();
                 KESUS_PROXY_LOG_TRACE("Kesus allocated {\"" << res->Resource << "\", " << amount << "}");
                 if (allocatedInfo.HasEffectiveProps()) { // changed
-                    res->SetProps(allocatedInfo.GetEffectiveProps(), ServerVersion);
+                    SetResProps(res, allocatedInfo.GetEffectiveProps());
                 }
                 res->SetAvailable(res->Available + amount);
                 res->LastAllocated = now;

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -905,7 +905,7 @@ private:
                         KESUS_PROXY_LOG_INFO("Initialized new session with resource \"" << resourcePaths[i] << "\"");
                         if (resState->ResId != Max<ui64>() && resState->ResId != resResult.GetResourceId()) { // Kesus was disconnected and then resource was recreated.
                             BreakResource(*resState, GetProxyUpdateEv());
-                            ResIndex[resState->ResId] = Resources.end();
+                            ResIndex.erase(resState->ResId);
                         }
                         resState->ResId = resResult.GetResourceId();
                         ResIndex[resState->ResId] = resourceIt;

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -1128,7 +1128,7 @@ void TQuoterService::Handle(TEvQuota::TEvProxyUpdate::TPtr &ev) {
         }
     }
 
-    BreakQuoterIfEmpty(quoterIt, "ProxyUpdate");
+    CloseQuoterIfEmpty(quoterIt, "ProxyUpdate");
 }
 
 void TQuoterService::Handle(TEvQuota::TEvRpcTimeout::TPtr &ev) {
@@ -1154,6 +1154,7 @@ void TQuoterService::HandleCleanup() {
         StartCleanupPass();
     }
 
+    const TInstant now = TActivationContext::Now();
     size_t resourcesProcessed = 0;
     while (!CleanupQuoters.empty() && resourcesProcessed < CleanupBatchLimit) {
         const ui64 quoterId = CleanupQuoters.front();
@@ -1164,13 +1165,26 @@ void TQuoterService::HandleCleanup() {
             continue;
         }
 
-        for (const auto& [resourceId, _] : quoterIt->second.Resources) {
-            Y_UNUSED(resourceId);
-            Y_UNUSED(_);
+        TVector<ui64> resourcesToEvict;
+        for (const auto& [resourceId, resHolder] : quoterIt->second.Resources) {
             ++resourcesProcessed;
 
-            // Resource cleanup conditions and eviction are added in later steps.
+            const TResource& quores = *resHolder.Get();
+            if (quores.Activation == TInstant::Zero()
+                && quores.NextTick == TInstant::Zero()
+                && quores.QueueHead == Max<ui32>()
+                && now - quores.LastTick >= CleanupResourceIdlePeriod
+                && now - quores.LastAllocated >= CleanupResourceIdlePeriod)
+            {
+                resourcesToEvict.push_back(resourceId);
+            }
         }
+
+        for (ui64 resourceId : resourcesToEvict) {
+            EvictResource(quoterIt->second, resourceId, "Cleanup");
+        }
+
+        CloseQuoterIfEmpty(quoterIt, "Cleanup");
     }
 
     if (!CleanupQuoters.empty()) {
@@ -1197,7 +1211,7 @@ void TQuoterService::EvictResource(TQuoterState& quoter, ui64 resourceId, TStrin
     quoter.Resources.erase(resourceIt);
 }
 
-bool TQuoterService::BreakQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason) {
+bool TQuoterService::CloseQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason) {
     if (!quoterIt->second.Empty()) {
         return false;
     }

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -1143,6 +1143,20 @@ void TQuoterService::Handle(TEvQuota::TEvRpcTimeout::TPtr &ev) {
     Counters.ResultRpcDeadline->Inc();
 }
 
+void TQuoterService::Handle(TEvents::TEvWakeup::TPtr &ev) {
+    switch (ev->Get()->Tag) {
+    case WakeupTagTick:
+        HandleTick();
+        return;
+    case WakeupTagCleanup:
+        // Reserved for periodic idle-resource cleanup added in later steps.
+        return;
+    default:
+        BLOG_WARN("Unknown TEvWakeup tag: " << ev->Get()->Tag);
+        return;
+    }
+}
+
 void TQuoterService::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev) {
     THolder<NSchemeCache::TSchemeCacheNavigate> navigate(ev->Get()->Request.Release());
     Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -1128,10 +1128,7 @@ void TQuoterService::Handle(TEvQuota::TEvProxyUpdate::TPtr &ev) {
         }
     }
 
-    if (quoter.Empty()) {
-        BLOG_I("closing quoter on ProxyUpdate as no activity left " << quoter.QuoterName);
-        return BreakQuoter(quoterIt);
-    }
+    BreakQuoterIfEmpty(quoterIt, "ProxyUpdate");
 }
 
 void TQuoterService::Handle(TEvQuota::TEvRpcTimeout::TPtr &ev) {
@@ -1198,6 +1195,16 @@ void TQuoterService::EvictResource(TQuoterState& quoter, ui64 resourceId, TStrin
     ForbidResource(quores);
     quoter.ResourcesIndex.erase(quores.Resource);
     quoter.Resources.erase(resourceIt);
+}
+
+bool TQuoterService::BreakQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason) {
+    if (!quoterIt->second.Empty()) {
+        return false;
+    }
+
+    BLOG_I("closing quoter on " << reason << " as no activity left " << quoterIt->second.QuoterName);
+    BreakQuoter(quoterIt);
+    return true;
 }
 
 void TQuoterService::Handle(TEvents::TEvWakeup::TPtr &ev) {

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -382,6 +382,7 @@ void TQuoterService::Bootstrap() {
     NLwTraceMonPage::ProbeRegistry().AddProbesList(LWTRACE_GET_PROBES(QUOTER_SERVICE_PROVIDER));
 
     Become(&TThis::StateFunc);
+    ScheduleNextCleanupPass();
 }
 
 void TQuoterService::TryTickSchedule(TInstant now) {
@@ -1143,13 +1144,59 @@ void TQuoterService::Handle(TEvQuota::TEvRpcTimeout::TPtr &ev) {
     Counters.ResultRpcDeadline->Inc();
 }
 
+void TQuoterService::StartCleanupPass() {
+    CleanupQuoters = {};
+
+    for (const auto& [quoterId, _] : Quoters) {
+        Y_UNUSED(_);
+        CleanupQuoters.push(quoterId);
+    }
+}
+
+void TQuoterService::ScheduleNextCleanupPass() {
+    Schedule(CleanupPeriod, new TEvents::TEvWakeup(WakeupTagCleanup));
+}
+
+void TQuoterService::HandleCleanup() {
+    if (CleanupQuoters.empty()) {
+        StartCleanupPass();
+    }
+
+    size_t resourcesProcessed = 0;
+    while (!CleanupQuoters.empty() && resourcesProcessed < CleanupBatchLimit) {
+        const ui64 quoterId = CleanupQuoters.front();
+        CleanupQuoters.pop();
+
+        auto quoterIt = Quoters.find(quoterId);
+        if (quoterIt == Quoters.end()) {
+            continue;
+        }
+
+        for (const auto& [resourceId, _] : quoterIt->second.Resources) {
+            Y_UNUSED(resourceId);
+            Y_UNUSED(_);
+            ++resourcesProcessed;
+
+            // Resource cleanup conditions and eviction are added in later steps.
+        }
+    }
+
+    if (!CleanupQuoters.empty()) {
+        // Allow external requests to be processed
+        Send(SelfId(), new TEvents::TEvWakeup(WakeupTagCleanup));
+        return;
+    }
+
+    ScheduleNextCleanupPass();
+}
+
 void TQuoterService::Handle(TEvents::TEvWakeup::TPtr &ev) {
     switch (ev->Get()->Tag) {
     case WakeupTagTick:
         HandleTick();
         return;
     case WakeupTagCleanup:
-        // Reserved for periodic idle-resource cleanup added in later steps.
+        HandleCleanup();
         return;
     default:
         BLOG_WARN("Unknown TEvWakeup tag: " << ev->Get()->Tag);

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -1109,12 +1109,7 @@ void TQuoterService::Handle(TEvQuota::TEvProxyUpdate::TPtr &ev) {
         if (resUpdate.ResourceState == EUpdateState::Broken
             || (resUpdate.ResourceState == EUpdateState::Evict && quores.QueueHead == Max<ui32>()))
         {
-            BLOG_I("closing resource on ProxyUpdate " << quoter.QuoterName << ":" << quores.Resource);
-            Send(quoter.ProxyId, new TEvQuota::TEvProxyCloseSession(quores.Resource, quores.ResourceId));
-
-            ForbidResource(quores);
-            quoter.ResourcesIndex.erase(quores.Resource);
-            quoter.Resources.erase(resourceIt);
+            EvictResource(quoter, resUpdate.ResourceId, "ProxyUpdate");
             continue;
         }
 
@@ -1188,6 +1183,21 @@ void TQuoterService::HandleCleanup() {
     }
 
     ScheduleNextCleanupPass();
+}
+
+void TQuoterService::EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason) {
+    auto resourceIt = quoter.Resources.find(resourceId);
+    if (resourceIt == quoter.Resources.end()) {
+        return;
+    }
+
+    TResource &quores = *resourceIt->second;
+    BLOG_I("closing resource on " << reason << " " << quoter.QuoterName << ":" << quores.Resource);
+    Send(quoter.ProxyId, new TEvQuota::TEvProxyCloseSession(quores.Resource, quores.ResourceId));
+
+    ForbidResource(quores);
+    quoter.ResourcesIndex.erase(quores.Resource);
+    quoter.Resources.erase(resourceIt);
 }
 
 void TQuoterService::Handle(TEvents::TEvWakeup::TPtr &ev) {

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -856,12 +856,24 @@ void TQuoterService::Handle(NMon::TEvHttpInfo::TPtr &ev) {
             PRE() {
                 str << "LastProcessed: " << LastProcessed << "\n"
                     << "Quoters:\n";
+                bool firstQuoter = true;
                 for (auto& [quoterId, quoterState] : Quoters) {
+                    if (firstQuoter) {
+                        firstQuoter = false;
+                    } else {
+                        str << "\n";
+                    }
                     str << "  Name: " << quoterState.QuoterName << "\n"
                         << "  Id: " << quoterId << "\n"
                         << "  ProxyId: " << quoterState.ProxyId << "\n"
                         << "  Resources:\n";
+                    bool firstRes = true;
                     for (auto& [resId, resPtr] : quoterState.Resources) {
+                        if (firstRes) {
+                            firstRes = false;
+                        } else {
+                            str << "\n";
+                        }
                         str << "    Id: " << resId << "\n";
                         if (resPtr) {
                             str << "    Name: " << resPtr->Resource << "\n"

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -320,6 +320,7 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void StartCleanupPass();
     void ScheduleNextCleanupPass();
     void HandleCleanup();
+    void EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason);
 
     void Handle(NMon::TEvHttpInfo::TPtr &ev);
     void Handle(TEvQuota::TEvRequest::TPtr &ev);

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -14,6 +14,7 @@
 
 #include <util/generic/set.h>
 #include <util/generic/deque.h>
+#include <util/generic/queue.h>
 
 namespace NKikimr {
 namespace NQuoter {
@@ -239,6 +240,9 @@ struct TQuoterState {
 };
 
 class TQuoterService : public TActorBootstrapped<TQuoterService> {
+    static constexpr TDuration CleanupPeriod = TDuration::Minutes(1);
+    static constexpr size_t CleanupBatchLimit = 1000;
+
     TQuoterServiceConfig Config;
     TInstant LastProcessed;
 
@@ -257,6 +261,7 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     TQuoterState StaticRatedQuoter; // ??? could be just static rated quoters, w/o all fancy quoter stuff
 
     bool TickScheduled;
+    TQueue<ui64> CleanupQuoters;
 
     TMap<ui64, TDeque<TEvQuota::TProxyStat>> StatsToPublish; // quoterId -> stats
 
@@ -312,6 +317,9 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void FeedResource(TResource &quores);
     void AllocateResource(TResource &quores);
     void PublishStats();
+    void StartCleanupPass();
+    void ScheduleNextCleanupPass();
+    void HandleCleanup();
 
     void Handle(NMon::TEvHttpInfo::TPtr &ev);
     void Handle(TEvQuota::TEvRequest::TPtr &ev);

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -321,6 +321,7 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void ScheduleNextCleanupPass();
     void HandleCleanup();
     void EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason);
+    bool BreakQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason);
 
     void Handle(NMon::TEvHttpInfo::TPtr &ev);
     void Handle(TEvQuota::TEvRequest::TPtr &ev);

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -282,6 +282,11 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
         GenericError,
     };
 
+    enum EWakeupTag : ui64 {
+        WakeupTagTick = 0,
+        WakeupTagCleanup = 1,
+    };
+
     void ScheduleNextTick(TInstant requested, TResource &quores);
     TInstant TimeToGranularity(TInstant rawTime);
     void TryTickSchedule(TInstant now = TInstant::Zero());
@@ -314,6 +319,7 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void Handle(TEvQuota::TEvProxySession::TPtr &ev);
     void Handle(TEvQuota::TEvProxyUpdate::TPtr &ev);
     void Handle(TEvQuota::TEvRpcTimeout::TPtr &ev);
+    void Handle(TEvents::TEvWakeup::TPtr &ev);
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev);
     void HandleTick();
 
@@ -340,7 +346,7 @@ public:
             hFunc(TEvQuota::TEvProxySession, Handle);
             hFunc(TEvQuota::TEvProxyUpdate, Handle);
             hFunc(TEvQuota::TEvRpcTimeout, Handle);
-            cFunc(TEvents::TEvWakeup::EventType, HandleTick);
+            hFunc(TEvents::TEvWakeup, Handle);
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
         default:
             LOG_WARN_S(*TlsActivationContext, NKikimrServices::QUOTER_SERVICE, "TQuoterService::StateFunc unexpected event type# "

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -242,6 +242,7 @@ struct TQuoterState {
 class TQuoterService : public TActorBootstrapped<TQuoterService> {
     static constexpr TDuration CleanupPeriod = TDuration::Minutes(1);
     static constexpr size_t CleanupBatchLimit = 1000;
+    static constexpr TDuration CleanupResourceIdlePeriod = TDuration::Hours(1);
 
     TQuoterServiceConfig Config;
     TInstant LastProcessed;
@@ -321,7 +322,7 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void ScheduleNextCleanupPass();
     void HandleCleanup();
     void EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason);
-    bool BreakQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason);
+    bool CloseQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason);
 
     void Handle(NMon::TEvHttpInfo::TPtr &ev);
     void Handle(TEvQuota::TEvRequest::TPtr &ev);

--- a/ydb/core/quoter/quoter_service_ut.cpp
+++ b/ydb/core/quoter/quoter_service_ut.cpp
@@ -115,30 +115,6 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
         }
     }
 
-#if defined(OPTIMIZED)
-#error "Macro conflict."
-#endif
-
-#if defined(_MSC_VER)
-
-#if defined(NDEBUG)
-#define OPTIMIZED // release builds
-#endif
-
-#else // non msvc compiler: use __OPTIMIZE__ flag to include relwithdebinfo builds
-
-#if defined(__OPTIMIZE__)
-#define OPTIMIZED // release builds and relwithdebinfo builds
-#endif
-
-#endif
-
-#if defined(OPTIMIZED) && !defined(_san_enabled_) && !defined(WITH_VALGRIND)
-    enum class ESpeedTestResourceType {
-        StaticTaggedRateResource,
-        KesusResource,
-    };
-
     // Send a scheme operation and wait for it to be accepted (ExecInProgress).
     // Use SimulateSleep after calling this to give schemeshard time to complete.
     void SendSchemeOpAndWaitAccepted(TTestActorRuntime* runtime, THolder<TEvTxUserProxy::TEvProposeTransaction> propose, const TString& opName) {
@@ -219,6 +195,30 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
         const NKikimrKesus::TEvAddQuoterResourceResult& record = handle->Get<NKesus::TEvKesus::TEvAddQuoterResourceResult>()->Record;
         UNIT_ASSERT_VALUES_EQUAL(record.GetError().GetStatus(), Ydb::StatusIds::SUCCESS);
     }
+
+#if defined(OPTIMIZED)
+#error "Macro conflict."
+#endif
+
+#if defined(_MSC_VER)
+
+#if defined(NDEBUG)
+#define OPTIMIZED // release builds
+#endif
+
+#else // non msvc compiler: use __OPTIMIZE__ flag to include relwithdebinfo builds
+
+#if defined(__OPTIMIZE__)
+#define OPTIMIZED // release builds and relwithdebinfo builds
+#endif
+
+#endif
+
+#if defined(OPTIMIZED) && !defined(_san_enabled_) && !defined(WITH_VALGRIND)
+    enum class ESpeedTestResourceType {
+        StaticTaggedRateResource,
+        KesusResource,
+    };
 
     // Tests that quoter service rate-limits correctly at the configured rate.
     // Uses simulated time (UseRealThreads=false) for deterministic results.
@@ -405,6 +405,157 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
         }
     }
 
+    Y_UNIT_TEST(CleanupDoesNotCloseKesusResourceBeforeOneHour) {
+        TPortManager portManager;
+        TServerSettings serverSettings(portManager.GetPort());
+        serverSettings.SetUseRealThreads(false);
+        TServer server = TServer(serverSettings, true);
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        const TActorId serviceId = MakeQuoterServiceID();
+        const TActorId serviceActorId = runtime->Register(CreateQuoterService());
+        runtime->RegisterService(serviceId, serviceActorId);
+
+        auto dispatchEvents = [&]() {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+            runtime->DispatchEvents(options, TDuration::MilliSeconds(1));
+        };
+
+        InitRootSchemeAsync(runtime);
+        CreateKesusAsync(runtime);
+        CreateKesusResourceAsync(runtime, 10.0);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        dispatchEvents();
+
+        const TActorId sender = runtime->AllocateEdgeActor();
+        const TEvQuota::TResourceLeaf resLeaf(
+            TStringBuilder() << "/" << Tests::TestDomainName,
+            TStringBuilder() << "/" << Tests::TestDomainName << "/KesusQuoter",
+            "Res",
+            1);
+
+        ui32 proxySessions = 0;
+        ui32 proxyCloseSessions = 0;
+        ui64 requestCookie = 1;
+        auto proxySessionObserver = runtime->AddObserver<TEvQuota::TEvProxySession>(
+            [&](TEvQuota::TEvProxySession::TPtr& ev) {
+                if (ev->Get()->Result == TEvQuota::TEvProxySession::Success) {
+                    ++proxySessions;
+                }
+            });
+        auto proxyCloseObserver = runtime->AddObserver<TEvQuota::TEvProxyCloseSession>(
+            [&](TEvQuota::TEvProxyCloseSession::TPtr&) {
+                ++proxyCloseSessions;
+            });
+
+        auto requestQuota = [&] {
+            const ui64 cookie = requestCookie++;
+            runtime->Send(new IEventHandle(
+                MakeQuoterServiceID(),
+                sender,
+                new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And, {resLeaf}, TDuration::Max()),
+                0,
+                cookie));
+            runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender},
+                [cookie](const auto& ev) {
+                    return ev->Cookie == cookie;
+                });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        };
+
+        requestQuota();
+        UNIT_ASSERT_VALUES_EQUAL(proxySessions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 0);
+
+        runtime->AdvanceCurrentTime(TDuration::Minutes(59));
+        dispatchEvents();
+
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 0);
+
+        requestQuota();
+        UNIT_ASSERT_VALUES_EQUAL(proxySessions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 0);
+    }
+
+    Y_UNIT_TEST(CleanupClosesAndReopensIdleKesusResource) {
+        TPortManager portManager;
+        TServerSettings serverSettings(portManager.GetPort());
+        serverSettings.SetUseRealThreads(false);
+        TServer server = TServer(serverSettings, true);
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        const TActorId serviceId = MakeQuoterServiceID();
+        const TActorId serviceActorId = runtime->Register(CreateQuoterService());
+        runtime->RegisterService(serviceId, serviceActorId);
+
+        auto dispatchEvents = [&]() {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+            runtime->DispatchEvents(options, TDuration::MilliSeconds(1));
+        };
+
+        InitRootSchemeAsync(runtime);
+        CreateKesusAsync(runtime);
+        CreateKesusResourceAsync(runtime, 10.0);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        dispatchEvents();
+
+        const TActorId sender = runtime->AllocateEdgeActor();
+        const TEvQuota::TResourceLeaf resLeaf(
+            TStringBuilder() << "/" << Tests::TestDomainName,
+            TStringBuilder() << "/" << Tests::TestDomainName << "/KesusQuoter",
+            "Res",
+            1);
+
+        ui32 proxySessions = 0;
+        ui32 proxyCloseSessions = 0;
+        ui64 requestCookie = 1;
+        auto proxySessionObserver = runtime->AddObserver<TEvQuota::TEvProxySession>(
+            [&](TEvQuota::TEvProxySession::TPtr& ev) {
+                if (ev->Get()->Result == TEvQuota::TEvProxySession::Success) {
+                    ++proxySessions;
+                }
+            });
+        auto proxyCloseObserver = runtime->AddObserver<TEvQuota::TEvProxyCloseSession>(
+            [&](TEvQuota::TEvProxyCloseSession::TPtr&) {
+                ++proxyCloseSessions;
+            });
+
+        auto requestQuota = [&] {
+            const ui64 cookie = requestCookie++;
+            runtime->Send(new IEventHandle(
+                MakeQuoterServiceID(),
+                sender,
+                new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And, {resLeaf}, TDuration::Max()),
+                0,
+                cookie));
+            runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender},
+                [cookie](const auto& ev) {
+                    return ev->Cookie == cookie;
+                });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        };
+
+        requestQuota();
+        UNIT_ASSERT_VALUES_EQUAL(proxySessions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 0);
+
+        runtime->AdvanceCurrentTime(TDuration::Hours(1) + TDuration::Minutes(2));
+        dispatchEvents();
+        UNIT_ASSERT_VALUES_EQUAL(proxySessions, 1);
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 1);
+
+        requestQuota();
+        UNIT_ASSERT_VALUES_EQUAL(proxySessions, 2);
+        UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 1);
+    }
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Quoter service has a problem if a client has a special pattern of usage:
- many resources in kesus
- the amount of active resources is constant, but some resources stop being used, while new ones start

In this case kesus quoter proxy collects many resources and CPU usage can significantly increase.

Additionally there is a cycle for all resources in SendDeferredEvents that is called every time when proxy processes any request. This cycle is related to the replication functionality. I also wrote a code that prevents running this cycle too often.