### PR TITLE
fix TRcBuf template constructor with CoW disabled

### DIFF
--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -782,9 +782,9 @@ public:
     {
         ptrdiff_t beginOffset = 0;
         if constexpr (std::is_same_v<std::decay_t<T>, IContiguousChunk::TPtr>) {
-            beginOffset = backend->GetData().data() - data.data();
+            beginOffset = data.data() - backend->GetData().data();
         } else {
-            beginOffset = backend.GetData().data() - data.data();
+            beginOffset = data.data() - backend.GetData().data();
         }
         Backend = std::move(backend);
         Begin = Backend.GetData().data() + beginOffset;

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -780,14 +780,13 @@ public:
     template<typename T>
     TRcBuf(T&& backend, const TContiguousSpan& data)
     {
-        const char* old_base;
+        ptrdiff_t beginOffset = 0;
         if constexpr (std::is_same_v<std::decay_t<T>, IContiguousChunk::TPtr>) {
-            old_base = backend->GetData().data();
+            beginOffset = backend->GetData().data() - data.data();
         } else {
-            old_base = backend.GetData().data();
+            beginOffset = backend.GetData().data() - data.data();
         }
-        ptrdiff_t beginOffset = data.data() - old_base;
-        Backend = TBackend(std::forward<T>(backend));
+        Backend = std::move(backend);
         Begin = Backend.GetData().data() + beginOffset;
         End = Begin + data.size();
     }

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -779,10 +779,18 @@ public:
 
     template<typename T>
     TRcBuf(T&& backend, const TContiguousSpan& data)
-        : Backend(std::forward<T>(backend))
-        , Begin(data.data())
-        , End(Begin + data.size())
-    {}
+    {
+        const char* old_base;
+        if constexpr (std::is_same_v<std::decay_t<T>, IContiguousChunk::TPtr>) {
+            old_base = backend->GetData().data();
+        } else {
+            old_base = backend.GetData().data();
+        }
+        ptrdiff_t beginOffset = data.data() - old_base;
+        Backend = TBackend(std::forward<T>(backend));
+        Begin = Backend.GetData().data() + beginOffset;
+        End = Begin + data.size();
+    }
 
     explicit TRcBuf(TString s)
         : Backend(std::move(s))

--- a/ydb/library/actors/util/rc_buf_ut.cpp
+++ b/ydb/library/actors/util/rc_buf_ut.cpp
@@ -216,4 +216,18 @@ Y_UNIT_TEST_SUITE(TRcBuf) {
         UNIT_ASSERT_EQUAL(data.Tailroom(), 8);
         UNIT_ASSERT_EQUAL(::memcmp(data.GetData(), "test", 4), 0);
     }
+
+    Y_UNIT_TEST(PieceWithStringBackend) {
+        TString str = "abcdefghijklmno";
+        TRcBuf original(str);
+        original.TrimFront(12);
+        original.TrimBack(8);
+
+        TRcBuf piece(TRcBuf::Piece, original.data(), original.size(), original);
+        UNIT_ASSERT_EQUAL(::memcmp(piece.data(), str.data() + 3, 8), 0);
+
+        piece.GrowBack(100);
+        UNIT_ASSERT_VALUES_EQUAL(piece.size(), 108);
+        UNIT_ASSERT_EQUAL(::memcmp(piece.data(), str.data() + 3, 8), 0);
+    }
 }


### PR DESCRIPTION

  The TRcBuf template constructor `TRcBuf(T&& backend, const TContiguousSpan& data)` set Begin = data.data() before moving the backend. When T is an lvalue (copy) and the backend is a TString 
  with CoW disabled, std::move copies the TString, which allocates a new independent buffer at a different address. Begin then ends up pointing into the source backend's buffer instead of the  
  newly owned one.                                                                                                                                                                                  
                  
  This is the read path of the same class of bug fixed earlier [39165](https://github.com/ydb-platform/ydb/pull/39165) in the copy constructor and operator=. Symptoms:                                                                                     
  
  - When the dangling Begin/End are later used by GrowFront, UnsafeTailroom() returns a garbage size_t (~0xFFFF_xxxx_xxxx) and checkedSum throws std::length_error: Allocate size overflow.         
  - When a tablet reboots and re-reads its recovery log from BlobStorage (gen ≥ 2), the resulting TRcBuf points at the wrong memory; ParseFromString reads garbage and the boot fails with a VERIFY                                                                                                                                                                
                                                                                                                                                                                                    
  capture old_base = backend.GetData().data() before std::move, compute begin_offset = data.data() - old_base, and re-derive Begin/End from Backend.GetData().data() after the backend is   
  moved into place. For IContiguousChunk::TPtr the data pointer is reached via operator->. When CoW is enabled or the backend is TInternalBackend/TSharedData (ref-counted, no realloc on copy), the
   offset stays the same and behaviour is unaffected.                                                                                                                                               
                            
  [5844](https://github.com/ydb-platform/nbs/issues/5844)                                                                                                                                           
                  
  cloud/blockstore/libs/storage/volume/ut:*                                                                                                                                                         
  cloud/blockstore/libs/storage/service/ut:*
