### PR TITLE
The topic writing session controls the predicate calculation

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,13 +1,3 @@
-* Added the `--no-producer-id-track` option to `ydb workload topic run write|full` to disable ProducerId tracking in transactions when using `--use-tx`.
-* Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).
-
-## 2.30.0 ##
-
-* Added the `direct-read` option to the `ydb workload topic` command
-* Added the `ydb config completion` command to generate shell completion scripts for bash and zsh.
-* Added the `ydb export nfs` and `ydb import nfs` commands, allowing users to create and restore backups directly to/from a shared NFS directory mounted on every host in the cluster.
-* Added `--compact` option to `ydb workload tpcc import` command.
-* When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
 
 ## 2.29.0 ##

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,13 @@
+* Added the `--no-producer-id-track` option to `ydb workload topic run write|full` to disable ProducerId tracking in transactions when using `--use-tx`.
+* Added `--stats` option to `ydb workload * run` benchmarks to enable extended execution stats collection (e.g. `--stats profile`).
+
+## 2.30.0 ##
+
+* Added the `direct-read` option to the `ydb workload topic` command
+* Added the `ydb config completion` command to generate shell completion scripts for bash and zsh.
+* Added the `ydb export nfs` and `ydb import nfs` commands, allowing users to create and restore backups directly to/from a shared NFS directory mounted on every host in the cluster.
+* Added `--compact` option to `ydb workload tpcc import` command.
+* When a profile is explicitly specified with the `-p`/`--profile` option, the active profile is no longer used: all options are taken only from the specified profile, environment variables, and command line. This avoids confusion when the chosen profile was unexpectedly supplemented with settings from the active profile.
 * Added `--tx-mode` option to `ydb workload * run` benchmark commands, allowing to set the transaction mode (e.g. `no-tx`, `serializable-rw`, `snapshot-rw`).
 
 ## 2.29.0 ##

--- a/ydb/core/kqp/common/kqp_tx_manager.cpp
+++ b/ydb/core/kqp/common/kqp_tx_manager.cpp
@@ -206,6 +206,7 @@ public:
     void SetTopicOperations(NTopic::TTopicOperations&& topicOperations) override {
         AFL_ENSURE(TopicOperations.GetSize() == 0);
         TopicOperations = std::move(topicOperations);
+        TopicOperations.SetSkipConflictCheck(SkipTopicsConflictCheck);
     }
 
     const NTopic::TTopicOperations& GetTopicOperations() const override {
@@ -222,6 +223,11 @@ public:
 
     bool HasTopics() const override {
         return GetTopicOperations().GetSize() != 0;
+    }
+
+    void SetSkipTopicsConflictCheck(bool skipConflictCheck) override {
+        SkipTopicsConflictCheck = skipConflictCheck;
+        TopicOperations.SetSkipConflictCheck(SkipTopicsConflictCheck);
     }
 
     TVector<NKikimrDataEvents::TLock> GetLocks() const override {
@@ -682,6 +688,7 @@ private:
     THashSet<ui64> ShardsToWait;
 
     NTopic::TTopicOperations TopicOperations;
+    bool SkipTopicsConflictCheck = false;
 
     ui64 MinStep = 0;
     ui64 MaxStep = 0;

--- a/ydb/core/kqp/common/kqp_tx_manager.h
+++ b/ydb/core/kqp/common/kqp_tx_manager.h
@@ -72,6 +72,7 @@ public:
     virtual const NTopic::TTopicOperations& GetTopicOperations() const = 0;
     virtual void BuildTopicTxs(NTopic::TTopicOperationTransactions& txs) = 0;
     virtual bool HasTopics() const = 0;
+    virtual void SetSkipTopicsConflictCheck(bool skipConflictCheck) = 0;
 
     virtual void AddParticipantNode(const ui32 nodeId) = 0;
     virtual const THashSet<ui32>& GetParticipantNodes() const = 0;

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -155,7 +155,7 @@ namespace {
                 transaction.AddReceivingShards(receivingShardId);
             }
 
-            AFL_ENSURE(transaction.GetSendingShards().size() == 1);
+            AFL_ENSURE(transaction.GetSendingShards().size() <= 1);
             AFL_ENSURE(transaction.GetReceivingShards().size() == 1);
         }
     }

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -129,18 +129,33 @@ namespace {
         }
     }
 
