### PR TITLE
tpcc: Limit TPCC SDK network thread multiplication

### DIFF
--- a/ydb/library/workload/tpcc/runner.cpp
+++ b/ydb/library/workload/tpcc/runner.cpp
@@ -186,13 +186,14 @@ TPCCRunner::TPCCRunner(const NConsoleClient::TClientCommand::TConfig& connection
             << ". It might affect benchmark results");
     }
 
-    // The number of terminals might be hundreds of thousands.
-    // For now, we don't have more than 32 network threads (check TClientCommand::TConfig::GetNetworkThreadNum()),
-    // so that maxTerminalThreads will be around more or less around 100.
     const size_t driverCount = Config.DriverCount == 0 ? threadCount : Config.DriverCount;
+    const size_t networkThreadsPerDriver = std::max<size_t>(1, (networkThreadCount + driverCount - 1) / driverCount);
+
     Drivers.reserve(driverCount);
     for (size_t i = 0; i < driverCount; ++i) {
-        Drivers.emplace_back(NConsoleClient::TYdbCommand::CreateDriver(ConnectionConfig));
+        auto driverConfig = ConnectionConfig.CreateDriverConfig();
+        driverConfig.SetNetworkThreadsNum(networkThreadsPerDriver);
+        Drivers.emplace_back(driverConfig);
     }
 
     if (Config.MaxInflight == 0) {
@@ -248,7 +249,8 @@ TPCCRunner::TPCCRunner(const NConsoleClient::TClientCommand::TConfig& connection
         Log);
 
     LOG_I("Creating " << terminalsCount << " terminals and " << threadCount
-        << " workers on " << cpuCount << " cpus, " << driverCount << " query clients with at most "
+        << " workers on " << cpuCount << " cpus, " << driverCount << " query clients with "
+        << networkThreadsPerDriver << " network threads and at most "
         << maxSessionsPerClient << " sessions per client");
 
     Terminals.reserve(terminalsCount);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce CPU overhead from SDK network threads in `ydb workload tpcc run`.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ydb workload tpcc run` may create multiple SDK drivers/query clients. Each driver previously used the full CLI network-intensive thread count, so the total gRPC completion-queue thread footprint scaled as `driverCount * networkThreadCount`.

This PR keeps the existing total network thread budget from `TConfig::GetNetworkThreadNum()` and distributes it across TPCC drivers, with at least one network thread per driver. The run log now includes the per-driver network-thread count.