### PR TITLE
MUTE: Повторный вход в fast unmute после успешного окончания

### DIFF
--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -3,6 +3,7 @@
 import logging
 
 from mute.update_mute_issues import (
+    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
     MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     ORG_NAME,
     PROJECT_ID,
@@ -11,7 +12,6 @@ from mute.update_mute_issues import (
     run_query,
 )
 
-LABEL_NAME = MANUAL_FAST_UNMUTE_GITHUB_LABEL
 _LABEL_ID_CACHE = {}
 
 PROJECT_STATUS_ON_FAST_UNMUTE_REOPEN = 'Observation'
@@ -216,17 +216,10 @@ def set_manual_unmute_project_board_status(issue_node_id, status_label):
         logging.warning('manual_unmute: updateProjectV2ItemFieldValue failed: %s', exc)
 
 
-def set_fast_unmute_reopen_project_status(issue_node_id):
-    """Set org project Status → Observation when entering fast-unmute."""
-    set_manual_unmute_project_board_status(
-        issue_node_id, PROJECT_STATUS_ON_FAST_UNMUTE_REOPEN
-    )
-
-
-def _get_label_id():
+def _get_label_id(label_name):
     """Resolve the pre-created label node id (cached). Returns None if missing."""
-    if LABEL_NAME in _LABEL_ID_CACHE:
-        return _LABEL_ID_CACHE[LABEL_NAME]
+    if label_name in _LABEL_ID_CACHE:
+        return _LABEL_ID_CACHE[label_name]
 
     query = """
     query ($owner: String!, $name: String!, $labelName: String!) {
@@ -237,25 +230,25 @@ def _get_label_id():
     """
     result = run_query(
         query,
-        {'owner': ORG_NAME, 'name': REPO_NAME, 'labelName': LABEL_NAME},
+        {'owner': ORG_NAME, 'name': REPO_NAME, 'labelName': label_name},
     )
     label = (((result.get('data') or {}).get('repository') or {}).get('label') or {})
     label_id = label.get('id')
     if not label_id:
         logging.warning(
             "Label %r not found in %s/%s — create it manually in the repository labels page",
-            LABEL_NAME,
+            label_name,
             ORG_NAME,
             REPO_NAME,
         )
         return None
-    _LABEL_ID_CACHE[LABEL_NAME] = label_id
+    _LABEL_ID_CACHE[label_name] = label_id
     return label_id
 
 
-def add_label_to_issue(issue_id):
-    """Attach the fast-unmute label. Idempotent — GitHub ignores duplicates."""
-    label_id = _get_label_id()
+def add_label_to_issue(issue_id, label_name=MANUAL_FAST_UNMUTE_GITHUB_LABEL):
+    """Attach a label to issue. Idempotent — GitHub ignores duplicates."""
+    label_id = _get_label_id(label_name)
     if not label_id:
         return
     mutation = """
@@ -268,12 +261,14 @@ def add_label_to_issue(issue_id):
     try:
         run_query(mutation, {'labelableId': issue_id, 'labelIds': [label_id]})
     except Exception as exc:
-        logging.warning('Failed to add label to issue %s: %s', issue_id, exc)
+        logging.warning(
+            'Failed to add label %r to issue %s: %s', label_name, issue_id, exc
+        )
 
 
-def remove_label_from_issue(issue_id):
-    """Detach the fast-unmute label. No-op if label is not present."""
-    label_id = _get_label_id()
+def remove_label_from_issue(issue_id, label_name=MANUAL_FAST_UNMUTE_GITHUB_LABEL):
+    """Detach a label from issue. No-op if the label is not present."""
+    label_id = _get_label_id(label_name)
     if not label_id:
         return
     mutation = """
@@ -286,7 +281,71 @@ def remove_label_from_issue(issue_id):
     try:
         run_query(mutation, {'labelableId': issue_id, 'labelIds': [label_id]})
     except Exception as exc:
-        logging.warning('Failed to remove label from issue %s: %s', issue_id, exc)
+        logging.warning(
+            'Failed to remove label %r from issue %s: %s', label_name, issue_id, exc
+        )
+
+
+def fetch_issue_label_names(issue_numbers):
+    """Return ``{issue_number: {label_name, ...}}`` from GitHub GraphQL."""
+    result = {}
+    numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
+    if not numbers:
+        return result
+    chunk_size = 50
+    for i in range(0, len(numbers), chunk_size):
+        chunk = numbers[i : i + chunk_size]
+        subqueries = [
+            f"n{n}: issue(number: {n}) {{ labels(first: 40) {{ nodes {{ name }} }} }}" for n in chunk
+        ]
+        query = f"""
+        query {{
+            repository(owner: "{ORG_NAME}", name: "{REPO_NAME}") {{
+                {' '.join(subqueries)}
+            }}
+        }}
+        """
+        response = run_query(query)
+        repo_data = (response.get('data') or {}).get('repository') or {}
+        for number in chunk:
+            node = repo_data.get(f'n{number}') or {}
+            labels = (node.get('labels') or {}).get('nodes') or []
+            result[number] = {
+                str(label.get('name') or '').strip()
+                for label in labels
+                if (label or {}).get('name')
+            }
+    return result
+
+
+def fetch_issue_numbers_in_manual_unmute_project(issue_numbers):
+    """Return issue numbers that currently have a card in configured manual-unmute project."""
+    result = set()
+    numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
+    if not numbers:
+        return result
+    chunk_size = 50
+    for i in range(0, len(numbers), chunk_size):
+        chunk = numbers[i : i + chunk_size]
+        subqueries = [
+            f"n{n}: issue(number: {n}) {{ projectItems(first: 40) {{ nodes {{ project {{ number }} }} }} }}"
+            for n in chunk
+        ]
+        query = f"""
+        query {{
+            repository(owner: "{ORG_NAME}", name: "{REPO_NAME}") {{
+                {' '.join(subqueries)}
+            }}
+        }}
+        """
+        response = run_query(query)
+        repo_data = (response.get('data') or {}).get('repository') or {}
+        for number in chunk:
+            node = repo_data.get(f'n{number}') or {}
+            items = (node.get('projectItems') or {}).get('nodes') or []
+            if any(int((item.get('project') or {}).get('number') or -1) == int(PROJECT_ID) for item in items):
+                result.add(number)
+    return result
 
 
 def fetch_issue_states(issue_numbers):
@@ -326,11 +385,3 @@ def fetch_issue_states(issue_numbers):
     return result
 
 
-def fetch_issue_node_ids(issue_numbers):
-    """Return ``{issue_number: issue_node_id}`` (same GraphQL batching as ``fetch_issue_states``)."""
-    return {n: data['id'] for n, data in fetch_issue_states(issue_numbers).items()}
-
-
-def issue_eligible_for_manual_fast_unmute_entry(state, state_reason):
-    """Same gate as YDB candidate issues: closed by human as completed."""
-    return (state or '').strip().upper() == 'CLOSED' and (state_reason or '').strip().upper() == 'COMPLETED'

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -3,7 +3,6 @@
 import logging
 
 from mute.update_mute_issues import (
-    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
     MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     ORG_NAME,
     PROJECT_ID,

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -245,7 +245,7 @@ def _get_label_id(label_name):
     return label_id
 
 
-def add_label_to_issue(issue_id, label_name=MANUAL_FAST_UNMUTE_GITHUB_LABEL):
+def add_label_to_issue(issue_id, label_name):
     """Attach a label to issue. Idempotent — GitHub ignores duplicates."""
     label_id = _get_label_id(label_name)
     if not label_id:
@@ -265,7 +265,7 @@ def add_label_to_issue(issue_id, label_name=MANUAL_FAST_UNMUTE_GITHUB_LABEL):
         )
 
 
-def remove_label_from_issue(issue_id, label_name=MANUAL_FAST_UNMUTE_GITHUB_LABEL):
+def remove_label_from_issue(issue_id, label_name):
     """Detach a label from issue. No-op if the label is not present."""
     label_id = _get_label_id(label_name)
     if not label_id:

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -3,7 +3,6 @@
 import logging
 
 from mute.update_mute_issues import (
-    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     ORG_NAME,
     PROJECT_ID,
     REPO_NAME,

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -323,6 +323,7 @@ def fetch_issue_numbers_in_manual_unmute_project(issue_numbers):
     numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
     if not numbers:
         return result
+    target_project_number = int(PROJECT_ID)
     chunk_size = 50
     for i in range(0, len(numbers), chunk_size):
         chunk = numbers[i : i + chunk_size]
@@ -342,7 +343,11 @@ def fetch_issue_numbers_in_manual_unmute_project(issue_numbers):
         for number in chunk:
             node = repo_data.get(f'n{number}') or {}
             items = (node.get('projectItems') or {}).get('nodes') or []
-            if any(int((item.get('project') or {}).get('number') or -1) == int(PROJECT_ID) for item in items):
+            if any(
+                int((item.get('project') or {}).get('number') or -1)
+                == target_project_number
+                for item in items
+            ):
                 result.add(number)
     return result
 

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -191,8 +191,8 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
 
     issue_numbers = {int(c['issue_number']) for c in candidates if c.get('issue_number') is not None}
     in_project_issue_numbers = fetch_issue_numbers_in_manual_unmute_project(issue_numbers)
-    closers = fetch_issue_closers(issue_numbers)
-    labels_by_issue = fetch_issue_label_names(issue_numbers)
+    closers = fetch_issue_closers(in_project_issue_numbers)
+    labels_by_issue = fetch_issue_label_names(in_project_issue_numbers)
 
     muted_cache = {}
     now = datetime.datetime.now(tz=datetime.timezone.utc)

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -62,6 +62,11 @@ BOT_LOGINS = frozenset({'ydbot', 'github-actions'})
 _LOG = logging.getLogger('manual_unmute')
 
 
+def issue_eligible_for_manual_fast_unmute_entry(state, state_reason):
+    """Gate for manual fast-unmute: issue must be CLOSED as COMPLETED."""
+    return (state or '').strip().upper() == 'CLOSED' and (state_reason or '').strip().upper() == 'COMPLETED'
+
+
 def grace_ttl_calendar_days(mute_window_days, manual_unmute_window_days):
     """Calendar days a ``fast_unmute_grace`` row is kept (same rule as ``expire_fast_unmute_grace``).
 
@@ -128,7 +133,7 @@ def abandon_fast_unmute_if_issue_not_completed(ydb_wrapper, table_path, grace_ta
         issue_id = meta.get('id')
         state = meta.get('state') or ''
         state_reason = meta.get('state_reason') or ''
-        if (state or '').strip().upper() == 'CLOSED' and (state_reason or '').strip().upper() == 'COMPLETED':
+        if issue_eligible_for_manual_fast_unmute_entry(state, state_reason):
             continue
         if not issue_id:
             logging.warning(
@@ -484,9 +489,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             )
 
         success_comment_issues = (
-            issues_to_delabel
-            & issues_cleared_via_unmute
-            - issues_ttl_shutdown
+            (issues_to_delabel & issues_cleared_via_unmute) - issues_ttl_shutdown
         )
         for issue_number in sorted(success_comment_issues):
             issue_id = issue_ids.get(issue_number)

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -51,6 +51,7 @@ from mute.fast_unmute_ydb import (
     upsert_rows,
 )
 from mute.update_mute_issues import (
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
     add_issue_comment,
     parse_body,
@@ -151,7 +152,7 @@ def abandon_fast_unmute_if_issue_not_completed(ydb_wrapper, table_path, grace_ta
             )
             rows_deleted += 1
 
-        remove_label_from_issue(issue_id)
+        remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
         set_manual_unmute_project_board_status(issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_FAIL)
         add_issue_comment(
             issue_id,
@@ -318,7 +319,7 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
                 workflow_run_url=run_url,
             ),
         )
-        add_label_to_issue(issue_id)
+        add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
 
         new_rows.extend(issue_rows)
         for row in issue_rows:
@@ -507,7 +508,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
         for issue_number in issues_to_delabel:
             issue_id = issue_ids.get(issue_number)
             if issue_id:
-                remove_label_from_issue(issue_id)
+                remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
 
     logging.info('manual_unmute_cleanup: removed %d row(s)', delete_count)
 

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -23,16 +23,17 @@ from mute.fast_unmute_comments import (
     format_bullet_list,
 )
 from mute.fast_unmute_github import (
+    PROJECT_ID,
     PROJECT_STATUS_ON_FAST_UNMUTE_FAIL,
+    PROJECT_STATUS_ON_FAST_UNMUTE_REOPEN,
     PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS,
     add_label_to_issue,
     fetch_issue_closers,
-    fetch_issue_node_ids,
+    fetch_issue_label_names,
+    fetch_issue_numbers_in_manual_unmute_project,
     fetch_issue_states,
-    issue_eligible_for_manual_fast_unmute_entry,
     remove_label_from_issue,
     reopen_issue,
-    set_fast_unmute_reopen_project_status,
     set_manual_unmute_project_board_status,
 )
 from mute.fast_unmute_ydb import (
@@ -49,7 +50,11 @@ from mute.fast_unmute_ydb import (
     upsert_fast_unmute_grace_row,
     upsert_rows,
 )
-from mute.update_mute_issues import add_issue_comment, parse_body
+from mute.update_mute_issues import (
+    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
+    add_issue_comment,
+    parse_body,
+)
 
 # GitHub ``__typename`` is ``User`` for PAT-based bot accounts; skip known bot logins (M2).
 BOT_LOGINS = frozenset({'ydbot', 'github-actions'})
@@ -123,7 +128,7 @@ def abandon_fast_unmute_if_issue_not_completed(ydb_wrapper, table_path, grace_ta
         issue_id = meta.get('id')
         state = meta.get('state') or ''
         state_reason = meta.get('state_reason') or ''
-        if issue_eligible_for_manual_fast_unmute_entry(state, state_reason):
+        if (state or '').strip().upper() == 'CLOSED' and (state_reason or '').strip().upper() == 'COMPLETED':
             continue
         if not issue_id:
             logging.warning(
@@ -185,7 +190,9 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
         return
 
     issue_numbers = {int(c['issue_number']) for c in candidates if c.get('issue_number') is not None}
+    in_project_issue_numbers = fetch_issue_numbers_in_manual_unmute_project(issue_numbers)
     closers = fetch_issue_closers(issue_numbers)
+    labels_by_issue = fetch_issue_label_names(issue_numbers)
 
     muted_cache = {}
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -203,6 +210,13 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
             )
             continue
         issue_number = int(issue_number_raw)
+        if issue_number not in in_project_issue_numbers:
+            _LOG.debug(
+                'enter: skip #%s: issue is not in project %s',
+                issue_number,
+                PROJECT_ID,
+            )
+            continue
 
         closer = closers.get(issue_number) or {}
         if closer.get('type') != 'User':
@@ -219,6 +233,14 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
                 'enter: skip #%s: closer login %r is bot-denylisted',
                 issue_number,
                 login,
+            )
+            continue
+        labels = labels_by_issue.get(issue_number) or set()
+        if MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL in labels:
+            _LOG.debug(
+                'enter: skip #%s: already has label %r',
+                issue_number,
+                MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
             )
             continue
 
@@ -277,7 +299,7 @@ def enter_manual_unmute(ydb_wrapper, table_path, issues_table_path, tests_monito
 
         upsert_rows(ydb_wrapper, table_path, issue_rows)
 
-        set_fast_unmute_reopen_project_status(issue_id)
+        set_manual_unmute_project_board_status(issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_REOPEN)
         raw_login = (closer.get('login') or '').strip()
         closer_mention_line = f'@{raw_login}\n\n' if raw_login else ''
         add_issue_comment(
@@ -406,7 +428,10 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
     if affected_issues:
         remaining = count_rows_per_issue(ydb_wrapper, table_path, affected_issues)
         issues_to_delabel = {num for num in affected_issues if remaining.get(num, 0) == 0}
-        issue_ids = fetch_issue_node_ids(affected_issues)
+        issue_ids = {
+            issue_number: data['id']
+            for issue_number, data in fetch_issue_states(affected_issues).items()
+        }
 
         for issue_number in sorted(issues_ttl_shutdown):
             issue_id = issue_ids.get(issue_number)
@@ -474,6 +499,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             set_manual_unmute_project_board_status(
                 issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
             )
+            add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
 
         for issue_number in issues_to_delabel:
             issue_id = issue_ids.get(issue_number)

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -15,6 +15,8 @@ REPO_NAME = 'ydb'
 PROJECT_ID = '45'
 # GitHub issue label set by ``mute/fast_unmute_github.py`` while fast-unmute rows exist.
 MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
+# GitHub issue label set once fast-unmute flow completed successfully.
+MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL = 'fast-unmute-finished'
 TEST_HISTORY_DASHBOARD = "https://datalens.yandex/4un3zdm0zcnyr"
 CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 


### PR DESCRIPTION
## Что делает PR

Исправляет баг повторного fast-unmute для уже успешно обработанных issue.

## Изменения

- После успешного fast-unmute ставим label `fast-unmute-finished`.
- При новом запуске fast-unmute такие issue пропускаются.
- Обработка ограничена issue из Project 45.

## пример проблемы
https://github.com/ydb-platform/ydb/issues/38286

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
