### PR TITLE
Add AI review label check and update workflows to support it

### DIFF
--- a/.github/scripts/tests/mute/llm_debug_comment.py
+++ b/.github/scripts/tests/mute/llm_debug_comment.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
 from typing import Dict, Sequence
 from urllib.parse import quote_plus
 
@@ -57,6 +58,11 @@ _LLM_HINT = (
     "Prefer lines like 'ydb/.../*.cpp:<line>' and requirement/assert text, and do NOT include "
     "stacktrace frames or addresses (e.g. '+0x...', function backtrace lines). -->"
 )
+
+
+def _is_need_ai_review_enabled() -> bool:
+    value = os.getenv('ENABLE_NEED_AI_REVIEW_LABEL', '').strip().lower()
+    return value in {'1', 'true', 'yes', 'on'}
 
 
 def _format_ts(value) -> str:
@@ -226,6 +232,8 @@ def post_llm_debug_comment(ydb_wrapper, issue_id: str, issue_url: str,
             add_issue_comment(issue_id, _build_comment(full_names, rows, branch, build_type))
     except Exception as exc:
         logging.warning('Failed to post LLM debug comment to %s: %s', issue_url, exc)
+        return
+    if not _is_need_ai_review_enabled():
         return
     try:
         # add_label_to_issue caches the label id and silently no-ops on most failures.

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -108,6 +108,7 @@ jobs:
         id: create_issues
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
+          ENABLE_NEED_AI_REVIEW_LABEL: ${{ vars.ENABLE_NEED_AI_REVIEW_LABEL || '' }}
         run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
 
       - name: Add issues to PR

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -365,7 +365,7 @@ jobs:
             });
             
             // Добавляем лейблы
-            const labelsToAdd = process.env.LABELS.split(',');
+            const labelsToAdd = process.env.LABELS.split(',').map(label => label.trim()).filter(Boolean);
             await github.rest.issues.addLabels({
               ...context.repo,
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},


### PR DESCRIPTION
- Introduced a new function `_is_need_ai_review_enabled` to determine if AI review labeling is enabled based on an environment variable.
- Updated the `post_llm_debug_comment` function to conditionally return early if AI review is not enabled.
- Modified the `create_issues_for_muted_tests.yml` workflow to pass the `ENABLE_NEED_AI_REVIEW_LABEL` environment variable.
- Enhanced the `update_muted_ya.yml` workflow to trim and filter labels from the environment variable before adding them to issues.

<img width="610" height="45" alt="image" src="https://github.com/user-attachments/assets/ac6f2c99-e89d-43db-aea6-42b20d9642b0" />


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
