### PR TITLE
[EXT-2181] OIDC shared context cookie for multiple auth flows

### DIFF
--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -14,7 +14,6 @@ namespace NMVP::NOIDC {
 
 TContext::TContext(const TInitializer& initializer)
     : State(initializer.State)
-    , NavigationRequest(initializer.NavigationRequest)
     , RequestedAddress(initializer.RequestedAddress)
 {}
 
@@ -25,13 +24,10 @@ TContext::TContext(const NHttp::THttpIncomingRequestPtr& request)
 {}
 
 TString TContext::GetState(const TString& key) const {
-    static const TDuration STATE_LIFE_TIME = TDuration::Minutes(10);
     TState payload;
     payload.AntiForgeryToken = State;
-    payload.ExpirationTime = TInstant::Now() + STATE_LIFE_TIME;
-    if (!NavigationRequest) {
-        payload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
-    }
+    payload.ExpirationTime = TInstant::Now() + TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME;
+    payload.CookieSuffix = CreateFlowId(key, RequestedAddress);
     return EncodeState(payload, key);
 }
 
@@ -44,11 +40,10 @@ TString TContext::GetRequestedAddress() const {
 }
 
 TString TContext::CreateYdbOidcCookie(const TString& secret) const {
-    static constexpr size_t COOKIE_MAX_AGE_SEC = 3600;
-    return TStringBuilder() << CreateNameYdbOidcCookie(NavigationRequest ? TStringBuf() : TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX) << "="
+    return TStringBuilder() << CreateNameYdbOidcCookie(CreateFlowId(secret, RequestedAddress)) << "="
                             << GenerateCookie(secret) << ";"
                             " Path=" << GetAuthCallbackUrl() << ";"
-                            " Max-Age=" << COOKIE_MAX_AGE_SEC << ";"
+                            " Max-Age=" << TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds() << ";"
                             " SameSite=None; Secure";
 }
 

--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -39,24 +39,18 @@ TString TContext::GetRequestedAddress() const {
     return RequestedAddress;
 }
 
-TString TContext::CreateYdbOidcCookie(const TString& secret) const {
-    return TStringBuilder() << CreateNameYdbOidcCookie(CreateFlowId(secret, RequestedAddress)) << "="
-                            << GenerateCookie(secret) << ";"
+TString TContext::CreateAuthFlowCookie(const TString& secret) const {
+    return TStringBuilder() << CreateAuthFlowCookieName(CreateFlowId(secret, RequestedAddress)) << "="
+                            << CreateAuthFlowCookieValue(secret) << ";"
                             " Path=" << GetAuthCallbackUrl() << ";"
                             " Max-Age=" << TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds() << ";"
                             " SameSite=None; Secure";
 }
 
-TString TContext::GenerateCookie(const TString& key) const {
-    NJson::TJsonValue json(NJson::JSON_MAP);
-    json["requested_address"] = RequestedAddress;
-    const TString requestedAddressContext = NJson::WriteJson(json, false);
-
-    TString digest = HmacSHA256(key, requestedAddressContext);
-
+TString TContext::CreateAuthFlowCookieValue(const TString& key) const {
     NJson::TJsonValue root(NJson::JSON_MAP);
-    root["requested_address_context"] = Base64Encode(requestedAddressContext);
-    root["digest"] = Base64Encode(digest);
+    root["requested_address"] = RequestedAddress;
+    root["digest"] = Base64Encode(HmacSHA256(key, RequestedAddress));
     return Base64Encode(NJson::WriteJson(root, false));
 }
 

--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -1,4 +1,5 @@
 #include "context.h"
+#include "oidc_cookie.h"
 #include "oidc_settings.h"
 #include "openid_connect.h"
 
@@ -27,7 +28,14 @@ TString TContext::GetState(const TString& key) const {
     TState payload;
     payload.AntiForgeryToken = State;
     payload.ExpirationTime = TInstant::Now() + TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME;
-    payload.CookieSuffix = CreateFlowId(key, RequestedAddress);
+    return EncodeState(payload, key);
+}
+
+TString TContext::GetStateWithFlowId(const TString& key) const {
+    TState payload;
+    payload.AntiForgeryToken = State;
+    payload.ExpirationTime = TInstant::Now() + TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME;
+    payload.FlowId = CreateFlowId(key, RequestedAddress);
     return EncodeState(payload, key);
 }
 
@@ -39,18 +47,23 @@ TString TContext::GetRequestedAddress() const {
     return RequestedAddress;
 }
 
-TString TContext::CreateAuthFlowCookie(const TString& secret) const {
-    return TStringBuilder() << CreateAuthFlowCookieName(CreateFlowId(secret, RequestedAddress)) << "="
-                            << CreateAuthFlowCookieValue(secret) << ";"
-                            " Path=" << GetAuthCallbackUrl() << ";"
-                            " Max-Age=" << TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds() << ";"
+TString TContext::CreateYdbOidcCookie(const TString& secret) const {
+    static constexpr size_t COOKIE_MAX_AGE_SEC = 3600;
+    return TStringBuilder() << CreateNameYdbOidcCookie() << "="
+                            << GenerateCookie(secret) << ";"
+                            << " Path=" << GetAuthCallbackUrl() << ";"
+                            << " Max-Age=" << COOKIE_MAX_AGE_SEC << ";"
                             " SameSite=None; Secure";
 }
 
-TString TContext::CreateAuthFlowCookieValue(const TString& key) const {
+TString TContext::GenerateCookie(const TString& key) const {
+    NJson::TJsonValue json(NJson::JSON_MAP);
+    json["requested_address"] = RequestedAddress;
+    const TString requestedAddressContext = NJson::WriteJson(json, false);
+
     NJson::TJsonValue root(NJson::JSON_MAP);
-    root["requested_address"] = RequestedAddress;
-    root["digest"] = Base64Encode(HmacSHA256(key, RequestedAddress));
+    root["requested_address_context"] = Base64Encode(requestedAddressContext);
+    root["digest"] = Base64Encode(HmacSHA256(key, requestedAddressContext));
     return Base64Encode(NJson::WriteJson(root, false));
 }
 

--- a/ydb/mvp/oidc_proxy/context.h
+++ b/ydb/mvp/oidc_proxy/context.h
@@ -17,7 +17,6 @@ public:
     struct TInitializer {
         TString State;
         TString RequestedAddress;
-        bool NavigationRequest = true;
     };
 
 private:

--- a/ydb/mvp/oidc_proxy/context.h
+++ b/ydb/mvp/oidc_proxy/context.h
@@ -30,16 +30,17 @@ public:
     TContext(const NHttp::THttpIncomingRequestPtr& request);
 
     TString GetState(const TString& key) const;
+    TString GetStateWithFlowId(const TString& key) const;
     bool IsNavigationRequest() const;
     TString GetRequestedAddress() const;
 
-    TString CreateAuthFlowCookie(const TString& secret) const;
+    TString CreateYdbOidcCookie(const TString& secret) const;
 
 private:
     static bool IsPageNavigationRequest(const NHttp::THttpIncomingRequestPtr& request);
     static TStringBuf GetRequestedUrl(const NHttp::THttpIncomingRequestPtr& request, bool isNavigationRequest);
 
-    TString CreateAuthFlowCookieValue(const TString& key) const;
+    TString GenerateCookie(const TString& key) const;
 };
 
 } // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/context.h
+++ b/ydb/mvp/oidc_proxy/context.h
@@ -33,13 +33,13 @@ public:
     bool IsNavigationRequest() const;
     TString GetRequestedAddress() const;
 
-    TString CreateYdbOidcCookie(const TString& secret) const;
+    TString CreateAuthFlowCookie(const TString& secret) const;
 
 private:
     static bool IsPageNavigationRequest(const NHttp::THttpIncomingRequestPtr& request);
     static TStringBuf GetRequestedUrl(const NHttp::THttpIncomingRequestPtr& request, bool isNavigationRequest);
 
-    TString GenerateCookie(const TString& key) const;
+    TString CreateAuthFlowCookieValue(const TString& key) const;
 };
 
 } // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/mvp.cpp
+++ b/ydb/mvp/oidc_proxy/mvp.cpp
@@ -208,6 +208,7 @@ void TMVP::TryGetOidcOptionsFromConfig(const NMvp::NOidcProxy::TOidcProxyConfig&
     OpenIdConnectSettings.ExchangeUrlPath = config.HasExchangeUrlPath() ? config.GetExchangeUrlPath() : OpenIdConnectSettings.DEFAULT_EXCHANGE_URL_PATH;
     OpenIdConnectSettings.ImpersonateUrlPath = config.HasImpersonateUrlPath() ? config.GetImpersonateUrlPath() : OpenIdConnectSettings.DEFAULT_IMPERSONATE_URL_PATH;
     OpenIdConnectSettings.WhoamiExtendedInfoEndpoint = config.GetWhoamiExtendedInfoEndpoint();
+    OpenIdConnectSettings.AuthenticationFlowMode = config.GetAuthenticationFlowMode();
 
     Cout << "Started processing allowed_proxy_hosts..." << Endl;
     OpenIdConnectSettings.AllowedProxyHosts.clear();

--- a/ydb/mvp/oidc_proxy/nebius_oidc_proxy_auth_flow_621e8550.md
+++ b/ydb/mvp/oidc_proxy/nebius_oidc_proxy_auth_flow_621e8550.md
@@ -1,0 +1,659 @@
+# Nebius OIDC Proxy Auth Flow
+
+Документ описывает, как работает `ydb/mvp/oidc_proxy` для `access_service_type = nebius_v1`
+в состоянии дерева на коммите `621e8550a009af531760cd5b2be3dd7c3ce0ba8a`.
+
+Важно: сам этот коммит не меняет OIDC-код, но ниже описано именно то поведение, которое видно
+в файлах под этим SHA.
+
+## Что именно здесь описано
+
+Фокус документа:
+
+- как прокси начинает OIDC authentication flow;
+- как он обменивает `authorization code` на Nebius `session token`;
+- как потом на каждый пользовательский запрос он меняет `session token` на обычный `access token`;
+- какие cookies и redirect'ы участвуют в процессе;
+- какие есть важные особенности и ограничения этой реализации.
+
+## Короткая версия для обсуждения
+
+Если цель только понять, как устроена аутентификация и почему решение в этом snapshot
+вызывает вопросы, достаточно этого раздела.
+
+### Тезаурус
+
+- `OIDC proxy` - сервис между браузером и `protected resource`, который организует логин и сам работает с токенами.
+- `Authorization Server` - Nebius-сервис, который логинит пользователя и выдает токены или коды для продолжения flow.
+- `protected resource` - целевой сервис или страница, куда пользователь в итоге хочет попасть.
+- `authorization code` или `code` - короткоживущий код, который Authorization Server возвращает в `/auth/callback` после успешного логина.
+- `state` - одноразовый идентификатор login flow. Он нужен, чтобы callback можно было связать с правильным запросом на логин.
+- `temporary context cookie` - временная cookie, в которой прокси хранит контекст login flow: например, на какую страницу нужно вернуть пользователя после логина.
+- `session token` - промежуточный токен, который прокси кладет в cookie браузера после callback. По нему прокси потом получает рабочий токен для `protected resource`.
+- `access token` - рабочий токен, с которым прокси идет в `protected resource`.
+- `session cookie` - cookie браузера, в которой прокси хранит `session token`.
+
+Важно для этого snapshot:
+
+- браузер не получает рабочий `access token` для `protected resource`;
+- браузер хранит `session token` в cookie;
+- в ответе token endpoint этот `session token` приходит в поле `access_token`, но дальше в коде используется именно как `session token`.
+
+### Кто участвует
+
+- Браузер пользователя
+- OIDC proxy
+- Nebius Authorization Server
+- `protected resource`
+
+### Как работает flow простыми словами
+
+1. Пользователь открывает страницу через OIDC proxy.
+2. Если у прокси еще нет сессии, прокси отправляет браузер на страницу логина Nebius.
+3. Перед этим прокси запоминает во временной cookie, на какую страницу надо вернуть пользователя после логина.
+4. После успешного логина Nebius возвращает браузер в прокси на `/auth/callback` с `code` и `state`.
+5. Прокси проверяет `state`, читает временную cookie, меняет `code` на `session token` и кладет `session token` в session cookie.
+6. На следующих запросах браузер приносит session cookie, а прокси сам меняет `session token` на `access token` и идет с ним в `protected resource`.
+
+Главная идея:
+
+- браузер не получает рабочий токен для `protected resource`;
+- браузер хранит только cookies;
+- вся логика с токенами живет внутри прокси.
+
+### Один пример, который сразу показывает проблему
+
+Представим две вкладки:
+
+1. Вкладка A открывает `/page-A`.
+2. Прокси кладет temporary cookie со значением "после логина верни на `/page-A`".
+3. До завершения логина во вкладке A пользователь открывает вкладку B с `/page-B`.
+4. Прокси использует ту же самую temporary cookie, но теперь уже со значением "после логина верни на `/page-B`".
+5. Потом callback от вкладки A приходит в прокси с правильным `state` для вкладки A, но cookie уже может содержать контекст от вкладки B.
+
+Из этого сценария сразу следуют три проблемы:
+
+- гонка страниц: вкладка B может перезаписать контекст вкладки A;
+- нет явной проверки, что temporary cookie относится именно к этому `state`;
+- если браузер нестабильно работает с нужными cookie attributes, flow становится еще менее предсказуемым.
+
+### Что именно здесь хрупкое
+
+| Проблема | Почему возникает | В каком направлении улучшать |
+| --- | --- | --- |
+| Гонка страниц при одновременной аутентификации | Для разных login flow используется одна и та же temporary context cookie | Делать context cookie не общей, а привязанной к конкретному login flow |
+| Нет проверки `state` у cookie | `state` и temporary cookie проверяются отдельно, но не связываются друг с другом | Явно связывать cookie и `state`, например через `flow_id` |
+| Атрибуты context cookie не совпадают с рекомендуемыми, а `Partitioned` плохо работает с Safari | Flow сильно зависит от browser cookie behavior | Привести cookie attributes к более совместимому и более предсказуемому набору |
+
+### Какие симптомы увидит пользователь
+
+| Проблема | Как это выглядит для пользователя |
+| --- | --- |
+| Гонка страниц при одновременной аутентификации | После логина пользователь возвращается не на ту страницу, с которой начинал |
+| Нет проверки `state` у cookie | Callback может завершиться формально успешно, но восстановить не тот контекст страницы |
+| Проблемы с cookie attributes / `Partitioned` / Safari | Логин может "иногда не работать", зацикливаться или вести себя по-разному в разных браузерах |
+
+Если человек понял только этот раздел, этого уже достаточно, чтобы обсуждать:
+
+- как работает текущий flow;
+- почему решение в этом snapshot хрупкое;
+- в каком направлении его стоит улучшать.
+
+## Участники flow
+
+- Браузер пользователя
+- OIDC proxy
+- Nebius Authorization Server
+- Protected resource, к которому прокси ходит от имени пользователя
+
+## Какие маршруты регистрирует прокси
+
+Для `nebius_v1` прокси поднимает следующие HTTP handlers:
+
+- `/` - основной вход в защищенные ресурсы
+- `/auth/callback` - callback после authorization code flow
+- `/auth/cleanup` - локальная очистка session cookie
+- `/impersonate/start` - старт impersonation flow
+- `/impersonate/stop` - остановка impersonation flow
+
+Это видно в `oidc_client.cpp`.
+
+## Важные настройки
+
+Ключевые поля конфигурации:
+
+- `client_id` - OIDC client id
+- `authorization_server_address` - базовый URL auth server
+- `session_service_token_name` - имя токена в Tokenator, который прокси кладет в `Authorization`
+- `secret_name` - имя секрета, из которого берется `client_secret`
+- `allowed_proxy_hosts` - список upstream hosts, куда можно проксировать запросы
+
+Нюанс по `nebius_v1`:
+
+- `authorization_server_address` реально используется для authorize/token/exchange/impersonate HTTP-запросов
+- `session_service_endpoint` в Nebius-ветке этого кода фактически не участвует
+
+## Дефолтные endpoint paths
+
+По умолчанию в этом срезе кода используются такие path'ы:
+
+- authorize: `/oauth/authorize`
+- token: `/oauth/token`
+- session exchange: `/oauth2/session/exchange`
+- impersonation: `/oauth2/impersonation/impersonate`
+
+Это важно, потому что внешняя документация часто показывает `/oauth2/authorize` и `/oauth2/token`,
+а в коде прокси по умолчанию стоят именно `/oauth/authorize` и `/oauth/token`.
+При необходимости эти path'ы можно переопределить конфигом.
+
+## Общая идея реализации
+
+Прокси работает как browser-facing BFF:
+
+1. Пользователь приходит на защищенный URL через прокси.
+2. Если готового Bearer-токена нет, прокси запускает OIDC authorization code flow.
+3. После callback прокси меняет `code` на Nebius `session token`.
+4. `session token` кладется в защищенную cookie браузера.
+5. На каждый следующий запрос прокси сам делает `session -> access token exchange`.
+6. В `protected resource` прокси уже ходит с обычным `Authorization: Bearer <access_token>`.
+
+То есть браузер не получает рабочий access token для `protected resource`.
+
+## Как прокси принимает решение, нужен ли OIDC flow
+
+Вход в защищенный ресурс идет через `TProtectedPageHandler` -> `THandlerSessionServiceCheckNebius`.
+
+Сначала выполняются общие проверки:
+
+- если метод `OPTIONS`, запрос просто проксируется дальше;
+- если в запросе уже есть `Authorization: Bearer ...`, запрос тоже сразу проксируется дальше;
+- если requested host не входит в `allowed_proxy_hosts`, прокси отвечает `403`.
+
+Только если Bearer-токена нет, запускается Nebius OIDC логика.
+
+## Cookie, которые использует прокси
+
+### 1. Temporary flow cookie
+
+Имя:
+
+- `ydb_oidc_cookie`
+
+Назначение:
+
+- хранит исходный URL, куда надо вернуть пользователя после `/auth/callback`
+
+Содержимое:
+
+- base64 от JSON со вложенным `requested_address_context`
+- внутри лежит `requested_address`
+- отдельно лежит `digest = HMAC-SHA256(client_secret, requested_address_context)`
+
+Атрибуты cookie:
+
+- `Path=/auth/callback`
+- `Max-Age=3600`
+- `SameSite=None`
+- `Secure`
+
+Нюанс:
+
+- у этой cookie в данной реализации нет `HttpOnly`
+
+### 2. Session cookie
+
+Имя:
+
+- `__Host_session_cookie_<hex(client_id)>`
+
+Содержимое:
+
+- base64(session_token)
+
+Атрибуты:
+
+- `Path=/`
+- `Secure`
+- `HttpOnly`
+- `SameSite=None`
+- `Partitioned`
+- `Max-Age=<expires_in, но не больше 7 дней>`
+
+### 3. Optional impersonation cookie
+
+Имя:
+
+- `__Host_impersonated_cookie_<hex(client_id)>`
+
+Содержимое:
+
+- base64(impersonation_token)
+
+Атрибуты такие же, как у session cookie.
+
+## Как прокси определяет navigation vs AJAX/API request
+
+Это влияет на то, что вернет прокси при отсутствии сессии.
+
+Логика в `context.cpp`:
+
+- если есть `Sec-Fetch-Mode=navigate` и `Sec-Fetch-Dest=document`, это navigation request;
+- если `X-Requested-With=XMLHttpRequest`, это не navigation;
+- если `Accept` содержит `application/json`, это не navigation;
+- иначе по умолчанию считается, что это navigation.
+
+Следствие:
+
+- для navigation запросов прокси делает обычный `302` redirect на auth server;
+- для AJAX/API запросов прокси отвечает `401` JSON с полем `authUrl`.
+
+## Полный authentication flow
+
+### Шаг 1. Пользователь приходит на защищенный URL
+
+Пример:
+
+- браузер делает `GET /<protected-resource-host>/<path>` на OIDC proxy
+
+Если нет Bearer-токена и нет валидной session cookie, прокси начинает auth flow.
+
+### Шаг 2. Прокси готовит state и temporary cookie
+
+Прокси создает `TContext`, в котором есть:
+
+- случайный `state`
+- флаг navigation/non-navigation
+- `requested_address`, куда потом надо вернуть пользователя
+
+`state` подписывается так:
+
+- JSON `{"state":"...","expiration_time":"..."}`
+- `digest = HMAC-SHA1(client_secret, json)`
+- наружу уходит base64(no padding) от JSON с `container` и `digest`
+
+Срок жизни `state`:
+
+- 10 минут
+
+Параллельно прокси кладет `ydb_oidc_cookie`, в которой сохраняет исходный URL.
+
+### Шаг 3. Прокси отправляет пользователя на Authorization Server
+
+Формируется redirect на:
+
+```text
+{authorization_server_address}{auth_url_path}
+  ?response_type=code
+  &scope=openid
+  &state=<signed_state>
+  &client_id=<client_id>
+  &redirect_uri={http|https}://{proxy_host}/auth/callback
+```
+
+Особенности этой реализации:
+
+- scope жестко зашит как `openid`
+- `nonce` не используется
+- PKCE (`code_challenge` / `code_verifier`) не используется
+- `redirect_uri` строится из host/scheme входящего запроса к прокси
+
+Для navigation:
+
+- ответ `302 Location: <auth-url>`
+
+Для AJAX/API:
+
+- ответ `401`
+- тело:
+
+```json
+{"error":"Authorization Required","authUrl":"..."}
+```
+
+### Шаг 4. Пользователь аутентифицируется на Nebius стороне
+
+Это уже внешний шаг:
+
+- браузер попадает на Nebius login page
+- проходит логин
+- auth server делает redirect обратно на `/auth/callback`
+
+### Шаг 5. Callback в прокси
+
+Прокси принимает:
+
+```text
+GET /auth/callback?code=<authorization_code>&state=<state>
+```
+
+Дальше он делает две независимые проверки:
+
+1. Проверяет `state`
+   - HMAC-SHA1
+   - срок жизни
+
+2. Восстанавливает исходный URL из `ydb_oidc_cookie`
+   - разбирает cookie
+   - проверяет HMAC-SHA256
+
+Если `state` валиден и cookie валидна:
+
+- прокси идет менять `code` на session token
+
+Если `state` сломан, но cookie еще можно восстановить:
+
+- прокси не отдает явную ошибку
+- он делает `302` обратно на исходный URL
+- следующий заход на этот URL запускает auth flow заново
+
+Если и `state`, и cookie плохие:
+
+- прокси отвечает `400` HTML-страницей с сообщением
+  `Unknown error has occurred. Please open the page again`
+
+Если `code` пустой:
+
+- прокси просто редиректит пользователя обратно на исходный URL
+
+## Exchange: authorization code -> session token
+
+Nebius-реализация делает HTTP POST на token endpoint:
+
+```text
+POST {authorization_server_address}{token_url_path}
+Authorization: Bearer <token from Tokenator by session_service_token_name>
+Content-Type: application/x-www-form-urlencoded
+
+code=<authorization_code>
+client_id=<client_id>
+client_assertion_type=urn:ietf:params:oauth:client-assertion-type:access_token_bearer
+grant_type=authorization_code
+redirect_uri={http|https}://{proxy_host}/auth/callback
+```
+
+Это важное отличие от более старого classic confidential client flow:
+
+- здесь не используется `Authorization: Basic base64(client_id:client_secret)`
+- `client_secret` не участвует в клиентской аутентификации на token endpoint
+- `client_secret` в этом коде используется только как локальный ключ для подписи `state` и temporary cookie
+
+Если auth server отвечает `200`, прокси ожидает JSON:
+
+```json
+{
+  "access_token": "...",
+  "expires_in": 300
+}
+```
+
+В контексте этого прокси:
+
+- поле `access_token` трактуется как Nebius `session token`
+
+После этого прокси:
+
+- base64-энкодит session token
+- кладет его в `__Host_session_cookie_<hex(client_id)>`
+- делает `302 Location: <requested_address>`
+
+## Exchange: session token -> access token
+
+На каждом следующем защищенном запросе прокси сначала достает session cookie.
+
+Если cookie есть, он делает новый POST:
+
+```text
+POST {authorization_server_address}{exchange_url_path}
+Authorization: Bearer <token from Tokenator by session_service_token_name>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+requested_token_type=urn:ietf:params:oauth:token-type:access_token
+subject_token_type=urn:ietf:params:oauth:token-type:session_token
+subject_token=<session_token>
+```
+
+Если ответ `200`, прокси достает:
+
+```json
+{
+  "access_token": "..."
+}
+```
+
+И уже с этим токеном пересылает исходный пользовательский запрос в `protected resource`:
+
+```text
+Authorization: Bearer <access_token>
+```
+
+То есть access token живет только внутри прокси и заново получается на каждый запрос.
+
+## Что происходит при уже существующей сессии
+
+Отдельно от login flow, steady-state выглядит так:
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant P as OIDC Proxy
+    participant A as Nebius Auth Server
+    participant U as Protected Resource
+
+    B->>P: GET /<protected-resource-host>/<path><br/>Cookie: __Host_session_cookie_<hex(client_id)>=base64(session_token)
+    P->>P: Decode __Host_session_cookie_<hex(client_id)> -> session_token
+    P->>A: POST /oauth2/session/exchange
+    A-->>P: 200 {access_token}
+    P->>U: Original request + Authorization: Bearer <access_token>
+    U-->>P: Upstream response
+    P-->>B: Same response
+```
+
+## Полный browser auth flow
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant P as OIDC Proxy
+    participant A as Nebius Auth Server
+    participant U as Protected Resource
+
+    B->>P: GET /<protected-resource-host>/<path>
+    P->>P: Check allowed host, Authorization header, cookies
+
+    alt No session cookie
+        P-->>B: 302 to /oauth/authorize or 401 {authUrl}
+        P-->>B: Set-Cookie ydb_oidc_cookie=base64(requested_address + HMAC)
+        B->>A: GET /oauth/authorize?...&state=...&redirect_uri=https://proxy/auth/callback
+        A-->>B: Login / external auth
+        A-->>P: GET /auth/callback?code=...&state=...<br/>Cookie: ydb_oidc_cookie
+        P->>P: Validate state and restore requested_address from ydb_oidc_cookie
+        P->>A: POST /oauth/token
+        A-->>P: 200 {access_token=session_token, expires_in}
+        P-->>B: 302 back to requested_address<br/>Set-Cookie: __Host_session_cookie_<hex(client_id)>=base64(session_token)
+        B->>P: Repeat original GET<br/>Cookie: __Host_session_cookie_<hex(client_id)>=base64(session_token)
+        P->>A: POST /oauth2/session/exchange
+        A-->>P: 200 {access_token}
+        P->>U: Forward request with Bearer access_token
+        U-->>P: Response
+        P-->>B: Response
+    else Session cookie already exists
+        P->>A: POST /oauth2/session/exchange
+        A-->>P: 200 {access_token}
+        P->>U: Forward request with Bearer access_token
+        U-->>P: Response
+        P-->>B: Response
+    end
+```
+
+## Error handling
+
+### Ошибка на session exchange
+
+Если `/oauth2/session/exchange` отвечает `400` или `401`:
+
+- для обычной session cookie прокси запускает новый auth flow;
+- для impersonation cookie прокси очищает impersonated cookie и делает `307` на тот же URL.
+
+### Ошибка на code -> session exchange
+
+Если token endpoint отвечает не `200`:
+
+- прокси почти прозрачно прокидывает этот ответ пользователю
+
+Если ответ `200`, но JSON не той формы:
+
+- прокси отвечает `400 Bad Request`
+
+### Ошибка восстановления callback context
+
+Если `state` или temporary cookie повреждены:
+
+- возможен либо `302` назад на исходную страницу,
+- либо `400 Unknown error has occurred...`
+
+### Logout
+
+В этом срезе кода `/auth/cleanup`:
+
+- только очищает локальную session cookie
+- не делает server-side logout в auth server
+- не вызывает `/oauth2/session/logout`
+
+Это важно: logout здесь локальный, а не полный logout на стороне Nebius auth.
+
+## Impersonation flow
+
+Для `nebius_v1` есть отдельная опциональная ветка.
+
+Старт:
+
+```text
+GET /impersonate/start?service_account_id=<sa-id>
+```
+
+Прокси требует:
+
+- существующую session cookie
+- отсутствие уже существующей impersonated cookie
+- обязательный `service_account_id`
+
+Дальше запрос:
+
+```text
+POST {authorization_server_address}{impersonate_url_path}
+Authorization: Bearer <token from Tokenator>
+Content-Type: application/x-www-form-urlencoded
+
+session=<session_token>
+service_account_id=<sa-id>
+```
+
+Если ответ успешный, прокси сохраняет:
+
+- `__Host_impersonated_cookie_<hex(client_id)>`
+
+На последующих запросах при наличии этой cookie прокси делает уже не обычный `session exchange`, а такой вариант:
+
+```text
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+requested_token_type=urn:ietf:params:oauth:token-type:access_token
+subject_token_type=urn:ietf:params:oauth:token-type:jwt
+subject_token=<impersonated_token>
+actor_token=<session_token>
+actor_token_type=urn:ietf:params:oauth:token-type:session_token
+```
+
+Остановка impersonation:
+
+- `GET /impersonate/stop`
+- прокси просто очищает impersonated cookie
+
+## Что особенно важно для обсуждения проблем и улучшений
+
+Ниже не "предложения", а именно свойства текущей реализации, которые стоит помнить.
+
+### 1. `state` и `requested_address` не связаны в одну сущность
+
+В callback:
+
+- `state` валидируется отдельно
+- исходный URL восстанавливается отдельно из `ydb_oidc_cookie`
+
+В `state` нет `requested_address` и нет `flow_id`.
+Это означает, что параллельные auth flow в нескольких вкладках не изолированы друг от друга одной связкой
+`state <-> requested page`.
+
+### 2. Temporary flow cookie одна и фиксированная
+
+Имя всегда одно:
+
+- `ydb_oidc_cookie`
+
+Следствие:
+
+- новая auth попытка может перезаписать контекст предыдущей
+- особенно это заметно при нескольких вкладках или нескольких параллельных переходах
+
+### 3. `client_secret` используется не как secret для token endpoint auth
+
+В Nebius-ветке:
+
+- `client_secret` используется как HMAC key для local state/cookie integrity
+- аутентификация на auth server идет через Bearer-токен, полученный из Tokenator
+
+### 4. Для browser API-запросов нет автоматического redirect
+
+Если запрос распознан как non-navigation:
+
+- прокси вернет `401` с `authUrl`
+- фронтенд должен сам решить, как довести пользователя до login flow
+
+### 5. Logout только локальный
+
+`/auth/cleanup`:
+
+- удаляет browser cookie
+- не инвалидирует Nebius session server-side
+
+### 6. Нет PKCE и нет nonce
+
+В этом snapshot'e прокси не отправляет:
+
+- `code_challenge`
+- `code_verifier`
+- `nonce`
+
+### 7. Ошибки `400/401` на session exchange сворачиваются в re-auth
+
+Для обычной session cookie это значит:
+
+- любой такой ответ от auth server приводит к новому authorization flow
+
+## Где смотреть в коде
+
+Если после вводной нужно быстро перейти к реализации, основные места такие:
+
+- `oidc_client.cpp` - регистрация HTTP handlers
+- `oidc_protected_page.cpp` - общий вход в protected resource
+- `oidc_protected_page_nebius.cpp` - Nebius-специфичный session/access token flow
+- `oidc_session_create.cpp` - обработка `/auth/callback`
+- `oidc_session_create_nebius.cpp` - обмен `code` на `session token`
+- `openid_connect.cpp` - redirect на логин, cookies, `state`, helper-функции
+- `context.cpp` - формирование временного контекста и определение navigation request
+- `oidc_settings.h` - основные настройки и endpoint paths
+
+## Краткое summary
+
+В этой реализации Nebius OIDC proxy делает три ключевые вещи:
+
+1. Сам инициирует browser-based authorization code flow.
+2. Меняет `authorization code` на Nebius `session token` и хранит его в `HttpOnly` cookie.
+3. На каждый защищенный запрос меняет `session token` на обычный `access token`, после чего проксирует запрос в `protected resource`.
+
+Главные архитектурные особенности этого snapshot'а:
+
+- одна temporary auth cookie на весь proxy host;
+- session exchange выполняется на каждый запрос;
+- logout локальный;
+- для token endpoint используется Bearer service token, а не Basic client credentials.

--- a/ydb/mvp/oidc_proxy/oidc_auth_start_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_auth_start_page.cpp
@@ -1,0 +1,62 @@
+#include "oidc_auth_start_page.h"
+
+#include "context.h"
+#include "oidc_cookie.h"
+#include "openid_connect.h"
+
+namespace NMVP::NOIDC {
+
+THandlerAuthStart::THandlerAuthStart(const NActors::TActorId& sender,
+                                     const NHttp::THttpIncomingRequestPtr& request,
+                                     const NActors::TActorId& httpProxyId,
+                                     const TOpenIdConnectSettings& settings)
+    : TMvpLogContextProvider(CreateMvpLogContext(request))
+    , Sender(sender)
+    , Request(request)
+    , HttpProxyId(httpProxyId)
+    , Settings(settings)
+{}
+
+void THandlerAuthStart::Bootstrap() {
+    NHttp::TUrlParameters urlParameters(Request->URL);
+    const TString returnTo = urlParameters["return_to"];
+    if (returnTo.empty()) {
+        NHttp::THeadersBuilder responseHeaders;
+        responseHeaders.Set("Content-Type", "text/plain");
+        SetCORS(Request, &responseHeaders);
+        SetRequestIdHeader(responseHeaders, GetRequestId());
+        return ReplyAndPassAway(Request->CreateResponse("400", "Bad Request", responseHeaders, "`return_to` parameter is required"));
+    }
+
+    NHttp::THeaders headers(Request->Headers);
+    NHttp::TCookies cookies(headers.Get("cookie"));
+    TContext context({
+        .State = GenerateRandomBase64(),
+        .RequestedAddress = returnTo,
+    });
+
+    ReplyAndPassAway(GetHttpOutgoingResponsePtrForAuthStart(
+        Request,
+        Settings,
+        context,
+        GetCookie(cookies, CreateSharedOidcCookieName()),
+        GetRequestId()
+    ));
+}
+
+void THandlerAuthStart::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
+    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(std::move(httpResponse)));
+    PassAway();
+}
+
+TAuthStartPageHandler::TAuthStartPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings)
+    : TBase(&TAuthStartPageHandler::StateWork)
+    , HttpProxyId(httpProxyId)
+    , Settings(settings)
+{}
+
+void TAuthStartPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event) {
+    Register(new THandlerAuthStart(event->Sender, event->Get()->Request, HttpProxyId, Settings));
+}
+
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_auth_start_page.h
+++ b/ydb/mvp/oidc_proxy/oidc_auth_start_page.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <ydb/mvp/core/mvp_log.h>
+
+#include "oidc_settings.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/http/http_proxy.h>
+
+namespace NMVP::NOIDC {
+
+class THandlerAuthStart
+    : public NActors::TActorBootstrapped<THandlerAuthStart>
+    , protected TMvpLogContextProvider {
+private:
+    using TBase = NActors::TActorBootstrapped<THandlerAuthStart>;
+
+protected:
+    const NActors::TActorId Sender;
+    const NHttp::THttpIncomingRequestPtr Request;
+    const NActors::TActorId HttpProxyId;
+    const TOpenIdConnectSettings Settings;
+
+public:
+    THandlerAuthStart(const NActors::TActorId& sender,
+                      const NHttp::THttpIncomingRequestPtr& request,
+                      const NActors::TActorId& httpProxyId,
+                      const TOpenIdConnectSettings& settings);
+
+    void Bootstrap();
+    void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
+};
+
+class TAuthStartPageHandler : public NActors::TActor<TAuthStartPageHandler> {
+    using TBase = NActors::TActor<TAuthStartPageHandler>;
+
+    const NActors::TActorId HttpProxyId;
+    const TOpenIdConnectSettings Settings;
+
+public:
+    TAuthStartPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event);
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
+        }
+    }
+};
+
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_client.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_client.cpp
@@ -1,4 +1,5 @@
 #include "oidc_client.h"
