### PR TITLE
Fix u-a-f in ticket_parser_ut

### DIFF
--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -2607,158 +2607,158 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         // IPv4
         {
-            auto* res = RunPeernameQuery(runtime, "192.168.1.1");
+            auto res = RunPeernameQuery(runtime, "192.168.1.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "10.0.0.1:65535");
+            auto res = RunPeernameQuery(runtime, "10.0.0.1:65535");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:127.0.0.1");
+            auto res = RunPeernameQuery(runtime, "ipv4:127.0.0.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:172.10.0.1:1234");
+            auto res = RunPeernameQuery(runtime, "ipv4:172.10.0.1:1234");
             UNIT_ASSERT(!res->HasError());
         }
 
         // IPv6
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:db8::1");
+            auto res = RunPeernameQuery(runtime, "2001:db8::1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]");
+            auto res = RunPeernameQuery(runtime, "[::1]");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:0");
+            auto res = RunPeernameQuery(runtime, "[::1]:0");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[fe80::1]:22");
+            auto res = RunPeernameQuery(runtime, "[fe80::1]:22");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:2001:db8::1");
+            auto res = RunPeernameQuery(runtime, "ipv6:2001:db8::1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:0");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:0");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80");
+            auto res = RunPeernameQuery(runtime, "ipv6:[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80");
             UNIT_ASSERT(!res->HasError());
         }
 
         // Invalid peername formats
         {
-            auto* res = RunPeernameQuery(runtime, "");
+            auto res = RunPeernameQuery(runtime, "");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "invalid_format");
+            auto res = RunPeernameQuery(runtime, "invalid_format");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[127.0.0.1]");
+            auto res = RunPeernameQuery(runtime, "[127.0.0.1]");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "127.0.0.1:65536");
+            auto res = RunPeernameQuery(runtime, "127.0.0.1:65536");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "256.1.1.1");
+            auto res = RunPeernameQuery(runtime, "256.1.1.1");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "1.-1.1.1");
+            auto res = RunPeernameQuery(runtime, "1.-1.1.1");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:");
+            auto res = RunPeernameQuery(runtime, "ipv4:");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:256.1.1.1");
+            auto res = RunPeernameQuery(runtime, "ipv4:256.1.1.1");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:[127.0.0.1]:1234");
+            auto res = RunPeernameQuery(runtime, "ipv4:[127.0.0.1]:1234");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e5:0370:7334");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e5:0370:7334");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:");
+            auto res = RunPeernameQuery(runtime, "[::1]:");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:65536");
+            auto res = RunPeernameQuery(runtime, "[::1]:65536");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:port");
+            auto res = RunPeernameQuery(runtime, "[::1]:port");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, ":::1");
+            auto res = RunPeernameQuery(runtime, ":::1");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime,  "ipv6:");
+            auto res = RunPeernameQuery(runtime,  "ipv6:");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:65536");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:65536");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:port");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:port");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:invalid");
+            auto res = RunPeernameQuery(runtime, "ipv6:invalid");
             UNIT_ASSERT(res->HasError());
             UNIT_ASSERT(!res->Error.Retryable);
         }
