### PR TITLE
Update GitHub Actions workflow to use self-hosted runner for PR checks

### DIFF
--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -10,7 +10,7 @@ env:
   GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
 jobs:
   check-pr:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tiny-worker]
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
.github/workflows/automerge_pr.yaml wf `runs on: ubuntu-latest` - for this reason, in fact wf runs not once every 5 minutes, but once an hour. I hope `tiny-worker` help us

https://github.com/ydb-platform/ydb/actions/workflows/automerge_pr.yaml

<img width="973" height="689" alt="image" src="https://github.com/user-attachments/assets/bc64dbb5-8924-404b-b75e-afd7a493a0f6" />


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
