### PR TITLE
fix(datashard_kqp_scan): return PRECONDITION_FAILED status instead of SCHEME_MISMATCH in case of invalid snapshot

### DIFF
--- a/ydb/core/tx/datashard/datashard__kqp_scan.cpp
+++ b/ydb/core/tx/datashard/datashard__kqp_scan.cpp
@@ -579,18 +579,17 @@ void TDataShard::HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorCont
 
     auto infoIt = TableInfos.find(request.GetLocalPathId());
 
-    auto reportError = [this, scanComputeActor, generation] (const TString& table, const TString& detailedReason) {
+    auto reportError = [this, scanComputeActor, generation] (const NYql::TIssuesIds_EIssueCode issueCode, const TString& detailedReason) {
         auto ev = MakeHolder<TEvKqpCompute::TEvScanError>(generation, TabletID());
         ev->Record.SetStatus(Ydb::StatusIds::ABORTED);
-        auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() <<
-            "Table '" << table << "' scheme changed.");
+        auto issue = NYql::YqlIssue({}, issueCode, detailedReason);
         IssueToMessage(issue, ev->Record.MutableIssues()->Add());
         Send(scanComputeActor, ev.Release(), IEventHandle::FlagTrackDelivery);
         LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, detailedReason);
     };
 
     if (infoIt == TableInfos.end()) {
-        reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+        reportError(NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() << "TxId: " << request.GetTxId() << "."
             << " Can not find table '" << request.GetTablePath() << "'"
             << " by LocalPathId " << request.GetLocalPathId() << " at " << TabletID());
         return;
@@ -603,7 +602,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorCont
     if (tableInfo->GetTableSchemaVersion() != 0 &&
         request.GetSchemaVersion() != tableInfo->GetTableSchemaVersion())
     {
-        reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+        reportError(NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() << "TxId: " << request.GetTxId() << "."
             << " Table '" << request.GetTablePath() << "'"
             << " schema version changed at " << TabletID());
         return;
@@ -612,7 +611,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorCont
     for (int i = 0; i < request.GetColumnTags().size(); ++i) {
         auto* column = tableColumns.FindPtr(request.GetColumnTags(i));
         if (!column) {
-            reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+            reportError(NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() << "TxId: " << request.GetTxId() << "."
                 << " Cant find table '" << request.GetTablePath() << "'"
                 << " column " << request.GetColumnTags(i)  << " at " << TabletID());
             return;
@@ -620,7 +619,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorCont
 
         const auto& typeInfoMod = NScheme::TypeInfoModFromProtoColumnType(request.GetColumnTypes(i), &request.GetColumnTypeInfos(i));
         if (column->Type != typeInfoMod.TypeInfo || column->TypeMod != typeInfoMod.TypeMod) {
-            reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+            reportError(NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() << "TxId: " << request.GetTxId() << "."
                 << " Table '" << request.GetTablePath() << "'"
                 << " column " << request.GetColumnTags(i)  << " type mismatch at " << TabletID());
             return;
@@ -644,13 +643,13 @@ void TDataShard::HandleSafe(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorCont
 
     auto snapshotKey = TSnapshotKey(PathOwnerId, request.GetLocalPathId(), snapshot.GetStep(), snapshot.GetTxId());
     if (!SnapshotManager.FindAvailable(snapshotKey)) {
-        reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+        reportError(NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED, TStringBuilder() << "TxId: " << request.GetTxId() << "."
             << " Snapshot is not valid, tabletId: " << TabletID() << ", step: " << snapshot.GetStep());
         return;
     }
 
     if (!IsStateActive()) {
-        reportError(request.GetTablePath(), TStringBuilder() << "TxId: " << request.GetTxId() << "."
+        reportError(NYql::TIssuesIds::KIKIMR_SCHEME_MISMATCH, TStringBuilder() << "TxId: " << request.GetTxId() << "."
             << " Shard " << TabletID() << " is not ready to process requests.");
         return;
     }

--- a/ydb/core/tx/datashard/datashard_ut_kqp_scan.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_kqp_scan.cpp
@@ -7,6 +7,8 @@
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/base/blobstorage.h>
 
+#include <limits>
+
 namespace NKikimr {
 namespace NKqp {
 
@@ -890,6 +892,67 @@ Y_UNIT_TEST_SUITE(KqpScan) {
         UNIT_ASSERT_VALUES_EQUAL(*status, Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT(result);
         UNIT_ASSERT_VALUES_EQUAL(*result, 596400);
+    }
+
+    Y_UNIT_TEST(ScanInvalidSnapshot) {
+        NKikimrConfig::TAppConfig appCfg;
+
+        auto* rm = appCfg.MutableTableServiceConfig()->MutableResourceManager();
+        rm->SetChannelBufferSize(100);
+        rm->SetMinChannelBufferSize(100);
+
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(2)
+            .SetAppConfig(appCfg)
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+        ExecSQL(server, sender, FillTableQuery());
+
+        bool injected = false;
+        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!injected && ev->GetTypeRewrite() == TEvDataShard::EvKqpScan) {
+                auto& request = ev->Get<TEvDataShard::TEvKqpScan>()->Record;
+                auto* snapshot = request.MutableSnapshot();
+                // set invalid snapshot
+                snapshot->SetStep(std::numeric_limits<ui64>::max());
+                snapshot->SetTxId(0);
+                injected = true;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        auto streamSender = runtime.AllocateEdgeActor();
+        SendRequest(runtime, streamSender, MakeStreamRequest(streamSender, "SELECT value FROM `/Root/table-1`;", false));
+        auto ev = runtime.GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(streamSender);
+        auto& record = ev->Get()->Record;
+
+        UNIT_ASSERT_VALUES_EQUAL(record.GetYdbStatus(), Ydb::StatusIds::ABORTED);
+
+        bool hasIssue = false;
+        for (const auto& issueMsg : record.GetResponse().GetQueryIssues()) {
+            if (issueMsg.issue_code() == (ui32)NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED) {
+                hasIssue = true;
+                break;
+            }
+            for (const auto& subIssue : issueMsg.issues()) {
+                if (subIssue.issue_code() == (ui32)NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED) {
+                    hasIssue = true;
+                    break;
+                }
+            }
+            if (hasIssue) {
+                break;
+            }
+        }
+        UNIT_ASSERT(hasIssue);
     }
 
     Y_UNIT_TEST(ScanPg) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR fixes invalid-snapshot handling for KQP scans.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The "Snapshot is not valid" path no longer reports ABORTED + KIKIMR_SCHEME_MISMATCH, it now returns ABORTED + KIKIMR_PRECONDITION_FAILED with detailed snapshot context. This prevents the scan fetcher from treating invalid snapshot as a recoverable schema mismatch and entering resolve/retry loops.