### PR TITLE
sdk: Avoid cancelling finished query streams

### DIFF
--- a/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
@@ -59,7 +59,9 @@ public:
     {}
 
     ~TReaderImpl() {
-        StreamProcessor_->Cancel();
+        if (!Finished_) {
+            StreamProcessor_->Cancel();
+        }
     }
 
     bool IsFinished() const {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Avoid unnecessary client-side cancellation after query streams finish normally.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TExecuteQueryIterator::TReaderImpl` used to call `StreamProcessor_->Cancel()` unconditionally from its destructor. For successfully drained query streams this still reaches `grpc::ClientContext::TryCancel()`, which showed up in the TPCC flamegraph as post-completion gRPC cancellation work.

This changes the destructor to cancel only unfinished streams.

