### PR TITLE
Fix tests that are killed by timeout

### DIFF
--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
 #include <ydb/public/sdk/cpp/src/client/impl/internal/logger/log.h>
+#include <ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h>
 
 #include <library/cpp/string_utils/quote/quote.h>
 
@@ -58,6 +59,18 @@ void TDbDriverState::SetCredentialsProvider(std::shared_ptr<ICredentialsProvider
     CallCredentials = grpc::MetadataCredentialsFromPlugin(
         std::unique_ptr<grpc::MetadataCredentialsPlugin>(new TYdbAuthenticator(CredentialsProvider)));
 #endif
+}
+
+bool TDbDriverState::AreClientTlsCredentialsValid() const {
+    std::call_once(ClientTlsValidationOnceFlag_, [this]() {
+        grpc::SslCredentialsOptions sslOptions{
+            .pem_root_certs = NYdb::TStringType{SslCredentials.CaCert},
+            .pem_private_key = NYdb::TStringType{SslCredentials.PrivateKey},
+            .pem_cert_chain = NYdb::TStringType{SslCredentials.Cert}
+        };
+        ClientTlsCredentialsValid_ = NYdbGrpc::ValidateClientCertificateAndKey(sslOptions);
+    });
+    return ClientTlsCredentialsValid_;
 }
 
 void TDbDriverState::AddCb(TCb&& cb, ENotifyType type) {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -63,14 +63,19 @@ void TDbDriverState::SetCredentialsProvider(std::shared_ptr<ICredentialsProvider
 
 bool TDbDriverState::AreClientTlsCredentialsValid() const {
     std::call_once(ClientTlsValidationOnceFlag_, [this]() {
+        ClientTlsValidationDetail_.clear();
         grpc::SslCredentialsOptions sslOptions{
             .pem_root_certs = NYdb::TStringType{SslCredentials.CaCert},
             .pem_private_key = NYdb::TStringType{SslCredentials.PrivateKey},
             .pem_cert_chain = NYdb::TStringType{SslCredentials.Cert}
         };
-        ClientTlsCredentialsValid_ = NYdbGrpc::ValidateTlsCredentials(sslOptions);
+        ClientTlsCredentialsValid_ = NYdbGrpc::ValidateTlsCredentials(sslOptions, ClientTlsValidationDetail_);
     });
     return ClientTlsCredentialsValid_;
+}
+
+const std::string& TDbDriverState::GetClientTlsValidationDetail() const {
+    return ClientTlsValidationDetail_;
 }
 
 void TDbDriverState::AddCb(TCb&& cb, ENotifyType type) {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -68,7 +68,7 @@ bool TDbDriverState::AreClientTlsCredentialsValid() const {
             .pem_private_key = NYdb::TStringType{SslCredentials.PrivateKey},
             .pem_cert_chain = NYdb::TStringType{SslCredentials.Cert}
         };
-        ClientTlsCredentialsValid_ = NYdbGrpc::ValidateClientCertificateAndKey(sslOptions);
+        ClientTlsCredentialsValid_ = NYdbGrpc::ValidateTlsCredentials(sslOptions);
     });
     return ClientTlsCredentialsValid_;
 }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
@@ -8,6 +8,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/common_client/ssl_credentials.h>
 #include <ydb/public/sdk/cpp/src/client/types/core_facility/core_facility.h>
 
+#include <mutex>
+
 namespace NYdb::inline Dev {
 
 class ICredentialsProvider;
@@ -48,6 +50,7 @@ public:
     TBalancingPolicy::TImpl::EPolicyType GetBalancingPolicyType() const;
     std::string GetEndpoint() const;
     void SetCredentialsProvider(std::shared_ptr<ICredentialsProvider> credentialsProvider);
+    bool AreClientTlsCredentialsValid() const;
 
     const std::string Database;
     const std::string DiscoveryEndpoint;
@@ -68,6 +71,10 @@ public:
     NSdkStats::TStatCollector StatCollector;
     TLog Log;
     NThreading::TPromise<void> DiscoveryCompletedPromise;
+
+private:
+    mutable std::once_flag ClientTlsValidationOnceFlag_;
+    mutable bool ClientTlsCredentialsValid_ = true;
 };
 
 // Tracker allows to get driver state by database and credentials

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
@@ -51,6 +51,7 @@ public:
     std::string GetEndpoint() const;
     void SetCredentialsProvider(std::shared_ptr<ICredentialsProvider> credentialsProvider);
     bool AreClientTlsCredentialsValid() const;
