### PR TITLE
improved auth fields validation for external data sources

### DIFF
--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -578,11 +578,34 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "Service account auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 1");
                     return;
                 }
+                if (authDescription.GetServiceAccount().GetId().empty()) {
+                    SetError(externalDataSourceMetadata, "Service account auth requires non-empty SERVICE_ACCOUNT_ID");
+                    return;
+                }
+                if (objectDescription.SecretValues[0].empty()) {
+                    SetError(externalDataSourceMetadata, "Service account auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME");
+                    return;
+                }
                 externalDataSourceMetadata.Metadata->ExternalSource.ServiceAccountIdSignature = objectDescription.SecretValues[0];
                 return;
             }
 
-            case NKikimrSchemeOp::TAuth::kIam:
+            case NKikimrSchemeOp::TAuth::kIam: {
+                if (objectDescription.SecretValues.size() != 0) {
+                    SetError(externalDataSourceMetadata, TStringBuilder{} << "IAM auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 0");
+                    return;
+                }
+                if (authDescription.GetIam().GetServiceAccountId().empty()) {
+                    SetError(externalDataSourceMetadata, "IAM auth requires non-empty SERVICE_ACCOUNT_ID");
+                    return;
+                }
+                if (authDescription.GetIam().GetResourceId().empty()) {
+                    SetError(externalDataSourceMetadata, "IAM auth requires non-empty RESOURCE_ID");
+                    return;
+                }
+                return;
+            }
+
             case NKikimrSchemeOp::TAuth::kNone: {
                 if (objectDescription.SecretValues.size() != 0) {
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "None auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 0");
@@ -596,12 +619,28 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "Basic auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 1");
                     return;
                 }
+                if (authDescription.GetBasic().GetLogin().empty()) {
+                    SetError(externalDataSourceMetadata, "Basic auth requires non-empty LOGIN");
+                    return;
+                }
                 externalDataSourceMetadata.Metadata->ExternalSource.Password = objectDescription.SecretValues[0];
                 return;
             }
             case NKikimrSchemeOp::TAuth::kMdbBasic: {
                 if (objectDescription.SecretValues.size() != 2) {
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "Mdb basic auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 2");
+                    return;
+                }
+                if (authDescription.GetMdbBasic().GetServiceAccountId().empty()) {
+                    SetError(externalDataSourceMetadata, "Mdb basic auth requires non-empty SERVICE_ACCOUNT_ID");
+                    return;
+                }
+                if (authDescription.GetMdbBasic().GetLogin().empty()) {
+                    SetError(externalDataSourceMetadata, "Mdb basic auth requires non-empty LOGIN");
+                    return;
+                }
+                if (objectDescription.SecretValues[0].empty()) {
+                    SetError(externalDataSourceMetadata, "Mdb basic auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME");
                     return;
                 }
                 externalDataSourceMetadata.Metadata->ExternalSource.ServiceAccountIdSignature = objectDescription.SecretValues[0];
@@ -613,6 +652,14 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "Aws auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 2");
                     return;
                 }
+                if (objectDescription.SecretValues[0].empty()) {
+                    SetError(externalDataSourceMetadata, "AWS auth requires non-empty value for the secret referenced by AWS_ACCESS_KEY_ID_SECRET_NAME");
+                    return;
+                }
+                if (objectDescription.SecretValues[1].empty()) {
+                    SetError(externalDataSourceMetadata, "AWS auth requires non-empty value for the secret referenced by AWS_SECRET_ACCESS_KEY_SECRET_NAME");
+                    return;
+                }
                 externalDataSourceMetadata.Metadata->ExternalSource.AwsAccessKeyId = objectDescription.SecretValues[0];
                 externalDataSourceMetadata.Metadata->ExternalSource.AwsSecretAccessKey = objectDescription.SecretValues[1];
                 return;