+#include "oidc_auth_start_page.h"
 #include "oidc_protected_page_handler.h"
 #include "oidc_session_create_handler.h"
 #include "oidc_cleanup_page.h"
@@ -10,6 +11,14 @@ namespace NMVP::NOIDC {
 void InitOIDC(NActors::TActorSystem& actorSystem,
               const NActors::TActorId& httpProxyId,
               const TOpenIdConnectSettings& settings) {
+    if (settings.UseLocalAuthStart()) {
+        actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                             "/auth/start",
+                             actorSystem.Register(new TAuthStartPageHandler(httpProxyId, settings))
+                             )
+                         );
+    }
+
     actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
                          "/auth/callback",
                          actorSystem.Register(new TSessionCreateHandler(httpProxyId, settings))

--- a/ydb/mvp/oidc_proxy/oidc_cookie.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_cookie.cpp
@@ -1,0 +1,310 @@
+#include "oidc_cookie.h"
+
+#include "oidc_settings.h"
+
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/string_utils/base64/base64.h>
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/maybe.h>
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+#include <util/string/hex.h>
+
+namespace NMVP::NOIDC {
+
+namespace {
+
+struct TOidcCookieData {
+    THashMap<TString, TString> ReturnTo;
+    TVector<TString> Recent;
+};
+
+TString HmacSHA256(TStringBuf key, TStringBuf data) {
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    ui32 hl = SHA256_DIGEST_LENGTH;
+    const auto* res = HMAC(EVP_sha256(), key.data(), key.size(), reinterpret_cast<const unsigned char*>(data.data()), data.size(), hash, &hl);
+    Y_ENSURE(res);
+    Y_ENSURE(hl == SHA256_DIGEST_LENGTH);
+    return TString{reinterpret_cast<const char*>(res), hl};
+}
+
+void NormalizeOidcCookieData(TOidcCookieData& data) {
+    THashSet<TString> seen;
+    TVector<TString> normalizedRecent;
+
+    normalizedRecent.reserve(data.ReturnTo.size());
+    for (const TString& flowId : data.Recent) {
+        if (!data.ReturnTo.contains(flowId) || !seen.insert(flowId).second) {
+            continue;
+        }
+        normalizedRecent.push_back(flowId);
+    }
+
+    for (const auto& entry : data.ReturnTo) {
+        const TString& flowId = entry.first;
+        if (seen.insert(flowId).second) {
+            normalizedRecent.push_back(flowId);
+        }
+    }
+
+    data.Recent = std::move(normalizedRecent);
+}
+
+TString BuildOidcCookieContainer(const TOidcCookieData& data) {
+    NJson::TJsonValue root(NJson::JSON_MAP);
+    NJson::TJsonValue returnTo(NJson::JSON_MAP);
+    NJson::TJsonValue recent(NJson::JSON_ARRAY);
+
+    for (const auto& [flowId, requestedAddress] : data.ReturnTo) {
+        returnTo[flowId] = requestedAddress;
+    }
+    for (const TString& flowId : data.Recent) {
+        recent.AppendValue(flowId);
+    }
+
+    root["return_to"] = std::move(returnTo);
+    root["recent"] = std::move(recent);
+    return NJson::WriteJson(root, false);
+}
+
+TString BuildOidcCookieValue(const TOidcCookieData& data, const TString& key) {
+    const TString oidcCookieContainer = BuildOidcCookieContainer(data);
+
+    NJson::TJsonValue root(NJson::JSON_MAP);
+    root["container"] = Base64Encode(oidcCookieContainer);
+    root["digest"] = Base64Encode(HmacSHA256(key, oidcCookieContainer));
+    return Base64Encode(NJson::WriteJson(root, false));
+}
+
+bool TryDecodeOidcCookieValue(TStringBuf cookieValue,
+                              const TString& key,
+                              TOidcCookieData& data,
+                              TString& errorMessage) {
+    TString signedCookie;
+    try {
+        signedCookie = Base64Decode(cookieValue);
+    } catch (const std::exception&) {
+        errorMessage = "OIDC context cookie payload is not valid base64";
+        return false;
+    }
+
+    TString oidcCookieContainer;
+    TString expectedDigest;
+    NJson::TJsonValue jsonValue;
+    NJson::TJsonReaderConfig jsonConfig;
+    if (!NJson::ReadJsonTree(signedCookie, &jsonConfig, &jsonValue)) {
+        errorMessage = "OIDC context cookie payload is not valid JSON";
+        return false;
+    }
+
+    const NJson::TJsonValue* jsonContainer = nullptr;
+    if (jsonValue.GetValuePointer("container", &jsonContainer) && jsonContainer->IsString()) {
+        try {
+            oidcCookieContainer = Base64Decode(jsonContainer->GetString());
+        } catch (const std::exception&) {
+            errorMessage = "OIDC context cookie container is not valid base64";
+            return false;
+        }
+    }
+    if (oidcCookieContainer.empty()) {
+        errorMessage = "OIDC context cookie container is missing";
+        return false;
+    }
+
+    const NJson::TJsonValue* jsonDigest = nullptr;
+    if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
+        try {
+            expectedDigest = Base64Decode(jsonDigest->GetString());
+        } catch (const std::exception&) {
+            errorMessage = "OIDC context cookie digest is not valid base64";
+            return false;
+        }
+    }
+    if (expectedDigest.empty()) {
+        errorMessage = "OIDC context cookie digest is missing";
+        return false;
+    }
+
+    const TString digest = HmacSHA256(key, oidcCookieContainer);
+    if (expectedDigest != digest) {
+        errorMessage = "OIDC context cookie digest mismatch";
+        return false;
+    }
+
+    if (!NJson::ReadJsonTree(oidcCookieContainer, &jsonConfig, &jsonValue)) {
+        errorMessage = "OIDC context cookie container is not valid JSON";
+        return false;
+    }
+
+    const NJson::TJsonValue* jsonReturnTo = nullptr;
+    if (!jsonValue.GetValuePointer("return_to", &jsonReturnTo) || jsonReturnTo->GetType() != NJson::JSON_MAP) {
+        errorMessage = "OIDC context cookie `return_to` map is missing";
+        return false;
+    }
+
+    data.ReturnTo.clear();
+    for (const auto& [flowId, requestedAddressValue] : jsonReturnTo->GetMapSafe()) {
+        if (requestedAddressValue.IsString()) {
+            data.ReturnTo[flowId] = requestedAddressValue.GetStringSafe();
+        }
+    }
+    if (data.ReturnTo.empty()) {
+        errorMessage = "OIDC context cookie `return_to` map is empty";
+        return false;
+    }
+
+    data.Recent.clear();
+    const NJson::TJsonValue* jsonRecent = nullptr;
+    if (jsonValue.GetValuePointer("recent", &jsonRecent) && jsonRecent->GetType() == NJson::JSON_ARRAY) {
+        for (const NJson::TJsonValue& recentFlowId : jsonRecent->GetArraySafe()) {
+            if (recentFlowId.IsString()) {
+                data.Recent.push_back(recentFlowId.GetStringSafe());
+            }
+        }
+    }
+
+    NormalizeOidcCookieData(data);
+    return true;
+}
+
+void RemoveFlowIdFromRecent(TVector<TString>& recent, TStringBuf flowId) {
+    TVector<TString> filteredRecent;
+    filteredRecent.reserve(recent.size());
+
+    for (const TString& recentFlowId : recent) {
+        if (recentFlowId != flowId) {
+            filteredRecent.push_back(recentFlowId);
+        }
+    }
+
+    recent = std::move(filteredRecent);
+}
+
+void TouchFlowId(TOidcCookieData& data, TStringBuf flowId) {
+    RemoveFlowIdFromRecent(data.Recent, flowId);
+    data.Recent.insert(data.Recent.begin(), TString(flowId));
+}
+
+TMaybe<TString> FindRequestedAddress(const TOidcCookieData& data, TStringBuf flowId) {
+    if (!flowId.empty()) {
+        if (auto it = data.ReturnTo.find(TString(flowId)); it != data.ReturnTo.end()) {
+            return it->second;
+        }
+    }
+
+    for (const TString& recentFlowId : data.Recent) {
+        if (auto it = data.ReturnTo.find(recentFlowId); it != data.ReturnTo.end()) {
+            return it->second;
+        }
+    }
+
+    return Nothing();
+}
+
+TString FindFallbackFlowIdToEvict(const TVector<TString>& recent, TStringBuf currentFlowId) {
+    for (auto it = recent.rbegin(); it != recent.rend(); ++it) {
+        if (*it != currentFlowId) {
+            return *it;
+        }
+    }
+    return {};
+}
+
+} // anonymous namespace
+
+TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress) {
+    static constexpr size_t FLOW_ID_BYTES = 5;
+
+    const TString digest = HmacSHA256(key, requestedAddress);
+    return HexEncode(TStringBuf(digest.data(), FLOW_ID_BYTES));
+}
+
+TString CreateSharedOidcCookieName() {
+    return TString(TOpenIdConnectSettings::SHARED_OIDC_COOKIE);
+}
+
+TString CreateSharedOidcCookie(const TString& key, TStringBuf currentCookieValue, TStringBuf requestedAddress) {
+    return TStringBuilder() << CreateSharedOidcCookieName() << "="
+                            << UpdateSharedOidcCookieValue(currentCookieValue, key, CreateFlowId(key, requestedAddress), requestedAddress) << ";"
+                            << " Path=/auth;"
+                            " Max-Age=" << TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds() << ";"
+                            " SameSite=None; Secure";
+}
+
+bool HasSharedOidcCookieEntry(TStringBuf cookieValue, const TString& key, TStringBuf flowId, TStringBuf requestedAddress) {
+    if (cookieValue.empty()) {
+        return false;
+    }
+
+    TOidcCookieData data;
+    TString errorMessage;
+    if (!TryDecodeOidcCookieValue(cookieValue, key, data, errorMessage)) {
+        return false;
+    }
+
+    if (auto it = data.ReturnTo.find(TString(flowId)); it != data.ReturnTo.end()) {
+        return it->second == requestedAddress;
+    }
+
+    return false;
+}
+
+TString UpdateSharedOidcCookieValue(TStringBuf currentCookieValue, const TString& key, TStringBuf flowId, TStringBuf requestedAddress) {
+    TOidcCookieData data;
+    TString errorMessage;
+    if (!currentCookieValue.empty()) {
+        TryDecodeOidcCookieValue(currentCookieValue, key, data, errorMessage);
+    }
+
+    data.ReturnTo[TString(flowId)] = TString(requestedAddress);
+    TouchFlowId(data, flowId);
+
+    TString cookieValue = BuildOidcCookieValue(data, key);
+    while (cookieValue.size() > TOpenIdConnectSettings::MAX_AUTH_FLOW_COOKIE_VALUE_SIZE) {
+        TString flowIdToEvict = FindFallbackFlowIdToEvict(data.Recent, flowId);
+        if (flowIdToEvict.empty()) {
+            break;
+        }
+        data.ReturnTo.erase(flowIdToEvict);
+        RemoveFlowIdFromRecent(data.Recent, flowIdToEvict);
+        cookieValue = BuildOidcCookieValue(data, key);
+    }
+
+    return cookieValue;
+}
+
+TFindRequestedAddressInOidcCookieResult FindRequestedAddressInSharedOidcCookieValue(TStringBuf cookieValue, const TString& key, TStringBuf flowId) {
+    TOidcCookieData data;
+    TString errorMessage;
+    if (!TryDecodeOidcCookieValue(cookieValue, key, data, errorMessage)) {
+        return {
+            .IsSuccess = false,
+            .RequestedAddress = "",
+            .ErrorMessage = errorMessage,
+        };
+    }
+
+    TMaybe<TString> requestedAddress = FindRequestedAddress(data, flowId);
+    if (!requestedAddress) {
+        return {
+            .IsSuccess = false,
+            .RequestedAddress = "",
+            .ErrorMessage = "Requested address is not found in the OIDC context cookie",
+        };
+    }
+
+    return {
+        .IsSuccess = true,
+        .RequestedAddress = *requestedAddress,
+        .ErrorMessage = "",
+    };
+}
+
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_cookie.h
+++ b/ydb/mvp/oidc_proxy/oidc_cookie.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NMVP::NOIDC {
+
+struct TFindRequestedAddressInOidcCookieResult {
+    bool IsSuccess = false;
+    TString RequestedAddress;
+    TString ErrorMessage;
+};
+
+TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress);
+TString CreateSharedOidcCookieName();
+TString CreateSharedOidcCookie(const TString& key, TStringBuf currentCookieValue, TStringBuf requestedAddress);
+bool HasSharedOidcCookieEntry(TStringBuf cookieValue, const TString& key, TStringBuf flowId, TStringBuf requestedAddress);
+TString UpdateSharedOidcCookieValue(TStringBuf currentCookieValue, const TString& key, TStringBuf flowId, TStringBuf requestedAddress);
+TFindRequestedAddressInOidcCookieResult FindRequestedAddressInSharedOidcCookieValue(TStringBuf cookieValue, const TString& key, TStringBuf flowId);
+
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_cookie_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_cookie_ut.cpp
@@ -1,0 +1,86 @@
+#include "oidc_cookie.h"
+#include "oidc_settings.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/string/builder.h>
+
+using namespace NMVP::NOIDC;
+
+namespace {
+
+const TString TEST_SECRET = "0123456789abcdef";
+
+TString MakeRequestedAddress(size_t index, size_t paddingSize = 0) {
+    return TStringBuilder()
+        << "https://site.example.com/path?index=" << index
+        << "&padding=" << TString(paddingSize, 'x');
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(OidcCookie) {
+    Y_UNIT_TEST(CreateFlowIdIsDeterministicForSameAddress) {
+        const TString requestedAddress = "https://site.example.com/path?x=1";
+        const TString flowId1 = CreateFlowId(TEST_SECRET, requestedAddress);
+        const TString flowId2 = CreateFlowId(TEST_SECRET, requestedAddress);
+
+        UNIT_ASSERT_STRINGS_EQUAL(flowId1, flowId2);
+        UNIT_ASSERT_VALUES_EQUAL(flowId1.size(), 10);
+    }
+
+    Y_UNIT_TEST(CreateFlowIdDiffersForDifferentAddresses) {
+        const TString flowId1 = CreateFlowId(TEST_SECRET, "https://site.example.com/path?x=1");
+        const TString flowId2 = CreateFlowId(TEST_SECRET, "https://site.example.com/path?x=2");
+
+        UNIT_ASSERT_UNEQUAL(flowId1, flowId2);
+    }
+
+    Y_UNIT_TEST(SharedOidcCookieRestoresExactRequestedAddress) {
+        const TString requestedAddress = MakeRequestedAddress(1);
+        const TString flowId = CreateFlowId(TEST_SECRET, requestedAddress);
+        const TString cookieValue = UpdateSharedOidcCookieValue("", TEST_SECRET, flowId, requestedAddress);
+
+        const TFindRequestedAddressInOidcCookieResult result =
+            FindRequestedAddressInSharedOidcCookieValue(cookieValue, TEST_SECRET, flowId);
+
+        UNIT_ASSERT(result.IsSuccess);
+        UNIT_ASSERT_STRINGS_EQUAL(result.RequestedAddress, requestedAddress);
+    }
+
+    Y_UNIT_TEST(SharedOidcCookieFallsBackToMostRecentRequestedAddress) {
+        const TString firstRequestedAddress = MakeRequestedAddress(1);
+        const TString secondRequestedAddress = MakeRequestedAddress(2);
+        const TString firstFlowId = CreateFlowId(TEST_SECRET, firstRequestedAddress);
+        const TString secondFlowId = CreateFlowId(TEST_SECRET, secondRequestedAddress);
+
+        TString cookieValue = UpdateSharedOidcCookieValue("", TEST_SECRET, firstFlowId, firstRequestedAddress);
+        cookieValue = UpdateSharedOidcCookieValue(cookieValue, TEST_SECRET, secondFlowId, secondRequestedAddress);
+
+        const TFindRequestedAddressInOidcCookieResult result =
+            FindRequestedAddressInSharedOidcCookieValue(cookieValue, TEST_SECRET, "missing-flow-id");
+
+        UNIT_ASSERT(result.IsSuccess);
+        UNIT_ASSERT_STRINGS_EQUAL(result.RequestedAddress, secondRequestedAddress);
+    }
+
+    Y_UNIT_TEST(SharedOidcCookieEvictsOldEntriesToFitSizeLimit) {
+        TString cookieValue;
+        TString lastFlowId;
+        TString lastRequestedAddress;
+
+        for (size_t index = 0; index < 12; ++index) {
+            lastRequestedAddress = MakeRequestedAddress(index, 500);
+            lastFlowId = CreateFlowId(TEST_SECRET, lastRequestedAddress);
+            cookieValue = UpdateSharedOidcCookieValue(cookieValue, TEST_SECRET, lastFlowId, lastRequestedAddress);
+        }
+
+        UNIT_ASSERT(cookieValue.size() <= TOpenIdConnectSettings::MAX_AUTH_FLOW_COOKIE_VALUE_SIZE);
+
+        const TFindRequestedAddressInOidcCookieResult result =
+            FindRequestedAddressInSharedOidcCookieValue(cookieValue, TEST_SECRET, lastFlowId);
+
+        UNIT_ASSERT(result.IsSuccess);
+        UNIT_ASSERT_STRINGS_EQUAL(result.RequestedAddress, lastRequestedAddress);
+    }
+}

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -566,6 +566,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
                                                                                    "Host: " + hostProxy + "\r\n"
                                                                                    "Cookie: yc_session=invalid_cookie\r\n"
                                                                                    "Referer: https://" + hostProxy + protectedPage + "\r\n"));
