### PR TITLE
Check empty token in monitoring in common way

### DIFF
--- a/ydb/core/blobstorage/ut_vdisk/lib/astest.h
+++ b/ydb/core/blobstorage/ut_vdisk/lib/astest.h
@@ -103,7 +103,8 @@ inline void TTestWithActorSystem::Run(NActors::IActor *testActor) {
     }
     Monitoring.reset(new NActors::TMon({
         .Port = MonPort,
-        .Title = "at"
+        .Title = "at",
+        .Authorizer = nullptr  // Disable authorization in test environment
     }));
     NMonitoring::TIndexMonPage *actorsMonPage = Monitoring->RegisterIndexPage("actors", "Actors");
     Y_UNUSED(actorsMonPage);

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -135,34 +135,7 @@ NActors::IEventHandle* SelectAuthorizationScheme(const NActors::TActorId& owner,
     } else if (!request->MTlsClientCertificate.empty()) {
         return GetRequestAuthAndCheckHandle(owner, GetDatabase(request), request->MTlsClientCertificate, NMonitoring::NAudit::ExtractRemoteAddress(request));
     } else {
-        return nullptr;
-    }
-}
-
-NActors::IEventHandle* GetAuthorizeTicketResult(const NActors::TActorId& owner) {
-    if (NKikimr::AppData()->EnforceUserTokenRequirement && NKikimr::AppData()->DefaultUserSIDs.empty()) {
-        return new NActors::IEventHandle(
-            owner,
-            owner,
-            new NKikimr::NGRpcService::TEvRequestAuthAndCheckResult(
-                Ydb::StatusIds::UNAUTHORIZED,
-                "No security credentials were provided",
-                {})
-        );
-    } else if (!NKikimr::AppData()->DefaultUserSIDs.empty()) {
-        TIntrusivePtr<NACLib::TUserToken> token = new NACLib::TUserToken(NKikimr::AppData()->DefaultUserSIDs);
-        return new NActors::IEventHandle(
-            owner,
-            owner,
-            new NKikimr::NGRpcService::TEvRequestAuthAndCheckResult(
-                {},
-                {},
-                token,
-                {}
-            )
-        );
-    } else {
-        return nullptr;
+        return GetRequestAuthAndCheckHandle(owner, GetDatabase(request), "", NMonitoring::NAudit::ExtractRemoteAddress(request));
     }
 }
 
@@ -230,11 +203,7 @@ IMonPage* TMon::RegisterActorPage(TIndexMonPage* index, const TString& relPath,
 }
 
 NActors::IEventHandle* TMon::DefaultAuthorizer(const NActors::TActorId& owner, NHttp::THttpIncomingRequest* request) {
-    NActors::IEventHandle* eventHandle = SelectAuthorizationScheme(owner, request);
-    if (eventHandle != nullptr) {
-        return eventHandle;
-    }
-    return GetAuthorizeTicketResult(owner);
+    return SelectAuthorizationScheme(owner, request);
 }
 
 // compatibility layer

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1525,6 +1525,7 @@ class TestViewer(object):
         response = cls.call_viewer_api_post("/viewer/query", body, headers={
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream',
+            'Cookie': 'ydb_session_id=' + cls.root_session_id,
         })
         result = {
             'status_code': response.status_code,

--- a/ydb/core/viewer/ut/ut_utils.cpp
+++ b/ydb/core/viewer/ut/ut_utils.cpp
@@ -6,7 +6,7 @@ void WaitForHttpReady(TKeepAliveHttpClient& client) {
     for (int retries = 0;; ++retries) {
         UNIT_ASSERT(retries < 100);
         TStringStream responseStream;
-        const TKeepAliveHttpClient::THttpCode statusCode = client.DoGet("/viewer/simple_counter?max_counter=1&period=100", &responseStream);
+        const TKeepAliveHttpClient::THttpCode statusCode = client.DoGet("/viewer/capabilities", &responseStream);
         const TString response = responseStream.ReadAll();
         if (statusCode == HTTP_OK) {
             break;

--- a/ydb/tests/functional/security/test_mon_endpoints_auth.py
+++ b/ydb/tests/functional/security/test_mon_endpoints_auth.py
@@ -176,7 +176,7 @@ EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN = {
         'root@builtin': 200,
     },
     '/ver': {
-        None: 200,
+        None: 401,
         'user@builtin': 403,
         'database@builtin': 403,
         'viewer@builtin': 403,
@@ -200,7 +200,7 @@ EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN = {
         'root@builtin': 200,
     },
     '/static/css/bootstrap.min.css': {
-        None: 200,
+        None: 401,
         'user@builtin': 403,
         'database@builtin': 403,
         'viewer@builtin': 403,
@@ -216,7 +216,7 @@ EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN = {
         'root@builtin': 200,
     },
     '/internal': {
-        None: 200,
+        None: 401,
         'user@builtin': 403,
         'database@builtin': 403,
         'viewer@builtin': 403,
@@ -224,7 +224,7 @@ EXPECTED_RESULTS_WITHOUT_ENFORCE_USER_TOKEN = {
         'root@builtin': 200,
     },
     '/actors/': {
-        None: 200,
+        None: 401,
         'user@builtin': 403,
         'database@builtin': 403,
         'viewer@builtin': 403,


### PR DESCRIPTION
All http requests to monitoring endpoints have to pass through grpc proxy and TGrpcRequestCheckActor respectively. It allows to check configuration flags affecting anonymous mode in one place.