### PR TITLE
updated schema inference with parquet format

### DIFF
--- a/ydb/core/external_sources/object_storage/inference/arrow_inferencinator.cpp
+++ b/ydb/core/external_sources/object_storage/inference/arrow_inferencinator.cpp
@@ -34,10 +34,16 @@ namespace {
 using ArrowField = std::shared_ptr<arrow::Field>;
 using ArrowFields = std::vector<ArrowField>;
 
-bool ShouldBeOptional(const arrow::DataType& type, const std::shared_ptr<FormatConfig>& config) {
+bool ShouldBeOptional(const arrow::Field& field, const std::shared_ptr<FormatConfig>& config) {
     if (!config->ShouldMakeOptional) {
         return false;
     }
+
+    if (config->Format == EFileFormat::Parquet) {
+        return field.nullable();
+    }
+
+    const auto& type = *field.type();
 
     // For JSON formats, TIMESTAMP is reinterpreted as UTF8 (see MapPrimitiveType),
     // so it should not be wrapped in Optional either.
@@ -99,12 +105,12 @@ std::optional<Ydb::Type::PrimitiveTypeId> MapPrimitiveType(const arrow::DataType
     return std::nullopt;
 }
 
-bool ArrowToYdbType(Ydb::Type& maybeOptionalType, const arrow::DataType& type, const std::shared_ptr<FormatConfig>& config) {
-    auto mapped = MapPrimitiveType(type, *config);
+bool ArrowToYdbType(Ydb::Type& maybeOptionalType, const arrow::Field& field, const std::shared_ptr<FormatConfig>& config) {
+    auto mapped = MapPrimitiveType(*field.type(), *config);
     if (!mapped) {
         return false;
     }
-    auto& resType = ShouldBeOptional(type, config)
+    auto& resType = ShouldBeOptional(field, config)
         ? *maybeOptionalType.mutable_optional_type()->mutable_item()
         : maybeOptionalType;
     resType.set_type_id(*mapped);
@@ -258,7 +264,7 @@ public:
                 continue;
             }
             Ydb::Column column;
-            if (!ArrowToYdbType(*column.mutable_type(), *field->type(), file.Config)) {
+            if (!ArrowToYdbType(*column.mutable_type(), *field, file.Config)) {
                 skippedUnsupported.push_back(TStringBuilder() << field->name() << " (" << field->type()->ToString() << ")");
                 continue;
             }

--- a/ydb/tests/fq/s3/test_inference.py
+++ b/ydb/tests/fq/s3/test_inference.py
@@ -147,28 +147,36 @@ Pear,15,33,2024-05-06'''
             "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
         )
 
-        # (name, pyarrow_array, expected_ydb_type, expected_optional)
-        # Reflects current kPrimitiveTypeTable in arrow_inferencinator.cpp.
-        # ShouldBeOptional() returns false for STRING / BINARY / LARGE_BINARY / NA,
-        # and true for everything else. DATE64, LARGE_*, and unsigned integer
-        # types are excluded because they don't survive a parquet round-trip
-        # cleanly (parquet's default reader widens unsigned ints to signed int64).
+        # (name, pyarrow_array, expected_ydb_type, nullable)
+        # `nullable` is the parquet-schema nullability (REQUIRED vs OPTIONAL):
+        # parquet inference takes it as-is from arrow::Field::nullable(), so it
+        # also drives whether the resulting YDB type is wrapped in Optional<>.
+        # We deliberately mix required and optional columns of identical types
+        # (e.g. c08_string_req vs c13_string_opt, c11_timestamp_req vs
+        # c14_timestamp_opt) to guard against the regression from the bug
+        # report where required parquet columns were inferred as Optional.
+        # DATE64, LARGE_*, and unsigned integer types are excluded because
+        # they don't survive a parquet round-trip cleanly (parquet's default
+        # reader widens unsigned ints to signed int64).
         columns = [
-            ("c01_bool",       pa.array([True],                          type=pa.bool_()),                          ydb.Type.BOOL,      True),
-            ("c02_int8",       pa.array([1],                             type=pa.int8()),                           ydb.Type.INT8,      True),
-            ("c03_int16",      pa.array([1],                             type=pa.int16()),                          ydb.Type.INT16,     True),
-            ("c04_int32",      pa.array([1],                             type=pa.int32()),                          ydb.Type.INT32,     True),
-            ("c05_int64",      pa.array([1],                             type=pa.int64()),                          ydb.Type.INT64,     True),
-            ("c06_float",      pa.array([1.0],                           type=pa.float32()),                        ydb.Type.FLOAT,     True),
-            ("c07_double",     pa.array([1.0],                           type=pa.float64()),                        ydb.Type.DOUBLE,    True),
-            ("c08_string",     pa.array(["s"],                           type=pa.string()),                         ydb.Type.UTF8,      False),
-            ("c09_binary",     pa.array([b"b"],                          type=pa.binary()),                         ydb.Type.STRING,    False),
-            ("c10_date32",     pa.array([date(2024, 1, 2)],              type=pa.date32()),                         ydb.Type.DATE,      True),
-            ("c11_timestamp",  pa.array([datetime(2024, 1, 2, 3, 4, 5)], type=pa.timestamp('us')),                  ydb.Type.TIMESTAMP, True),
-            ("c12_decimal",    pa.array([decimal.Decimal("1.5")],        type=pa.decimal128(precision=5, scale=2)), ydb.Type.DOUBLE,    True),
+            ("c01_bool",          pa.array([True],                          type=pa.bool_()),                          ydb.Type.BOOL,      False),
+            ("c02_int8",          pa.array([1],                             type=pa.int8()),                           ydb.Type.INT8,      False),
+            ("c03_int16",         pa.array([1],                             type=pa.int16()),                          ydb.Type.INT16,     False),
+            ("c04_int32",         pa.array([1],                             type=pa.int32()),                          ydb.Type.INT32,     False),
+            ("c05_int64",         pa.array([1],                             type=pa.int64()),                          ydb.Type.INT64,     False),
+            ("c06_float",         pa.array([1.0],                           type=pa.float32()),                        ydb.Type.FLOAT,     False),
+            ("c07_double",        pa.array([1.0],                           type=pa.float64()),                        ydb.Type.DOUBLE,    False),
+            ("c08_string_req",    pa.array(["s"],                           type=pa.string()),                         ydb.Type.UTF8,      False),
+            ("c09_binary_req",    pa.array([b"b"],                          type=pa.binary()),                         ydb.Type.STRING,    False),
+            ("c10_date32",        pa.array([date(2024, 1, 2)],              type=pa.date32()),                         ydb.Type.DATE,      False),
+            ("c11_timestamp_req", pa.array([datetime(2024, 1, 2, 3, 4, 5)], type=pa.timestamp('us')),                  ydb.Type.TIMESTAMP, False),
+            ("c12_decimal",       pa.array([decimal.Decimal("1.5")],        type=pa.decimal128(precision=5, scale=2)), ydb.Type.DOUBLE,    False),
+            ("c13_string_opt",    pa.array(["s"],                           type=pa.string()),                         ydb.Type.UTF8,      True),
+            ("c14_timestamp_opt", pa.array([datetime(2024, 1, 2, 3, 4, 5)], type=pa.timestamp('us')),                  ydb.Type.TIMESTAMP, True),
         ]
 
-        table = pa.table([col[1] for col in columns], names=[col[0] for col in columns])
+        schema = pa.schema([pa.field(name, arr.type, nullable=nullable) for name, arr, _t, nullable in columns])
+        table = pa.Table.from_arrays([arr for _n, arr, _t, _o in columns], schema=schema)
         buf = io.BytesIO()
         pq.write_table(table, buf)
         s3_client.put_object(
@@ -203,7 +211,7 @@ Pear,15,33,2024-05-06'''
                     f"column {name}: got {actual.type}, want Optional<{expected_type}>"
             else:
                 assert actual.type.type_id == expected_type, \
-                    f"column {name}: got {actual.type}, want {expected_type}"
+                    f"column {name}: got {actual.type}, want {expected_type} (non-Optional)"
 
     @yq_v2
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)

--- a/ydb/tests/fq/s3/test_inference.py
+++ b/ydb/tests/fq/s3/test_inference.py
@@ -204,9 +204,9 @@ Pear,15,33,2024-05-06'''
         logging.debug(str(result_set))
 
         assert len(result_set.columns) == len(columns)
-        for actual, (name, _arr, expected_type, expected_optional) in zip(result_set.columns, columns):
+        for actual, (name, _arr, expected_type, nullable) in zip(result_set.columns, columns):
             assert actual.name == name, f"unexpected column name: got {actual.name}, want {name}"
-            if expected_optional:
+            if nullable:
                 assert actual.type.optional_type.item.type_id == expected_type, \
                     f"column {name}: got {actual.type}, want Optional<{expected_type}>"
             else:
@@ -836,11 +836,14 @@ Pear,15,33'''
         s3_helpers.create_bucket_and_put_object(s3.s3_url, bucket_name, object_key, body, content_type)
         kikimr.control_plane.wait_bootstrap(1)
 
-    def _validate_result_inference(self, result_set):
+    def _validate_result_inference(self, result_set, fruit_nullable=False):
         logging.debug(str(result_set))
         assert len(result_set.columns) == 3
         assert result_set.columns[0].name == "Fruit"
-        assert result_set.columns[0].type.type_id == ydb.Type.UTF8
+        if fruit_nullable:
+            assert result_set.columns[0].type.optional_type.item.type_id == ydb.Type.UTF8
+        else:
+            assert result_set.columns[0].type.type_id == ydb.Type.UTF8
         assert result_set.columns[1].name == "Price"
         assert result_set.columns[1].type.optional_type.item.type_id == ydb.Type.INT64
         assert result_set.columns[2].name == "Weight"
@@ -883,7 +886,7 @@ Pear,15,33'''
 
         data = client.get_result_data(query_id)
         result_set = data.result.result_set
-        self._validate_result_inference(result_set)
+        self._validate_result_inference(result_set, fruit_nullable=(type_format == "parquet"))
 
     @yq_v2
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

now schema inference with parquet format takes nullability information from parquet schema as is, and doesnt try to infer it.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

fix for [YQ-4963](https://st.yandex-team.ru/YQ-4963)