-    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager) {
+    void FillTopicsCommit(const bool isImmediateCommit, NKikimrPQ::TDataTransaction& transaction, const NKikimr::NKqp::IKqpTransactionManagerPtr& txManager, ui64 recipientTopicTabletId,
+                          bool omitPeerTopicTablets, const THashSet<ui64>& topicTabletPeers) {
         transaction.SetOp(NKikimrPQ::TDataTransaction::Commit);
 
         if (!isImmediateCommit) {
             const auto prepareSettings = txManager->GetPrepareTransactionInfo();
 
+            const auto keepShardForPropose = [&](ui64 shardId) {
+                if (!omitPeerTopicTablets) {
+                    return true;
+                }
+                if (!topicTabletPeers.contains(shardId)) {
+                    return true;
+                }
+                return shardId == recipientTopicTabletId;
+            };
+
             if (!prepareSettings.ArbiterColumnShard) {
                 for (const ui64 sendingShardId : prepareSettings.SendingShards) {
-                    transaction.AddSendingShards(sendingShardId);
+                    if (keepShardForPropose(sendingShardId)) {
+                        transaction.AddSendingShards(sendingShardId);
+                    }
                 }
                 for (const ui64 receivingShardId : prepareSettings.ReceivingShards) {
-                    transaction.AddReceivingShards(receivingShardId);
+                    if (keepShardForPropose(receivingShardId)) {
+                        transaction.AddReceivingShards(receivingShardId);
+                    }
                 }
             } else {
                 transaction.AddSendingShards(*prepareSettings.ArbiterColumnShard);
@@ -3877,10 +3892,25 @@ public:
         }
         bool kafkaTransaction = TxManager->GetTopicOperations().HasKafkaOperations();
 
+        THashSet<ui64> topicTabletPeers;
+        bool omitPeerTopicTablets = false;
+        if (!isImmediateCommit) {
+            const auto& topicOps = TxManager->GetTopicOperations();
+            omitPeerTopicTablets = topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange();
+            if (omitPeerTopicTablets) {
+                for (ui64 id : topicOps.GetReceivingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+                for (ui64 id : topicOps.GetSendingTabletIds()) {
+                    topicTabletPeers.insert(id);
+                }
+            }
+        }
+
         for (auto& [tabletId, t] : topicTxs) {
             auto& transaction = t.tx;
 
-            FillTopicsCommit(isImmediateCommit, transaction, TxManager);
+            FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId, omitPeerTopicTablets, topicTabletPeers);
 
             if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
                 auto* w = transaction.MutableWriteId();

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -472,6 +472,10 @@ void TKqpQueryState::FillTopicOperations() {
     }
 
     TopicOperations = NTopic::TTopicOperations();
+
+    bool trackProducerId = !operations.HasTrackProducerId() || operations.GetTrackProducerId();
+    TopicOperations.SetTrackProducerId(trackProducerId);
+
     for (auto& topic : operations.GetTopics()) {
         auto path = CanonizePath(NPersQueue::GetFullTopicPath(GetDatabase(), topic.path()));
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2007,9 +2007,8 @@ public:
         if (txCtx->EnableOltpSink.value_or(false) && !txCtx->TxManager) {
             txCtx->TxManager = CreateKqpTransactionManager();
             txCtx->TxManager->SetAllowVolatile(AppData()->FeatureFlags.GetEnableDataShardVolatileTransactions());
+            txCtx->TxManager->SetSkipTopicsConflictCheck(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
         }
-
-        txCtx->TxManager->SetSkipTopicsConflictCheck(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
 
         if (txCtx->EnableOltpSink.value_or(false)
             && !txCtx->BufferActorId

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1927,6 +1927,7 @@ public:
                 }
             }
             request.TopicOperations = std::move(txCtx.TopicOperations);
+            request.TopicOperations.SetSkipConflictCheck(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
         } else if (QueryState->ShouldAcquireLocks(tx) && (!txCtx.HasOlapTable || txCtx.EnableOlapSink.value_or(false))) {
             request.AcquireLocksTxId = txCtx.Locks.GetLockTxId();
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2009,6 +2009,8 @@ public:
             txCtx->TxManager->SetAllowVolatile(AppData()->FeatureFlags.GetEnableDataShardVolatileTransactions());
         }
 
+        txCtx->TxManager->SetSkipTopicsConflictCheck(AppData()->FeatureFlags.GetEnableSkipConflictCheckForTopicsInTransaction());
+
         if (txCtx->EnableOltpSink.value_or(false)
             && !txCtx->BufferActorId
             && (txCtx->HasTableWrite || request.TopicOperations.GetSize() != 0)) {

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -698,4 +698,9 @@ bool TTopicOperations::CalcSkipConflictCheck() const
     return !TrackProducerId_ && SkipConflictCheck_;
 }
 
+bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
+{
+    return CalcSkipConflictCheck() && !HasReadOperations();
+}
+
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -223,7 +223,7 @@ void TTopicPartitionOperations::AddKafkaApiReadOperation(const TString& topic, u
     Operations_[consumerName].AddKafkaApiOffsetCommit(consumerName, offset);
 }
 
-void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
+void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, bool skipConflictCheck)
 {
     Y_ENSURE(TabletId_.Defined());
     Y_ENSURE(Partition_.Defined());
@@ -261,6 +261,7 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
         } else if (SupportivePartition_.Defined()) {
             o->SetSupportivePartition(*SupportivePartition_);
         }
+        o->SetSkipConflictCheck(skipConflictCheck);
         t.hasWrite = true;
     }
 }
@@ -614,7 +615,7 @@ void TTopicOperations::CacheSchemeCacheNavigate(const NSchemeCache::TSchemeCache
 void TTopicOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
 {
     for (auto& [_, operations] : Operations_) {
-        operations.BuildTopicTxs(txs);
+        operations.BuildTopicTxs(txs, CalcSkipConflictCheck());
     }
 }
 
@@ -628,6 +629,9 @@ void TTopicOperations::Merge(const TTopicOperations& rhs)
     HasReadOperations_ |= rhs.HasReadOperations_;
     HasWriteOperations_ |= rhs.HasWriteOperations_;
     HasKafkaOperations_ |= rhs.HasKafkaOperations_;
+
+    MergeSkipConflictCheck(rhs.SkipConflictCheck_);
+    MergeTrackProducerId(rhs.TrackProducerId_);
 }
 
 TSet<ui64> TTopicOperations::GetReceivingTabletIds() const
@@ -643,6 +647,11 @@ TSet<ui64> TTopicOperations::GetSendingTabletIds() const
 {
     TSet<ui64> ids;
     for (auto& [_, operations] : Operations_) {
+        if (!operations.HasReadOperations() &&
+            operations.HasWriteOperations() && CalcSkipConflictCheck()) {
+            continue;
+        }
+
         ids.insert(operations.GetTabletId());
     }
     return ids;
@@ -662,6 +671,31 @@ TMaybe<TString> TTopicOperations::GetTabletName(ui64 tabletId) const {
 size_t TTopicOperations::GetSize() const
 {
     return Operations_.size();
+}
+
+void TTopicOperations::SetSkipConflictCheck(bool skipConflictCheck)
+{
+    SkipConflictCheck_ = skipConflictCheck;
+}
+
+void TTopicOperations::SetTrackProducerId(bool trackProducerId)
+{
+    TrackProducerId_ = trackProducerId;
+}
+
+void TTopicOperations::MergeSkipConflictCheck(bool rhs)
+{
+    SkipConflictCheck_ = SkipConflictCheck_ && rhs;
+}
+
+void TTopicOperations::MergeTrackProducerId(bool rhs)
+{
+    TrackProducerId_ = TrackProducerId_ || rhs;
+}
+
+bool TTopicOperations::CalcSkipConflictCheck() const
+{
+    return !TrackProducerId_ && SkipConflictCheck_;
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -186,6 +186,13 @@ public:
     void SetSkipConflictCheck(bool skipConflictCheck);
     void SetTrackProducerId(bool trackProducerId);
 
+    // Returns true when KQP may omit other PQ tablets of this transaction from
+    // TDataTransaction SendingShards/ReceivingShards (so PQ does not run a distributed
+    // predicate / ReadSet exchange only between topic peers). Preconditions:
+    // CalcSkipConflictCheck() is true (!TrackProducerId_ && SkipConflictCheck_) and
+    // there are no topic read operations (no consumer / offset-commit reads).
+    bool ShouldOmitPeerTopicTabletsForPredicateExchange() const;
+
 private:
     void MergeSkipConflictCheck(bool rhs);
     void MergeTrackProducerId(bool rhs);

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -95,7 +95,7 @@ public:
     
     void AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset);
 
-    void BuildTopicTxs(TTopicOperationTransactions &txs);
+    void BuildTopicTxs(TTopicOperationTransactions &txs, bool skipConflictCheck);
 
     void Merge(const TTopicPartitionOperations& rhs);
 
@@ -183,7 +183,15 @@ public:
     void SetTabletId(const TString& topic, ui32 partition,
                      ui64 tabletId);
 
+    void SetSkipConflictCheck(bool skipConflictCheck);
+    void SetTrackProducerId(bool trackProducerId);
+
 private:
+    void MergeSkipConflictCheck(bool rhs);
+    void MergeTrackProducerId(bool rhs);
+
+    bool CalcSkipConflictCheck() const;
+
     THashMap<TTopicPartition, TTopicPartitionOperations, TTopicPartition::THash> Operations_;
     bool HasReadOperations_ = false;
     bool HasWriteOperations_ = false;
@@ -194,6 +202,8 @@ private:
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
+    bool SkipConflictCheck_ = true;
+    bool TrackProducerId_ = false;
 };
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -1,0 +1,260 @@
+#include <ydb/core/kqp/topics/kqp_topics.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NKqp {
+
+Y_UNIT_TEST_SUITE(KqpTopics) {
+
+static
+bool ShouldSkipConflictCheck(bool skipConflictCheck, bool trackProducerId) {
+    return skipConflictCheck && !trackProducerId;
+}
+
+static
+void AddReadOperation(NTopic::TTopicOperations& ops,
+                      const TString& topic, ui32 partition,
+                      const ui64 begin, const ui64 end,
+                      const TString& consumer)
+{
+    NKikimrKqp::TTopicOperationsRequest_TopicOffsets_PartitionOffsets_OffsetsRange range;
+    range.set_start(begin);
+    range.set_end(end);
+
+    ops.AddOperation(topic, partition,
+                     consumer,
+                     range,
+                     false,
+                     false,
+                     false,
+                     "read-session");
+}
+
+static
+void AddWriteOperation(NTopic::TTopicOperations& ops,
+                       const TString& topic, ui32 partition,
+                       const ui32 supportivePartition)
+{
+    ops.AddOperation(topic, partition,
+                     supportivePartition);
+}
+
+static
+void AssertReadOperation(const NTopic::TTopicOperationTransactions& txs,
+                         const ui64 tabletId,
+                         const size_t opsCount,
+                         const size_t opIndex)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& readOp = t.tx.GetOperations(opIndex);
+    UNIT_ASSERT(not readOp.HasSkipConflictCheck());
+}
+
+static
+void AssertWriteOperation(const NTopic::TTopicOperationTransactions& txs,
+                          const ui64 tabletId,
+                          const size_t opsCount,
+                          const size_t opIndex,
+                          const bool skipConflictCheck)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT(t.hasWrite);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& writeOp = t.tx.GetOperations(opIndex);
+    UNIT_ASSERT(writeOp.HasSkipConflictCheck());
+    UNIT_ASSERT_EQUAL(writeOp.GetSkipConflictCheck(), skipConflictCheck);
+}
+
+Y_UNIT_TEST(OnlyReadOperations) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(false);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 1, 0);
+}
+
+static
+void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
+    const TString TOPIC_A = "topic_A";
+    const TString TOPIC_B = "topic_B";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID_A = 1'000'000;
+    const ui64 TABLETID_B = 2'000'000;
+
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
+
+    AddReadOperation(topicOps, TOPIC_A, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC_B, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC_A, PARTITION, TABLETID_A);
+    topicOps.SetTabletId(TOPIC_B, PARTITION, TABLETID_B);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    size_t expectedSendCount = shouldSkip ? 1 : 2;
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), expectedSendCount);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+    if (!shouldSkip) {
+        UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+    }
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 2);
+
+    AssertReadOperation(txs, TABLETID_A, 1, 0);
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, shouldSkip);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperations(false, false);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_TrackProducerId) {
+    TestReadWriteOperations(false, true);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperations(true, false);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_SkipConflictCheck_TrackProducerId) {
+    TestReadWriteOperations(true, true);
+}
+
+static
+void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
+
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    size_t expectedSendCount = shouldSkip ? 0 : 1;
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), expectedSendCount);
+    if (!shouldSkip) {
+        UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+    }
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertWriteOperation(txs, TABLETID, 1, 0, shouldSkip);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
+    TestOnlyWriteOperations(false, false);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_TrackProducerId) {
+    TestOnlyWriteOperations(false, true);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_NoTrackProducerId) {
+    TestOnlyWriteOperations(true, false);
+}
+
+Y_UNIT_TEST(OnlyWriteOperations_SkipConflictCheck_TrackProducerId) {
+    TestOnlyWriteOperations(true, true);
+}
+
+static
+void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProducerId) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    const bool shouldSkip = ShouldSkipConflictCheck(skipConflictCheck, trackProducerId);
+
+    NTopic::TTopicOperations topicOps;
+
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
+
+    AddReadOperation(topicOps, TOPIC, PARTITION, 100, 105, "consumer");
+    AddWriteOperation(topicOps, TOPIC, PARTITION, 100'001);
+
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 1);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+
+    AssertReadOperation(txs, TABLETID, 2, 0);
+    AssertWriteOperation(txs, TABLETID, 2, 1, shouldSkip);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperationsOnePartition(false, false);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_TrackProducerId) {
+    TestReadWriteOperationsOnePartition(false, true);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_NoTrackProducerId) {
+    TestReadWriteOperationsOnePartition(true, false);
+}
+
+Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) {
+    TestReadWriteOperationsOnePartition(true, true);
+}
+
+}
+
+}

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -255,6 +255,69 @@ Y_UNIT_TEST(ReadWriteOperations_OnePartition_SkipConflictCheck_TrackProducerId) 
     TestReadWriteOperationsOnePartition(true, true);
 }
 
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_WriteOnlySkipConflict) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
+
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenConsumerReads) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID = 100'001;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
+
+    AddReadOperation(topicOps, TOPIC, 0, 1, 2, "c");
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenSkipConflictCheckOff) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(false);
+    topicOps.SetTrackProducerId(false);
+
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenTrackProducerId) {
+    const TString TOPIC = "topic";
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_0 = 100'001;
+    constexpr ui32 SUPPORTIVE_PARTITION_ID_1 = 100'002;
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(true);
+
+    AddWriteOperation(topicOps, TOPIC, 0, SUPPORTIVE_PARTITION_ID_0);
+    topicOps.SetTabletId(TOPIC, 0, 100);
+    AddWriteOperation(topicOps, TOPIC, 1, SUPPORTIVE_PARTITION_ID_1);
+    topicOps.SetTabletId(TOPIC, 1, 200);
+
+    UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
 }
 
 }

