### PR TITLE
Invoke check_integrity bsproxy requests from monpage

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1591,6 +1591,7 @@ struct TEvBlobStorage {
             : Id(origin.Id)
             , Deadline(origin.Deadline)
             , GetHandleClass(origin.GetHandleClass)
+            , SingleLine(origin.SingleLine)
         {}
 
         TEvCheckIntegrity(
@@ -1682,6 +1683,7 @@ struct TEvBlobStorage {
             }
         }
 
+        TBlobStorageGroupType::EErasureSpecies Erasure = TBlobStorageGroupType::ErasureNone;
         EPlacementStatus PlacementStatus = PS_OK;
         EDataStatus DataStatus = DS_OK;
         TString DataInfo; // textual info about checks in blob data
@@ -1698,6 +1700,7 @@ struct TEvBlobStorage {
                 << " Id# " << Id
                 << " Status# " << NKikimrProto::EReplyStatus_Name(Status)
                 << " ErrorReason# " << ErrorReason
+                << " Erasure# " << TBlobStorageGroupType::ErasureSpeciesName(Erasure)
                 << " PlacementStatus# " << PlacementStatusToString(PlacementStatus)
                 << " DataStatus# " << DataStatusToString(DataStatus)
                 << " DataInfo# " << DataInfo

--- a/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
@@ -24,7 +24,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
     bool HasErrorDisks = false;
 
     ui32 VGetsInFlight = 0;
-    TVector<TString> VGetsResults;
+    THashMap<ui32, TString> VGetsResults;
 
     using TEvCheckIntegrityResult = TEvBlobStorage::TEvCheckIntegrityResult;
     std::unique_ptr<TEvCheckIntegrityResult> PendingResult;
@@ -108,7 +108,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         --VGetsInFlight;
 
         TEvBlobStorage::TEvVGetResult* msg = ev->Get();
-        ui32 idxInSubgroup = Info->GetIdxInSubgroup(vDiskId, Id.Hash());
+        const ui32 idxInSubgroup = Info->GetIdxInSubgroup(vDiskId, Id.Hash());
         VGetsResults[idxInSubgroup] = msg->ToString();
 
         switch (NKikimrProto::EReplyStatus newStatus = QuorumTracker.ProcessReply(vDiskId, status)) {
@@ -193,8 +193,11 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         str << "Disks:" << separator;
         for (ui32 diskIdx = 0; diskIdx < Info->Type.BlobSubgroupSize(); ++diskIdx) {
             auto vDiskIdShort = Info->GetTopology().GetVDiskInSubgroup(diskIdx, Id.Hash());
-            auto vGetResult = diskIdx < VGetsResults.size() ? VGetsResults[diskIdx] : "";
-            str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort) << " " << vGetResult << separator;
+            str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort);
+            if (auto it = VGetsResults.find(diskIdx); it != VGetsResults.end()) {
+                str << " " << it->second;
+            }
+            str << separator;
         }
 
         PendingResult->DataInfo = str.Str();
@@ -247,8 +250,6 @@ public:
             SendToQueue(std::move(vGet), 0);
             ++VGetsInFlight;
         }
-
-        VGetsResults.resize(VGetsInFlight);
 
         Become(&TBlobStorageGroupCheckIntegrityRequest::StateWait);
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
@@ -24,6 +24,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
     bool HasErrorDisks = false;
 
     ui32 VGetsInFlight = 0;
+    TVector<TString> VGetsResults;
 
     using TEvCheckIntegrityResult = TEvBlobStorage::TEvCheckIntegrityResult;
     std::unique_ptr<TEvCheckIntegrityResult> PendingResult;
@@ -34,9 +35,10 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
             PendingResult->ErrorReason = ErrorReason;
             PendingResult->PlacementStatus = TEvCheckIntegrityResult::PS_UNKNOWN;
             PendingResult->DataStatus = TEvCheckIntegrityResult::DS_UNKNOWN;
-            PendingResult->Id = Id;
         }
 
+        PendingResult->Id = Id;
+        PendingResult->Erasure = Info->Type.GetErasure();
         SendResponseAndDie(std::move(PendingResult));
     }
 
@@ -105,6 +107,10 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         Y_ABORT_UNLESS(VGetsInFlight > 0);
         --VGetsInFlight;
 
+        TEvBlobStorage::TEvVGetResult* msg = ev->Get();
+        ui32 idxInSubgroup = Info->GetIdxInSubgroup(vDiskId, Id.Hash());
+        VGetsResults[idxInSubgroup] = msg->ToString();
+
         switch (NKikimrProto::EReplyStatus newStatus = QuorumTracker.ProcessReply(vDiskId, status)) {
             case NKikimrProto::ERROR:
                 ErrorReason = "Group is disintegrated or has network problems";
@@ -121,7 +127,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
 
         if (status == NKikimrProto::OK) {
             for (size_t i = 0; i < record.ResultSize(); ++i) {
-                UpdateFromResponseData(ev->Get(), record.GetResult(i), vDiskId);
+                UpdateFromResponseData(msg, record.GetResult(i), vDiskId);
             }
         } else {
             HasErrorDisks = true;
@@ -134,7 +140,6 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
 
     void Analyze() {
         PendingResult.reset(new TEvCheckIntegrityResult(NKikimrProto::OK));
-        PendingResult->Id = Id;
         PendingResult->DataStatus = TEvCheckIntegrityResult::DS_UNKNOWN;
 
         TBlobStorageGroupInfo::TSubgroupVDisks faultyDisks(&Info->GetTopology()); // empty set
@@ -188,7 +193,8 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         str << "Disks:" << separator;
         for (ui32 diskIdx = 0; diskIdx < Info->Type.BlobSubgroupSize(); ++diskIdx) {
             auto vDiskIdShort = Info->GetTopology().GetVDiskInSubgroup(diskIdx, Id.Hash());
-            str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort) << separator;
+            auto vGetResult = diskIdx < VGetsResults.size() ? VGetsResults[diskIdx] : "";
+            str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort) << " " << vGetResult << separator;
         }
 
         PendingResult->DataInfo = str.Str();
@@ -201,7 +207,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         ++*Mon->NodeMon->RestartCheckIntegrity;
 
         auto ev = std::make_unique<TEvBlobStorage::TEvCheckIntegrity>(
-            Id, Deadline, GetHandleClass);
+            Id, Deadline, GetHandleClass, SingleLine);
         ev->RestartCounter = counter;
         return ev;
     }
