### PR TITLE
MUTE: Enhance mute update workflow to include debug lists for muted tests

### DIFF
--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -204,10 +204,23 @@ jobs:
           to_delete = read_lines("mute_update/to_delete.txt")
           to_mute = read_lines("mute_update/to_mute.txt")
           to_unmute = read_lines("mute_update/to_unmute.txt")
+          to_delete_debug = read_lines("mute_update/to_delete_debug.txt")
+          to_mute_debug = read_lines("mute_update/to_mute_debug.txt")
+          to_unmute_debug = read_lines("mute_update/to_unmute_debug.txt")
 
           body = [f"# Muted tests update for {base_branch} (build: {build_type})\n\n"]
-          append_debug_section(body, "Removed from mute", to_delete, count_override=len(to_delete))
-          append_debug_section(body, "Muted flaky", to_mute, count_override=len(to_mute))
+          append_debug_section(
+              body,
+              "Removed from mute",
+              to_delete_debug or to_delete,
+              count_override=len(to_delete),
+          )
+          append_debug_section(
+              body,
+              "Muted flaky",
+              to_mute_debug or to_mute,
+              count_override=len(to_mute),
+          )
 
           if to_mute:
               url = (
@@ -219,7 +232,12 @@ jobs:
                   url += f"&full_name={quote(test_name.replace(' ', '/'), safe='')}"
               body.append(f"[View history of muted flaky tests on Dashboard]({url})\n")
 
-          append_debug_section(body, "Unmuted stable", to_unmute, count_override=len(to_unmute))
+          append_debug_section(
+              body,
+              "Unmuted stable",
+              to_unmute_debug or to_unmute,
+              count_override=len(to_unmute),
+          )
           Path("pr_body_content.txt").write_text("".join(body), encoding="utf-8")
           PY
           echo "PR_BODY_PATH=pr_body_content.txt" >> "$GITHUB_ENV"


### PR DESCRIPTION
Added support for reading debug lists of tests to be muted, unmuted, and deleted. The workflow now appends debug information to the PR body, allowing for better tracking of changes in muted tests.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