--- a/ydb/core/kqp/ut/topics/ya.make
+++ b/ydb/core/kqp/ut/topics/ya.make
@@ -1,0 +1,20 @@
+UNITTEST_FOR(ydb/core/kqp)
+
+FORK_SUBTESTS()
+SPLIT_FACTOR(50)
+
+SIZE(SMALL)
+
+SRCS(
+    kqp_topics_ut.cpp
+)
+
+PEERDIR(
+    ydb/core/kqp/ut/common
+    ydb/core/kqp/topics
+    yql/essentials/sql/pg_dummy
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/ut/ya.make
+++ b/ydb/core/kqp/ut/ya.make
@@ -23,6 +23,8 @@ RECURSE_FOR_TESTS(
     service
     runtime
     sysview
+    tli
+    topics
     tx
     view
     yql

--- a/ydb/core/kqp/ut/ya.make
+++ b/ydb/core/kqp/ut/ya.make
@@ -23,7 +23,6 @@ RECURSE_FOR_TESTS(
     service
     runtime
     sysview
-    tli
     topics
     tx
     view

--- a/ydb/core/persqueue/events/global.cpp
+++ b/ydb/core/persqueue/events/global.cpp
@@ -1,0 +1,11 @@
+#include "global.h"
+#include <ydb/core/persqueue/pqtablet/common/event_helpers.h>
+
+bool NKikimr::TEvPersQueue::TEvProposeTransaction::GetSkipSrcIdInfo() const
+{
+    if (Record.GetTxBodyCase() != NKikimrPQ::TEvProposeTransaction::kData) {
+        return false;
+    }
+
+    return NPQ::AllExistingWritesSkipConflictCheck(Record.GetData().GetOperations());
+}

--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -237,6 +237,8 @@ namespace NKikimr::TEvPersQueue {
     };
 
     struct TEvProposeTransaction : public TEventPreSerializedPB<TEvProposeTransaction, NKikimrPQ::TEvProposeTransaction, EvProposeTransaction> {
+        bool GetSkipSrcIdInfo() const;
+
         NWilson::TSpan ExecuteSpan;
     };
 

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -910,6 +910,9 @@ struct TEvPQ {
             Operations.push_back(std::move(operation));
         }
 
+        bool GetSkipSrcIdInfo() const { return SkipSrcIdInfo; }
+        void SetSkipSrcIdInfo(bool value) { SkipSrcIdInfo = value; }
+
         ui64 Step;
         ui64 TxId;
         TVector<NKikimrPQ::TPartitionOperation> Operations;
@@ -917,6 +920,9 @@ struct TEvPQ {
         bool ForcePredicateFalse = false;
 
         NWilson::TSpan Span;
+
+    private:
+        bool SkipSrcIdInfo = false;
     };
 
     struct TEvTxCalcPredicateResult : public TEventLocal<TEvTxCalcPredicateResult, EvTxCalcPredicateResult> {
@@ -1179,9 +1185,18 @@ struct TEvPQ {
     };
 
     struct TEvGetWriteInfoRequest : public TEventLocal<TEvGetWriteInfoRequest, EvGetWriteInfoRequest> {
-        TActorId OriginalPartition;
+        explicit TEvGetWriteInfoRequest(bool skipSrcIdInfo = false) :
+            SkipSrcIdInfo(skipSrcIdInfo)
+        {
+        }
 
+        bool GetSkipSrcIdInfo() const { return SkipSrcIdInfo; }
+
+        TActorId OriginalPartition;
         NWilson::TSpan Span;
+
+    private:
+        bool SkipSrcIdInfo = false;
     };
 
     struct TEvGetWriteInfoResponse : public TEventLocal<TEvGetWriteInfoResponse, EvGetWriteInfoResponse> {

--- a/ydb/core/persqueue/events/ya.make
+++ b/ydb/core/persqueue/events/ya.make
@@ -1,7 +1,7 @@
 LIBRARY()
 
 SRCS(
-    global.cpp
+    events.cpp
     internal.cpp
 )
 

--- a/ydb/core/persqueue/events/ya.make
+++ b/ydb/core/persqueue/events/ya.make
@@ -1,7 +1,7 @@
 LIBRARY()
 
 SRCS(
-    events.cpp
+    global.cpp
     internal.cpp
 )
 

--- a/ydb/core/persqueue/events/ya.make
+++ b/ydb/core/persqueue/events/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     events.cpp
+    global.cpp
     internal.cpp
 )
 

--- a/ydb/core/persqueue/pqtablet/common/event_helpers.h
+++ b/ydb/core/persqueue/pqtablet/common/event_helpers.h
@@ -6,6 +6,7 @@
 #include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h>
+#include <ydb/core/protos/pqconfig.pb.h>
 
 namespace NKikimr {
 namespace NPQ {
@@ -24,6 +25,34 @@ void ReplyPersQueueError(
     bool logDebug = false,
     bool isInternal = false
 );
+
+inline
+bool IsWriteTxOperation(const NKikimrPQ::TPartitionOperation& operation)
+{
+    bool isRead = operation.HasCommitOffsetsBegin() || (operation.GetKafkaTransaction() && operation.HasCommitOffsetsEnd());
+    return !isRead;
+}
+
+template <class C>
+bool AllExistingWritesSkipConflictCheck(const C& ops)
+{
+    size_t writeOpsCount = 0;
+    size_t flagsCount = 0;
+
+    for (const auto& op : ops) {
+        if (!IsWriteTxOperation(op)) {
+            continue;
+        }
+
+        ++writeOpsCount;
+
+        if (op.GetSkipConflictCheck()) {
+            ++flagsCount;
+        }
+    }
+
+    return (writeOpsCount > 0) && (writeOpsCount == flagsCount);
+}
 
 }// NPQ
 }// NKikimr

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1518,6 +1518,7 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoReque
               std::back_inserter(response->BodyKeys));
     if (!ev->GetSkipSrcIdInfo()) {
         response->SrcIdInfo = std::move(SourceIdStorage.ExtractInMemorySourceIds());
+        response->SrcIdInfo.erase("");
     }
 
     response->BytesWrittenGrpc = BytesWrittenGrpc.Value();

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1508,6 +1508,7 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoReque
         return;
     }
     ClosedInternalPartition = true;
+
     auto response = new TEvPQ::TEvGetWriteInfoResponse();
     response->Cookie = Partition.InternalPartitionId;
     response->BodyKeys = std::move(CompactionBlobEncoder.DataKeysBody);
@@ -1515,7 +1516,9 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoReque
               std::back_inserter(response->BodyKeys));
     std::move(BlobEncoder.DataKeysBody.begin(), BlobEncoder.DataKeysBody.end(),
               std::back_inserter(response->BodyKeys));
-    response->SrcIdInfo = std::move(SourceIdStorage.ExtractInMemorySourceIds());
+    if (!ev->GetSkipSrcIdInfo()) {
+        response->SrcIdInfo = std::move(SourceIdStorage.ExtractInMemorySourceIds());
+    }
 
     response->BytesWrittenGrpc = BytesWrittenGrpc.Value();
     response->BytesWrittenUncompressed = BytesWrittenUncompressed.Value();
@@ -1598,7 +1601,7 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx,
         return EProcessResult::Continue;
     }
 
-    auto& srcIdInfo = tx.WriteInfo->SrcIdInfo;
+    const auto& srcIdInfo = tx.WriteInfo->SrcIdInfo;
 
     EProcessResult ret = EProcessResult::Continue;
     const auto& knownSourceIds = SourceIdStorage.GetInMemorySourceIds();
@@ -2261,17 +2264,18 @@ void TPartition::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
 
 void TPartition::PushBackDistrTx(TSimpleSharedPtr<TEvPQ::TEvTxCalcPredicate> event)
 {
+    const bool skipSrcIdInfo = event->GetSkipSrcIdInfo();
     UserActionAndTransactionEvents.emplace_back(MakeSimpleShared<TTransaction>(std::move(event), Now()));
-    RequestWriteInfoIfRequired();
+    RequestWriteInfoIfRequired(skipSrcIdInfo);
 }
 
