### PR TITLE
MUTE:Рассинхрон mute test <-> issue =>заведение дубликатов

### DIFF
--- a/.github/scripts/analytics/data_mart_queries/muted_tests_with_issue_and_area.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_with_issue_and_area.sql
@@ -29,9 +29,11 @@ $gim_latest = (
         github_issue_url AS github_issue_url,
         github_issue_number AS github_issue_number,
         github_issue_state AS github_issue_state,
+        github_issue_state_reason AS github_issue_state_reason,
         github_issue_created_at AS github_issue_created_at,
         area_override AS area_override,
-        area_override_since AS area_override_since
+        area_override_since AS area_override_since,
+        info AS github_issue_info
     FROM (
         SELECT
             g.full_name AS full_name,
@@ -40,9 +42,11 @@ $gim_latest = (
             g.github_issue_url AS github_issue_url,
             g.github_issue_number AS github_issue_number,
             g.github_issue_state AS github_issue_state,
+            g.github_issue_state_reason AS github_issue_state_reason,
             g.github_issue_created_at AS github_issue_created_at,
             g.area_override AS area_override,
             g.area_override_since AS area_override_since,
+            g.info AS info,
             ROW_NUMBER() OVER (
                 PARTITION BY g.full_name, g.branch, g.build_type
                 ORDER BY g.github_issue_created_at DESC, g.github_issue_number DESC
@@ -100,9 +104,11 @@ SELECT
     gim.github_issue_url AS github_issue_url,
     gim.github_issue_number AS github_issue_number,
     gim.github_issue_state AS github_issue_state,
+    gim.github_issue_state_reason AS github_issue_state_reason,
     gim.github_issue_created_at AS github_issue_created_at,
     gim.area_override AS area_override,
     gim.area_override_since AS area_override_since,
+    gim.github_issue_info AS github_issue_info,
     CAST(CASE WHEN mfu.full_name IS NOT NULL THEN 1 ELSE 0 END AS Uint8) AS is_manual_fast_unmute,
     mfu.mfu_since AS manual_fast_unmute_since,
     mfu.mfu_window_days AS manual_fast_unmute_window_days,

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -15,9 +15,17 @@ row; downstream marts use those columns.
 
 Edge cases:
   * No ``area`` in issue ``info`` → area_override = NULL
+  * Closed **NOT_PLANNED** / **DUPLICATE** → area_override = NULL (issues excluded from mapping query)
+  * Closed **COMPLETED** with ``manual-fast-unmute`` label → override can apply (fast-track window)
+  * Closed **COMPLETED** without that label: override cleared **only** when **project Status** is
+    ``Unmuted`` (do not infer from closer — avoids clearing during the gap before fast-unmute label).
   * Area resolves to the same team as the default owner → area_override = NULL
   * Area not found in mapping → area_override = NULL
   * Labels change → we always see the *current* ``info`` snapshot
+
+``github_issue_state_reason`` / ``info`` (Json): GitHub close reason and a snapshot (assignees,
+labels, project fields, …). For existing deployments run ``ALTER TABLE``; ``CREATE TABLE`` below
+is for new installs only.
 
 ``area_override_since`` (Date)
 -------------------------------
@@ -39,14 +47,20 @@ from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from github_issue_utils import (
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     create_test_issue_mapping,
     DEFAULT_BUILD_TYPE,
+    issue_label_names_lower,
     scan_to_utc_date,
 )
 
 
 def get_github_issues_data(ydb_wrapper):
-    """Get GitHub issues data from the issues table, including labels info."""
+    """Get GitHub issues data from the issues table, including labels info.
+
+    Excludes issues closed as **Not planned** or **Duplicate** so they cannot win
+    ``latest per build_type`` in :func:`convert_mapping_to_table_data`.
+    """
     issues_table = ydb_wrapper.get_table_path("issues")
     query = f"""
     SELECT
@@ -54,13 +68,28 @@ def get_github_issues_data(ydb_wrapper):
         title,
         url,
         state,
+        state_reason,
         body,
         created_at,
         updated_at,
-        info
+        info,
+        assignees,
+        labels,
+        milestone,
+        project_fields,
+        issue_type,
+        author_login,
+        repository_name,
+        project_status,
+        project_owner,
+        project_priority
     FROM `{issues_table}`
     WHERE body IS NOT NULL
     AND body != ''
+    AND NOT (
+        state = 'CLOSED'
+        AND state_reason IN ('NOT_PLANNED', 'DUPLICATE')
+    )
     """
 
     print("Fetching GitHub issues data...")
@@ -204,11 +233,45 @@ def _resolve_area_to_team(area_label: str, area_to_owner: dict) -> str:
     return best_team
 
 
-def resolve_area_override(body: str, info_raw, area_to_owner: dict):
+def resolve_area_override(
+    body: str,
+    info_raw,
+    area_to_owner: dict,
+    issue_state=None,
+    state_reason=None,
+    labels_raw=None,
+    project_status=None,
+):
     """If GitHub ``area/...`` implies a different team than ``Owner:``, return that area path.
+
+    **Closed issues**
+
+    * ``NOT_PLANNED`` / ``DUPLICATE``: no override.
+    * ``COMPLETED`` (or empty ``state_reason`` on **CLOSED**) + label ``manual-fast-unmute``: override stays (fast-track active).
+    * ``COMPLETED`` (or empty ``state_reason``) without that label: override cleared **only** when **project Status** is ``Unmuted``.
+
+    Open issues: unchanged area logic.
 
     Stored value matches issue info (e.g. ``area/blobstorage``), not the resolved team slug.
     """
+    st = (issue_state or "").strip().upper()
+    sr = (state_reason or "").strip().upper()
+    labels_lo = issue_label_names_lower(labels_raw)
+
+    if st == "CLOSED":
+        if sr in ("NOT_PLANNED", "DUPLICATE"):
+            return None
+        # Empty ``state_reason`` in export/API: treat like COMPLETED for override / Unmuted logic.
+        if sr == "COMPLETED" or not sr:
+            if MANUAL_FAST_UNMUTE_GITHUB_LABEL.lower() in labels_lo:
+                pass
+            else:
+                ps = (project_status or "").strip().lower()
+                if ps == "unmuted":
+                    return None
+        else:
+            return None
+
     area_label = (_extract_area_from_info(info_raw) or "").strip()
     if not area_label:
         return None
@@ -237,10 +300,12 @@ def create_test_issue_mapping_table(ydb_wrapper, table_path):
         `github_issue_url`        Utf8,
         `github_issue_title`      Utf8,
         `github_issue_number`     Uint64     NOT NULL,
-        `github_issue_state`      Utf8,
-        `github_issue_created_at` Timestamp,
-        `area_override`           Utf8,
-        `area_override_since`     Date,
+        `github_issue_state`        Utf8,
+        `github_issue_state_reason` Utf8,
+        `github_issue_created_at`   Timestamp,
+        `area_override`             Utf8,
+        `area_override_since`       Date,
+        `info`                      Json,
         PRIMARY KEY (full_name, branch, build_type, github_issue_number)
     )
     PARTITION BY HASH(full_name)
@@ -259,7 +324,8 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
         if not issues:
             continue
 
-        # Group issues by build_type, then pick the latest per group
+        # Group issues by build_type, then pick the latest created issue per group.
+        # Issues closed as not-planned/duplicate are omitted upstream (get_github_issues_data).
         by_build_type = {}
         for issue in issues:
             bt = issue.get('build_type', DEFAULT_BUILD_TYPE)
@@ -268,6 +334,11 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
                 by_build_type[bt] = issue
 
         for bt, latest_issue in by_build_type.items():
+            snap = dict(latest_issue.get('mapping_info') or {})
+            ao = latest_issue.get('area_override')
+            if ao:
+                snap['area_override'] = ao
+            info_json = json.dumps(snap, ensure_ascii=False)
             for branch in latest_issue['branches']:
                 table_data.append({
                     'full_name': test_name,
@@ -277,8 +348,10 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
                     'github_issue_title': latest_issue['title'],
                     'github_issue_number': latest_issue['issue_number'],
                     'github_issue_state': latest_issue['state'],
+                    'github_issue_state_reason': latest_issue.get('state_reason'),
                     'github_issue_created_at': latest_issue.get('created_at'),
                     'area_override': latest_issue.get('area_override'),
+                    'info': info_json,
                 })
 
     return table_data
@@ -296,9 +369,13 @@ def bulk_upsert_mapping_data(ydb_wrapper, table_path, mapping_data):
     column_types.add_column('github_issue_title', ydb.OptionalType(ydb.PrimitiveType.Utf8))
     column_types.add_column('github_issue_number', ydb.PrimitiveType.Uint64)
     column_types.add_column('github_issue_state', ydb.OptionalType(ydb.PrimitiveType.Utf8))
+    column_types.add_column(
+        'github_issue_state_reason', ydb.OptionalType(ydb.PrimitiveType.Utf8)
+    )
     column_types.add_column('github_issue_created_at', ydb.OptionalType(ydb.PrimitiveType.Timestamp))
     column_types.add_column('area_override', ydb.OptionalType(ydb.PrimitiveType.Utf8))
     column_types.add_column('area_override_since', ydb.OptionalType(ydb.PrimitiveType.Date))
+    column_types.add_column('info', ydb.OptionalType(ydb.PrimitiveType.Json))
 
     ydb_wrapper.bulk_upsert(table_path, mapping_data, column_types)
     print(f"Bulk upsert completed")
@@ -335,6 +412,10 @@ def main():
                         issue.get('body', ''),
                         issue.get('info'),
                         area_to_owner,
+                        issue.get('state'),
+                        issue.get('state_reason'),
+                        issue.get('labels'),
+                        issue.get('project_status'),
                     )
 
             print("Creating test-to-issue mapping...")

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -88,7 +88,7 @@ def get_github_issues_data(ydb_wrapper):
     AND body != ''
     AND NOT (
         state = 'CLOSED'
-        AND state_reason IN ('NOT_PLANNED', 'DUPLICATE')
+        AND Coalesce(state_reason, '') IN ('NOT_PLANNED', 'DUPLICATE')
     )
     """
 

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -46,7 +46,12 @@ import sys
 from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from tests.mute.update_mute_issues import MANUAL_FAST_UNMUTE_GITHUB_LABEL
+_mute_scripts_dir = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), '..', 'tests', 'mute')
+)
+if _mute_scripts_dir not in sys.path:
+    sys.path.insert(0, _mute_scripts_dir)
+from update_mute_issues import MANUAL_FAST_UNMUTE_GITHUB_LABEL
 from github_issue_utils import (
     create_test_issue_mapping,
     DEFAULT_BUILD_TYPE,

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -46,8 +46,8 @@ import sys
 from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from tests.mute.update_mute_issues import MANUAL_FAST_UNMUTE_GITHUB_LABEL
 from github_issue_utils import (
-    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     create_test_issue_mapping,
     DEFAULT_BUILD_TYPE,
     issue_label_names_lower,

--- a/.github/scripts/github_issue_utils.py
+++ b/.github/scripts/github_issue_utils.py
@@ -30,10 +30,6 @@ def team_slug_from_monitor_owner(owner) -> str:
 DEFAULT_BUILD_TYPE = 'relwithdebinfo'
 DEFAULT_BRANCH = 'main'
 
-# Same strings as ``mute/update_mute_issues`` / ``mute.fast_unmute_pipeline`` (GraphQL labels).
-MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
-MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL = 'fast-unmute-finished'
-
 
 def scan_to_utc_date(val) -> Optional[dt.date]:
     """YDB scan value → UTC calendar date.

--- a/.github/scripts/github_issue_utils.py
+++ b/.github/scripts/github_issue_utils.py
@@ -6,6 +6,7 @@ Used by both the muted test analytics and issue management scripts.
 """
 
 import datetime as dt
+import json
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -28,6 +29,10 @@ def team_slug_from_monitor_owner(owner) -> str:
 
 DEFAULT_BUILD_TYPE = 'relwithdebinfo'
 DEFAULT_BRANCH = 'main'
+
+# Same strings as ``mute/update_mute_issues`` / ``mute.fast_unmute_pipeline`` (GraphQL labels).
+MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
+MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL = 'fast-unmute-finished'
 
 
 def scan_to_utc_date(val) -> Optional[dt.date]:
@@ -229,6 +234,69 @@ def parse_body(body: str) -> ParsedIssueBody:
     return result
 
 
+def _decode_issues_json_column(val):
+    """YDB ``Json`` / UTF8 JSON / scan row → Python ``dict`` / ``list`` or ``None``."""
+    if val is None:
+        return None
+    if isinstance(val, (dict, list)):
+        return val
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def issue_label_names_lower(raw_labels) -> frozenset:
+    """Parse ``issues.labels`` JSON (export schema) → frozenset of lowercase label names."""
+    decoded = _decode_issues_json_column(raw_labels)
+    if not decoded:
+        return frozenset()
+    names = []
+    for item in decoded:
+        if isinstance(item, dict):
+            n = item.get('name')
+            if n:
+                names.append(str(n).strip().lower())
+    return frozenset(names)
+
+
+def build_github_issue_mapping_info_snapshot(issue_row: dict) -> dict:
+    """JSON payload for ``github_issue_mapping.info`` (assignees, labels, project fields, …)."""
+    assignees = _decode_issues_json_column(issue_row.get('assignees')) or []
+    labels = _decode_issues_json_column(issue_row.get('labels')) or []
+    milestone = _decode_issues_json_column(issue_row.get('milestone'))
+    project_fields = _decode_issues_json_column(issue_row.get('project_fields'))
+    raw_info = issue_row.get('info')
+    if isinstance(raw_info, str):
+        try:
+            info_extra = json.loads(raw_info) if raw_info.strip() else {}
+        except json.JSONDecodeError:
+            info_extra = {}
+    elif isinstance(raw_info, dict):
+        info_extra = raw_info
+    else:
+        info_extra = {}
+
+    out = {
+        'assignees': assignees,
+        'labels': labels,
+        'issue_type': issue_row.get('issue_type'),
+        'author_login': issue_row.get('author_login'),
+        'repository_name': issue_row.get('repository_name'),
+        'project_status': issue_row.get('project_status'),
+        'project_owner': issue_row.get('project_owner'),
+        'project_priority': issue_row.get('project_priority'),
+        'info': info_extra,
+    }
+    if milestone is not None:
+        out['milestone'] = milestone
+    if project_fields is not None:
+        out['project_fields'] = project_fields
+    return out
+
+
 def make_profile_id(branch: str, build_type: str) -> str:
     """Canonical profile_id used by digest_queue and notification config.
 
@@ -243,7 +311,7 @@ def create_test_issue_mapping(issues_data):
     """Create a mapping from test names to GitHub issue information
 
     Args:
-        issues_data (list): List of issue dictionaries with 'body', 'url', 'title', 'issue_number' fields
+        issues_data (list): Rows from YDB ``issues`` (or compatible dicts with body, url, labels, …).
 
     Returns:
         dict: Mapping from test name to list of issue information
@@ -259,6 +327,7 @@ def create_test_issue_mapping(issues_data):
 
         try:
             parsed = parse_body(body)
+            snapshot = build_github_issue_mapping_info_snapshot(issue)
 
             for test in parsed.tests:
                 if test not in test_to_issue:
@@ -268,9 +337,11 @@ def create_test_issue_mapping(issues_data):
                     'title': issue.get('title', ''),
                     'issue_number': issue.get('issue_number', 0),
                     'state': issue.get('state', ''),
+                    'state_reason': issue.get('state_reason'),
                     'created_at': issue.get('created_at', 0),
                     'branches': parsed.branches,
                     'build_type': parsed.build_type,
+                    'mapping_info': snapshot,
                 })
         except Exception as e:
             print(f"Warning: Could not parse issue body for issue {url}: {e}")

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -7,8 +7,6 @@ from collections import defaultdict
 
 from github_issue_utils import (
     DEFAULT_BUILD_TYPE,
-    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
-    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
 )
 
 from mute.constants import (
@@ -56,6 +54,8 @@ from mute.fast_unmute_ydb import (
 )
 from mute.update_mute_issues import (
     add_issue_comment,
+    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     parse_body,
 )
 

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -5,7 +5,11 @@ import logging
 import os
 from collections import defaultdict
 
-from github_issue_utils import DEFAULT_BUILD_TYPE
+from github_issue_utils import (
+    DEFAULT_BUILD_TYPE,
+    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
+)
 
 from mute.constants import (
     get_manual_unmute_issue_closed_lookback_days,
@@ -51,8 +55,6 @@ from mute.fast_unmute_ydb import (
     upsert_rows,
 )
 from mute.update_mute_issues import (
-    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
-    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
     add_issue_comment,
     parse_body,
 )

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -9,8 +9,6 @@ if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 from github_issue_utils import (
     DEFAULT_BUILD_TYPE,
-    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
-    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     parse_body,
 )
 
@@ -30,6 +28,8 @@ CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 # project
 
 GITHUB_MAX_BODY_LENGTH = 65000  # Setting slightly below 65536 to be safe
+MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
+MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL = 'fast-unmute-finished'
 
 def truncate_issue_body(body):
     """Truncates issue body if it exceeds GitHub's maximum length.

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -7,16 +7,17 @@ from urllib.parse import quote_plus
 _scripts_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
-from github_issue_utils import parse_body, DEFAULT_BUILD_TYPE
+from github_issue_utils import (
+    DEFAULT_BUILD_TYPE,
+    MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL,
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
+    parse_body,
+)
 
 
 ORG_NAME = 'ydb-platform'
 REPO_NAME = 'ydb'
 PROJECT_ID = '45'
-# GitHub issue label set by ``mute/fast_unmute_github.py`` while fast-unmute rows exist.
-MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
-# GitHub issue label set once fast-unmute flow completed successfully.
-MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL = 'fast-unmute-finished'
 TEST_HISTORY_DASHBOARD = "https://datalens.yandex/4un3zdm0zcnyr"
 CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 
@@ -275,6 +276,7 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
                   title
                   url
                   state
+                  stateReason
                   body
                   createdAt
                   labels(first: 40) {
@@ -414,13 +416,29 @@ def generate_github_issue_title_and_body(test_data):
     )
 
 
+def _issue_body_has_mute_list_marker(body: str) -> bool:
+    """True when body uses the mute workflow markers (auto-created mute issues)."""
+    return bool(body) and '<!--mute_list_start-->' in body
+
+
+def _muted_issue_reservation_sort_key(entry: dict):
+    """Prefer **OPEN** over **CLOSED**; then newest ``createdAt`` (GraphQL ISO-8601 string)."""
+    open_rank = 1 if entry.get('state') == 'OPEN' else 0
+    created = entry.get('createdAt') or ''
+    return (open_rank, created)
+
 
 def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
     """Project items → issue index.
 
-    Includes **open** issues and **closed** issues only when the GitHub label
-    ``manual-fast-unmute`` is present (fast-unmute without reopening the issue).
-    Other closed cards are skipped so downstream logic matches project 45 only.
+    Includes **open** issues.
+
+    Includes **closed** issues when either:
+    - GitHub label ``manual-fast-unmute`` is present (fast-unmute tracking without reopening), or
+    - ``stateReason`` is ``COMPLETED`` (manual close as done — canonical mute issue until reopened), or
+    - ``stateReason`` is empty and the body has the mute list marker (GraphQL/export may omit reason briefly).
+
+    Other closed cards (e.g. ``NOT_PLANNED``) are skipped.
     """
     issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
     all_issues_with_contet = {}
@@ -428,12 +446,20 @@ def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
         content = issue['content']
         if content:
             state = content.get('state')
+            body = content.get('body') or ''
+            state_reason = (content.get('stateReason') or '').strip().upper()
             label_nodes = (content.get('labels') or {}).get('nodes') or []
             label_names = [n['name'] for n in label_nodes if n and n.get('name')]
-            if state == 'CLOSED' and MANUAL_FAST_UNMUTE_GITHUB_LABEL not in label_names:
-                continue
+            if state == 'CLOSED':
+                if MANUAL_FAST_UNMUTE_GITHUB_LABEL in label_names:
+                    pass
+                elif state_reason == 'COMPLETED':
+                    pass
+                elif not state_reason and _issue_body_has_mute_list_marker(body):
+                    pass
+                else:
+                    continue
 
-            body = content['body']
             parsed = parse_body(body)
 
             status = 'N/A'
@@ -464,6 +490,7 @@ def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
             all_issues_with_contet[content['id']]['title'] = content['title']
             all_issues_with_contet[content['id']]['url'] = content['url']
             all_issues_with_contet[content['id']]['state'] = content['state']
+            all_issues_with_contet[content['id']]['state_reason'] = content.get('stateReason') or ''
             all_issues_with_contet[content['id']]['createdAt'] = content['createdAt']
             all_issues_with_contet[content['id']]['status_updated'] = status_updated
             all_issues_with_contet[content['id']]['status'] = status
@@ -472,6 +499,7 @@ def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
             all_issues_with_contet[content['id']]['branches'] = parsed.branches
             all_issues_with_contet[content['id']]['build_type'] = parsed.build_type
             all_issues_with_contet[content['id']]['labels'] = label_names
+            all_issues_with_contet[content['id']]['has_mute_body'] = _issue_body_has_mute_list_marker(body)
 
             for test in parsed.tests:
                 all_issues_with_contet[content['id']]['tests'].append(test)
@@ -507,33 +535,64 @@ def get_muted_tests_from_issues(issues_dict=None):
 
     # First, collect all issues for each (test, build_type) key
     for issue in issues_dict:
-        if issues_dict[issue]["state"] != 'CLOSED':
-            bt = issues_dict[issue].get('build_type') or DEFAULT_BUILD_TYPE
-            for test in issues_dict[issue]['tests']:
+        info = issues_dict[issue]
+        state = info['state']
+        state_reason = (info.get('state_reason') or '').strip().upper()
+        bt = info.get('build_type') or DEFAULT_BUILD_TYPE
+
+        # Open issues: reserve (test, build_type) for mute/issue automation.
+        # Closed as COMPLETED (or empty reason + mute body): do not open a duplicate.
+        if state == 'CLOSED':
+            closed_ok = state_reason == 'COMPLETED' or (
+                not state_reason and info.get('has_mute_body')
+            )
+            if not closed_ok:
+                continue
+            for test in info['tests']:
                 key = (test, bt)
                 if key not in muted_tests:
                     muted_tests[key] = []
                 muted_tests[key].append(
                     {
-                        'url': issues_dict[issue]['url'],
-                        'createdAt': issues_dict[issue]['createdAt'],
-                        'status_updated': issues_dict[issue]['status_updated'],
-                        'status': issues_dict[issue]['status'],
-                        'state': issues_dict[issue]['state'],
-                        'branches': issues_dict[issue]['branches'],
+                        'url': info['url'],
+                        'createdAt': info['createdAt'],
+                        'status_updated': info['status_updated'],
+                        'status': info['status'],
+                        'state': state,
+                        'branches': info['branches'],
                         'build_type': bt,
                         'id': issue,
                     }
                 )
-    
-    # Then, for each test, keep only the latest issue (by createdAt)
+            continue
+
+        if state != 'OPEN':
+            continue
+
+        for test in info['tests']:
+            key = (test, bt)
+            if key not in muted_tests:
+                muted_tests[key] = []
+            muted_tests[key].append(
+                {
+                    'url': info['url'],
+                    'createdAt': info['createdAt'],
+                    'status_updated': info['status_updated'],
+                    'status': info['status'],
+                    'state': state,
+                    'branches': info['branches'],
+                    'build_type': bt,
+                    'id': issue,
+                }
+            )
+
+    # Then, for each test, keep one issue: prefer OPEN over CLOSED, then newest createdAt.
     for test in muted_tests:
         if len(muted_tests[test]) > 1:
-            # Sort by createdAt (most recent first) and keep only the first one
             muted_tests[test] = sorted(
-                muted_tests[test], 
-                key=lambda x: x['createdAt'], 
-                reverse=True
+                muted_tests[test],
+                key=_muted_issue_reservation_sort_key,
+                reverse=True,
             )[:1]
 
     return muted_tests

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -541,10 +541,14 @@ def get_muted_tests_from_issues(issues_dict=None):
         bt = info.get('build_type') or DEFAULT_BUILD_TYPE
 
         # Open issues: reserve (test, build_type) for mute/issue automation.
-        # Closed as COMPLETED (or empty reason + mute body): do not open a duplicate.
+        # Closed issues with manual-fast-unmute label, COMPLETED reason, or empty reason + mute body:
+        # do not open a duplicate.
         if state == 'CLOSED':
-            closed_ok = state_reason == 'COMPLETED' or (
-                not state_reason and info.get('has_mute_body')
+            labels = info.get('labels') or []
+            closed_ok = (
+                MANUAL_FAST_UNMUTE_GITHUB_LABEL in labels
+                or state_reason == 'COMPLETED'
+                or (not state_reason and info.get('has_mute_body'))
             )
             if not closed_ok:
                 continue


### PR DESCRIPTION
## Сценарии: проблема → решение

| Сценарий | Проблема | Решение |
|----------|-----------|---------|
| **Ручной fast-track** — закрыли mute-issue как **Completed**, лейбла `manual-fast-unmute` ещё нет | В индекс проекта 45 попадали только **OPEN** и **CLOSED** с лейблом `manual-fast-unmute`. **CLOSED** без лейбла выпадал из индекса → `get_muted_tests_from_issues` не резервировал `(test, build_type)` → риск **дубликата issue** и потери связи mute ↔ issue. | В индекс включаем **CLOSED + `stateReason` = COMPLETED** (в GraphQL запрошен `stateReason`). Если `stateReason` **пустой**, но в body есть **`<!--mute_list_start-->`**, карточку оставляем (узкий fallback на пропуск reason в API). |
| **Два issue на один тест** (старый ещё **OPEN**, новый создан по ошибке) | Побеждал только **самый новый по `createdAt`** — **CLOSED** мог перекрыть **OPEN** → логика «уже есть issue» смотрела не на ту карточку. | При выборе одной записи на `(test, build_type)`: **сначала OPEN**, затем среди равных — более новый **`createdAt`**. |
| **`github_issue_mapping` — «последний» issue** | По `created_at` мог выиграть issue, закрытый как **Not planned** / **Duplicate** → неверная ссылка / owner в цепочке к мартам. | В выборке из таблицы `issues` **не берём** `CLOSED` с `state_reason IN ('NOT_PLANNED', 'DUPLICATE')`. |
| **`area_override` после размьюта** | `resolve_area_override` не учитывал закрытие и доску: у **CLOSED** в `info` оставались `area/*` → в mapping писался override → **`tests_monitor`** (без своих правок) продолжал отдавать **effective** от override. | Для **CLOSED**: `NOT_PLANNED`/`DUPLICATE` → override **NULL**. Для **COMPLETED** и для **пустого** `state_reason` на **CLOSED** (та же семантика, что у Completed): с лейблом **`manual-fast-unmute`** override может сохраняться; **без** него снимаем override **только** при **`project_status` = `Unmuted`**. |
| **Наблюдаемость** | Не хватало явных полей резолюции и снимка в mapping. | Колонки **`github_issue_state_reason`**, **`info` (Json)**; в mart **`muted_tests_with_issue_and_area`** поля проброшены наружу. |

**Примечание:** `tests_monitor.py` **не менялся** — он уже читает `area_override` из `github_issue_mapping`; снятие override делается на этапе заполнения mapping после актуального экспорта `issues`.

---

## Миграция YDB (один раз, до первого UPSERT с новыми колонками)

```sql
ALTER TABLE `test_results/analytics/github_issue_mapping`
  ADD COLUMN github_issue_state_reason Utf8;
ALTER TABLE `test_results/analytics/github_issue_mapping`
  ADD COLUMN info Json;
```

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
