### PR TITLE
Bloom index import fix

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -1897,7 +1897,10 @@ private:
                 Cancel(*importInfo, itemIdx, "issues during index building");
                 Self->EraseEncryptionKey(db, *importInfo);
             } else {
-                if (item.Table && ++item.NextIndexIdx < item.Table->indexes_size()) {
+                if (item.Table) {
+                    ++item.NextIndexIdx;
+                }
+                if (PrepareNextBuildableIndex(*importInfo, itemIdx, item)) {
                     AllocateTxId(*importInfo, itemIdx);
                 } else if (item.NextChangefeedIdx < item.Changefeeds.changefeeds_size() &&
                            AppData()->FeatureFlags.GetEnableChangefeedsImport()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Раньше после сборки очередного индекса код просто делал ++item.NextIndexIdx и сразу отправлял следующий индекс на build. Из-за этого локальные bloom-индексы могли ошибочно попадать в index builder, хотя они являются частью схемы таблицы и не должны строиться отдельно
Теперь после инкремента вызывается PrepareNextBuildableIndex(...), которая уже умеет пропускать локальные индексы и находить следующий индекс, который действительно нужно строить. Если такой индекс найден то вызывается AllocateTxId(...)