+    const std::string& GetClientTlsValidationDetail() const;
 
     const std::string Database;
     const std::string DiscoveryEndpoint;
@@ -75,6 +76,7 @@ public:
 private:
     mutable std::once_flag ClientTlsValidationOnceFlag_;
     mutable bool ClientTlsCredentialsValid_ = true;
+    mutable std::string ClientTlsValidationDetail_;
 };
 
 // Tracker allows to get driver state by database and credentials

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -15,6 +15,7 @@
 
 #include <ydb/public/sdk/cpp/src/library/issue/yql_issue_message.h>
 
+#include <optional>
 
 namespace NYdb::inline Dev {
 
@@ -215,17 +216,8 @@ public:
         using TConnection = std::unique_ptr<TServiceConnection<TService>>;
         Y_ABORT_UNLESS(dbState);
 
-        grpc::SslCredentialsOptions sslOptions{
-            .pem_root_certs = NYdb::TStringType{dbState->SslCredentials.CaCert},
-            .pem_private_key = NYdb::TStringType{dbState->SslCredentials.PrivateKey},
-            .pem_cert_chain = NYdb::TStringType{dbState->SslCredentials.Cert}
-        };
-        if (!NYdbGrpc::ValidateClientCertificateAndKey(sslOptions)) {
-            userResponseCb(
-                nullptr,
-                TPlainStatus(
-                    EStatus::TRANSPORT_UNAVAILABLE,
-                    TStringBuilder() << "Client TLS credentials validation failed"));
+        if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
+            userResponseCb(nullptr, std::move(*tlsValidationStatus));
             return;
         }
 
@@ -456,6 +448,11 @@ public:
         using TConnection = std::unique_ptr<TServiceConnection<TService>>;
         using TProcessor = typename NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
 
+        if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
+            responseCb(std::move(*tlsValidationStatus), nullptr);
+            return;
+        }
+
         if (!TryCreateContext(context)) {
             responseCb(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
             return;
@@ -528,6 +525,11 @@ public:
         using NYdbGrpc::TGrpcStatus;
         using TConnection = std::unique_ptr<TServiceConnection<TService>>;
         using TProcessor = typename NYdbGrpc::IStreamRequestReadWriteProcessor<TRequest, TResponse>::TPtr;
+
+        if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
+            connectedCallback(std::move(*tlsValidationStatus), nullptr);
+            return;
+        }
 
         if (!TryCreateContext(context)) {
             connectedCallback(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
@@ -614,6 +616,16 @@ public:
     const TLog& GetLog() const override;
 
 private:
+    static std::optional<TPlainStatus> ValidateClientTlsCredentials(const TDbDriverStatePtr& dbState) {
+        Y_ABORT_UNLESS(dbState);
+        if (dbState->AreClientTlsCredentialsValid()) {
+            return std::nullopt;
+        }
+        return TPlainStatus(
+            EStatus::TRANSPORT_UNAVAILABLE,
+            TStringBuilder() << "Client TLS credentials validation failed");
+    }
+
     template <typename TService, typename TCallback>
     void WithServiceConnection(TCallback callback, TDbDriverStatePtr dbState,
         const TEndpointKey& preferredEndpoint, TRpcRequestSettings::TEndpointPolicy endpointPolicy)

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -215,6 +215,20 @@ public:
         using TConnection = std::unique_ptr<TServiceConnection<TService>>;
         Y_ABORT_UNLESS(dbState);
 
+        grpc::SslCredentialsOptions sslOptions{
+            .pem_root_certs = NYdb::TStringType{dbState->SslCredentials.CaCert},
+            .pem_private_key = NYdb::TStringType{dbState->SslCredentials.PrivateKey},
+            .pem_cert_chain = NYdb::TStringType{dbState->SslCredentials.Cert}
+        };
+        if (!NYdbGrpc::ValidateClientCertificateAndKey(sslOptions)) {
+            userResponseCb(
+                nullptr,
+                TPlainStatus(
+                    EStatus::TRANSPORT_UNAVAILABLE,
+                    TStringBuilder() << "Client TLS credentials validation failed"));
+            return;
+        }
+
         if (!TryCreateContext(context)) {
             TPlainStatus status(EStatus::CLIENT_CANCELLED, "Client is stopped");
             userResponseCb(nullptr, TPlainStatus{status.Status, std::move(status.Issues)});

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -621,9 +621,13 @@ private:
         if (dbState->AreClientTlsCredentialsValid()) {
             return std::nullopt;
         }
-        return TPlainStatus(
-            EStatus::TRANSPORT_UNAVAILABLE,
-            TStringBuilder() << "Client TLS credentials validation failed");
+        std::string msg = "Client TLS credentials validation failed";
+        const auto& detail = dbState->GetClientTlsValidationDetail();
+        if (!detail.empty()) {
+            msg += ": ";
+            msg += detail;
+        }
+        return TPlainStatus(EStatus::TRANSPORT_UNAVAILABLE, msg);
     }
 
     template <typename TService, typename TCallback>

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
@@ -41,7 +41,8 @@ bool ValidateRootCertificates(const std::string& pemRootCerts) {
             &X509_free);
         if (!cert) {
             const unsigned long errorCode = ERR_peek_last_error();
-            if (errorCode == 0) {
+            if (errorCode == 0 || ERR_GET_REASON(errorCode) == PEM_R_NO_START_LINE) {
+                ERR_clear_error();
                 break;
             }
             ERR_clear_error();

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
@@ -1,0 +1,107 @@
+#include "grpc_common.h"
+
+#include <library/cpp/openssl/holders/holder.h>
+
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+#include <memory>
+
+namespace NYdbGrpc {
+inline namespace Dev {
+
+namespace {
+
+X509* ReadX509FromBio(BIO* bio) {
+    return PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+}
+
+EVP_PKEY* ReadPrivateKeyFromBio(BIO* bio) {
+    return PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+}
+
+bool ValidateRootCertificates(const std::string& pemRootCerts) {
+    if (pemRootCerts.empty()) {
+        return true;
+    }
+
+    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
+    TBioHolder rootCertsBio(pemRootCerts.data(), static_cast<int>(pemRootCerts.size()));
+
+    ERR_clear_error();
+    size_t certsParsed = 0;
+    while (true) {
+        std::unique_ptr<X509, decltype(&X509_free)> cert(
+            PEM_read_bio_X509(rootCertsBio, nullptr, nullptr, nullptr),
+            &X509_free);
+        if (!cert) {
+            const unsigned long errorCode = ERR_peek_last_error();
+            if (errorCode == 0) {
+                break;
+            }
+            ERR_clear_error();
+            return false;
+        }
+
+        std::unique_ptr<BASIC_CONSTRAINTS, decltype(&BASIC_CONSTRAINTS_free)> basicConstraints(
+            static_cast<BASIC_CONSTRAINTS*>(X509_get_ext_d2i(cert.get(), NID_basic_constraints, nullptr, nullptr)),
+            &BASIC_CONSTRAINTS_free);
+        const auto isCaCert = basicConstraints && basicConstraints->ca;
+
+        if (!isCaCert) {
+            return false;
+        }
+        ++certsParsed;
+    }
+
+    return certsParsed > 0;
+}
+
+} // namespace
+
+bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials) {
+    if (!ValidateRootCertificates(sslCredentials.pem_root_certs)) {
+        return false;
+    }
+
+    const bool hasClientCert = !sslCredentials.pem_cert_chain.empty();
+    const bool hasPrivateKey = !sslCredentials.pem_private_key.empty();
+    if (!hasClientCert && !hasPrivateKey) {
+        return true;
+    }
+    if (!hasClientCert || !hasPrivateKey) {
+        return false;
+    }
+
+    using TSslCtxHolder = NOpenSSL::THolder<SSL_CTX, SSL_CTX_new, SSL_CTX_free, const SSL_METHOD*>;
+    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
+    using TX509Holder = NOpenSSL::THolder<X509, ReadX509FromBio, X509_free, BIO*>;
+    using TPkeyHolder = NOpenSSL::THolder<EVP_PKEY, ReadPrivateKeyFromBio, EVP_PKEY_free, BIO*>;
+    try {
+        TSslCtxHolder sslCtx(TLS_method());
+        TBioHolder certBio(sslCredentials.pem_cert_chain.data(), static_cast<int>(sslCredentials.pem_cert_chain.size()));
+        TX509Holder cert(certBio);
+        if (SSL_CTX_use_certificate(sslCtx, cert) != 1) {
+            return false;
+        }
+        TBioHolder keyBio(sslCredentials.pem_private_key.data(), static_cast<int>(sslCredentials.pem_private_key.size()));
+        TPkeyHolder privateKey(keyBio);
+        if (SSL_CTX_use_PrivateKey(sslCtx, privateKey) != 1) {
+            return false;
+        }
+        if (SSL_CTX_check_private_key(sslCtx) != 1) {
+            return false;
+        }
+    } catch (const std::exception& e) {
+        return false;
+    }
+    return true;
+}
+
+}
+}

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
@@ -11,11 +11,29 @@
 #include <openssl/x509v3.h>
 
 #include <memory>
+#include <string>
 
 namespace NYdbGrpc {
 inline namespace Dev {
 
 namespace {
+
+std::string DrainOpenSslErrors() {
+    std::string out;
+    unsigned long e = 0;
+    while ((e = ERR_get_error()) != 0) {
+        char buf[256];
+        ERR_error_string_n(e, buf, sizeof(buf));
+        if (!out.empty()) {
+            out += "; ";
+        }
+        out += buf;
+    }
+    if (out.empty()) {
+        return "OpenSSL error queue empty";
+    }
+    return out;
+}
 
 X509* ReadX509FromBio(BIO* bio) {
     return PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
@@ -25,7 +43,7 @@ EVP_PKEY* ReadPrivateKeyFromBio(BIO* bio) {
     return PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
 }
 
-bool ValidateRootCertificates(const std::string& pemRootCerts) {
+bool ValidateRootCertificates(const std::string& pemRootCerts, std::string& errorMessage) {
     if (pemRootCerts.empty()) {
         return true;
     }
@@ -45,7 +63,7 @@ bool ValidateRootCertificates(const std::string& pemRootCerts) {
                 ERR_clear_error();
                 break;
             }
-            ERR_clear_error();
+            errorMessage = "root CA PEM: " + DrainOpenSslErrors();
             return false;
         }
 
@@ -55,18 +73,27 @@ bool ValidateRootCertificates(const std::string& pemRootCerts) {
         const auto isCaCert = basicConstraints && basicConstraints->ca;
 
         if (!isCaCert) {
+            ERR_clear_error();
+            errorMessage = "root CA PEM: certificate is not a CA (BasicConstraints)";
             return false;
         }
+        ERR_clear_error();
         ++certsParsed;
     }
 
-    return certsParsed > 0;
+    if (certsParsed == 0) {
+        errorMessage = "root CA PEM: no certificates parsed";
+        return false;
+    }
+    return true;
 }
 
 } // namespace
 
-bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials) {
-    if (!ValidateRootCertificates(sslCredentials.pem_root_certs)) {
+bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials, std::string& errorMessage) {
+    errorMessage.clear();
+
+    if (!ValidateRootCertificates(sslCredentials.pem_root_certs, errorMessage)) {
         return false;
     }
 
@@ -76,6 +103,7 @@ bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials) {
         return true;
     }
     if (!hasClientCert || !hasPrivateKey) {
+        errorMessage = "client TLS: certificate and private key must both be set";
         return false;
     }
 
@@ -84,23 +112,32 @@ bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials) {
     using TX509Holder = NOpenSSL::THolder<X509, ReadX509FromBio, X509_free, BIO*>;
     using TPkeyHolder = NOpenSSL::THolder<EVP_PKEY, ReadPrivateKeyFromBio, EVP_PKEY_free, BIO*>;
     try {
+        ERR_clear_error();
         TSslCtxHolder sslCtx(TLS_method());
         TBioHolder certBio(sslCredentials.pem_cert_chain.data(), static_cast<int>(sslCredentials.pem_cert_chain.size()));
         TX509Holder cert(certBio);
         if (SSL_CTX_use_certificate(sslCtx, cert) != 1) {
+            errorMessage = "client certificate: " + DrainOpenSslErrors();
             return false;
         }
+        ERR_clear_error();
         TBioHolder keyBio(sslCredentials.pem_private_key.data(), static_cast<int>(sslCredentials.pem_private_key.size()));
         TPkeyHolder privateKey(keyBio);
         if (SSL_CTX_use_PrivateKey(sslCtx, privateKey) != 1) {
+            errorMessage = "client private key: " + DrainOpenSslErrors();
             return false;
         }
+        ERR_clear_error();
         if (SSL_CTX_check_private_key(sslCtx) != 1) {
+            errorMessage = "client cert/key: " + DrainOpenSslErrors();
             return false;
         }
     } catch (const std::exception& e) {
+        ERR_clear_error();
+        errorMessage = std::string("client TLS: ") + e.what();
         return false;
     }
+    ERR_clear_error();
     return true;
 }
 

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
@@ -9,14 +9,17 @@
 #include <library/cpp/openssl/holders/holder.h>
 
 #include <openssl/bio.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 
 #include <util/datetime/base.h>
 #include <unordered_map>
 #include <string>
+#include <memory>
 #include <new>
 
 namespace NYdbGrpc {
@@ -69,9 +72,50 @@ inline EVP_PKEY* ReadPrivateKeyFromBio(BIO* bio) {
     return PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
 }
 
-inline bool ValidateClientCertificateAndKey(
+inline bool ValidateRootCertificates(const std::string& pemRootCerts) {
+    if (pemRootCerts.empty()) {
+        return true;
+    }
+
+    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
+    TBioHolder rootCertsBio(pemRootCerts.data(), static_cast<int>(pemRootCerts.size()));
+
+    ERR_clear_error();
+    size_t certsParsed = 0;
+    while (true) {
+        std::unique_ptr<X509, decltype(&X509_free)> cert(
+            PEM_read_bio_X509(rootCertsBio, nullptr, nullptr, nullptr),
+            &X509_free);
+        if (!cert) {
+            const unsigned long errorCode = ERR_peek_last_error();
+            if (errorCode == 0) {
+                break;
+            }
+            ERR_clear_error();
+            return false;
+        }
+
+        std::unique_ptr<BASIC_CONSTRAINTS, decltype(&BASIC_CONSTRAINTS_free)> basicConstraints(
+            static_cast<BASIC_CONSTRAINTS*>(X509_get_ext_d2i(cert.get(), NID_basic_constraints, nullptr, nullptr)),
+            &BASIC_CONSTRAINTS_free);
+        const auto isCaCert = basicConstraints && basicConstraints->ca;
+
+        if (!isCaCert) {
+            return false;
+        }
+        ++certsParsed;
+    }
+
+    return certsParsed > 0;
+}
+
+inline bool ValidateTlsCredentials(
         const grpc::SslCredentialsOptions& sslCredentials)
 {
+    if (!ValidateRootCertificates(sslCredentials.pem_root_certs)) {
+        return false;
+    }
+
     const bool hasClientCert = !sslCredentials.pem_cert_chain.empty();
     const bool hasPrivateKey = !sslCredentials.pem_private_key.empty();
     if (!hasClientCert && !hasPrivateKey) {

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
@@ -54,7 +54,7 @@ struct TGRpcClientConfig {
     {}
 };
 
-bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials);
+bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials, std::string& errorMessage);
 
 inline std::shared_ptr<grpc::ChannelInterface> CreateChannelInterface(const TGRpcClientConfig& config, grpc_socket_mutator* mutator = nullptr){
     grpc::ChannelArguments args;

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
@@ -6,9 +6,18 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/type_switcher.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/grpc_common/constants.h>
 
+#include <library/cpp/openssl/holders/holder.h>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
 #include <util/datetime/base.h>
 #include <unordered_map>
 #include <string>
+#include <new>
 
 namespace NYdbGrpc {
 inline namespace Dev {
@@ -51,6 +60,51 @@ struct TGRpcClientConfig {
         , UseXds((Locator.starts_with("xds:///")))
     {}
 };
+
+inline X509* ReadX509FromBio(BIO* bio) {
+    return PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+}
+
+inline EVP_PKEY* ReadPrivateKeyFromBio(BIO* bio) {
+    return PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+}
+
+inline bool ValidateClientCertificateAndKey(
+        const grpc::SslCredentialsOptions& sslCredentials)
+{
+    const bool hasClientCert = !sslCredentials.pem_cert_chain.empty();
+    const bool hasPrivateKey = !sslCredentials.pem_private_key.empty();
+    if (!hasClientCert && !hasPrivateKey) {
+        return true;
+    }
+    if (!hasClientCert || !hasPrivateKey) {
+        return false;
+    }
+
+    using TSslCtxHolder = NOpenSSL::THolder<SSL_CTX, SSL_CTX_new, SSL_CTX_free, const SSL_METHOD*>;
+    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
+    using TX509Holder = NOpenSSL::THolder<X509, ReadX509FromBio, X509_free, BIO*>;
+    using TPkeyHolder = NOpenSSL::THolder<EVP_PKEY, ReadPrivateKeyFromBio, EVP_PKEY_free, BIO*>;
+    try {
+        TSslCtxHolder sslCtx(TLS_method());
+        TBioHolder certBio(sslCredentials.pem_cert_chain.data(), static_cast<int>(sslCredentials.pem_cert_chain.size()));
+        TX509Holder cert(certBio);
+        if (SSL_CTX_use_certificate(sslCtx, cert) != 1) {
+            return false;
+        }
+        TBioHolder keyBio(sslCredentials.pem_private_key.data(), static_cast<int>(sslCredentials.pem_private_key.size()));
+        TPkeyHolder privateKey(keyBio);
+        if (SSL_CTX_use_PrivateKey(sslCtx, privateKey) != 1) {
+            return false;
+        }
+        if (SSL_CTX_check_private_key(sslCtx) != 1) {
+            return false;
+        }
+    } catch (const std::exception& e) {
+        return false;
+    }
+    return true;
+}
 
 inline std::shared_ptr<grpc::ChannelInterface> CreateChannelInterface(const TGRpcClientConfig& config, grpc_socket_mutator* mutator = nullptr){
     grpc::ChannelArguments args;

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
@@ -6,16 +6,6 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/type_switcher.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/grpc_common/constants.h>
 
-#include <library/cpp/openssl/holders/holder.h>
-
-#include <openssl/bio.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
-#include <openssl/pem.h>
-#include <openssl/ssl.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
-
 #include <util/datetime/base.h>
 #include <unordered_map>
 #include <string>
@@ -64,91 +54,7 @@ struct TGRpcClientConfig {
     {}
 };
 
-inline X509* ReadX509FromBio(BIO* bio) {
-    return PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
-}
-
-inline EVP_PKEY* ReadPrivateKeyFromBio(BIO* bio) {
-    return PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
-}
-
-inline bool ValidateRootCertificates(const std::string& pemRootCerts) {
-    if (pemRootCerts.empty()) {
-        return true;
-    }
-
-    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
-    TBioHolder rootCertsBio(pemRootCerts.data(), static_cast<int>(pemRootCerts.size()));
-
-    ERR_clear_error();
-    size_t certsParsed = 0;
-    while (true) {
-        std::unique_ptr<X509, decltype(&X509_free)> cert(
-            PEM_read_bio_X509(rootCertsBio, nullptr, nullptr, nullptr),
-            &X509_free);
-        if (!cert) {
-            const unsigned long errorCode = ERR_peek_last_error();
-            if (errorCode == 0) {
-                break;
-            }
-            ERR_clear_error();
-            return false;
-        }
-
-        std::unique_ptr<BASIC_CONSTRAINTS, decltype(&BASIC_CONSTRAINTS_free)> basicConstraints(
-            static_cast<BASIC_CONSTRAINTS*>(X509_get_ext_d2i(cert.get(), NID_basic_constraints, nullptr, nullptr)),
-            &BASIC_CONSTRAINTS_free);
-        const auto isCaCert = basicConstraints && basicConstraints->ca;
-
-        if (!isCaCert) {
-            return false;
-        }
-        ++certsParsed;
-    }
-
-    return certsParsed > 0;
-}
-
-inline bool ValidateTlsCredentials(
-        const grpc::SslCredentialsOptions& sslCredentials)
-{
-    if (!ValidateRootCertificates(sslCredentials.pem_root_certs)) {
-        return false;
-    }
-
-    const bool hasClientCert = !sslCredentials.pem_cert_chain.empty();
-    const bool hasPrivateKey = !sslCredentials.pem_private_key.empty();
-    if (!hasClientCert && !hasPrivateKey) {
-        return true;
-    }
-    if (!hasClientCert || !hasPrivateKey) {
-        return false;
-    }
-
-    using TSslCtxHolder = NOpenSSL::THolder<SSL_CTX, SSL_CTX_new, SSL_CTX_free, const SSL_METHOD*>;
-    using TBioHolder = NOpenSSL::THolder<BIO, BIO_new_mem_buf, BIO_free, const void*, int>;
-    using TX509Holder = NOpenSSL::THolder<X509, ReadX509FromBio, X509_free, BIO*>;
-    using TPkeyHolder = NOpenSSL::THolder<EVP_PKEY, ReadPrivateKeyFromBio, EVP_PKEY_free, BIO*>;
-    try {
-        TSslCtxHolder sslCtx(TLS_method());
-        TBioHolder certBio(sslCredentials.pem_cert_chain.data(), static_cast<int>(sslCredentials.pem_cert_chain.size()));
-        TX509Holder cert(certBio);
-        if (SSL_CTX_use_certificate(sslCtx, cert) != 1) {
-            return false;
-        }
-        TBioHolder keyBio(sslCredentials.pem_private_key.data(), static_cast<int>(sslCredentials.pem_private_key.size()));
-        TPkeyHolder privateKey(keyBio);
-        if (SSL_CTX_use_PrivateKey(sslCtx, privateKey) != 1) {
-            return false;
-        }
-        if (SSL_CTX_check_private_key(sslCtx) != 1) {
-            return false;
-        }
-    } catch (const std::exception& e) {
-        return false;
-    }
-    return true;
-}
+bool ValidateTlsCredentials(const grpc::SslCredentialsOptions& sslCredentials);
 
 inline std::shared_ptr<grpc::ChannelInterface> CreateChannelInterface(const TGRpcClientConfig& config, grpc_socket_mutator* mutator = nullptr){
     grpc::ChannelArguments args;

--- a/ydb/public/sdk/cpp/src/library/grpc/client/ya.make
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/ya.make
@@ -2,6 +2,7 @@ LIBRARY(sdk-library-grpc-client-v3)
 
 SRCS(
     grpc_client_low.cpp
+    grpc_common.cpp
 )
 
 PEERDIR(

--- a/ydb/public/sdk/cpp/src/library/grpc/client/ya.make
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/ya.make
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     contrib/libs/grpc
     library/cpp/containers/stack_vector
+    library/cpp/openssl/holders
     ydb/public/sdk/cpp/src/library/time
 )
 

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -110,6 +110,24 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(Coordination) {
+    Y_UNIT_TEST(InvalidRootCertificatePemFailsFastForSessionStream) {
+        auto config = TDriverConfig()
+            .SetEndpoint("localhost:100")
+            .SetDiscoveryMode(EDiscoveryMode::Off)
+            .SetDatabase("/Root/My/DB")
+            .UseSecureConnection("not-a-certificate");
+        TDriver driver(config);
+        TClient client(driver);
+
+        auto settings = TSessionSettings()
+            .Timeout(TDuration::MilliSeconds(500));
+
+        auto res = client.StartSession("/Some/Path", settings).ExtractValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE, res.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(res.GetIssues().ToString(), "Client TLS credentials validation failed");
+    }
+
     Y_UNIT_TEST(InvalidClientCertificateFailsFastForSessionStream) {
         const std::string privateKeyOnly = "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----\n";
 

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -110,6 +110,7 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(Coordination) {
+
     Y_UNIT_TEST(SessionStartTimeout) {
         TPortManager pm;
 

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -110,6 +110,25 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(Coordination) {
+    Y_UNIT_TEST(InvalidClientCertificateFailsFastForSessionStream) {
+        const std::string privateKeyOnly = "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----\n";
+
+        auto config = TDriverConfig()
+            .SetEndpoint("localhost:100")
+            .SetDiscoveryMode(EDiscoveryMode::Off)
+            .SetDatabase("/Root/My/DB")
+            .UseClientCertificate("", privateKeyOnly);
+        TDriver driver(config);
+        TClient client(driver);
+
+        auto settings = TSessionSettings()
+            .Timeout(TDuration::MilliSeconds(500));
+
+        auto res = client.StartSession("/Some/Path", settings).ExtractValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE, res.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(res.GetIssues().ToString(), "Client TLS credentials validation failed");
+    }
 
     Y_UNIT_TEST(SessionStartTimeout) {
         TPortManager pm;

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -110,44 +110,6 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(Coordination) {
-    Y_UNIT_TEST(InvalidRootCertificatePemFailsFastForSessionStream) {
-        auto config = TDriverConfig()
-            .SetEndpoint("localhost:100")
-            .SetDiscoveryMode(EDiscoveryMode::Off)
-            .SetDatabase("/Root/My/DB")
-            .UseSecureConnection("not-a-certificate");
-        TDriver driver(config);
-        TClient client(driver);
-
-        auto settings = TSessionSettings()
-            .Timeout(TDuration::MilliSeconds(500));
-
-        auto res = client.StartSession("/Some/Path", settings).ExtractValueSync();
-
-        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE, res.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(res.GetIssues().ToString(), "Client TLS credentials validation failed");
-    }
-
-    Y_UNIT_TEST(InvalidClientCertificateFailsFastForSessionStream) {
-        const std::string privateKeyOnly = "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----\n";
-
-        auto config = TDriverConfig()
-            .SetEndpoint("localhost:100")
-            .SetDiscoveryMode(EDiscoveryMode::Off)
-            .SetDatabase("/Root/My/DB")
-            .UseClientCertificate("", privateKeyOnly);
-        TDriver driver(config);
-        TClient client(driver);
-
-        auto settings = TSessionSettings()
-            .Timeout(TDuration::MilliSeconds(500));
-
-        auto res = client.StartSession("/Some/Path", settings).ExtractValueSync();
-
-        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE, res.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(res.GetIssues().ToString(), "Client TLS credentials validation failed");
-    }
-
     Y_UNIT_TEST(SessionStartTimeout) {
         TPortManager pm;
 

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -80,6 +80,33 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
+    Y_UNIT_TEST(InvalidRootCertificatePemFailsFast) {
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint("localhost:100")
+                .UseSecureConnection("not-a-certificate"));
+        auto client = NTable::TTableClient(driver);
+
+        auto result = client.CreateSession().GetValueSync();
+
+        UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Client TLS credentials validation failed");
+    }
+
+    Y_UNIT_TEST(EmptyRootCertificateWithoutClientCredentialsKeepsBehavior) {
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint("localhost:100")
+                .UseSecureConnection(""));
+        auto client = NTable::TTableClient(driver);
+
+        auto result = client.CreateSession().GetValueSync();
+        auto issues = result.GetIssues().ToString();
+
+        UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
+        UNIT_ASSERT(issues.find("Client TLS credentials validation failed") == std::string::npos);
+    }
+
     Y_UNIT_TEST(InvalidClientCertificateFailsFast) {
         const std::string privateKeyOnly = "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----\n";
 

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -91,6 +91,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
 
         UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Client TLS credentials validation failed");
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "root CA PEM:");
     }
 
     Y_UNIT_TEST(EmptyRootCertificateWithoutClientCredentialsKeepsBehavior) {
@@ -120,6 +121,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
 
         UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Client TLS credentials validation failed");
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "client TLS:");
     }
 
     Y_UNIT_TEST(ConnectWrongPort) {

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -80,6 +80,21 @@ namespace {
 } // namespace
 
 Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
+    Y_UNIT_TEST(InvalidClientCertificateFailsFast) {
+        const std::string privateKeyOnly = "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----\n";
+
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint("localhost:100")
+                .UseClientCertificate("", privateKeyOnly));
+        auto client = NTable::TTableClient(driver);
+
+        auto result = client.CreateSession().GetValueSync();
+
+        UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Client TLS credentials validation failed");
+    }
+
     Y_UNIT_TEST(ConnectWrongPort) {
         auto driver = TDriver(
             TDriverConfig()

--- a/ydb/services/ydb/ydb_register_node_ut.cpp
+++ b/ydb/services/ydb/ydb_register_node_ut.cpp
@@ -652,7 +652,6 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
 }
 
 void TestCorruptedClientAuthData(const TCertAndKey& caCert, const TCertAndKey& clientServerCert) {
-    const auto timeout = TDuration::Seconds(2);
     const auto expectedStatus = EStatus::TRANSPORT_UNAVAILABLE;
 
     for (bool enforceUserToken : {true, false}) {
@@ -673,9 +672,9 @@ void TestCorruptedClientAuthData(const TCertAndKey& caCert, const TCertAndKey& c
             .SetDatabase(database)
             .SetEndpoint(location);
 
-        CheckAccessDenied(RegisterNode(config, timeout), expectedStatus);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT), timeout), expectedStatus);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token"), timeout), expectedStatus);
+        CheckAccessDenied(RegisterNode(config), expectedStatus);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedStatus);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedStatus);
     }
 }
 


### PR DESCRIPTION
### Changelog entry
Grpc infinitely reconnects on invalid TLS certificate. The code pre-verifies certificate so that invalid certificates now fail gracefully.
### Changelog category
* Bugfix 

