### PR TITLE
Fix listing method in S3 mock

### DIFF
--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -186,10 +186,11 @@ bool TS3Mock::TRequest::HttpServeList(const TReplyParams& params, TStringBuf buc
     THttpHeaders headers;
 
     TVector<TString> paths;
-    const TString keyPrefix = TStringBuilder() << bucketName << "/" << prefix;
+    const TString bucketPrefix = TStringBuilder() << bucketName << "/";
+    const TString keyPrefix = TStringBuilder() << bucketPrefix << prefix;
     for (const auto& [key, value] : Parent->Data) {
         if (key.StartsWith(keyPrefix)) {
-            paths.push_back(key.substr(TString(bucketName).size() + 1));
+            paths.push_back(key.substr(bucketPrefix.size()));
         }
     }
 

--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -186,9 +186,10 @@ bool TS3Mock::TRequest::HttpServeList(const TReplyParams& params, TStringBuf buc
     THttpHeaders headers;
 
     TVector<TString> paths;
+    const TString keyPrefix = TStringBuilder() << bucketName << "/" << prefix;
     for (const auto& [key, value] : Parent->Data) {
-        if (key.StartsWith(TStringBuilder() << bucketName << "/" << prefix)) {
-            paths.push_back(key);
+        if (key.StartsWith(keyPrefix)) {
+            paths.push_back(key.substr(TString(bucketName).size() + 1));
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

S3 mock incorrectly lists objects: it must not include bucket name to the result list, like in the examples of AWS API: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
