### PR TITLE
Updated default s3 read actor settings

### DIFF
--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
@@ -699,9 +699,9 @@ public:
     }
 
 private:
-    size_t MaxHandlers = 1024U;
+    size_t MaxHandlers = 2048U;
     size_t MaxSimulatenousDownloadsSize = 8_GB;
-    size_t BuffersSizePerStream = CURL_MAX_WRITE_SIZE << 3U;
+    size_t BuffersSizePerStream = 5_MB;
     TCurlInitConfig InitConfig;
 
     void InitCurl() {

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_gateway.cpp
@@ -699,9 +699,9 @@ public:
     }
 
 private:
-    size_t MaxHandlers = 2048U;
+    size_t MaxHandlers = 1024U;
     size_t MaxSimulatenousDownloadsSize = 8_GB;
-    size_t BuffersSizePerStream = 5_MB;
+    size_t BuffersSizePerStream = CURL_MAX_WRITE_SIZE << 3U;
     TCurlInitConfig InitConfig;
 
     void InitCurl() {

--- a/ydb/library/yql/providers/s3/actors_factory/yql_s3_actors_factory.h
+++ b/ydb/library/yql/providers/s3/actors_factory/yql_s3_actors_factory.h
@@ -20,7 +20,7 @@ namespace NDq {
         ui64 RowsInBatch = 1000;
         ui64 MaxInflight = 20;
         ui64 DataInflight = 200_MB;
-        ui64 FileSizeLimit = 2_GB;
+        ui64 FileSizeLimit = 100_GB;
         ui64 BlockFileSizeLimit = 50_GB;
         std::unordered_map<std::string, ui64> FormatSizeLimits;
     };

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -68,7 +68,7 @@ void TS3Configuration::Init(const TS3GatewayConfig& config, TIntrusivePtr<TTypeA
         config.HasMaxInflightListsPerQuery() ? config.GetMaxInflightListsPerQuery() : 10;
     ListingCallbackThreadCount = config.HasListingCallbackThreadCount()
                                      ? config.GetListingCallbackThreadCount()
-                                     : 1;
+                                     : 0;
     ListingCallbackPerThreadQueueSize = config.HasListingCallbackPerThreadQueueSize()
                                             ? config.GetListingCallbackPerThreadQueueSize()
                                             : 100;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -50,30 +50,30 @@ void TS3Configuration::Init(const TS3GatewayConfig& config, TIntrusivePtr<TTypeA
         }
     }
     S3ReadActorFactoryConfig = NDq::CreateReadActorFactoryConfig(config);
-    FileSizeLimit = config.HasFileSizeLimit() ? config.GetFileSizeLimit() : 2_GB;
+    FileSizeLimit = config.HasFileSizeLimit() ? config.GetFileSizeLimit() : 100_GB;
     BlockFileSizeLimit = config.HasBlockFileSizeLimit() ? config.GetBlockFileSizeLimit() : 50_GB;
-    MaxFilesPerQuery = config.HasMaxFilesPerQuery() ? config.GetMaxFilesPerQuery() : 7000;
+    MaxFilesPerQuery = config.HasMaxFilesPerQuery() ? config.GetMaxFilesPerQuery() : 50000;
     MaxDiscoveryFilesPerQuery = config.HasMaxDiscoveryFilesPerQuery()
                                     ? config.GetMaxDiscoveryFilesPerQuery()
-                                    : 9000;
+                                    : 50000;
     MaxDirectoriesAndFilesPerQuery = config.HasMaxDirectoriesAndFilesPerQuery()
                                          ? config.GetMaxDirectoriesAndFilesPerQuery()
-                                         : 9000;
+                                         : 50000;
     MinDesiredDirectoriesOfFilesPerQuery =
         config.HasMinDesiredDirectoriesOfFilesPerQuery()
             ? config.GetMinDesiredDirectoriesOfFilesPerQuery()
             : 100;
     MaxInflightListsPerQuery =
-        config.HasMaxInflightListsPerQuery() ? config.GetMaxInflightListsPerQuery() : 1;
+        config.HasMaxInflightListsPerQuery() ? config.GetMaxInflightListsPerQuery() : 10;
     ListingCallbackThreadCount = config.HasListingCallbackThreadCount()
                                      ? config.GetListingCallbackThreadCount()
-                                     : 0;
+                                     : 1;
     ListingCallbackPerThreadQueueSize = config.HasListingCallbackPerThreadQueueSize()
                                             ? config.GetListingCallbackPerThreadQueueSize()
                                             : 100;
     RegexpCacheSize = config.HasRegexpCacheSize() ? config.GetRegexpCacheSize() : 100;
     AllowConcurrentListings =
-        config.HasAllowConcurrentListings() ? config.GetAllowConcurrentListings() : false;
+        config.HasAllowConcurrentListings() ? config.GetAllowConcurrentListings() : true;
     AllowLocalFiles =
         config.HasAllowLocalFiles() ? config.GetAllowLocalFiles() : false;
     GeneratorPathsLimit =

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -51,6 +51,7 @@ void TS3Configuration::Init(const TS3GatewayConfig& config, TIntrusivePtr<TTypeA
     }
     S3ReadActorFactoryConfig = NDq::CreateReadActorFactoryConfig(config);
     FileSizeLimit = config.HasFileSizeLimit() ? config.GetFileSizeLimit() : 100_GB;
+    S3ReadActorFactoryConfig.FileSizeLimit = FileSizeLimit;
     BlockFileSizeLimit = config.HasBlockFileSizeLimit() ? config.GetBlockFileSizeLimit() : 50_GB;
     MaxFilesPerQuery = config.HasMaxFilesPerQuery() ? config.GetMaxFilesPerQuery() : 50000;
     MaxDiscoveryFilesPerQuery = config.HasMaxDiscoveryFilesPerQuery()

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.h
@@ -76,7 +76,7 @@ public:
     TS3ConfSettingDefault<bool, false> AtomicUploadCommit;            // Commit each file independently, w/o transaction semantic over all files
     TS3ConfSettingOptional<bool> UseConcurrentDirectoryLister;        // By default TS3GatewayConfig::AllowConcurrentListings
     TS3ConfSettingOptional<ui64> MaxDiscoveryFilesPerDirectory;       // By default TS3GatewayConfig::MaxListingResultSizePerPartition
-    TS3ConfSettingDefault<bool, false> UseRuntimeListing;             // Enables runtime listing
+    TS3ConfSettingDefault<bool, true> UseRuntimeListing;              // Enables runtime listing
     TS3ConfSettingDefault<ui64, 1000'000> FileQueueBatchSizeLimit;    // Limits total size of files in one PathBatch from FileQueue
     TS3ConfSettingDefault<ui64, 1000> FileQueueBatchObjectCountLimit; // Limits count of files in one PathBatch from FileQueue
     TS3ConfSettingOptional<ui64> FileQueuePrefetchSize;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Updated default settings for ObjectStorage federated queries, enabling parallel runtime listing and faster reading without lengty configuration

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

feature is old, stable and enabled on every prod stand that uses s3 federated queries
