### PR TITLE
fix TRcBuf copy/assign with CoW disabled

### DIFF
--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -821,7 +821,7 @@ public:
     {
         auto delta = Backend.GetData().data() - other.Backend.GetData().data();
         Begin = other.Begin + delta;
-        End   = other.End   + delta;
+        End = other.End + delta;
     }
 
     TRcBuf(TRcBuf&& other)
@@ -836,7 +836,7 @@ public:
             Backend = other.Backend;
             auto delta = Backend.GetData().data() - oldBase;
             Begin = other.Begin + delta;
-            End   = other.End   + delta;
+            End = other.End + delta;
         }
         return *this;
     }

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -818,9 +818,11 @@ public:
 
     TRcBuf(const TRcBuf& other)
         : Backend(other.Backend)
-        , Begin(other.Begin)
-        , End(other.End)
-    {}
+    {
+        auto delta = Backend.GetData().data() - other.Backend.GetData().data();
+        Begin = other.Begin + delta;
+        End   = other.End   + delta;
+    }
 
     TRcBuf(TRcBuf&& other)
         : Backend(std::move(other.Backend))
@@ -828,7 +830,17 @@ public:
         , End(other.End)
     {}
 
-    TRcBuf& operator =(const TRcBuf&) = default;
+    TRcBuf& operator =(const TRcBuf& other) {
+        if (this != &other) {
+            auto oldBase = other.Backend.GetData().data();
+            Backend = other.Backend;
+            auto delta = Backend.GetData().data() - oldBase;
+            Begin = other.Begin + delta;
+            End   = other.End   + delta;
+        }
+        return *this;
+    }
+
     TRcBuf& operator =(TRcBuf&&) = default;
 
     static TRcBuf Uninitialized(size_t size, size_t headroom = 0, size_t tailroom = 0)

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -819,9 +819,9 @@ public:
     TRcBuf(const TRcBuf& other)
         : Backend(other.Backend)
     {
-        auto delta = Backend.GetData().data() - other.Backend.GetData().data();
-        Begin = other.Begin + delta;
-        End = other.End + delta;
+        auto span = Backend.GetData();
+        Begin = span.data();
+        End = Begin + span.size();
     }
 
     TRcBuf(TRcBuf&& other)
@@ -832,11 +832,10 @@ public:
 
     TRcBuf& operator =(const TRcBuf& other) {
         if (this != &other) {
-            auto oldBase = other.Backend.GetData().data();
             Backend = other.Backend;
-            auto delta = Backend.GetData().data() - oldBase;
-            Begin = other.Begin + delta;
-            End = other.End + delta;
+            auto span = Backend.GetData();
+            Begin = span.data();
+            End = Begin + span.size();
         }
         return *this;
     }

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -819,10 +819,10 @@ public:
     TRcBuf(const TRcBuf& other)
         : Backend(other.Backend)
     {
-        ptrdiff_t begin_offset = other.Begin - other.Backend.GetData().data();
-        ptrdiff_t end_offset = other.End - other.Backend.GetData().data();
-        Begin = Backend.GetData().data() + begin_offset;
-        End = Backend.GetData().data() + end_offset;
+        ptrdiff_t beginOffset = other.Begin - other.Backend.GetData().data();
+        ptrdiff_t endOffset = other.End - other.Backend.GetData().data();
+        Begin = Backend.GetData().data() + beginOffset;
+        End = Backend.GetData().data() + endOffset;
     }
 
     TRcBuf(TRcBuf&& other)
@@ -834,11 +834,11 @@ public:
     TRcBuf& operator =(const TRcBuf& other) {
         if (this != &other) {
             Backend = other.Backend;
-            ptrdiff_t begin_offset =
+            ptrdiff_t beginOffset =
                 other.Begin - other.Backend.GetData().data();
-            ptrdiff_t end_offset = other.End - other.Backend.GetData().data();
-            Begin = Backend.GetData().data() + begin_offset;
-            End = Backend.GetData().data() + end_offset;
+            ptrdiff_t endOffset = other.End - other.Backend.GetData().data();
+            Begin = Backend.GetData().data() + beginOffset;
+            End = Backend.GetData().data() + endOffset;
         }
         return *this;
     }

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -819,9 +819,10 @@ public:
     TRcBuf(const TRcBuf& other)
         : Backend(other.Backend)
     {
-        auto span = Backend.GetData();
-        Begin = span.data();
-        End = Begin + span.size();
+        ptrdiff_t begin_offset = other.Begin - other.Backend.GetData().data();
+        ptrdiff_t end_offset = other.End - other.Backend.GetData().data();
+        Begin = Backend.GetData().data() + begin_offset;
+        End = Backend.GetData().data() + end_offset;
     }
 
     TRcBuf(TRcBuf&& other)
@@ -833,9 +834,11 @@ public:
     TRcBuf& operator =(const TRcBuf& other) {
         if (this != &other) {
             Backend = other.Backend;
-            auto span = Backend.GetData();
-            Begin = span.data();
-            End = Begin + span.size();
+            ptrdiff_t begin_offset =
+                other.Begin - other.Backend.GetData().data();
+            ptrdiff_t end_offset = other.End - other.Backend.GetData().data();
+            Begin = Backend.GetData().data() + begin_offset;
+            End = Backend.GetData().data() + end_offset;
         }
         return *this;
     }

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -186,6 +186,27 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
         UNIT_ASSERT_EQUAL(otherData.Tailroom(), 0);
     }
 