+        const TString expectedRequestedAddress = TContext(incomingRequest).GetRequestedAddress();
         runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
 
         TAutoPtr<IEventHandle> handle;
@@ -587,7 +588,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuf setCookie = headers.Get("Set-Cookie");
         UNIT_ASSERT_STRING_CONTAINS(
             setCookie,
-            CreateNameYdbOidcCookie(redirectStrategy.IsNavigationRequest() ? TStringBuf() : TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX));
+            CreateNameYdbOidcCookie(CreateFlowId(settings.ClientSecret, expectedRequestedAddress)));
         redirectStrategy.CheckSpecificHeaders(headers);
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
@@ -671,7 +672,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
-        TContext context({.State = "good_state", .RequestedAddress = "/requested/page", .NavigationRequest = redirectStrategy.IsNavigationRequest()});
+        TContext context({.State = "good_state", .RequestedAddress = "/requested/page"});
         TString wrongState = context.GetState(settings.ClientSecret);
         if (wrongState[0] != 'a') {
             wrongState[0] = 'a';
@@ -695,15 +696,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
 
         TAutoPtr<IEventHandle> handle;
         NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
-        const NHttp::THeaders protectedPageHeaders(outgoingResponseEv->Response->Headers);
-        if (redirectStrategy.IsNavigationRequest()) {
-            UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
-            UNIT_ASSERT(protectedPageHeaders.Has("Location"));
-            UNIT_ASSERT_STRINGS_EQUAL(protectedPageHeaders.Get("Location"), "/requested/page");
-        } else {
-            UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "400");
-            UNIT_ASSERT(!protectedPageHeaders.Has("Location"));
-        }
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
     }
 
     Y_UNIT_TEST(OpenIdConnectWrongStateAuthorizationFlow) {
@@ -716,20 +709,20 @@ Y_UNIT_TEST_SUITE(Mvp) {
         OidcWrongStateAuthorizationFlow(redirectStrategy);
     }
 
-    Y_UNIT_TEST(OpenIdConnectExpiredBackgroundStateKeepsCookieSuffix) {
+    Y_UNIT_TEST(OpenIdConnectExpiredStateKeepsCookieSuffix) {
         TPortManager tp;
         auto settings = BuildBaseSettings(tp);
         TState sourcePayload;
         sourcePayload.AntiForgeryToken = "state";
         sourcePayload.ExpirationTime = TInstant::Seconds(0);
-        sourcePayload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
+        sourcePayload.CookieSuffix = "_flow-id";
 
         TCheckStateResult result = CheckState(EncodeState(sourcePayload, settings.ClientSecret), settings.ClientSecret);
-        const TString expectedCookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
+        const TString expectedCookieSuffix = "_flow-id";
 
         UNIT_ASSERT(!result.Ok);
         UNIT_ASSERT_STRINGS_EQUAL(result.CookieSuffix, expectedCookieSuffix);
-        UNIT_ASSERT_STRING_CONTAINS(result.ErrorMessage, "State life time expired");
+        UNIT_ASSERT_STRING_CONTAINS(result.ErrorMessage, "State lifetime expired");
     }
 
     Y_UNIT_TEST(OpenIdConnectSessionServiceCreateAuthorizationFail) {
@@ -748,7 +741,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
-        TContext context({.State = "test_state", .RequestedAddress = "/requested/page", .NavigationRequest = true});
+        TContext context({.State = "test_state", .RequestedAddress = "/requested/page"});
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
@@ -796,7 +789,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
-        TContext context({.State = "test_state", .RequestedAddress = "/requested/page", .NavigationRequest = redirectStrategy.IsNavigationRequest()});
+        TContext context({.State = "test_state", .RequestedAddress = "/requested/page"});
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
@@ -858,7 +851,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
-        TContext context({.State = "test_state", .RequestedAddress = "/requested/page", .NavigationRequest = true});
+        TContext context({.State = "test_state", .RequestedAddress = "/requested/page"});
         TStringBuilder request;
         request << "GET /callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
@@ -1003,7 +996,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
-        TContext context({.State = "good_state", .RequestedAddress = "/requested/page", .NavigationRequest = true});
+        TContext context({.State = "good_state", .RequestedAddress = "/requested/page"});
         const TString hostProxy = "oidcproxy.net";
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
@@ -1035,7 +1028,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
-        TContext context({.State = "good_state", .RequestedAddress = "/requested/page", .NavigationRequest = true});
+        TContext context({.State = "good_state", .RequestedAddress = "/requested/page"});
         TString wrongState = context.GetState(settings.ClientSecret);
         if (wrongState[0] != 'a') {
             wrongState[0] = 'a';
@@ -1637,8 +1630,10 @@ Y_UNIT_TEST_SUITE(Utils) {
 
         TState sourcePayload;
         sourcePayload.AntiForgeryToken = "state";
-        sourcePayload.ExpirationTime = TInstant::Seconds(TInstant::Now().Seconds() + TDuration::Minutes(10).Seconds());
-        sourcePayload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
+        sourcePayload.ExpirationTime = TInstant::Seconds(
+            TInstant::Now().Seconds() + TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds()
+        );
+        sourcePayload.CookieSuffix = "_flow-id";
 
         const TString state = EncodeState(sourcePayload, settings.ClientSecret);
         const TCheckStateResult result = CheckState(state, settings.ClientSecret);
@@ -1651,6 +1646,47 @@ Y_UNIT_TEST_SUITE(Utils) {
         UNIT_ASSERT(decodedResult.HasStateContainerJson);
         UNIT_ASSERT(decodedResult.Payload == sourcePayload);
         UNIT_ASSERT_STRINGS_EQUAL(EncodeState(decodedResult.Payload, settings.ClientSecret), state);
+    }
+
+    Y_UNIT_TEST(OpenIdConnectFlowIdIsDeterministicForSameAddress) {
+        TPortManager tp;
+        auto settings = BuildBaseSettings(tp);
+
+        const TString requestedAddress = "https://site.example.com/path?x=1";
+        const TString flowId1 = CreateFlowId(settings.ClientSecret, requestedAddress);
+        const TString flowId2 = CreateFlowId(settings.ClientSecret, requestedAddress);
+
+        UNIT_ASSERT_STRINGS_EQUAL(flowId1, flowId2);
+        UNIT_ASSERT_VALUES_EQUAL(flowId1.size(), 17);
+        UNIT_ASSERT_VALUES_EQUAL(flowId1[0], '_');
+    }
+
+    Y_UNIT_TEST(OpenIdConnectFlowIdDiffersForDifferentAddresses) {
+        TPortManager tp;
+        auto settings = BuildBaseSettings(tp);
+
+        const TString flowId1 = CreateFlowId(settings.ClientSecret, "https://site.example.com/path?x=1");
+        const TString flowId2 = CreateFlowId(settings.ClientSecret, "https://site.example.com/path?x=2");
+
+        UNIT_ASSERT_UNEQUAL(flowId1, flowId2);
+    }
+
+    Y_UNIT_TEST(OpenIdConnectStateUsesFlowIdAsCookieSuffix) {
+        TPortManager tp;
+        auto settings = BuildBaseSettings(tp);
+
+        const TString requestedAddress = "https://site.example.com/path?x=1";
+        TContext context({
+            .State = "state",
+            .RequestedAddress = requestedAddress,
+        });
+
+        const TString state = context.GetState(settings.ClientSecret);
+        const TDecodeStateResult decodedResult = DecodeState(state);
+
+        UNIT_ASSERT(decodedResult.HasSignedStateJson);
+        UNIT_ASSERT(decodedResult.HasStateContainerJson);
+        UNIT_ASSERT_STRINGS_EQUAL(decodedResult.Payload.CookieSuffix, CreateFlowId(settings.ClientSecret, requestedAddress));
     }
 
     Y_UNIT_TEST(GenerateRandomBase64RandomUniqueness) {

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -588,7 +588,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuf setCookie = headers.Get("Set-Cookie");
         UNIT_ASSERT_STRING_CONTAINS(
             setCookie,
-            CreateNameYdbOidcCookie(CreateFlowId(settings.ClientSecret, expectedRequestedAddress)));
+            CreateAuthFlowCookieName(CreateFlowId(settings.ClientSecret, expectedRequestedAddress)));
         redirectStrategy.CheckSpecificHeaders(headers);
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
@@ -683,7 +683,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << wrongState << " HTTP/1.1\r\n";
         request << "Host: " + hostProxy + "\r\n";
-        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
         TStringBuf cookieValue, suffixCookie;
         cookieBuf.TrySplit(';', cookieValue, suffixCookie);
@@ -745,7 +745,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
         TStringBuf cookieValue, suffixCookie;
         cookieBuf.TrySplit(';', cookieValue, suffixCookie);
@@ -793,7 +793,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
         TStringBuf cookieValue, suffixCookie;
         cookieBuf.TrySplit(';', cookieValue, suffixCookie);
@@ -855,7 +855,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
         TStringBuf cookieValue, suffixCookie;
         cookieBuf.TrySplit(';', cookieValue, suffixCookie);
@@ -1039,7 +1039,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << wrongState << " HTTP/1.1\r\n";
         request << "Host: " + hostProxy + "\r\n";
-        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
         TStringBuf cookieValue, suffixCookie;
         cookieBuf.TrySplit(';', cookieValue, suffixCookie);

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1,7 +1,9 @@
 #include "oidc_protected_page_handler.h"
 #include "oidc_session_create_handler.h"
+#include "oidc_auth_start_page.h"
 #include "oidc_impersonate_start_page_nebius.h"
 #include "oidc_impersonate_stop_page_nebius.h"
+#include "oidc_cookie.h"
 #include "oidc_settings.h"
 #include "openid_connect.h"
 #include "context.h"
@@ -566,7 +568,6 @@ Y_UNIT_TEST_SUITE(Mvp) {
                                                                                    "Host: " + hostProxy + "\r\n"
                                                                                    "Cookie: yc_session=invalid_cookie\r\n"
                                                                                    "Referer: https://" + hostProxy + protectedPage + "\r\n"));
-        const TString expectedRequestedAddress = TContext(incomingRequest).GetRequestedAddress();
         runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
 
         TAutoPtr<IEventHandle> handle;
@@ -586,9 +587,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         UNIT_ASSERT(headers.Has("X-Request-Id"));
         UNIT_ASSERT(headers.Has("Set-Cookie"));
         TStringBuf setCookie = headers.Get("Set-Cookie");
-        UNIT_ASSERT_STRING_CONTAINS(
-            setCookie,
-            CreateAuthFlowCookieName(CreateFlowId(settings.ClientSecret, expectedRequestedAddress)));
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, CreateNameYdbOidcCookie());
         redirectStrategy.CheckSpecificHeaders(headers);
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
@@ -656,6 +655,187 @@ Y_UNIT_TEST_SUITE(Mvp) {
         OidcFullAuthorizationFlow(redirectStrategy);
     }
 
+    void OpenIdConnectLocalAuthStartFlow(TRedirectStrategyBase& redirectStrategy) {
+        TPortManager tp;
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        auto settings = BuildBaseSettings(tp, NMvp::nebius_v1);
+        settings.AuthenticationFlowMode = NMvp::NOidcProxy::local_auth_start;
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+        const NActors::TActorId target = runtime.Register(new TProtectedPageHandler(edge, settings));
+        const NActors::TActorId authStart = runtime.Register(new TAuthStartPageHandler(edge, settings));
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        incomingRequest->Endpoint->Secure = true;
+
+        const TString hostProxy = "oidcproxy.net";
+        const TString protectedPage = "/" + ALLOWED_PROXY_HOST + "/counters";
+
+        EatWholeString(incomingRequest, redirectStrategy.CreateRequest("GET " + protectedPage + " HTTP/1.1\r\n"
+                                                                                   "Host: " + hostProxy + "\r\n"
+                                                                                   "Cookie: yc_session=invalid_cookie\r\n"
+                                                                                   "Referer: https://" + hostProxy + protectedPage + "\r\n"));
+        runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv =
+            runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        redirectStrategy.CheckRedirectStatus(outgoingResponseEv);
+
+        TString localAuthStartUrl = redirectStrategy.GetRedirectUrl(outgoingResponseEv);
+        localAuthStartUrl = redirectStrategy.GetUrlFromLocationHeader(localAuthStartUrl);
+        UNIT_ASSERT_STRING_CONTAINS(localAuthStartUrl, "/auth/start?");
+        NHttp::TUrlParameters startUrlParameters(localAuthStartUrl);
+        const TString expectedRequestedAddress = redirectStrategy.IsNavigationRequest()
+            ? protectedPage
+            : TStringBuilder() << "https://" << hostProxy << protectedPage;
+        const TString returnTo = TString(startUrlParameters["return_to"]);
+        UNIT_ASSERT_STRINGS_EQUAL(returnTo, expectedRequestedAddress);
+
+        incomingRequest = new NHttp::THttpIncomingRequest();
+        incomingRequest->Endpoint->Secure = true;
+        EatWholeString(incomingRequest, TStringBuilder()
+            << "GET " << localAuthStartUrl << " HTTP/1.1\r\n"
+            << "Host: " << hostProxy << "\r\n\r\n");
+        runtime.Send(new IEventHandle(authStart, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+        const NHttp::THeaders authStartHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(authStartHeaders.Has("Set-Cookie"));
+        TStringBuf setCookie = authStartHeaders.Get("Set-Cookie");
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, CreateSharedOidcCookieName());
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, "Path=/auth;");
+
+        const TString redirectUrl = TString(authStartHeaders.Get("Location"));
+        UNIT_ASSERT_STRING_CONTAINS(redirectUrl, "https://auth.test.net/oauth/authorize");
+        NHttp::TUrlParameters urlParameters(redirectUrl);
+        UNIT_ASSERT_STRINGS_EQUAL(urlParameters["response_type"], "code");
+        UNIT_ASSERT_STRINGS_EQUAL(urlParameters["scope"], "openid");
+        UNIT_ASSERT_STRINGS_EQUAL(urlParameters["client_id"], settings.ClientId);
+        UNIT_ASSERT_STRINGS_EQUAL(urlParameters["redirect_uri"], "https://" + hostProxy + "/auth/callback");
+        const TString state = TString(urlParameters.Get("state"));
+
+        const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
+        incomingRequest = new NHttp::THttpIncomingRequest();
+        TStringBuilder callbackRequest;
+        callbackRequest << "GET /auth/callback?code=code_template#&state=" << state << " HTTP/1.1\r\n";
+        callbackRequest << "Host: " + hostProxy + "\r\n";
+        callbackRequest << "Cookie: " << setCookie.NextTok(";") << "\r\n";
+        EatWholeString(incomingRequest, redirectStrategy.CreateRequest(callbackRequest));
+        runtime.Send(new IEventHandle(sessionCreator, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
+        const TStringBuf& body = outgoingRequestEv->Request->Body;
+        UNIT_ASSERT_STRING_CONTAINS(body, "code=code_template%23");
+        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type=authorization_code");
+
+        const TString authorizationServerResponse = R"___({"access_token":"access_token_value","token_type":"bearer","expires_in":43199,"scope":"openid","id_token":"id_token_value"})___";
+        NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
+        EatWholeString(incomingResponse, "HTTP/1.1 200 OK\r\n"
+                                                    "Connection: close\r\n"
+                                                    "Content-Type: application/json; charset=utf-8\r\n"
+                                                    "Content-Length: " + ToString(authorizationServerResponse.length()) + "\r\n\r\n" + authorizationServerResponse);
+        runtime.Send(new IEventHandle(handle->Sender, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(outgoingRequestEv->Request, incomingResponse)));
+
+        outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+        const NHttp::THeaders protectedPageHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(protectedPageHeaders.Has("Location"));
+        redirectStrategy.CheckLocationHeader(protectedPageHeaders.Get("Location"), hostProxy, protectedPage);
+        UNIT_ASSERT_STRING_CONTAINS(protectedPageHeaders.Get("Set-Cookie"), "__Host_session_cookie_");
+    }
+
+    Y_UNIT_TEST(OpenIdConnectLocalAuthStartFlow) {
+        TRedirectStrategy redirectStrategy;
+        OpenIdConnectLocalAuthStartFlow(redirectStrategy);
+    }
+
+    Y_UNIT_TEST(OpenIdConnectLocalAuthStartFlowAjax) {
+        TAjaxRedirectStrategy redirectStrategy;
+        OpenIdConnectLocalAuthStartFlow(redirectStrategy);
+    }
+
+    Y_UNIT_TEST(OpenIdConnectCallbackUsesLatestCookieWithoutLocalAuthStart) {
+        TPortManager tp;
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        auto settings = BuildBaseSettings(tp);
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+        const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
+
+        const TString firstRequestedAddress = "/requested/first";
+        const TString secondRequestedAddress = "/requested/second";
+        TContext firstContext({.State = "first_state", .RequestedAddress = firstRequestedAddress});
+        TContext secondContext({.State = "second_state", .RequestedAddress = secondRequestedAddress});
+
+        TString secondCookie = secondContext.CreateYdbOidcCookie(settings.ClientSecret);
+        TStringBuf secondCookieBuf(secondCookie);
+        TStringBuf secondCookieValue, secondCookieAttributes;
+        secondCookieBuf.TrySplit(';', secondCookieValue, secondCookieAttributes);
+
+        TStringBuilder request;
+        request << "GET /auth/callback?state=" << firstContext.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
+        request << "Host: oidcproxy.net\r\n";
+        request << "Cookie: " << secondCookieValue << "\r\n";
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        incomingRequest->Endpoint->Secure = true;
+        EatWholeString(incomingRequest, TRedirectStrategy().CreateRequest(request));
+        runtime.Send(new IEventHandle(sessionCreator, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv =
+            runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+
+        const NHttp::THeaders headers(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(headers.Has("Location"));
+        UNIT_ASSERT_STRINGS_EQUAL(TString(headers.Get("Location")), secondRequestedAddress);
+    }
+
+    Y_UNIT_TEST(OpenIdConnectCallbackUsesStateEntryWithLocalAuthStart) {
+        TPortManager tp;
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        auto settings = BuildBaseSettings(tp, NMvp::nebius_v1);
+        settings.AuthenticationFlowMode = NMvp::NOidcProxy::local_auth_start;
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+        const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
+
+        const TString firstRequestedAddress = "/requested/first";
+        const TString secondRequestedAddress = "/requested/second";
+        TContext firstContext({.State = "first_state", .RequestedAddress = firstRequestedAddress});
+
+        TString sharedCookieValue = UpdateSharedOidcCookieValue("", settings.ClientSecret, CreateFlowId(settings.ClientSecret, firstRequestedAddress), firstRequestedAddress);
+        sharedCookieValue = UpdateSharedOidcCookieValue(sharedCookieValue, settings.ClientSecret, CreateFlowId(settings.ClientSecret, secondRequestedAddress), secondRequestedAddress);
+
+        TStringBuilder request;
+        request << "GET /auth/callback?state=" << firstContext.GetStateWithFlowId(settings.ClientSecret) << " HTTP/1.1\r\n";
+        request << "Host: oidcproxy.net\r\n";
+        request << "Cookie: " << CreateSharedOidcCookieName() << "=" << sharedCookieValue << "\r\n";
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        incomingRequest->Endpoint->Secure = true;
+        EatWholeString(incomingRequest, TRedirectStrategy().CreateRequest(request));
+        runtime.Send(new IEventHandle(sessionCreator, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv =
+            runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+
+        const NHttp::THeaders headers(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(headers.Has("Location"));
+        UNIT_ASSERT_STRINGS_EQUAL(TString(headers.Get("Location")), firstRequestedAddress);
+    }
+
     void OidcWrongStateAuthorizationFlow(TRedirectStrategyBase& redirectStrategy) {
         TPortManager tp;
         TMvpTestRuntime runtime;
@@ -683,10 +863,10 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << wrongState << " HTTP/1.1\r\n";
         request << "Host: " + hostProxy + "\r\n";
-        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
+        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
-        TStringBuf cookieValue, suffixCookie;
-        cookieBuf.TrySplit(';', cookieValue, suffixCookie);
+        TStringBuf cookieValue, cookieAttributes;
+        cookieBuf.TrySplit(';', cookieValue, cookieAttributes);
         cookie = TString(cookieValue);
         request << "Cookie: " << cookie << "\r\n";
         NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
@@ -709,19 +889,19 @@ Y_UNIT_TEST_SUITE(Mvp) {
         OidcWrongStateAuthorizationFlow(redirectStrategy);
     }
 
-    Y_UNIT_TEST(OpenIdConnectExpiredStateKeepsCookieSuffix) {
+    Y_UNIT_TEST(OpenIdConnectExpiredStateKeepsFlowId) {
         TPortManager tp;
         auto settings = BuildBaseSettings(tp);
         TState sourcePayload;
         sourcePayload.AntiForgeryToken = "state";
         sourcePayload.ExpirationTime = TInstant::Seconds(0);
-        sourcePayload.CookieSuffix = "_flow-id";
+        sourcePayload.FlowId = "flow-id";
 
         TCheckStateResult result = CheckState(EncodeState(sourcePayload, settings.ClientSecret), settings.ClientSecret);
-        const TString expectedCookieSuffix = "_flow-id";
+        const TString expectedFlowId = "flow-id";
 
         UNIT_ASSERT(!result.Ok);
-        UNIT_ASSERT_STRINGS_EQUAL(result.CookieSuffix, expectedCookieSuffix);
+        UNIT_ASSERT_STRINGS_EQUAL(result.FlowId, expectedFlowId);
         UNIT_ASSERT_STRING_CONTAINS(result.ErrorMessage, "State lifetime expired");
     }
 
@@ -745,10 +925,10 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
+        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
-        TStringBuf cookieValue, suffixCookie;
-        cookieBuf.TrySplit(';', cookieValue, suffixCookie);
+        TStringBuf cookieValue, cookieAttributes;
+        cookieBuf.TrySplit(';', cookieValue, cookieAttributes);
         cookie = TString(cookieValue);
         request << "Cookie: " << cookie << "\r\n\r\n";
         NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
@@ -793,10 +973,10 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
+        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
-        TStringBuf cookieValue, suffixCookie;
-        cookieBuf.TrySplit(';', cookieValue, suffixCookie);
+        TStringBuf cookieValue, cookieAttributes;
+        cookieBuf.TrySplit(';', cookieValue, cookieAttributes);
         cookie = TString(cookieValue);
         request << "Cookie: " << cookie << "\r\n";
         NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
@@ -855,10 +1035,10 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /callback?code=code_template#&state=" << context.GetState(settings.ClientSecret) << " HTTP/1.1\r\n";
         request << "Host: oidcproxy.net\r\n";
-        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
+        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
-        TStringBuf cookieValue, suffixCookie;
-        cookieBuf.TrySplit(';', cookieValue, suffixCookie);
+        TStringBuf cookieValue, cookieAttributes;
+        cookieBuf.TrySplit(';', cookieValue, cookieAttributes);
         cookie = TString(cookieValue);
         request << "Cookie: " << cookie << "\r\n\r\n";
         NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
@@ -1039,10 +1219,10 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TStringBuilder request;
         request << "GET /auth/callback?code=code_template#&state=" << wrongState << " HTTP/1.1\r\n";
         request << "Host: " + hostProxy + "\r\n";
-        TString cookie = context.CreateAuthFlowCookie(settings.ClientSecret);
+        TString cookie = context.CreateYdbOidcCookie(settings.ClientSecret);
         TStringBuf cookieBuf(cookie);
-        TStringBuf cookieValue, suffixCookie;
-        cookieBuf.TrySplit(';', cookieValue, suffixCookie);
+        TStringBuf cookieValue, cookieAttributes;
+        cookieBuf.TrySplit(';', cookieValue, cookieAttributes);
         cookie = TString(cookieValue);
         if (cookie.back() != 'a') {
             cookie.back() = 'a';
@@ -1633,60 +1813,19 @@ Y_UNIT_TEST_SUITE(Utils) {
         sourcePayload.ExpirationTime = TInstant::Seconds(
             TInstant::Now().Seconds() + TOpenIdConnectSettings::DEFAULT_OIDC_FLOW_LIFETIME.Seconds()
         );
-        sourcePayload.CookieSuffix = "_flow-id";
+        sourcePayload.FlowId = "flow-id";
 
         const TString state = EncodeState(sourcePayload, settings.ClientSecret);
         const TCheckStateResult result = CheckState(state, settings.ClientSecret);
         const TDecodeStateResult decodedResult = DecodeState(state);
 
         UNIT_ASSERT(result.Ok);
-        UNIT_ASSERT_STRINGS_EQUAL(result.CookieSuffix, sourcePayload.CookieSuffix);
+        UNIT_ASSERT_STRINGS_EQUAL(result.FlowId, sourcePayload.FlowId);
         UNIT_ASSERT(result.ErrorMessage.empty());
         UNIT_ASSERT(decodedResult.HasSignedStateJson);
         UNIT_ASSERT(decodedResult.HasStateContainerJson);
         UNIT_ASSERT(decodedResult.Payload == sourcePayload);
         UNIT_ASSERT_STRINGS_EQUAL(EncodeState(decodedResult.Payload, settings.ClientSecret), state);
-    }
-
-    Y_UNIT_TEST(OpenIdConnectFlowIdIsDeterministicForSameAddress) {
-        TPortManager tp;
-        auto settings = BuildBaseSettings(tp);
-
-        const TString requestedAddress = "https://site.example.com/path?x=1";
-        const TString flowId1 = CreateFlowId(settings.ClientSecret, requestedAddress);
-        const TString flowId2 = CreateFlowId(settings.ClientSecret, requestedAddress);
-
-        UNIT_ASSERT_STRINGS_EQUAL(flowId1, flowId2);
-        UNIT_ASSERT_VALUES_EQUAL(flowId1.size(), 17);
-        UNIT_ASSERT_VALUES_EQUAL(flowId1[0], '_');
-    }
-
-    Y_UNIT_TEST(OpenIdConnectFlowIdDiffersForDifferentAddresses) {
-        TPortManager tp;
-        auto settings = BuildBaseSettings(tp);
-
-        const TString flowId1 = CreateFlowId(settings.ClientSecret, "https://site.example.com/path?x=1");
-        const TString flowId2 = CreateFlowId(settings.ClientSecret, "https://site.example.com/path?x=2");
-
-        UNIT_ASSERT_UNEQUAL(flowId1, flowId2);
-    }
-
-    Y_UNIT_TEST(OpenIdConnectStateUsesFlowIdAsCookieSuffix) {
-        TPortManager tp;
-        auto settings = BuildBaseSettings(tp);
-
-        const TString requestedAddress = "https://site.example.com/path?x=1";
-        TContext context({
-            .State = "state",
-            .RequestedAddress = requestedAddress,
-        });
-
-        const TString state = context.GetState(settings.ClientSecret);
-        const TDecodeStateResult decodedResult = DecodeState(state);
-
-        UNIT_ASSERT(decodedResult.HasSignedStateJson);
-        UNIT_ASSERT(decodedResult.HasStateContainerJson);
-        UNIT_ASSERT_STRINGS_EQUAL(decodedResult.Payload.CookieSuffix, CreateFlowId(settings.ClientSecret, requestedAddress));
     }
 
     Y_UNIT_TEST(GenerateRandomBase64RandomUniqueness) {

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -31,7 +31,10 @@ void THandlerSessionCreate::Bootstrap() {
 
     NHttp::THeaders headers(Request->Headers);
     NHttp::TCookies cookies(headers.Get("cookie"));
-    TRestoreOidcContextResult restoreContextResult = RestoreOidcContext(cookies, Settings.ClientSecret, checkStateResult.CookieSuffix);
+    TRestoreOidcContextResult restoreContextResult = RestoreOidcContext(cookies, Settings.ClientSecret);
+    if (Settings.UseSharedAuthenticationContext()) {
+        restoreContextResult = RestoreSharedOidcContext(cookies, Settings.ClientSecret, checkStateResult.FlowId);
+    }
     Context = restoreContextResult.Context;
 
     if (checkStateResult.Ok) {

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -37,6 +37,18 @@ bool TOpenIdConnectSettings::EnabledExtensionWhoami() const {
     return AccessServiceType == NMvp::nebius_v1 && !WhoamiExtendedInfoEndpoint.empty();
 }
 
+bool TOpenIdConnectSettings::UseLocalAuthStart() const {
+    return AuthenticationFlowMode == NMvp::NOidcProxy::local_auth_start;
+}
+
+bool TOpenIdConnectSettings::UseSharedAuthenticationContext() const {
+    return UseLocalAuthStart();
+}
+
+bool TOpenIdConnectSettings::UseFlowIdInState() const {
+    return UseSharedAuthenticationContext();
+}
+
 void TOpenIdConnectSettings::InitRequestTimeoutsByPath() {
     RequestTimeoutsByPath.clear();
 

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/mvp/core/protos/mvp.pb.h>
+#include <ydb/mvp/oidc_proxy/protos/config.pb.h>
+
 #include <util/datetime/base.h>
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
@@ -9,7 +10,8 @@
 namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings {
-    static const inline TString AUTH_FLOW_COOKIE = "auth_flow";
+    static const inline TString OIDC_COOKIE = "ydb_oidc_cookie";
+    static const inline TString SHARED_OIDC_COOKIE = "ydb_oidc_shared_cookie";
     static const inline TString SESSION_COOKIE = "session_cookie";
     static const inline TString IMPERSONATED_COOKIE = "impersonated_cookie";
 
@@ -19,6 +21,7 @@ struct TOpenIdConnectSettings {
     static const inline TString DEFAULT_EXCHANGE_URL_PATH = "/oauth2/session/exchange";
     static const inline TString DEFAULT_IMPERSONATE_URL_PATH = "/oauth2/impersonation/impersonate";
 
+    static constexpr inline ui32 MAX_AUTH_FLOW_COOKIE_VALUE_SIZE = 3700;
     static constexpr inline TDuration DEFAULT_REQUEST_TIMEOUT = TDuration::Seconds(120);
     static constexpr inline TDuration DEFAULT_OIDC_FLOW_LIFETIME = TDuration::Minutes(10);
 
@@ -38,12 +41,16 @@ struct TOpenIdConnectSettings {
     THashMap<TStringBuf, TDuration> RequestTimeoutsByPath;
 
     NMvp::EAccessServiceType AccessServiceType = NMvp::yandex_v2;
+    NMvp::NOidcProxy::EAuthenticationFlowMode AuthenticationFlowMode = NMvp::NOidcProxy::direct_to_authorization_server;
     TString AuthUrlPath = DEFAULT_AUTH_URL_PATH;
     TString TokenUrlPath = DEFAULT_TOKEN_URL_PATH;
     TString ExchangeUrlPath = DEFAULT_EXCHANGE_URL_PATH;
     TString ImpersonateUrlPath = DEFAULT_IMPERSONATE_URL_PATH;
 
     bool EnabledExtensionWhoami() const;
+    bool UseLocalAuthStart() const;
+    bool UseSharedAuthenticationContext() const;
+    bool UseFlowIdInState() const;
     void InitRequestTimeoutsByPath();
 
     TString GetAuthorizationString() const;

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -10,7 +10,6 @@ namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings {
     static const inline TString YDB_OIDC_COOKIE = "ydb_oidc_cookie";
-    static const inline TStringBuf YDB_OIDC_COOKIE_BACKGROUND_SUFFIX = "_background";
     static const inline TString SESSION_COOKIE = "session_cookie";
     static const inline TString IMPERSONATED_COOKIE = "impersonated_cookie";
 
@@ -21,6 +20,7 @@ struct TOpenIdConnectSettings {
     static const inline TString DEFAULT_IMPERSONATE_URL_PATH = "/oauth2/impersonation/impersonate";
 
     static constexpr inline TDuration DEFAULT_REQUEST_TIMEOUT = TDuration::Seconds(120);
+    static constexpr inline TDuration DEFAULT_OIDC_FLOW_LIFETIME = TDuration::Minutes(10);
 
     static const TVector<TStringBuf> REQUEST_HEADERS_WHITE_LIST;
     static const TVector<TStringBuf> RESPONSE_HEADERS_WHITE_LIST;

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -9,7 +9,7 @@
 namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings {
-    static const inline TString YDB_OIDC_COOKIE = "ydb_oidc_cookie";
+    static const inline TString AUTH_FLOW_COOKIE = "auth_flow";
     static const inline TString SESSION_COOKIE = "session_cookie";
     static const inline TString IMPERSONATED_COOKIE = "impersonated_cookie";
 

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -1,4 +1,6 @@
 #include "openid_connect.h"
+
+#include "oidc_cookie.h"
 #include "context.h"
 
 #include <ydb/core/util/random.h>
@@ -27,48 +29,6 @@ TRestoreOidcContextResult MakeRestoreOidcContextError(TStringBuf errorMessage) {
         .ErrorMessage = TStringBuilder() << "Restore OIDC context failed: " << errorMessage,
     });
 }
-
-bool IsAuthFlowCookieName(TStringBuf cookieName) {
-    return cookieName.StartsWith(TOpenIdConnectSettings::AUTH_FLOW_COOKIE);
-}
-
-TRestoreOidcContextResult TryRestoreOidcContextFromCookieValue(TStringBuf cookieValue, const TString& key) {
-    TString signedRequestedAddress = Base64Decode(cookieValue);
-    TString requestedAddress;
-    TString expectedDigest;
-    NJson::TJsonValue jsonValue;
-    NJson::TJsonReaderConfig jsonConfig;
-    if (!NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
-        return MakeRestoreOidcContextError("OIDC context cookie payload is not valid JSON");
-    }
-
-    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
-    if (!jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) || !jsonRequestedAddress->IsString()) {
-        return MakeRestoreOidcContextError("Requested address is missing in the OIDC context cookie");
-    }
-    requestedAddress = jsonRequestedAddress->GetString();
-
-    const NJson::TJsonValue* jsonDigest = nullptr;
-    if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
-        expectedDigest = jsonDigest->GetString();
-        expectedDigest = Base64Decode(expectedDigest);
-    }
-    if (expectedDigest.empty()) {
-        return MakeRestoreOidcContextError("Requested address digest is missing");
-    }
-
-    const TString digest = HmacSHA256(key, requestedAddress);
-    if (expectedDigest != digest) {
-        return MakeRestoreOidcContextError("Requested address digest mismatch");
-    }
-
-    return TRestoreOidcContextResult({
-        .IsSuccess = true,
-        .IsErrorRetryable = true,
-        .ErrorMessage = "",
-    }, TContext({.RequestedAddress = requestedAddress}));
-}
-
 } // anonymous namespace
 
 TRestoreOidcContextResult::TRestoreOidcContextResult(const TStatus& status, const TContext& context)
@@ -81,18 +41,18 @@ bool TRestoreOidcContextResult::IsSuccess() const {
     return Status.IsSuccess;
 }
 
-TCheckStateResult::TCheckStateResult(bool ok, const TString& cookieSuffix, const TString& errorMessage)
+TCheckStateResult::TCheckStateResult(bool ok, const TString& flowId, const TString& errorMessage)
     : Ok(ok)
     , ErrorMessage(errorMessage)
-    , CookieSuffix(cookieSuffix)
+    , FlowId(flowId)
 {}
 
-TCheckStateResult TCheckStateResult::Error(const TString& errorMessage, const TString& cookieSuffix) {
-    return TCheckStateResult(false, cookieSuffix, errorMessage);
+TCheckStateResult TCheckStateResult::Error(const TString& errorMessage, const TString& flowId) {
+    return TCheckStateResult(false, flowId, errorMessage);
 }
 
-TCheckStateResult TCheckStateResult::Success(const TString& cookieSuffix) {
-    return TCheckStateResult(true, cookieSuffix, "");
+TCheckStateResult TCheckStateResult::Success(const TString& flowId) {
+    return TCheckStateResult(true, flowId, "");
 }
 
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers) {
@@ -126,13 +86,6 @@ TString HmacSHA1(TStringBuf key, TStringBuf data) {
     return TString{reinterpret_cast<const char*>(res), hl};
 }
 
-TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress) {
-    static constexpr size_t FLOW_ID_BYTES = 8;
-
-    const TString digest = HmacSHA256(key, requestedAddress);
-    return "_" + HexEncode(TStringBuf(digest.data(), FLOW_ID_BYTES));
-}
-
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value) {
     for (auto& [exname, exvalue] : meta.Aux) {
         if (exname == name) {
@@ -143,8 +96,243 @@ void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& va
     meta.Aux.emplace_back(name, value);
 }
 
+namespace {
+
+NHttp::THttpOutgoingResponsePtr CreateAuthorizationRequiredResponse(const NHttp::THttpIncomingRequestPtr& request,
+                                                                    bool isNavigationRequest,
+                                                                    TStringBuf navigationUrl,
+                                                                    TStringBuf authUrl,
+                                                                    TStringBuf requestId,
+                                                                    const TString* setCookie = nullptr);
+
+TString BuildProxyUrl(const NHttp::THttpIncomingRequestPtr& request, TStringBuf path) {
+    return TStringBuilder()
+        << (request->Endpoint->Secure ? "https://" : "http://")
+        << request->Host
+        << path;
+}
+
+TString BuildLocalAuthStartUrl(const TContext& context) {
+    TCgiParameters authStartParams;
+    authStartParams.InsertUnescaped("return_to", context.GetRequestedAddress());
+    return TStringBuilder() << GetAuthStartUrl() << "?" << authStartParams.Print();
+}
+
+TString BuildAuthorizationServerRedirectUrl(const NHttp::THttpIncomingRequestPtr& request,
+                                            const TOpenIdConnectSettings& settings,
+                                            TStringBuf state) {
+    const TString redirectUri = TStringBuilder()
+        << (request->Endpoint->Secure ? "https://" : "http://")
+        << request->Host
+        << GetAuthCallbackUrl();
+    TCgiParameters authParams;
+    authParams.InsertUnescaped("response_type", "code");
+    authParams.InsertUnescaped("scope", "openid");
+    authParams.InsertUnescaped("state", state);
+    authParams.InsertUnescaped("client_id", settings.ClientId);
+    authParams.InsertUnescaped("redirect_uri", redirectUri);
+
+    return settings.GetAuthEndpointURL() + "?" + authParams.Print();
+}
+
+NHttp::THttpOutgoingResponsePtr CreateAuthorizationServerRedirectResponse(const NHttp::THttpIncomingRequestPtr& request,
+                                                                          const TOpenIdConnectSettings& settings,
+                                                                          const TContext& context,
+                                                                          TStringBuf currentCookieValue,
+                                                                          TStringBuf requestId) {
+    const TString flowId = CreateFlowId(settings.ClientSecret, context.GetRequestedAddress());
+    const TString state = settings.UseFlowIdInState()
+        ? context.GetStateWithFlowId(settings.ClientSecret)
+        : context.GetState(settings.ClientSecret);
+    const TString redirectUrl = BuildAuthorizationServerRedirectUrl(request, settings, state);
+    NHttp::THeadersBuilder responseHeaders;
+    SetCORS(request, &responseHeaders);
+    SetRequestIdHeader(responseHeaders, requestId);
+    if (!HasSharedOidcCookieEntry(currentCookieValue, settings.ClientSecret, flowId, context.GetRequestedAddress())) {
+        responseHeaders.Set("Set-Cookie", CreateSharedOidcCookie(settings.ClientSecret, currentCookieValue, context.GetRequestedAddress()));
+    }
+    responseHeaders.Set(LOCATION_HEADER, redirectUrl);
+    return request->CreateResponse("302", "Authorization required", responseHeaders);
+}
+
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtrForLocalAuthStart(const NHttp::THttpIncomingRequestPtr& request,
+                                                                            const TContext& context,
+                                                                            TStringBuf requestId) {
+    const TString authStartPath = BuildLocalAuthStartUrl(context);
+    return CreateAuthorizationRequiredResponse(
+        request,
+        context.IsNavigationRequest(),
+        authStartPath,
+        BuildProxyUrl(request, authStartPath),
+        requestId
+    );
+}
+
+NHttp::THttpOutgoingResponsePtr CreateAuthorizationRequiredResponse(const NHttp::THttpIncomingRequestPtr& request,
+                                                                    bool isNavigationRequest,
+                                                                    TStringBuf navigationUrl,
+                                                                    TStringBuf authUrl,
+                                                                    TStringBuf requestId,
+                                                                    const TString* setCookie) {
+    NHttp::THeadersBuilder responseHeaders;
+    SetCORS(request, &responseHeaders);
+    SetRequestIdHeader(responseHeaders, requestId);
+    if (setCookie) {
+        responseHeaders.Set("Set-Cookie", *setCookie);
+    }
+
+    if (isNavigationRequest) {
+        responseHeaders.Set(LOCATION_HEADER, navigationUrl);
+        return request->CreateResponse("302", "Authorization required", responseHeaders);
+    }
+
+    responseHeaders.Set("Content-Type", "application/json; charset=utf-8");
+    NJson::TJsonValue json(NJson::JSON_MAP);
+    json["error"] = "Authorization Required";
+    json["authUrl"] = authUrl;
+    const TString body = NJson::WriteJson(json, false);
+    return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
+}
+
+TRestoreOidcContextResult RestoreSharedOidcContextImpl(const NHttp::TCookies& cookies, const TString& key, TStringBuf flowId) {
+    const TString cookieName = CreateSharedOidcCookieName();
+    if (cookies.Has(cookieName)) {
+        const TFindRequestedAddressInOidcCookieResult result =
+            FindRequestedAddressInSharedOidcCookieValue(cookies.Get(cookieName), key, flowId);
+        if (!result.IsSuccess) {
+            return MakeRestoreOidcContextError(result.ErrorMessage);
+        }
+
+        return TRestoreOidcContextResult({
+            .IsSuccess = true,
+            .IsErrorRetryable = true,
+            .ErrorMessage = "",
+        }, TContext({.RequestedAddress = result.RequestedAddress}));
+    }
+
+    return MakeRestoreOidcContextError(TStringBuilder() << "Cannot find OIDC context cookie " << cookieName);
+}
+
+TRestoreOidcContextResult RestoreOidcContextImpl(const NHttp::TCookies& cookies, const TString& key) {
+    TStringBuilder errorMessage;
+    errorMessage << "Restore oidc context failed: ";
+    const TString cookieName = CreateNameYdbOidcCookie();
+    if (!cookies.Has(cookieName)) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "Cannot find cookie " << cookieName,
+        });
+    }
+
+    TString signedRequestedAddress;
+    try {
+        signedRequestedAddress = Base64Decode(cookies.Get(cookieName));
+    } catch (const std::exception&) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie payload is not valid base64",
+        });
+    }
+
+    TString requestedAddressContext;
+    TString expectedDigest;
+    NJson::TJsonValue jsonValue;
+    NJson::TJsonReaderConfig jsonConfig;
+    if (!NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie payload is not valid JSON",
+        });
+    }
+
+    const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
+    if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
+        try {
+            requestedAddressContext = Base64Decode(jsonRequestedAddressContext->GetString());
+        } catch (const std::exception&) {
+            return TRestoreOidcContextResult({
+                .IsSuccess = false,
+                .IsErrorRetryable = false,
+                .ErrorMessage = errorMessage << "OIDC auth flow cookie requested address context is not valid base64",
+            });
+        }
+    }
+    if (requestedAddressContext.empty()) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie requested address context is missing",
+        });
+    }
+
+    const NJson::TJsonValue* jsonDigest = nullptr;
+    if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
+        try {
+            expectedDigest = Base64Decode(jsonDigest->GetString());
+        } catch (const std::exception&) {
+            return TRestoreOidcContextResult({
+                .IsSuccess = false,
+                .IsErrorRetryable = false,
+                .ErrorMessage = errorMessage << "OIDC auth flow cookie digest is not valid base64",
+            });
+        }
+    }
+    if (expectedDigest.empty()) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie digest is missing",
+        });
+    }
+
+    const TString digest = HmacSHA256(key, requestedAddressContext);
+    if (expectedDigest != digest) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie digest mismatch",
+        });
+    }
+
+    if (!NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &jsonValue)) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie requested address context is not valid JSON",
+        });
+    }
+
+    TString requestedAddress;
+    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
+    if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
+        requestedAddress = jsonRequestedAddress->GetString();
+    }
+    if (requestedAddress.empty()) {
+        return TRestoreOidcContextResult({
+            .IsSuccess = false,
+            .IsErrorRetryable = false,
+            .ErrorMessage = errorMessage << "OIDC auth flow cookie requested address is missing",
+        });
+    }
+
+    return TRestoreOidcContextResult({
+        .IsSuccess = true,
+        .IsErrorRetryable = true,
+        .ErrorMessage = "",
+    }, TContext({.RequestedAddress = requestedAddress}));
+}
+
+} // anonymous namespace
+
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId) {
     TContext context(request);
+    if (settings.UseLocalAuthStart()) {
+        return GetHttpOutgoingResponsePtrForLocalAuthStart(request, context, requestId);
+    }
+
     const TString redirectUri = TStringBuilder()
         << (request->Endpoint->Secure ? "https://" : "http://")
         << request->Host
@@ -161,7 +349,7 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(request, &responseHeaders);
     SetRequestIdHeader(responseHeaders, requestId);
-    responseHeaders.Set("Set-Cookie", context.CreateAuthFlowCookie(settings.ClientSecret));
+    responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
     if (context.IsNavigationRequest()) {
         responseHeaders.Set(LOCATION_HEADER, redirectUrl);
         return request->CreateResponse("302", "Authorization required", responseHeaders);
@@ -174,8 +362,24 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
     return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
 }
 
-TString CreateAuthFlowCookieName(TStringBuf suffix) {
-    return TString(TOpenIdConnectSettings::AUTH_FLOW_COOKIE) + TString(suffix);
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtrForAuthStart(const NHttp::THttpIncomingRequestPtr& request,
+                                                                       const TOpenIdConnectSettings& settings,
+                                                                       const TContext& context,
+                                                                       TStringBuf currentCookieValue,
+                                                                       TStringBuf requestId) {
+    return CreateAuthorizationServerRedirectResponse(request, settings, context, currentCookieValue, requestId);
+}
+
+TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key) {
+    return RestoreOidcContextImpl(cookies, key);
+}
+
+TRestoreOidcContextResult RestoreSharedOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf flowId) {
+    return RestoreSharedOidcContextImpl(cookies, key, flowId);
+}
+
+TString CreateNameYdbOidcCookie(TStringBuf suffix) {
+    return TString(TOpenIdConnectSettings::OIDC_COOKIE) + TString(suffix);
 }
 
 TString CreateNameSessionCookie(TStringBuf key) {
@@ -184,6 +388,11 @@ TString CreateNameSessionCookie(TStringBuf key) {
 
 TString CreateNameImpersonatedCookie(TStringBuf key) {
     return "__Host_" + TOpenIdConnectSettings::IMPERSONATED_COOKIE + "_" + HexEncode(key);
+}
+
+const TString& GetAuthStartUrl() {
+    static const TString startUrl = "/auth/start";
+    return startUrl;
 }
 
 const TString& GetAuthCallbackUrl() {
@@ -203,28 +412,6 @@ TString ClearSecureCookie(const TString& name) {
     TStringBuilder cookieBuilder;
     cookieBuilder << name << "=; Path=/; Secure; HttpOnly; SameSite=None; Partitioned; Max-Age=0";
     return cookieBuilder;
-}
-
-TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix) {
-    TString cookieName = CreateAuthFlowCookieName(cookieSuffix);
-    if (cookies.Has(cookieName)) {
-        return TryRestoreOidcContextFromCookieValue(cookies.Get(cookieName), key);
-    }
-
-    // fallback to search for any cookie with AUTH_FLOW_COOKIE prefix if cookie with specific suffix was not found
-    for (const auto& [currentCookieName, currentCookieValue] : cookies.Cookies) {
-        if (currentCookieName == cookieName || !IsAuthFlowCookieName(currentCookieName)) {
-            continue;
-        }
-
-        TRestoreOidcContextResult restoreResult = TryRestoreOidcContextFromCookieValue(currentCookieValue, key);
-        if (restoreResult.IsSuccess()) {
-            return restoreResult;
-        }
-    }
-
-    return MakeRestoreOidcContextError(
-        TStringBuilder() << "Cannot find OIDC context cookie " << cookieName << " or any other valid OIDC context cookie");
 }
 
 TCheckStateResult TDecodeStateResult::Check(const TString& key) const {
@@ -247,12 +434,12 @@ TCheckStateResult TDecodeStateResult::Check(const TString& key) const {
         return TCheckStateResult::Error(TString(ErrorPrefix) + "State container is not valid JSON");
     }
     if (!Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time is missing in state", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time is missing in state", Payload.FlowId);
     }
     if (TInstant::Now() > *Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "State lifetime expired", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State lifetime expired", Payload.FlowId);
     }
-    return TCheckStateResult::Success(Payload.CookieSuffix);
+    return TCheckStateResult::Success(Payload.FlowId);
 }
 
 TString EncodeState(const TState& payload, TStringBuf signingKey) {
@@ -261,8 +448,8 @@ TString EncodeState(const TState& payload, TStringBuf signingKey) {
     if (payload.ExpirationTime) {
         json["expiration_time"] = ToString(payload.ExpirationTime->TimeT());
     }
-    if (!payload.CookieSuffix.empty()) {
-        json["cookie_suffix"] = payload.CookieSuffix;
+    if (!payload.FlowId.empty()) {
+        json["flow_id"] = payload.FlowId;
     }
     const TString stateContainer = NJson::WriteJson(json, false);
 
@@ -300,9 +487,9 @@ TDecodeStateResult DecodeState(TStringBuf encodedState) {
             if (jsonValue.GetValuePointer("state", &jsonState) && jsonState->IsString()) {
                 result.Payload.AntiForgeryToken = jsonState->GetString();
             }
-            const NJson::TJsonValue* jsonCookieSuffix = nullptr;
-            if (jsonValue.GetValuePointer("cookie_suffix", &jsonCookieSuffix) && jsonCookieSuffix->IsString()) {
-                result.Payload.CookieSuffix = jsonCookieSuffix->GetString();
+            const NJson::TJsonValue* jsonFlowId = nullptr;
+            if (jsonValue.GetValuePointer("flow_id", &jsonFlowId) && jsonFlowId->IsString()) {
+                result.Payload.FlowId = jsonFlowId->GetString();
             }
             const NJson::TJsonValue* jsonExpirationTime = nullptr;
             if (jsonValue.GetValuePointer("expiration_time", &jsonExpirationTime)) {

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -28,13 +28,13 @@ TRestoreOidcContextResult MakeRestoreOidcContextError(TStringBuf errorMessage) {
     });
 }
 
-bool IsOidcContextCookieName(TStringBuf cookieName) {
-    return cookieName.StartsWith(TOpenIdConnectSettings::YDB_OIDC_COOKIE);
+bool IsAuthFlowCookieName(TStringBuf cookieName) {
+    return cookieName.StartsWith(TOpenIdConnectSettings::AUTH_FLOW_COOKIE);
 }
 
 TRestoreOidcContextResult TryRestoreOidcContextFromCookieValue(TStringBuf cookieValue, const TString& key) {
     TString signedRequestedAddress = Base64Decode(cookieValue);
-    TString requestedAddressContext;
+    TString requestedAddress;
     TString expectedDigest;
     NJson::TJsonValue jsonValue;
     NJson::TJsonReaderConfig jsonConfig;
@@ -42,38 +42,24 @@ TRestoreOidcContextResult TryRestoreOidcContextFromCookieValue(TStringBuf cookie
         return MakeRestoreOidcContextError("OIDC context cookie payload is not valid JSON");
     }
 
-    const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
-    if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
-        requestedAddressContext = jsonRequestedAddressContext->GetString();
-        requestedAddressContext = Base64Decode(requestedAddressContext);
+    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
+    if (!jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) || !jsonRequestedAddress->IsString()) {
+        return MakeRestoreOidcContextError("Requested address is missing in the OIDC context cookie");
     }
-    if (requestedAddressContext.empty()) {
-        return MakeRestoreOidcContextError("Requested address context is missing");
-    }
+    requestedAddress = jsonRequestedAddress->GetString();
+
     const NJson::TJsonValue* jsonDigest = nullptr;
     if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
         expectedDigest = jsonDigest->GetString();
         expectedDigest = Base64Decode(expectedDigest);
     }
     if (expectedDigest.empty()) {
-        return MakeRestoreOidcContextError("Requested address context digest is missing");
+        return MakeRestoreOidcContextError("Requested address digest is missing");
     }
 
-    TString digest = HmacSHA256(key, requestedAddressContext);
+    const TString digest = HmacSHA256(key, requestedAddress);
     if (expectedDigest != digest) {
-        return MakeRestoreOidcContextError("Requested address context digest mismatch");
-    }
-
-    TString requestedAddress;
-    if (!NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &jsonValue)) {
-        return MakeRestoreOidcContextError("Requested address context is not valid JSON");
-    }
-
-    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
-    if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
-        requestedAddress = jsonRequestedAddress->GetString();
-    } else {
-        return MakeRestoreOidcContextError("Requested address is missing in the OIDC context cookie");
+        return MakeRestoreOidcContextError("Requested address digest mismatch");
     }
 
     return TRestoreOidcContextResult({
@@ -175,7 +161,7 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(request, &responseHeaders);
     SetRequestIdHeader(responseHeaders, requestId);
-    responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
+    responseHeaders.Set("Set-Cookie", context.CreateAuthFlowCookie(settings.ClientSecret));
     if (context.IsNavigationRequest()) {
         responseHeaders.Set(LOCATION_HEADER, redirectUrl);
         return request->CreateResponse("302", "Authorization required", responseHeaders);
@@ -188,8 +174,8 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
     return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
 }
 
-TString CreateNameYdbOidcCookie(TStringBuf suffix) {
-    return TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE) + TString(suffix);
+TString CreateAuthFlowCookieName(TStringBuf suffix) {
+    return TString(TOpenIdConnectSettings::AUTH_FLOW_COOKIE) + TString(suffix);
 }
 
 TString CreateNameSessionCookie(TStringBuf key) {
@@ -220,14 +206,14 @@ TString ClearSecureCookie(const TString& name) {
 }
 
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix) {
-    TString cookieName = CreateNameYdbOidcCookie(cookieSuffix);
+    TString cookieName = CreateAuthFlowCookieName(cookieSuffix);
     if (cookies.Has(cookieName)) {
         return TryRestoreOidcContextFromCookieValue(cookies.Get(cookieName), key);
     }
 
-    // fallback to search for any cookie with YDB_OIDC_COOKIE prefix if cookie with specific suffix was not found
+    // fallback to search for any cookie with AUTH_FLOW_COOKIE prefix if cookie with specific suffix was not found
     for (const auto& [currentCookieName, currentCookieValue] : cookies.Cookies) {
-        if (currentCookieName == cookieName || !IsOidcContextCookieName(currentCookieName)) {
+        if (currentCookieName == cookieName || !IsAuthFlowCookieName(currentCookieName)) {
             continue;
         }
 

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -18,6 +18,73 @@
 #include <util/string/hex.h>
 namespace NMVP::NOIDC {
 
+namespace {
+
+TRestoreOidcContextResult MakeRestoreOidcContextError(TStringBuf errorMessage) {
+    return TRestoreOidcContextResult({
+        .IsSuccess = false,
+        .IsErrorRetryable = false,
+        .ErrorMessage = TStringBuilder() << "Restore OIDC context failed: " << errorMessage,
+    });
+}
+
+bool IsOidcContextCookieName(TStringBuf cookieName) {
+    return cookieName.StartsWith(TOpenIdConnectSettings::YDB_OIDC_COOKIE);
+}
+
+TRestoreOidcContextResult TryRestoreOidcContextFromCookieValue(TStringBuf cookieValue, const TString& key) {
+    TString signedRequestedAddress = Base64Decode(cookieValue);
+    TString requestedAddressContext;
+    TString expectedDigest;
+    NJson::TJsonValue jsonValue;
+    NJson::TJsonReaderConfig jsonConfig;
+    if (!NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
+        return MakeRestoreOidcContextError("OIDC context cookie payload is not valid JSON");
+    }
+
+    const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
+    if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
+        requestedAddressContext = jsonRequestedAddressContext->GetString();
+        requestedAddressContext = Base64Decode(requestedAddressContext);
+    }
+    if (requestedAddressContext.empty()) {
+        return MakeRestoreOidcContextError("Requested address context is missing");
+    }
+    const NJson::TJsonValue* jsonDigest = nullptr;
+    if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
+        expectedDigest = jsonDigest->GetString();
+        expectedDigest = Base64Decode(expectedDigest);
+    }
+    if (expectedDigest.empty()) {
+        return MakeRestoreOidcContextError("Requested address context digest is missing");
+    }
+
+    TString digest = HmacSHA256(key, requestedAddressContext);
+    if (expectedDigest != digest) {
+        return MakeRestoreOidcContextError("Requested address context digest mismatch");
+    }
+
+    TString requestedAddress;
+    if (!NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &jsonValue)) {
+        return MakeRestoreOidcContextError("Requested address context is not valid JSON");
+    }
+
+    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
+    if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
+        requestedAddress = jsonRequestedAddress->GetString();
+    } else {
+        return MakeRestoreOidcContextError("Requested address is missing in the OIDC context cookie");
+    }
+
+    return TRestoreOidcContextResult({
+        .IsSuccess = true,
+        .IsErrorRetryable = true,
+        .ErrorMessage = "",
+    }, TContext({.RequestedAddress = requestedAddress}));
+}
+
+} // anonymous namespace
+
 TRestoreOidcContextResult::TRestoreOidcContextResult(const TStatus& status, const TContext& context)
     : Context(context)
     , Status(status)
@@ -71,6 +138,13 @@ TString HmacSHA1(TStringBuf key, TStringBuf data) {
     Y_ENSURE(res);
     Y_ENSURE(hl == SHA_DIGEST_LENGTH);
     return TString{reinterpret_cast<const char*>(res), hl};
+}
+
+TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress) {
+    static constexpr size_t FLOW_ID_BYTES = 8;
+
+    const TString digest = HmacSHA256(key, requestedAddress);
+    return "_" + HexEncode(TStringBuf(digest.data(), FLOW_ID_BYTES));
 }
 
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value) {
@@ -146,90 +220,51 @@ TString ClearSecureCookie(const TString& name) {
 }
 
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix) {
-    TStringBuilder errorMessage;
-    errorMessage << "Restore oidc context failed: ";
     TString cookieName = CreateNameYdbOidcCookie(cookieSuffix);
-    if (!cookies.Has(cookieName)) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Cannot find cookie " << cookieName});
+    if (cookies.Has(cookieName)) {
+        return TryRestoreOidcContextFromCookieValue(cookies.Get(cookieName), key);
     }
-    TString signedRequestedAddress = Base64Decode(cookies.Get(cookieName));
-    TString requestedAddressContext;
-    TString expectedDigest;
-    NJson::TJsonValue jsonValue;
-    NJson::TJsonReaderConfig jsonConfig;
-    if (NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
-        const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
-        if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
-            requestedAddressContext = jsonRequestedAddressContext->GetString();
-            requestedAddressContext = Base64Decode(requestedAddressContext);
+
+    // fallback to search for any cookie with YDB_OIDC_COOKIE prefix if cookie with specific suffix was not found
+    for (const auto& [currentCookieName, currentCookieValue] : cookies.Cookies) {
+        if (currentCookieName == cookieName || !IsOidcContextCookieName(currentCookieName)) {
+            continue;
         }
-        if (requestedAddressContext.empty()) {
-            return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Struct with state is empty"});
-        }
-        const NJson::TJsonValue* jsonDigest = nullptr;
-        if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
-            expectedDigest = jsonDigest->GetString();
-            expectedDigest = Base64Decode(expectedDigest);
-        }
-        if (expectedDigest.empty()) {
-            return TRestoreOidcContextResult({.IsSuccess = false,
-                                            .IsErrorRetryable = false,
-                                            .ErrorMessage = errorMessage << "Expected digest is empty"});
+
+        TRestoreOidcContextResult restoreResult = TryRestoreOidcContextFromCookieValue(currentCookieValue, key);
+        if (restoreResult.IsSuccess()) {
+            return restoreResult;
         }
     }
-    TString digest = HmacSHA256(key, requestedAddressContext);
-    if (expectedDigest != digest) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Calculated digest is not equal expected digest"});
-    }
-    TString requestedAddress;
-    if (!NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &jsonValue)) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Requested address context is not valid json"});
-    }
-    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
-    if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
-        requestedAddress = jsonRequestedAddress->GetString();
-    } else {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Requested address was not found in the cookie"});
-    }
-    return TRestoreOidcContextResult({.IsSuccess = true,
-                                     .IsErrorRetryable = true,
-                                     .ErrorMessage = ""}, TContext({.RequestedAddress = requestedAddress}));
+
+    return MakeRestoreOidcContextError(
+        TStringBuilder() << "Cannot find OIDC context cookie " << cookieName << " or any other valid OIDC context cookie");
 }
 
 TCheckStateResult TDecodeStateResult::Check(const TString& key) const {
     static constexpr TStringBuf ErrorPrefix = "Check state failed: ";
     if (!HasSignedStateJson) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Signed state is not valid json");
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "Signed state is not valid JSON");
     }
     if (StateContainer.empty()) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Container with state is empty");
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State container is missing");
     }
     if (ExpectedDigest.empty()) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expected digest is empty");
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State digest is missing");
     }
 
     TString digest = HmacSHA1(key, StateContainer);
     if (ExpectedDigest != digest) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Calculated digest is not equal expected digest");
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State digest mismatch");
     }
     if (!HasStateContainerJson) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "State container is not valid json");
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State container is not valid JSON");
     }
     if (!Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time not found in json", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time is missing in state", Payload.CookieSuffix);
     }
     if (TInstant::Now() > *Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "State life time expired", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State lifetime expired", Payload.CookieSuffix);
     }
     return TCheckStateResult::Success(Payload.CookieSuffix);
 }

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -89,7 +89,7 @@ TString HmacSHA1(TStringBuf key, TStringBuf data);
 TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId);
