### PR TITLE
Lower logging level while creating session to unexisting rate limiter resource

### DIFF
--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -942,7 +942,7 @@ private:
                         SendProxySessionIfNotSent(resState);
                     } else {
                         // TODO: make cache with error results.
-                        KESUS_PROXY_LOG_WARN("Resource \"" << resourcePaths[i] << "\" session initialization error: " << KesusErrorToString(resResult.GetError()));
+                        KESUS_PROXY_LOG_INFO("Resource \"" << resourcePaths[i] << "\" session initialization error: " << KesusErrorToString(resResult.GetError()));
                         ProcessSubscribeResourceError(resResult.GetError().GetStatus(), resState);
                     }
                 }

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -925,7 +925,8 @@ private:
                 if (resourceIt != Resources.end()) {
                     auto* resState = resourceIt->second.Get();
                     Y_ABORT_UNLESS(resState != nullptr);
-                    if (resResult.GetError().GetStatus() == Ydb::StatusIds::SUCCESS) {
+                    const Ydb::StatusIds::StatusCode resStatus = resResult.GetError().GetStatus();
+                    if (resStatus == Ydb::StatusIds::SUCCESS) {
                         KESUS_PROXY_LOG_INFO("Initialized new session with resource \"" << resourcePaths[i] << "\"");
                         if (resState->ResId != Max<ui64>() && resState->ResId != resResult.GetResourceId()) { // Kesus was disconnected and then resource was recreated.
                             BreakResource(*resState, GetProxyUpdateEv());
@@ -942,7 +943,11 @@ private:
                         SendProxySessionIfNotSent(resState);
                     } else {
                         // TODO: make cache with error results.
-                        KESUS_PROXY_LOG_INFO("Resource \"" << resourcePaths[i] << "\" session initialization error: " << KesusErrorToString(resResult.GetError()));
+                        if (resStatus == Ydb::StatusIds::NOT_FOUND) {
+                            KESUS_PROXY_LOG_INFO("Resource \"" << resourcePaths[i] << "\" session initialization error: " << KesusErrorToString(resResult.GetError()));
+                        } else {
+                            KESUS_PROXY_LOG_ERROR("Resource \"" << resourcePaths[i] << "\" session initialization error: " << KesusErrorToString(resResult.GetError()));
+                        }
                         ProcessSubscribeResourceError(resResult.GetError().GetStatus(), resState);
                     }
                 }


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Lower logging level when the client tries to use unexisting rate limiter resource as it does not mark any problems on server side.