### PR TITLE
mkql_proto: improve error message when TYPE_NOT_SET in ImportTypeFromProto

### DIFF
--- a/ydb/library/mkql_proto/mkql_proto.cpp
+++ b/ydb/library/mkql_proto/mkql_proto.cpp
@@ -1476,6 +1476,10 @@ TType* TProtoImporter::ImportTypeFromProto(const Ydb::Type& input) {
             }
             break;
         }
+        case Ydb::Type::TYPE_NOT_SET:
+            ythrow yexception() << "Protobuf type is not set (TYPE_NOT_SET). "
+                "Possible cause: an empty list [] was passed as a query parameter without an explicit type declaration. "
+                "Use DECLARE $param AS List<SomeType> to specify the parameter type.";
         default: {
             ythrow yexception() << "Unknown protobuf type: "
                                 << input.DebugString();


### PR DESCRIPTION
## Problem

When a query parameter is an empty list `[]` without an explicit `DECLARE`, the SDK sends a `Ydb::Type` with `type_case() == TYPE_NOT_SET` (value 0). This falls into the `default` branch of the `switch` in `ImportTypeFromProto`, which produces:

```
Unknown protobuf type: 
```

The trailing space with no content comes from `input.DebugString()` returning an empty string for an unset oneof — completely unhelpful for the user.

## Fix

Add an explicit `case Ydb::Type::TYPE_NOT_SET:` before `default:` with a message that explains the likely cause and suggests the fix:

```
Protobuf type is not set (TYPE_NOT_SET). Possible cause: an empty list [] was passed as a query parameter without an explicit type declaration. Use DECLARE $param AS List<SomeType> to specify the parameter type.
```

The `default:` branch is retained for any genuinely unknown future type values.

## Reproducer

```python
import ydb
# pass [] without DECLARE — triggers TYPE_NOT_SET
session.execute("SELECT * FROM t WHERE id IN $ids", {"$ids": []})
```