### PR TITLE
sdk: Move first query result chunk into buffer

### DIFF
--- a/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
@@ -156,6 +156,7 @@ struct TExecuteQueryBuffer : public TThrRefBase, TNonCopyable {
     std::optional<TTransaction> Tx_;
     std::vector<std::string> ArrowSchemas_;
     std::vector<std::vector<std::string>> BytesData_;
+    std::vector<bool> ResultSetSeen_;
 
     void Next() {
         TPtr self(this);
@@ -215,24 +216,31 @@ struct TExecuteQueryBuffer : public TThrRefBase, TNonCopyable {
                 // TODO: Use result sets metadata
                 if (self->ResultSets_.size() <= part.GetResultSetIndex()) {
                     self->ResultSets_.resize(part.GetResultSetIndex() + 1);
+                    self->ResultSetSeen_.resize(part.GetResultSetIndex() + 1);
                 }
 
                 auto& resultSet = self->ResultSets_[part.GetResultSetIndex()];
-                resultSet.set_format(inRsProto.format());
+                const auto resultSetIndex = part.GetResultSetIndex();
 
-                switch (resultSet.format()) {
+                switch (inRsProto.format()) {
                     case Ydb::ResultSet::FORMAT_UNSPECIFIED:
                     case Ydb::ResultSet::FORMAT_VALUE: {
-                        self->CollectYdbValues(resultSet, inRsProto);
+                        if (!self->ResultSetSeen_[resultSetIndex]) {
+                            resultSet = std::move(inRsProto);
+                        } else {
+                            self->CollectYdbValues(resultSet, inRsProto);
+                        }
                         break;
                     }
                     case Ydb::ResultSet::FORMAT_ARROW: {
+                        resultSet.set_format(inRsProto.format());
                         self->CollectArrowBytes(resultSet, inRs.MutableProto(), part.GetResultSetIndex());
                         break;
                     }
                     default:
                         break;
                 }
+                self->ResultSetSeen_[resultSetIndex] = true;
             }
 
             if (const auto& tx = part.GetTransaction()) {

--- a/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
@@ -211,7 +211,7 @@ struct TExecuteQueryBuffer : public TThrRefBase, TNonCopyable {
 
             if (part.HasResultSet()) {
                 auto inRs = part.ExtractResultSet();
-                auto& inRsProto = TProtoAccessor::GetProto(inRs);
+                auto& inRsProto = inRs.MutableProto();
 
                 // TODO: Use result sets metadata
                 if (self->ResultSets_.size() <= part.GetResultSetIndex()) {
@@ -234,7 +234,7 @@ struct TExecuteQueryBuffer : public TThrRefBase, TNonCopyable {
                     }
                     case Ydb::ResultSet::FORMAT_ARROW: {
                         resultSet.set_format(inRsProto.format());
-                        self->CollectArrowBytes(resultSet, inRs.MutableProto(), part.GetResultSetIndex());
+                        self->CollectArrowBytes(resultSet, inRsProto, part.GetResultSetIndex());
                         break;
                     }
                     default:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce result-set copying in C++ SDK `ExecuteQuery` buffering.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TExecuteQueryBuffer` previously copied rows and columns from every value-format result chunk into its accumulated `Ydb::ResultSet`. For the common case where a result set fits in one response part, this adds avoidable protobuf copy/allocation work.

This PR tracks whether each result-set index has been seen and moves the first value-format chunk directly into the buffer. Later chunks keep the existing append-copy behavior. Arrow handling keeps its specialized schema/data accumulation path.