@@ -2790,139 +2790,139 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
         // IPv4
         {
-            auto* res = RunPeernameQuery(runtime, "192.168.1.1");
+            auto res = RunPeernameQuery(runtime, "192.168.1.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "10.0.0.1:65535");
+            auto res = RunPeernameQuery(runtime, "10.0.0.1:65535");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:127.0.0.1");
+            auto res = RunPeernameQuery(runtime, "ipv4:127.0.0.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:172.10.0.1:1234");
+            auto res = RunPeernameQuery(runtime, "ipv4:172.10.0.1:1234");
             UNIT_ASSERT(!res->HasError());
         }
 
         // IPv6
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:db8::1");
+            auto res = RunPeernameQuery(runtime, "2001:db8::1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[fe80::1]:22");
+            auto res = RunPeernameQuery(runtime, "[fe80::1]:22");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:2001:db8::1");
+            auto res = RunPeernameQuery(runtime, "ipv6:2001:db8::1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80");
+            auto res = RunPeernameQuery(runtime, "ipv6:[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80");
             UNIT_ASSERT(!res->HasError());
         }
 
         // Invalid peername formats
         {
-            auto* res = RunPeernameQuery(runtime, "");
+            auto res = RunPeernameQuery(runtime, "");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "invalid_format");
+            auto res = RunPeernameQuery(runtime, "invalid_format");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[127.0.0.1]");
+            auto res = RunPeernameQuery(runtime, "[127.0.0.1]");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "127.0.0.1:65536");
+            auto res = RunPeernameQuery(runtime, "127.0.0.1:65536");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "256.1.1.1");
+            auto res = RunPeernameQuery(runtime, "256.1.1.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "1.-1.1.1");
+            auto res = RunPeernameQuery(runtime, "1.-1.1.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:");
+            auto res = RunPeernameQuery(runtime, "ipv4:");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:256.1.1.1");
+            auto res = RunPeernameQuery(runtime, "ipv4:256.1.1.1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv4:[127.0.0.1]:1234");
+            auto res = RunPeernameQuery(runtime, "ipv4:[127.0.0.1]:1234");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]");
+            auto res = RunPeernameQuery(runtime, "[::1]");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e5:0370:7334");
+            auto res = RunPeernameQuery(runtime, "2001:0db8:85a3:0000:0000:8a2e5:0370:7334");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:");
+            auto res = RunPeernameQuery(runtime, "[::1]:");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:0");
+            auto res = RunPeernameQuery(runtime, "[::1]:0");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:65536");
+            auto res = RunPeernameQuery(runtime, "[::1]:65536");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "[::1]:port");
+            auto res = RunPeernameQuery(runtime, "[::1]:port");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, ":::1");
+            auto res = RunPeernameQuery(runtime, ":::1");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:");
+            auto res = RunPeernameQuery(runtime, "ipv6:");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:0");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:0");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:65536");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:65536");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:[::1]:port");
+            auto res = RunPeernameQuery(runtime, "ipv6:[::1]:port");
             UNIT_ASSERT(!res->HasError());
         }
         {
-            auto* res = RunPeernameQuery(runtime, "ipv6:invalid");
+            auto res = RunPeernameQuery(runtime, "ipv6:invalid");
             UNIT_ASSERT(!res->HasError());
         }
     }

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -2562,7 +2562,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         AuthorizationWithPeerName<NKikimr::TNebiusAccessServiceMock>();
     }
 
