### PR TITLE
Fix dry run scenario when overlay item is being deleted from config

### DIFF
--- a/ydb/core/mind/bscontroller/types.h
+++ b/ydb/core/mind/bscontroller/types.h
@@ -456,7 +456,7 @@ namespace NKikimr {
                     if (baseIt == Base.end()) {
                         break;
                     }
-                    if (overlay && baseIt->first == key) {
+                    if (baseIt->first == key) {
                         baseIt->second->OnRollback();
                     }
                 }

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -1432,6 +1432,23 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
         }
     }
 
+    Y_UNIT_TEST(OverlayMapRollbackAfterCloneThenDelete) {
+        TMap<unsigned, THolder<TAlpha>> alphas;
+        alphas.emplace(1, MakeHolder<TAlpha>(1));
+
+        {
+            TOverlayMap<unsigned, TAlpha> overlay(alphas);
+            UNIT_ASSERT(overlay.FindForUpdate(1));
+            overlay.DeleteExistingEntry(1);
+            overlay.Rollback();
+        }
+
+        TOverlayMap<unsigned, TAlpha> overlay(alphas);
+        const TAlpha *alpha = overlay.FindForUpdate(1);
+        UNIT_ASSERT(alpha);
+        UNIT_ASSERT_VALUES_EQUAL(alpha->Key, 1);
+    }
+
     Y_UNIT_TEST(CommandRollbackWhenAlone) {
         TEnvironmentSetup env(1, 1);
         RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix dry run scenario when overlay item is being deleted from config

Issue: #39236 

Example scenario: we want to remove node from config with PDisk on it, using distconf. First of all, update will be validated in BSC with dry-run transaction:

1) ValidateConfigUpdates() will check the removed pdisk:
[PDisk to remove cycle](https://github.com/ydb-platform/ydb/blob/a5009c26885c4d79528fb98851201bb4685cbb50/ydb/core/mind/bscontroller/config.cpp#L493-L505)

2) In FindForUpdate for pdisk we call Clone()
https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/types.h#L352

3) In OnClone() we check that Current pointer points to this and if so, we are assinging Current to the new copy

https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/indir.h#L61-L64

4) And then we call DeleteExistingEntry(), which cause overlay entry to Reset(), but remain the Current pointer

https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/types.h#L381

5) In non-delete scenario, we reset Current to this in Rollback() after dry-run:
     https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/config_cmd.cpp#L332
     But there we are skipping OnRollback() because of empty overlay entry
     https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/types.h#L459
  
6) After dry-run, we call real transaction and it aborts on 
  https://github.com/ydb-platform/ydb/blob/f06927ab544ab69aba45d16785b8ec71de2c6153/ydb/core/mind/bscontroller/indir.h#L62
 
In this fix we assigning Current to to this anyway, not checking overlay existing

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
