### PR TITLE
Fix incorrect vector argument type IGNIETFERRO-1955

### DIFF
--- a/ydb/core/tablet_flat/flat_util_binary.h
+++ b/ydb/core/tablet_flat/flat_util_binary.h
@@ -83,10 +83,10 @@ namespace NBin {
 
         inline TOut& Array(TStringBuf array)
         {
-            return Array<const char>(array);
+            return Array(MakeConstArrayRef(array));
         }
 
-        template<typename T, typename = TStdLayout<T>>
+        template<typename T, typename = std::enable_if_t<!std::is_const_v<T>>, typename = TStdLayout<T>>
         inline TOut& Array(const TVector<T> &array)
         {
             return Array(TArrayRef<const T>(array.begin(), array.end()));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`std::allocator<const T>` is considered ill-formed in standard C++ because containers require value_type to be mutable for construction, assignment, and reorganization.

Instantiating `vector<const T>` will result in compilation error under the C++20 standard.

See: https://nda.ya.ru/t/XI1Q00Po7b9jMa

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