@@ -620,6 +667,10 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
             case NKikimrSchemeOp::TAuth::kToken: {
                 if (objectDescription.SecretValues.size() != 1) {
                     SetError(externalDataSourceMetadata, TStringBuilder{} << "Token auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 1");
+                    return;
+                }
+                if (objectDescription.SecretValues[0].empty()) {
+                    SetError(externalDataSourceMetadata, "Token auth requires non-empty value for the secret referenced by TOKEN_SECRET_NAME");
                     return;
                 }
                 externalDataSourceMetadata.Metadata->ExternalSource.Token = objectDescription.SecretValues[0];

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -591,16 +591,16 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
             }
 
             case NKikimrSchemeOp::TAuth::kIam: {
-                if (objectDescription.SecretValues.size() != 0) {
-                    SetError(externalDataSourceMetadata, TStringBuilder{} << "IAM auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 0");
-                    return;
-                }
                 if (authDescription.GetIam().GetServiceAccountId().empty()) {
                     SetError(externalDataSourceMetadata, "IAM auth requires non-empty SERVICE_ACCOUNT_ID");
                     return;
                 }
                 if (authDescription.GetIam().GetResourceId().empty()) {
                     SetError(externalDataSourceMetadata, "IAM auth requires non-empty RESOURCE_ID");
+                    return;
+                }
+                if (objectDescription.SecretValues.size() != 0) {
+                    SetError(externalDataSourceMetadata, TStringBuilder{} << "IAM auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 0");
                     return;
                 }
                 return;
@@ -641,6 +641,10 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
                 }
                 if (objectDescription.SecretValues[0].empty()) {
                     SetError(externalDataSourceMetadata, "Mdb basic auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME");
+                    return;
+                }
+                if (objectDescription.SecretValues[1].empty()) {
+                    SetError(externalDataSourceMetadata, "Mdb basic auth requires non-empty value for the secret referenced by PASSWORD_SECRET_NAME");
                     return;
                 }
                 externalDataSourceMetadata.Metadata->ExternalSource.ServiceAccountIdSignature = objectDescription.SecretValues[0];

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -591,18 +591,11 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
             }
 
             case NKikimrSchemeOp::TAuth::kIam: {
-                if (authDescription.GetIam().GetServiceAccountId().empty()) {
-                    SetError(externalDataSourceMetadata, "IAM auth requires non-empty SERVICE_ACCOUNT_ID");
-                    return;
-                }
-                if (authDescription.GetIam().GetResourceId().empty()) {
-                    SetError(externalDataSourceMetadata, "IAM auth requires non-empty RESOURCE_ID");
-                    return;
-                }
-                if (objectDescription.SecretValues.size() != 0) {
-                    SetError(externalDataSourceMetadata, TStringBuilder{} << "IAM auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 0");
-                    return;
-                }
+                // SERVICE_ACCOUNT_ID and RESOURCE_ID are not user-provided here:
+                // RESOURCE_ID is auto-resolved from the database's cloud_id at CREATE
+                // time, and post-creation INITIAL_TOKEN_SECRET is not resolved into
+                // SecretValues. Emptiness of these fields/secret list is therefore an
+                // internal-contract violation and not an actionable BAD_REQUEST.
                 return;
             }
 

