### PR TITLE
Add Ydb.sensitive annotation to YQL params in proto files

### DIFF
--- a/ydb/public/api/protos/ydb_query.proto
+++ b/ydb/public/api/protos/ydb_query.proto
@@ -7,6 +7,7 @@ option java_outer_classname = "QueryProtos";
 
 import "google/protobuf/duration.proto";
 
+import "ydb/public/api/protos/annotations/sensitive.proto";
 import "ydb/public/api/protos/annotations/validation.proto";
 import "ydb/public/api/protos/ydb_common.proto";
 import "ydb/public/api/protos/ydb_formats.proto";
@@ -196,7 +197,7 @@ message ExecuteQueryRequest {
         QueryContent query_content = 4;
     }
 
-    map<string, TypedValue> parameters = 6;
+    map<string, TypedValue> parameters = 6 [(Ydb.sensitive) = true];
     StatsMode stats_mode = 7;
 
     // For queries with multiple result sets, some of them may be computed concurrently.
@@ -255,7 +256,7 @@ message ExecuteScriptRequest {
 
     QueryContent script_content = 3;
 
-    map<string, TypedValue> parameters = 4;
+    map<string, TypedValue> parameters = 4 [(Ydb.sensitive) = true];
 
     StatsMode stats_mode = 5;
 

--- a/ydb/public/api/protos/ydb_scripting.proto
+++ b/ydb/public/api/protos/ydb_scripting.proto
@@ -5,6 +5,7 @@ package Ydb.Scripting;
 option java_package = "com.yandex.ydb.scripting";
 option java_outer_classname = "ScriptingProtos";
 
+import "ydb/public/api/protos/annotations/sensitive.proto";
 import "ydb/public/api/protos/ydb_operation.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 
@@ -18,7 +19,7 @@ import "ydb/public/api/protos/ydb_query.proto";
 message ExecuteYqlRequest {
     Ydb.Operations.OperationParams operation_params = 1;
     string script = 2;
-    map<string, TypedValue> parameters = 3;
+    map<string, TypedValue> parameters = 3 [(Ydb.sensitive) = true];
     Ydb.Table.QueryStatsCollection.Mode collect_stats = 4;
     Ydb.Query.Syntax syntax = 5;
 }

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 option cc_enable_arenas = true;
 
+import "ydb/public/api/protos/annotations/sensitive.proto";
 import "ydb/public/api/protos/annotations/validation.proto";
 import "ydb/public/api/protos/ydb_common.proto";
 import "ydb/public/api/protos/ydb_issue_message.proto";
@@ -1314,7 +1315,7 @@ message ExecuteDataQueryRequest {
     TransactionControl tx_control = 2;
     Query query = 3;
     // Map of query parameters (optional)
-    map<string, TypedValue> parameters = 4;
+    map<string, TypedValue> parameters = 4 [(Ydb.sensitive) = true];
     QueryCachePolicy query_cache_policy = 5;
     Ydb.Operations.OperationParams operation_params = 6;
     QueryStatsCollection.Mode collect_stats = 7;
@@ -1659,7 +1660,7 @@ message ExecuteScanQueryRequest {
     reserved 1; // session_id
     reserved 2; // tx_control
     Query query = 3;
-    map<string, TypedValue> parameters = 4;
+    map<string, TypedValue> parameters = 4 [(Ydb.sensitive) = true];
     reserved 5; // query_cache_policy
     Mode mode = 6;
     reserved 7; // report_progress


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Параметры – пользовательская информация, которую мы не хотим логировать. Сейчас она попадает в **дебажные** логи GRPC_SERVER в сообщения вида
```
... GRPC_SERVER DEBUG... request... StreamExecuteYql... script... parameters... text_value: <значение...
```