### PR TITLE
Disable RETURNING for ColumnShards and External Tables

### DIFF
--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1301,12 +1301,12 @@ TMaybe<TKqlQueryList> BuildKqlQuery(TKiDataQueryBlocks dataQueryBlocks, const TK
                     if (tableData.Metadata->Kind == EKikimrTableKind::Olap) {
                         ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                             TStringBuilder() << "RETURNING is not supported for column-oriented tables."));
-                        return input;
+                        return TExprNode::TPtr{};
                     }
                     if (tableData.Metadata->Kind == EKikimrTableKind::External) {
                         ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                             TStringBuilder() << "RETURNING is not supported for external data sources."));
-                        return input;
+                        return TExprNode::TPtr{};
                     }
 
                     const auto& tableMeta = BuildTableMeta(tableData, effect.Pos(), ctx);

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1297,6 +1297,18 @@ TMaybe<TKqlQueryList> BuildKqlQuery(TKiDataQueryBlocks dataQueryBlocks, const TK
                     }
 
                     auto& tableData = GetTableData(tablesData, cluster, table);
+
+                    if (tableData.Metadata->Kind == EKikimrTableKind::Olap) {
+                        ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                            TStringBuilder() << "RETURNING is not supported for column-oriented tables."));
+                        return TExprNode::TPtr{};
+                    }
+                    if (tableData.Metadata->Kind == EKikimrTableKind::External) {
+                        ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                            TStringBuilder() << "RETURNING is not supported for external data sources."));
+                        return TExprNode::TPtr{};
+                    }
+
                     const auto& tableMeta = BuildTableMeta(tableData, effect.Pos(), ctx);
                     YQL_ENSURE(effectsMap[effect.Raw()]);
 

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -1301,12 +1301,12 @@ TMaybe<TKqlQueryList> BuildKqlQuery(TKiDataQueryBlocks dataQueryBlocks, const TK
                     if (tableData.Metadata->Kind == EKikimrTableKind::Olap) {
                         ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                             TStringBuilder() << "RETURNING is not supported for column-oriented tables."));
-                        return TExprNode::TPtr{};
+                        return input;
                     }
                     if (tableData.Metadata->Kind == EKikimrTableKind::External) {
                         ctx.AddError(YqlIssue(ctx.GetPosition(effect.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                             TStringBuilder() << "RETURNING is not supported for external data sources."));
-                        return TExprNode::TPtr{};
+                        return input;
                     }
 
                     const auto& tableMeta = BuildTableMeta(tableData, effect.Pos(), ctx);

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -1001,6 +1001,13 @@ public:
             return true;
         }
 
