### PR TITLE
Viewer: extend list of operation kinds in swagger

### DIFF
--- a/ydb/core/viewer/operation_list.h
+++ b/ydb/core/viewer/operation_list.h
@@ -63,10 +63,16 @@ public:
                         kind:
                           * `ss/backgrounds`
                           * `export`
-                          * `import/S3`
-                          * `import/YT`
+                          * `export/s3`
+                          * `export/yt`
+                          * `export/nfs`
+                          * `import/s3`
+                          * `import/nfs`
                           * `buildindex`
                           * `scriptexec`
+                          * `incbackup`
+                          * `restore`
+                          * `compaction`
                     required: true
                     type: string
                   - name: page_size


### PR DESCRIPTION
Added missing operation kinds (compaction, restore, incbackup, export/import subkinds) to the viewer's operation list swagger documentation.

### Category
* Documentation

### Description
Updates the swagger description of the `kind` parameter in the viewer's operation list endpoint (`ydb/core/viewer/operation_list.h`) to include all kinds supported by the YDB CLI's `ydb operation list` command (per `ydb/public/lib/ydb_cli/commands/ydb_service_operation.cpp`):

- `ss/backgrounds`
- `export`, `export/s3`, `export/yt`, `export/nfs`
- `import/s3`, `import/nfs`
- `buildindex`
- `scriptexec`
- `incbackup`
- `restore`
- `compaction`