-void TPartition::RequestWriteInfoIfRequired()
+void TPartition::RequestWriteInfoIfRequired(bool skipSrcIdInfo)
 {
     auto tx = std::get<1>(UserActionAndTransactionEvents.back().Event);
     auto supportId = tx->SupportivePartitionActor;
     if (supportId) {
         PQ_LOG_TX_D("Send TEvGetWriteInfoRequest for TxId " << tx->GetTxId());
-        Send(supportId, new TEvPQ::TEvGetWriteInfoRequest(),
+        Send(supportId, new TEvPQ::TEvGetWriteInfoRequest(skipSrcIdInfo),
              0, 0,
              tx->CalcPredicateSpan.GetTraceId());
         WriteInfosToTx.insert(std::make_pair(supportId, tx));
@@ -2296,9 +2300,10 @@ void TPartition::PushBackDistrTx(TSimpleSharedPtr<TEvPQ::TEvProposePartitionConf
 
 void TPartition::AddImmediateTx(TSimpleSharedPtr<TEvPersQueue::TEvProposeTransaction> tx)
 {
+    const bool skipSrcIdInfo = tx->GetSkipSrcIdInfo();
     UserActionAndTransactionEvents.emplace_back(MakeSimpleShared<TTransaction>(std::move(tx)));
     ++ImmediateTxCount;
-    RequestWriteInfoIfRequired();
+    RequestWriteInfoIfRequired(skipSrcIdInfo);
 }
 
 void TPartition::AddUserAct(TSimpleSharedPtr<TEvPQ::TEvSetClientInfo> act)

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -391,7 +391,7 @@ private:
     void PushFrontDistrTx(TSimpleSharedPtr<TEvPQ::TEvChangePartitionConfig> event);
     void PushBackDistrTx(TSimpleSharedPtr<TEvPQ::TEvProposePartitionConfig> event);
 
-    void RequestWriteInfoIfRequired();
+    void RequestWriteInfoIfRequired(bool skipSrcIdInfo);
 
     void ProcessDistrTxs(const TActorContext& ctx);
     void ProcessDistrTx(const TActorContext& ctx);

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3287,11 +3287,6 @@ bool TPersQueue::CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& ope
     return Partitions.contains(partitionId);
 }
 
-static bool IsWriteTxOperation(const NKikimrPQ::TPartitionOperation& operation) {
-    bool isRead = operation.HasCommitOffsetsBegin() || (operation.GetKafkaTransaction() && operation.HasCommitOffsetsEnd());
-    return !isRead;
-}
-
 bool TPersQueue::CheckTxWriteOperations(const NKikimrPQ::TDataTransaction& txBody) const
 {
     if (!txBody.HasWriteId()) {
@@ -4209,6 +4204,7 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
                 const TPartitionInfo& partition = Partitions.at(partitionId);
 
                 event->SupportivePartitionActor = partition.Actor;
+                event->SetSkipSrcIdInfo(tx.GetSkipSrcIdInfo());
             }
         } else {
             PQ_LOG_TX_W("Unknown WriteId " << writeId << " for TxId " << tx.TxId);

--- a/ydb/core/persqueue/pqtablet/transaction.cpp
+++ b/ydb/core/persqueue/pqtablet/transaction.cpp
@@ -1,6 +1,7 @@
 #include "transaction.h"
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/persqueue/pqtablet/common/logging.h>
+#include <ydb/core/persqueue/pqtablet/common/event_helpers.h>
 
 #include <ydb/library/wilson_ids/wilson.h>
 
@@ -524,6 +525,11 @@ const TVector<NKikimrTx::TEvReadSet>& TDistributedTransaction::GetBindedMsgs(ui6
     static TVector<NKikimrTx::TEvReadSet> empty;
 
     return empty;
+}
+
+bool TDistributedTransaction::GetSkipSrcIdInfo() const
+{
+    return AllExistingWritesSkipConflictCheck(Operations);
 }
 
 void TDistributedTransaction::SetExecuteSpan(NWilson::TSpan&& span)

--- a/ydb/core/persqueue/pqtablet/transaction.h
+++ b/ydb/core/persqueue/pqtablet/transaction.h
@@ -39,6 +39,8 @@ struct TDistributedTransaction {
 
     void SendPlanStepAcksAfterCompletion(const TActorId& sender, std::unique_ptr<TEvTxProcessing::TEvPlanStep>&& event);
 
+    bool GetSkipSrcIdInfo() const;
+
     using EDecision = NKikimrTx::TReadSetData::EDecision;
     using EState = NKikimrPQ::TTransaction::EState;
 

--- a/ydb/core/persqueue/public/constants.h
+++ b/ydb/core/persqueue/public/constants.h
@@ -12,6 +12,8 @@ constexpr TStringBuf MESSAGE_ATTRIBUTE_DEDUPLICATION_ID = "message_deduplication
 constexpr TStringBuf MESSAGE_ATTRIBUTE_ATTRIBUTES = "__message_attributes";
 constexpr TStringBuf MESSAGE_ATTRIBUTE_DELAY_SECONDS = "__delay_seconds";
 
+constexpr TStringBuf WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX = "track_producer_id_in_tx";
+
 constexpr ui32 METRICS_LEVEL_DISABLED = 0;
 constexpr ui32 METRICS_LEVEL_DATABASE = 1;
 constexpr ui32 METRICS_LEVEL_OBJECT = 2;

--- a/ydb/core/persqueue/public/constants.h
+++ b/ydb/core/persqueue/public/constants.h
@@ -12,8 +12,6 @@ constexpr TStringBuf MESSAGE_ATTRIBUTE_DEDUPLICATION_ID = "message_deduplication
 constexpr TStringBuf MESSAGE_ATTRIBUTE_ATTRIBUTES = "__message_attributes";
 constexpr TStringBuf MESSAGE_ATTRIBUTE_DELAY_SECONDS = "__delay_seconds";
 
-constexpr TStringBuf WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX = "track_producer_id_in_tx";
-
 constexpr ui32 METRICS_LEVEL_DISABLED = 0;
 constexpr ui32 METRICS_LEVEL_DATABASE = 1;
 constexpr ui32 METRICS_LEVEL_OBJECT = 2;

--- a/ydb/core/persqueue/ut/events_ut.cpp
+++ b/ydb/core/persqueue/ut/events_ut.cpp
@@ -1,0 +1,214 @@
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/pqtablet/common/event_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#ifndef UNIT_ASSERT_TRUE
+#define UNIT_ASSERT_TRUE(e)  UNIT_ASSERT((e))
+#endif
+
+#ifndef UNIT_ASSERT_FALSE
+#define UNIT_ASSERT_FALSE(e) UNIT_ASSERT(!(e))
+#endif
+
+namespace NKikimr::NPQ {
+
+Y_UNIT_TEST_SUITE(EventsTest) {
+
+void AddReadOperation(NKikimrPQ::TDataTransaction& tx)
+{
+    auto* op = tx.AddOperations();
+    op->SetCommitOffsetsBegin(0);
+    op->SetCommitOffsetsEnd(0);
+}
+
+void AddKafkaReadOperation(NKikimrPQ::TDataTransaction& tx)
+{
+    auto* op = tx.AddOperations();
+    op->SetKafkaTransaction(true);
+    op->SetCommitOffsetsBegin(0);
+    op->SetCommitOffsetsEnd(0);
+}
+
+void AddWriteOperation(NKikimrPQ::TDataTransaction& tx, bool skipConflictCheck)
+{
+    auto* op = tx.AddOperations();
+    op->SetSkipConflictCheck(skipConflictCheck);
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_NonDataTx)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    event.Record.MutableConfig();
+
+    UNIT_ASSERT_FALSE(event.GetSkipSrcIdInfo());
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_DataEmptyOps)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    event.Record.MutableData();
+
+    UNIT_ASSERT_FALSE(event.GetSkipSrcIdInfo());
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_DataOnlyReads)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    auto* tx = event.Record.MutableData();
+    AddReadOperation(*tx);
+    AddKafkaReadOperation(*tx);
+
+    UNIT_ASSERT_FALSE(event.GetSkipSrcIdInfo());
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_DataAllWritesTrue)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    auto* tx = event.Record.MutableData();
+    AddWriteOperation(*tx, true);
+    AddWriteOperation(*tx, true);
+
+    UNIT_ASSERT_TRUE(event.GetSkipSrcIdInfo());
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_DataAllWritesFalse)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    auto* tx = event.Record.MutableData();
+    AddWriteOperation(*tx, false);
+    AddWriteOperation(*tx, false);
+
+    UNIT_ASSERT_FALSE(event.GetSkipSrcIdInfo());
+}
+
+Y_UNIT_TEST(TEvProposeTransaction_GetSkipSrcIdInfo_DataMixedFlags)
+{
+    TEvPersQueue::TEvProposeTransactionBuilder event;
+
+    auto* tx = event.Record.MutableData();
+    AddWriteOperation(*tx, false);
+    AddWriteOperation(*tx, true);
+
+    UNIT_ASSERT_FALSE(event.GetSkipSrcIdInfo());
+}
+
+void AddReadOperation(TVector<NKikimrPQ::TPartitionOperation>& ops)
+{
+    NKikimrPQ::TPartitionOperation op;
+    op.SetCommitOffsetsBegin(0);
+    op.SetCommitOffsetsEnd(0);
+    ops.push_back(std::move(op));
+}
+
+void AddWriteOperation(TVector<NKikimrPQ::TPartitionOperation>& ops, bool skipConflictCheck)
+{
+    NKikimrPQ::TPartitionOperation op;
+    op.SetSkipConflictCheck(skipConflictCheck);
+
+    ops.push_back(std::move(op));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_Empty)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_OnlyReads)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddReadOperation(ops);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_OneWriteTrue)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddWriteOperation(ops, true);
+
+    UNIT_ASSERT_TRUE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_MultipleWritesTrue)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddWriteOperation(ops, true);
+    AddWriteOperation(ops, true);
+
+    UNIT_ASSERT_TRUE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_OneWriteFalse)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddWriteOperation(ops, false);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_MultipleWritesFalse)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddWriteOperation(ops, false);
+    AddWriteOperation(ops, false);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_MixedFlagsOneEach)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddWriteOperation(ops, false);
+    AddWriteOperation(ops, true);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_ReadsAndWritesTrue)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddReadOperation(ops);
+    AddWriteOperation(ops, true);
+
+    UNIT_ASSERT_TRUE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_ReadsAndWritesFalse)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddReadOperation(ops);
+    AddWriteOperation(ops, false);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+Y_UNIT_TEST(AllExistingWritesSkipConflictCheck_ReadsAndWritesMixed)
+{
+    TVector<NKikimrPQ::TPartitionOperation> ops;
+
+    AddReadOperation(ops);
+    AddWriteOperation(ops, true);
+    AddWriteOperation(ops, false);
+
+    UNIT_ASSERT_FALSE(AllExistingWritesSkipConflictCheck(ops));
+}
+
+}
+
+}

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -295,7 +295,7 @@ protected:
     void SendChangeOwner(const ui64 cookie, const TString& owner, const TActorId& pipeClient, const bool force = true);
     void SendWrite(const ui64 cookie, const ui64 messageNo, const TString& ownerCookie, const TMaybe<ui64> offset, const TString& data,
                    bool ignoreQuotaDeadline = false, ui64 seqNo = 0, bool isDirectWrite = false);
-    void SendGetWriteInfo();
+    void SendGetWriteInfo(bool skipSrcIdInfo);
     void ShadowPartitionCountersTest(bool isFirstClass);
 
     void TestWriteSubDomainOutOfSpace(TDuration quotaWaitDuration, bool ignoreQuotaDeadline);
@@ -694,8 +694,8 @@ void TPartitionFixture::SendChangeOwner(const ui64 cookie, const TString& owner,
     Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
 }
 
