### PR TITLE
[IC] Suppress repeated IC handshake failure logs. NBYDB-2145 (#39097)

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -332,13 +332,17 @@ namespace NActors {
 
         bool runDelayedRdmaHandshakeTimer = false;
 
+        const auto handshakeSuccessLogPriority = HoldByErrorWakeupDuration != TDuration::Zero()
+            ? NLog::PRI_NOTICE
+            : NLog::PRI_INFO;
+
         // Terminate handshake actor working in opposite direction, if set up.
         if (ev->Sender == IncomingHandshakeActor) {
-            LOG_INFO_IC("ICP19", "incoming handshake succeeded");
+            LOG_LOG_IC(NActorsServices::INTERCONNECT, "ICP19", handshakeSuccessLogPriority, "incoming handshake succeeded");
             DropIncomingHandshake(false);
             DropOutgoingHandshake();
         } else if (ev->Sender == OutgoingHandshakeActor) {
-            LOG_INFO_IC("ICP20", "outgoing handshake succeeded");
+            LOG_LOG_IC(NActorsServices::INTERCONNECT, "ICP20", handshakeSuccessLogPriority, "outgoing handshake succeeded");
             if (auto rdmaDisabled = ev->Get()->RdmaHanshakeResult.GetDisabled()) {
                 runDelayedRdmaHandshakeTimer = rdmaDisabled->RunDelayedHandshake;
             }
@@ -411,12 +415,18 @@ namespace NActors {
             (IncomingHandshakeActor && OutgoingHandshakeActor);
         LogHandshakeFail(ev, inconclusive);
 
+        const auto handshakeFailLogPriority = HoldByErrorWakeupDuration != TDuration::Zero()
+            ? NLog::PRI_DEBUG
+            : NLog::PRI_NOTICE;
+
         if (ev->Sender == IncomingHandshakeActor) {
-            LOG_NOTICE_IC("ICP24", "incoming handshake failed, temporary: %" PRIu32 " explanation: %s outgoing: %s",
+            LOG_LOG_IC(NActorsServices::INTERCONNECT, "ICP24", handshakeFailLogPriority,
+                          "incoming handshake failed, temporary: %" PRIu32 " explanation: %s outgoing: %s",
                           ui32(ev->Get()->Temporary), ev->Get()->Explanation.data(), OutgoingHandshakeActor.ToString().data());
             DropIncomingHandshake(false);
         } else if (ev->Sender == OutgoingHandshakeActor) {
-            LOG_NOTICE_IC("ICP25", "outgoing handshake failed, temporary: %" PRIu32 " explanation: %s incoming: %s held: %s",
+            LOG_LOG_IC(NActorsServices::INTERCONNECT, "ICP25", handshakeFailLogPriority,
+                          "outgoing handshake failed, temporary: %" PRIu32 " explanation: %s incoming: %s held: %s",
                           ui32(ev->Get()->Temporary), ev->Get()->Explanation.data(), IncomingHandshakeActor.ToString().data(),
                           HeldHandshakeReply ? "yes" : "no");
             DropOutgoingHandshake(false);

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -1,8 +1,13 @@
 #include <ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h>
 #include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
+#include <ydb/library/actors/protos/services_common.pb.h>
+#include <library/cpp/logger/backend.h>
+#include <library/cpp/logger/record.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/digest/md5/md5.h>
+#include <atomic>
 #include <cstring>
+#include <memory>
 #include <util/random/fast.h>
 #include <util/string/cast.h>
 #include <util/string/vector.h>
@@ -113,6 +118,35 @@ private:
     const TActorId Recipient;
     const size_t Messages;
     const size_t PayloadSize;
+};
+
+struct THandshakeFailureLogCounters {
+    std::atomic<ui32> Notice = 0;
+    std::atomic<ui32> Debug = 0;
+};
+
+class TCountingLogBackend : public TLogBackend {
+public:
+    explicit TCountingLogBackend(std::shared_ptr<THandshakeFailureLogCounters> outgoingHandshakeFailures)
+        : OutgoingHandshakeFailures(std::move(outgoingHandshakeFailures))
+    {}
+
+    void WriteData(const TLogRecord& rec) override {
+        const TStringBuf line(rec.Data, rec.Len);
+        if (line.Contains("ICP25") && line.Contains("outgoing handshake failed")) {
+            if (rec.Priority == TLOG_NOTICE) {
+                OutgoingHandshakeFailures->Notice.fetch_add(1, std::memory_order_relaxed);
+            } else if (rec.Priority == TLOG_DEBUG) {
+                OutgoingHandshakeFailures->Debug.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    }
+
+    void ReopenLog() override {
+    }
+
+private:
+    std::shared_ptr<THandshakeFailureLogCounters> OutgoingHandshakeFailures;
 };
 
 } // namespace
@@ -628,6 +662,55 @@ Y_UNIT_TEST_SUITE(Interconnect) {
 
     Y_UNIT_TEST(KernelLivenessReconnectLocalFallbackNotAppliedRdma) {
         RunKernelLivenessReconnectLocalFallbackNotApplied(true);
+    }
+
+    Y_UNIT_TEST(UnavailableNodeOutgoingHandshakeLogCount) {
+        auto outgoingHandshakeFailures = std::make_shared<THandshakeFailureLogCounters>();
+        auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+            settings.Handshake = TDuration::Seconds(1);
+            settings.FirstErrorSleep = TDuration::MilliSeconds(10);
+            settings.MaxErrorSleep = TDuration::Seconds(1);
+            settings.ErrorSleepRetryMultiplier = 4.0;
+        };
+        auto loggerSettings = MakeIntrusive<NLog::TSettings>(
+            TActorId(0, "logger"),
+            static_cast<NLog::EComponent>(NActorsServices::LOGGER),
+            NLog::PRI_DEBUG,
+            NLog::PRI_DEBUG,
+            0U);
+        loggerSettings->Append(
+            NActorsServices::EServiceCommon_MIN,
+            NActorsServices::EServiceCommon_MAX,
+            NActorsServices::EServiceCommon_Name);
+        loggerSettings->SetAllowDrop(false);
+        loggerSettings->SetThrottleDelay(TDuration::Zero());
+        auto logBackendFactory = [outgoingHandshakeFailures] {
+            return TAutoPtr<TLogBackend>(new TCountingLogBackend(outgoingHandshakeFailures));
+        };
+
+        TTestICCluster cluster(2, TChannelsConfig(), nullptr, loggerSettings, TTestICCluster::DISABLE_RDMA,
+            {}, TDuration::Seconds(2), TNode::DefaultInflight(), settingsCustomizer, logBackendFactory);
+
+        auto* recipientPtr = new TRecipientActor;
+        const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+        cluster.RegisterActor(new TSenderActor(recipient), 2);
+
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            return recipientPtr->GetReceived() >= 1;
+        }, "initial interconnect message delivery");
+
+        outgoingHandshakeFailures->Notice.store(0, std::memory_order_relaxed);
+        outgoingHandshakeFailures->Debug.store(0, std::memory_order_relaxed);
+        cluster.StopNode(1);
+        Sleep(TDuration::Seconds(10));
+
+        const ui32 noticeLogCount = outgoingHandshakeFailures->Notice.load(std::memory_order_relaxed);
+        const ui32 debugLogCount = outgoingHandshakeFailures->Debug.load(std::memory_order_relaxed);
+        UNIT_ASSERT_C(noticeLogCount == 1 || noticeLogCount == 2,
+            TStringBuilder() << "expected one or two notice-level ICP25 outgoing handshake failure log records in 10 seconds, got "
+                << noticeLogCount);
+        UNIT_ASSERT_C(debugLogCount > 0,
+            "expected repeated ICP25 outgoing handshake failure log records to be demoted to debug");
     }
 
     Y_UNIT_TEST(SetupRdmaSession) {

--- a/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
+++ b/ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h
@@ -39,18 +39,21 @@ private:
     NActors::TChannelsConfig ChannelsConfig;
     NInterconnectTest::IPortManager::TPtr PortManager;
     TIntrusivePtr<NLog::TSettings> LoggerSettings;
+    TNode::TLogBackendFactory LogBackendFactory;
 
 public:
     TTestICCluster(ui32 numNodes = 1, NActors::TChannelsConfig channelsConfig = NActors::TChannelsConfig(),
                    TTrafficInterrupterSettings* tiSettings = nullptr, TIntrusivePtr<NLog::TSettings> loggerSettings = nullptr, Flags flags = EMPTY,
                    TCheckerFactory checkerFactory = {}, TDuration deadPeerTimeout = TDuration::Seconds(2), ui32 inflight = TNode::DefaultInflight(),
-                   std::function<void(ui32, NActors::TInterconnectSettings&)> settingsCustomizer = {})
+                   std::function<void(ui32, NActors::TInterconnectSettings&)> settingsCustomizer = {},
+                   TNode::TLogBackendFactory logBackendFactory = {})
         : NumNodes(numNodes)
         , DeadPeerTimeout(deadPeerTimeout)
         , Counters(new NMonitoring::TDynamicCounters)
         , ChannelsConfig(channelsConfig)
         , PortManager(NInterconnectTest::CreatePortmanager())
         , LoggerSettings(loggerSettings)
+        , LogBackendFactory(std::move(logBackendFactory))
     {
         THashMap<ui32, ui16> nodeToPortMap;
         THashMap<ui32, THashMap<ui32, ui16>> specificNodePortMap;
@@ -84,7 +87,8 @@ public:
                 flags & USE_ZC ? ESocketSendOptimization::IC_MSG_ZEROCOPY : ESocketSendOptimization::DISABLED,
                 flags & USE_TLS, checkerFactory, flags & RDMA_POLLING_CQ ? NInterconnect::NRdma::ECqMode::POLLING : NInterconnect::NRdma::ECqMode::EVENT,
                 !(flags & DISABLE_RDMA),
-                settingsCustomizer));
+                settingsCustomizer,
+                LogBackendFactory));
         }
     }
 