-TString CreateNameYdbOidcCookie(TStringBuf suffix = "");
+TString CreateAuthFlowCookieName(TStringBuf suffix = "");
 TString CreateNameSessionCookie(TStringBuf key);
 TString CreateNameImpersonatedCookie(TStringBuf key);
 const TString& GetAuthCallbackUrl();

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -86,6 +86,7 @@ private:
 
 TString HmacSHA256(TStringBuf key, TStringBuf data);
 TString HmacSHA1(TStringBuf key, TStringBuf data);
+TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId);
 TString CreateNameYdbOidcCookie(TStringBuf suffix = "");

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -51,12 +51,12 @@ struct TCheckStateResult;
 
 struct TState {
     TString AntiForgeryToken;
-    TString CookieSuffix;
+    TString FlowId;
     TMaybe<TInstant> ExpirationTime;
 
     bool operator==(const TState& other) const {
         return AntiForgeryToken == other.AntiForgeryToken
-            && CookieSuffix == other.CookieSuffix
+            && FlowId == other.FlowId
             && ExpirationTime == other.ExpirationTime;
     }
 };
@@ -75,28 +75,32 @@ struct TDecodeStateResult {
 struct TCheckStateResult {
     bool Ok = true;
     TString ErrorMessage;
-    TString CookieSuffix;
+    TString FlowId;
 
-    static TCheckStateResult Error(const TString& errorMessage, const TString& cookieSuffix = "");
-    static TCheckStateResult Success(const TString& cookieSuffix = "");
+    static TCheckStateResult Error(const TString& errorMessage, const TString& flowId = "");
+    static TCheckStateResult Success(const TString& flowId = "");
 
 private:
-    TCheckStateResult(bool ok, const TString& cookieSuffix, const TString& errorMessage);
+    TCheckStateResult(bool ok, const TString& flowId, const TString& errorMessage);
 };
 
-TString HmacSHA256(TStringBuf key, TStringBuf data);
-TString HmacSHA1(TStringBuf key, TStringBuf data);
-TString CreateFlowId(TStringBuf key, TStringBuf requestedAddress);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId);
-TString CreateAuthFlowCookieName(TStringBuf suffix = "");
+NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtrForAuthStart(const NHttp::THttpIncomingRequestPtr& request,
+                                                                       const TOpenIdConnectSettings& settings,
+                                                                       const TContext& context,
+                                                                       TStringBuf currentCookieValue,
+                                                                       TStringBuf requestId);
 TString CreateNameSessionCookie(TStringBuf key);
 TString CreateNameImpersonatedCookie(TStringBuf key);
