### PR TITLE
[26-1] Implement online unique index build

### DIFF
--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -129,7 +129,8 @@ template<typename TIndexProto>
 void CheckWritesAreDisabled(const TIndexProto& indexes, NYql::TKikimrTableMetadataPtr tableMeta) {
     TStringBuilder disableReason;
     for (const NKikimrSchemeOp::TIndexDescription& index : indexes) {
-        if (index.GetType() == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique && index.GetState() != NKikimrSchemeOp::EIndexState::EIndexStateReady) {
+        if (index.GetType() == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique &&
+            index.GetState() != NKikimrSchemeOp::EIndexState::EIndexStateReady) {
             if (disableReason) {
                 disableReason << ", ";
             }
@@ -148,7 +149,8 @@ TString GetTypeName(const NScheme::TTypeInfoMod& typeInfoMod) {
 }
 
 TTableMetadataResult GetTableMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry,
-        const TString& cluster, const TString& tableName, std::optional<TString> queryName = std::nullopt) {
+    const TString& cluster, const TString& tableName, std::optional<TString> queryName,
+    bool enableOnlineAddUniqueIndex = false) {
     using EKind = NSchemeCache::TSchemeCacheNavigate::EKind;
 
     TTableMetadataResult result;
@@ -257,7 +259,9 @@ TTableMetadataResult GetTableMetadataResult(const NSchemeCache::TSchemeCacheNavi
     IndexProtoToMetadata(entry.Indexes, tableMeta);
 
     // Check if we have unique indexes that are not built
-    CheckWritesAreDisabled(entry.Indexes, tableMeta);
+    if (!enableOnlineAddUniqueIndex) {
+        CheckWritesAreDisabled(entry.Indexes, tableMeta);
+    }
 
     return result;
 }
@@ -441,7 +445,8 @@ TTableMetadataResult GetTopicMetadataResult(const NSchemeCache::TSchemeCacheNavi
 
 TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry,
     const TString& cluster, const TString& mainCluster, const TString& database, const TString& tableName,
-    const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, std::optional<TString> queryName = std::nullopt)
+    const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, std::optional<TString> queryName = std::nullopt,
+    bool enableOnlineAddUniqueIndex = false)
 {
     using TResult = NYql::IKikimrGateway::TTableMetadataResult;
     using EStatus = NSchemeCache::TSchemeCacheNavigate::EStatus;
@@ -499,7 +504,7 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
             result = GetTopicMetadataResult(entry, cluster, database, tableName, userToken);
             break;
         default:
-            result = GetTableMetadataResult(entry, cluster, tableName, queryName);
+            result = GetTableMetadataResult(entry, cluster, tableName, queryName, enableOnlineAddUniqueIndex);
     }
     return result;
 }
@@ -1028,12 +1033,15 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
 
     const auto schemeCacheId = MakeSchemeCacheID();
 
+    const bool enableOnlineAddUniqueIndex = Config && Config->FeatureFlags.GetEnableOnlineAddUniqueIndex();
+
     auto ptr = weak_from_base();
     auto future = SendActorRequest<TRequest, TResponse, TResult>(
         ActorSystem,
         schemeCacheId,
         ev.Release(),
-        [userToken, database, cluster, mainCluster = Cluster, table, settings, expectedSchemaVersion, ptr, queryName, externalPath]
+        [userToken, database, cluster, mainCluster = Cluster, table, settings,
+            expectedSchemaVersion, ptr, queryName, externalPath, enableOnlineAddUniqueIndex]
             (TPromise<TResult> promise, TResponse&& response) mutable
         {
             try {
@@ -1044,7 +1052,8 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                 auto& entry = InferEntry(navigate.ResultSet);
 
                 if (entry.Status != EStatus::Ok) {
-                    promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken));
+                    promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken,
+                        std::nullopt, enableOnlineAddUniqueIndex));
                     return;
                 }
 
@@ -1082,7 +1091,8 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
 
                 switch (entry.Kind) {
                     case EKind::KindExternalDataSource: {
-                        auto externalDataSourceMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken);
+                        auto externalDataSourceMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table,
+                            userToken, std::nullopt, enableOnlineAddUniqueIndex);
                         if (!externalDataSourceMetadata.Success() || !settings.RequestAuthInfo_) {
                             promise.SetValue(externalDataSourceMetadata);
                             return;
@@ -1183,7 +1193,8 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                     case EKind::KindExternalTable: {
                         YQL_ENSURE(entry.ExternalTableInfo, "expected external table info");
                         const auto& dataSourcePath = entry.ExternalTableInfo->Description.GetDataSourcePath();
-                        auto externalTableMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken);
+                        auto externalTableMetadata = GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken,
+                            std::nullopt, enableOnlineAddUniqueIndex);
                         if (!externalTableMetadata.Success()) {
                             promise.SetValue(externalTableMetadata);
                             return;
@@ -1216,7 +1227,7 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadTableMeta
                         break;
                     }
                     default: {
-                        promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken, queryName));
+                        promise.SetValue(GetLoadTableMetadataResult(entry, cluster, mainCluster, database, table, userToken, queryName, enableOnlineAddUniqueIndex));
                     }
                 }
             }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -70,7 +70,7 @@ NYql::NNodes::TExprBase MakeRowsFromTupleDict(const NYql::NNodes::TDqPhyPrecompu
 
 NYql::NNodes::TMaybeNode<NYql::NNodes::TDqCnUnionAll> MakeConditionalInsertRows(const NYql::NNodes::TExprBase& input,
     const NYql::TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumn, bool abortOnError,
-    NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+    NYql::TPositionHandle pos, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx);
 
 enum class TKqpPhyUpsertIndexMode {
     Upsert,

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert.cpp
@@ -9,14 +9,15 @@ using namespace NYql::NDq;
 using namespace NYql::NNodes;
 
 TMaybeNode<TDqCnUnionAll> MakeConditionalInsertRows(const TExprBase& input, const TKikimrTableDescription& table,
-    const TMaybe<THashSet<TStringBuf>>& inputColumns, bool abortOnError, TPositionHandle pos, TExprContext& ctx)
+    const TMaybe<THashSet<TStringBuf>>& inputColumns, bool abortOnError, TPositionHandle pos, TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx)
 {
     auto condenseResult = CondenseInput(input, ctx);
     if (!condenseResult) {
         return {};
     }
 
-    auto helper = CreateInsertUniqBuildHelper(table, inputColumns, pos, ctx);
+    auto helper = CreateInsertUniqBuildHelper(table, inputColumns, pos, ctx, kqpCtx);
     auto computeKeysStage = helper->CreateComputeKeysStage(condenseResult.GetRef(), pos, ctx);
 
     auto inputPrecompute = helper->CreateInputPrecompute(computeKeysStage, pos, ctx);
@@ -132,7 +133,7 @@ TExprBase KqpBuildInsertStages(TExprBase node, TExprContext& ctx, const TKqpOpti
 
     if (needPrecompute) {
         const static TMaybe<THashSet<TStringBuf>> empty;
-        auto insertRows = MakeConditionalInsertRows(insert.Input(), table, empty, abortOnError, insert.Pos(), ctx);
+        auto insertRows = MakeConditionalInsertRows(insert.Input(), table, empty, abortOnError, insert.Pos(), ctx, kqpCtx);
         if (!insertRows) {
             return node;
         }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
@@ -136,7 +136,7 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
     std::optional<TExprBase> insertRows;
     if (needPrecompute) {
         // TODO: don't use precompute here!
-        auto conditionalInsertRows = MakeConditionalInsertRows(insert.Input(), table, inputColumnsSet, abortOnError, insert.Pos(), ctx);
+        auto conditionalInsertRows = MakeConditionalInsertRows(insert.Input(), table, inputColumnsSet, abortOnError, insert.Pos(), ctx, kqpCtx);
         if (!conditionalInsertRows) {
             return node;
         }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.cpp
@@ -40,8 +40,8 @@ NYql::TExprNode::TPtr MakeUniqCheckDict(const TCoLambda& selector,
 class TInsertUniqBuildHelper : public TUniqBuildHelper {
 public:
     TInsertUniqBuildHelper(const NYql::TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumns,
-        NYql::TPositionHandle pos, NYql::TExprContext& ctx)
-    : TUniqBuildHelper(table, inputColumns, nullptr, pos, ctx, true)
+        NYql::TPositionHandle pos, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
+    : TUniqBuildHelper(table, inputColumns, nullptr, pos, ctx, kqpCtx, true)
     {}
 
 private:
@@ -122,8 +122,8 @@ private:
 class TUpsertUniqBuildHelper : public TUniqBuildHelper {
 public:
     TUpsertUniqBuildHelper(const NYql::TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumns, const THashSet<TString>& usedIndexes,
-        NYql::TPositionHandle pos, NYql::TExprContext& ctx)
-    : TUniqBuildHelper(table, inputColumns, &usedIndexes, pos, ctx, false)
+        NYql::TPositionHandle pos, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
+    : TUniqBuildHelper(table, inputColumns, &usedIndexes, pos, ctx, kqpCtx, false)
     , PkDict(MakeUniqCheckDict(MakeTableKeySelector(table.Metadata, pos, ctx), RowsListArg, pos, ctx))
     {}
 
@@ -258,7 +258,7 @@ TVector<TUniqBuildHelper::TUniqCheckNodes> TUniqBuildHelper::Prepare(const TCoAr
 
     // make uniq check for each uniq constraint
     for (size_t i = 0; i < table.Metadata->Indexes.size(); i++) {
-        if (table.Metadata->Indexes[i].State != TIndexDescription::EIndexState::Ready)
+        if (!EnableOnlineAddUniqueIndex && table.Metadata->Indexes[i].State != TIndexDescription::EIndexState::Ready)
             continue;
         if (table.Metadata->Indexes[i].Type != TIndexDescription::EType::GlobalSyncUnique)
             continue;
@@ -346,9 +346,10 @@ static TExprNode::TPtr CreateRowsToPass(const TCoArgument& rowsListArg, const TM
 }
 
 TUniqBuildHelper::TUniqBuildHelper(const TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumns, const THashSet<TString>* usedIndexes,
-    TPositionHandle pos, TExprContext& ctx, bool insertMode)
+    TPositionHandle pos, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx, bool insertMode)
     : RowsListArg(ctx.NewArgument(pos, "rows_list"))
     , False(MakeBool(pos, false, ctx))
+    , EnableOnlineAddUniqueIndex(kqpCtx.Config->FeatureFlags.GetEnableOnlineAddUniqueIndex())
     , Checks(Prepare(RowsListArg, table, inputColumns, usedIndexes, pos, ctx, insertMode))
     , RowsToPass(CreateRowsToPass(RowsListArg, inputColumns, pos, ctx))
 {}
@@ -569,16 +570,17 @@ namespace NKikimr::NKqp::NOpt {
 
 TUniqBuildHelper::TPtr CreateInsertUniqBuildHelper(const NYql::TKikimrTableDescription& table,
     const TMaybe<THashSet<TStringBuf>>& inputColumns, NYql::TPositionHandle pos,
-    NYql::TExprContext& ctx)
+    NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
 {
-    return std::make_unique<TInsertUniqBuildHelper>(table, inputColumns, pos, ctx);
+    return std::make_unique<TInsertUniqBuildHelper>(table, inputColumns, pos, ctx, kqpCtx);
 }
 
 TUniqBuildHelper::TPtr CreateUpsertUniqBuildHelper(const NYql::TKikimrTableDescription& table,
     const TMaybe<THashSet<TStringBuf>>& inputColumns,
-    const THashSet<TString>& usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx)
+    const THashSet<TString>& usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx)
 {
-    return std::make_unique<TUpsertUniqBuildHelper>(table, inputColumns, usedIndexes, pos, ctx);
+    return std::make_unique<TUpsertUniqBuildHelper>(table, inputColumns, usedIndexes, pos, ctx, kqpCtx);
 }
 
 }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.h
@@ -28,7 +28,8 @@ public:
 protected:
     // table - metadata of table
     TUniqBuildHelper(const NYql::TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumns,
-        const THashSet<TString>* usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx, bool insertMode);
+        const THashSet<TString>* usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx,
+        const TKqpOptimizeContext& kqpCtx, bool insertMode);
     size_t CalcComputeKeysStageOutputNum() const;
 
     struct TUniqCheckNodes {
@@ -61,7 +62,7 @@ private:
 
     static TUniqCheckNodes MakeUniqCheckNodes(const NYql::NNodes::TCoLambda& selector,
         const NYql::NNodes::TExprBase& rowsListArg, NYql::TPositionHandle pos, NYql::TExprContext& ctx);
-    static TVector<TUniqCheckNodes> Prepare(const NYql::NNodes::TCoArgument& rowsListArg,
+    TVector<TUniqCheckNodes> Prepare(const NYql::NNodes::TCoArgument& rowsListArg,
         const NYql::TKikimrTableDescription& table, const TMaybe<THashSet<TStringBuf>>& inputColumns,
         const THashSet<TString>* usedIndexes, NYql::TPositionHandle pos,
         NYql::TExprContext& ctx, bool skipPkCheck);
@@ -74,15 +75,18 @@ private:
 protected:
     const NYql::NNodes::TCoArgument RowsListArg;
     const NYql::TExprNode::TPtr False;
+    const bool EnableOnlineAddUniqueIndex;
 private:
     const TChecks Checks;
     const NYql::TExprNode::TPtr RowsToPass;
 };
 
 TUniqBuildHelper::TPtr CreateInsertUniqBuildHelper(const NYql::TKikimrTableDescription& table,
-    const TMaybe<THashSet<TStringBuf>>& inputColumns, NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+    const TMaybe<THashSet<TStringBuf>>& inputColumns, NYql::TPositionHandle pos, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx);
 
 TUniqBuildHelper::TPtr CreateUpsertUniqBuildHelper(const NYql::TKikimrTableDescription& table,
     const TMaybe<THashSet<TStringBuf>>& inputColumns,
-    const THashSet<TString>& usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+    const THashSet<TString>& usedIndexes, NYql::TPositionHandle pos, NYql::TExprContext& ctx,
+    const TKqpOptimizeContext& kqpCtx);
 }

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -322,7 +322,7 @@ TExprBase MakeUpsertIndexRows(TKqpPhyUpsertIndexMode mode, const TDqPhyPrecomput
 TMaybe<std::pair<TCondenseInputResult, TMaybeNode<TDqPhyPrecompute>>>
 RewriteInputForConstraint(const TExprBase& inputRows, const THashSet<TStringBuf> inputColumns,
     const THashSet<TString>& checkDefaults, const TKikimrTableDescription& table,
-    const TSecondaryIndexes& indexes, const bool useStreamIndexes, TPositionHandle pos, TExprContext& ctx)
+    const TSecondaryIndexes& indexes, const bool useStreamIndexes, TPositionHandle pos, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
 {
     auto condenseResult = CondenseInput(inputRows, ctx);
     if (!condenseResult) {
@@ -508,7 +508,7 @@ RewriteInputForConstraint(const TExprBase& inputRows, const THashSet<TStringBuf>
         YQL_ENSURE(condenseResult);
     }
 
-    auto helper = CreateUpsertUniqBuildHelper(table, inputColumns, usedIndexes, pos, ctx);
+    auto helper = CreateUpsertUniqBuildHelper(table, inputColumns, usedIndexes, pos, ctx, kqpCtx);
     if (helper->GetChecksNum() == 0) {
         // Return result of read stage only in case of uniq index
         // We do not want to change plan for non uniq index for a while
@@ -669,7 +669,7 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
             .Done();
     }
 
-    auto checkedInput = RewriteInputForConstraint(inputRows, inputColumnsSet, columnsWithDefaultsSet, table, indexes, useStreamIndex, pos, ctx);
+    auto checkedInput = RewriteInputForConstraint(inputRows, inputColumnsSet, columnsWithDefaultsSet, table, indexes, useStreamIndex, pos, ctx, kqpCtx);
 
     if (!checkedInput) {
         return {};

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/tx/datashard/datashard.h>
 
 #include <ydb/core/client/minikql_compile/mkql_compile_service.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
@@ -6279,6 +6280,158 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
         }
+    }
+
+    void DoTestOnlineDuplicates(bool expectInsertOk, int toCapture, std::function<bool(const TAutoPtr<IEventHandle>&)> condition) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableAddUniqueIndex(true);
+        featureFlags.SetEnableOnlineAddUniqueIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            // SetUseRealThreads(false) is required to capture events (!) but then you have to do kikimr.RunCall() for everything
+            .SetUseRealThreads(false)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+
+        auto runtime = kikimr.GetTestServer().GetRuntime();
+
+        TVector<TAutoPtr<IEventHandle>> capturedEvents;
+        int captured = 0;
+        NThreading::TPromise<void> eventPromise = NThreading::NewPromise<void>();
+        NThreading::TFuture<void> eventFuture = eventPromise.GetFuture();
+        runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) -> NActors::TTestActorRuntimeBase::EEventAction {
+            if (captured < toCapture && condition(event)) {
+                captured++;
+                capturedEvents.push_back(event.Release());
+                if (captured >= toCapture) {
+                    eventPromise.SetValue();
+                }
+                return NActors::TTestActorRuntimeBase::EEventAction::DROP;
+            }
+            return NActors::TTestActorRuntimeBase::EEventAction::PROCESS;
+        });
+
+        kikimr.RunCall([&]
+        {
+            auto queryClient = kikimr.GetQueryClient();
+
+            {
+                // Create table
+                auto result = queryClient.ExecuteQuery(R"(
+                    CREATE TABLE `/Root/TestOnlineUniq` (
+                        id Int64 NOT NULL,
+                        uniq Int64 NOT NULL,
+                        PRIMARY KEY (id)
+                    )
+                )", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+
+            // Fill initial data
+            {
+                auto result = queryClient.ExecuteQuery(R"(
+                    INSERT INTO `/Root/TestOnlineUniq` (id, uniq) VALUES
+                    (1, 101), (2, 102), (3, 103), (4, 104), (5, 105)
+                )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+
+            NYdb::NQuery::TAsyncExecuteQueryResult addIndexFuture = queryClient.ExecuteQuery(R"sql(
+                ALTER TABLE `/Root/TestOnlineUniq`
+                ADD INDEX idx_uniq GLOBAL UNIQUE ON (uniq)
+            )sql", NYdb::NQuery::TTxControl::NoTx());
+
+            eventFuture.Wait();
+
+            // Insert a normal row
+            {
+                auto result = queryClient.ExecuteQuery(R"(
+                    INSERT INTO `/Root/TestOnlineUniq` (id, uniq) VALUES (100, 1000)
+                )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+
+            // Insert a duplicate
+            {
+                auto result = queryClient.ExecuteQuery(R"(
+                    INSERT INTO `/Root/TestOnlineUniq` (id, uniq) VALUES (101, 101)
+                )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(),
+                    expectInsertOk ? EStatus::SUCCESS : EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            }
+
+            // Unblock and let index build fail if insertion succeeds
+            for (auto& ev: capturedEvents) {
+                runtime->Send(ev.Release());
+            }
+            capturedEvents.clear();
+
+            {
+                auto result = addIndexFuture.GetValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(),
+                    !expectInsertOk ? EStatus::SUCCESS : EStatus::PRECONDITION_FAILED, result.GetIssues().ToString());
+            }
+        });
+    }
+
+    Y_UNIT_TEST(OnlineDuplicatesStage1) {
+        // Stage 1: after CreateTableIndex (index tables are created), but before DataShard::EvBuildIndexCreate
+        // (main table snapshot is not taken and index filling is not started yet). New duplicates can be inserted
+        // into the 'user' index table because it's not filled yet.
+        DoTestOnlineDuplicates(true, 1, [](const TAutoPtr<IEventHandle>& ev) {
+            return ev->GetTypeRewrite() == NKikimr::TEvDataShard::TEvBuildIndexCreateRequest::EventType;
+        });
+    }
+
+    Y_UNIT_TEST(OnlineDuplicatesStage2) {
+        // Stage 2: after DataShard::EvBuildIndexCreate and scans (main table snapshot is taken, index table
+        // shadow is filled with data), but before PrepareValidation (shadow is not published yet and
+        // index is not validated). New duplicates can still be inserted - 'user' index table is still empty.
+        DoTestOnlineDuplicates(true, 1, [](const TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvDataShard::TEvProposeTransaction::EventType) {
+                const auto& rec = ev->Get<TEvDataShard::TEvProposeTransaction>()->Record;
+                if (rec.GetTxKind() == NKikimrTxDataShard::TX_KIND_SCHEME) {
+                    NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                    bool ok = schemeTx.ParseFromArray(rec.GetTxBody().data(), rec.GetTxBody().size());
+                    if (ok) {
+                        return schemeTx.HasPrepareIndexValidation();
+                    }
+                }
+            }
+            return false;
+        });
+    }
+
+    Y_UNIT_TEST(OnlineDuplicatesStage3) {
+        // Stage 3: after PrepareValidation (shadow data is published), but before actual validation.
+        // New duplicates can't be inserted - user+shadow are merged, uniqueness check fails.
+        DoTestOnlineDuplicates(false, 1, [](const TAutoPtr<IEventHandle>& ev) {
+            return ev->GetTypeRewrite() == NKikimr::TEvDataShard::TEvValidateUniqueIndexRequest::EventType;
+        });
+    }
+
+    Y_UNIT_TEST(OnlineDuplicatesStage4) {
+        // Stage 4: after validation, but before FinalizeBuildIndex (2 requests - one for the main
+        // table shard, one for the index table shard). New duplicates can't be inserted - index build
+        // is almost done.
+        DoTestOnlineDuplicates(false, 2, [](const TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvDataShard::TEvProposeTransaction::EventType) {
+                const auto& rec = ev->Get<TEvDataShard::TEvProposeTransaction>()->Record;
+                if (rec.GetTxKind() == NKikimrTxDataShard::TX_KIND_SCHEME) {
+                    NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                    bool ok = schemeTx.ParseFromArray(rec.GetTxBody().data(), rec.GetTxBody().size());
+                    if (ok) {
+                        return schemeTx.HasFinalizeBuildIndex();
+                    }
+                }
+            }
+            return false;
+        });
     }
 
 }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -3526,9 +3526,10 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
     class TKikimrRunnerWithPauseIndexBuild : public TKikimrRunner {
     public:
-        static TKikimrSettings MakeSettings() {
+        static TKikimrSettings MakeSettings(bool onlineUnique = false) {
             NKikimrConfig::TFeatureFlags featureFlags;
             featureFlags.SetEnableAddUniqueIndex(true);
+            featureFlags.SetEnableOnlineAddUniqueIndex(onlineUnique);
 
             TKikimrSettings settings;
             settings
@@ -3538,10 +3539,12 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             return settings;
         }
 
-        TKikimrRunnerWithPauseIndexBuild(bool yqlDetailedLogging = false)
-            : TKikimrRunner(MakeSettings())
+        TKikimrRunnerWithPauseIndexBuild(bool yqlDetailedLogging = false, bool onlineUnique = false)
+            : TKikimrRunner(MakeSettings(onlineUnique))
             , BuildIndexRequestPromise(NThreading::NewPromise<void>())
             , BuildIndexRequest(BuildIndexRequestPromise.GetFuture())
+            , ValidateIndexRequestPromise(NThreading::NewPromise<void>())
+            , ValidateIndexRequest(ValidateIndexRequestPromise.GetFuture())
         {
             GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
             if (yqlDetailedLogging) {
@@ -3557,6 +3560,12 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                     BuildIndexRequestPromise.SetValue();
                     BuildIndexRequestEvent.Swap(event);
                     return NActors::TTestActorRuntimeBase::EEventAction::DROP;
+                } else if (!ValidateIndexEventIsIntercepted && event->Type == static_cast<ui32>(NKikimr::TEvDataShard::EvValidateUniqueIndexRequest)) {
+                    Cerr << "NKikimr::TEvDataShard::TEvValidateUniqueIndexRequest is intercepted\n";
+                    ValidateIndexEventIsIntercepted = true;
+                    ValidateIndexRequestPromise.SetValue();
+                    ValidateIndexRequestEvent.Swap(event);
+                    return NActors::TTestActorRuntimeBase::EEventAction::DROP;
                 }
                 return NActors::TTestActorRuntimeBase::EEventAction::PROCESS;
             });
@@ -3570,15 +3579,28 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             GetTestServer().GetRuntime()->Send(BuildIndexRequestEvent.Release());
         }
 
+        void WaitValidateIndex() {
+            ValidateIndexRequest.Wait();
+        }
+
+        void ContinueValidateIndex() {
+            GetTestServer().GetRuntime()->Send(ValidateIndexRequestEvent.Release());
+        }
+
     private:
         NThreading::TPromise<void> BuildIndexRequestPromise;
         NThreading::TFuture<void> BuildIndexRequest;
         TAutoPtr<IEventHandle> BuildIndexRequestEvent;
         bool BuildIndexEventIsIntercepted = false;
+
+        NThreading::TPromise<void> ValidateIndexRequestPromise;
+        NThreading::TFuture<void> ValidateIndexRequest;
+        TAutoPtr<IEventHandle> ValidateIndexRequestEvent;
+        bool ValidateIndexEventIsIntercepted = false;
     };
 
-    void BuildingUniqIndexDeniesTableModifications(bool sqlInterface) {
-        TKikimrRunnerWithPauseIndexBuild kikimr(false /* yqlDetailedLogging */);
+    void BuildingUniqIndexAllowsTableModifications(bool sqlInterface, bool onlineBuild) {
+        TKikimrRunnerWithPauseIndexBuild kikimr(false /* yqlDetailedLogging */, onlineBuild);
         kikimr.RunCall([&]
         {
             auto db = kikimr.GetTableClient();
@@ -3629,108 +3651,117 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             kikimr.WaitBuildIndex();
 
-            TString upsertQuery = R"sql(
-                UPSERT INTO `/Root/TestTable` (Key, Value) VALUES (1, "1");
-            )sql";
+            for (int i = 0; i < 3; i++) {
 
-            TString insertQuery = R"sql(
-                INSERT INTO `/Root/TestTable` (Key, Value) VALUES (2, "2");
-            )sql";
+                TString upsertQuery = R"sql(
+                    UPSERT INTO `/Root/TestTable` (Key, Value) VALUES (1, "1");
+                )sql";
 
-            TString updateQuery = R"sql(
-                UPDATE `/Root/TestTable` SET Value = "11" WHERE Key = 1;
-            )sql";
+                TString insertQuery = Sprintf(R"sql(
+                    INSERT INTO `/Root/TestTable` (Key, Value) VALUES (%d, "%d");
+                )sql", 2+i, 2+i);
 
-            TString deleteQuery = R"sql(
-                DELETE FROM `/Root/TestTable` WHERE Key = 2;
-            )sql";
+                TString updateQuery = R"sql(
+                    UPDATE `/Root/TestTable` SET Value = "11" WHERE Key = 1;
+                )sql";
 
-            TString returningQuery = R"sql(
-                REPLACE INTO `/Root/TestTable` (Key, Value) VALUES (1, "1") RETURNING Key, Value;
-            )sql";
+                TString deleteQuery = R"sql(
+                    DELETE FROM `/Root/TestTable` WHERE Key = 2;
+                )sql";
 
-            auto modificationQueries = {
-                upsertQuery,
-                insertQuery,
-                updateQuery,
-                deleteQuery,
-                returningQuery,
-            };
+                TString returningQuery = R"sql(
+                    REPLACE INTO `/Root/TestTable` (Key, Value) VALUES (1, "1") RETURNING Key, Value;
+                )sql";
 
