### PR TITLE
Improve dev ui memory page backtraces

### DIFF
--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -922,10 +922,29 @@ public:
         Token = tcmalloc::MallocExtension::StartAllocationProfiling();
     }
 
+    static bool UseDwarfBacktracePrinting() {
+        const TAppData* appData = AppData();
+        if (!appData) {
+            return false;
+        }
+
+        const auto& icb = appData->Icb;
+        if (!icb) {
+            return false;
+        }
+
+        const auto value = icb->TCMallocControls.UseDwarfBacktracePrinting.AtomicLoad();
+        if (!value) {
+            return false;
+        }
+
+        return value->Get();
+    }
+
     void Stop(IOutputStream& out, size_t countLimit, bool forLog) override {
         auto profile = std::move(Token).Stop();
 
-        const bool useDwarfBacktracePrinting = AppData()->Icb->TCMallocControls.UseDwarfBacktracePrinting.AtomicLoad()->Get();
+        const bool useDwarfBacktracePrinting = UseDwarfBacktracePrinting();
         TAllocationAnalyzer analyzer(std::move(profile), useDwarfBacktracePrinting);
         TAllocationStats allocationStats;
         analyzer.Prepare(&allocationStats);

--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -6,10 +6,12 @@
 #include <ydb/core/mon/mon.h>
 #include <ydb/library/actors/prof/tag.h>
 
+#include <library/cpp/svnversion/svnversion.h>
 #include <library/cpp/cache/cache.h>
 #if defined(USE_DWARF_BACKTRACE)
 #   include <library/cpp/dwarf_backtrace/backtrace.h>
 #endif
+#include <library/cpp/html/escape/escape.h>
 #include <library/cpp/html/pcdata/pcdata.h>
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/svnversion/svnversion.h>
@@ -216,10 +218,31 @@ class TAllocationAnalyzer {
 private:
 // Using DWARF to resolve backtraces is expensive - i.e. the cloud disk I/O may block process for minutes, while loading debug sections.
 #if defined(USE_DWARF_BACKTRACE)
-    void PrintDwarfBackTrace(IOutputStream& out, void* const* stack, size_t size, const char* sep) {
+    void PrintDwarfBackTrace(IOutputStream& out, void* const* stack, size_t size, const char* sep, bool forLog) {
+        static const TStringBuf commitId = GetProgramCommitId() ? GetProgramCommitId() : "";
         // TODO: ignore symbol cache for now - because of inlines.
         if (auto error = NDwarf::ResolveBacktrace(TArrayRef<const void* const>(stack, size), [&](const NDwarf::TLineInfo& info) {
-            out << "#" << info.Index << " " << info.FunctionName << " at " << info.FileName << ':' << info.Line << sep;
+            out << "#" << info.Index << " ";
+            if (forLog) {
+                out << info.FunctionName;
+            } else {
+                out << NHtml::EscapeText(info.FunctionName);
+            }
+            out << " at ";
+            constexpr TStringBuf repositoryRootPrefix = "/-S/";
+            if (info.FileName.StartsWith(repositoryRootPrefix)) {
+                const TStringBuf fileName = info.FileName;
+                const TStringBuf relativePath = TStringBuf(fileName).Skip(repositoryRootPrefix.size());
+                if (!forLog && commitId) {
+                    out << "<a href=\"https://github.com/ydb-platform/ydb/blob/" << commitId << '/'
+                        << relativePath << "#L" << info.Line << "\" target=\"_blank\">"
+                        << relativePath << ':' << info.Line << "</a>" << sep;
+                } else {
+                    out << relativePath << ':' << info.Line << sep;
+                }
+            } else {
+                out << info.FileName << ':' << info.Line << sep;
+            }
             return NDwarf::EResolving::Continue;
         })) {
             // TODO: print error message.
@@ -251,7 +274,7 @@ private:
         }
     }
 
-    void PrintBackTrace(IOutputStream& out, void* const* stack, size_t sz, const char* sep) {
+    void PrintBackTrace(IOutputStream& out, void* const* stack, size_t sz, const char* sep, bool forLog) {
 #if defined(USE_DWARF_BACKTRACE)
         if (UseDwarfBacktracePrinting) {
             PrintDwarfBackTrace(out, stack, sz, sep, forLog);
@@ -273,7 +296,7 @@ private:
     }
 
     void PrintStack(IOutputStream& out, const TStackStats* stats, size_t sampleCountLimit,
-        const char* marker, const char* sep)
+        const char* marker, const char* sep, bool forLog)
     {
         std::vector<const tcmalloc::Profile::Sample*> samples;
         samples.reserve(stats->Samples.size());
@@ -310,7 +333,7 @@ private:
 
         if (samples.size()) {
             const auto& sample = samples.front();
-            PrintBackTrace(out, sample->stack, sample->depth, sep);
+            PrintBackTrace(out, sample->stack, sample->depth, sep, forLog);
         }
         out << Endl;
     }
@@ -420,7 +443,7 @@ public:
 
         size_t i = 0;
         for (const auto* stackStats : stats) {
-            PrintStack(out, stackStats, sampleCountLimit, marker, sep);
+            PrintStack(out, stackStats, sampleCountLimit, marker, sep, forLog);
             if (++i >= stackCountLimit) {
                 break;
             }

--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -799,6 +799,10 @@ private:
                     }
                 }
             }
+            if (!Controls.UseDwarfBacktracePrinting) {
+                out << "<p>The <a href=\"../../actors/icb\">UseDwarfBacktracePrinting</a> setting enables more informative stack printing, "
+                    << "but can be significantly slower. Use with caution in production.</p>" << Endl;
+            }
             PRE() {
                 out << "Snapshot calculation time: " << (end - start).MicroSeconds() << " us" << Endl
                     << Endl;

--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -2,8 +2,9 @@
 
 #include <contrib/libs/tcmalloc/tcmalloc/malloc_extension.h>
 
-#include <ydb/library/actors/prof/tag.h>
+#include <ydb/core/base/appdata_fwd.h>
 #include <ydb/core/mon/mon.h>
+#include <ydb/library/actors/prof/tag.h>
 
 #include <library/cpp/cache/cache.h>
 #if defined(USE_DWARF_BACKTRACE)
@@ -11,6 +12,7 @@
 #endif
 #include <library/cpp/html/pcdata/pcdata.h>
 #include <library/cpp/monlib/service/pages/templates.h>
+#include <library/cpp/svnversion/svnversion.h>
 
 #include <util/stream/format.h>
 
@@ -209,14 +211,15 @@ class TAllocationAnalyzer {
     size_t RequestedSize = 0;
 
     bool Prepared = false;
+    bool UseDwarfBacktracePrinting = false;
 
 private:
 // Using DWARF to resolve backtraces is expensive - i.e. the cloud disk I/O may block process for minutes, while loading debug sections.
-#if defined(USE_DWARF_BACKTRACE) && defined(PROFILE_MEMORY_ALLOCATIONS)
-    void PrintBackTrace(IOutputStream& out, void* const* stack, size_t size, const char* sep) {
+#if defined(USE_DWARF_BACKTRACE)
+    void PrintDwarfBackTrace(IOutputStream& out, void* const* stack, size_t size, const char* sep) {
         // TODO: ignore symbol cache for now - because of inlines.
         if (auto error = NDwarf::ResolveBacktrace(TArrayRef<const void* const>(stack, size), [&](const NDwarf::TLineInfo& info) {
-            out << "#" << info.Index << " " << info.FunctionName << " at " << info.FileName << ':' << info.Line << ':' << info.Col << sep;
+            out << "#" << info.Index << " " << info.FunctionName << " at " << info.FileName << ':' << info.Line << sep;
             return NDwarf::EResolving::Continue;
         })) {
             // TODO: print error message.
@@ -225,8 +228,9 @@ private:
             out << sep;
         }
     }
-#else
-    void PrintBackTrace(IOutputStream& out, void* const* stack, size_t sz, const char* sep) {
+#endif
+
+    void PrintResolvedBackTrace(IOutputStream& out, void* const* stack, size_t sz, const char* sep) {
         char name[1024];
         for (size_t i = 0; i < sz; ++i) {
             TSymbol symbol;
@@ -246,7 +250,17 @@ private:
             out << sep;
         }
     }
+
+    void PrintBackTrace(IOutputStream& out, void* const* stack, size_t sz, const char* sep) {
+#if defined(USE_DWARF_BACKTRACE)
+        if (UseDwarfBacktracePrinting) {
+            PrintDwarfBackTrace(out, stack, sz, sep, forLog);
+            return;
+        }
 #endif
+
+        PrintResolvedBackTrace(out, stack, sz, sep);
+    }
 
     void PrintSample(IOutputStream& out, const tcmalloc::Profile::Sample* sample,
         const char* sep) const
@@ -319,9 +333,10 @@ private:
     }
 
 public:
-    explicit TAllocationAnalyzer(tcmalloc::Profile&& profile)
+    explicit TAllocationAnalyzer(tcmalloc::Profile&& profile, bool useDwarfBacktracePrinting)
         : Profile(std::move(profile))
         , SymbolCache(2048)
+        , UseDwarfBacktracePrinting(useDwarfBacktracePrinting)
     {}
 
     void Prepare(TAllocationStats* allocationStats) {
@@ -542,7 +557,7 @@ private:
 
             try {
                 auto profile = tcmalloc::MallocExtension::SnapshotCurrent(tcmalloc::ProfileType::kHeap);
-                TAllocationAnalyzer analyzer(std::move(profile));
+                TAllocationAnalyzer analyzer(std::move(profile), false);
                 TAllocationStats allocationStats;
                 analyzer.Prepare(&allocationStats);
                 analyzer.Dump(*Out_, 256, 1024, true, true);
@@ -581,10 +596,13 @@ class TTcMallocMonitor : public IAllocMonitor {
         static constexpr size_t DefaultPageCacheTargetSize = 512ll << 20;
         static constexpr size_t DefaultPageCacheReleaseRate = 8ll << 20;
 
+        static constexpr ui64 DefaultUseDwarfBacktracePrinting = 0;
+
         TControlWrapper ProfileSamplingRate;
         TControlWrapper GuardedSamplingRate;
         TControlWrapper PageCacheTargetSize;
         TControlWrapper PageCacheReleaseRate;
+        TControlWrapper UseDwarfBacktracePrinting;
 
         TControls()
             : ProfileSamplingRate(tcmalloc::MallocExtension::GetProfileSamplingInterval(),
@@ -595,6 +613,8 @@ class TTcMallocMonitor : public IAllocMonitor {
                 0, MaxPageCacheTargetSize)
             , PageCacheReleaseRate(DefaultPageCacheReleaseRate,
                 0, MaxPageCacheReleaseRate)
+            , UseDwarfBacktracePrinting(DefaultUseDwarfBacktracePrinting,
+                0, 1)
         {}
 
         void Register(TIntrusivePtr<TControlBoard> icb) {
@@ -602,6 +622,7 @@ class TTcMallocMonitor : public IAllocMonitor {
             TControlBoard::RegisterSharedControl(GuardedSamplingRate, icb->TCMallocControls.GuardedSamplingRate);
             TControlBoard::RegisterSharedControl(PageCacheTargetSize, icb->TCMallocControls.PageCacheTargetSize);
             TControlBoard::RegisterSharedControl(PageCacheReleaseRate, icb->TCMallocControls.PageCacheReleaseRate);
+            TControlBoard::RegisterSharedControl(UseDwarfBacktracePrinting, icb->TCMallocControls.UseDwarfBacktracePrinting);
         }
     };
     TControls Controls;
@@ -610,7 +631,7 @@ private:
     void UpdateCounters() {
         auto profile = tcmalloc::MallocExtension::SnapshotCurrent(tcmalloc::ProfileType::kHeap);
 
-        TAllocationAnalyzer analyzer(std::move(profile));
+        TAllocationAnalyzer analyzer(std::move(profile), Controls.UseDwarfBacktracePrinting);
         TAllocationStats allocationStats;
         analyzer.Prepare(&allocationStats);
 
@@ -677,7 +698,7 @@ private:
         auto profile = tcmalloc::MallocExtension::SnapshotCurrent(type);
         auto end = TInstant::Now();
 
-        TAllocationAnalyzer analyzer(std::move(profile));
+        TAllocationAnalyzer analyzer(std::move(profile), Controls.UseDwarfBacktracePrinting);
         TAllocationStats allocationStats;
         analyzer.Prepare(&allocationStats);
 
@@ -878,7 +899,8 @@ public:
     void Stop(IOutputStream& out, size_t countLimit, bool forLog) override {
         auto profile = std::move(Token).Stop();
 
-        TAllocationAnalyzer analyzer(std::move(profile));
+        const bool useDwarfBacktracePrinting = AppData()->Icb->TCMallocControls.UseDwarfBacktracePrinting.AtomicLoad()->Get();
+        TAllocationAnalyzer analyzer(std::move(profile), useDwarfBacktracePrinting);
         TAllocationStats allocationStats;
         analyzer.Prepare(&allocationStats);
 

--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -6,7 +6,6 @@
 #include <ydb/core/mon/mon.h>
 #include <ydb/library/actors/prof/tag.h>
 
-#include <library/cpp/svnversion/svnversion.h>
 #include <library/cpp/cache/cache.h>
 #if defined(USE_DWARF_BACKTRACE)
 #   include <library/cpp/dwarf_backtrace/backtrace.h>
@@ -219,7 +218,7 @@ private:
 // Using DWARF to resolve backtraces is expensive - i.e. the cloud disk I/O may block process for minutes, while loading debug sections.
 #if defined(USE_DWARF_BACKTRACE)
     void PrintDwarfBackTrace(IOutputStream& out, void* const* stack, size_t size, const char* sep, bool forLog) {
-        static const TStringBuf commitId = GetProgramCommitId() ? GetProgramCommitId() : "";
+        static const TString commitId = GetProgramCommitId() ? GetProgramCommitId() : "";
         // TODO: ignore symbol cache for now - because of inlines.
         if (auto error = NDwarf::ResolveBacktrace(TArrayRef<const void* const>(stack, size), [&](const NDwarf::TLineInfo& info) {
             out << "#" << info.Index << " ";
@@ -232,16 +231,16 @@ private:
             constexpr TStringBuf repositoryRootPrefix = "/-S/";
             if (info.FileName.StartsWith(repositoryRootPrefix)) {
                 const TStringBuf fileName = info.FileName;
-                const TStringBuf relativePath = TStringBuf(fileName).Skip(repositoryRootPrefix.size());
+                const TString relativePath(TStringBuf(fileName).Skip(repositoryRootPrefix.size()));
                 if (!forLog && commitId) {
-                    out << "<a href=\"https://github.com/ydb-platform/ydb/blob/" << commitId << '/'
-                        << relativePath << "#L" << info.Line << "\" target=\"_blank\">"
-                        << relativePath << ':' << info.Line << "</a>" << sep;
+                    out << "<a href=\"https://github.com/ydb-platform/ydb/blob/" << NHtml::EscapeAttributeValue(commitId) << '/'
+                        << NHtml::EscapeAttributeValue(relativePath) << "#L" << info.Line << "\" target=\"_blank\" rel=\"noopener\">"
+                        << NHtml::EscapeText(relativePath) << ':' << info.Line << "</a>" << sep;
                 } else {
                     out << relativePath << ':' << info.Line << sep;
                 }
             } else {
-                out << info.FileName << ':' << info.Line << sep;
+                out << NHtml::EscapeText(info.FileName) << ':' << info.Line << sep;
             }
             return NDwarf::EResolving::Continue;
         })) {

--- a/ydb/core/mon_alloc/ya.make
+++ b/ydb/core/mon_alloc/ya.make
@@ -19,6 +19,7 @@ ENDIF()
 
 PEERDIR(
     contrib/libs/tcmalloc/malloc_extension
+    library/cpp/html/escape
     library/cpp/html/pcdata
     library/cpp/lfalloc/alloc_profiler
     library/cpp/lfalloc/dbg_info

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1622,6 +1622,11 @@ message TImmediateControlsConfig {
             MinValue: 0,
             MaxValue: 134217728,
             DefaultValue: 8388608 }];
+        optional uint64 UseDwarfBacktracePrinting = 6 [(ControlOptions) = {
+            Description: "Use DWARF symbolization for TCMalloc heap/profile dump backtraces.",
+            MinValue: 0,
+            MaxValue: 1,
+            DefaultValue: 0 }];
     }
 
     message TVDiskControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Intruduced `UseDwarfBacktracePrinting` option that can be modified via Immediate Control Board without restart
- This option enables improved stack printing for memory pages of tcmalloc allocator in dev ui
- Improved stack printing: now file names provide references to GitHub so that they can be opened from dev ui page
