### PR TITLE
CI: Workaround for gh bug with sheduling for PR Automerge

### DIFF
--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -39,18 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           cd ./ydb/ci/rightlib
-          loop_interval_seconds=300
-          max_loop_duration_seconds=3300
-          loop_deadline_seconds=$((SECONDS + max_loop_duration_seconds))
+          end_time=$(( SECONDS + 55 * 60 ))
           iteration=1
 
-          while (( SECONDS < loop_deadline_seconds )); do
+          while (( SECONDS < end_time )); do
             echo "::group::automerge iteration ${iteration}"
             ./automerge.py || echo "::warning::automerge iteration ${iteration} failed with exit code $?"
             echo "::endgroup::"
-
-            remaining_seconds=$((loop_deadline_seconds - SECONDS))
-            (( remaining_seconds <= 0 )) && break
-            sleep $(( remaining_seconds < loop_interval_seconds ? remaining_seconds : loop_interval_seconds ))
-            iteration=$((iteration + 1))
+            (( SECONDS < end_time )) && sleep 300
+            iteration=$(( iteration + 1 ))
           done

--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -40,6 +40,7 @@ jobs:
           set -euo pipefail
           cd ./ydb/ci/rightlib
           end_time=$(( SECONDS + 55 * 60 ))
+          poll_interval=300
           iteration=1
 
           while (( SECONDS < end_time )); do
@@ -47,6 +48,6 @@ jobs:
             ./automerge.py || echo "::warning::automerge iteration ${iteration} failed with exit code $?"
             echo "::endgroup::"
             remaining=$(( end_time - SECONDS ))
-            (( remaining > 0 )) && sleep $(( remaining < 300 ? remaining : 300 ))
+            (( remaining > 0 )) && sleep $(( remaining < poll_interval ? remaining : poll_interval ))
             iteration=$(( iteration + 1 ))
           done

--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -46,6 +46,7 @@ jobs:
             echo "::group::automerge iteration ${iteration}"
             ./automerge.py || echo "::warning::automerge iteration ${iteration} failed with exit code $?"
             echo "::endgroup::"
-            (( SECONDS < end_time )) && sleep 300
+            remaining=$(( end_time - SECONDS ))
+            (( remaining > 0 )) && sleep $(( remaining < 300 ? remaining : 300 ))
             iteration=$(( iteration + 1 ))
           done

--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -40,14 +40,17 @@ jobs:
           set -euo pipefail
           cd ./ydb/ci/rightlib
           loop_interval_seconds=300
-          loop_iterations=12
+          max_loop_duration_seconds=3300
+          loop_deadline_seconds=$((SECONDS + max_loop_duration_seconds))
+          iteration=1
 
-          for ((iteration=1; iteration<=loop_iterations; iteration++)); do
-            echo "::group::automerge iteration ${iteration}/${loop_iterations}"
-            ./automerge.py
+          while (( SECONDS < loop_deadline_seconds )); do
+            echo "::group::automerge iteration ${iteration}"
+            ./automerge.py || echo "::warning::automerge iteration ${iteration} failed with exit code $?"
             echo "::endgroup::"
 
-            if (( iteration < loop_iterations )); then
-              sleep "${loop_interval_seconds}"
-            fi
+            remaining_seconds=$((loop_deadline_seconds - SECONDS))
+            (( remaining_seconds <= 0 )) && break
+            sleep $(( remaining_seconds < loop_interval_seconds ? remaining_seconds : loop_interval_seconds ))
+            iteration=$((iteration + 1))
           done

--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -10,7 +10,7 @@ env:
   GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
 jobs:
   check-pr:
-    runs-on: [self-hosted, tiny-worker]
+    runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     timeout-minutes: 70
     steps:
       - name: checkout

--- a/.github/workflows/automerge_pr.yaml
+++ b/.github/workflows/automerge_pr.yaml
@@ -1,7 +1,7 @@
 name: Automerge PR
 on:
   schedule:
-    - cron: "*/5 * * * *"   # At every 5th minute
+    - cron: "17 * * * *"   # At minute 17 past every hour
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}
@@ -11,6 +11,7 @@ env:
 jobs:
   check-pr:
     runs-on: [self-hosted, tiny-worker]
+    timeout-minutes: 70
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -36,5 +37,17 @@ jobs:
           REPO: ${{ github.repository }}
           TOKEN: ${{ env.GH_TOKEN }}
         run: |
