### PR TITLE
Fix heap-use-after-free and another rare datashard crash

### DIFF
--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.cpp
@@ -357,7 +357,7 @@ NHdrf::NDynamic::TQueryPtr TComputeScheduler::GetReadQuery(const NHdrf::TDatabas
         return queryIt->second;
     }
 
-    return {}; // TODO: no such pool?
+    return {};
 }
 
 bool TComputeScheduler::RemoveQuery(const NHdrf::TQueryId& queryId) {

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_read.cpp
@@ -104,10 +104,16 @@ TSchedulableReadPtr TSchedulableReadFactory::Get(const NHdrf::TDatabaseId& datab
         ReadsCache.erase(readIt);
     }
 
-    auto query = Scheduler->GetReadQuery(databaseId, poolId);
-    auto result = std::make_shared<TSchedulableRead>(query);
-    ReadsCache.emplace(databaseAndPoolId, result);
-    return result;
+    if (auto query = Scheduler->GetReadQuery(databaseId, poolId)) {
+        auto result = std::make_shared<TSchedulableRead>(query);
+        ReadsCache.emplace(databaseAndPoolId, result);
+        return result;
+    }
+
+    // Potentially in some cases a datashard may receive read request from new Resource Pool
+    // before it's registered in Compute Scheduler, then the read query will be nullptr.
+    // Just pass empty Schedulable Read further and handle the problem in datashard.
+    return {};
 }
 
 void TSchedulableReadFactory::CleanupReadsCache() const {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -3413,15 +3413,13 @@ public:
             }
         }
 
-        // Return read quota after reading
-        Y_DEFER {
+        if (Reader->Read(txc)) {
+            // Call before sending result, because `schedulableRead` gets deleted
             if (schedulableRead) {
                 Reader->UpdateCycles();
                 schedulableRead->ReturnQuota(Reader->ElapsedCycles());
             }
-        };
 
-        if (Reader->Read(txc)) {
             // Retry later when dependencies are resolved
             if (!Reader->GetVolatileReadDependencies().empty()) {
                 state.ReadContinuePending = true;
@@ -3444,6 +3442,11 @@ public:
                 SendResult(ctx);
             }
             return true;
+        }
+
+        if (schedulableRead) {
+            Reader->UpdateCycles();
+            schedulableRead->ReturnQuota(Reader->ElapsedCycles());
         }
         return false;
     }

--- a/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
+++ b/ydb/core/tx/datashard/ut_read_iterator/datashard_ut_read_iterator_scheduler.cpp
@@ -372,6 +372,30 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorScheduler) {
         UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
     }
 
+    // When the datashard receives a read request with a pool ID that is not registered
+    // in ComputeScheduler, the read must succeed without quota enforcement.
+    //
+    // For the leader: SchedulableRead is nullptr, quota check is bypassed.
+    // For the follower: quota is never applied regardless of pool registration.
+    Y_UNIT_TEST_TWIN(ShouldReadWithUnknownPoolId, WithFollower) {
+        TSchedulerTestHelper helper(/*readLimitMs=*/std::nullopt,
+                                    /*blockSchedulerFactory=*/false,
+                                    /*withFollower=*/WithFollower);
+        helper.Upsert(1, 100);
+
+        const TString unknownPoolId = "unknown_pool";
+        auto request = helper.MakeReadRequest(1, unknownPoolId);
+        AddKeyQuery(*request, {1, 1, 1});
+
+        auto result = helper.SendRead(request.release());
+        UNIT_ASSERT_C(result, "Expected read to succeed with unknown pool ID");
+        UNIT_ASSERT_VALUES_EQUAL(result->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(result->GetRowsCount(), 1);
+        auto cells = result->GetCells(0);
+        UNIT_ASSERT_VALUES_EQUAL(cells.size(), 4u);
+        UNIT_ASSERT_VALUES_EQUAL(cells[3].AsValue<ui32>(), 100u);
+    }
+
     // When the datashard never receives a factory response from the scheduler
     // (e.g. the scheduler is temporarily unavailable), it falls back to reading
     // without quota after the built-in 1-second fail-safe timer fires.


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)