### PR TITLE
Fix race

### DIFF
--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -2,6 +2,7 @@
 
 #include "ydb/library/testlib/service_mocks/common.h"
 
+#include <util/system/mutex.h>
 #include <ydb/public/api/client/yc_private/servicecontrol/access_service.grpc.pb.h>
 #include <ydb/public/api/client/yc_private/accessservice/access_service.grpc.pb.h>
 
@@ -40,6 +41,8 @@ public:
 
     THashMap<TString, TResponse<yandex::cloud::priv::servicecontrol::v1::AuthenticateResponse>> AuthenticateData;
     THashMap<TString, TResponse<yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse>> AuthorizeData;
+
+    TMutex UserIpMutex;
     TString CapturedXUserIP;
 
     template <class TResonseProto>
@@ -78,7 +81,10 @@ public:
             const yandex::cloud::priv::servicecontrol::v1::AuthorizeRequest* request,
             yandex::cloud::priv::servicecontrol::v1::AuthorizeResponse* response) override {
 
-        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        {
+            std::lock_guard guard(UserIpMutex);
+            CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        }
 
         const TString& lastResourceId = request->resource_path(request->resource_path_size() - 1).id();
         const TString& token = request->signature().access_key_id() + request->iam_token() + "-" + request->permission() + "-" + lastResourceId;
@@ -170,6 +176,8 @@ public:
     THashMap<TString, TString> AllowedServicePermissions = {{"service1-something.write", "root1/folder1"}};
     THashSet<TString> AllowedResourceIds = {};
     THashSet<TString> UnavailableUserPermissions;
+
+    TMutex UserIPMutex;
     TString CapturedXUserIP;
 
     grpc::Status Authorize(
@@ -179,7 +187,10 @@ public:
 
         // Do not use authentication for "Authorize" handler
 
-        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        {
+            std::lock_guard guard(UserIPMutex);
+            CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        }
 
         ++AuthorizeCount;
         if (request->has_signature()) {
@@ -239,6 +250,8 @@ public:
         "user1-monitoring.view"
     };
     THashMap<TString, TString> AllowedServicePermissions = {{"service1-something.write", "root1/folder1"}};
+
+    TMutex UserIPMutex;
     TString CapturedXUserIP;
 
 public:
@@ -246,7 +259,10 @@ public:
                                  const ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeRequest* request,
                                  ::yandex::cloud::priv::accessservice::v2::BulkAuthorizeResponse* response) {
 
-        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        {
+            std::lock_guard guard(UserIPMutex);
+            CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        }
 
         if (!IsServiceAuthenticated(AllowedServiceAuthTokens, ctx)) {
             return grpc::Status(grpc::StatusCode::UNAUTHENTICATED, "Unauthenticated service");

--- a/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/nebius_access_service_mock.h
@@ -2,6 +2,7 @@
 
 #include "ydb/library/testlib/service_mocks/common.h"
 
+#include <util/system/mutex.h>
 #include <ydb/public/api/client/nc_private/iam/v1/access_service.grpc.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -19,6 +20,8 @@ public:
 
     THashMap<TString, TResponse<nebius::iam::v1::AuthenticateResponse>> AuthenticateData;
     THashMap<TString, TResponse<nebius::iam::v1::AuthorizeResponse>> AuthorizeData;
+
+    TMutex UserIPMutex;
     TString CapturedXUserIP;
 
     template <class TResonseProto>
@@ -51,8 +54,11 @@ public:
             grpc::ServerContext* ctx,
             const nebius::iam::v1::AuthorizeRequest* request,
             nebius::iam::v1::AuthorizeResponse* response) override {
-        
-        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+
+        {
+            std::lock_guard guard(UserIPMutex);
+            CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        }
 
         UNIT_ASSERT_VALUES_EQUAL_C(request->checks_size(), 1, "Nebius access service mock does not support multiple checks yet");
         const auto checkIt = request->checks().find(0);
@@ -196,6 +202,8 @@ public:
     THashSet<TString> AllowedResourceIds;
     THashSet<TString> UnavailableUserPermissions;
     TString ContainerId;
+
+    TMutex UserIPMutex;
     TString CapturedXUserIP;
 
     grpc::Status Authorize(
@@ -206,7 +214,10 @@ public:
              << request->Utf8DebugString()
              << Endl;
 
-        CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        {
+            std::lock_guard guard(UserIPMutex);
+            CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
+        }
 
         ++AuthorizeCount;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

начал нестабильно работать тест ydb/core/http_proxy/ut/inside_ydb_ut/TestKinesisHttpProxy.TestListStreamConsumersWithToken. он иногда падает с SIGSEGV