-    TEvTicketParser::TEvAuthorizeTicketResult* RunPeernameQuery(
+    TEvTicketParser::TEvAuthorizeTicketResult::TPtr RunPeernameQuery(
         TTestActorRuntime* runtime,
         const TString& peername) {
         TActorId sender = runtime->AllocateEdgeActor();

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -2562,11 +2562,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         AuthorizationWithPeerName<NKikimr::TNebiusAccessServiceMock>();
     }
 
-    TEvTicketParser::TEvAuthorizeTicketResult::TPtr RunPeernameQuery(
+    THolder<TEvTicketParser::TEvAuthorizeTicketResult> RunPeernameQuery(
         TTestActorRuntime* runtime,
         const TString& peername) {
         TActorId sender = runtime->AllocateEdgeActor();
-        TAutoPtr<IEventHandle> handle;
 
         runtime->Send(new IEventHandle(
             MakeTicketParserID(),
@@ -2578,7 +2577,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                 .Entries = {},
             })
         ), 0);
-        return runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        return runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>();
     }
 
     Y_UNIT_TEST(TicketParserPeerNameValidationWithFeatureFlagEnabled) {


### PR DESCRIPTION
Regression by #38108

ydb/core/security/ut/TTicketParserTest.TicketParserPeerNameValidationWithFeatureFlagDisabled ydb/core/security/ut/TTicketParserTest.TicketParserPeerNameValidationWithFeatureFlagEnabled

```
    #0 0x00001b5e27d2 in HasError /-S/ydb/core/base/ticket_parser.h:206:25
    #1 0x00001b5e27d2 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TTestCaseTicketParserPeerNameValidationWithFeatureFlagDisabled::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/security/ticket_parser_ut.cpp:2798:13
    #2 0x00001b60a237 in operator() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #3 0x00001b60a237 in __invoke<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #4 0x00001b60a237 in __call<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #5 0x00001b60a237 in __invoke_r<void, (lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #6 0x00001b60a237 in std::__y1::__function::__func<NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #7 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #8 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #9 0x00001bfc3079 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #10 0x00001bf92737 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #11 0x00001b609535 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #12 0x00001bf93eef in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #13 0x00001bfbd2ac in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #14 0x7ff0d02afd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #15 0x7ff0d02afe3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #16 0x000019146028 in _start (/home/runner/.ya/build/build_root/p6sp/0022fc/ydb/core/security/ut/ydb-core-security-ut+0x19146028) (BuildId: f33ecc9f67c2adbf31c0c702d36b9eee9369d1d4)
0x7c50cfb096b8 is located 56 bytes inside of 64-byte region [0x7c50cfb09680,0x7c50cfb096c0)
freed by thread T0 here:
    #0 0x00001b7cc222 in operator delete(void*, unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x00001b5ba1d9 in CheckedDelete<NActors::IEventBase> /-S/util/generic/ptr.h:36:5
    #2 0x00001b5ba1d9 in Destroy<NActors::IEventBase> /-S/util/generic/ptr.h:57:9
    #3 0x00001b5ba1d9 in DoDestroy /-S/util/generic/ptr.h:376:13
    #4 0x00001b5ba1d9 in ~THolder /-S/util/generic/ptr.h:306:9
    #5 0x00001b5ba1d9 in ~IEventHandle /-S/ydb/library/actors/core/event.h:59:11
    #6 0x00001b5ba1d9 in CheckedDelete<NActors::IEventHandle> /-S/util/generic/ptr.h:36:5
    #7 0x00001b5ba1d9 in Destroy<NActors::IEventHandle> /-S/util/generic/ptr.h:57:9
    #8 0x00001b5ba1d9 in DoDestroy /-S/util/generic/ptr.h:254:13
    #9 0x00001b5ba1d9 in ~TAutoPtr /-S/util/generic/ptr.h:200:9
    #10 0x00001b5ba1d9 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::RunPeernameQuery(NActors::TTestActorRuntime*, TBasicString<char, std::__y1::char_traits<char>> const&) /-S/ydb/core/security/ticket_parser_ut.cpp:2582:5
    #11 0x00001b5d5c38 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TTestCaseTicketParserPeerNameValidationWithFeatureFlagDisabled::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/security/ticket_parser_ut.cpp:2797:25
    #12 0x00001b60a237 in operator() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #13 0x00001b60a237 in __invoke<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #14 0x00001b60a237 in __call<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #15 0x00001b60a237 in __invoke_r<void, (lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #16 0x00001b60a237 in std::__y1::__function::__func<NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #17 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #18 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #19 0x00001bfc3079 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #20 0x00001bf92737 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #21 0x00001b609535 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #22 0x00001bf93eef in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #23 0x00001bfbd2ac in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #24 0x7ff0d02afd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
previously allocated by thread T339 (ydb-core.User) here:
    #0 0x00001b7cb5bd in operator new(unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x0000234a3804 in NKikimr::TTicketParserImpl<NKikimr::TTicketParser>::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::TEvTicketParser::TEvAuthorizeTicket>, TDelete>&) /-S/ydb/core/security/ticket_parser_impl.h:1068:26
    #2 0x00001db5ef87 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:394:17
    #3 0x00001dc42e7e in NActors::TExecutorThread::Execute(NActors::TMailbox*, bool, long) /-S/ydb/library/actors/core/executor_thread.cpp:279:28
    #4 0x00001dc4cb0b in NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool, long) const /-S/ydb/library/actors/core/executor_thread.cpp:468:39
    #5 0x00001dc4c099 in NActors::TExecutorThread::ProcessExecutorPool() /-S/ydb/library/actors/core/executor_thread.cpp:520:13
    #6 0x00001dc4e13e in NActors::TExecutorThread::ThreadProc() /-S/ydb/library/actors/core/executor_thread.cpp:546:9
    #7 0x00001bb0e3b4 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:245:20
    #8 0x00001b78f0d6 in asan_thread_start(void*) /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:239:28
Thread T339 (ydb-core.User) created by T0 here:
    #0 0x00001b775d11 in pthread_create /-S/contrib/libs/clang20-rt/lib/asan/asan_interceptors.cpp:250:3
    #1 0x00001baff1f5 in Start /-S/util/system/thread.cpp:230:27
    #2 0x00001baff1f5 in TThread::Start() /-S/util/system/thread.cpp:315:34
    #3 0x00001dc119dc in NActors::TBasicExecutorPool::Start() /-S/ydb/library/actors/core/executor_pool_basic.cpp:608:32
    #4 0x00001dbab113 in NActors::TCpuManager::Start() /-S/ydb/library/actors/core/cpu_manager.cpp:140:32
    #5 0x00001db790a1 in NActors::TActorSystem::Start() /-S/ydb/library/actors/core/actorsystem.cpp:513:21
    #6 0x00004245c4c5 in NActors::TTestActorRuntimeBase::StartActorSystem(unsigned int, NActors::TTestActorRuntimeBase::TNodeDataBase*) /-S/ydb/library/actors/testlib/test_runtime.cpp:1872:28
    #7 0x0000426a3af5 in NActors::TTestActorRuntime::Initialize(NActors::TTestActorRuntime::TEgg) /-S/ydb/core/testlib/actors/test_runtime.cpp:250:13
    #8 0x000042c7b603 in NActors::TTestBasicRuntime::Initialize(NActors::TTestActorRuntime::TEgg) /-S/ydb/core/testlib/basics/runtime.cpp:23:28
    #9 0x000042f2984c in NKikimr::SetupBasicServices(NActors::TTestActorRuntime&, NKikimr::TAppPrepare&, bool, NKikimr::NFake::INode*, NKikimr::NFake::TStorage, NKikimrSharedCache::TSharedCacheConfig const*, bool, TVector<TIntrusivePtr<NKikimr::NFake::TProxyDS, TDefaultIntrusivePtrOps<NKikimr::NFake::TProxyDS>>, std::__y1::allocator<TIntrusivePtr<NKikimr::NFake::TProxyDS, TDefaultIntrusivePtrOps<NKikimr::NFake::TProxyDS>>>>) /-S/ydb/core/testlib/basics/services.cpp:495:17
    #10 0x000042d48504 in NKikimr::SetupTabletServices(NActors::TTestActorRuntime&, NKikimr::TAppPrepare*, bool, NKikimr::NFake::TStorage, NKikimrSharedCache::TSharedCacheConfig const*, bool, TVector<TIntrusivePtr<NKikimr::NFake::TProxyDS, TDefaultIntrusivePtrOps<NKikimr::NFake::TProxyDS>>, std::__y1::allocator<TIntrusivePtr<NKikimr::NFake::TProxyDS, TDefaultIntrusivePtrOps<NKikimr::NFake::TProxyDS>>>>) /-S/ydb/core/testlib/tablet_helpers.cpp:652:9
    #11 0x000042710be3 in NKikimr::Tests::TServer::Initialize() /-S/ydb/core/testlib/test_client.cpp:611:9
    #12 0x00004270eaab in NKikimr::Tests::TServer::TServer(TIntrusiveConstPtr<NKikimr::Tests::TServerSettings, TDefaultIntrusivePtrOps<NKikimr::Tests::TServerSettings>>, bool) /-S/ydb/core/testlib/test_client.cpp:467:13
    #13 0x000042711a8b in NKikimr::Tests::TServer::TServer(NKikimr::Tests::TServerSettings const&, bool) /-S/ydb/core/testlib/test_client.cpp:472:11
    #14 0x00001b5d59e1 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TTestCaseTicketParserPeerNameValidationWithFeatureFlagDisabled::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/security/ticket_parser_ut.cpp:2786:17
    #15 0x00001b60a237 in operator() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #16 0x00001b60a237 in __invoke<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #17 0x00001b60a237 in __call<(lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #18 0x00001b60a237 in __invoke_r<void, (lambda at /-S/ydb/core/security/ticket_parser_ut.cpp:126:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #19 0x00001b60a237 in std::__y1::__function::__func<NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #20 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #21 0x00001bfc3079 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #22 0x00001bfc3079 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #23 0x00001bf92737 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #24 0x00001b609535 in NKikimr::NCertTestUtils::NTestSuiteTTicketParserTest::TCurrentTest::Execute() /-S/ydb/core/security/ticket_parser_ut.cpp:126:1
    #25 0x00001bf93eef in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #26 0x00001bfbd2ac in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #27 0x7ff0d02afd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
SUMMARY: AddressSanitizer: heap-use-after-free /-S/ydb/core/base/ticket_parser.h:206:25 in HasError
```

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