@@ -241,6 +247,8 @@ public:
             SendToQueue(std::move(vGet), 0);
             ++VGetsInFlight;
         }
+
+        VGetsResults.resize(VGetsInFlight);
 
         Become(&TBlobStorageGroupCheckIntegrityRequest::StateWait);
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_monactor.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_monactor.cpp
@@ -219,6 +219,28 @@ public:
 
             DIV_CLASS("panel panel-info") {
                 DIV_CLASS("panel-heading") {
+                    str << "Blob check integrity service";
+                }
+                DIV_CLASS("panel-body") {
+                    FORM_CLASS("form-horizontal") {
+                        DIV_CLASS("control-group") {
+                            LABEL_CLASS_FOR("control-label", "inputBlobCheck") { str << "Blob ID"; }
+                            DIV_CLASS("controls") {
+                                str << "<input id=\"inputBlobCheck\" name=\"blob\" type=\"text\"/>";
+                            }
+                        }
+                        str << "<input type=\"hidden\" name=\"groupId\" value=\"" << GroupId << "\">";
+                        DIV_CLASS("control-group") {
+                            DIV_CLASS("controls") {
+                                str << "<button type=\"submit\" formaction=\"/check_integrity\" class=\"btn btn-default\">Query</button>";
+                            }
+                        }
+                    }
+                }
+            }
+
+            DIV_CLASS("panel panel-info") {
+                DIV_CLASS("panel-heading") {
                     str << "Blob range index query service";
                 }
                 DIV_CLASS("panel-body") {
@@ -494,4 +516,3 @@ IActor* CreateBlobStorageGroupProxyMon(TIntrusivePtr<TBlobStorageGroupProxyMon> 
 }
 
 } // NKikimr
-

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_check_integrity_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_check_integrity_ut.cpp
@@ -1,0 +1,499 @@
+#include "defs.h"
+#include "dsproxy_env_mock_ut.h"
+#include "dsproxy_vdisk_mock_ut.h"
+#include "dsproxy_test_state_ut.h"
+
+#include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+
+#include <ydb/core/testlib/basics/runtime.h>
+#include <ydb/core/testlib/actor_helpers.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace NDSProxyCheckIntegrityTest {
+
+namespace {
+
+using TEvCheckIntegrityResult = TEvBlobStorage::TEvCheckIntegrityResult;
+using EPlacementStatus = TEvCheckIntegrityResult::EPlacementStatus;
+using EDataStatus = TEvCheckIntegrityResult::EDataStatus;
+
+enum class EDiskReply : ui32 {
+    ND   = 0, // NODATA
+    OK1  = 1,  OK2  = 2,  OK3  = 3,  OK4  = 4,  OK5  = 5,  OK6  = 6,  // The numbers encode PartId
+    RND1 = 11, RND2 = 12, RND3 = 13, RND4 = 14, RND5 = 15, RND6 = 16, // OK, but random data (corrupted)
+    NY1  = 21, NY2  = 22, NY3  = 23, NY4  = 24, NY5  = 25, NY6  = 26, // NOT_YET
+    ERR  = 99, // including timeout
+};
+using enum EDiskReply;
+
+struct TFixture {
+    TTestBasicRuntime Runtime;
+    TDSProxyEnv Env;
+    std::unique_ptr<TTestState> TestState;
+    TBlobStorageGroupType GroupType;
+
+    explicit TFixture(TBlobStorageGroupType::EErasureSpecies erasure)
+        : Runtime(1, false)
+        , GroupType(erasure)
+    {
+        Runtime.SetDispatchTimeout(TDuration::Seconds(5));
+        SetupRuntime(Runtime);
+        Env.Configure(Runtime, GroupType, 0, 0, TBlobStorageGroupInfo::EEM_NONE);
+        TestState.reset(new TTestState(Runtime, Env.Info));
+    }
+
+    ui32 SubgroupSize() const { return GroupType.BlobSubgroupSize(); }
+    ui32 TotalParts() const { return GroupType.TotalPartCount(); }
+
+    TLogoBlobID MakeBlobId(ui64 tabletId) const {
+        return TLogoBlobID(tabletId, 1, 1, 0, TestState->BlobSize, 0);
+    }
+
+    void SendCheckIntegrity(TLogoBlobID id, TInstant deadline = TInstant::Max()) {
+        auto ev = std::make_unique<TEvBlobStorage::TEvCheckIntegrity>(
+            id, deadline, NKikimrBlobStorage::FastRead, false);
+        Runtime.Send(new IEventHandle(Env.RealProxyActorId, TestState->EdgeActor,
+            ev.release()), 0, true);
+    }
+
+    TEvCheckIntegrityResult* GrabResult(TAutoPtr<IEventHandle>& handle) {
+        auto* result = Runtime.GrabEdgeEventRethrow<TEvCheckIntegrityResult>(handle);
+        Cerr << (result ? result->ToString() : "<null>") << Endl;
+        return result;
+    }
+
+    void SetupAndRun(TLogoBlobID blobId, std::initializer_list<EDiskReply> pattern) {
+        UNIT_ASSERT_VALUES_EQUAL(pattern.size(), SubgroupSize());
+
+        auto& gm = TestState->GetGroupMock();
+        ui32 slot = 0;
+        for (auto reply : pattern) {
+            ui32 partId = 0;
+            switch (reply) {
+                case ND: break;
+                case ERR: break;
+                case OK1: case RND1: case NY1: partId = 1; break;
+                case OK2: case RND2: case NY2: partId = 2; break;
+                case OK3: case RND3: case NY3: partId = 3; break;
+                case OK4: case RND4: case NY4: partId = 4; break;
+                case OK5: case RND5: case NY5: partId = 5; break;
+                case OK6: case RND6: case NY6: partId = 6; break;
+            }
+
+            switch (reply) {
+                case ND:
+                    break;
+                case ERR: {
+                    TVDiskID vDiskId = Env.Info->GetVDiskInSubgroup(slot, blobId.Hash());
+                    gm.SetError(vDiskId, NKikimrProto::ERROR);
+                    break;
+                }
+                case OK1: case OK2: case OK3: case OK4: case OK5: case OK6:
+                    gm.PutPartAtSlot(blobId, slot, partId, TestState->BlobData);
+                    break;
+                case RND1: case RND2: case RND3: case RND4: case RND5: case RND6:
+                    gm.PutPartAtSlot(blobId, slot, partId, TestState->BlobData);
+                    gm.CorruptPart(blobId, slot, partId);
+                    break;
+                case NY1: case NY2: case NY3: case NY4: case NY5: case NY6:
+                    gm.PutPartAtSlot(blobId, slot, partId, TestState->BlobData);
+                    gm.MarkPartNotYet(blobId, slot, partId);
+                    break;
+            }
+            ++slot;
+        }
+
+        SendCheckIntegrity(blobId);
+        TestState->HandleVGetsWithMock(SubgroupSize());
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Assertion helpers
+////////////////////////////////////////////////////////////////////////////////
+
+void AssertResultOk(TEvCheckIntegrityResult* r, TLogoBlobID expectedId,
+        EPlacementStatus ps, EDataStatus ds)
+{
+    UNIT_ASSERT(r);
+    UNIT_ASSERT_VALUES_EQUAL(r->Status, NKikimrProto::OK);
+    UNIT_ASSERT_VALUES_EQUAL(r->Id, expectedId);
+    UNIT_ASSERT_VALUES_EQUAL_C(static_cast<int>(r->PlacementStatus), static_cast<int>(ps),
+        "expected " << TEvCheckIntegrityResult::PlacementStatusToString(ps)
+        << " but got " << TEvCheckIntegrityResult::PlacementStatusToString(r->PlacementStatus));
+    UNIT_ASSERT_VALUES_EQUAL_C(static_cast<int>(r->DataStatus), static_cast<int>(ds),
+        "expected " << TEvCheckIntegrityResult::DataStatusToString(ds)
+        << " but got " << TEvCheckIntegrityResult::DataStatusToString(r->DataStatus));
+}
+
+void AssertActorError(TEvCheckIntegrityResult* r) {
+    UNIT_ASSERT(r);
+    UNIT_ASSERT_VALUES_EQUAL(r->Status, NKikimrProto::ERROR);
+    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(r->PlacementStatus),
+        static_cast<int>(TEvCheckIntegrityResult::PS_UNKNOWN));
+    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(r->DataStatus),
+        static_cast<int>(TEvCheckIntegrityResult::DS_UNKNOWN));
+    UNIT_ASSERT(!r->ErrorReason.empty());
+}
+
+} // anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+// ErasureNone
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDSProxyCheckIntegrityErasureNone) {
+
+Y_UNIT_TEST(PlacementOk) {
+    TFixture fx(TBlobStorageGroupType::ErasureNone);
+    auto id = fx.MakeBlobId(100001);
+    fx.SetupAndRun(id, {OK1});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementBlobIsLost) {
+    // The only replica is missing and no disk has errored -> blob is lost.
+    TFixture fx(TBlobStorageGroupType::ErasureNone);
+    auto id = fx.MakeBlobId(100002);
+    fx.SetupAndRun(id, {ND});
+
+    TAutoPtr<IEventHandle> h;
+    auto* r = fx.GrabResult(h);
+    AssertResultOk(r, id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_LOST,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementUnknownOnError) {
+    // The single disk replied with ERROR. QuorumTracker says ERROR for the
+    // whole group (only disk is faulty) -> actor replies Status=ERROR.
+    TFixture fx(TBlobStorageGroupType::ErasureNone);
+    auto id = fx.MakeBlobId(100003);
+    fx.SetupAndRun(id, {ERR});
+
+    TAutoPtr<IEventHandle> h;
+    auto* r = fx.GrabResult(h);
+    AssertActorError(r);
+    UNIT_ASSERT_VALUES_EQUAL(r->Id, id);
+}
+
+} // ErasureNone
+
+////////////////////////////////////////////////////////////////////////////////
+// Block 4+2
+//
+// Subgroup size = 8 (6 parts + 2 handoff). Quorum:
+//   EBS_FULL                      effectiveReplicas == 6
+//   EBS_RECOVERABLE_FRAGMENTARY   distinctParts >= 4
+//   EBS_UNRECOVERABLE_FRAGMENTARY distinctParts < 4
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDSProxyCheckIntegrityBlock42) {
+
+Y_UNIT_TEST(PlacementOkAllPartsPresent) {
+    // All 6 parts present at their canonical primary slots, both handoff
+    // slots empty -> EBS_FULL.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200001);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, OK5, OK6, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementOkHandoffsUsed) {
+    // Two primary slots (0, 1) carry no data; their parts (1, 2) live on the
+    // two handoff slots (6, 7) instead.  All 6 distinct partIds are still
+    // present on 6 distinct disks -> EBS_FULL.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200101);
+    fx.SetupAndRun(id, {ND, ND, OK3, OK4, OK5, OK6, OK1, OK2});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementOkOneErrorOnHandoff) {
+    // All 6 parts present on primary slots; one handoff disk is errored.
+    // Failure model tolerates 1 errored disk -> still EBS_FULL.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200002);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, OK5, OK6, ND, ERR});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementRecoverable5of6) {
+    // 5 parts present, 1 missing, no errors -> recoverable.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200003);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, OK5, ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementRecoverable4of6) {
+    // Exactly 4 distinct parts -> at the boundary of recoverability.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200004);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, ND, ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementBlobIsLost) {
+    // Part 4 is missing, part 3 is duplicated
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200005);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK3, ND, ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_LOST,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementBlobIsLostNoParts) {
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200006);
+    fx.SetupAndRun(id, {ND, ND, ND, ND, ND, ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_LOST,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementUnknownUnrecoverableWithErrors) {
+    // 3 OK parts (unrecoverable on its own) + 1 ERROR disk:
+    // the missing parts may sit on the errored disk -> PS_UNKNOWN, not LOST.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200007);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, ND, ND, ND, ND, ERR});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_UNKNOWN,
+        TEvCheckIntegrityResult::DS_UNKNOWN);
+}
+
+Y_UNIT_TEST(PlacementRecoverableWithErrors) {
+    // 4 OK parts + ERROR disk: recoverable wins over PS_UNKNOWN because
+    // PS_UNKNOWN is only returned for unrecoverable layouts.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200008);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, ND, ND, ND, ERR});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(ReplicationInProgress) {
+    // 5 parts OK + 1 NOT_YET. PartLayout has 5 parts (recoverable);
+    // PartLayoutWithNotYet has 6 (full) -> PS_REPLICATION_IN_PROGRESS.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200009);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, OK5, NY6, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_REPLICATION_IN_PROGRESS,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(DataCorruptionDetected) {
+    // 6 parts placed, one of them carries random bytes -> PS_OK, DS_ERROR.
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200010);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, OK5, RND6, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_ERROR);
+}
+
+Y_UNIT_TEST(DataCorruptionTwoParts) {
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto id = fx.MakeBlobId(200011);
+    fx.SetupAndRun(id, {OK1, OK2, OK3, OK4, RND5, RND6, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_ERROR);
+}
+
+} // Block42
+
+////////////////////////////////////////////////////////////////////////////////
+// Mirror 3 DC
+//
+// Subgroup is a 3x3 matrix: rows are fail domains, columns are realms (DCs).
+// Slots 0,1,2 are the main holders (one per realm); 3..8 are handoff slots
+// distributed across realms in the same column-wise pattern.
+//
+// Quorum:
+//   EBS_FULL                      CheckQuorumForSubgroup: at least 1 disk per
+//                                 realm (num1==3) or 2 disks in 2 realms.
+//   EBS_RECOVERABLE_FRAGMENTARY   any disk has the part, but not full quorum.
+//   EBS_UNRECOVERABLE_FRAGMENTARY no disk has the part.
+//
+// Mirror-3-dc has TotalParts==3, so partId in (1, 2, 3).  All "parts" are
+// full copies of the data, and the placement check looks only at which
+// slots host *any* replica - the partId does not influence the verdict.
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TDSProxyCheckIntegrityMirror3dc) {
+
+Y_UNIT_TEST(PlacementOkOnePerRealm) {
+    // One replica in each of the three realms -> num1 == 3 -> EBS_FULL.
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300001);
+    fx.SetupAndRun(id, {OK1, OK2, OK3,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementRecoverableOnlyOneRealm) {
+    // 3 replicas all in the same realm (column 0) -> only 1 realm has the
+    // blob, num1==1 -> not full but disksWithReplica != 0 -> recoverable.
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300002);
+    fx.SetupAndRun(id, {OK1, ND, ND,   OK2, ND, ND,   OK3, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementOk2Plus2DuringDcOutage) {
+    // Simulates a write that completed during a DC2 outage: two replicas
+    // landed in realm 0 (slots 0, 3) and two in realm 1 (slots 1, 4); all
+    // disks of realm 2 are errored. num2 == 2 (two realms have >=2 disks
+    // with the part) -> EBS_FULL -> PS_OK. Fail model is satisfied since
+    // failures are confined to a single realm.
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300011);
+    fx.SetupAndRun(id, {OK1, OK1, ERR,   OK1, OK1, ERR,   ND, ND, ERR});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementRecoverable2Plus0OneRealmAlive) {
+    // Only realm 0 has replicas (slots 0 and 3); realm 1 has none; realm 2
+    // is fully errored. disksWithReplica != 0 -> recoverable, but neither
+    // num1 nor num2 reaches the EBS_FULL threshold.
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300012);
+    fx.SetupAndRun(id, {OK1, ND, ERR,   OK1, ND, ERR,   ND, ND, ERR});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementRecoverablePhantomBlob) {
+    // Single residual replica from a deleted blob -> still recoverable
+    // (mirror-3-dc only flags as unrecoverable when *zero* disks have it).
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300003);
+    fx.SetupAndRun(id, {OK1, ND, ND,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementBlobIsLost) {
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300004);
+    fx.SetupAndRun(id, {ND, ND, ND,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_LOST,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+Y_UNIT_TEST(PlacementUnknownNoBlobButErrors) {
+    // No replicas, but some disks errored -> the blob may live on those
+    // disks -> PS_UNKNOWN.
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300005);
+    fx.SetupAndRun(id, {ND, ND, ND,   ND, ND, ND,   ERR, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_UNKNOWN,
+        TEvCheckIntegrityResult::DS_UNKNOWN);
+}
+
+Y_UNIT_TEST(DataCorruption) {
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300006);
+    fx.SetupAndRun(id, {OK1, OK2, RND3,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_ERROR);
+}
+
+Y_UNIT_TEST(DataCorruptionAndPlacementRecoverable) {
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300007);
+    fx.SetupAndRun(id, {OK1, RND2, ND,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_ERROR);
+}
+
+Y_UNIT_TEST(ReplicationInProgress) {
+    TFixture fx(TBlobStorageGroupType::ErasureMirror3dc);
+    auto id = fx.MakeBlobId(300008);
+    fx.SetupAndRun(id, {OK1, OK2, NY3,   ND, ND, ND,   ND, ND, ND});
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_REPLICATION_IN_PROGRESS,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
+} // Mirror3dc
+
+} // namespace NDSProxyCheckIntegrityTest
+} // namespace NKikimr

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_vdisk_mock_ut.h
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_vdisk_mock_ut.h
@@ -97,14 +97,14 @@ public:
         SpecialStatuses[blobID] = status;
     }
 
-    const TString& GetBlobData(const TLogoBlobID& id) const {
+    bool CorruptData(const TLogoBlobID& id) {
         auto it = Blobs.find(id);
-        static const TString empty;
-        return it == Blobs.end() ? empty : it->second;
-    }
-
-    void OverwriteBlob(const TLogoBlobID& id, const TString& data) {
-        Blobs[id] = data;
+        if (it == Blobs.end() || it->second.empty()) {
+            return false;
+        }
+        TString& data = it->second;
+        data = TString(data.size(), 'X');
+        return true;
     }
 
     void OnVGet(const TEvBlobStorage::TEvVGet &vGet, TEvBlobStorage::TEvVGetResult &outVGetResult) {
@@ -540,7 +540,6 @@ public:
         return GetVDisk(vDisksId[subgroupIdx]);
     }
 
-    // Helper method to encrypt data and create part set
     void PrepareDataParts(const TLogoBlobID& id, const TString& data, TDataPartSet& partSet) {
         Y_ABORT_UNLESS(id.BlobSize() == data.size());
         const ui32 totalParts = Info->Type.TotalPartCount();
@@ -553,11 +552,6 @@ public:
         Info->Type.SplitData((TErasureType::ECrcMode)id.CrcMode(), encryptedData, partSet);
     }
 
-    // Places a single part of `blobId` at the given subgroup slot.  Unlike
-    // Put(), which assumes the canonical "part i goes to slot i" mapping for
-    // block-* erasures and only writes to primary slots, this helper lets the
-    // caller pick any (subgroupIdx, partId) pair and is therefore suitable
-    // for mirror-3-dc layouts where parts are replicated across realms.
     void PutPartAtSlot(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId,
         const TString& data)
     {
@@ -571,22 +565,12 @@ public:
         GetVDiskInSubgroup(blobId, subgroupIdx).Put(pId, pData);
     }
 
-    // Replaces the data of an existing part with corrupted bytes (xor 0xFF).
-    // Requires the part to be already stored on the disk at the given subgroup index.
     void CorruptPart(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId) {
         TVDiskMock& vdisk = GetVDiskInSubgroup(blobId, subgroupIdx);
         TLogoBlobID partBlobId(blobId, partId);
-        TString existing = vdisk.GetBlobData(partBlobId);
-        Y_ABORT_UNLESS(!existing.empty(), "Part is not stored on the selected disk");
-        char* p = existing.Detach();
-        for (size_t i = 0; i < existing.size(); ++i) {
-            p[i] ^= 0xff;
-        }
-        vdisk.OverwriteBlob(partBlobId, existing);
+        Y_ABORT_UNLESS(vdisk.CorruptData(partBlobId), "Part is not stored on the selected disk");
     }
 
-    // Marks a previously-stored part as NOT_YET (replication in progress) on the
-    // disk that holds it at the given subgroup slot.
     void MarkPartNotYet(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId) {
         GetVDiskInSubgroup(blobId, subgroupIdx).SetNotYet(TLogoBlobID(blobId, partId));
     }

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_vdisk_mock_ut.h
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_vdisk_mock_ut.h
@@ -97,6 +97,16 @@ public:
         SpecialStatuses[blobID] = status;
     }
 
+    const TString& GetBlobData(const TLogoBlobID& id) const {
+        auto it = Blobs.find(id);
+        static const TString empty;
+        return it == Blobs.end() ? empty : it->second;
+    }
+
+    void OverwriteBlob(const TLogoBlobID& id, const TString& data) {
+        Blobs[id] = data;
+    }
+
     void OnVGet(const TEvBlobStorage::TEvVGet &vGet, TEvBlobStorage::TEvVGetResult &outVGetResult) {
         auto &request = vGet.Record;
         if (IsError) {
@@ -523,25 +533,77 @@ public:
         }
     }
 
+    TVDiskMock& GetVDiskInSubgroup(const TLogoBlobID& blobId, ui32 subgroupIdx) {
+        TBlobStorageGroupInfo::TVDiskIds vDisksId;
+        Info->PickSubgroup(blobId.Hash(), &vDisksId, nullptr);
+        Y_ABORT_UNLESS(subgroupIdx < vDisksId.size());
+        return GetVDisk(vDisksId[subgroupIdx]);
+    }
+
+    // Helper method to encrypt data and create part set
+    void PrepareDataParts(const TLogoBlobID& id, const TString& data, TDataPartSet& partSet) {
+        Y_ABORT_UNLESS(id.BlobSize() == data.size());
+        const ui32 totalParts = Info->Type.TotalPartCount();
+
+        TString encryptedData = data;
+        char* dataBytes = encryptedData.Detach();
+        Encrypt(dataBytes, dataBytes, 0, encryptedData.size(), id, *Info);
+
+        partSet.Parts.resize(totalParts);
+        Info->Type.SplitData((TErasureType::ECrcMode)id.CrcMode(), encryptedData, partSet);
+    }
+
+    // Places a single part of `blobId` at the given subgroup slot.  Unlike
+    // Put(), which assumes the canonical "part i goes to slot i" mapping for
+    // block-* erasures and only writes to primary slots, this helper lets the
+    // caller pick any (subgroupIdx, partId) pair and is therefore suitable
+    // for mirror-3-dc layouts where parts are replicated across realms.
+    void PutPartAtSlot(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId,
+        const TString& data)
+    {
+        Y_ABORT_UNLESS(partId >= 1 && partId <= Info->Type.TotalPartCount());
+
+        TDataPartSet partSet;
+        PrepareDataParts(blobId, data, partSet);
+
+        TLogoBlobID pId(blobId, partId);
+        TString pData = partSet.Parts[partId - 1].OwnedString.ConvertToString();
+        GetVDiskInSubgroup(blobId, subgroupIdx).Put(pId, pData);
+    }
+
+    // Replaces the data of an existing part with corrupted bytes (xor 0xFF).
+    // Requires the part to be already stored on the disk at the given subgroup index.
+    void CorruptPart(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId) {
+        TVDiskMock& vdisk = GetVDiskInSubgroup(blobId, subgroupIdx);
+        TLogoBlobID partBlobId(blobId, partId);
+        TString existing = vdisk.GetBlobData(partBlobId);
+        Y_ABORT_UNLESS(!existing.empty(), "Part is not stored on the selected disk");
+        char* p = existing.Detach();
+        for (size_t i = 0; i < existing.size(); ++i) {
+            p[i] ^= 0xff;
+        }
+        vdisk.OverwriteBlob(partBlobId, existing);
+    }
+
+    // Marks a previously-stored part as NOT_YET (replication in progress) on the
+    // disk that holds it at the given subgroup slot.
+    void MarkPartNotYet(const TLogoBlobID& blobId, ui32 subgroupIdx, ui32 partId) {
+        GetVDiskInSubgroup(blobId, subgroupIdx).SetNotYet(TLogoBlobID(blobId, partId));
+    }
+
     void Put(const TLogoBlobID id, const TString &data, ui32 handoffsToUse = 0,
         const THashSet<ui32>* selectedParts = nullptr)
     {
         const ui32 hash = id.Hash();
         const ui32 totalvd = Info->Type.BlobSubgroupSize();
         const ui32 totalParts = Info->Type.TotalPartCount();
-        Y_ABORT_UNLESS(id.BlobSize() == data.size());
         Y_ABORT_UNLESS(totalvd >= totalParts);
         TBlobStorageGroupInfo::TServiceIds vDisksSvc;
         TBlobStorageGroupInfo::TVDiskIds vDisksId;
         Info->PickSubgroup(hash, &vDisksId, &vDisksSvc);
 
-        TString encryptedData = data;
-        char *dataBytes = encryptedData.Detach();
-        Encrypt(dataBytes, dataBytes, 0, encryptedData.size(), id, *Info);
-
         TDataPartSet partSet;
-        partSet.Parts.resize(totalParts);
-        Info->Type.SplitData((TErasureType::ECrcMode)id.CrcMode(), encryptedData, partSet);
+        PrepareDataParts(id, data, partSet);
 
         if (Info->Type.GetErasure() == TErasureType::ErasureMirror3of4) {
             auto part1 = partSet.Parts[0].OwnedString.ConvertToString();

--- a/ydb/core/blobstorage/dsproxy/ut/ya.make
+++ b/ydb/core/blobstorage/dsproxy/ut/ya.make
@@ -28,6 +28,7 @@ SRCS(
     dsproxy_counters_ut.cpp
     dsproxy_request_reporting_ut.cpp
     dsproxy_discover_ut.cpp
+    dsproxy_check_integrity_ut.cpp
 )
 
 IF (BUILD_TYPE != "DEBUG")

--- a/ydb/core/blobstorage/other/mon_blob_range_page.cpp
+++ b/ydb/core/blobstorage/other/mon_blob_range_page.cpp
@@ -79,7 +79,8 @@ namespace {
             }
 
             const ui64 cookie = ++LastCookie;
-            auto query = std::make_unique<TEvBlobStorage::TEvRange>(tabletId, from, to, mustRestoreFirst, TInstant::Max(), true);
+            auto query = std::make_unique<TEvBlobStorage::TEvRange>(tabletId, from, to, mustRestoreFirst,
+                TActivationContext::Now() + TDuration::Seconds(10), true);
             SendToBSProxy(SelfId(), groupId, query.release(), cookie);
             RequestsInFlight[cookie] = {ev->Sender, ev->Cookie, ev->Get()->SubRequestId, json};
         }

--- a/ydb/core/blobstorage/other/mon_check_integrity.cpp
+++ b/ydb/core/blobstorage/other/mon_check_integrity.cpp
@@ -1,0 +1,176 @@
+#include "mon_check_integrity.h"
+#include <ydb/core/base/blobstorage.h>
+#include <library/cpp/monlib/service/pages/templates.h>
+#include <library/cpp/threading/future/future.h>
+
+namespace NKikimr {
+
+namespace {
+
+    class TMonCheckIntegrityActor
+        : public TActor<TMonCheckIntegrityActor>
+    {
+        ui64 LastCookie = 0;
+        // sender, senderCookie, subRequestId, groupId
+        THashMap<ui64, std::tuple<TActorId, ui64, int, ui32>> RequestsInFlight;
+
+    public:
+        TMonCheckIntegrityActor()
+            : TActor(&TThis::StateFunc)
+        {}
+
+        void Handle(NMon::TEvHttpInfo::TPtr ev) {
+            // parse HTTP request
+            const TCgiParameters& params = ev->Get()->Request.GetParams();
+
+            auto generateError = [&](const TString& msg) {
+                TStringStream out;
+
+                out << "HTTP/1.1 400 Bad Request\r\n"
+                    << "Content-Type: text/plain\r\n"
+                    << "Connection: close\r\n"
+                    << "\r\n"
+                    << msg << "\r\n";
+
+                Send(ev->Sender, new NMon::TEvHttpInfoRes(out.Str(), ev->Get()->SubRequestId, NMon::TEvHttpInfoRes::Custom), 0,
+                    ev->Cookie);
+            };
+
+            ui32 groupId = 0;
+            if (!params.Has("groupId")) {
+                return generateError("Missing groupId parameter");
+            } else if (!TryFromString(params.Get("groupId"), groupId)) {
+                return generateError("Failed to parse groupId parameter -- must be an integer");
+            }
+
+            TLogoBlobID logoBlobId;
+            TString errorExplanation;
+            if (!params.Has("blob")) {
+                return generateError("Missing blob parameter");
+            } else if (!TLogoBlobID::Parse(logoBlobId, params.Get("blob"), errorExplanation)) {
+                return generateError("Failed to parse blob parameter -- " + errorExplanation);
+            } else if (logoBlobId != logoBlobId.FullID()) {
+                return generateError("Desired blob must be full one");
+            } else if (!logoBlobId || !logoBlobId.BlobSize()) {
+                return generateError("Invalid blob id");
+            }
+
+            const ui64 cookie = ++LastCookie;
+            auto query = std::make_unique<TEvBlobStorage::TEvCheckIntegrity>(
+                logoBlobId, TActivationContext::Now() + TDuration::Seconds(10), NKikimrBlobStorage::AsyncRead);
+            SendToBSProxy(SelfId(), groupId, query.release(), cookie);
+            RequestsInFlight[cookie] = {ev->Sender, ev->Cookie, ev->Get()->SubRequestId, groupId};
+        }
+
+        void Handle(TEvBlobStorage::TEvCheckIntegrityResult::TPtr ev) {
+            const auto it = RequestsInFlight.find(ev->Cookie);
+            Y_ABORT_UNLESS(it != RequestsInFlight.end());
+            const auto& [sender, senderCookie, subRequestId, groupId] = it->second;
+
+            TEvBlobStorage::TEvCheckIntegrityResult& msg = *ev->Get();
+
+            TStringStream out;
+            out << NMonitoring::HTTPOKHTML;
+
+            HTML(out) {
+                out << "<!DOCTYPE html>\n";
+                HTML_TAG() {
+                    HEAD() {
+                        out << "<title>Blob Check Integrity</title>\n";
+                        out << "<link rel='stylesheet' href='../static/css/bootstrap.min.css'>\n";
+                        out << "<script language='javascript' type='text/javascript' src='../static/js/jquery.min.js'></script>\n";
+                        out << "<script language='javascript' type='text/javascript' src='../static/js/bootstrap.min.js'></script>\n";
+                        out << "<style type=\"text/css\">\n";
+                        out << ".table-nonfluid { width: auto; }\n";
+                        out << "</style>\n";
+                    }
+                    BODY() {
+                        DIV_CLASS("panel panel-info") {
+                            DIV_CLASS("panel-heading") {
+                                out << "Blob Check Integrity";
+                            }
+                            DIV_CLASS("panel-body") {
+                                DIV() {
+                                    out << "GroupId: ";
+                                    STRONG() {
+                                        out << groupId;
+                                    }
+                                }
+
+                                DIV() {
+                                    out << "LogoBlobId: ";
+                                    STRONG() {
+                                        out << msg.Id.ToString();
+                                    }
+                                }
+
+                                DIV() {
+                                    out << "Status: ";
+                                    STRONG() {
+                                        out << NKikimrProto::EReplyStatus_Name(msg.Status);
+                                    }
+                                }
+
+                                if (msg.ErrorReason) {
+                                    DIV() {
+                                        out << "ErrorReason: ";
+                                        STRONG() {
+                                            out << msg.ErrorReason;
+                                        }
+                                    }
+                                }
+
+                                DIV() {
+                                    out << "Erasure: ";
+                                    STRONG() {
+                                        out << TBlobStorageGroupType::ErasureSpeciesName(msg.Erasure);
+                                    }
+                                }
+
+                                DIV() {
+                                    out << "PlacementStatus: ";
+                                    STRONG() {
+                                        out << TEvBlobStorage::TEvCheckIntegrityResult::PlacementStatusToString(msg.PlacementStatus);
+                                    }
+                                }
+
+                                DIV() {
+                                    out << "DataStatus: ";
+                                    STRONG() {
+                                        out << TEvBlobStorage::TEvCheckIntegrityResult::DataStatusToString(msg.DataStatus);
+                                    }
+                                }
+
+                                if (msg.DataInfo) {
+                                    DIV() {
+                                        out << "DataInfo:";
+                                        DIV() {
+                                            out << "<pre><small>";
+                                            out << msg.DataInfo;
+                                            out << "</small></pre>";
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Send(sender, new NMon::TEvHttpInfoRes(out.Str(), subRequestId, NMon::TEvHttpInfoRes::Custom), 0, senderCookie);
+            RequestsInFlight.erase(it);
+        }
+
+        STRICT_STFUNC(StateFunc,
+            hFunc(NMon::TEvHttpInfo, Handle);
+            hFunc(TEvBlobStorage::TEvCheckIntegrityResult, Handle);
+        )
+    };
+
+} // anon
+
+IActor *CreateMonCheckIntegrityActor() {
+    return new TMonCheckIntegrityActor;
+}
+
+} // NKikimr

--- a/ydb/core/blobstorage/other/mon_check_integrity.cpp
+++ b/ydb/core/blobstorage/other/mon_check_integrity.cpp
@@ -145,7 +145,16 @@ namespace {
                                         out << "DataInfo:";
                                         DIV() {
                                             out << "<pre><small>";
-                                            out << msg.DataInfo;
+                                            for (char ch : msg.DataInfo) {
+                                                switch (ch) {
+                                                    case '&':  out << "&amp;"; break;
+                                                    case '<':  out << "&lt;" ; break;
+                                                    case '>':  out << "&gt;" ; break;
+                                                    case '\'': out << "&#39;"; break;
+                                                    case '"':  out << "&quot;"; break;
+                                                    default:   out << ch     ; break;
+                                                }
+                                            }
                                             out << "</small></pre>";
                                         }
                                     }

--- a/ydb/core/blobstorage/other/mon_check_integrity.cpp
+++ b/ydb/core/blobstorage/other/mon_check_integrity.cpp
@@ -1,7 +1,6 @@
 #include "mon_check_integrity.h"
 #include <ydb/core/base/blobstorage.h>
 #include <library/cpp/monlib/service/pages/templates.h>
-#include <library/cpp/threading/future/future.h>
 
 namespace NKikimr {
 

--- a/ydb/core/blobstorage/other/mon_check_integrity.h
+++ b/ydb/core/blobstorage/other/mon_check_integrity.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "defs.h"
+
+#include <library/cpp/monlib/service/pages/mon_page.h>
+
+namespace NKikimr {
+
+    inline TActorId MakeMonCheckIntegrityId() {
+        return TActorId(0, TStringBuf("check_integ", 11));
+    }
+
+    IActor *CreateMonCheckIntegrityActor();
+
+} // NKikimr

--- a/ydb/core/blobstorage/other/mon_check_integrity.h
+++ b/ydb/core/blobstorage/other/mon_check_integrity.h
@@ -7,7 +7,7 @@
 namespace NKikimr {
 
     inline TActorId MakeMonCheckIntegrityId() {
-        return TActorId(0, TStringBuf("check_integ", 11));
+        return TActorId(0, TStringBuf("check_integr", 12));
     }
 
     IActor *CreateMonCheckIntegrityActor();

--- a/ydb/core/blobstorage/other/mon_get_blob_page.cpp
+++ b/ydb/core/blobstorage/other/mon_get_blob_page.cpp
@@ -78,9 +78,20 @@ namespace {
                 }
             }
 
+            bool mustRestoreFirst = false;
+            if (params.Has("mustRestoreFirst")) {
+                int value;
+                if (!TryFromString(params.Get("mustRestoreFirst"), value) || !(value >= 0 && value <= 1)) {
+                    return generateError("Failed to parse mustRestoreFirst parameter -- must be an integer in range [0, 1]");
+                } else {
+                    mustRestoreFirst = value != 0;
+                }
+            }
+
             const ui64 cookie = ++LastCookie;
-            auto query = std::make_unique<TEvBlobStorage::TEvGet>(logoBlobId, 0, 0, TInstant::Max(),
-                NKikimrBlobStorage::AsyncRead);
+            auto query = std::make_unique<TEvBlobStorage::TEvGet>(logoBlobId, 0, 0,
+                TActivationContext::Now() + TDuration::Seconds(10),
+                NKikimrBlobStorage::AsyncRead, mustRestoreFirst);
             query->CollectDebugInfo = collectDebugInfo;
             query->ReportDetailedPartMap = true;
             SendToBSProxy(SelfId(), groupId, query.release(), cookie);

--- a/ydb/core/blobstorage/other/ya.make
+++ b/ydb/core/blobstorage/other/ya.make
@@ -12,6 +12,8 @@ SRCS(
     defs.h
     mon_blob_range_page.cpp
     mon_blob_range_page.h
+    mon_check_integrity.cpp
+    mon_check_integrity.h
     mon_get_blob_page.cpp
     mon_get_blob_page.h
     mon_vdisk_stream.cpp

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -106,6 +106,7 @@
 
 #include <ydb/core/blobstorage/other/mon_get_blob_page.h>
 #include <ydb/core/blobstorage/other/mon_blob_range_page.h>
+#include <ydb/core/blobstorage/other/mon_check_integrity.h>
 #include <ydb/core/blobstorage/other/mon_vdisk_stream.h>
 
 #include <ydb/public/lib/deprecated/client/msgbus_client.h>
@@ -1802,6 +1803,8 @@ void TKikimrRunner::InitializeActorSystem(
             TMailboxType::HTSwap, AppData->SystemPoolId));
         setup->LocalServices.emplace_back(MakeMonBlobRangeId(), TActorSetupCmd(CreateMonBlobRangeActor(),
             TMailboxType::HTSwap, AppData->SystemPoolId));
+        setup->LocalServices.emplace_back(MakeMonCheckIntegrityId(), TActorSetupCmd(CreateMonCheckIntegrityActor(),
+            TMailboxType::HTSwap, AppData->SystemPoolId));
     }
 
     ApplyLogSettings(runConfig);
@@ -1872,6 +1875,14 @@ void TKikimrRunner::InitializeActorSystem(
                 false,
                 ActorSystem.Get(),
                 MakeMonBlobRangeId());
+
+        Monitoring->RegisterActorPage(
+                nullptr,
+                "check_integrity",
+                TString(),
+                false,
+                ActorSystem.Get(),
+                MakeMonCheckIntegrityId());
 
         Monitoring->RegisterActorPage(
                 nullptr,

--- a/ydb/tests/functional/blobstorage/test_other.py
+++ b/ydb/tests/functional/blobstorage/test_other.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import requests
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+
+
+class TestOther(object):
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = KiKiMR()
+        cls.cluster.start()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.stop()
+
+    def http_get(self, path, params):
+        host = self.cluster.nodes[1].host
+        port = self.cluster.nodes[1].mon_port
+        return requests.get("http://%s:%s%s" % (host, port, path), params=params)
+
+    def test_nodata(self):
+        fake_blob = "[123456:1:1:0:0:1024:0]"
+        group_id = "0"
+
+        r = self.http_get("/blob_range", {
+            "groupId": group_id,
+            "tabletId": "123456",
+            "from": fake_blob,
+            "to": fake_blob,
+        })
+        r.raise_for_status()
+
+        r = self.http_get("/get_blob", {
+            "groupId": group_id,
+            "blob": fake_blob,
+        })
+        r.raise_for_status()
+        assert "NODATA" in r.text, r.text
+
+        r = self.http_get("/check_integrity", {
+            "groupId": group_id,
+            "blob": fake_blob,
+        })
+        r.raise_for_status()
+        assert "BLOB_IS_LOST" in r.text, r.text
+        assert "NODATA" in r.text, r.text

--- a/ydb/tests/functional/blobstorage/ya.make
+++ b/ydb/tests/functional/blobstorage/ya.make
@@ -9,6 +9,7 @@ TEST_SRCS(
     test_self_heal.py
     test_tablet_channel_migration.py
     test_vdisks.py
+    test_other.py
 )
 
 IF (SANITIZER_TYPE)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Handle HTTP `/get_blob` option `mustRestoreFirst` for feature-parity with `/blob_range`
- Handle HTTP `/check_integrity`
- Reflect it in Developer UI HTML
- Make TEvCheckIntegrityResult more informative: add Erasure field, extend DataInfo with original VDisk responses
- Fix absent TEvCheckIntegrity field SingleLine in constructor
- Fix infinite timeouts in `/get_blob` and `/blob_range` HTTP handlers
- Add ut TDSProxyCheckIntegrity
- Add functional test covering mon pages from `blobstorage/other`

<img width="1804" height="471" alt="image" src="https://github.com/user-attachments/assets/6be0f058-8e6a-451e-ac63-5ebb072de9fc" />