-void TPartitionFixture::SendGetWriteInfo() {
-    auto event = MakeHolder<TEvPQ::TEvGetWriteInfoRequest>();
+void TPartitionFixture::SendGetWriteInfo(bool skipSrcIdInfo) {
+    auto event = MakeHolder<TEvPQ::TEvGetWriteInfoRequest>(skipSrcIdInfo);
     Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
 }
 
@@ -1251,7 +1251,7 @@ void TPartitionFixture::ShadowPartitionCountersTest(bool isFirstClass) {
     }
     TVector<ui64> msgSizesExpected{2, 2, 1, 1, 1, 1, 1, 1};
     CompareVectors(msgSizesExpected, finalCounters.GetMessagesSizes());
-    SendGetWriteInfo();
+    SendGetWriteInfo(false);
     {
         auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoResponse>(TDuration::Seconds(1));
         UNIT_ASSERT(event != nullptr);
@@ -2678,7 +2678,7 @@ Y_UNIT_TEST_F(GetPartitionWriteInfoSuccess, TPartitionFixture) {
         auto event = Ctx->Runtime->GrabEdgeEventIf<TEvPQ::TEvProxyResponse>(handle, truth, TDuration::Seconds(1));
         UNIT_ASSERT(event != nullptr);
     }
-    SendGetWriteInfo();
+    SendGetWriteInfo(false);
     {
         {
             auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoError>(TDuration::Seconds(1));
@@ -2751,7 +2751,7 @@ Y_UNIT_TEST_F(GetPartitionWriteInfoError, TPartitionFixture) {
     SendWrite(++cookie, 0, ownerCookie, 100, data, false, 1);
 
     {
-        SendGetWriteInfo();
+        SendGetWriteInfo(false);
         auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoError>(TDuration::Seconds(1));
         UNIT_ASSERT(event != nullptr);
     }
@@ -2762,7 +2762,7 @@ Y_UNIT_TEST_F(GetPartitionWriteInfoError, TPartitionFixture) {
         UNIT_ASSERT(event != nullptr);
     }
     {
-        SendGetWriteInfo();
+        SendGetWriteInfo(false);
         Cerr << "Wait write info error(2)\n";
         auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoError>(TDuration::Seconds(1));
         UNIT_ASSERT(event != nullptr);
@@ -4550,6 +4550,65 @@ Y_UNIT_TEST_F(AddBlobsFromBodyLastOffsetAndUpdateUsageSkips, TPartitionFixture) 
         return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
     });
     Ctx->Runtime->DispatchEvents(options);
+}
+
+Y_UNIT_TEST_F(GetPartitionWriteInfoWithoutSrcIdInfo, TPartitionFixture) {
+    Ctx->Runtime->GetAppData().PQConfig.MutableQuotingConfig()->SetEnableQuoting(false);
+
+    CreatePartition({
+                    .Partition=TPartitionId{2, TWriteId{0, 10}, 100'001},
+                    //
+                    // partition configuration
+                    //
+                    .Config={.Version=1, .Consumers={}}
+                    },
+                    //
+                    // tablet configuration
+                    //
+                    {.Version=2, .Consumers={}}
+    );
+
+    ui64 cookie = 1;
+
+    SendChangeOwner(cookie, "owner1", Ctx->Edge, true);
+    auto ownerEvent = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvProxyResponse>(TDuration::Seconds(1));
+    UNIT_ASSERT(ownerEvent != nullptr);
+    auto ownerCookie = ownerEvent->Response->GetPartitionResponse().GetCmdGetOwnershipResult().GetOwnerCookie();
+
+    TAutoPtr<IEventHandle> handle;
+    auto truth = [&](const TEvPQ::TEvProxyResponse& e) { return cookie == e.Cookie; };
+
+    TString data = "data for write";
+
+    for (auto i = 0; i < 3; i++) {
+        SendWrite(++cookie, i, ownerCookie, i + 100, data, true, (i+1)*2);
+        SendDiskStatusResponse();
+        {
+            auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvError>(TDuration::Seconds(1));
+            UNIT_ASSERT(event == nullptr);
+        }
+        auto event = Ctx->Runtime->GrabEdgeEventIf<TEvPQ::TEvProxyResponse>(handle, truth, TDuration::Seconds(1));
+        UNIT_ASSERT(event != nullptr);
+    }
+    SendWrite(++cookie, 3, ownerCookie, 110, data, true, 7);
+    SendDiskStatusResponse();
+    {
+        auto event = Ctx->Runtime->GrabEdgeEventIf<TEvPQ::TEvProxyResponse>(handle, truth, TDuration::Seconds(1));
+        UNIT_ASSERT(event != nullptr);
+    }
+    SendGetWriteInfo(true);
+    {
+        {
+            auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoError>(TDuration::Seconds(1));
+            UNIT_ASSERT(event == nullptr);
+        }
+        auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoResponse>(TDuration::Seconds(1));
+        UNIT_ASSERT(event != nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(event->BodyKeys.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(event->SrcIdInfo.size(), 0);
+
+        UNIT_ASSERT(event->BodyKeys.begin()->Key.ToString().StartsWith("D0000100001_"));
+    }
 }
 
 } // End of suite

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -48,6 +48,7 @@ SRCS(
     pqrb_describes_ut.cpp
     partition_scale_manager_graph_cmp_ut.cpp
     utils_ut.cpp
+    events_ut.cpp
 )
 
 RESOURCE(

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -331,6 +331,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         ev->Record.MutableRequest()->MutableTxControl()->set_tx_id(Opts.TxId);
 
         auto* operations = ev->Record.MutableRequest()->MutableTopicOperations();
+        operations->SetTrackProducerId(Opts.TrackProducerId);
         auto* topics = operations->AddTopics();
         topics->set_path(Opts.TopicPath);
         auto* partitions = topics->add_partitions();

--- a/ydb/core/persqueue/writer/writer.h
+++ b/ydb/core/persqueue/writer/writer.h
@@ -184,6 +184,7 @@ struct TPartitionWriterOpts {
     bool CheckState = false;
     bool AutoRegister = false;
     bool UseDeduplication = true;
+    bool TrackProducerId = true;
 
     TString SourceId;
     std::optional<ui32> ExpectedGeneration;
@@ -223,6 +224,7 @@ struct TPartitionWriterOpts {
     TPartitionWriterOpts& WithInitialSeqNo(const std::optional<ui64> value) { InitialSeqNo = value; return *this; }
     TPartitionWriterOpts& WithKafkaProducerInstanceId(const std::optional<NKafka::TProducerInstanceId>& value) { KafkaProducerInstanceId = value; return *this; }
     TPartitionWriterOpts& WithKafkaTransactionalId(const std::optional<TString>& value) { KafkaTransactionalId = value; return *this; }
+    TPartitionWriterOpts& WithTrackProducerId(bool value) { TrackProducerId = value; return *this; }
 };
 
 IActor* CreatePartitionWriter(const TActorId& client,

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -260,6 +260,7 @@ message TFeatureFlags {
     optional bool EnableLocalBloomNgramFilterIndex = 233 [default = false];
     optional bool EnableSetDropDefaultValue = 234 [ default = false];
     optional bool EnableStreamingQueriesPqSinkDeduplication = 235 [default = false];
+    optional bool EnableSkipConflictCheckForTopicsInTransaction = 243 [default = false];
     // Split protocol control.
     // By default, the schemeshard handles sorting and split boundary selection.
     // These flags move that work to the datashard side:

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -66,6 +66,7 @@ message TTopicOperationsRequest {
     repeated TopicOffsets Topics = 2;
     optional uint32 SupportivePartition = 3;
     optional uint64 TabletId = 4;
+    optional bool TrackProducerId = 5 [default = true];
 
     message TopicOffsets {
         // Topic path.

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -1037,6 +1037,7 @@ message TPartitionOperation {
     optional string ReadSessionId = 10;
     optional bool KafkaTransaction = 11 [default = false];
     optional TKafkaProducerInstanceId KafkaProducerInstanceId = 12;
+    optional bool SkipConflictCheck = 13;
 };
 
 message TWriteId {

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -82,6 +82,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardWriteAlwaysVolatile)
     FEATURE_FLAG_SETTER(EnableStreamingQueries)
     FEATURE_FLAG_SETTER(EnableSecureScriptExecutions)
+    FEATURE_FLAG_SETTER(EnableSkipConflictCheckForTopicsInTransaction)
     FEATURE_FLAG_SETTER(DisableMissingDefaultColumnsInBulkUpsert)
     FEATURE_FLAG_SETTER(EnableTopicMessageLevelParallelism)
     FEATURE_FLAG_SETTER(EnableTopicAutopartitioningForReplication)

--- a/ydb/library/persqueue/constants.h
+++ b/ydb/library/persqueue/constants.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NPersQueue {
+
+constexpr TStringBuf WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX = "track_producer_id_in_tx";
+
+}

--- a/ydb/library/persqueue/ya.make
+++ b/ydb/library/persqueue/ya.make
@@ -1,3 +1,11 @@
+LIBRARY()
+
+SRCS(
+    constants.h
+)
+
+END()
+
 RECURSE(
     counter_time_keeper
     deprecated

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -301,6 +301,7 @@ void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void
             .Direct = Direct,
             .Codec = Codec,
             .UseTransactions = UseTransactions,
+            .TrackProducerIdInTx = !NoTrackProducerIdInTx,
             .UseAutoPartitioning = useAutoPartitioning,
             .CommitIntervalMs = TxCommitIntervalMs != 0 ? TxCommitIntervalMs : CommitPeriodSeconds * 1000, // seconds to ms conversion
             .CommitMessages = CommitMessages,

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -73,6 +73,7 @@ public:
     TString TableName;
     ui32 TablePartitionCount = 1;
     bool UseTransactions = false;
+    bool NoTrackProducerIdInTx = false;
     size_t CommitPeriodSeconds = 1;
     size_t TxCommitIntervalMs = 0;
     size_t CommitMessages = 1'000'000;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_keyed_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_keyed_writer.cpp
@@ -2,8 +2,6 @@
 #include "topic_workload_keyed_writer_producer.h"
 #include "topic_workload_writer_worker_common.h"
 
-#include <ydb/core/persqueue/public/constants.h>
-
 #include <util/generic/overloaded.h>
 #include <util/generic/guid.h>
 
@@ -151,9 +149,7 @@ std::shared_ptr<TTopicWorkloadKeyedWriterProducer> TTopicWorkloadKeyedWriterWork
     settings.DirectWriteToPartition(Params.Direct);
 
     if (Params.UseTransactions) {
-        settings.AppendSessionMeta(
-            std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX},
-            Params.TrackProducerIdInTx ? "true" : "false");
+        settings.SetTrackProducerIdInTx(Params.TrackProducerIdInTx);
     }
 
     producer->SetWriteSession(topicClient.CreateKeyedWriteSession(settings));

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_keyed_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_keyed_writer.cpp
@@ -2,8 +2,12 @@
 #include "topic_workload_keyed_writer_producer.h"
 #include "topic_workload_writer_worker_common.h"
 
+#include <ydb/core/persqueue/public/constants.h>
+
 #include <util/generic/overloaded.h>
 #include <util/generic/guid.h>
+
+#include <string>
 
 namespace NYdb::NConsoleClient {
 
@@ -145,6 +149,12 @@ std::shared_ptr<TTopicWorkloadKeyedWriterProducer> TTopicWorkloadKeyedWriterWork
     settings.EventHandlers(eventHandlers);
 
     settings.DirectWriteToPartition(Params.Direct);
+
+    if (Params.UseTransactions) {
+        settings.AppendSessionMeta(
+            std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX},
+            Params.TrackProducerIdInTx ? "true" : "false");
+    }
 
     producer->SetWriteSession(topicClient.CreateKeyedWriteSession(settings));
     return producer;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -99,6 +99,9 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .Optional()
         .DefaultValue(false)
         .StoreTrue(&Scenario.UseTransactions);
+    config.Opts->AddLongOption("no-producer-id-track", "Disable ProducerId tracking in tx (only applies with --use-tx).")
+        .Optional()
+        .StoreTrue(&Scenario.NoTrackProducerIdInTx);
     config.Opts->AddLongOption("tx-commit-interval", "Interval of transaction commit in milliseconds."
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1000)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -101,6 +101,7 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .StoreTrue(&Scenario.UseTransactions);
     config.Opts->AddLongOption("no-producer-id-track", "Disable ProducerId tracking in tx (only applies with --use-tx).")
         .Optional()
+        .Hidden()
         .StoreTrue(&Scenario.NoTrackProducerIdInTx);
     config.Opts->AddLongOption("tx-commit-interval", "Interval of transaction commit in milliseconds."
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -87,6 +87,9 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .Optional()
         .DefaultValue(false)
         .StoreTrue(&Scenario.UseTransactions);
+    config.Opts->AddLongOption("no-producer-id-track", "Disable ProducerId tracking in tx (only applies with --use-tx).")
+        .Optional()
+        .StoreTrue(&Scenario.NoTrackProducerIdInTx);
     config.Opts->AddLongOption("commit-period", "DEPRECATED: use tx-commit-intervall-ms instead. Waiting time between commit in seconds. Default - 1 second")
         .Optional()
         .Hidden()

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -89,6 +89,7 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .StoreTrue(&Scenario.UseTransactions);
     config.Opts->AddLongOption("no-producer-id-track", "Disable ProducerId tracking in tx (only applies with --use-tx).")
         .Optional()
+        .Hidden()
         .StoreTrue(&Scenario.NoTrackProducerIdInTx);
     config.Opts->AddLongOption("commit-period", "DEPRECATED: use tx-commit-intervall-ms instead. Waiting time between commit in seconds. Default - 1 second")
         .Optional()

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -4,8 +4,6 @@
 #include "topic_workload_configurator.h"
 #include "topic_workload_describe.h"
 
-#include <ydb/core/persqueue/public/constants.h>
-
 #include <util/generic/overloaded.h>
 #include <util/generic/guid.h>
 
@@ -168,9 +166,7 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
     settings.DirectWriteToPartition(Params.Direct);
 
     if (Params.UseTransactions) {
-        settings.AppendSessionMeta(
-            std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX},
-            Params.TrackProducerIdInTx ? "true" : "false");
+        settings.SetTrackProducerIdInTx(Params.TrackProducerIdInTx);
     }
 
     producer->SetWriteSession(NYdb::NTopic::TTopicClient(Params.Driver).CreateWriteSession(settings));

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -4,8 +4,12 @@
 #include "topic_workload_configurator.h"
 #include "topic_workload_describe.h"
 
+#include <ydb/core/persqueue/public/constants.h>
+
 #include <util/generic/overloaded.h>
 #include <util/generic/guid.h>
+
+#include <string>
 
 using namespace NYdb::NConsoleClient;
 
@@ -162,6 +166,12 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
     }
 
     settings.DirectWriteToPartition(Params.Direct);
+
+    if (Params.UseTransactions) {
+        settings.AppendSessionMeta(
+            std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX},
+            Params.TrackProducerIdInTx ? "true" : "false");
+    }
 
     producer->SetWriteSession(NYdb::NTopic::TTopicClient(Params.Driver).CreateWriteSession(settings));
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -32,6 +32,7 @@ namespace NYdb {
             bool Direct;
             ui32 Codec = 0;
             bool UseTransactions = false;
+            bool TrackProducerIdInTx = true;
             bool UseAutoPartitioning = false;
             bool UseTableSelect = false;
             bool UseTableUpsert = false;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -21,6 +21,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/persqueue/public
     yql/essentials/public/issue
     yql/essentials/public/issue/protos
     ydb/library/backup

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ya.make
@@ -21,7 +21,6 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/core/persqueue/public
     yql/essentials/public/issue
     yql/essentials/public/issue/protos
     ydb/library/backup

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
@@ -142,6 +142,8 @@ struct TWriteSessionSettings : public TRequestSettings<TWriteSessionSettings> {
 
     //! Enables validation of SeqNo. If enabled, then writer will check writing with seqNo and without it and throws exception.
     FLUENT_SETTING_DEFAULT(bool, ValidateSeqNo, true);
+
+    TWriteSessionSettings& SetTrackProducerIdInTx(bool value);
 };
 
 struct TKeyedWriteSessionSettings : public TWriteSessionSettings {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session.cpp
@@ -4,6 +4,8 @@
 #include <ydb/public/sdk/cpp/src/client/topic/common/simple_blocking_helpers.h>
 #include <ydb/public/sdk/cpp/src/library/decimal/yql_decimal.h>
 
+#include <ydb/library/persqueue/constants.h>
+
 #include <library/cpp/threading/future/wait/wait.h>
 #include <library/cpp/threading/future/subscription/wait_any.h>
 
@@ -14,6 +16,13 @@
 #include <format>
 
 namespace NYdb::inline Dev::NTopic {
+
+TWriteSessionSettings& TWriteSessionSettings::SetTrackProducerIdInTx(bool value)
+{
+    const auto& key = NPersQueue::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX;
+    return AppendSessionMeta({key.data(), key.size()},
+                             value ? "true" : "false");
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TWriteSession

--- a/ydb/public/sdk/cpp/src/client/topic/impl/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     library/cpp/threading/future/subscription
     library/cpp/monlib/metrics
     library/cpp/string_utils/url
+    ydb/library/persqueue
     ydb/public/sdk/cpp/src/library/persqueue/obfuscate
     ydb/public/api/grpc/draft
     ydb/public/api/grpc

--- a/ydb/public/sdk/cpp/src/client/topic/ut/topic_tx_skip_conflict_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/topic_tx_skip_conflict_ut.cpp
@@ -1,6 +1,6 @@
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.h>
 
-#include <ydb/core/persqueue/public/constants.h>
+#include <ydb/library/persqueue/constants.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -208,10 +208,9 @@ protected:
     }
 
     void AugmentWriteSessionSettings(NTopic::TWriteSessionSettings& options) override {
-        if constexpr (TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::True) {
-            options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "true");
-        } else if constexpr (TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::False) {
-            options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "false");
+        if ((TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::True) ||
+            (TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::False)) {
+            options.SetTrackProducerIdInTx(TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::True);
         }
     }
 };
@@ -284,7 +283,8 @@ Y_UNIT_TEST_F(InvalidWriteSessionAttributeTrackProducerIdInTx_RejectsInit, TFixt
     options.ProducerId(TEST_MESSAGE_GROUP_ID);
     options.MessageGroupId(TEST_MESSAGE_GROUP_ID);
     options.Codec(ECodec::RAW);
-    options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "not-a-bool");
+    const auto& key = ::NPersQueue::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX;
+    options.AppendSessionMeta({key.data(), key.size()}, "not-a-bool");
 
     auto ws = client.CreateWriteSession(options);
 
@@ -306,7 +306,7 @@ Y_UNIT_TEST_F(InvalidWriteSessionAttributeTrackProducerIdInTx_RejectsInit, TFixt
     UNIT_ASSERT_C(closed.has_value(), "session must close after invalid WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX");
     UNIT_ASSERT_VALUES_EQUAL(closed->GetStatus(), EStatus::BAD_REQUEST);
     const TString issues = closed->GetIssues().ToOneLineString();
-    UNIT_ASSERT_STRING_CONTAINS(issues, NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX);
+    UNIT_ASSERT_STRING_CONTAINS(issues, key);
     UNIT_ASSERT_STRING_CONTAINS(issues, "not-a-bool");
 
     ws->Close(TDuration::Seconds(5));

--- a/ydb/public/sdk/cpp/src/client/topic/ut/topic_tx_skip_conflict_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/topic_tx_skip_conflict_ut.cpp
@@ -1,0 +1,317 @@
+#include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.h>
+
+#include <ydb/core/persqueue/public/constants.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/base.h>
+
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace NYdb::inline Dev::NTopic::NTests::NTxUsage {
+
+namespace {
+
+enum class ETrackProducerIdInTxMeta {
+    Absent,
+    True,
+    False,
+};
+
+class TFixtureTopicTxMatrixBase : public TFixtureTable {
+protected:
+    size_t CountTableRowsWithKey(const std::string& tablePath, const std::string& key) {
+        auto session = CreateSession();
+        auto tx = session->BeginTx();
+        const auto query = Sprintf(
+            R"(DECLARE $k AS Utf8; SELECT COUNT(*) AS cnt FROM `%s` WHERE key = $k;)",
+            tablePath.c_str());
+        auto params = TParamsBuilder().AddParam("$k").Utf8(key).Build().Build();
+        auto result = session->Execute(query, tx.get(), true, params);
+        NYdb::TResultSetParser parser(result.at(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        return static_cast<size_t>(parser.ColumnParser(0).GetUint64());
+    }
+
+    void AssertTableKeyValue(const std::string& tablePath, const std::string& key, const std::string& expectedValue) {
+        auto session = CreateSession();
+        auto tx = session->BeginTx();
+        const auto query = Sprintf(
+            R"(DECLARE $k AS Utf8; SELECT value FROM `%s` WHERE key = $k;)",
+            tablePath.c_str());
+        auto params = TParamsBuilder().AddParam("$k").Utf8(key).Build().Build();
+        auto result = session->Execute(query, tx.get(), true, params);
+        NYdb::TResultSetParser parser(result.at(0));
+        UNIT_ASSERT_C(parser.TryNextRow(), key.c_str());
+        UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(0).GetUtf8(), expectedValue);
+    }
+
+    /// Two table sessions, same producer id, two writes per tx, both write sessions closed before any commit.
+    /// First commit is always SUCCESS; \p expectedTx2CommitStatus is asserted for the second (SeqNo / conflict policy).
+    void RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus expectedTx2CommitStatus) {
+        CreateTopic("topic_A", TEST_CONSUMER, 1);
+
+        const std::string producer = TEST_MESSAGE_GROUP_ID;
+
+        auto makeSettings = [&]() {
+            NTopic::TWriteSessionSettings options;
+            options.Path(GetTopicUtPath("topic_A"));
+            options.ProducerId(producer);
+            options.MessageGroupId(producer);
+            options.Codec(ECodec::RAW);
+            AugmentWriteSessionSettings(options);
+            return options;
+        };
+
+        NTopic::TTopicClient client(GetDriver());
+
+        auto session1 = CreateSession();
+        auto tx1 = session1->BeginTx();
+        {
+            auto ws1 = client.CreateSimpleBlockingWriteSession(makeSettings());
+            UNIT_ASSERT_C(ws1->Write(NTopic::TWriteMessage("m1"), tx1.get()), "write session 1, message 1");
+            UNIT_ASSERT_C(ws1->Write(NTopic::TWriteMessage("m2"), tx1.get()), "write session 1, message 2");
+            UNIT_ASSERT_C(ws1->Close(), "close write session 1");
+        }
+
+        auto session2 = CreateSession();
+        auto tx2 = session2->BeginTx();
+        {
+            auto ws2 = client.CreateSimpleBlockingWriteSession(makeSettings());
+            UNIT_ASSERT_C(ws2->Write(NTopic::TWriteMessage("m3"), tx2.get()), "write session 2, message 1");
+            UNIT_ASSERT_C(ws2->Write(NTopic::TWriteMessage("m4"), tx2.get()), "write session 2, message 2");
+            UNIT_ASSERT_C(ws2->Close(), "close write session 2");
+        }
+
+        session1->CommitTx(*tx1, EStatus::SUCCESS);
+        session2->CommitTx(*tx2, expectedTx2CommitStatus);
+
+        auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+        switch (expectedTx2CommitStatus) {
+        case EStatus::ABORTED:
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0], "m1");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1], "m2");
+            break;
+        case EStatus::SUCCESS:
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 4u);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0], "m1");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1], "m2");
+            UNIT_ASSERT_VALUES_EQUAL(messages[2], "m3");
+            UNIT_ASSERT_VALUES_EQUAL(messages[3], "m4");
+            break;
+        default:
+            UNIT_FAIL("unexpected expectedTx2CommitStatus for topic read assertions");
+            break;
+        }
+    }
+
+    /// Same as \ref RunSeqNoConflictTwoWriteSessionsSameProducer, but each transaction also upserts disjoint rows
+    /// into a row table so KQP uses distributed commit (topic tablet + data shard), not immediate topic-only commit.
+    void RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus expectedTx2CommitStatus) {
+        static constexpr const char* kTable = "table_A";
+        const std::vector<TTableRecord> tx1Rows = {
+            {"dist_seq_tx1_a", "v1"},
+            {"dist_seq_tx1_b", "v2"},
+        };
+        const std::vector<TTableRecord> tx2Rows = {
+            {"dist_seq_tx2_a", "v3"},
+            {"dist_seq_tx2_b", "v4"},
+        };
+
+        CreateTopic("topic_A", TEST_CONSUMER, 1);
+        CreateTable("/Root/table_A");
+
+        const std::string producer = TEST_MESSAGE_GROUP_ID;
+
+        auto makeSettings = [&]() {
+            NTopic::TWriteSessionSettings options;
+            options.Path(GetTopicUtPath("topic_A"));
+            options.ProducerId(producer);
+            options.MessageGroupId(producer);
+            options.Codec(ECodec::RAW);
+            AugmentWriteSessionSettings(options);
+            return options;
+        };
+
+        NTopic::TTopicClient client(GetDriver());
+
+        auto session1 = CreateSession();
+        auto tx1 = session1->BeginTx();
+        {
+            auto ws1 = client.CreateSimpleBlockingWriteSession(makeSettings());
+            UNIT_ASSERT_C(ws1->Write(NTopic::TWriteMessage("m1"), tx1.get()), "write session 1, message 1");
+            UNIT_ASSERT_C(ws1->Write(NTopic::TWriteMessage("m2"), tx1.get()), "write session 1, message 2");
+            UNIT_ASSERT_C(ws1->Close(), "close write session 1");
+        }
+        UpsertToTable(kTable, tx1Rows, *session1, tx1.get());
+
+        auto session2 = CreateSession();
+        auto tx2 = session2->BeginTx();
+        {
+            auto ws2 = client.CreateSimpleBlockingWriteSession(makeSettings());
+            UNIT_ASSERT_C(ws2->Write(NTopic::TWriteMessage("m3"), tx2.get()), "write session 2, message 1");
+            UNIT_ASSERT_C(ws2->Write(NTopic::TWriteMessage("m4"), tx2.get()), "write session 2, message 2");
+            UNIT_ASSERT_C(ws2->Close(), "close write session 2");
+        }
+        UpsertToTable(kTable, tx2Rows, *session2, tx2.get());
+
+        session1->CommitTx(*tx1, EStatus::SUCCESS);
+        session2->CommitTx(*tx2, expectedTx2CommitStatus);
+
+        auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+
+        switch (expectedTx2CommitStatus) {
+        case EStatus::ABORTED:
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0], "m1");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1], "m2");
+            UNIT_ASSERT_VALUES_EQUAL(GetTableRecordsCount(kTable), 2u);
+            for (const auto& row : tx1Rows) {
+                UNIT_ASSERT_VALUES_EQUAL(CountTableRowsWithKey(kTable, row.Key), 1u);
+                AssertTableKeyValue(kTable, row.Key, row.Value);
+            }
+            for (const auto& row : tx2Rows) {
+                UNIT_ASSERT_VALUES_EQUAL(CountTableRowsWithKey(kTable, row.Key), 0u);
+            }
+            break;
+        case EStatus::SUCCESS:
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 4u);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0], "m1");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1], "m2");
+            UNIT_ASSERT_VALUES_EQUAL(messages[2], "m3");
+            UNIT_ASSERT_VALUES_EQUAL(messages[3], "m4");
+            UNIT_ASSERT_VALUES_EQUAL(GetTableRecordsCount(kTable), 4u);
+            for (const auto& row : tx1Rows) {
+                UNIT_ASSERT_VALUES_EQUAL(CountTableRowsWithKey(kTable, row.Key), 1u);
+                AssertTableKeyValue(kTable, row.Key, row.Value);
+            }
+            for (const auto& row : tx2Rows) {
+                UNIT_ASSERT_VALUES_EQUAL(CountTableRowsWithKey(kTable, row.Key), 1u);
+                AssertTableKeyValue(kTable, row.Key, row.Value);
+            }
+            break;
+        default:
+            UNIT_FAIL("unexpected expectedTx2CommitStatus for distributed topic/table assertions");
+            break;
+        }
+    }
+};
+
+template<bool EnableSkipConflictCheckForTopicsInTransaction, ETrackProducerIdInTxMeta TrackProducerIdInTxMeta>
+class TFixtureTopicTxMatrix : public TFixtureTopicTxMatrixBase {
+protected:
+    void AugmentServerSettings(NKikimr::Tests::TServerSettings& settings) override {
+        settings.SetEnableSkipConflictCheckForTopicsInTransaction(EnableSkipConflictCheckForTopicsInTransaction);
+    }
+
+    void AugmentWriteSessionSettings(NTopic::TWriteSessionSettings& options) override {
+        if constexpr (TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::True) {
+            options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "true");
+        } else if constexpr (TrackProducerIdInTxMeta == ETrackProducerIdInTxMeta::False) {
+            options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "false");
+        }
+    }
+};
+
+using TFixture_SkipConflictOff_MetaAbsent = TFixtureTopicTxMatrix<false, ETrackProducerIdInTxMeta::Absent>;
+using TFixture_SkipConflictOff_MetaTrue = TFixtureTopicTxMatrix<false, ETrackProducerIdInTxMeta::True>;
+using TFixture_SkipConflictOff_MetaFalse = TFixtureTopicTxMatrix<false, ETrackProducerIdInTxMeta::False>;
+using TFixture_SkipConflictOn_MetaAbsent = TFixtureTopicTxMatrix<true, ETrackProducerIdInTxMeta::Absent>;
+using TFixture_SkipConflictOn_MetaTrue = TFixtureTopicTxMatrix<true, ETrackProducerIdInTxMeta::True>;
+using TFixture_SkipConflictOn_MetaFalse = TFixtureTopicTxMatrix<true, ETrackProducerIdInTxMeta::False>;
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TopicTxSkipConflictAndProducerMeta) {
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOff_MetaAbsent, TFixture_SkipConflictOff_MetaAbsent) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOff_MetaTrue, TFixture_SkipConflictOff_MetaTrue) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOff_MetaFalse, TFixture_SkipConflictOff_MetaFalse) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOn_MetaAbsent, TFixture_SkipConflictOn_MetaAbsent) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOn_MetaTrue, TFixture_SkipConflictOn_MetaTrue) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_TwoWriteSessions_SkipConflictOn_MetaFalse, TFixture_SkipConflictOn_MetaFalse) {
+    RunSeqNoConflictTwoWriteSessionsSameProducer(EStatus::SUCCESS);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOff_MetaAbsent, TFixture_SkipConflictOff_MetaAbsent) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOff_MetaTrue, TFixture_SkipConflictOff_MetaTrue) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOff_MetaFalse, TFixture_SkipConflictOff_MetaFalse) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOn_MetaAbsent, TFixture_SkipConflictOn_MetaAbsent) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOn_MetaTrue, TFixture_SkipConflictOn_MetaTrue) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(SeqNoConflict_Distributed_TwoWriteSessions_SkipConflictOn_MetaFalse, TFixture_SkipConflictOn_MetaFalse) {
+    RunSeqNoConflictTwoWriteSessionsSameProducerDistributed(EStatus::SUCCESS);
+}
+
+Y_UNIT_TEST_F(InvalidWriteSessionAttributeTrackProducerIdInTx_RejectsInit, TFixtureTable) {
+    CreateTopic("topic_A", TEST_CONSUMER, 1);
+
+    NTopic::TTopicClient client(GetDriver());
+    NTopic::TWriteSessionSettings options;
+    options.Path(GetTopicUtPath("topic_A"));
+    options.ProducerId(TEST_MESSAGE_GROUP_ID);
+    options.MessageGroupId(TEST_MESSAGE_GROUP_ID);
+    options.Codec(ECodec::RAW);
+    options.AppendSessionMeta(std::string{NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}, "not-a-bool");
+
+    auto ws = client.CreateWriteSession(options);
+
+    std::optional<NTopic::TSessionClosedEvent> closed;
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+    while (!closed.has_value()) {
+        UNIT_ASSERT_C(
+            TInstant::Now() < deadline,
+            "timed out waiting for write session close after invalid WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX");
+
+        if (auto ev = ws->GetEvent(false)) {
+            if (auto* c = std::get_if<NTopic::TSessionClosedEvent>(&*ev)) {
+                closed.emplace(*c);
+            }
+        } else {
+            Sleep(TDuration::MilliSeconds(50));
+        }
+    }
+    UNIT_ASSERT_C(closed.has_value(), "session must close after invalid WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX");
+    UNIT_ASSERT_VALUES_EQUAL(closed->GetStatus(), EStatus::BAD_REQUEST);
+    const TString issues = closed->GetIssues().ToOneLineString();
+    UNIT_ASSERT_STRING_CONTAINS(issues, NKikimr::NPQ::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX);
+    UNIT_ASSERT_STRING_CONTAINS(issues, "not-a-bool");
+
+    ws->Close(TDuration::Seconds(5));
+}
+
+} // Y_UNIT_TEST_SUITE(TopicTxSkipConflictAndProducerMeta)
+
+} // namespace NYdb::inline Dev::NTopic::NTests::NTxUsage

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.cpp
@@ -42,6 +42,7 @@ void TFixture::SetUp(NUnitTest::TTestContext&)
     settings.SetEnableOlapSink(GetEnableOlapSink());
     settings.SetEnableHtapTx(GetEnableHtapTx());
     settings.SetAllowOlapDataQuery(GetAllowOlapDataQuery());