--- a/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
@@ -461,7 +461,7 @@ Y_UNIT_TEST_SUITE(KikimrIcGateway) {
                 SOURCE_TYPE="ObjectStorage",
                 LOCATION="my-bucket",
                 AUTH_METHOD="SERVICE_ACCOUNT",
-                SERVICE_ACCOUNT_ID="",
+                SERVICE_ACCOUNT_ID="mySaId",
                 SERVICE_ACCOUNT_SECRET_NAME=")" << secretId << R"("
             );
             CREATE EXTERNAL TABLE `)" << externalTableName << R"(` (

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -286,48 +286,111 @@ def test_success_external_data_table(db_fixture, ydb_cluster):
     assert isinstance(data, bytes) and data.decode() == 'Hello S3!'
 
 
+# Cases for the empty-auth-field validation in
+# kqp_metadata_loader.cpp::UpdateExternalDataSourceSecretsValue.
+#
+# Validation runs after secret resolution, so CREATE always succeeds and the
+# error is observed on SELECT. We never actually connect to the external
+# source — UpdateExternalDataSourceSecretsValue rejects the request before
+# the I/O layer runs.
+EMPTY_AUTH_FIELD_CASES = [
+    # --- ObjectStorage / S3: SERVICE_ACCOUNT, AWS ---
+    (
+        "s3_sa_empty_id",
+        'SOURCE_TYPE="ObjectStorage", LOCATION="{s3_location}"',
+        'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
+        [('s0', 'nonemptysig')],
+        "Service account auth requires non-empty SERVICE_ACCOUNT_ID",
+    ),
+    (
+        "s3_sa_empty_secret_value",
+        'SOURCE_TYPE="ObjectStorage", LOCATION="{s3_location}"',
+        'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
+        [('s0', '')],
+        "Service account auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME",
+    ),
+    (
+        "s3_aws_empty_access_key",
+        'SOURCE_TYPE="ObjectStorage", LOCATION="{s3_location}"',
+        'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
+        [('s0', ''), ('s1', 'nonemptysecret')],
+        "AWS auth requires non-empty value for the secret referenced by AWS_ACCESS_KEY_ID_SECRET_NAME",
+    ),
+    (
+        "s3_aws_empty_secret_key",
+        'SOURCE_TYPE="ObjectStorage", LOCATION="{s3_location}"',
+        'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
+        [('s0', 'nonemptyid'), ('s1', '')],
+        "AWS auth requires non-empty value for the secret referenced by AWS_SECRET_ACCESS_KEY_SECRET_NAME",
+    ),
+    # --- Ydb source: BASIC, TOKEN ---
+    (
+        "ydb_basic_empty_login",
+        'SOURCE_TYPE="Ydb", LOCATION="localhost:1", DATABASE_NAME="db"',
+        'AUTH_METHOD="BASIC", LOGIN="", PASSWORD_SECRET_NAME="{s0}"',
+        [('s0', 'nonemptypwd')],
+        "Basic auth requires non-empty LOGIN",
+    ),
+    (
+        "ydb_token_empty_value",
+        'SOURCE_TYPE="Ydb", LOCATION="localhost:1", DATABASE_NAME="db"',
+        'AUTH_METHOD="TOKEN", TOKEN_SECRET_NAME="{s0}"',
+        [('s0', '')],
+        "Token auth requires non-empty value for the secret referenced by TOKEN_SECRET_NAME",
+    ),
+    # --- PostgreSQL source: MDB_BASIC ---
+    (
+        "pg_mdb_basic_empty_sa_id",
+        'SOURCE_TYPE="PostgreSQL", MDB_CLUSTER_ID="cid", DATABASE_NAME="db", PROTOCOL="NATIVE", USE_TLS="FALSE"',
+        'AUTH_METHOD="MDB_BASIC", SERVICE_ACCOUNT_ID="", SERVICE_ACCOUNT_SECRET_NAME="{s0}", LOGIN="user", PASSWORD_SECRET_NAME="{s1}"',
+        [('s0', 'nonemptysig'), ('s1', 'nonemptypwd')],
+        "Mdb basic auth requires non-empty SERVICE_ACCOUNT_ID",
+    ),
+    (
+        "pg_mdb_basic_empty_login",
+        'SOURCE_TYPE="PostgreSQL", MDB_CLUSTER_ID="cid", DATABASE_NAME="db", PROTOCOL="NATIVE", USE_TLS="FALSE"',
+        'AUTH_METHOD="MDB_BASIC", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}", LOGIN="", PASSWORD_SECRET_NAME="{s1}"',
+        [('s0', 'nonemptysig'), ('s1', 'nonemptypwd')],
+        "Mdb basic auth requires non-empty LOGIN",
+    ),
+    (
+        "pg_mdb_basic_empty_signature_value",
+        'SOURCE_TYPE="PostgreSQL", MDB_CLUSTER_ID="cid", DATABASE_NAME="db", PROTOCOL="NATIVE", USE_TLS="FALSE"',
+        'AUTH_METHOD="MDB_BASIC", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}", LOGIN="user", PASSWORD_SECRET_NAME="{s1}"',
+        [('s0', ''), ('s1', 'nonemptypwd')],
+        "Mdb basic auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME",
+    ),
+]
+
+
 @pytest.mark.parametrize(
-    "case_id,auth_clause,secrets,expected_err",
-    [
-        # SERVICE_ACCOUNT: empty SERVICE_ACCOUNT_ID
-        (
-            1,
-            'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
-            [('s0', 'nonemptysig')],
-            "Service account auth requires non-empty SERVICE_ACCOUNT_ID",
-        ),
-        # SERVICE_ACCOUNT: empty resolved secret value
-        (
-            2,
-            'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
-            [('s0', '')],
-            "Service account auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME",
-        ),
-        # AWS: empty resolved access-key secret value
-        (
-            3,
-            'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
-            [('s0', ''), ('s1', 'nonemptysecret')],
-            "AWS auth requires non-empty value for the secret referenced by AWS_ACCESS_KEY_ID_SECRET_NAME",
-        ),
-        # AWS: empty resolved secret-access-key secret value
-        (
-            4,
-            'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
-            [('s0', 'nonemptyid'), ('s1', '')],
-            "AWS auth requires non-empty value for the secret referenced by AWS_SECRET_ACCESS_KEY_SECRET_NAME",
-        ),
-    ],
+    "case_name,source_clause,auth_clause,secrets,expected_err",
+    EMPTY_AUTH_FIELD_CASES,
+    ids=[c[0] for c in EMPTY_AUTH_FIELD_CASES],
 )
 def test_external_data_source_with_empty_auth_fields(
-    db_fixture, ydb_cluster, case_id, auth_clause, secrets, expected_err
+    db_fixture, ydb_cluster, case_name, source_clause, auth_clause, secrets, expected_err
 ):
     """
-    Reading from an EXTERNAL DATA SOURCE with empty auth fields (empty LOGIN
-    for BASIC, empty SERVICE_ACCOUNT_ID, empty resolved secret values for
-    SERVICE_ACCOUNT/AWS, etc.) must fail with a clear BAD_REQUEST error
-    instead of silently falling back to no-auth.
+    Reading from an EXTERNAL DATA SOURCE with empty auth fields must fail
+    with a clear BAD_REQUEST error from
+    kqp_metadata_loader.cpp::UpdateExternalDataSourceSecretsValue, instead
+    of silently falling back to no-auth.
+
+    Each parametrised case pairs a SOURCE_TYPE with an AUTH_METHOD that the
+    schema actually accepts for it (see external_source_factory.cpp), so
+    that CREATE succeeds and validation can be observed on SELECT:
+      - SERVICE_ACCOUNT (S3): empty SERVICE_ACCOUNT_ID / empty resolved secret
+      - AWS             (S3): empty access-key / secret-access-key values
+      - BASIC           (Ydb): empty LOGIN
+      - TOKEN           (Ydb): empty resolved TOKEN_SECRET_NAME value
+      - MDB_BASIC       (PG):  empty SERVICE_ACCOUNT_ID / empty LOGIN /
+                               empty resolved signature value
+
+    AUTH_METHOD="NONE" has nothing to validate; AUTH_METHOD="IAM" requires
+    a registered MDB cluster and is exercised in dedicated tests.
     """
+    case_id = abs(hash(case_name)) % 10_000_000
     user_name = f"emptyauthuser{case_id}"
     user_config = create_user(ydb_cluster, db_fixture, user_name)
     provide_grants(db_fixture, user_name, DATABASE, ["ydb.granular.create_table"])
@@ -343,15 +406,16 @@ def test_external_data_source_with_empty_auth_fields(
         values_list.append(value)
     create_secrets(user_config, paths_list, values_list)
 
-    auth_clause_filled = auth_clause.format(**secret_paths)
-
     s3_endpoint, _, _, s3_bucket = setup_s3()
-    eds_name = f"s3eds{case_id}"
+    fmt_args = {"s3_location": f"{s3_endpoint}/{s3_bucket}", **secret_paths}
+    source_clause_filled = source_clause.format(**fmt_args)
+    auth_clause_filled = auth_clause.format(**fmt_args)
+
+    eds_name = f"eds{case_id}"
 
     create_eds_query = f"""
         CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
-            SOURCE_TYPE="ObjectStorage",
-            LOCATION="{s3_endpoint}/{s3_bucket}",
+            {source_clause_filled},
             {auth_clause_filled}
         );"""
     # CREATE itself must succeed; validation runs on read, after secret resolution.

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -360,6 +360,13 @@ EMPTY_AUTH_FIELD_CASES = [
         [('s0', ''), ('s1', 'nonemptypwd')],
         "Mdb basic auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME",
     ),
+    (
+        "pg_mdb_basic_empty_password_value",
+        'SOURCE_TYPE="PostgreSQL", MDB_CLUSTER_ID="cid", DATABASE_NAME="db", PROTOCOL="NATIVE", USE_TLS="FALSE"',
+        'AUTH_METHOD="MDB_BASIC", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}", LOGIN="user", PASSWORD_SECRET_NAME="{s1}"',
+        [('s0', 'nonemptysig'), ('s1', '')],
+        "Mdb basic auth requires non-empty value for the secret referenced by PASSWORD_SECRET_NAME",
+    ),
 ]
 
 
@@ -385,7 +392,8 @@ def test_external_data_source_with_empty_auth_fields(
       - BASIC           (Ydb): empty LOGIN
       - TOKEN           (Ydb): empty resolved TOKEN_SECRET_NAME value
       - MDB_BASIC       (PG):  empty SERVICE_ACCOUNT_ID / empty LOGIN /
-                               empty resolved signature value
+                               empty resolved signature value /
+                               empty resolved password value
 
     AUTH_METHOD="NONE" has nothing to validate; AUTH_METHOD="IAM" requires
     a registered MDB cluster and is exercised in dedicated tests.

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -286,6 +286,85 @@ def test_success_external_data_table(db_fixture, ydb_cluster):
     assert isinstance(data, bytes) and data.decode() == 'Hello S3!'
 
 
+@pytest.mark.parametrize(
+    "case_id,auth_clause,secrets,expected_err",
+    [
+        # SERVICE_ACCOUNT: empty SERVICE_ACCOUNT_ID
+        (
+            1,
+            'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
+            [('s0', 'nonemptysig')],
+            "Service account auth requires non-empty SERVICE_ACCOUNT_ID",
+        ),
+        # SERVICE_ACCOUNT: empty resolved secret value
+        (
+            2,
+            'AUTH_METHOD="SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID="mysa", SERVICE_ACCOUNT_SECRET_NAME="{s0}"',
+            [('s0', '')],
+            "Service account auth requires non-empty value for the secret referenced by SERVICE_ACCOUNT_SECRET_NAME",
+        ),
+        # AWS: empty resolved access-key secret value
+        (
+            3,
+            'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
+            [('s0', ''), ('s1', 'nonemptysecret')],
+            "AWS auth requires non-empty value for the secret referenced by AWS_ACCESS_KEY_ID_SECRET_NAME",
+        ),
+        # AWS: empty resolved secret-access-key secret value
+        (
+            4,
+            'AUTH_METHOD="AWS", AWS_ACCESS_KEY_ID_SECRET_NAME="{s0}", AWS_SECRET_ACCESS_KEY_SECRET_NAME="{s1}", AWS_REGION="ru-central-1"',
+            [('s0', 'nonemptyid'), ('s1', '')],
+            "AWS auth requires non-empty value for the secret referenced by AWS_SECRET_ACCESS_KEY_SECRET_NAME",
+        ),
+    ],
+)
+def test_external_data_source_with_empty_auth_fields(
+    db_fixture, ydb_cluster, case_id, auth_clause, secrets, expected_err
+):
+    """
+    Reading from an EXTERNAL DATA SOURCE with empty auth fields (empty LOGIN
+    for BASIC, empty SERVICE_ACCOUNT_ID, empty resolved secret values for
+    SERVICE_ACCOUNT/AWS, etc.) must fail with a clear BAD_REQUEST error
+    instead of silently falling back to no-auth.
+    """
+    user_name = f"emptyauthuser{case_id}"
+    user_config = create_user(ydb_cluster, db_fixture, user_name)
+    provide_grants(db_fixture, user_name, DATABASE, ["ydb.granular.create_table"])
+
+    # Pre-create secrets referenced in auth_clause; values may be empty by design.
+    secret_paths = {}
+    paths_list = []
+    values_list = []
+    for placeholder, value in secrets:
+        path = f'{DATABASE}/case{case_id}{placeholder}'
+        secret_paths[placeholder] = path
+        paths_list.append(path)
+        values_list.append(value)
+    create_secrets(user_config, paths_list, values_list)
+
+    auth_clause_filled = auth_clause.format(**secret_paths)
+
+    s3_endpoint, _, _, s3_bucket = setup_s3()
+    eds_name = f"s3eds{case_id}"
+
+    create_eds_query = f"""
+        CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
+            SOURCE_TYPE="ObjectStorage",
+            LOCATION="{s3_endpoint}/{s3_bucket}",
+            {auth_clause_filled}
+        );"""
+    # CREATE itself must succeed; validation runs on read, after secret resolution.
+    run_with_assert(user_config, create_eds_query)
+
+    read_query = f"""
+        SELECT * FROM `{eds_name}`.`file.txt` WITH (
+            FORMAT = "raw",
+            SCHEMA = ( Data String )
+        );"""
+    run_with_assert(user_config, read_query, expected_err)
+
+
 def test_migration_to_new_secrets_in_external_data_source(db_fixture, ydb_cluster):
     user1_config = create_user(ydb_cluster, db_fixture, "user1")
     provide_grants(db_fixture, "user1", DATABASE, ["ydb.granular.create_table"])


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

improved auth fields validation for external data sources, trying to read data with empty secrets will now lead to BAD_REQUEST error

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

fix for [YDB-3321](https://st.yandex-team.ru/YDB-3321), [YQ-3685](https://st.yandex-team.ru/YQ-3685)