+        NCommon::TWriteTableSettings writeSettings = NCommon::ParseWriteTableSettings(TExprList(node->Child(4)), ctx);
+        if (writeSettings.ReturningList.IsValid() && writeSettings.ReturningList.Cast().Size() > 0) {
+            ctx.AddError(YqlIssue(ctx.GetPosition(node->Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
+                TStringBuilder() << "RETURNING is not supported for external data sources."));
+            return false;
+        }
+
         if (mode != "insert_abort") {
             if (mode == "drop" || mode == "drop_if_exists") {
                 TString dropHint;

--- a/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
+++ b/ydb/core/kqp/ut/arrow/kqp_result_set_formats_ut.cpp
@@ -654,6 +654,9 @@ Y_UNIT_TEST_SUITE(KqpResultSetFormats) {
                 (45, false, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), "[12]", "[13]", JsonDocument("[14]"))
                 RETURNING *;
             )";
+            auto arrowSettings = TExecuteQuerySettings().Format(TResultSet::EFormat::Arrow);
+            auto arrowResponse = client.ExecuteQuery(query, TTxControl::BeginTx().CommitTx(), arrowSettings).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(arrowResponse.GetStatus(), EStatus::BAD_REQUEST, arrowResponse.GetIssues().ToString());
         } else {
             CreateAllTypesRowTable(client);
             query = R"(
@@ -663,9 +666,8 @@ Y_UNIT_TEST_SUITE(KqpResultSetFormats) {
                 (45, true, -1, 1, -2, 2, -3, 3, -4, 4, CAST(3.0 AS Float), 4.0, "five", Utf8("six"), Date("2007-07-07"), Datetime("2008-08-08T08:08:08Z"), Timestamp("2009-09-09T09:09:09.09Z"), Interval("P10D"), CAST("11.11" AS Decimal(22, 9)), "[12]", "[13]", JsonDocument("[14]"), DyNumber("15.15"), 123)
                 RETURNING *;
             )";
+            Y_UNUSED(ExecuteAndCombineBatches(client, query, /* assertSize */ true));
         }
-
-        Y_UNUSED(ExecuteAndCombineBatches(client, query, /* assertSize */ true));
     }
 
     /**

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -3737,6 +3737,17 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
             auto result = resultFuture.GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
         }
+
+        {
+            const TString query = fmt::format(R"(
+                INSERT INTO `{tbl}` WITH (FORMAT = "tsv_with_names", SCHEMA (key Utf8 NOT NULL, value Utf8 NOT NULL)) (key, value) VALUES ('1', 'test') RETURNING key;
+            )", "tbl"_a = tableName);
+
+            auto resultFuture = db.ExecuteQuery(query, TTxControl::BeginTx().CommitTx());
+            resultFuture.Wait();
+            auto result = resultFuture.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        }
     }
 }
 

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -3740,8 +3740,8 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
 
         {
             const TString query = fmt::format(R"(
-                INSERT INTO `{tbl}` WITH (FORMAT = "tsv_with_names", SCHEMA (key Utf8 NOT NULL, value Utf8 NOT NULL)) (key, value) VALUES ('1', 'test') RETURNING key;
-            )", "tbl"_a = tableName);
+                INSERT INTO `{ds}`.`{obj}` WITH (FORMAT = "tsv_with_names", SCHEMA (key Utf8 NOT NULL, value Utf8 NOT NULL)) (key, value) VALUES ('1', 'test') RETURNING key;
+            )", "ds"_a = dataSourceName, "obj"_a = object);
 
             auto resultFuture = db.ExecuteQuery(query, TTxControl::BeginTx().CommitTx());
             resultFuture.Wait();

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -3678,6 +3678,66 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
             UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(0).GetUint64(), size);
         }
     }
+
+    Y_UNIT_TEST(ReturningWithInsertOnS3Storage) {
+        const TString dataSourceName = "/Root/s3_data_source";
+        const TString tableName = "/Root/external_table";
+        const TString bucket = "test_bucket_insert_returning";
+        const TString object = "test_object/";
+
+        {
+            Aws::S3::S3Client s3Client = MakeS3Client();
+            CreateBucket(bucket, s3Client);
+        }
+
+        auto kikimr = NTestUtils::MakeKikimrRunner();
+
+        auto client = kikimr->GetTableClient();
+        auto session = client.CreateSession().GetValueSync().GetSession();
+
+        const TString createQuery = fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE `{ds}` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="{loc}",
+                AUTH_METHOD="NONE"
+            );
+            CREATE EXTERNAL TABLE `{tbl}` (
+                key Utf8 NOT NULL,
+                value Utf8 NOT NULL
+            ) WITH (
+                DATA_SOURCE="{ds}",
+                LOCATION="{obj}",
+                FORMAT="tsv_with_names"
+            );
+        )", "ds"_a = dataSourceName, "loc"_a = GetBucketLocation(bucket), "tbl"_a = tableName, "obj"_a = object);
+
+        auto resultCreateDS = session.ExecuteSchemeQuery(createQuery).GetValueSync();
+        UNIT_ASSERT_C(resultCreateDS.IsSuccess(), resultCreateDS.GetIssues().ToString());
+
+        auto db = kikimr->GetQueryClient();
+
+        {
+            const TString query = fmt::format(R"(
+                INSERT INTO `{tbl}` (key, value) VALUES ('1', 'test') RETURNING *;
+            )", "tbl"_a = tableName);
+
+            auto resultFuture = db.ExecuteQuery(query, TTxControl::BeginTx().CommitTx());
+            resultFuture.Wait();
+            auto result = resultFuture.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        }
+
+        {
+            const TString query = fmt::format(R"(
+                INSERT INTO `{tbl}` (key, value) VALUES ('1', 'test') RETURNING key;
+            )", "tbl"_a = tableName);
+
+            auto resultFuture = db.ExecuteQuery(query, TTxControl::BeginTx().CommitTx());
+            resultFuture.Wait();
+            auto result = resultFuture.GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        }
+    }
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/opt/kqp_returning_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_returning_ut.cpp
@@ -1066,6 +1066,98 @@ Y_UNIT_TEST(ReturningDeleteUpdate) {
     }
 }
 
+Y_UNIT_TEST(ReturningWithUpsertOnColumnShard) {
+    TKikimrSettings serverSettings;
+    serverSettings.SetWithSampleTables(false);
+    TKikimrRunner kikimr(serverSettings);
+
+    auto client = kikimr.GetTableClient();
+    auto session = client.CreateSession().GetValueSync().GetSession();
+
+    const auto queryCreate = Q_(R"(
+        CREATE TABLE `/Root/ColumnShardTest` (
+            Col1 Uint64 NOT NULL,
+            Col2 String NOT NULL,
+            Col3 Int32 NOT NULL,
+            PRIMARY KEY (Col1)
+        )
+        WITH (STORE = COLUMN);
+    )");
+
+    auto resultCreate = session.ExecuteSchemeQuery(queryCreate).GetValueSync();
+    UNIT_ASSERT_C(resultCreate.IsSuccess(), resultCreate.GetIssues().ToString());
+
+    auto db = kikimr.GetQueryClient();
+
+    {
+        const auto query = Q_(R"(
+            UPSERT INTO `/Root/ColumnShardTest` (Col1, Col2, Col3) VALUES (1u, "test", 10) RETURNING *;
+        )");
+
+        auto resultFuture = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx());
+        resultFuture.Wait();
+        auto result = resultFuture.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+    }
+
+    {
+        const auto query = Q_(R"(
+            UPSERT INTO `/Root/ColumnShardTest` (Col1, Col2, Col3) VALUES (1u, "test", 10) RETURNING Col1, Col2;
+        )");
+
+        auto resultFuture = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx());
+        resultFuture.Wait();
+        auto result = resultFuture.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+    }
+}
+
+Y_UNIT_TEST(ReturningWithInsertOnColumnShard) {
+    TKikimrSettings serverSettings;
+    serverSettings.SetWithSampleTables(false);
+    TKikimrRunner kikimr(serverSettings);
+
+    auto client = kikimr.GetTableClient();
+    auto session = client.CreateSession().GetValueSync().GetSession();
+
+    const auto queryCreate = Q_(R"(
+        CREATE TABLE `/Root/ColumnShardTest` (
+            Col1 Uint64 NOT NULL,
+            Col2 String NOT NULL,
+            Col3 Int32 NOT NULL,
+            PRIMARY KEY (Col1)
+        )
+        WITH (STORE = COLUMN);
+    )");
+
+    auto resultCreate = session.ExecuteSchemeQuery(queryCreate).GetValueSync();
+    UNIT_ASSERT_C(resultCreate.IsSuccess(), resultCreate.GetIssues().ToString());
+
+    auto db = kikimr.GetQueryClient();
+
+    {
+        const auto query = Q_(R"(
+            INSERT INTO `/Root/ColumnShardTest` (Col1, Col2, Col3) VALUES (1u, "test", 10) RETURNING *;
+        )");
+
+        auto resultFuture = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx());
+        resultFuture.Wait();
+        auto result = resultFuture.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+    }
+
+    {
+        const auto query = Q_(R"(
+            INSERT INTO `/Root/ColumnShardTest` (Col1, Col2, Col3) VALUES (1u, "test", 10) RETURNING Col1, Col2;
+        )");
+
+        auto resultFuture = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::BeginTx().CommitTx());
+        resultFuture.Wait();
+        auto result = resultFuture.GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+    }
+}
+
 }
 
 } // namespace NKikimr::NKqp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Disabled RETURNING for ColumnShards and External Tables #39891

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Disable RETURNING for ColumnShards and External Tables