+    AugmentServerSettings(settings);
 
     Setup = std::make_unique<TTopicSdkTestSetup>(TEST_CASE_NAME, settings);
 
@@ -56,6 +57,14 @@ void TFixture::SetUp(NUnitTest::TTestContext&)
 
     TableClient = std::make_unique<NTable::TTableClient>(*Driver, tableSettings);
     QueryClient = std::make_unique<NQuery::TQueryClient>(*Driver, querySettings);
+}
+
+void TFixture::AugmentServerSettings(NKikimr::Tests::TServerSettings&)
+{
+}
+
+void TFixture::AugmentWriteSessionSettings(NTopic::TWriteSessionSettings&)
+{
 }
 
 void TFixture::NotifySchemeShard(const TFeatureFlags& flags)
@@ -395,6 +404,7 @@ auto TFixture::CreateTopicWriteSession(const std::string& topicPath,
     options.MessageGroupId(messageGroupId);
     options.PartitionId(partitionId);
     options.Codec(ECodec::RAW);
+    AugmentWriteSessionSettings(options);
     return client.CreateWriteSession(options);
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.h
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.h
@@ -189,6 +189,11 @@ protected:
     void WriteMessagesInTx(std::size_t big, size_t small);
 
     const TDriver& GetDriver() const;
+    /// Topic path for SDK: `TTopicSdkTestSetup::GetTopicPath(name)` (typically `TopicPrefix_ + name`; prefix is empty by default),
+    /// i.e. relative to the driver database, not a cluster-absolute path. For use outside TFixture members without `Setup` access.
+    std::string GetTopicUtPath(const std::string& name) const {
+        return Setup->GetTopicPath(name);
+    }
     NTable::TTableClient& GetTableClient();
 
     void CheckTabletKeys(const std::string& topicName);
@@ -272,6 +277,11 @@ protected:
     virtual bool GetEnableOlapSink() const;
     virtual bool GetEnableHtapTx() const;
     virtual bool GetAllowOlapDataQuery() const;
+
+    /// Called from SetUp after TTopicSdkTestSetup::MakeServerSettings() and HTAP-related setters.
+    virtual void AugmentServerSettings(NKikimr::Tests::TServerSettings& settings);
+    /// Called from CreateTopicWriteSession before CreateWriteSession (Topic API write_session_meta).
+    virtual void AugmentWriteSessionSettings(NTopic::TWriteSessionSettings& settings);
 
     size_t GetPQCacheRenameKeysCount();
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
@@ -12,7 +12,7 @@ ENDIF()
 FORK_SUBTESTS()
 
 PEERDIR(
-    ydb/core/persqueue/public
+    ydb/library/persqueue
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
 )
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
@@ -12,6 +12,7 @@ ENDIF()
 FORK_SUBTESTS()
 
 PEERDIR(
+    ydb/core/persqueue/public
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
 )
 
@@ -22,6 +23,7 @@ SRCS(
     describe_topic_ut.cpp
     local_partition_ut.cpp
     topic_to_table_ut.cpp
+    topic_tx_skip_conflict_ut.cpp
 )
 
 RESOURCE(

--- a/ydb/services/persqueue_v1/actors/write_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.cpp
@@ -6,6 +6,7 @@
 #include <ydb/services/metadata/manager/common.h>
 
 #include <ydb/library/persqueue/topic_parser/counters.h>
+#include <ydb/library/persqueue/constants.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/core/base/wilson_tracing_control.h>
 #include <ydb/core/persqueue/public/constants.h>
@@ -119,7 +120,7 @@ inline void FillExtraFieldsForDataChunk(
             logType = item.second;
         } else if (item.first == "file") {
             file = item.second;
-        } else if (item.first == WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
+        } else if (item.first == NPersQueue::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
             continue;
         } else {
             auto res = data.MutableExtraFields()->AddItems();
@@ -750,12 +751,12 @@ bool TWriteSessionActor<UseMigrationProtocol>::CreatePartitionWriterCache(const 
 
     if constexpr (!UseMigrationProtocol) {
         for (const auto& item : InitRequest.write_session_meta()) {
-            if (item.first == WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
+            if (item.first == NPersQueue::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
                 bool trackProducerId = opts.TrackProducerId;
                 if (!TryFromString<bool>(item.second, trackProducerId)) {
                     CloseSession(
                         Sprintf("invalid value for write_session_meta key '%s': expected boolean, got '%s'",
-                                TString{WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}.c_str(),
+                                TString{NPersQueue::WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}.c_str(),
                                 item.second.c_str()),
                         PersQueue::ErrorCode::BAD_REQUEST,
                         ctx);

--- a/ydb/services/persqueue_v1/actors/write_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.cpp
@@ -8,6 +8,7 @@
 #include <ydb/library/persqueue/topic_parser/counters.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/core/base/wilson_tracing_control.h>
+#include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/pq_database.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/base/feature_flags.h>
@@ -17,6 +18,7 @@
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 #include <ydb/library/actors/core/log.h>
 #include <google/protobuf/util/time_util.h>
+#include <util/string/cast.h>
 #include <util/string/hex.h>
 #include <util/string/vector.h>
 #include <util/string/escape.h>
@@ -117,6 +119,8 @@ inline void FillExtraFieldsForDataChunk(
             logType = item.second;
         } else if (item.first == "file") {
             file = item.second;
+        } else if (item.first == WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
+            continue;
         } else {
             auto res = data.MutableExtraFields()->AddItems();
             res->SetKey(item.first);
@@ -715,7 +719,9 @@ void TWriteSessionActor<UseMigrationProtocol>::ProceedPartition(const ui32 parti
         return;
     }
 
-    CreatePartitionWriterCache(ctx);
+    if (!CreatePartitionWriterCache(ctx)) {
+        return;
+    }
 
     State = ES_WAIT_WRITER_INIT;
 
@@ -733,7 +739,7 @@ void TWriteSessionActor<UseMigrationProtocol>::ProceedPartition(const ui32 parti
 }
 
 template <bool UseMigrationProtocol>
-void TWriteSessionActor<UseMigrationProtocol>::CreatePartitionWriterCache(const TActorContext& ctx)
+bool TWriteSessionActor<UseMigrationProtocol>::CreatePartitionWriterCache(const TActorContext& ctx)
 {
     NPQ::TPartitionWriterOpts opts;
 
@@ -741,6 +747,25 @@ void TWriteSessionActor<UseMigrationProtocol>::CreatePartitionWriterCache(const 
     opts.WithSourceId(SourceId);
     opts.WithInitialSeqNo(InitialSeqNo);
     opts.WithExpectedGeneration(ExpectedGeneration);
+
+    if constexpr (!UseMigrationProtocol) {
+        for (const auto& item : InitRequest.write_session_meta()) {
+            if (item.first == WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX) {
+                bool trackProducerId = opts.TrackProducerId;
+                if (!TryFromString<bool>(item.second, trackProducerId)) {
+                    CloseSession(
+                        Sprintf("invalid value for write_session_meta key '%s': expected boolean, got '%s'",
+                                TString{WRITE_SESSION_ATTRIBUTE_TRACK_PRODUCER_ID_IN_TX}.c_str(),
+                                item.second.c_str()),
+                        PersQueue::ErrorCode::BAD_REQUEST,
+                        ctx);
+                    return false;
+                }
+                opts.WithTrackProducerId(trackProducerId);
+                break;
+            }
+        }
+    }
 
     if constexpr (UseMigrationProtocol) {
         opts.WithTopicPath(InitRequest.topic());
@@ -767,6 +792,7 @@ void TWriteSessionActor<UseMigrationProtocol>::CreatePartitionWriterCache(const 
                                                      opts);
 
     PartitionWriterCache = ctx.RegisterWithSameMailbox(actor.release());
+    return true;
 }
 
 template <bool UseMigrationProtocol>

--- a/ydb/services/persqueue_v1/actors/write_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.h
@@ -172,7 +172,7 @@ private:
     void CloseSpans(const TString& errorReason, const PersQueue::ErrorCode::ErrorCode errorCode);
 
 private:
-    void CreatePartitionWriterCache(const TActorContext& ctx);
+    bool CreatePartitionWriterCache(const TActorContext& ctx);
     void DestroyPartitionWriterCache(const TActorContext& ctx);
     NWilson::TSpan GenerateSpan(NJaegerTracing::ERequestType subrequestType, const TStringBuf name) const;
     NWilson::TSpan GenerateInitSpan() const {

--- a/ydb/services/persqueue_v1/actors/ya.make
+++ b/ydb/services/persqueue_v1/actors/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     ydb/core/tx/scheme_cache
     ydb/core/ydb_convert
     ydb/library/aclib
+    ydb/library/persqueue
     ydb/library/persqueue/topic_parser
     ydb/library/cloud_permissions
     ydb/public/api/protos


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR introduces an optimization and configurability for Topic-in-transaction conflict handling by allowing ProducerId tracking (and related conflict checks / metadata exchange) to be disabled in specific transaction scenarios, with supporting feature flags, protocol fields, and tests.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
