### PR TITLE
Fix inflight retries problems with saturated disks in system tablet backup

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3036,6 +3036,8 @@ message TSystemTabletBackupConfig {
     }
     optional EFailBehaviour FailBehaviour = 6 [default = RETRY_BACKUP];
     optional uint32 RetryBackupTimeoutSeconds = 7 [default = 60];
+    optional uint32 RetryBackupMaxTimeoutSeconds = 8 [default = 900];
+    optional uint32 SnapshotWorkBudgetPercent = 9 [default = 25];
 }
 
 message TClusterDiagnosticsConfig {

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -72,9 +72,9 @@ namespace NTabletFlatExecutor {
                 Manager->MonCo->Simple()[TMonCo::BACKUP_RUNNING].Set(1);
             }
 
-            void Stop() {
+            void Stop(bool flush = false) {
                 if (Running) {
-                    Manager->Ops->Send(Writer, new TEvents::TEvPoisonPill);
+                    Manager->Ops->Send(Writer, new NBackup::TEvStop(flush));
 
                     Manager->MonCo->Simple()[TMonCo::BACKUP_RUNNING].Set(0);
                     Manager->MonCo->Simple()[TMonCo::BACKUP_CHANGELOG_INFLIGHT_BYTES].Set(0);

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -64,10 +64,9 @@ namespace NTabletFlatExecutor {
             {
             }
 
-            void Start(TActorId owner, TActorId changelogWriter, ui64 inFlightBytesLimit) {
+            void Start(TActorId owner, TActorId changelogWriter) {
                 Owner = owner;
                 Writer = changelogWriter;
-                InFlightBytesLimit = inFlightBytesLimit;
                 Running = true;
 
                 Manager->MonCo->Simple()[TMonCo::BACKUP_RUNNING].Set(1);
@@ -92,10 +91,6 @@ namespace NTabletFlatExecutor {
                     return false;
                 }
 
-                if (InFlightOverflow) {
-                    return false;
-                }
-
                 return commit.Type == ECommit::Redo;
             }
 
@@ -105,26 +100,7 @@ namespace NTabletFlatExecutor {
                 }
 
                 auto ev = MakeHolder<NBackup::TEvWriteChangelog>(commit.Step, commit.Embedded, commit.Refs, TActivationContext::Monotonic());
-                ui64 evSize = ev->GetTotalSize();
-                if (evSize <= InFlightBytesLimit - InFlightBytes) {
-                    InFlightBytes += evSize;
-                    Manager->Ops->Send(Writer, ev.Release());
-                    Manager->MonCo->Simple()[TMonCo::BACKUP_CHANGELOG_INFLIGHT_BYTES].Set(InFlightBytes);
-                } else {
-                    InFlightOverflow = true;
-                    auto error = TStringBuilder()
-                        << "Backup changelog in flight bytes limit exceeded: "
-                        << "InFlightBytes# " << InFlightBytes << ", "
-                        << "evSize# " << evSize << ", "
-                        << "InFlightBytesLimit# " << InFlightBytesLimit;
-                    TActivationContext::Send(new IEventHandle(Owner, Writer, new NBackup::TEvChangelogFailed(error)));
-                }
-            }
-
-            void OnProcessedBytes(ui64 bytes) {
-                Y_ENSURE(InFlightBytes >= bytes);
-                InFlightBytes -= bytes;
-                Manager->MonCo->Simple()[TMonCo::BACKUP_CHANGELOG_INFLIGHT_BYTES].Set(InFlightBytes);
+                Manager->Ops->Send(Writer, ev.Release());
             }
 
             void OnSnapshotCompleted(NBackup::TEvSnapshotCompleted::TPtr& ev) {
@@ -135,18 +111,11 @@ namespace NTabletFlatExecutor {
                 return Writer;
             }
 
-            ui64 GetInFlightBytes() const {
-                return InFlightBytes;
-            }
-
         private:
             TCommitManager* Manager = nullptr;
             TActorId Owner;
             TActorId Writer;
             bool Running = false;
-            ui64 InFlightBytes = 0;
-            ui64 InFlightBytesLimit = Max<ui64>();
-            bool InFlightOverflow = false;
         };
 
         TCommitManager(NBoot::TSteppedCookieAllocatorFactory &steppedCookieAllocatorFactory, TIntrusivePtr<NSnap::TWaste> waste, TGcLogic *logic)

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -48,6 +48,7 @@
 
 #include <util/generic/xrange.h>
 #include <util/generic/ymath.h>
+#include <util/random/random.h>
 
 
 #define LOG_BACKUP_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::LOCAL_DB_BACKUP, BackupLogPrefix() << stream)
@@ -5210,30 +5211,23 @@ void TExecutor::StartNewBackup() {
     if (snapshotWriter && changelogWriter) {
         LOG_BACKUP_N("Starting new backup" << " Type# " << tabletType << " Gen# " << Generation0 << " Step# " << Step0);
         auto snapshotWriterActor = Register(snapshotWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
+        const ui32 workBudgetPercent = std::clamp<ui32>(backupConfig.GetSnapshotWorkBudgetPercent(), 1, 100);
         for (const auto& [tableId, table] : tables) {
             if (exclusion && exclusion->HasTable(tableId)) {
                 continue;
             }
 
             auto opts = TScanOptions().SetResourceBroker("system_tablet_backup", 10);
-            QueueScan(tableId, NBackup::CreateSnapshotScan(snapshotWriterActor, tableId, table.Columns, exclusion), 0, opts);
+            QueueScan(tableId, NBackup::CreateSnapshotScan(snapshotWriterActor, tableId, table.Columns, exclusion, workBudgetPercent), 0, opts);
         }
         BackupSnapshotInProgress = true;
         Counters->Simple()[TExecutorCounters::BACKUP_SNAPSHOT_IN_PROGRESS].Set(1);
 
-        auto changelogWriterActor = Register(changelogWriter, TMailboxType::HTSwap, AppData()->IOPoolId);
-        CommitManager->BackupLogic.Start(SelfId(), changelogWriterActor, backupConfig.GetChangelogInFlightBytesLimit());
+        auto changelogWriterActor = Register(changelogWriter, TMailboxType::HTSwap, AppData()->SystemPoolId);
+        CommitManager->BackupLogic.Start(SelfId(), changelogWriterActor);
     } else {
         LOG_BACKUP_D("Backup not configured");
     }
-}
-
-void TExecutor::Handle(NBackup::TEvWriteChangelogAck::TPtr& ev) {
-    if (ev->Sender != CommitManager->BackupLogic.GetWriter()) {
-        return;
-    }
-
-    CommitManager->BackupLogic.OnProcessedBytes(ev->Get()->ProcessedBytes);
 }
 
 void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
@@ -5245,6 +5239,7 @@ void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
 
         if (CommitManager->BackupLogic.IsRunning()) {
             CommitManager->BackupLogic.OnSnapshotCompleted(ev);
+            BackupRetryAttempt = 0;
         } else {
             ScheduleRetryBackup();
         }
@@ -5275,11 +5270,18 @@ void TExecutor::FailBackup(const TString& error) {
     ScheduleRetryBackup();
 }
 
-void TExecutor::ScheduleRetryBackup() const {
+void TExecutor::ScheduleRetryBackup() {
     if (!BackupSnapshotInProgress) {
-        auto retryTimeout = TDuration::Seconds(AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
-        LOG_BACKUP_N("Scheduling backup retry" << " Timeout# " << retryTimeout);
+        ui64 baseSec = AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds();
+        ui64 maxSec = AppData()->SystemTabletBackupConfig.GetRetryBackupMaxTimeoutSeconds();
+        ui64 capSec = Min<ui64>(maxSec, baseSec << Min<ui32>(BackupRetryAttempt, 32));
+
+        auto retryTimeout = TDuration::Seconds(RandomNumber<ui64>(capSec + 1));
+        LOG_BACKUP_N("Scheduling backup retry"
+            << " Timeout# " << retryTimeout
+            << " Attempt# " << BackupRetryAttempt);
         Schedule(retryTimeout, new NBackup::TEvStartNewBackup);
+        ++BackupRetryAttempt;
     }
 }
 
@@ -5291,14 +5293,27 @@ void TExecutor::Handle(NBackup::TEvStartNewBackup::TPtr& ev) {
     StartNewBackup();
 }
 
+void TExecutor::Handle(NBackup::TEvWriteChangelogAck::TPtr& ev) {
+    if (ev->Sender != CommitManager->BackupLogic.GetWriter()) {
+        return;
+    }
+
+    Counters->Simple()[TExecutorCounters::BACKUP_CHANGELOG_INFLIGHT_BYTES].Add(ev->Get()->Bytes);
+}
+
 void TExecutor::Handle(NBackup::TEvSnapshotStats::TPtr& ev) {
     Counters->Cumulative()[TExecutorCounters::BACKUP_SNAPSHOT_BYTES_WRITTEN].Increment(ev->Get()->BytesWritten);
 }
 
 void TExecutor::Handle(NBackup::TEvChangelogStats::TPtr& ev) {
+    if (ev->Sender != CommitManager->BackupLogic.GetWriter()) {
+        return;
+    }
+
     const auto* msg = ev->Get();
     Counters->Cumulative()[TExecutorCounters::BACKUP_CHANGELOG_BYTES_WRITTEN].Increment(msg->BytesWritten);
-    Counters->Percentile()[TExecutorCounters::TX_PERCENTILE_BACKUP_CHANGELOG_FLUSH_LATENCY].IncrementFor(msg->FlushLatency.MicroSeconds());
+    Counters->Simple()[TExecutorCounters::BACKUP_CHANGELOG_INFLIGHT_BYTES].Sub(ev->Get()->BytesWritten);
+    Counters->Percentile()[TExecutorCounters::TX_PERCENTILE_BACKUP_CHANGELOG_FLUSH_LATENCY].IncrementFor(msg->Latency.MicroSeconds());
     Counters->Percentile()[TExecutorCounters::TX_PERCENTILE_BACKUP_CHANGELOG_LAG].IncrementFor(msg->Lag.MicroSeconds());
 }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5201,7 +5201,7 @@ void TExecutor::StartNewBackup() {
     Y_ENSURE(!BackupSnapshotInProgress);
 
     // Stop the old backup changelog
-    CommitManager->BackupLogic.Stop();
+    CommitManager->BackupLogic.Stop(true);
 
     auto* snapshotWriter = NBackup::CreateSnapshotWriter(SelfId(), backupConfig, tables, tabletType,
         tabletId, Generation0, Step0, scheme.GetSnapshot(), exclusion);

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5276,7 +5276,7 @@ void TExecutor::ScheduleRetryBackup() {
             const auto& backupConfig = AppData()->SystemTabletBackupConfig;
             auto initialDelay = TDuration::Seconds(Max<ui64>(backupConfig.GetRetryBackupTimeoutSeconds(), 1));
             auto maxDelay = TDuration::Seconds(Max<ui64>(backupConfig.GetRetryBackupMaxTimeoutSeconds(), 1));
-            BackupRetry.emplace(initialDelay, maxDelay);
+            BackupRetry.emplace(initialDelay, Max(initialDelay, maxDelay));
         }
 
         auto retryTimeout = BackupRetry->Next();

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5272,16 +5272,17 @@ void TExecutor::FailBackup(const TString& error) {
 
 void TExecutor::ScheduleRetryBackup() {
     if (!BackupSnapshotInProgress) {
-        ui64 baseSec = AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds();
-        ui64 maxSec = AppData()->SystemTabletBackupConfig.GetRetryBackupMaxTimeoutSeconds();
-        ui64 capSec = Min<ui64>(maxSec, baseSec << Min<ui32>(BackupRetryAttempt, 32));
+        ++BackupRetryAttempt;
 
-        auto retryTimeout = TDuration::Seconds(RandomNumber<ui64>(capSec + 1));
+        ui64 baseTimeoutSeconds = Max<ui64>(AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds(), 1);
+        ui64 maxTimeoutSeconds = Max<ui64>(AppData()->SystemTabletBackupConfig.GetRetryBackupMaxTimeoutSeconds(), 1);
+        ui64 halfTimeoutSeconds = Min<ui64>(maxTimeoutSeconds, baseTimeoutSeconds << Min<ui32>(BackupRetryAttempt, 32)) / 2;
+
+        auto retryTimeout = TDuration::Seconds(halfTimeoutSeconds + RandomNumber<ui64>(halfTimeoutSeconds + 1));
         LOG_BACKUP_N("Scheduling backup retry"
             << " Timeout# " << retryTimeout
             << " Attempt# " << BackupRetryAttempt);
         Schedule(retryTimeout, new NBackup::TEvStartNewBackup);
-        ++BackupRetryAttempt;
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -5239,7 +5239,7 @@ void TExecutor::Handle(NBackup::TEvSnapshotCompleted::TPtr& ev) {
 
         if (CommitManager->BackupLogic.IsRunning()) {
             CommitManager->BackupLogic.OnSnapshotCompleted(ev);
-            BackupRetryAttempt = 0;
+            BackupRetry.reset();
         } else {
             ScheduleRetryBackup();
         }
@@ -5272,16 +5272,17 @@ void TExecutor::FailBackup(const TString& error) {
 
 void TExecutor::ScheduleRetryBackup() {
     if (!BackupSnapshotInProgress) {
-        ++BackupRetryAttempt;
+        if (!BackupRetry) {
+            const auto& backupConfig = AppData()->SystemTabletBackupConfig;
+            auto initialDelay = TDuration::Seconds(Max<ui64>(backupConfig.GetRetryBackupTimeoutSeconds(), 1));
+            auto maxDelay = TDuration::Seconds(Max<ui64>(backupConfig.GetRetryBackupMaxTimeoutSeconds(), 1));
+            BackupRetry.emplace(initialDelay, maxDelay);
+        }
 
-        ui64 baseTimeoutSeconds = Max<ui64>(AppData()->SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds(), 1);
-        ui64 maxTimeoutSeconds = Max<ui64>(AppData()->SystemTabletBackupConfig.GetRetryBackupMaxTimeoutSeconds(), 1);
-        ui64 halfTimeoutSeconds = Min<ui64>(maxTimeoutSeconds, baseTimeoutSeconds << Min<ui32>(BackupRetryAttempt, 32)) / 2;
-
-        auto retryTimeout = TDuration::Seconds(halfTimeoutSeconds + RandomNumber<ui64>(halfTimeoutSeconds + 1));
+        auto retryTimeout = BackupRetry->Next();
         LOG_BACKUP_N("Scheduling backup retry"
             << " Timeout# " << retryTimeout
-            << " Attempt# " << BackupRetryAttempt);
+            << " Attempt# " << BackupRetry->GetIteration());
         Schedule(retryTimeout, new NBackup::TEvStartNewBackup);
     }
 }

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -29,6 +29,7 @@
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 #include <ydb/core/tablet/tablet_metrics.h>
+#include <ydb/core/util/backoff.h>
 #include <ydb/core/util/queue_oneone_inplace.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 
@@ -504,7 +505,7 @@ class TExecutor
     ui64 TransactionPagesMemory = 0;
 
     bool BackupSnapshotInProgress = false;
-    ui32 BackupRetryAttempt = 0;
+    std::optional<TBackoff> BackupRetry;
 
     TActorContext SelfCtx() const;
     TActorContext OwnerCtx() const;

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -504,6 +504,7 @@ class TExecutor
     ui64 TransactionPagesMemory = 0;
 
     bool BackupSnapshotInProgress = false;
+    ui32 BackupRetryAttempt = 0;
 
     TActorContext SelfCtx() const;
     TActorContext OwnerCtx() const;
@@ -560,7 +561,7 @@ class TExecutor
     void DropPageCollection(const TLogoBlobID& pageCollectionId);
     void StartNewBackup();
     void FailBackup(const TString& error);
-    void ScheduleRetryBackup() const;
+    void ScheduleRetryBackup();
     TStringBuilder BackupLogPrefix() const;
 
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -16,6 +16,7 @@
 #include <ydb/core/util/pb.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/io_dispatcher.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 #include <yql/essentials/types/binary_json/read.h>
@@ -517,12 +518,13 @@ private:
 class TBackupSnapshotScan : public IScan, public TActor<TBackupSnapshotScan> {
 public:
     TBackupSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, TColumn>& columns,
-                        TIntrusiveConstPtr<TBackupExclusion> exclusion)
+                        TIntrusiveConstPtr<TBackupExclusion> exclusion, ui32 workBudgetPercent)
         : TActor(&TThis::StateWork)
         , SnapshotWriter(snapshotWriter)
         , TableId(tableId)
         , Columns(columns)
         , Exclusion(exclusion)
+        , WorkBudgetPercent(workBudgetPercent)
     {}
 
     void Describe(IOutputStream& o) const override {
@@ -581,7 +583,15 @@ public:
     }
 
     void Handle(TEvWriteSnapshotAck::TPtr&) {
+        auto now = TActivationContext::Monotonic();
+        TDuration workTime = now - InFlightStartedAt;
+        TDuration sleepTime = workTime * (100 - WorkBudgetPercent) / WorkBudgetPercent;
+        Schedule(sleepTime, new TEvents::TEvWakeup);
+    }
+
+    void Handle() {
         InFlight = false;
+        InFlightStartedAt = TMonotonic::Zero();
         Driver->Touch(MaybeContinue());
     }
 
@@ -597,6 +607,7 @@ public:
 
     void SendBuffer(EScanStatus status = EScanStatus::InProgress) {
         InFlight = true;
+        InFlightStartedAt = TActivationContext::Monotonic();
         Send(SnapshotWriter, new TEvWriteSnapshot(TableId, std::move(Buffer), status));
     }
 
@@ -611,6 +622,7 @@ public:
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvWriteSnapshotAck, Handle);
+            cFunc(TEvents::TEvWakeup::EventType, Handle);
         }
     }
 
@@ -622,9 +634,11 @@ private:
     ui32 TableId;
     THashMap<ui32, TColumn> Columns;
     TIntrusiveConstPtr<TBackupExclusion> Exclusion;
+    ui32 WorkBudgetPercent;
 
     TBuffer Buffer;
     bool InFlight = false;
+    TMonotonic InFlightStartedAt;
 };
 
 class TChangelogSerializer {
@@ -780,24 +794,32 @@ private:
 class TChangelogWriter : public TActorBootstrapped<TChangelogWriter>, public IActorExceptionHandler {
     struct TEvPrivate {
         enum EEv {
-            EvFlush = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+            EvIoComplete = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
             EvEnd
         };
 
         static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE));
 
-        struct TEvFlush : TEventLocal<TEvFlush, EvFlush> {
-            TEvFlush(ui64 cookie)
-                : Cookie(cookie)
+        struct TEvIoComplete : TEventLocal<TEvIoComplete, EvIoComplete> {
+            TEvIoComplete(TDuration latency, TDuration lag)
+                : Latency(latency)
+                , Lag(lag)
             {}
 
-            ui64 Cookie;
+            TEvIoComplete(TString&& error)
+                : Error(std::move(error))
+            {}
+
+            TDuration Latency;
+            TDuration Lag;
+            TString Error;
         };
     };
 public:
     TChangelogWriter(TActorId owner, const TFsPath& path, const TScheme& schema,
                      TIntrusiveConstPtr<TBackupExclusion> exclusion,
-                     ui64 tabletId, ui32 generation, ui32 step)
+                     ui64 tabletId, ui32 generation, ui32 step,
+                     ui64 inFlightBytesLimit)
         : Owner(owner)
         , ChangelogPath(path.Child("changelog.json"))
         , ChangelogChecksumPath(path.Child("changelog.json.sha256"))
@@ -806,6 +828,7 @@ public:
         , TabletId(tabletId)
         , Generation(generation)
         , Step(step)
+        , InFlightBytesLimit(inFlightBytesLimit)
     {}
 
     TStringBuilder LogPrefix() const {
@@ -815,28 +838,18 @@ public:
     void Bootstrap() {
         LOG_N("Starting changelog" << " Path# " << ChangelogPath);
 
-        try {
-            ChangelogPath.Parent().MkDirs();
-            ChangelogFile = TFile(ChangelogPath, EOpenModeFlag::CreateNew | EOpenModeFlag::WrOnly);
-        } catch (const TIoException& e) {
-            return ReplyAndDie(TStringBuilder() << "Failed to create changelog file " << ChangelogPath << ": " << e.what());
-        }
-
-        try {
-            WriteChangelogChecksum();
-        } catch (const std::exception& e) {
-            return ReplyAndDie(TStringBuilder() << "Failed to write changelog checksum " << ChangelogChecksumPath << ": " << e.what());
-        }
+        // writing empty changelog and checksum files
+        BufferCreatedAt = TActivationContext::Monotonic();
+        StartIO();
 
         Become(&TThis::StateWork);
-        Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
     }
 
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvWriteChangelog, Handle);
-            hFunc(TEvPrivate::TEvFlush, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, FlushAndDie);
+            hFunc(TEvPrivate::TEvIoComplete, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
             hFunc(TEvSnapshotCompleted, Handle);
         }
     }
@@ -847,8 +860,7 @@ public:
         NJson::TJsonWriter writer(&out, BackupJsonConfig());
 
         const auto* msg = ev->Get();
-        const ui64 msgSize = msg->GetTotalSize();
-        LOG_D("Writing changelog" << " Step# " << msg->Step << " Bytes# " << msgSize);
+        LOG_D("Writing changelog" << " Step# " << msg->Step);
 
         TString dataUpdate;
         TString schemeUpdate;
@@ -946,13 +958,19 @@ public:
             if (!BufferCreatedAt) {
                 BufferCreatedAt = msg->CreatedAt;
             }
+
+            Send(Owner, new TEvWriteChangelogAck(changesSize));
         }
 
-        Send(Owner, new TEvWriteChangelogAck(msgSize));
-
-        if (Buffer.Size() >= 1_MB) {
-            Flush();
+        if (Buffer.Size() + IOInFlightBytes > InFlightBytesLimit) {
+            return ReplyAndDie(TStringBuilder()
+                << "Backup changelog in flight bytes limit exceeded: "
+                << "BufferBytes# " << Buffer.Size() << ", "
+                << "IOInFlightBytes# " << IOInFlightBytes << ", "
+                << "InFlightBytesLimit# " << InFlightBytesLimit);
         }
+
+        MaybeStartIO();
     }
 
     void Handle(TEvSnapshotCompleted::TPtr& ev) {
@@ -963,10 +981,30 @@ public:
         }
     }
 
-    void Handle(TEvPrivate::TEvFlush::TPtr& ev) {
-        if (ev->Get()->Cookie == ExpectedFlushCookie) {
-            Flush();
+    void Handle(TEvPrivate::TEvIoComplete::TPtr& ev) {
+        const auto* msg = ev->Get();
+
+        if (!msg->Error.empty()) {
+            return ReplyAndDie(msg->Error);
         }
+
+        LOG_D("Changelog IO completed"
+            << " Bytes# " << IOInFlightBytes
+            << " Latency# " << msg->Latency
+            << " Lag# " << msg->Lag);
+
+        Send(Owner, new TEvChangelogStats(IOInFlightBytes, msg->Latency, msg->Lag));
+
+        WrittenBytes += IOInFlightBytes;
+        IOInFlightBytes = 0;
+        IoInProgress = false;
+
+        if (NeedNewBackup()) {
+            LOG_N("Requesting new backup" << " ChangelogBytes# " << WrittenBytes << " SnapshotBytes# " << *SnapshotWrittenBytes);
+            Send(Owner, new TEvStartNewBackup());
+        }
+
+        MaybeStartIO();
     }
 
     bool NeedNewBackup() const {
@@ -975,68 +1013,69 @@ public:
             && WrittenBytes >= NewBackupChangelogMinBytes();
     }
 
-    void Flush() {
-        if (!Buffer.Empty()) {
-            THPTimer timer;
-            try {
-                ChangelogFile.Write(Buffer.data(), Buffer.size());
-                ChangelogFile.Flush();
-                WrittenBytes += Buffer.size();
-            } catch (const TIoException& e) {
-                return ReplyAndDie(TStringBuilder() << "Failed to write changelog data " << ChangelogFile.GetName() << ": " << e.what());
-            }
-            TDuration flushLatency = TDuration::Seconds(timer.Passed());
-
-            ui64 flushedBytes = Buffer.size();
-            Buffer.Clear();
-
-            Y_ENSURE(BufferCreatedAt);
-            TDuration lag = TActivationContext::Monotonic() - *BufferCreatedAt;
-            BufferCreatedAt = std::nullopt;
-
-            LOG_D("Flushed" << " Bytes# " << flushedBytes << " TotalBytes# " << WrittenBytes << " Lag# " << lag);
-            Send(Owner, new TEvChangelogStats(flushedBytes, flushLatency, lag));
-
-            try {
-                WriteChangelogChecksum();
-            } catch (const std::exception& e) {
-                return ReplyAndDie(TStringBuilder() << "Failed to write changelog checksum " << ChangelogChecksumPath << ": " << e.what());
-            }
-
-            if (Dying) {
-                return;
-            }
-
-            if (NeedNewBackup()) {
-                LOG_N("Requesting new backup" << " ChangelogBytes# " << WrittenBytes << " SnapshotBytes# " << *SnapshotWrittenBytes);
-                Send(Owner, new TEvStartNewBackup());
-            }
+    void MaybeStartIO() {
+        if (IoInProgress || Buffer.Empty()) {
+            return;
         }
-        Schedule(TDuration::Seconds(5), new TEvPrivate::TEvFlush(++ExpectedFlushCookie));
+
+        StartIO();
     }
 
-    void FlushAndDie() {
-        Dying = true;
-        Flush();
-        LOG_N("Everything is flushed, shutting down");
-        PassAway();
+    void StartIO() {
+        LOG_D("Starting Changelog IO" << " Bytes# " << Buffer.Size());
+
+        IOInFlightBytes = Buffer.Size();
+        IoInProgress = true;
+
+        Y_ENSURE(BufferCreatedAt);
+        TMonotonic lagStart = *BufferCreatedAt;
+        BufferCreatedAt = std::nullopt;
+
+        auto selfId = SelfId();
+        auto changelogPath = ChangelogPath;
+        auto checksumPath = ChangelogChecksumPath;
+        auto* actorSystem = TActivationContext::ActorSystem();
+
+        NActors::InvokeIoCallback(
+            [data = std::move(Buffer), checksum = Checksum.Intermediate(), changelogPath, checksumPath,
+             selfId, actorSystem, lagStart]() {
+                THPTimer timer;
+                try {
+                    WriteChangelog(changelogPath, data);
+                    WriteChangelogChecksum(checksumPath, checksum);
+                } catch (const std::exception& e) {
+                    actorSystem->Send(selfId, new TEvPrivate::TEvIoComplete(
+                        TStringBuilder() << "Failed to write changelog data: " << e.what()));
+                    return;
+                }
+                TDuration latency = TDuration::Seconds(timer.Passed());
+                TDuration lag = actorSystem->Monotonic() - lagStart;
+                actorSystem->Send(selfId, new TEvPrivate::TEvIoComplete(latency, lag));
+            },
+            AppData()->IOPoolId,
+            IActor::EActivityType::OTHER);
     }
 
     void ReplyAndDie(const TString& error) {
-        if (!Dying) {
-            LOG_E("Changelog failed" << " Error# " << error);
-            Send(Owner, new TEvChangelogFailed(error));
-            PassAway();
-        }
+        LOG_E("Changelog failed" << " Error# " << error);
+        Send(Owner, new TEvChangelogFailed(error));
+        PassAway();
     }
 
-    void WriteChangelogChecksum() {
-        TFsPath tmpPath(ChangelogChecksumPath.GetPath() + ".tmp");
+    static void WriteChangelog(const TFsPath& changelogPath, const TBuffer& data) {
+        changelogPath.Parent().MkDirs();
+        TFile file(changelogPath, EOpenModeFlag::OpenAlways | EOpenModeFlag::ForAppend);
+        file.Write(data.Data(), data.Size());
+        file.Flush();
+    }
+
+    static void WriteChangelogChecksum(const TFsPath& checksumPath, const TString& checksum) {
+        TFsPath tmpPath(checksumPath.GetPath() + ".tmp");
         TFileOutput out(tmpPath);
-        out.Write(Checksum.Intermediate());
+        out.Write(checksum);
         out.Flush();
-        tmpPath.RenameTo(ChangelogChecksumPath);
-        TFile(ChangelogChecksumPath.Parent(), EOpenModeFlag::RdOnly).Flush();
+        tmpPath.RenameTo(checksumPath);
+        TFile(checksumPath.Parent(), EOpenModeFlag::RdOnly).Flush();
     }
 
     bool OnUnhandledException(const std::exception& exc) override {
@@ -1049,7 +1088,6 @@ private:
 
     TFsPath ChangelogPath;
     TFsPath ChangelogChecksumPath;
-    TFile ChangelogFile;
 
     TScheme Schema;
     TIntrusiveConstPtr<TBackupExclusion> Exclusion;
@@ -1059,9 +1097,11 @@ private:
     const ui32 Step;
 
     TBuffer Buffer;
-    ui64 ExpectedFlushCookie = 0;
+    ui64 IOInFlightBytes = 0;
+    bool IoInProgress = false;
 
-    bool Dying = false;
+    const ui64 InFlightBytesLimit;
+
     ui64 WrittenBytes = 0;
     std::optional<ui64> SnapshotWrittenBytes;
 
@@ -1084,9 +1124,9 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
 }
 
 IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, TColumn>& columns,
-                          TIntrusiveConstPtr<TBackupExclusion> exclusion)
+                          TIntrusiveConstPtr<TBackupExclusion> exclusion, ui32 workBudgetPercent)
 {
-    return new TBackupSnapshotScan(snapshotWriter, tableId, columns, exclusion);
+    return new TBackupSnapshotScan(snapshotWriter, tableId, columns, exclusion, workBudgetPercent);
 }
 
 IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
@@ -1096,7 +1136,8 @@ IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTablet
     if (config.HasFilesystem()) {
         auto path = TFsPath(config.GetFilesystem().GetPath())
             .Child(CreateBackupPath(tabletType, tabletId, generation, step));
-        return new TChangelogWriter(owner, path, schema, exclusion, tabletId, generation, step);
+        return new TChangelogWriter(owner, path, schema, exclusion, tabletId, generation, step,
+                                    config.GetChangelogInFlightBytesLimit());
     } else {
         return nullptr;
     }

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -634,7 +634,7 @@ private:
     ui32 TableId;
     THashMap<ui32, TColumn> Columns;
     TIntrusiveConstPtr<TBackupExclusion> Exclusion;
-    ui32 WorkBudgetPercent;
+    const ui32 WorkBudgetPercent;
 
     TBuffer Buffer;
     bool InFlight = false;

--- a/ydb/core/tablet_flat/flat_executor_backup.cpp
+++ b/ydb/core/tablet_flat/flat_executor_backup.cpp
@@ -838,9 +838,9 @@ public:
     void Bootstrap() {
         LOG_N("Starting changelog" << " Path# " << ChangelogPath);
 
-        // writing empty changelog and checksum files
+        // writing initial changelog and checksum files
         BufferCreatedAt = TActivationContext::Monotonic();
-        StartIO();
+        StartIO(EOpenModeFlag::CreateNew);
 
         Become(&TThis::StateWork);
     }
@@ -849,7 +849,7 @@ public:
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvWriteChangelog, Handle);
             hFunc(TEvPrivate::TEvIoComplete, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+            hFunc(TEvStop, Handle);
             hFunc(TEvSnapshotCompleted, Handle);
         }
     }
@@ -962,11 +962,11 @@ public:
             Send(Owner, new TEvWriteChangelogAck(changesSize));
         }
 
-        if (Buffer.Size() + IOInFlightBytes > InFlightBytesLimit) {
+        if (Buffer.Size() + IoInFlightBytes > InFlightBytesLimit) {
             return ReplyAndDie(TStringBuilder()
                 << "Backup changelog in flight bytes limit exceeded: "
                 << "BufferBytes# " << Buffer.Size() << ", "
-                << "IOInFlightBytes# " << IOInFlightBytes << ", "
+                << "IOInFlightBytes# " << IoInFlightBytes << ", "
                 << "InFlightBytesLimit# " << InFlightBytesLimit);
         }
 
@@ -989,14 +989,14 @@ public:
         }
 
         LOG_D("Changelog IO completed"
-            << " Bytes# " << IOInFlightBytes
+            << " Bytes# " << IoInFlightBytes
             << " Latency# " << msg->Latency
             << " Lag# " << msg->Lag);
 
-        Send(Owner, new TEvChangelogStats(IOInFlightBytes, msg->Latency, msg->Lag));
+        Send(Owner, new TEvChangelogStats(IoInFlightBytes, msg->Latency, msg->Lag));
 
-        WrittenBytes += IOInFlightBytes;
-        IOInFlightBytes = 0;
+        WrittenBytes += IoInFlightBytes;
+        IoInFlightBytes = 0;
         IoInProgress = false;
 
         if (NeedNewBackup()) {
@@ -1005,6 +1005,14 @@ public:
         }
 
         MaybeStartIO();
+    }
+
+    void Handle(TEvStop::TPtr& ev) {
+        if (ev->Get()->Flush && IoInProgress && !Buffer.Empty()) {
+            DieAfterIo = true;
+        } else {
+            PassAway();
+        }
     }
 
     bool NeedNewBackup() const {
@@ -1019,12 +1027,16 @@ public:
         }
 
         StartIO();
+
+        if (DieAfterIo) {
+            PassAway();
+        }
     }
 
-    void StartIO() {
+    void StartIO(EOpenMode openMode = EOpenModeFlag::OpenExisting | EOpenModeFlag::ForAppend) {
         LOG_D("Starting Changelog IO" << " Bytes# " << Buffer.Size());
 
-        IOInFlightBytes = Buffer.Size();
+        IoInFlightBytes = Buffer.Size();
         IoInProgress = true;
 
         Y_ENSURE(BufferCreatedAt);
@@ -1038,10 +1050,10 @@ public:
 
         NActors::InvokeIoCallback(
             [data = std::move(Buffer), checksum = Checksum.Intermediate(), changelogPath, checksumPath,
-             selfId, actorSystem, lagStart]() {
+             selfId, actorSystem, lagStart, openMode]() {
                 THPTimer timer;
                 try {
-                    WriteChangelog(changelogPath, data);
+                    WriteChangelog(changelogPath, data, openMode);
                     WriteChangelogChecksum(checksumPath, checksum);
                 } catch (const std::exception& e) {
                     actorSystem->Send(selfId, new TEvPrivate::TEvIoComplete(
@@ -1062,9 +1074,9 @@ public:
         PassAway();
     }
 
-    static void WriteChangelog(const TFsPath& changelogPath, const TBuffer& data) {
+    static void WriteChangelog(const TFsPath& changelogPath, const TBuffer& data, EOpenMode openMode) {
         changelogPath.Parent().MkDirs();
-        TFile file(changelogPath, EOpenModeFlag::OpenAlways | EOpenModeFlag::ForAppend);
+        TFile file(changelogPath, openMode);
         file.Write(data.Data(), data.Size());
         file.Flush();
     }
@@ -1097,8 +1109,9 @@ private:
     const ui32 Step;
 
     TBuffer Buffer;
-    ui64 IOInFlightBytes = 0;
+    ui64 IoInFlightBytes = 0;
     bool IoInProgress = false;
+    bool DieAfterIo = false;
 
     const ui64 InFlightBytesLimit;
 

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -83,14 +83,6 @@ struct TEvWriteChangelog : public TEventLocal<TEvWriteChangelog, EvWriteChangelo
         , CreatedAt(createdAt)
     {}
 
-    ui64 GetTotalSize() const {
-        ui64 totalSize = EmbeddedLogBody.size();
-        for (const auto& ref : References) {
-            totalSize += ref.Buffer.size();
-        }
-        return totalSize;
-    }
-
     ui32 Step;
     TString EmbeddedLogBody;
     TVector<TEvTablet::TLogEntryReference> References;
@@ -98,11 +90,11 @@ struct TEvWriteChangelog : public TEventLocal<TEvWriteChangelog, EvWriteChangelo
 };
 
 struct TEvWriteChangelogAck : public TEventLocal<TEvWriteChangelogAck, EvWriteChangelogAck> {
-    TEvWriteChangelogAck(ui64 processedBytes)
-        : ProcessedBytes(processedBytes)
+    TEvWriteChangelogAck(ui64 bytes)
+        : Bytes(bytes)
     {}
 
-    ui64 ProcessedBytes;
+    ui64 Bytes;
 };
 
 struct TEvChangelogFailed : public TEventLocal<TEvChangelogFailed, EvChangelogFailed> {
@@ -124,14 +116,14 @@ struct TEvSnapshotStats : public TEventLocal<TEvSnapshotStats, EvSnapshotStats> 
 };
 
 struct TEvChangelogStats : public TEventLocal<TEvChangelogStats, EvChangelogStats> {
-    TEvChangelogStats(ui64 bytesWritten, TDuration flushLatency, TDuration lag)
+    TEvChangelogStats(ui64 bytesWritten, TDuration latency, TDuration lag)
         : BytesWritten(bytesWritten)
-        , FlushLatency(flushLatency)
+        , Latency(latency)
         , Lag(lag)
     {}
 
     ui64 BytesWritten;
-    TDuration FlushLatency;
+    TDuration Latency;
     TDuration Lag;
 };
 
@@ -141,7 +133,8 @@ IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletB
                              TAutoPtr<NTable::TSchemeChanges> schema, TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
 
 NTable::IScan* CreateSnapshotScan(TActorId snapshotWriter, ui32 tableId, const THashMap<ui32, NTable::TColumn>& columns,
-                                  TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion);
+                                  TIntrusiveConstPtr<NTable::TBackupExclusion> exclusion,
+                                  ui32 workBudgetPercent);
 
 IActor* CreateChangelogWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,
                               TTabletTypes::EType tabletType, ui64 tabletId, ui32 generation, ui32 step,

--- a/ydb/core/tablet_flat/flat_executor_backup.h
+++ b/ydb/core/tablet_flat/flat_executor_backup.h
@@ -32,6 +32,8 @@ enum EEv {
     EvSnapshotStats,
     EvChangelogStats,
 
+    EvStop,
+
     EvEnd
 };
 
@@ -125,6 +127,14 @@ struct TEvChangelogStats : public TEventLocal<TEvChangelogStats, EvChangelogStat
     ui64 BytesWritten;
     TDuration Latency;
     TDuration Lag;
+};
+
+struct TEvStop : public TEventLocal<TEvStop, EvStop> {
+    TEvStop(bool flush = false)
+        : Flush(flush)
+    {}
+
+    bool Flush;
 };
 
 IActor* CreateSnapshotWriter(TActorId owner, const NKikimrConfig::TSystemTabletBackupConfig& config,

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -2761,7 +2761,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         TEnv env;
 
         // Small limit
-        env->GetAppData().SystemTabletBackupConfig.SetNewBackupChangelogMinBytes(100);
+        env->GetAppData().SystemTabletBackupConfig.SetNewBackupChangelogMinBytes(10_KB);
 
         Cerr << "...starting tablet" << Endl;
         env.FireDummyTablet(TestTabletFlags);

--- a/ydb/core/tablet_flat/ut/ut_backup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_backup.cpp
@@ -1267,7 +1267,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         TFsPath(env->GetTempDir()).Child("dummy").ForceDelete();
 
         Cerr << "...backup retry should start automatically" << Endl;
-        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        auto retryTimeout = TDuration::Seconds(2 * env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
         env.Env.AdvanceCurrentTime(retryTimeout);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
     }
@@ -1297,7 +1297,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         TFsPath(env->GetTempDir()).Child("dummy").ForceDelete();
 
         Cerr << "...backup retry should start automatically" << Endl;
-        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        auto retryTimeout = TDuration::Seconds(2 * env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
         env.Env.AdvanceCurrentTime(retryTimeout);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
     }
@@ -3451,7 +3451,7 @@ Y_UNIT_TEST_SUITE(Backup) {
         UNIT_ASSERT_VALUES_EQUAL(env.ReadValue<TSchema::Data::Value>(3), 30);
 
         Cerr << "...backup retry should start automatically" << Endl;
-        auto retryTimeout = TDuration::Seconds(env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
+        auto retryTimeout = TDuration::Seconds(2 * env->GetAppData().SystemTabletBackupConfig.GetRetryBackupTimeoutSeconds());
         env.Env.AdvanceCurrentTime(retryTimeout);
         env.WaitFor<NFake::TEvSnapshotBackedUp>();
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Added**:
1. Backoff with jitter for backup retries. It prevents thundering herd when all tablets retry backup at the same time and saturate disk.
2. Snapshot scan throttling via a configurable work-budget. It prevents snapshot from saturating disk.
3. Async changelog I/O via InvokeIoCallback. It allows to immediately stop writing changelog when its inflight reached over the limit.