-            for (const TString& query : modificationQueries) {
-                Cerr << "Running query:\n" << query << Endl;
-                auto result = queryClient.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-                if (result.GetStatus() != EStatus::BAD_REQUEST
-                    || result.GetIssues().ToString().find("Table `/Root/TestTable` modification is disabled: Unique index uniq_value_idx is under construction") == TString::npos)
-                {
-                    Cerr << "Execute query issues. Query: " << query << Endl;
-                    Cerr << "Execute issues:\n" << result.GetIssues().ToString() << Endl;
-                    ythrow yexception() << "Unexpected status of modification query: " << result.GetStatus() << ": " << result.GetIssues().ToString();
+                auto modificationQueries = {
+                    upsertQuery,
+                    insertQuery,
+                    updateQuery,
+                    deleteQuery,
+                    returningQuery,
+                };
+
+                for (const TString& query : modificationQueries) {
+                    Cerr << "Running query:\n" << query << Endl;
+                    auto result = queryClient.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+                    bool ok = false;
+                    if (onlineBuild || i == 2) {
+                        ok = (result.GetStatus() == EStatus::SUCCESS);
+                    } else {
+                        ok = (result.GetStatus() == EStatus::BAD_REQUEST
+                            && result.GetIssues().ToString().find("Table `/Root/TestTable` modification is disabled: Unique index uniq_value_idx is under construction") != TString::npos);
+                    }
+                    if (!ok) {
+                        Cerr << "Execute query issues. Query: " << query << Endl;
+                        Cerr << "Execute issues:\n" << result.GetIssues().ToString() << Endl;
+                        ythrow yexception() << "Unexpected status of modification query: " << result.GetStatus() << ": " << result.GetIssues().ToString();
+                    }
+                }
+
+                auto checkBulkUpsert = [&]{
+                    NYdb::TValueBuilder rows;
+                    rows.BeginList();
+                    rows.AddListItem()
+                        .BeginStruct()
+                        .AddMember("Key").Uint64(42)
+                        .AddMember("Value").String("42")
+                        .EndStruct();
+                    rows.EndList();
+
+                    auto bulkUpsertResult = db.BulkUpsert("/Root/TestTable", rows.Build()).GetValueSync();
+                    if (bulkUpsertResult.IsSuccess()
+                        || (bulkUpsertResult.GetStatus() == EStatus::BAD_REQUEST && bulkUpsertResult.GetIssues().ToString().find("Only async-indexed tables are supported by BulkUpsert") == TString::npos))
+                    {
+                        ythrow yexception() << "Unexpected status of bulk upsert: " << bulkUpsertResult.GetStatus() << ": " << bulkUpsertResult.GetIssues().ToString();
+                    }
+                };
+
+                checkBulkUpsert();
+
+                if (i == 0) {
+                    kikimr.ContinueBuildIndex();
+                    kikimr.WaitValidateIndex();
+                } else if (i == 1) {
+                    kikimr.ContinueValidateIndex();
+
+                    // Wait for index to be built
+                    if (sqlInterface) {
+                        auto result = alterTableResultFuture.GetValueSync();
+                        if (!result.IsSuccess()) {
+                            ythrow yexception() << "Unexpected status of index build: " << result.GetStatus() << ": " << result.GetIssues().ToString();
+                        }
+                    } else {
+                        bool ready = false;
+                        TMaybe<NYdb::NTable::TBuildIndexOperation> buildOp;
+                        while (!ready) {
+                            Sleep(TDuration::MilliSeconds(100));
+                            NYdb::NOperation::TOperationClient opClient(kikimr.GetDriver());
+                            buildOp = opClient.Get<NYdb::NTable::TBuildIndexOperation>(alterOpId).GetValueSync();
+                            ready = buildOp->Ready();
+                        }
+                        if (!buildOp->Status().IsSuccess()) {
+                            ythrow yexception() << "Unexpected status of index build: " << buildOp->Status().GetStatus() << ": " << buildOp->Status().GetIssues().ToString();
+                        }
+                    }
                 }
             }
-
-            auto checkBulkUpsert = [&]{
-                NYdb::TValueBuilder rows;
-                rows.BeginList();
-                rows.AddListItem()
-                    .BeginStruct()
-                    .AddMember("Key").Uint64(42)
-                    .AddMember("Value").String("42")
-                    .EndStruct();
-                rows.EndList();
-
-                auto bulkUpsertResult = db.BulkUpsert("/Root/TestTable", rows.Build()).GetValueSync();
-                if (bulkUpsertResult.IsSuccess()
-                    || (bulkUpsertResult.GetStatus() == EStatus::BAD_REQUEST && bulkUpsertResult.GetIssues().ToString().find("Only async-indexed tables are supported by BulkUpsert") == TString::npos))
-                {
-                    ythrow yexception() << "Unexpected status of bulk upsert: " << bulkUpsertResult.GetStatus() << ": " << bulkUpsertResult.GetIssues().ToString();
-                }
-            };
-
-            checkBulkUpsert();
-
-            kikimr.ContinueBuildIndex();
-
-            // Wait for index to be built
-            if (sqlInterface) {
-                auto result = alterTableResultFuture.GetValueSync();
-                if (!result.IsSuccess()) {
-                    ythrow yexception() << "Unexpected status of index build: " << result.GetStatus() << ": " << result.GetIssues().ToString();
-                }
-            } else {
-                bool ready = false;
-                TMaybe<NYdb::NTable::TBuildIndexOperation> buildOp;
-                while (!ready) {
-                    Sleep(TDuration::MilliSeconds(100));
-                    NYdb::NOperation::TOperationClient opClient(kikimr.GetDriver());
-                    buildOp = opClient.Get<NYdb::NTable::TBuildIndexOperation>(alterOpId).GetValueSync();
-                    ready = buildOp->Ready();
-                }
-                if (!buildOp->Status().IsSuccess()) {
-                    ythrow yexception() << "Unexpected status of index build: " << buildOp->Status().GetStatus() << ": " << buildOp->Status().GetIssues().ToString();
-                }
-            }
-
-            for (const TString& query : modificationQueries) {
-                auto result = queryClient.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-                if (result.GetStatus() != EStatus::SUCCESS) {
-                    Cerr << "Execute query issues. Query: " << query << Endl;
-                    Cerr << "Execute issues:\n" << result.GetIssues().ToString() << Endl;
-                    ythrow yexception() << "Unexpected status of upsert query: " << result.GetStatus() << ": " << result.GetIssues().ToString();
-                }
-            }
-
-            // Bulk upsert must be denied even after index is built
-            checkBulkUpsert();
         });
     }
 
     Y_UNIT_TEST(BuildingUniqIndexDeniesTableModificationsPublicApi) {
-        BuildingUniqIndexDeniesTableModifications(false);
+        BuildingUniqIndexAllowsTableModifications(false, false);
     }
 
     Y_UNIT_TEST(BuildingUniqIndexDeniesTableModificationsSql) {
-        BuildingUniqIndexDeniesTableModifications(true);
+        BuildingUniqIndexAllowsTableModifications(true, false);
+    }
+
+    Y_UNIT_TEST(BuildingUniqIndexAllowsTableModificationsPublicApi) {
+        BuildingUniqIndexAllowsTableModifications(false, true);
+    }
+
+    Y_UNIT_TEST(BuildingUniqIndexAllowsTableModificationsSql) {
+        BuildingUniqIndexAllowsTableModifications(true, true);
     }
 
     void ValidatingUniqIndex(bool sqlInterface, bool isUnique) {

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -281,6 +281,8 @@ enum ESimpleCounters {
     COUNTER_FORCED_COMPACTION_OPERATIONS_QUEUE_SIZE = 217    [(CounterOpts) = {Name: "ForcedCompactionOperationsQueueSize"}];
     COUNTER_FORCED_COMPACTION_PROCESSING_QUEUE_SIZE = 218    [(CounterOpts) = {Name: "ForcedCompactionProcessingQueueSize"}];
     COUNTER_FORCED_COMPACTION_PROCESSING_QUEUE_RUNNING = 219 [(CounterOpts) = {Name: "ForcedCompactionProcessingQueueRunning"}];
+
+    COUNTER_IN_FLIGHT_OPS_TxPrepareIndexValidation = 220 [(CounterOpts) = {Name: "InFlightOps/PrepareIndexValidation"}];
 }
 
 enum ECumulativeCounters {
@@ -461,6 +463,8 @@ enum ECumulativeCounters {
     COUNTER_FORCED_COMPACTION_TIMEOUT = 137       [(CounterOpts) = {Name: "ForcedCompactionTimeout"}];
     COUNTER_FORCED_COMPACTION_NOT_NEEDED = 138    [(CounterOpts) = {Name: "ForcedCompactionNotNeeded"}];
     COUNTER_FORCED_COMPACTION_LOANED = 139        [(CounterOpts) = {Name: "ForcedCompactionLoaned"}];
+
+    COUNTER_FINISHED_OPS_TxPrepareIndexValidation = 140 [(CounterOpts) = {Name: "FinishedOps/PrepareIndexValidation"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -275,7 +275,7 @@ message TFeatureFlags {
     optional bool EnableDataShardSplitHistogramSorting = 244 [default = false];
     optional bool EnableDataShardSplitKeySelection = 245 [default = false];
     optional bool EnableDataShardSplitHistogramOmission  = 246 [default = false];
-
+    optional bool EnableOnlineAddUniqueIndex = 247 [default = false];
     optional bool EnableSharedReadingInStreamingQueries = 248 [default = false];
     optional bool EnableCsDictionaryEncoding = 249 [default = false];
     optional bool EnableTopicPartitionSplitBasedOnKllSketch = 250 [default = false];

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1302,6 +1302,10 @@ message TFinalizeBuildIndexMainTable {
     optional TBuildIndexOutcome Outcome = 4;
 }
 
+message TPrepareIndexValidation {
+    optional string TableName = 1;
+}
+
 message TCopyTableConfig { //TTableDescription implemets copying a table in original and full way
     optional string SrcPath = 1;
     optional string DstPath = 2;
@@ -1970,6 +1974,8 @@ message TModifyScheme {
     // but in the future it may have an indirect impact on the schema,
     // for example, by resetting all sequences.
     optional TTruncateTable TruncateTable = 92;
+
+    optional TPrepareIndexValidation PrepareIndexValidation = 93;
 
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -211,5 +211,8 @@ enum EOperationType {
     // Truncate table
     ESchemeOpTruncateTable = 133;
 
+    // Publish shadow data and take snapshot in one step
+    ESchemeOpPrepareIndexValidation = 134;
+
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -432,6 +432,8 @@ message TCreatePersistentSnapshot {
     optional uint64 OwnerId = 1;
     optional uint64 PathId = 2;
     optional string Name = 3;
+    optional bool PrepareValidation = 4;
+    optional uint64 TableSchemaVersion = 5;
 }
 
 message TDropPersistentSnapshot {
@@ -447,6 +449,12 @@ message TInitiateBuildIndex {
     optional uint64 TableSchemaVersion = 3;
 
     optional NKikimrSchemeOp.TIndexDescription IndexDescription = 4;
+}
+
+message TPrepareIndexValidation {
+    optional NKikimrProto.TPathID IndexId = 1;
+    optional string SnapshotName = 2;
+    optional uint64 TableSchemaVersion = 3;
 }
 
 message TFinalizeBuildIndex {
@@ -578,6 +586,8 @@ message TFlatSchemeTransaction {
     optional TCreateIncrementalBackupSrc CreateIncrementalBackupSrc = 23;
 
     optional TTruncateTable TruncateTable = 25;
+
+    optional TPrepareIndexValidation PrepareIndexValidation = 26;
 }
 
 message TDistributedEraseTransaction {
@@ -2705,6 +2715,8 @@ message TEvValidateUniqueIndexRequest {
 
     optional uint64 SeqNoGeneration = 6; // monotonically increasing sequence, first part
     optional uint64 SeqNoRound = 7; // monotonically increasing sequence, second part
+
+    optional NKikimrProto.TRowVersion Snapshot = 8;
 }
 
 message TEvValidateUniqueIndexResponse {

--- a/ydb/core/tx/datashard/alter_table_unit.cpp
+++ b/ydb/core/tx/datashard/alter_table_unit.cpp
@@ -27,26 +27,35 @@ public:
         TActiveTransaction* tx = dynamic_cast<TActiveTransaction*>(op.Get());
         Y_ENSURE(tx, "cannot cast operation of kind " << op->GetKind());
 
-        // Only applicable when ALTER TABLE is in the transaction
+        // AlterMoveShadow is only applicable when AlterTable or PrepareIndexValidation is in the transaction
         auto& schemeTx = tx->GetSchemeTx();
-        if (!schemeTx.HasAlterTable())
+        bool shadowDisabled = false;
+        ui64 tableId = 0;
+        if (schemeTx.HasAlterTable()) {
+            // Only applicable when ALTER TABLE has disabled ShadowData
+            const auto& alter = schemeTx.GetAlterTable();
+            shadowDisabled = (
+                alter.HasPartitionConfig() &&
+                alter.GetPartitionConfig().HasShadowData() &&
+                !alter.GetPartitionConfig().GetShadowData());
+            tableId = alter.GetId_Deprecated();
+            if (alter.HasPathId()) {
+                auto& pathId = alter.GetPathId();
+                Y_ENSURE(DataShard.GetPathOwnerId() == pathId.GetOwnerId());
+                tableId = pathId.GetLocalId();
+            }
+        } else if (schemeTx.HasPrepareIndexValidation()) {
+            const auto& snap = schemeTx.GetPrepareIndexValidation();
+            shadowDisabled = true;
+            tableId = snap.GetIndexId().GetLocalId();
+            Y_ENSURE(DataShard.GetPathOwnerId() == snap.GetIndexId().GetOwnerId());
+        } else {
             return EExecutionStatus::Executed;
+        }
 
-        // Only applicable when ALTER TABLE has disabled ShadowData
-        const auto& alter = schemeTx.GetAlterTable();
-        const bool shadowDisabled = (
-            alter.HasPartitionConfig() &&
-            alter.GetPartitionConfig().HasShadowData() &&
-            !alter.GetPartitionConfig().GetShadowData());
+        // Only applicable when tx has disabled ShadowData
         if (!shadowDisabled)
             return EExecutionStatus::Executed;
-
-        ui64 tableId = alter.GetId_Deprecated();
-        if (alter.HasPathId()) {
-            auto& pathId = alter.GetPathId();
-            Y_ENSURE(DataShard.GetPathOwnerId() == pathId.GetOwnerId());
-            tableId = pathId.GetLocalId();
-        }
 
         // Only applicable when table has ShadowData enabled
         Y_ENSURE(DataShard.GetUserTables().contains(tableId));

--- a/ydb/core/tx/datashard/build_index/unique_index.cpp
+++ b/ydb/core/tx/datashard/build_index/unique_index.cpp
@@ -236,6 +236,9 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateUniqueIndexRequest::TPtr& e
     auto& request = ev->Get()->Record;
 
     const ui64 id = request.GetId();
+    auto rowVersion = request.HasSnapshot()
+        ? TRowVersion::FromProto(request.GetSnapshot())
+        : GetMvccTxVersion(EMvccTxMode::ReadOnly);
     TScanRecord::TSeqNo seqNo = {request.GetSeqNoGeneration(), request.GetSeqNoRound()};
 
     try {
@@ -244,6 +247,11 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateUniqueIndexRequest::TPtr& e
 
         LOG_N("Starting TValidateUniqueIndexScan TabletId: " << TabletID()
             << " " << request.ShortDebugString());
+
+        if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
+            VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
+            return;
+        }
 
         auto badRequest = [&](const TString& error) {
             response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
@@ -277,6 +285,15 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateUniqueIndexRequest::TPtr& e
             badRequest("Empty index columns list");
         }
 
+        if (request.HasSnapshot()) {
+            const auto& pathId = tableId.PathId;
+            const TSnapshotKey snapshotKey(pathId, rowVersion.Step, rowVersion.TxId);
+            if (!SnapshotManager.FindAvailable(snapshotKey)) {
+                badRequest(TStringBuilder() << "Unknown snapshot for path id " << pathId.OwnerId << ":" << pathId.LocalPathId
+                    << ", snapshot step is " << snapshotKey.Step << ", snapshot tx is " << snapshotKey.TxId);
+            }
+        }
+
         if (trySendBadRequest()) {
             return;
         }
@@ -302,7 +319,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateUniqueIndexRequest::TPtr& e
             ev->Sender);
 
         // We don't need a specific row version here, because KQP level forbids table modification during unique index building.
-        StartScan(this, std::move(scan), id, seqNo, std::nullopt, userTable.LocalTid);
+        StartScan(this, std::move(scan), id, seqNo, rowVersion, userTable.LocalTid);
     } catch (const std::exception& exc) {
         FailScan<TEvDataShard::TEvValidateUniqueIndexResponse>(id, TabletID(), ev->Sender, seqNo, exc, "TValidateUniqueIndexScan");
     }

--- a/ydb/core/tx/datashard/check_scheme_tx_unit.cpp
+++ b/ydb/core/tx/datashard/check_scheme_tx_unit.cpp
@@ -32,6 +32,7 @@ private:
     bool CheckCreatePersistentSnapshot(TActiveTransaction *activeTx);
     bool CheckDropPersistentSnapshot(TActiveTransaction *activeTx);
     bool CheckInitiateBuildIndex(TActiveTransaction *activeTx);
+    bool CheckPrepareIndexValidation(TActiveTransaction *activeTx);
     bool CheckFinalizeBuildIndex(TActiveTransaction *activeTx);
     bool CheckDropIndexNotice(TActiveTransaction *activeTx);
     bool CheckMoveTable(TActiveTransaction *activeTx);
@@ -358,6 +359,9 @@ bool TCheckSchemeTxUnit::CheckSchemeTx(TActiveTransaction *activeTx)
     case TSchemaOperation::ETypeCreatePersistentSnapshot:
         res = CheckCreatePersistentSnapshot(activeTx);
         break;
+    case TSchemaOperation::ETypePrepareIndexValidation:
+        res = CheckPrepareIndexValidation(activeTx);
+        break;
     case TSchemaOperation::ETypeDropPersistentSnapshot:
         res = CheckDropPersistentSnapshot(activeTx);
         break;
@@ -621,6 +625,18 @@ bool TCheckSchemeTxUnit::CheckCreatePersistentSnapshot(TActiveTransaction *activ
     const auto& tx = activeTx->GetSchemeTx();
 
     if (HasDuplicate(activeTx, "CreatePersistentSnapshot", &TPipeline::HasCreatePersistentSnapshot)) {
+        return false;
+    }
+
+    Y_UNUSED(tx);
+
+    return true;
+}
+
+bool TCheckSchemeTxUnit::CheckPrepareIndexValidation(TActiveTransaction *activeTx) {
+    const auto& tx = activeTx->GetSchemeTx();
+
+    if (HasDuplicate(activeTx, "PrepareIndexValidation", &TPipeline::HasPrepareIndexValidation)) {
         return false;
     }
 

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -490,6 +490,11 @@ bool TActiveTransaction::BuildSchemeTx()
         count++;
     }
     
+    if (SchemeTx->HasPrepareIndexValidation()) {
+        SchemeTxType = TSchemaOperation::ETypePrepareIndexValidation;
+        count++;
+    }
+    
     if (SchemeTx->HasFinalizeBuildIndex()) {
         SchemeTxType = TSchemaOperation::ETypeFinalizeBuildIndex;
         count++;
@@ -920,6 +925,7 @@ void TActiveTransaction::BuildExecutionPlan(bool loaded)
         plan.push_back(EExecutionUnitKind::AlterMoveShadow);
         plan.push_back(EExecutionUnitKind::AlterTable);
         plan.push_back(EExecutionUnitKind::DropTable);
+        plan.push_back(EExecutionUnitKind::PrepareIndexValidation);
         plan.push_back(EExecutionUnitKind::CreatePersistentSnapshot);
         plan.push_back(EExecutionUnitKind::DropPersistentSnapshot);
         plan.push_back(EExecutionUnitKind::InitiateBuildIndex);

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -58,6 +58,7 @@ struct TSchemaOperation {
         ETypeCreateIncrementalBackupSrc = 18,
         ETypeRotateCdcStream = 19,
         ETypeTruncate = 20,
+        ETypePrepareIndexValidation = 21,
 
         ETypeUnknown = Max<ui32>()
     };
@@ -106,6 +107,7 @@ struct TSchemaOperation {
     bool IsCreatePersistentSnapshot() const { return Type == ETypeCreatePersistentSnapshot; }
     bool IsDropPersistentSnapshot() const { return Type == ETypeDropPersistentSnapshot; }
     bool IsInitiateBuildIndex() const { return Type == ETypeInitiateBuildIndex; }
+    bool IsPrepareIndexValidation() const { return Type == ETypePrepareIndexValidation; }
     bool IsFinalizeBuildIndex() const { return Type == ETypeFinalizeBuildIndex; }
     bool IsDropIndexNotice() const { return Type == ETypeDropIndexNotice; }
     bool IsMove() const { return Type == ETypeMoveTable; }

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -165,6 +165,7 @@ public:
     bool HasCreatePersistentSnapshot() const { return SchemaTx && SchemaTx->IsCreatePersistentSnapshot(); }
     bool HasDropPersistentSnapshot() const { return SchemaTx && SchemaTx->IsDropPersistentSnapshot(); }
     bool HasInitiateBuilIndex() const { return SchemaTx && SchemaTx->IsInitiateBuildIndex(); }
+    bool HasPrepareIndexValidation() const { return SchemaTx && SchemaTx->IsPrepareIndexValidation(); }
     bool HasFinalizeBuilIndex() const { return SchemaTx && SchemaTx->IsFinalizeBuildIndex(); }
     bool HasDropIndexNotice() const { return SchemaTx && SchemaTx->IsDropIndexNotice(); }
     bool HasMove() const { return SchemaTx && SchemaTx->IsMove(); }

--- a/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_erase_rows.cpp
@@ -4,6 +4,7 @@
 #include "datashard_ut_common_kqp.h"
 
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/tx/tx.h>
@@ -2015,6 +2016,81 @@ tkey = 100, key = 4
                 {"by_tkey", {"tkey"}, {}, NKikimrSchemeOp::EIndexTypeGlobalAsync}
             })
         );
+    }
+
+    Y_UNIT_TEST(ConditionalEraseRowsOnlineUniqueIndex) {
+        using TEvResponse = TEvDataShard::TEvConditionalEraseRowsResponse;
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableAddUniqueIndex(true);
+        featureFlags.SetEnableOnlineAddUniqueIndex(true);
+
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings
+            .SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetFeatureFlags(featureFlags);
+
+        TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        const TActorId sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-1", TShardedTableOptions()
+            .EnableOutOfOrder(false)
+            .Columns({
+                {"key", "Uint32", true, false},
+                {"skey", "Uint32", false, false},
+                {"tkey", "Uint32", false, false},
+                {"value", "Timestamp", false, false}
+            })
+            .Indexes({
+                {"by_skey", {"skey"}, {}, NKikimrSchemeOp::EIndexTypeGlobalUnique},
+            }));
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table-1` (key, skey, tkey, value) VALUES
+            (1, 10, 300, CAST("1970-01-01T00:00:00.000000Z" AS Timestamp)),
+            (2, 20, 200, CAST("1990-03-01T00:00:00.000000Z" AS Timestamp)),
+            (3, 30, 100, CAST("2020-04-15T00:00:00.000000Z" AS Timestamp));
+        )");
+
+        TBlockEvents<TEvDataShard::TEvProposeTransaction> blockedPrepare(runtime, [&](auto& ev) {
+            const auto& rec = ev->Get()->Record;
+            if (rec.GetTxKind() == NKikimrTxDataShard::TX_KIND_SCHEME) {
+                NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                bool ok = schemeTx.ParseFromArray(rec.GetTxBody().data(), rec.GetTxBody().size());
+                if (ok) {
+                    return schemeTx.HasPrepareIndexValidation();
+                }
+            }
+            return false;
+        });
+        auto createIndexFuture = KqpSchemeExecSend(runtime, R"(
+            ALTER TABLE `/Root/table-1` ADD INDEX by_tkey GLOBAL UNIQUE ON (tkey)
+            )", "/Root");
+        runtime.WaitFor("blocked prepare validation", [&]{ return blockedPrepare.size() > 0; });
+
+        auto tableId = ResolveTableId(server, sender, "/Root/table-1");
+        auto indexes = GetIndexes(server, sender, "/Root/table-1");
+        ConditionalEraseRows(server, sender, "/Root/table-1", tableId, 4, currentTime, TUnit::AUTO, indexes);
+
+        auto ev = server->GetRuntime()->GrabEdgeEventRethrow<TEvResponse>(sender);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetStatus(), TEvResponse::ProtoRecordType::OK);
+
+        // Unblock and wait for the finished index build
+        blockedPrepare.Stop().Unblock();
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExecWait(runtime, std::move(createIndexFuture)),
+            "SUCCESS");
+
+        for (const auto& index : {"by_skey", "by_tkey"}) {
+            auto content = ReadShardedTable(server, Sprintf("/Root/table-1/%s/indexImplTable", index));
+            UNIT_ASSERT_STRINGS_EQUAL(StripInPlace(content), "");
+        }
     }
 }
 

--- a/ydb/core/tx/datashard/execution_unit.cpp
+++ b/ydb/core/tx/datashard/execution_unit.cpp
@@ -124,6 +124,8 @@ THolder<TExecutionUnit> CreateExecutionUnit(EExecutionUnitKind kind,
         return CreateDropTableUnit(dataShard, pipeline);
     case EExecutionUnitKind::DirectOp:
         return CreateDirectOpUnit(dataShard, pipeline);
+    case EExecutionUnitKind::PrepareIndexValidation:
+        return CreatePrepareIndexValidationUnit(dataShard, pipeline);
     case EExecutionUnitKind::CreatePersistentSnapshot:
         return CreateCreatePersistentSnapshotUnit(dataShard, pipeline);
     case EExecutionUnitKind::DropPersistentSnapshot:

--- a/ydb/core/tx/datashard/execution_unit_ctors.h
+++ b/ydb/core/tx/datashard/execution_unit_ctors.h
@@ -68,6 +68,7 @@ THolder<TExecutionUnit> CreateDropPersistentSnapshotUnit(TDataShard &dataShard, 
 THolder<TExecutionUnit> CreateCreateVolatileSnapshotUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateDropVolatileSnapshotUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateInitiateBuildIndexUnit(TDataShard &dataShard, TPipeline &pipeline);
+THolder<TExecutionUnit> CreatePrepareIndexValidationUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateFinalizeBuildIndexUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateDropIndexNoticeUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateMoveIndexUnit(TDataShard &dataShard, TPipeline &pipeline);

--- a/ydb/core/tx/datashard/execution_unit_kind.h
+++ b/ydb/core/tx/datashard/execution_unit_kind.h
@@ -70,6 +70,7 @@ enum class EExecutionUnitKind: ui32 {
     CreateVolatileSnapshot,
     DropVolatileSnapshot,
     InitiateBuildIndex,
+    PrepareIndexValidation,
     FinalizeBuildIndex,
     DropIndexNotice,
     MoveTable,

--- a/ydb/core/tx/datashard/prepare_index_validation_unit.cpp
+++ b/ydb/core/tx/datashard/prepare_index_validation_unit.cpp
@@ -1,0 +1,83 @@
+#include "datashard_impl.h"
+#include "datashard_locks_db.h"
+#include "datashard_pipeline.h"
+#include "execution_unit_ctors.h"
+
+namespace NKikimr {
+namespace NDataShard {
+
+// Moves shadow data and creates a snapshot in one transaction
+// TAlterMoveShadowUnit is used to move shadow
+
+class TPrepareIndexValidationUnit : public TExecutionUnit {
+public:
+    TPrepareIndexValidationUnit(TDataShard& dataShard, TPipeline& pipeline)
+        : TExecutionUnit(EExecutionUnitKind::PrepareIndexValidation, false, dataShard, pipeline)
+    { }
+
+    bool IsReadyToExecute(TOperation::TPtr) const override {
+        return true;
+    }
+
+    EExecutionStatus Execute(TOperation::TPtr op, TTransactionContext& txc, const TActorContext& ctx) override {
+        Y_ENSURE(op->IsSchemeTx());
+
+        TActiveTransaction* tx = dynamic_cast<TActiveTransaction*>(op.Get());
+        Y_ENSURE(tx, "cannot cast operation of kind " << op->GetKind());
+
+        auto& schemeTx = tx->GetSchemeTx();
+        if (!schemeTx.HasPrepareIndexValidation()) {
+            return EExecutionStatus::Executed;
+        }
+
+        const auto& params = schemeTx.GetPrepareIndexValidation();
+
+        const TPathId tableId = TPathId::FromProto(params.GetIndexId());
+        ui64 step = tx->GetStep();
+        ui64 txId = tx->GetTxId();
+        Y_ENSURE(step != 0);
+
+        auto oldInfo = DataShard.FindUserTable(tableId);
+        Y_ENSURE(oldInfo);
+        NKikimrSchemeOp::TTableDescription description;
+        oldInfo->GetSchema(description);
+        Y_ENSURE(description.GetTableSchemaVersion() == params.GetTableSchemaVersion()-1);
+        description.SetTableSchemaVersion(params.GetTableSchemaVersion());
+        Y_ENSURE(description.MutablePartitionConfig()->GetShadowData());
+        description.MutablePartitionConfig()->SetShadowData(false);
+        description.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(false);
+        auto newInfo = DataShard.AlterUserTable(ctx, txc, description);
+        TDataShardLocksDb locksDb(DataShard, txc);
+        DataShard.AddUserTable(tableId, newInfo, &locksDb);
+
+        const TSnapshotKey key(tableId.OwnerId, tableId.LocalPathId, step, txId);
+
+        ui64 flags = TSnapshot::FlagScheme;
+
+        bool added = DataShard.GetSnapshotManager().AddSnapshot(
+                txc.DB, key, params.GetSnapshotName(), flags, TDuration::Zero());
+
+        BuildResult(op, NKikimrTxDataShard::TEvProposeTransactionResult::COMPLETE);
+        op->Result()->SetStepOrderId(op->GetStepOrder().ToPair());
+
+        if (added) {
+            return EExecutionStatus::ExecutedNoMoreRestarts;
+        } else {
+            return EExecutionStatus::Executed;
+        }
+    }
+
+    void Complete(TOperation::TPtr, const TActorContext&) override {
+        // nothing
+    }
+};
+
+THolder<TExecutionUnit> CreatePrepareIndexValidationUnit(
+        TDataShard& dataShard,
+        TPipeline& pipeline)
+{
+    return THolder(new TPrepareIndexValidationUnit(dataShard, pipeline));
+}
+
+} // namespace NDataShard
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -183,6 +183,7 @@ SRCS(
     plan_queue_unit.cpp
     prepare_data_tx_in_rs_unit.cpp
     prepare_distributed_erase_tx_in_rs_unit.cpp
+    prepare_index_validation_unit.cpp
     prepare_kqp_data_tx_in_rs_unit.cpp
     prepare_scheme_tx_in_rs_unit.cpp
     prepare_write_tx_in_rs_unit.cpp

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -124,6 +124,7 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpUpgradeSubDomainDecision:
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateIndexBuild:
         case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpPrepareIndexValidation:
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLock:
         case NKikimrSchemeOp::EOperationType::ESchemeOpApplyIndexBuild:
         case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexMainTable:

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1111,6 +1111,8 @@ ISubOperation::TPtr TOperation::RestorePart(TTxState::ETxType txType, TTxState::
         return CreateDropKesus(NextPartId(), txState);
     case TTxState::ETxType::TxInitializeBuildIndex:
         return CreateInitializeBuildIndexMainTable(NextPartId(), txState);
+    case TTxState::ETxType::TxPrepareIndexValidation:
+        return CreatePrepareIndexValidation(NextPartId(), txState);
     case TTxState::ETxType::TxFinalizeBuildIndex:
         return CreateFinalizeBuildIndexMainTable(NextPartId(), txState);
     case TTxState::ETxType::TxDropTableIndexAtMainTable:
@@ -1490,6 +1492,9 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         Y_ABORT("multipart operations are handled before, also they require transaction details");
     case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexMainTable:
         Y_ABORT("multipart operations are handled before, also they require transaction details");
+
+    case NKikimrSchemeOp::EOperationType::ESchemeOpPrepareIndexValidation:
+        return {CreatePrepareIndexValidation(op.NextPartId(), tx)};
 
     case NKikimrSchemeOp::EOperationType::ESchemeOpCancelIndexBuild:
         return CancelBuildIndex(op.NextPartId(), tx, context);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -153,6 +153,14 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
                     return {std::move(op)};
                 }
                 result.push_back(std::move(op));
+            } else if (context.SS->TablesWithSnapshots.contains(indexChildItems.second)) {
+                auto finalize = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexMainTable);
+                *finalize.MutableLockGuard() = tx.GetLockGuard();
+                auto op = finalize.MutableFinalizeBuildIndexMainTable();
+                op->SetTableName(indexImplTableName);
+                op->SetSnapshotTxId(ui64(context.SS->TablesWithSnapshots.at(indexChildItems.second)));
+                op->SetBuildIndexId(config.GetBuildIndexId());
+                result.push_back(CreateFinalizeBuildIndexMainTable(partId, finalize));
             } else {
                 result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second, tx.GetLockGuard()));
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -813,6 +813,8 @@ void UpdatePartitioningForTableModification(TOperationId operationId, TTxState &
         commonShardOp = TTxState::ConfigureParts;
     } else if (txState.TxType == TTxState::TxFinalizeBuildIndex) {
         commonShardOp = TTxState::ConfigureParts;
+    } else if (txState.TxType == TTxState::TxPrepareIndexValidation) {
+        commonShardOp = TTxState::ConfigureParts;
     } else if (txState.TxType == TTxState::TxDropTableIndexAtMainTable) {
         commonShardOp = TTxState::ConfigureParts;
     } else if (txState.TxType == TTxState::TxUpdateMainTableOnIndexMove) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -165,7 +165,8 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
     }
 
     auto createImplTable = [&](NKikimrSchemeOp::TTableDescription&& implTableDesc, const THashSet<TString>& localSequences = {}) {
-        if (GetIndexType(indexDesc) != NKikimrSchemeOp::EIndexTypeGlobalUnique) {
+        if (GetIndexType(indexDesc) != NKikimrSchemeOp::EIndexTypeGlobalUnique ||
+            context.SS->EnableOnlineAddUniqueIndex) {
             implTableDesc.MutablePartitionConfig()->SetShadowData(true);
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -64,7 +64,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             // no feature flag, everything is fine
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-            if (!context.SS->EnableInitialUniqueIndex) {
+            if (!context.SS->EnableAddUniqueIndex) {
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Adding a unique index to an existing table is disabled")};
             }
             break;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_prepare_index_validation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_prepare_index_validation.cpp
@@ -1,0 +1,416 @@
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_impl.h"
+
+#include <ydb/core/base/subdomain.h>
+#include <ydb/core/mind/hive/hive.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+// Consistently publish shadow data and create snapshot of a table in one transaction
+// Used for example in unique index build to validate index state while allowing online changes
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TConfigureParts: public TSubOperationState {
+private:
+    TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TPrepareIndexValidation TConfigureParts"
+            << " operationId# " << OperationId;
+    }
+
+public:
+    TConfigureParts(TOperationId id)
+        : OperationId(id)
+    {
+        IgnoreMessages(DebugHint(), {TEvHive::TEvCreateTabletReply::EventType});
+    }
+
+    bool HandleReply(TEvDataShard::TEvProposeTransactionResult::TPtr& ev, TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " HandleReply TEvProposeTransactionResult"
+                               << " at tabletId# " << ssId);
+        LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    DebugHint() << " HandleReply TEvProposeTransactionResult"
+                                << " message: " << ev->Get()->Record.ShortDebugString());
+
+        return NTableState::CollectProposeTransactionResults(OperationId, ev, context);
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " ProgressState"
+                               << " at tabletId# " << ssId);
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxPrepareIndexValidation);
+
+        TPathId pathId = txState->TargetPathId;
+        TTableInfo::TPtr table = context.SS->Tables.at(pathId);
+
+        txState->ClearShardsInProgress();
+
+        for (ui32 i = 0; i < txState->Shards.size(); ++i) {
+            TShardIdx shardIdx = txState->Shards[i].Idx;
+            TTabletId datashardId = context.SS->ShardInfos[shardIdx].TabletID;
+
+            auto seqNo = context.SS->StartRound(*txState);
+
+            NKikimrTxDataShard::TFlatSchemeTransaction tx;
+
+            auto* createSnapshot = tx.MutablePrepareIndexValidation();
+            pathId.ToProto(createSnapshot->MutableIndexId());
+            createSnapshot->SetSnapshotName("Snapshot0");
+            createSnapshot->SetTableSchemaVersion(table->AlterVersion+1);
+
+            context.SS->FillSeqNo(tx, seqNo);
+
+            LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                        DebugHint() << " ProgressState"
+                                    << " SEND TFlatSchemeTransaction to datashard: " << datashardId
+                                    << " with publish shadow data request"
+                                    << " operationId: " << OperationId
+                                    << " seqNo: " << seqNo
+                                    << " at schemeshard: " << ssId);
+
+            auto event = context.SS->MakeDataShardProposal(txState->TargetPathId, OperationId, tx.SerializeAsString(), context.Ctx);
+            context.OnComplete.BindMsgToPipe(OperationId, datashardId, shardIdx, event.Release());
+        }
+
+        txState->UpdateShardsInProgress();
+        return false;
+    }
+};
+
+class TPropose: public TSubOperationState {
+private:
+    TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TPrepareIndexValidation TPropose"
+            << " operationId# " << OperationId;
+    }
+
+public:
+    TPropose(TOperationId id)
+        : OperationId(id)
+    {
+        IgnoreMessages(DebugHint(), {TEvHive::TEvCreateTabletReply::EventType, TEvDataShard::TEvProposeTransactionResult::EventType});
+    }
+
+    bool HandleReply(TEvDataShard::TEvSchemaChanged::TPtr& ev, TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+        const auto& evRecord = ev->Get()->Record;
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " HandleReply TEvSchemaChanged"
+                               << " at tablet: " << ssId);
+        LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    DebugHint() << " HandleReply TEvSchemaChanged"
+                                << " triggered early"
+                                << ", message: " << evRecord.ShortDebugString());
+
+        NTableState::CollectSchemaChanged(OperationId, ev, context);
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        TStepId step = TStepId(ev->Get()->StepId);
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " HandleReply TEvOperationPlan"
+                               << " at tablet: " << ssId
+                               << ", stepId: " << step);
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxPrepareIndexValidation);
+
+        NIceDb::TNiceDb db(context.GetDB());
+        context.SS->SnapshotsStepIds[OperationId.GetTxId()] = step;
+        context.SS->PersistSnapshotStepId(db, OperationId.GetTxId(), step);
+
+        const TTableInfo::TPtr tableInfo = context.SS->Tables.at(txState->TargetPathId);
+        tableInfo->AlterVersion += 1;
+        tableInfo->MutablePartitionConfig().SetShadowData(false);
+        tableInfo->MutablePartitionConfig().MutableCompactionPolicy()->SetKeepEraseMarkers(false);
+        context.SS->PersistTableAlterVersion(db, txState->TargetPathId, tableInfo);
+
+        auto tablePath = context.SS->PathsById.at(txState->TargetPathId);
+        context.SS->ClearDescribePathCaches(tablePath);
+        context.OnComplete.PublishToSchemeBoard(OperationId, txState->TargetPathId);
+
+        if (context.SS->Indexes.contains(tablePath->ParentPathId)) {
+            auto parentDir = context.SS->PathsById.at(tablePath->ParentPathId);
+            ++parentDir->DirAlterVersion;
+            context.SS->PersistPathDirAlterVersion(db, parentDir);
+            context.SS->ClearDescribePathCaches(parentDir);
+            context.OnComplete.PublishToSchemeBoard(OperationId, parentDir->PathId);
+        }
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::ProposedWaitParts);
+        return true;
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " HandleReply ProgressState"
+                               << " at tablet: " << ssId);
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxPrepareIndexValidation);
+
+        TSet<TTabletId> shardSet;
+        for (const auto& shard : txState->Shards) {
+            TShardIdx idx = shard.Idx;
+            TTabletId tablet = context.SS->ShardInfos.at(idx).TabletID;
+            shardSet.insert(tablet);
+        }
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, txState->MinStep, shardSet);
+        return false;
+    }
+};
+
+class TCreateTxShards: public TSubOperationState {
+private:
+    TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TPrepareIndexValidation TCreateTxShards"
+            << " operationId: " << OperationId;
+    }
+
+public:
+    TCreateTxShards(TOperationId id)
+        : OperationId(id)
+    {
+        IgnoreMessages(DebugHint(), {});
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        TTabletId ssId = context.SS->SelfTabletId();
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+
+        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   DebugHint() << " ProgressState"
+                               << ", operation type: " << TTxState::TypeName(txState->TxType)
+                               << ", at tablet# " << ssId);
+
+        if (NTableState::CheckPartitioningChangedForTableModification(*txState, context)) {
+            LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                       DebugHint() << " ProgressState"
+                                   << " SourceTablePartitioningChangedForModification"
+                                   << ", tx type: " << TTxState::TypeName(txState->TxType));
+            NTableState::UpdatePartitioningForTableModification(OperationId, *txState, context);
+        }
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::ConfigureParts);
+
+        return true;
+    }
+};
+
+class TPrepareIndexValidation: public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::CreateParts;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Waiting:
+        case TTxState::CreateParts:
+            return TTxState::ConfigureParts;
+        case TTxState::ConfigureParts:
+            return TTxState::Propose;
+        case TTxState::Propose:
+            return TTxState::ProposedWaitParts;
+        case TTxState::ProposedWaitParts:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Waiting:
+        case TTxState::CreateParts:
+            return MakeHolder<TCreateTxShards>(OperationId);
+        case TTxState::ConfigureParts:
+            return MakeHolder<TConfigureParts>(OperationId);
+        case TTxState::Propose:
+            return MakeHolder<TPropose>(OperationId);
+        case TTxState::ProposedWaitParts:
+            return MakeHolder<NTableState::TProposedWaitParts>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString&, TOperationContext& context) override {
+        const TTabletId ssId = context.SS->SelfTabletId();
+
+        auto& publish = Transaction.GetPrepareIndexValidation();
+
+        const TString& parentPathStr = Transaction.GetWorkingDir();
+        const TString& tableName = publish.GetTableName();
+
+        LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                     "TPrepareIndexValidation Propose"
+                         << ", path: " << parentPathStr << "/" << tableName
+                         << ", opId: " << OperationId
+                         << ", at schemeshard: " << ssId);
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ui64(ssId));
+
+        TPath path = TPath::Resolve(parentPathStr, context.SS).Dive(tableName);
+
+        if (!Transaction.GetInternal()) {
+            result->SetError(NKikimrScheme::EStatus::StatusNameConflict, "PrepareIndexValidation is an internal operation");
+            return result;
+        }
+
+        {
+            TPath::TChecker checks = path.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsTable()
+                .NotUnderDeleting()
+                .NotUnderOperation()
+                .IsInsideTableIndexPath();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        TPath parent = path.Parent();
+        {
+            TPath::TChecker checks = parent.Check();
+            checks
+                .NotEmpty()
+                .IsResolved()
+                .NotDeleted();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        TString errStr;
+
+        TPathElement::TPtr pathEl = path.Base();
+        TPathId tablePathId = pathEl->PathId;
+        result->SetPathId(tablePathId.LocalPathId);
+
+        if (!context.SS->CheckLocks(path.Base()->PathId, Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, errStr);
+            return result;
+        }
+
+        {
+            Y_ABORT_UNLESS(context.SS->Tables.contains(tablePathId));
+            TTableInfo::TPtr tableInfo = context.SS->Tables.at(tablePathId);
+            const NKikimrSchemeOp::TPartitionConfig &srcPartitionConfig = tableInfo->PartitionConfig();
+            if (!srcPartitionConfig.GetShadowData()) {
+                errStr = TStringBuilder()
+                    << "Shadow data is not enabled for table"
+                    << ", tableId:" << tablePathId
+                    << ", txId: " << OperationId.GetTxId();
+                result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+                return result;
+            }
+        }
+
+        if (context.SS->TablesWithSnapshots.contains(tablePathId)) {
+            errStr = TStringBuilder()
+                << "Snapshots already present for table"
+                << ", tableId:" << tablePathId
+                << ", txId: " << OperationId.GetTxId();
+            result->SetError(TEvSchemeShard::EStatus::StatusAlreadyExists, errStr);
+            return result;
+        }
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        pathEl->LastTxId = OperationId.GetTxId();
+        pathEl->PathState = NKikimrSchemeOp::EPathState::EPathStateAlter;
+
+        context.SS->CreateTx(OperationId, TTxState::TxPrepareIndexValidation, tablePathId);
+
+        context.SS->PersistTxState(db, OperationId);
+
+        TTableInfo::TPtr table = context.SS->Tables.at(tablePathId);
+        Y_ABORT_UNLESS(table->GetSplitOpsInFlight().empty());
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::CreateParts);
+        context.OnComplete.ActivateTx(OperationId);
+
+        context.DbChanges.PersistTableSnapshot(tablePathId, OperationId.GetTxId());
+        context.SS->TablesWithSnapshots.emplace(tablePathId, OperationId.GetTxId());
+        context.SS->SnapshotTables[OperationId.GetTxId()].insert(tablePathId);
+        context.SS->TabletCounters->Simple()[COUNTER_SNAPSHOTS_COUNT].Add(1);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext&) override {
+        Y_ABORT("no AbortPropose for TPrepareIndexValidation");
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                     "TPrepareIndexValidation AbortUnsafe"
+                         << ", opId: " << OperationId
+                         << ", forceDropId: " << forceDropTxId
+                         << ", at schemeshard: " << context.SS->TabletID());
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+ISubOperation::TPtr CreatePrepareIndexValidation(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TPrepareIndexValidation>(id, tx);
+}
+
+ISubOperation::TPtr CreatePrepareIndexValidation(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TPrepareIndexValidation>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -131,6 +131,8 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
         return "BUILD INDEX";
     case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable:
         return "ALTER TABLE BUILD INDEX INIT";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpPrepareIndexValidation:
+        return "ALTER TABLE BUILD INDEX PUBLISH SHADOW";
     case NKikimrSchemeOp::EOperationType::ESchemeOpApplyIndexBuild:
         return "ALTER TABLE BUILD INDEX APPLY";
     case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexMainTable:
@@ -434,6 +436,9 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetInitiateBuildIndexMainTable().GetTableName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpPrepareIndexValidation:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetPrepareIndexValidation().GetTableName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLock:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetLockConfig().GetName()}));

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -440,6 +440,29 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
     return propose;
 }
 
+THolder<TEvSchemeShard::TEvModifySchemeTransaction> PrepareValidationPropose(
+    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+{
+    Y_ENSURE(buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildSecondaryUniqueIndex, "Unknown operation kind while building PrepareValidationPropose");
+
+    auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
+    propose->Record.SetFailOnExist(true);
+
+    auto path = TPath::Init(buildInfo.TablePathId, ss);
+
+    NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpPrepareIndexValidation);
+    modifyScheme.SetInternal(true);
+    modifyScheme.SetWorkingDir(path.Dive(buildInfo.IndexName).PathString());
+    modifyScheme.MutableLockGuard()->SetOwnerTxId(ui64(buildInfo.LockTxId));
+    modifyScheme.MutablePrepareIndexValidation()->SetTableName(NTableIndex::ImplTable);
+
+    LOG_NOTICE_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX,
+        "PrepareValidationPropose " << buildInfo.Id << " " << buildInfo.State << " " << propose->Record.ShortDebugString());
+
+    return propose;
+}
+
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> ApplyPropose(
     TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
 {
@@ -1040,6 +1063,14 @@ private:
             buildInfo.IndexColumns.end()
         };
 
+        // Check snapshot and pass it to Validate if it's present
+        if (buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation) {
+            // TablesWithSnapshots.at() is already checked in ValidateSecondaryUniqueIndex()
+            auto snapId = Self->TablesWithSnapshots.at(path->PathId);
+            record.MutableSnapshot()->SetTxId(ui64(snapId));
+            record.MutableSnapshot()->SetStep(ui64(Self->SnapshotsStepIds.at(snapId)));
+        }
+
         TTabletId shardId = Self->ShardInfos.at(shardIdx).TabletID;
         record.SetTabletId(ui64(shardId));
 
@@ -1324,11 +1355,19 @@ private:
         return done;
     }
 
-    bool ValidateSecondaryUniqueIndex(TIndexBuildInfo& buildInfo) {
+    bool ValidateSecondaryUniqueIndex(TIndexBuildInfo& buildInfo, TString& errorDesc) {
         LOG_D("ValidateSecondaryUniqueIndex Start");
 
         if (NoShardsAdded(buildInfo)) {
             AddAllShards(buildInfo);
+        }
+
+        if (buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation) {
+            auto path = GetBuildPath(Self, buildInfo, NTableIndex::ImplTable);
+            if (!Self->TablesWithSnapshots.contains(path->PathId)) {
+                errorDesc = "Consistent validation requested, but index table snapshot is not found";
+                return true;
+            }
         }
 
         auto done = SendToShards(buildInfo, [&](TShardIdx shardIdx) { SendValidateUniqueIndexRequest(shardIdx, buildInfo); }) &&
@@ -1350,28 +1389,48 @@ private:
                 // After filling unique index we need to validate it.
                 // This includes:
                 // - Locking index shards
+                // - Publishing shadow data and creating a consistent snapshot if enabled
                 // - Validating each index shard for index keys uniqueness
                 // - Applying cross-shard validation
                 NIceDb::TNiceDb db{txc.DB};
-                buildInfo.SubState = TIndexBuildInfo::ESubState::UniqIndexValidation;
+                if (Self->EnableOnlineAddUniqueIndex) {
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::PrepareValidation;
+                } else {
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::UniqIndexValidation;
+                    Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+                }
                 Self->PersistBuildIndexState(db, buildInfo);
-                Self->PersistBuildIndexShardStatusReset(db, buildInfo);
                 ChangeState(BuildId, TIndexBuildInfo::EState::LockBuild);
                 Progress(BuildId);
             }
             return false;
         }
-        case TIndexBuildInfo::ESubState::UniqIndexValidation: {
-            const bool done = ValidateSecondaryUniqueIndex(buildInfo);
-            if (done) {
-                TString errorDesc;
-                if (!PerformCrossShardUniqIndexValidation(buildInfo, errorDesc)) {
-                    NIceDb::TNiceDb db(txc.DB);
-                    Self->PersistBuildIndexAddIssue(db, buildInfo, errorDesc);
-                    ChangeState(BuildId, TIndexBuildInfo::EState::Rejection_Applying);
-                    Progress(BuildId);
-                    return false;
-                }
+        case TIndexBuildInfo::ESubState::PrepareValidation: {
+            // LockBuild from above finishes here at Filling again
+            // Switch to PrepareValidation + UniqConsistentValidation, it will also finish at Filling
+            NIceDb::TNiceDb db{txc.DB};
+            if (buildInfo.SubState == TIndexBuildInfo::ESubState::PrepareValidation) {
+                buildInfo.SubState = TIndexBuildInfo::ESubState::UniqConsistentValidation;
+            } else {
+                buildInfo.SubState = TIndexBuildInfo::ESubState::UniqIndexValidation;
+            }
+            Self->PersistBuildIndexState(db, buildInfo);
+            Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+            ChangeState(BuildId, TIndexBuildInfo::EState::PrepareValidation);
+            Progress(BuildId);
+            return false;
+        }
+        case TIndexBuildInfo::ESubState::UniqIndexValidation:
+        case TIndexBuildInfo::ESubState::UniqConsistentValidation: {
+            TString errorDesc;
+            const bool done = ValidateSecondaryUniqueIndex(buildInfo, errorDesc);
+            if (done &&
+                (errorDesc != "" || !PerformCrossShardUniqIndexValidation(buildInfo, errorDesc))) {
+                NIceDb::TNiceDb db(txc.DB);
+                Self->PersistBuildIndexAddIssue(db, buildInfo, errorDesc);
+                ChangeState(BuildId, TIndexBuildInfo::EState::Rejection_Applying);
+                Progress(BuildId);
+                return false;
             }
             return done;
         }
@@ -2090,6 +2149,8 @@ public:
             Y_ENSURE(buildInfo.IsBuildVectorIndex() && (buildInfo.KMeans.Level > 1 ||
                 buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::Filter) ||
                 buildInfo.SubState == TIndexBuildInfo::ESubState::UniqIndexValidation ||
+                buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation ||
+                buildInfo.SubState == TIndexBuildInfo::ESubState::PrepareValidation ||
                 buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary);
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
@@ -2097,7 +2158,9 @@ public:
                 TString tableName;
                 if (buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary) {
                     tableName = NTableIndex::ImplTable;
-                } else if (buildInfo.SubState == TIndexBuildInfo::ESubState::UniqIndexValidation) {
+                } else if (buildInfo.SubState == TIndexBuildInfo::ESubState::UniqIndexValidation ||
+                    buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation ||
+                    buildInfo.SubState == TIndexBuildInfo::ESubState::PrepareValidation) {
                     tableName = NTableIndex::ImplTable;
                 } else {
                     tableName = buildInfo.KMeans.ReadFrom();
@@ -2126,6 +2189,28 @@ public:
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
                 Send(Self->SelfId(), AlterSequencePropose(Self, buildInfo), 0, ui64(BuildId));
+            } else if (!buildInfo.ApplyTxDone) {
+                Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
+            } else {
+                buildInfo.ApplyTxId = {};
+                buildInfo.ApplyTxStatus = NKikimrScheme::StatusSuccess;
+                buildInfo.ApplyTxDone = false;
+
+                NIceDb::TNiceDb db(txc.DB);
+                Self->PersistBuildIndexApplyTxId(db, buildInfo);
+                Self->PersistBuildIndexApplyTxStatus(db, buildInfo);
+                Self->PersistBuildIndexApplyTxDone(db, buildInfo);
+
+                ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                Progress(BuildId);
+            }
+            break;
+        case TIndexBuildInfo::EState::PrepareValidation:
+            Y_ENSURE(buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildSecondaryUniqueIndex);
+            if (buildInfo.ApplyTxId == InvalidTxId) {
+                AllocateTxId(BuildId);
+            } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
+                Send(Self->SelfId(), PrepareValidationPropose(Self, buildInfo), 0, ui64(BuildId));
             } else if (!buildInfo.ApplyTxDone) {
                 Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
             } else {
@@ -3067,6 +3152,7 @@ public:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
+        case TIndexBuildInfo::EState::PrepareValidation:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:
@@ -3239,6 +3325,7 @@ public:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
+        case TIndexBuildInfo::EState::PrepareValidation:
         {
             Y_ENSURE(txId == buildInfo.ApplyTxId);
 
@@ -3418,6 +3505,7 @@ public:
         case TIndexBuildInfo::EState::CreateBuild:
         case TIndexBuildInfo::EState::LockBuild:
         case TIndexBuildInfo::EState::AlterSequence:
+        case TIndexBuildInfo::EState::PrepareValidation:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -233,6 +233,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::Fill(NKikimrIndexBuilder::TIndexBuild
     case TIndexBuildInfo::EState::CreateBuild:
     case TIndexBuildInfo::EState::LockBuild:
     case TIndexBuildInfo::EState::AlterSequence:
+    case TIndexBuildInfo::EState::PrepareValidation:
         index.SetState(Ydb::Table::IndexBuildState::STATE_TRANSFERING_DATA);
         index.SetProgress(indexInfo.CalcProgressPercent());
         break;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1775,6 +1775,7 @@ TPathElement::EPathState TSchemeShard::CalcPathState(TTxState::ETxType txType, T
     case TTxState::TxAlterExtSubDomainCreateHive:
     case TTxState::TxAlterUserAttributes:
     case TTxState::TxInitializeBuildIndex:
+    case TTxState::TxPrepareIndexValidation:
     case TTxState::TxFinalizeBuildIndex:
     case TTxState::TxCreateLock:
     case TTxState::TxDropLock:
@@ -5196,6 +5197,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     EnableTempTables = appData->FeatureFlags.GetEnableTempTables();
     EnableInitialUniqueIndex = appData->FeatureFlags.GetEnableUniqConstraint();
     EnableAddUniqueIndex = appData->FeatureFlags.GetEnableAddUniqueIndex();
+    EnableOnlineAddUniqueIndex = appData->FeatureFlags.GetEnableOnlineAddUniqueIndex();
     EnableFulltextIndex = appData->FeatureFlags.GetEnableFulltextIndex();
     EnableResourcePoolsOnServerless = appData->FeatureFlags.GetEnableResourcePoolsOnServerless();
     EnableExternalDataSourcesOnServerless = appData->FeatureFlags.GetEnableExternalDataSourcesOnServerless();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -409,6 +409,7 @@ public:
     bool EnableResourcePoolsOnServerless = false;
     bool EnableInitialUniqueIndex = false;
     bool EnableAddUniqueIndex = false;
+    bool EnableOnlineAddUniqueIndex = false;
     bool EnableFulltextIndex = false;
     bool EnableExternalDataSourcesOnServerless = false;
     bool EnableShred = false;

--- a/ydb/core/tx/schemeshard/schemeshard_index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_index_build_info.cpp
@@ -318,6 +318,7 @@ bool TIndexBuildInfo::IsValidState(EState value)
         case EState::Applying:
         case EState::Unlocking:
         case EState::AlterSequence:
+        case EState::PrepareValidation:
         case EState::Done:
         case EState::Cancellation_Applying:
         case EState::Cancellation_Unlocking:
@@ -336,7 +337,9 @@ bool TIndexBuildInfo::IsValidSubState(ESubState value)
 {
     switch (value) {
         case ESubState::None:
+        case ESubState::PrepareValidation:
         case ESubState::UniqIndexValidation:
+        case ESubState::UniqConsistentValidation:
         case ESubState::FulltextIndexStats:
         case ESubState::FulltextIndexDictionary:
         case ESubState::FulltextIndexBorders:

--- a/ydb/core/tx/schemeshard/schemeshard_index_build_info.h
+++ b/ydb/core/tx/schemeshard/schemeshard_index_build_info.h
@@ -66,6 +66,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         Applying = 50,
         Unlocking = 60,
         AlterSequence = 61,
+        PrepareValidation = 62,
         Done = 200,
 
         Cancellation_Applying = 350,
@@ -85,6 +86,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         // Filling
         UniqIndexValidation = 100,
+        PrepareValidation = 101,
+        UniqConsistentValidation = 102,
 
         // Fulltext
         FulltextIndexStats = 200,
@@ -746,7 +749,7 @@ public:
     }
 
     bool IsValidatingUniqueIndex() const {
-        return SubState == ESubState::UniqIndexValidation;
+        return SubState == ESubState::UniqIndexValidation || SubState == ESubState::UniqConsistentValidation;
     }
 
     bool IsFlatRelevanceFulltext() const {

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -89,6 +89,7 @@ bool IsCreate(ETxType t) {
         case TxIncrementalRestoreFinalize:
             return false; // IsCreate
         case TxInitializeBuildIndex: //this is more like alter
+        case TxPrepareIndexValidation:
         case TxCreateCdcStreamAtTable:
         case TxCreateCdcStreamAtTableWithInitialScan:
             return false; // IsCreate
@@ -246,6 +247,7 @@ bool IsDrop(ETxType t) {
         case TxCreateTransfer:
         case TxCreateBlobDepot:
         case TxInitializeBuildIndex:
+        case TxPrepareIndexValidation:
         case TxCreateLock:
         case TxDropLock:
         case TxFinalizeBuildIndex:
@@ -384,6 +386,7 @@ bool CanDeleteParts(ETxType t) {
         case TxCreateTransfer:
         case TxCreateBlobDepot:
         case TxInitializeBuildIndex:
+        case TxPrepareIndexValidation:
         case TxCreateLock:
         case TxDropLock:
         case TxDropTableIndexAtMainTable:
@@ -581,6 +584,7 @@ ETxType ConvertToTxType(NKikimrSchemeOp::EOperationType opType) {
         case NKikimrSchemeOp::ESchemeOpAlterStreamingQuery: return TxAlterStreamingQuery;
         case NKikimrSchemeOp::ESchemeOpDropStreamingQuery: return TxDropStreamingQuery;
         case NKikimrSchemeOp::ESchemeOpTruncateTable: return TxTruncateTable;
+        case NKikimrSchemeOp::ESchemeOpPrepareIndexValidation: return TxPrepareIndexValidation;
 
         // no matching tx-type
         case NKikimrSchemeOp::ESchemeOpBackupBackupCollection:

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.h
@@ -133,6 +133,7 @@ enum ESimpleCounters : int;
     item(TxAlterStreamingQuery, 116) \
     item(TxTruncateTable, 117) \
     item(TxReadOnlyCopyColumnTable, 118) \
+    item(TxPrepareIndexValidation, 119) \
 
 // TX_STATE_TYPE_ENUM
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -630,6 +630,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnablePublicApiExternalBlobs(true);
     app.FeatureFlags.SetEnableTableDatetime64(true);
     app.FeatureFlags.SetEnableAddUniqueIndex(true);
+    app.FeatureFlags.SetEnableOnlineAddUniqueIndex(true);
     app.FeatureFlags.SetEnableFulltextIndex(true);
     app.FeatureFlags.SetEnableColumnStore(true);
     app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -383,13 +383,15 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(billRecords.size(), 0);
 
-        UNIT_ASSERT_VALUES_EQUAL(shadowData.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(shadowData[0], indexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobal);
+        UNIT_ASSERT_VALUES_EQUAL(shadowData.size(), indexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobal ? 2 : 3);
+        UNIT_ASSERT_VALUES_EQUAL(shadowData[0], true);
         UNIT_ASSERT_VALUES_EQUAL(shadowData[1], false);
+        UNIT_ASSERT(shadowData.size() < 3 || shadowData[2] == false);
 
-        UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers.size(), indexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobal ? 2 : 3);
         UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers[0], true);
         UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers[1], false);
+        UNIT_ASSERT(keepEraseMarkers.size() < 3 || keepEraseMarkers[2] == false);
     }
 
     Y_UNIT_TEST(BaseCase) {

--- a/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
+++ b/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
@@ -272,6 +272,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         CreateTableOnIndexedTable(NKikimrSchemeOp::EIndexTypeGlobalAsync);
     }
 
+    Y_UNIT_TEST(CreateTableShouldSucceedUniqueOnIndexedTable) {
+        CreateTableOnIndexedTable(NKikimrSchemeOp::EIndexTypeGlobalUnique);
+    }
+
     Y_UNIT_TEST(AlterTableShouldSuccess) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -426,6 +430,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         AlterTableOnIndexedTable(NKikimrSchemeOp::EIndexTypeGlobalAsync);
     }
 
+    Y_UNIT_TEST(AlterTableShouldSucceedOnUniqueIndexedTable) {
+        AlterTableOnIndexedTable(NKikimrSchemeOp::EIndexTypeGlobalUnique);
+    }
+
     void BuildIndex(NKikimrSchemeOp::EIndexType indexType) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -468,6 +476,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
     Y_UNIT_TEST(BuildAsyncIndexShouldSucceed) {
         BuildIndex(NKikimrSchemeOp::EIndexTypeGlobalAsync);
+    }
+
+    Y_UNIT_TEST(BuildUniqueIndexShouldSucceed) {
+        BuildIndex(NKikimrSchemeOp::EIndexTypeGlobalUnique);
     }
 
     using TEvCondEraseReq = TEvDataShard::TEvConditionalEraseRowsRequest;

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -218,6 +218,7 @@ SRCS(
     schemeshard__operation_move_tables.cpp
     schemeshard__operation_part.cpp
     schemeshard__operation_part.h
+    schemeshard__operation_prepare_index_validation.cpp
     schemeshard__operation_restore_backup_collection.cpp
     schemeshard__operation_rmdir.cpp
     schemeshard__operation_rotate_cdc_stream.cpp

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -304,6 +304,9 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpInitiateBuildIndexImplTable:
             Y_ABORT("no implementation for ESchemeOpInitiateBuildIndexImplTable");
 
+        case NKikimrSchemeOp::ESchemeOpPrepareIndexValidation:
+            Y_ABORT("no implementation for ESchemeOpPrepareIndexValidation");
+
         case NKikimrSchemeOp::ESchemeOpDropIndex:
             return *modifyScheme.MutableDropIndex()->MutableTableName();
 
@@ -1151,6 +1154,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropColumnBuild:
         case NKikimrSchemeOp::ESchemeOpCreateIndexBuild:
         case NKikimrSchemeOp::ESchemeOpInitiateBuildIndexMainTable:
+        case NKikimrSchemeOp::ESchemeOpPrepareIndexValidation:
         case NKikimrSchemeOp::ESchemeOpCreateLock:
         case NKikimrSchemeOp::ESchemeOpApplyIndexBuild:
         case NKikimrSchemeOp::ESchemeOpFinalizeBuildIndexMainTable:

--- a/ydb/tests/compatibility/test_unique_index.py
+++ b/ydb/tests/compatibility/test_unique_index.py
@@ -1,0 +1,155 @@
+import pytest
+import ydb as ydbs
+import random
+
+from ydb.tests.library.compatibility.fixtures import RollingUpgradeAndDowngradeFixture
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+
+class TestUniqueIndex(RollingUpgradeAndDowngradeFixture):
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        if min(self.versions) < (25, 4):
+            pytest.skip("Only available since 25-4")
+        flags = {"enable_add_unique_index": True}
+        if min(self.versions) >= (26, 2):
+            flags["enable_online_add_unique_index"] = True
+        self.row_count = 50
+        self.append_row_count = 5
+        yield from self.setup_cluster(extra_feature_flags=flags)
+
+    def create_table(self, table_name, with_index):
+        if with_index:
+            with_index = ", INDEX idx_uniq GLOBAL UNIQUE ON (uniq)"
+        else:
+            with_index = ""
+        query = f"""
+            CREATE TABLE {table_name} (
+                key Uint64 NOT NULL,
+                uniq String NOT NULL,
+                PRIMARY KEY (key)
+                {with_index}
+            )
+            """
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            session_pool.execute_with_retries(query)
+
+    def _write_initial(self, table_name):
+        values = []
+        self.cur_key = 1
+        while self.cur_key <= self.row_count:
+            values.append(f'({self.cur_key}, "{self.cur_key}")')
+            self.cur_key = self.cur_key+1
+        return f"""
+            UPSERT INTO `{table_name}` (`key`, `uniq`)
+            VALUES {",".join(values)};
+            """
+
+    def _get_queries(self, table_name, with_index):
+        queries = []
+        queries.append(["ok", self._write_initial(table_name)])
+        if not with_index:
+            queries.append([
+                "ok", f"""
+                    ALTER TABLE `{table_name}`
+                    ADD INDEX idx_uniq GLOBAL UNIQUE ON (uniq)
+                """
+            ])
+        while self.cur_key <= self.row_count + self.append_row_count:
+            queries.append([
+                "select", f"""
+                SELECT `key`, `uniq` FROM `{table_name}` VIEW idx_uniq
+                WHERE `key` IN ({self.row_count}, {self.row_count-1}, {self.row_count-2})
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                INSERT INTO `{table_name}` (`key`, `uniq`)
+                VALUES ({self.cur_key}, "{self.cur_key}")
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                UPSERT INTO `{table_name}` (`key`, `uniq`)
+                VALUES ({self.cur_key+1}, "{self.cur_key+1}")
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                UPDATE `{table_name}` SET `uniq`="{self.cur_key+2}" WHERE `key`={self.cur_key+1}
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                    ALTER TABLE `{table_name}` DROP INDEX idx_uniq
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                    ALTER TABLE `{table_name}`
+                    ADD INDEX idx_uniq GLOBAL UNIQUE ON (uniq)
+                """
+            ])
+            queries.append([
+                "ok", f"""
+                DELETE FROM `{table_name}` WHERE `key`={self.cur_key+1}
+                """
+            ])
+            queries.append([
+                "error", f"""
+                INSERT INTO `{table_name}` (`key`, `uniq`)
+                VALUES ({self.cur_key+1}, "{random.randint(1, self.row_count)}")
+                """
+            ])
+            queries.append([
+                "error", f"""
+                INSERT INTO `{table_name}` (`key`, `uniq`)
+                VALUES ({self.cur_key+1}, "{self.cur_key}")
+                """
+            ])
+            queries.append([
+                "error", f"""
+                UPSERT INTO `{table_name}` (`key`, `uniq`)
+                VALUES ({self.cur_key+1}, "{self.cur_key}")
+                """
+            ])
+            queries.append([
+                "error", f"""
+                UPDATE `{table_name}` SET `uniq`="1"
+                WHERE `key`={random.randint(2, self.row_count)}
+                """
+            ])
+            self.cur_key = self.cur_key+1
+        if not with_index:
+            queries.append([
+                "ok", f"ALTER TABLE `{table_name}` DROP INDEX idx_uniq"
+            ])
+        queries.append([
+            "ok", f"DELETE FROM `{table_name}`"
+        ])
+        return queries
+
+    def _do_queries(self, table_name, with_index):
+        queries = self._get_queries(table_name, with_index)
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            for [query_type, query] in queries:
+                if query_type == "error":
+                    ok = False
+                    try:
+                        session_pool.execute_with_retries(query)
+                    except ydbs.issues.PreconditionFailed as ex:
+                        ok = ("Conflict with existing key" in str(ex))
+                        pass
+                    assert ok, "Conflict expected"
+                elif query_type == "select":
+                    result_sets = session_pool.execute_with_retries(query)
+                    assert len(result_sets[0].rows) > 0, "Query returned an empty set"
+                else:
+                    session_pool.execute_with_retries(query)
+
+    def test_unique_index(self):
+        self.create_table("test_table", False)
+        self.create_table("test_indexed", True)
+        for _ in self.roll():
+            self._do_queries("test_table", False)
+            self._do_queries("test_indexed", True)

--- a/ydb/tests/compatibility/ya.make
+++ b/ydb/tests/compatibility/ya.make
@@ -21,6 +21,7 @@ TEST_SRCS(
     test_data_type.py
     test_ctas.py
     test_vector_index.py
+    test_unique_index.py
     test_batch_operations.py
     test_topic.py
     test_kafka_topic.py


### PR DESCRIPTION
### Changelog entry

* Allow to build unique indexes without blocking updates of the indexed table

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers

Feature for 26-2

Cherry-pick of #35981, #39296, #39846, #40050, #40048, #40076

Does not include pessmistic lock support as locks are not in 26-2