+    Y_UNIT_TEST(CopyWithStringBackend) {
+        TString str(100, 'x');
+        TRcBuf original(str);
+
+        TRcBuf byCtor = original;
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), original.size());
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 0);
+        UNIT_ASSERT_EQUAL(::memcmp(byCtor.data(), str.data(), str.size()), 0);
+
+        TRcBuf byAssign;
+        byAssign = original;
+        UNIT_ASSERT_VALUES_EQUAL(byAssign.size(), original.size());
+        UNIT_ASSERT_VALUES_EQUAL(byAssign.Headroom(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(byAssign.Tailroom(), 0);
+        UNIT_ASSERT_EQUAL(::memcmp(byAssign.data(), str.data(), str.size()), 0);
+
+        byCtor.GrowFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 104);
+    }
+
     Y_UNIT_TEST(Reserve) {
         TRcBuf data = TRcBuf::Copy("test", 4, 5, 6);
         TRcBuf data2 = data;

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -191,20 +191,45 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
         TRcBuf original(str);
 
         TRcBuf byCtor = original;
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), original.size());
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 100);
         UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 0);
         UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 0);
         UNIT_ASSERT_EQUAL(::memcmp(byCtor.data(), str.data(), str.size()), 0);
 
         TRcBuf byAssign;
         byAssign = original;
-        UNIT_ASSERT_VALUES_EQUAL(byAssign.size(), original.size());
-        UNIT_ASSERT_VALUES_EQUAL(byAssign.Headroom(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(byAssign.Tailroom(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(byAssign.size(), 100);
         UNIT_ASSERT_EQUAL(::memcmp(byAssign.data(), str.data(), str.size()), 0);
 
-        byCtor.GrowFront(4);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 104);
+        byCtor.GrowFront(10);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 110);
+        UNIT_ASSERT_EQUAL(::memcmp(byCtor.data() + 10, str.data(), str.size()), 0);
+        UNIT_ASSERT_VALUES_EQUAL(original.size(), 100);
+
+        byCtor.ReserveBidi(20, 30);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 110);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 20);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 30);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
+
+        byCtor.GrowFront(5);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 115);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 15);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 30);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
+
+        byCtor.GrowBack(10);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 125);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 15);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 20);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
+
+        byCtor.GrowFront(20);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 145);
+        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            byCtor.GetOccupiedMemorySize(),
+            byCtor.size() + byCtor.Headroom() + byCtor.Tailroom());
     }
 
     Y_UNIT_TEST(Reserve) {

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -187,49 +187,16 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
     }
 
     Y_UNIT_TEST(CopyWithStringBackend) {
-        TString str(100, 'x');
+        TString str = "abcdefghijklmno";
         TRcBuf original(str);
+        original.TrimFront(10);
 
-        TRcBuf byCtor = original;
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 100);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 0);
-        UNIT_ASSERT_EQUAL(::memcmp(byCtor.data(), str.data(), str.size()), 0);
+        TRcBuf copy = original;
+        UNIT_ASSERT_EQUAL(::memcmp(copy.data(), str.data() + 5, 10), 0);
 
-        TRcBuf byAssign;
-        byAssign = original;
-        UNIT_ASSERT_VALUES_EQUAL(byAssign.size(), 100);
-        UNIT_ASSERT_EQUAL(::memcmp(byAssign.data(), str.data(), str.size()), 0);
-
-        byCtor.GrowFront(10);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 110);
-        UNIT_ASSERT_EQUAL(::memcmp(byCtor.data() + 10, str.data(), str.size()), 0);
-        UNIT_ASSERT_VALUES_EQUAL(original.size(), 100);
-
-        byCtor.ReserveBidi(20, 30);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 110);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 20);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 30);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
-
-        byCtor.GrowFront(5);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 115);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 15);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 30);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
-
-        byCtor.GrowBack(10);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 125);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 15);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Tailroom(), 20);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.GetOccupiedMemorySize(), 160);
-
-        byCtor.GrowFront(20);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.size(), 145);
-        UNIT_ASSERT_VALUES_EQUAL(byCtor.Headroom(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(
-            byCtor.GetOccupiedMemorySize(),
-            byCtor.size() + byCtor.Headroom() + byCtor.Tailroom());
+        copy.GrowFront(100);
+        UNIT_ASSERT_VALUES_EQUAL(copy.size(), 110);
+        UNIT_ASSERT_EQUAL(::memcmp(copy.data() + 100, str.data() + 5, 10), 0);
     }
 
     Y_UNIT_TEST(Reserve) {


### PR DESCRIPTION
  * Bugfix
                                                                                                                                                                                                    


   TRcBuf copy constructor and copy-assignment copied Begin/End as absolute pointers. When the backend is a TString with CoW disabled, copying the backend allocates a new independent buffer at a   
  different address, so Begin/End end up pointing into the original (now unowned) allocation.                                                                                                       
                                                                                                                                                                                                    
  UnsafeTailroom() then computes (new_ptr + size) − old_ptr — a garbage value ~`0xFFFF_xxxx_xxxx. GrowFrontpasses it as tailroom toUninitialized, checkedSum` detects the overflow and throws:      
                                                                                                                                                                                                    
  std::length_error: Allocate size overflow                                                                                                                                                         
                                                                                                                                                                                                    
  Fix: after copying the backend, re-derive Begin and End directly from Backend.GetData(). When CoW is enabled or the backend is TInternalBackend, the returned span is unchanged and behaviour is  
  unaffected.                                                                                                                                                                                       
                                                                                                                                                                                                    
  Added CopyWithStringBackend unit test covering both copy constructor and operator= with a TString backend, including a GrowFront call.                                                                                                                            
                                                                                                                                                                                                    
  [5844](https://github.com/ydb-platform/nbs/issues/5844)

  cloud/blockstore/libs/storage/volume/ut:*