+const TString& GetAuthStartUrl();
 const TString& GetAuthCallbackUrl();
 TString CreateSecureCookie(const TString& name, const TString& value, const ui32 expiredSeconds);
 TString ClearSecureCookie(const TString& name);
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers);
-TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix = "");
+TString HmacSHA256(TStringBuf key, TStringBuf data);
+TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key);
+TRestoreOidcContextResult RestoreSharedOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf flowId = "");
 TString EncodeState(const TState& payload, TStringBuf signingKey);
 TDecodeStateResult DecodeState(TStringBuf encodedState);
 TCheckStateResult CheckState(const TString& state, const TString& key);
@@ -104,6 +108,7 @@ TString DecodeToken(const TStringBuf& cookie);
 TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName);
 TString GetAddressWithoutPort(const TString& address);
 TString GenerateRandomBase64(size_t byteNumber = 32);
+TString CreateNameYdbOidcCookie(TStringBuf suffix = "");
 
 
 struct TProxiedRequestParams {

--- a/ydb/mvp/oidc_proxy/protos/config.proto
+++ b/ydb/mvp/oidc_proxy/protos/config.proto
@@ -4,6 +4,18 @@ package NMvp.NOidcProxy;
 
 import "ydb/mvp/core/protos/mvp.proto";
 
+// Controls how browser-based OIDC authentication is started.
+enum EAuthenticationFlowMode {
+    // Legacy behavior: browser is redirected directly to the authorization server.
+    direct_to_authorization_server = 1;
+    // Browser first goes through local /auth/start.
+    // This keeps authentication context in /auth-scoped cookies instead of sending
+    // context cookie on every proxied request, and allows the proxy to keep
+    // multiple requested addresses in authentication context instead of
+    // overwriting a single callback cookie.
+    local_auth_start = 2;
+}
+
 message TOidcProxyConfig {
     optional string SecretName = 1;
     optional string ClientId = 2;
@@ -16,6 +28,7 @@ message TOidcProxyConfig {
     optional string ImpersonateUrlPath = 9;
     optional string WhoamiExtendedInfoEndpoint = 10;
     repeated string AllowedProxyHosts = 11;
+    optional EAuthenticationFlowMode AuthenticationFlowMode = 12 [default = direct_to_authorization_server];
 }
 
 message TOidcProxyAppConfig {

--- a/ydb/mvp/oidc_proxy/ut/ya.make
+++ b/ydb/mvp/oidc_proxy/ut/ya.make
@@ -3,6 +3,7 @@ UNITTEST_FOR(ydb/mvp/oidc_proxy)
 SIZE(SMALL)
 
 SRCS(
+    oidc_cookie_ut.cpp
     mvp_config_validation_ut.cpp
     oidc_proxy_ut.cpp
     openid_connect.cpp

--- a/ydb/mvp/oidc_proxy/ya.make
+++ b/ydb/mvp/oidc_proxy/ya.make
@@ -1,6 +1,8 @@
 LIBRARY()
 
 SRCS(
+    oidc_auth_start_page.cpp
+    oidc_cookie.cpp
     context.cpp
     extension.cpp
     extension_final.cpp

--- a/ydb/tests/functional/mvp/oidc_proxy/conftest.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/conftest.py
@@ -1,7 +1,11 @@
 import pytest
 import yatest.common
 
-from oidc_proxy_env import started_oidc_proxy_env, started_oidc_proxy_full_flow_env
+from oidc_proxy_env import (
+    started_oidc_proxy_env,
+    started_oidc_proxy_full_flow_env,
+    started_oidc_proxy_full_flow_env_with_options,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,4 +23,10 @@ def oidc_proxy_env():
 @pytest.fixture
 def oidc_proxy_full_flow_env():
     with started_oidc_proxy_full_flow_env() as env:
+        yield env
+
+
+@pytest.fixture
+def oidc_proxy_full_flow_local_auth_start_env():
+    with started_oidc_proxy_full_flow_env_with_options(enable_local_auth_start=True) as env:
         yield env

--- a/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_env.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_env.py
@@ -25,6 +25,7 @@ def write_oidc_proxy_config(
     authorization_server_address,
     session_service_endpoint="localhost:8655",
     allowed_proxy_host=None,
+    enable_local_auth_start=False,
 ):
     with open(config_path, "w") as config:
         config_lines = [
@@ -54,6 +55,8 @@ def write_oidc_proxy_config(
             '  session_service_token_name: "session-service-token"',
             f'  authorization_server_address: "{authorization_server_address}"',
         ])
+        if enable_local_auth_start:
+            config_lines.append('  authentication_flow_mode: "local_auth_start"')
         if allowed_proxy_host is not None:
             config_lines.append(f'  allowed_proxy_hosts: ["{allowed_proxy_host}"]')
         config.write("\n".join(config_lines))
@@ -70,14 +73,15 @@ class OidcProxyService(MvpHttpService):
 
 
 class OidcProxyEnv(BaseHttpEnv):
-    def __init__(self, oidc_proxy, auth_service=None):
+    def __init__(self, oidc_proxy, auth_service=None, use_local_auth_start=False):
         super().__init__(oidc_proxy)
         self.auth_service = auth_service
+        self.use_local_auth_start = use_local_auth_start
 
 
 class OidcFullFlowEnv(OidcProxyEnv):
-    def __init__(self, oidc_proxy, auth_service, cluster):
-        super().__init__(oidc_proxy)
+    def __init__(self, oidc_proxy, auth_service, cluster, use_local_auth_start=False):
+        super().__init__(oidc_proxy, use_local_auth_start=use_local_auth_start)
         self.auth_service = auth_service
         self.cluster = cluster
 
@@ -98,6 +102,12 @@ def started_oidc_proxy_env():
 
 @contextmanager
 def started_oidc_proxy_full_flow_env():
+    with started_oidc_proxy_full_flow_env_with_options() as env:
+        yield env
+
+
+@contextmanager
+def started_oidc_proxy_full_flow_env_with_options(enable_local_auth_start=False):
     with PortManager() as port_manager:
         http_port = port_manager.get_port()
 
@@ -113,10 +123,16 @@ def started_oidc_proxy_full_flow_env():
                     authorization_server_address=auth_service.endpoint,
                     allowed_proxy_host=allowed_proxy_host,
                     session_service_endpoint=None,
+                    enable_local_auth_start=enable_local_auth_start,
                 )
                 oidc_proxy = OidcProxyService(config_path, http_port).start()
                 try:
-                    yield OidcFullFlowEnv(oidc_proxy, auth_service, cluster)
+                    yield OidcFullFlowEnv(
+                        oidc_proxy,
+                        auth_service,
+                        cluster,
+                        use_local_auth_start=enable_local_auth_start,
+                    )
                 finally:
                     oidc_proxy.stop()
             finally:

--- a/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
@@ -142,6 +142,21 @@ def get_auth_callback(env, headers=None, **kwargs):
     )
 
 
+def finish_auth_callback(env, state, oidc_cookies):
+    return env.get(
+        "/auth/callback",
+        params={
+            "code": "code_template#",
+            "state": state,
+        },
+        allow_redirects=False,
+        headers={
+            "Host": "oidcproxy.net",
+            "Cookie": "; ".join(oidc_cookies),
+        },
+    )
+
+
 def post_json_with_bearer(env, path, payload, token=TEST_IAM_TOKEN):
     return env.post(
         path,
@@ -198,12 +213,27 @@ def authenticate_session(oidc_proxy_full_flow_env, start_path):
     )
 
     assert start_response.status_code == 302
-    assert "Set-Cookie" in start_response.headers
     redirect_url = start_response.headers["Location"]
+    if oidc_proxy_full_flow_env.use_local_auth_start:
+        parsed_start_redirect = urlparse(redirect_url)
+        assert parsed_start_redirect.path == "/auth/start", redirect_url
+        assert parse_qs(parsed_start_redirect.query)["return_to"] == [start_path], redirect_url
+        auth_start_response = oidc_proxy_full_flow_env.get(
+            redirect_url,
+            allow_redirects=False,
+            headers={"Host": "oidcproxy.net"},
+        )
+        assert auth_start_response.status_code == 302, auth_start_response.text
+        assert "Set-Cookie" in auth_start_response.headers, auth_start_response.headers
+        redirect_url = auth_start_response.headers["Location"]
+        oidc_cookie = auth_start_response.headers["Set-Cookie"].split(";", 1)[0]
+    else:
+        assert "Set-Cookie" in start_response.headers, start_response.headers
+        oidc_cookie = start_response.headers["Set-Cookie"].split(";", 1)[0]
+
     parsed_redirect = urlparse(redirect_url)
     assert redirect_url.startswith(oidc_proxy_full_flow_env.auth_service.endpoint + "/oauth/authorize"), redirect_url
     state = parse_qs(parsed_redirect.query)["state"][0]
-    oidc_cookie = start_response.headers["Set-Cookie"].split(";", 1)[0]
 
     callback_response = oidc_proxy_full_flow_env.get(
         f"/auth/callback?code=code_template%23&state={state}",

--- a/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
@@ -104,6 +104,21 @@ def assert_cookie_is_cleared(response, expected_status, cookie_marker):
     assert "Max-Age=0" in set_cookie
 
 
+def assert_redirect_target(response, expected_target):
+    assert response.status_code == 302, response.text
+    redirect_url = response.headers["Location"]
+    parsed_redirect = urlparse(redirect_url)
+    if parsed_redirect.netloc:
+        assert parsed_redirect.scheme in ("http", "https"), response.headers
+        assert parsed_redirect.netloc == "oidcproxy.net", response.headers
+    else:
+        assert parsed_redirect.scheme == "", response.headers
+    actual_target = parsed_redirect.path
+    if parsed_redirect.query:
+        actual_target += f"?{parsed_redirect.query}"
+    assert actual_target == expected_target, response.headers
+
+
 def assert_successful_multipart_counter_response(response):
     assert response.status_code == 200, response.text
     content_type = response.headers["Content-Type"]
@@ -199,8 +214,7 @@ def authenticate_session(oidc_proxy_full_flow_env, start_path):
         },
     )
 
-    assert callback_response.status_code == 302, callback_response.text
-    assert callback_response.headers["Location"] == start_path, callback_response.headers
+    assert_redirect_target(callback_response, start_path)
     assert "__Host_session_cookie_" in callback_response.headers["Set-Cookie"], callback_response.headers["Set-Cookie"]
 
     return callback_response.headers["Set-Cookie"].split(";", 1)[0]

--- a/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
@@ -5,6 +5,7 @@ from oidc_proxy_testlib import (
     CALLBACK_PATH,
     assert_redirect_target,
     assert_nc_auth_not_started,
+    finish_auth_callback,
     get_auth_callback,
     protected_host,
     session_cookie_header,
@@ -138,21 +139,6 @@ def start_navigation_auth_flow(env, start_path):
     return state, oidc_cookie
 
 
-def finish_auth_callback(env, state, oidc_cookies):
-    return env.get(
-        "/auth/callback",
-        params={
-            "code": "code_template#",
-            "state": state,
-        },
-        allow_redirects=False,
-        headers={
-            "Host": "oidcproxy.net",
-            "Cookie": "; ".join(oidc_cookies),
-        },
-    )
-
-
 def test_background_request_returns_json_401_with_auth_url(oidc_proxy_full_flow_env):
     response = start_background_auth_challenge_request(oidc_proxy_full_flow_env)
     assert_background_auth_challenge(response)
@@ -163,34 +149,22 @@ def test_navigation_request_returns_oidc_redirect(oidc_proxy_full_flow_env):
     assert_navigation_auth_redirect(oidc_proxy_full_flow_env, response)
 
 
-def test_callback_uses_cookie_from_state_when_other_cookie_exists(oidc_proxy_full_flow_env):
+def test_callback_uses_latest_cookie_without_local_auth_start(oidc_proxy_full_flow_env):
     env = oidc_proxy_full_flow_env
     host = protected_host(env)
     first_target = f"/{host}{LANDING_DATA_PATH}&from=first"
     second_target = f"/{host}{LANDING_DATA_PATH}&from=second"
 
     first_state, first_oidc_cookie = start_navigation_auth_flow(env, first_target)
-    _, second_oidc_cookie = start_navigation_auth_flow(env, second_target)
-
-    assert first_oidc_cookie.split("=", 1)[0] != second_oidc_cookie.split("=", 1)[0]
-
-    callback_response = finish_auth_callback(
-        env,
-        first_state,
-        [first_oidc_cookie, second_oidc_cookie],
+    second_response = env.get(
+        second_target,
+        allow_redirects=False,
+        headers={"Host": "oidcproxy.net"},
     )
+    assert_navigation_auth_redirect(env, second_response)
+    second_oidc_cookie = second_response.headers["Set-Cookie"].split(";", 1)[0]
 
-    assert_redirect_target(callback_response, first_target)
-
-
-def test_callback_falls_back_to_other_cookie_when_cookie_from_state_is_missing(oidc_proxy_full_flow_env):
-    env = oidc_proxy_full_flow_env
-    host = protected_host(env)
-    first_target = f"/{host}{LANDING_DATA_PATH}&from=first"
-    second_target = f"/{host}{LANDING_DATA_PATH}&from=second"
-
-    first_state, _ = start_navigation_auth_flow(env, first_target)
-    _, second_oidc_cookie = start_navigation_auth_flow(env, second_target)
+    assert first_oidc_cookie.split("=", 1)[0] == second_oidc_cookie.split("=", 1)[0]
 
     callback_response = finish_auth_callback(
         env,

--- a/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
@@ -3,6 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 from oidc_proxy_testlib import (
     CALLBACK_PATH,
+    assert_redirect_target,
     assert_nc_auth_not_started,
     get_auth_callback,
     protected_host,
@@ -162,17 +163,39 @@ def test_navigation_request_returns_oidc_redirect(oidc_proxy_full_flow_env):
     assert_navigation_auth_redirect(oidc_proxy_full_flow_env, response)
 
 
-def test_navigation_callback_uses_cookie_from_state_when_background_cookie_exists(oidc_proxy_full_flow_env):
+def test_callback_uses_cookie_from_state_when_other_cookie_exists(oidc_proxy_full_flow_env):
     env = oidc_proxy_full_flow_env
     host = protected_host(env)
-    navigation_target = f"/{host}{LANDING_DATA_PATH}&from=navigation"
+    first_target = f"/{host}{LANDING_DATA_PATH}&from=first"
+    second_target = f"/{host}{LANDING_DATA_PATH}&from=second"
 
-    navigation_state, navigation_oidc_cookie = start_navigation_auth_flow(env, navigation_target)
-    background_response = start_background_auth_challenge_request(env)
-    assert_background_auth_challenge(background_response)
-    background_oidc_cookie = background_response.headers["Set-Cookie"].split(";", 1)[0]
+    first_state, first_oidc_cookie = start_navigation_auth_flow(env, first_target)
+    _, second_oidc_cookie = start_navigation_auth_flow(env, second_target)
 
-    callback_response = finish_auth_callback(env, navigation_state, [navigation_oidc_cookie, background_oidc_cookie])
+    assert first_oidc_cookie.split("=", 1)[0] != second_oidc_cookie.split("=", 1)[0]
 
-    assert callback_response.status_code == 302, callback_response.text
-    assert callback_response.headers["Location"] == navigation_target, callback_response.headers
+    callback_response = finish_auth_callback(
+        env,
+        first_state,
+        [first_oidc_cookie, second_oidc_cookie],
+    )
+
+    assert_redirect_target(callback_response, first_target)
+
+
+def test_callback_falls_back_to_other_cookie_when_cookie_from_state_is_missing(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    first_target = f"/{host}{LANDING_DATA_PATH}&from=first"
+    second_target = f"/{host}{LANDING_DATA_PATH}&from=second"
+
+    first_state, _ = start_navigation_auth_flow(env, first_target)
+    _, second_oidc_cookie = start_navigation_auth_flow(env, second_target)
+
+    callback_response = finish_auth_callback(
+        env,
+        first_state,
+        [second_oidc_cookie],
+    )
+
+    assert_redirect_target(callback_response, second_target)

--- a/ydb/tests/functional/mvp/oidc_proxy/test_local_auth_start.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/test_local_auth_start.py
@@ -1,0 +1,89 @@
+from urllib.parse import parse_qs, urlparse
+
+from oidc_proxy_testlib import (
+    assert_redirect_target,
+    authenticate_session,
+    finish_auth_callback,
+    protected_host,
+)
+
+
+LANDING_DATA_PATH = "/tablets/app?TabletID=72057594037968897&page=LandingData"
+
+
+def test_navigation_request_redirects_to_local_auth_start(oidc_proxy_full_flow_local_auth_start_env):
+    env = oidc_proxy_full_flow_local_auth_start_env
+    start_path = f"/{protected_host(env)}{LANDING_DATA_PATH}"
+
+    response = env.get(
+        start_path,
+        allow_redirects=False,
+        headers={"Host": "oidcproxy.net"},
+    )
+
+    assert response.status_code == 302, response.text
+    redirect_url = response.headers["Location"]
+    parsed_redirect = urlparse(redirect_url)
+    assert parsed_redirect.scheme == "", redirect_url
+    assert parsed_redirect.path == "/auth/start", redirect_url
+    assert parse_qs(parsed_redirect.query)["return_to"] == [start_path], redirect_url
+
+
+def test_full_authorization_flow_with_local_auth_start(oidc_proxy_full_flow_local_auth_start_env):
+    env = oidc_proxy_full_flow_local_auth_start_env
+    start_path = f"/{protected_host(env)}{LANDING_DATA_PATH}"
+
+    session_cookie = authenticate_session(env, start_path)
+
+    assert "__Host_session_cookie_" in session_cookie, session_cookie
+
+
+def start_navigation_auth_flow_with_local_auth_start(env, start_path, shared_oidc_cookie=None):
+    start_response = env.get(
+        start_path,
+        allow_redirects=False,
+        headers={"Host": "oidcproxy.net"},
+    )
+
+    assert start_response.status_code == 302, start_response.text
+    start_redirect_url = start_response.headers["Location"]
+    parsed_start_redirect = urlparse(start_redirect_url)
+    assert parsed_start_redirect.path == "/auth/start", start_redirect_url
+    assert parse_qs(parsed_start_redirect.query)["return_to"] == [start_path], start_redirect_url
+
+    auth_start_response = env.get(
+        start_redirect_url,
+        allow_redirects=False,
+        headers={
+            "Host": "oidcproxy.net",
+            **({"Cookie": shared_oidc_cookie} if shared_oidc_cookie is not None else {}),
+        },
+    )
+
+    assert auth_start_response.status_code == 302, auth_start_response.text
+    assert "Set-Cookie" in auth_start_response.headers, auth_start_response.headers
+
+    redirect_url = auth_start_response.headers["Location"]
+    state = parse_qs(urlparse(redirect_url).query)["state"][0]
+    next_shared_oidc_cookie = auth_start_response.headers["Set-Cookie"].split(";", 1)[0]
+    return state, next_shared_oidc_cookie
+
+
+def test_callback_uses_entry_from_state_with_local_auth_start(oidc_proxy_full_flow_local_auth_start_env):
+    env = oidc_proxy_full_flow_local_auth_start_env
+    host = protected_host(env)
+    first_target = f"/{host}{LANDING_DATA_PATH}&from=first"
+    second_target = f"/{host}{LANDING_DATA_PATH}&from=second"
+
+    first_state, first_shared_oidc_cookie = start_navigation_auth_flow_with_local_auth_start(env, first_target)
+    _, second_shared_oidc_cookie = start_navigation_auth_flow_with_local_auth_start(env, second_target, first_shared_oidc_cookie)
+
+    assert first_shared_oidc_cookie.split("=", 1)[0] == second_shared_oidc_cookie.split("=", 1)[0]
+
+    callback_response = finish_auth_callback(
+        env,
+        first_state,
+        [second_shared_oidc_cookie],
+    )
+
+    assert_redirect_target(callback_response, first_target)

--- a/ydb/tests/functional/mvp/oidc_proxy/ya.make
+++ b/ydb/tests/functional/mvp/oidc_proxy/ya.make
@@ -13,6 +13,7 @@ TEST_SRCS(
     oidc_proxy_testlib.py
     test_auth_failures.py
     test_basic_scenarios.py
+    test_local_auth_start.py
     test_streaming.py
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR updates the MVP OIDC proxy’s “return-to” context handling so concurrent auth flows can safely coexist. Instead of relying on separate cookie names/suffixes, it generates a deterministic flow_id per target and stores multiple target mappings inside a single OIDC context cookie value, allowing /auth/callback to redirect back to the correct target even when multiple flows are in progress.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Replace cookie_suffix with deterministic flow_id in the signed state, and use it to select the correct return target on callback.
- Introduce oidc_cookie.{h,cpp} to encode/decode a multi-entry, size-bounded OIDC context cookie value with LRU-like eviction and fallback behavior.
- Update functional and unit tests to validate multi-flow behavior and redirect target selection.
