### PR TITLE
Datashard bloom filter improvements

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1179,10 +1179,21 @@ public:
             // DataShard LocalBloomFilter: not a real secondary index — maps to ByKeyFilterPrefixes
             // in the partition config via ESchemeOpAlterTable. ColumnShard LocalBloomFilter is
             // handled by AlterColumnTable and never reaches this path.
-            const bool isLocalBloom = std::all_of(req.add_indexes().begin(), req.add_indexes().end(),
+            const bool hasLocalBloom = std::any_of(req.add_indexes().begin(), req.add_indexes().end(),
                 [](const auto& idx) {
                     return idx.type_case() == Ydb::Table::TableIndex::kLocalBloomFilterIndex;
                 });
+            const bool isLocalBloom = hasLocalBloom && std::all_of(req.add_indexes().begin(), req.add_indexes().end(),
+                [](const auto& idx) {
+                    return idx.type_case() == Ydb::Table::TableIndex::kLocalBloomFilterIndex;
+                });
+            if (hasLocalBloom && !isLocalBloom) {
+                IKqpGateway::TGenericResult errResult;
+                errResult.AddIssue(NYql::TIssue("ALTER TABLE cannot mix LocalBloomFilter indexes with secondary indexes in a single request"));
+                errResult.SetStatus(NYql::YqlStatusFromYdbStatus(Ydb::StatusIds::BAD_REQUEST));
+                tablePromise.SetValue(errResult);
+                return tablePromise.GetFuture();
+            }
 
             if (isLocalBloom) {
                 Ydb::StatusIds::StatusCode code;

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1959,7 +1959,7 @@ public:
                 if (desc.FalsePositiveProbability) {
                     proto->set_false_positive_probability(*desc.FalsePositiveProbability);
                 }
-                
+
                 if (desc.CaseSensitive) {
                     proto->set_case_sensitive(*desc.CaseSensitive);
                 }
@@ -2573,7 +2573,7 @@ public:
                                 const auto& pk = table.Metadata->KeyColumnNames;
                                 const auto& idxCols = add_index->index_columns();
                                 bool validPrefix = static_cast<size_t>(idxCols.size()) <= pk.size();
-                                for (int i = 0; validPrefix && i < idxCols.size(); ++i) {
+                                for (size_t i = 0; validPrefix && i < static_cast<size_t>(idxCols.size()); ++i) {
                                     validPrefix = (idxCols[i] == pk[i]);
                                 }
                                 if (!validPrefix) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1715,6 +1715,14 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=1);
         )");
+        // Mixing a LocalBloomFilter index with a regular secondary index in a single ALTER TABLE
+        // The bloom path and the BuildOperation path are dispatched mutually exclusively.
+        expectBadRequest(R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T`
+                ADD INDEX idx_bloom_mix LOCAL USING bloom_filter ON (Key1),
+                ADD INDEX idx_global_mix GLOBAL ON (Value);
+        )");
     }
 
     void CreateTableWithReadReplicas(bool compat) {

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -1,5 +1,6 @@
 #include "flat_dbase_apply.h"
 #include "util_fmt_abort.h"
+#include "bloom_filter_defaults.h"
 
 #include <ydb/core/base/localdb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
@@ -177,6 +178,7 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
                     Y_ENSURE(len <= keyCount,
                         "Bloom filter prefix " << len << " exceeds key column count " << keyCount);
                     double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : DefaultBloomFilterFpp;
+                    Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
                     prefixMap[len] = fpp;
                 }
             }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4833,6 +4833,10 @@ bool TExecutor::HasSchemaChanges(const NTable::TPartView& partView, const NTable
     }
 
     { // Check bloom filters
+        // Note: Both ByKeyPrefixes and ByKeyFilterPrefixes are sorted by prefix length.
+        // This invariant is maintained by TPart constructor validation and by the sorted TMap
+        // intermediate used when building ByKeyFilterPrefixes in flat_dbase_apply.cpp.
+        // Positional comparison is safe as long as this ordering is preserved.
         if (partView->ByKeyPrefixes.size() != tableInfo.ByKeyFilterPrefixes.size()) {
             return true;
         }

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -88,12 +88,12 @@ void TLoader::StageParseMeta()
             for (bool history : {false, true}) {
                 for (const auto &meta : history ? layout.GetBTreeHistoricIndexes() : layout.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
-                        meta.GetRootPageId(), 
-                        meta.GetRowCount(), 
+                        meta.GetRootPageId(),
+                        meta.GetRowCount(),
                         meta.GetDataSize(),
                         meta.GetGroupDataSize(),
-                        meta.GetErasedRowCount()}, 
-                        meta.GetLevelCount(), 
+                        meta.GetErasedRowCount()},
+                        meta.GetLevelCount(),
                         meta.GetIndexSize()};
                     (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);
                 }
@@ -143,7 +143,7 @@ void TLoader::StageParseMeta()
         Y_TABLET_ERROR("Part " << PageCollections[0]->PageCollection->Label() << " has"
             << " invalid layout : " << (Rooted ? "rooted" : "legacy")
             << " " << PageCollections.size() << "s " << meta.TotalPages() << "pg"
-            << ", Scheme " << SchemeId 
+            << ", Scheme " << SchemeId
             << ", FlatIndex " << (FlatGroupIndexes.size() ? FlatGroupIndexes[0] : Max<TPageId>())
             << ", BTreeIndex " << (BTreeGroupIndexes.size() ? BTreeGroupIndexes[0].GetPageId() : Max<TPageId>())
             << ", Blobs " << GlobsId << ", Small " << SmallId
@@ -159,8 +159,8 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
     Y_ENSURE(PageCollections && PageCollections.front());
 
     auto getPage = [&](TPageId pageId) {
-        return pageId == Max<TPageId>() 
-            ? nullptr 
+        return pageId == Max<TPageId>()
+            ? nullptr
             : LoaderEnv->TryGetPage(nullptr, pageId, {});
     };
 
@@ -255,6 +255,8 @@ TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
             [&](const auto& meta) { return meta.PageId == ByKeyId; });
         if (!alreadyPresent) {
             ui32 keyCount = partScheme->Groups[0].KeyTypes.size();
+            // Appending at the end maintains sorted order because keyCount (full key)
+            // is always >= any prefix length in ByKeyPrefixMetas.
             byKeyPrefixes.emplace_back(keyCount, new NPage::TBloom(*byKey));
         }
     }
@@ -349,7 +351,7 @@ TLoader::TFetch TLoader::StagePreloadData()
 {
     auto partStore = PartView.As<TPartStore>();
 
-    // Note: preload works only for main group pages    
+    // Note: preload works only for main group pages
     auto total = partStore->PageCollections[0]->PageCollection->Total();
 
     TVector<TPageId> toLoad(::Reserve(total));

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -147,11 +147,13 @@ namespace NTable {
 
         bool MightHaveKeyPrefix(const NBloom::TPrefix& prefix) const
         {
-            // ByKeyPrefixes are sorted by prefixLen; pick the longest (most selective) filter
+            // Check from the longest (most selective) prefix first
             for (auto it = ByKeyPrefixes.rbegin(); it != ByKeyPrefixes.rend(); ++it) {
                 const auto& [prefixLen, bloom] = *it;
                 if (bloom && prefixLen > 0) {
-                    return bloom->MightHave(prefix.Get(prefixLen));
+                    if (!bloom->MightHave(prefix.Get(prefixLen))) {
+                        return false;
+                    }
                 }
             }
             return true;

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -490,6 +490,7 @@ void TUserTable::DoApplyCreate(
         for (const auto& p : partConfig.GetByKeyFilterPrefixes()) {
             if (p.GetPrefixLength() > 0) {
                 double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
                 prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
@@ -643,6 +644,7 @@ void TUserTable::ApplyAlter(
         for (const auto& p : config.GetByKeyFilterPrefixes()) {
             if (p.GetPrefixLength() > 0) {
                 double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
                 prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
@@ -663,6 +665,7 @@ void TUserTable::ApplyAlter(
             for (const auto& p : configDelta.GetByKeyFilterPrefixes()) {
                 if (p.GetPrefixLength() > 0) {
                     double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                    Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
                     prefixMap[p.GetPrefixLength()] = fpp;
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1140,12 +1140,20 @@ bool TPartitionConfigMerger::ApplyChanges(
         for (const auto& p : result.GetByKeyFilterPrefixes()) {
             if (p.GetPrefixLength() > 0) {
                 double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                if (fpp <= 0.0 || fpp >= 1.0) {
+                    errDescr = TStringBuilder() << "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)";
+                    return false;
+                }
                 prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
         for (const auto& p : changes.GetByKeyFilterPrefixes()) {
             if (p.GetPrefixLength() > 0) {
                 double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
+                if (fpp <= 0.0 || fpp >= 1.0) {
+                    errDescr = TStringBuilder() << "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)";
+                    return false;
+                }
                 prefixMap[p.GetPrefixLength()] = fpp;
             }
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Missing FPP validation at data layer — invalid `FalsePositiveProbability` values (≤0 or ≥1) from proto can cause undefined behavior via `static_cast<ui64>(std::ceil(-std::log2(fpp)))` — `flat_dbase_apply.cpp:179`, `flat_executor.cpp:4839`
- `MightHaveKeyPrefix` only checks the longest bloom filter instead of all — contradicts PR description stating "all bloom filters are checked" — `flat_table_part.h:150`
- Mixed bloom/non-bloom indexes in a single ALTER TABLE request causes bloom indexes to go through the wrong code path — `kqp_gateway_proxy.cpp:1159`
- Signed/unsigned comparison — loop variable `int i` compared with `idxCols.size()` returning unsigned — `yql_kikimr_exec.cpp:2512`
- Legacy bloom filter appended without explicit sort in loader — `flat_part_loader.cpp:258`
- `HasSchemaChanges` compares bloom filters positionally — correctness relies on both vectors being sorted, which is implicitly guaranteed but fragile — `flat_executor.cpp:4832`

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