@@ -112,6 +116,10 @@ public:
         auto it = InterrupterByNode.find(nodeId);
         Y_ABORT_UNLESS(it != InterrupterByNode.end());
         it->second->StopBlackhole();
+    }
+
+    void StopNode(ui32 nodeId) {
+        Nodes.at(nodeId)->Stop();
     }
 
     ~TTestICCluster() {

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -14,6 +14,8 @@
 #include <ydb/library/actors/interconnect/rdma/mem_pool.h>
 #include <ydb/library/actors/interconnect/rdma/cq_actor/cq_actor.h>
 
+#include <library/cpp/logger/backend.h>
+
 #include "tls/tls.h"
 
 using namespace NActors;
@@ -24,6 +26,8 @@ class TNode {
     TInterconnectProxyCommon::TPtr Common;
 
 public:
+    using TLogBackendFactory = std::function<TAutoPtr<TLogBackend>()>;
+
     static constexpr ui32 DefaultInflight() { return 512 * 1024; }
     TNode(ui32 nodeId, ui32 numNodes, const THashMap<ui32, ui16>& nodeToPort, const TString& address,
           NMonitoring::TDynamicCounterPtr counters, TDuration deadPeerTimeout,
@@ -34,7 +38,8 @@ public:
           bool withTls = false, std::function<IActor*(ui32)> checkerFactory = {},
           NInterconnect::NRdma::ECqMode rdmaCqMode = NInterconnect::NRdma::ECqMode::EVENT,
           bool withRdma = true,
-          std::function<void(ui32, TInterconnectSettings&)> settingsCustomizer = {}) {
+          std::function<void(ui32, TInterconnectSettings&)> settingsCustomizer = {},
+          TLogBackendFactory logBackendFactory = {}) {
         TActorSystemSetup setup;
         setup.NodeId = nodeId;
         setup.ExecutorsCount = 2;
@@ -148,8 +153,9 @@ public:
             interconnectPoolId));
 
         // register logger
+        TAutoPtr<TLogBackend> logBackend = logBackendFactory ? logBackendFactory() : CreateStderrBackend();
         setup.LocalServices.emplace_back(loggerActorId, TActorSetupCmd(new TLoggerActor(loggerSettings,
-            CreateStderrBackend(), counters->GetSubgroup("subsystem", "logger")),
+            logBackend, counters->GetSubgroup("subsystem", "logger")),
             TMailboxType::ReadAsFilled, 1));
 
         if (common->OutgoingHandshakeInflightLimit) {
@@ -165,8 +171,15 @@ public:
     }
 
     ~TNode() {
-        ActorSystem->Stop();
+        Stop();
         unlink(CaPath.c_str());
+    }
+
+    void Stop() {
+        if (ActorSystem) {
+            ActorSystem->Stop();
+            ActorSystem.Reset();
+        }
     }
 
     bool Send(const TActorId& recipient, IEventBase* ev) {

--- a/ydb/library/actors/interconnect/ut/lib/ya.make
+++ b/ydb/library/actors/interconnect/ut/lib/ya.make
@@ -8,6 +8,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/logger
     ydb/library/actors/interconnect/ut/lib/tls
 )
 

--- a/ydb/library/actors/interconnect/ut/ya.make
+++ b/ydb/library/actors/interconnect/ut/ya.make
@@ -27,6 +27,7 @@ PEERDIR(
     ydb/library/actors/interconnect/ut/protos
     ydb/library/actors/testlib
     library/cpp/digest/md5
+    library/cpp/logger
     library/cpp/testing/unittest
 )
 


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Log the first interconnect TCP handshake failure at NOTICE and demote repeated failures while the proxy is held by error to DEBUG. Promote handshake success after an error back to NOTICE so recovery is visible.

Add an interconnect unit test that stops a connected node and verifies ICP25 is emitted once at NOTICE and then at DEBUG on retries.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
