### PR TITLE
MUTE: fix build_type to analytics and mute scripts

### DIFF
--- a/.github/scripts/analytics/monitoring_queries/test_history_by_test_name_per_day_status.sql
+++ b/.github/scripts/analytics/monitoring_queries/test_history_by_test_name_per_day_status.sql
@@ -46,13 +46,15 @@ FROM
          run_timestamp_last,
          is_muted,
          branch,
-         date
+         date,
+         build_type
                     FROM `test_results/all_tests_with_owner_and_mute`
                     WHERE date >= CurrentUtcDate() - 90 * Interval("P1D") ) AS owners_t
                         ON hist.test_name = owners_t.test_name
                             AND hist.suite_folder = owners_t.suite_folder
                             AND hist.date_window = owners_t.date
-                            AND hist.branch = owners_t.branch ) AS `t1`
+                            AND hist.branch = owners_t.branch
+                            AND hist.build_type = owners_t.build_type ) AS `t1`
                     WHERE `t1`.`branch` = 'main'
                             AND `t1`.`date_window` >= CurrentUtcDate() - 7 * Interval("P1D")
                             AND IF(String::Contains(`t1`.`full_name`, 'chunk chunk')
@@ -331,13 +333,15 @@ FROM
          run_timestamp_last,
          is_muted,
          branch,
-         date
+         date,
+         build_type
                             FROM `test_results/all_tests_with_owner_and_mute`
                             WHERE date >= CurrentUtcDate() - 90 * Interval("P1D") ) AS owners_t
                                 ON hist.test_name = owners_t.test_name
                                     AND hist.suite_folder = owners_t.suite_folder
                                     AND hist.date_window = owners_t.date
-                                    AND hist.branch = owners_t.branch ) AS `t1`
+                                    AND hist.branch = owners_t.branch
+                                    AND hist.build_type = owners_t.build_type ) AS `t1`
                             WHERE `t1`.`branch` = 'main'
                                     AND `t1`.`date_window` >= CurrentUtcDate() - 7 * Interval("P1D")
                                     AND IF(String::Contains(`t1`.`full_name`, 'chunk chunk')

--- a/.github/scripts/analytics/tests_monitor.py
+++ b/.github/scripts/analytics/tests_monitor.py
@@ -562,18 +562,21 @@ def main():
                         suite_folder,
                         owners,
                         is_muted,
-                        date
+                        date,
+                        build_type
                     FROM 
                         `{all_tests_table}`
                     WHERE 
                         branch = '{branch}'
+                        AND build_type = '{build_type}'
                         AND date = Date('{date}')
                         AND run_timestamp_last >= Timestamp('{thirty_days_ago_ts}')
                 ) AS owners_t
                 ON 
                     hist.test_name = owners_t.test_name
                     AND hist.suite_folder = owners_t.suite_folder
-                    AND hist.date_window = owners_t.date;
+                    AND hist.date_window = owners_t.date
+                    AND hist.build_type = owners_t.build_type;
             """
             results = ydb_wrapper.execute_scan_query(query_get_history, query_name=f"get_monitor_history_for_date_{branch}")
 

--- a/.github/scripts/tests/mute/get_muted_tests.py
+++ b/.github/scripts/tests/mute/get_muted_tests.py
@@ -47,6 +47,8 @@ def get_all_tests(job_id=None, branch=None, build_type=None):
         testowners_table = ydb_wrapper.get_table_path("testowners")
         
         if job_id and branch:  # extend all tests from main by new tests from pr
+            if not build_type:
+                raise ValueError("build_type is required when job_id and branch are set")
             print(f'🔄 Mode: Extend all tests from main by new tests from PR')
             print(f'   - job_id: {job_id}')
             print(f'   - branch: {branch}')
@@ -70,6 +72,7 @@ def get_all_tests(job_id=None, branch=None, build_type=None):
             WHERE
                 job_id = {job_id} 
                 and branch = '{branch}'
+                and build_type = '{build_type}'
                 and run_timestamp >= CurrentUtcDate() - 30*Interval("P1D")
                 and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
         )

--- a/.github/scripts/tests/mute/get_muted_tests.py
+++ b/.github/scripts/tests/mute/get_muted_tests.py
@@ -132,10 +132,11 @@ def create_tables(ydb_wrapper, table_path):
             `run_timestamp_last` Timestamp NOT NULL,
             `owners` Utf8,
             `branch` Utf8 NOT NULL,
+            `build_type` Utf8 NOT NULL,
             `is_muted` Uint32 ,
-            PRIMARY KEY (`date`,branch, `test_name`, `suite_folder`, `full_name`)
+            PRIMARY KEY (`date`,branch,build_type, `test_name`, `suite_folder`, `full_name`)
         )
-            PARTITION BY HASH(date,branch)
+            PARTITION BY HASH(date,branch,build_type)
             WITH (STORE = COLUMN)
         """
     
@@ -176,6 +177,7 @@ def upload_muted_tests(tests):
             .add_column("run_timestamp_last", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
             .add_column("owners", ydb.OptionalType(ydb.PrimitiveType.Utf8))
             .add_column("branch", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+            .add_column("build_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
             .add_column("is_muted", ydb.OptionalType(ydb.PrimitiveType.Uint32))
         )
         
@@ -226,6 +228,7 @@ def mute_applier(args):
             testsuite = to_str(test['suite_folder'])
             testcase = to_str(test['test_name'])
             test['branch'] = args.branch
+            test['build_type'] = args.build_type
             is_muted = int(mute_check(testsuite, testcase))
             test['is_muted'] = is_muted
             


### PR DESCRIPTION
Updated SQL queries and Python scripts to include build_type in the relevant tables and queries. This change ensures that build_type is considered in the analytics and mute functionalities, enhancing the accuracy of test monitoring and results.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