+          set -euo pipefail
           cd ./ydb/ci/rightlib
-          ./automerge.py
+          loop_interval_seconds=300
+          loop_iterations=12
+
+          for ((iteration=1; iteration<=loop_iterations; iteration++)); do
+            echo "::group::automerge iteration ${iteration}/${loop_iterations}"
+            ./automerge.py
+            echo "::endgroup::"
+
+            if (( iteration < loop_iterations )); then
+              sleep "${loop_interval_seconds}"
+            fi
+          done

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import shutil
 import datetime
 import logging
 import subprocess
@@ -79,26 +80,31 @@ class PrAutomerger:
         pr.add_to_labels(pr_label_fail)
 
     def git_merge_pr(self, pr: PullRequest):
-        self.git_run("clone", f"https://{self.token}@github.com/{self.repo_name}.git", "merge-repo")
-        os.chdir("merge-repo")
-        self.git_run("fetch", "origin", f"pull/{pr.number}/head:PR")
-        self.git_run("checkout", pr.base.ref)
-
-        commit_msg = f"Merge pull request #{pr.number} from {pr.head.user.login}/{pr.head.ref}"
+        shutil.rmtree("merge-repo", ignore_errors=True)
+        original_dir = os.getcwd()
         try:
-            self.git_run("merge", "PR", "-m", commit_msg)
-        except subprocess.CalledProcessError:
-            self.add_failed_comment(pr, "Unable to merge PR.")
-            self.add_pr_failed_label(pr)
-            return False
+            self.git_run("clone", f"https://{self.token}@github.com/{self.repo_name}.git", "merge-repo")
+            os.chdir("merge-repo")
+            self.git_run("fetch", "origin", f"pull/{pr.number}/head:PR")
+            self.git_run("checkout", pr.base.ref)
 
-        try:
-            self.git_run("push")
-            return True
-        except subprocess.CalledProcessError:
-            self.add_failed_comment(pr, "Unable to push merged revision.")
-            self.add_pr_failed_label(pr)
-            return False
+            commit_msg = f"Merge pull request #{pr.number} from {pr.head.user.login}/{pr.head.ref}"
+            try:
+                self.git_run("merge", "PR", "-m", commit_msg)
+            except subprocess.CalledProcessError:
+                self.add_failed_comment(pr, "Unable to merge PR.")
+                self.add_pr_failed_label(pr)
+                return False
+
+            try:
+                self.git_run("push")
+                return True
+            except subprocess.CalledProcessError:
+                self.add_failed_comment(pr, "Unable to push merged revision.")
+                self.add_pr_failed_label(pr)
+                return False
+        finally:
+            os.chdir(original_dir)
 
     def merge_pr(self, pr: PullRequest):
         self.logger.info("start merge %s into %s", pr, pr.base.ref)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -105,6 +105,7 @@ class PrAutomerger:
                 return False
         finally:
             os.chdir(original_dir)
+            shutil.rmtree("merge-repo", ignore_errors=True)
 
     def merge_pr(self, pr: PullRequest):
         self.logger.info("start merge %s into %s", pr, pr.base.ref)


### PR DESCRIPTION
## Summary
- Перевёл `Automerge PR` workflow на запуск раз в час с `cron: "17 * * * *"`.
- Добавил внутренний цикл запуска `automerge.py` (несколько итераций с паузой), чтобы один workflow-run обрабатывал PR в течение часа.
- Включено прерывание параллельных запусков через `concurrency.cancel-in-progress: true`.

## Why start at minute 17
Выбран запуск на `17`-й минуте часа, потому что в документации GitHub Actions есть оговорка: для cron, который срабатывает на круглых и часто используемых интервалах (например, `0 * * * *`, `*/5 * * * *`), запуск может задерживаться и не происходить строго вовремя из-за нагрузки на планировщик.  
Смещение на менее популярную минуту уменьшает риск таких задержек.

Решение работает, вот запуск https://github.com/ydb-platform/ydb/actions/runs/25457760643/job/74692588962

Через 10 минут после прохождение проверок влилось  https://github.com/ydb-platform/ydb/pull/39705#issuecomment-4391652528
<img width="748" height="380" alt="image" src="https://github.com/user-attachments/assets/8a724289-c357-4311-aab4-285ed339ad15" />


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
