### PR TITLE
[NEW RBO] Pretty print simple expressions in explain plan

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_expression.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_expression.cpp
@@ -1,7 +1,10 @@
 #include "kqp_expression.h"
 
+#include <yql/essentials/ast/yql_ast_escaping.h>
 #include <yql/essentials/core/yql_expr_type_annotation.h>
 #include <yql/essentials/core/yql_expr_optimize.h>
+#include <util/stream/str.h>
+#include <optional>
 
 using namespace NYql::NNodes;
 
@@ -133,6 +136,221 @@ TExprNode::TPtr FindMemberArg(TExprNode::TPtr input) {
     }
     return TExprNode::TPtr();
 }
+
+TString FormatInfoUnits(const TVector<TInfoUnit>& infoUnits) {
+    TStringBuilder result;
+    for (size_t i = 0; i < infoUnits.size(); ++i) {
+        if (i != 0) {
+            result << ",";
+        }
+        result << infoUnits[i].GetFullName();
+    }
+    return result;
+}
+
+TVector<TInfoUnit> DeduplicateInfoUnits(const TVector<TInfoUnit>& infoUnits) {
+    THashSet<TInfoUnit, TInfoUnit::THashFunction> seen;
+    TVector<TInfoUnit> result;
+    for (const auto& infoUnit : infoUnits) {
+        if (!seen.contains(infoUnit)) {
+            seen.insert(infoUnit);
+            result.push_back(infoUnit);
+        }
+    }
+    return result;
+}
+
+TString QuoteString(TStringBuf value) {
+    TStringStream out;
+    out << '"';
+    EscapeArbitraryAtom(value, '"', &out);
+    out << '"';
+    return out.Str();
+}
+
+std::optional<TString> FormatSimpleExpression(TExprNode::TPtr node, ui32 depth = 0);
+
+bool IsBinaryCallable(TStringBuf callable) {
+    return callable == "+" || callable == "-" || callable == "*" || callable == "/" || callable == "%" ||
+        callable == "==" || callable == "!=" || callable == "<" || callable == "<=" || callable == ">" || callable == ">=" ||
+        callable == "DecimalAdd" || callable == "DecimalSub" || callable == "DecimalMul" || callable == "DecimalDiv";
+}
+
+TString GetBinaryOperator(TStringBuf callable) {
+    if (callable == "DecimalAdd") {
+        return "+";
+    }
+    if (callable == "DecimalSub") {
+        return "-";
+    }
+    if (callable == "DecimalMul") {
+        return "*";
+    }
+    if (callable == "DecimalDiv") {
+        return "/";
+    }
+    return TString(callable);
+}
+
+TString GetLogicOperator(TStringBuf callable) {
+    if (callable == "And") {
+        return "AND";
+    }
+    if (callable == "Or") {
+        return "OR";
+    }
+    if (callable == "Xor") {
+        return "XOR";
+    }
+    return TString(callable);
+}
+
+bool NeedParens(TExprNode::TPtr node) {
+    return node->IsCallable() && (IsBinaryCallable(node->Content()) || node->IsCallable({"And", "Or", "Xor"}));
+}
+
+std::optional<TString> FormatAtomLiteral(TExprNode::TPtr node) {
+    if (!node->IsCallable() || node->ChildrenSize() == 0 || !node->Child(0)->IsAtom()) {
+        return {};
+    }
+
+    const auto callable = node->Content();
+    const auto value = node->Child(0)->Content();
+    if (callable == "String" || callable == "Utf8") {
+        return QuoteString(value);
+    }
+    if (callable == "Bool") {
+        return ToString(value);
+    }
+    if (callable == "Date" || callable == "Datetime" || callable == "Timestamp") {
+        return TStringBuilder() << callable << "(" << value << ")";
+    }
+    if (callable == "Decimal") {
+        return ToString(value);
+    }
+    if (callable == "Int8" || callable == "Int16" || callable == "Int32" || callable == "Int64" ||
+        callable == "Uint8" || callable == "Uint16" || callable == "Uint32" || callable == "Uint64" ||
+        callable == "Float" || callable == "Double")
+    {
+        return ToString(value);
+    }
+
+    return {};
+}
+
+std::optional<TString> FormatSimpleBinary(TExprNode::TPtr node, ui32 depth) {
+    if (node->ChildrenSize() != 2) {
+        return {};
+    }
+
+    auto left = FormatSimpleExpression(node->ChildPtr(0), depth + 1);
+    auto right = FormatSimpleExpression(node->ChildPtr(1), depth + 1);
+    if (!left || !right) {
+        return {};
+    }
+
+    if (NeedParens(node->ChildPtr(0))) {
+        left = TStringBuilder() << "(" << *left << ")";
+    }
+    if (NeedParens(node->ChildPtr(1))) {
+        right = TStringBuilder() << "(" << *right << ")";
+    }
+
+    return TStringBuilder() << *left << " " << GetBinaryOperator(node->Content()) << " " << *right;
+}
+
+std::optional<TString> FormatSimpleLogic(TExprNode::TPtr node, ui32 depth) {
+    TVector<TString> parts;
+    for (const auto& child : node->Children()) {
+        auto part = FormatSimpleExpression(child, depth + 1);
+        if (!part) {
+            return {};
+        }
+        parts.push_back(*part);
+    }
+
+    TStringBuilder result;
+    const auto logicOp = GetLogicOperator(node->Content());
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i != 0) {
+            result << " " << logicOp << " ";
+        }
+        result << parts[i];
+    }
+    return result;
+}
+
+std::optional<TString> FormatSimpleExpression(TExprNode::TPtr node, ui32 depth) {
+    if (!node || depth > 12) {
+        return {};
+    }
+    if (node->IsLambda()) {
+        return node->ChildrenSize() >= 2 ? FormatSimpleExpression(node->ChildPtr(1), depth + 1) : std::optional<TString>();
+    }
+    if (!node->IsCallable()) {
+        return {};
+    }
+    if (auto literal = FormatAtomLiteral(node)) {
+        return literal;
+    }
+    if (node->IsCallable("Member")) {
+        if (node->ChildrenSize() == 2 && node->Child(1)->IsAtom()) {
+            return TString(node->Child(1)->Content());
+        }
+        return {};
+    }
+    if (node->IsCallable({"ToPg", "FromPg", "SafeCast", "Just", "Unwrap", "Convert"})) {
+        return node->ChildrenSize() >= 1 ? FormatSimpleExpression(node->ChildPtr(0), depth + 1) : std::optional<TString>();
+    }
+    if (node->IsCallable("Coalesce")) {
+        if (node->ChildrenSize() != 2) {
+            return {};
+        }
+        auto value = FormatSimpleExpression(node->ChildPtr(0), depth + 1);
+        auto fallback = FormatSimpleExpression(node->ChildPtr(1), depth + 1);
+        if (!value || !fallback) {
+            return {};
+        }
+        return TStringBuilder() << "Coalesce(" << *value << ", " << *fallback << ")";
+    }
+    if (IsBinaryCallable(node->Content())) {
+        return FormatSimpleBinary(node, depth);
+    }
+    if (node->IsCallable({"And", "Or", "Xor"})) {
+        return FormatSimpleLogic(node, depth);
+    }
+    if (node->IsCallable("Not")) {
+        if (node->ChildrenSize() != 1) {
+            return {};
+        }
+        auto value = FormatSimpleExpression(node->ChildPtr(0), depth + 1);
+        if (!value) {
+            return {};
+        }
+        if (NeedParens(node->ChildPtr(0))) {
+            return TStringBuilder() << "NOT (" << *value << ")";
+        }
+        return TStringBuilder() << "NOT " << *value;
+    }
+
+    return {};
+}
+
+TString FormatExpressionDependencies(const TExpression& expr) {
+    TVector<TInfoUnit> deps;
+    try {
+        deps = expr.GetInputIUs(true, true);
+    } catch (...) {
+        GetAllMembers(expr.Node, deps);
+    }
+
+    deps = DeduplicateInfoUnits(deps);
+    if (deps.empty()) {
+        return "<expr>";
+    }
+    return TStringBuilder() << "<expr depends on: " << FormatInfoUnits(deps) << ">";
+}
+
 }
 
 namespace NKikimr {
@@ -311,6 +529,13 @@ TString PrintRBOExpression(TExprNode::TPtr expr, TExprContext & ctx) {
 
 TString TExpression::ToString() const {
     return PrintRBOExpression(Node, *Ctx);
+}
+
+TString TExpression::ToExplainString() const {
+    if (auto simple = FormatSimpleExpression(Node)) {
+        return *simple;
+    }
+    return FormatExpressionDependencies(*this);
 }
 
 TEquiJoinCondition::TEquiJoinCondition(const TExpression& expr) : Expr(expr)

--- a/ydb/core/kqp/opt/rbo/kqp_expression.h
+++ b/ydb/core/kqp/opt/rbo/kqp_expression.h
@@ -74,6 +74,9 @@ class TExpression {
     // Produce a pretty string for this expression
     TString ToString() const;
 
+    // Produce a compact string suitable for explain output. Complex expressions are summarized by dependencies.
+    TString ToExplainString() const;
+
     TExprNode::TPtr Node;
     TExprContext* Ctx;
     TPlanProps* PlanProps;

--- a/ydb/core/kqp/opt/rbo/kqp_operator.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.cpp
@@ -170,6 +170,10 @@ NJson::TJsonValue TOpRead::ToJson(ui32 explainFlags) {
         res["Limit"] = *limit;
     }
 
+    if (OriginalPredicate) {
+        res["Predicate"] = OriginalPredicate->ToExplainString();
+    }
+
     return res;
 }
 
@@ -425,6 +429,33 @@ TString TOpMap::ToString(TExprContext& ctx) {
     return res;
 }
 
+NJson::TJsonValue TOpMap::ToJson(ui32 explainFlags) {
+    auto res = IOperator::ToJson(explainFlags);
+
+    TStringBuilder name;
+    name << "Map [";
+    for (size_t i = 0, e = MapElements.size(); i < e; ++i) {
+        const auto& mapElement = MapElements[i];
+        name << mapElement.GetElementName().GetFullName() << ": ";
+        if (mapElement.IsRename()) {
+            name << mapElement.GetRename().GetFullName();
+        } else {
+            name << mapElement.GetExpression().ToExplainString();
+        }
+
+        if (i + 1 != e) {
+            name << ", ";
+        }
+    }
+    name << "]";
+    if (Project) {
+        name << " Project";
+    }
+
+    res["Name"] = name;
+    return res;
+}
+
 /**
  * OpAddDependencies methods
  */
@@ -580,6 +611,12 @@ TVector<TInfoUnit> TOpFilter::GetSubplanIUs(TPlanProps& props) {
 TString TOpFilter::ToString(TExprContext& ctx) {
     Y_UNUSED(ctx);
     return TStringBuilder() << "Filter :" << FilterExpr.ToString();
+}
+
+NJson::TJsonValue TOpFilter::ToJson(ui32 explainFlags) {
+    auto res = IOperator::ToJson(explainFlags);
+    res["Predicate"] = FilterExpr.ToExplainString();
+    return res;
 }
 
 /**
@@ -739,6 +776,13 @@ NJson::TJsonValue TOpJoin::ToJson(ui32 explainFlags) {
     if (!JoinKeys.empty()) {
         res["Condition"] = FormatJoinKeys(JoinKeys);
     }
+    if (!JoinFilters.empty()) {
+        NJson::TJsonValue filters(NJson::EJsonValueType::JSON_ARRAY);
+        for (const auto& filter : JoinFilters) {
+            filters.AppendValue(filter.ToExplainString());
+        }
+        res["Filters"] = filters;
+    }
 
     return res;
 }
@@ -816,6 +860,18 @@ TString TOpLimit::ToString(TExprContext& ctx) {
     }
     builder << "Phase: " << ToStringPhase(LimitPhase);
     return builder;
+}
+
+NJson::TJsonValue TOpLimit::ToJson(ui32 explainFlags) {
+    auto res = IOperator::ToJson(explainFlags);
+    res["Limit"] = LimitCond.ToExplainString();
+    if (OffsetCond) {
+        res["Offset"] = OffsetCond->ToExplainString();
+    }
+    if (LimitPhase != EOpPhase::Undefined) {
+        res["Phase"] = ToStringPhase(LimitPhase);
+    }
+    return res;
 }
 
 TVector<std::reference_wrapper<TExpression>> TOpLimit::GetExpressions() {
@@ -906,8 +962,8 @@ NJson::TJsonValue TOpSort::ToJson(ui32 explainFlags) {
     auto res = IOperator::ToJson(explainFlags);
     if (IsTopSort()) {
         res["TopSortBy"] = FormatSortElements(SortElements);
-        if (const auto limit = GetUint64Literal(LimitCond->GetExpressionBody())) {
-            res["Limit"] = *limit;
+        if (LimitCond) {
+            res["Limit"] = LimitCond->ToExplainString();
         }
     } else {
         res["SortBy"] = FormatSortElements(SortElements);

--- a/ydb/core/kqp/opt/rbo/kqp_operator.h
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.h
@@ -329,6 +329,7 @@ public:
     virtual void ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) override;
 
     virtual TString ToString(TExprContext& ctx) override;
+    virtual NJson::TJsonValue ToJson(ui32 explainFlags) override;
     virtual TString GetExplainName() const override { return "Map"; }
 
     bool IsOrdered() const {
@@ -435,6 +436,7 @@ public:
     virtual TVector<TInfoUnit> GetUsedIUs(TPlanProps& props) override;
     virtual TVector<TInfoUnit> GetSubplanIUs(TPlanProps& props) override;
     virtual TString ToString(TExprContext& ctx) override;
+    virtual NJson::TJsonValue ToJson(ui32 explainFlags) override;
     virtual TString GetExplainName() const override { return "Filter"; }
 
     virtual TVector<std::reference_wrapper<TExpression>> GetExpressions() override;
@@ -505,6 +507,7 @@ public:
     void RenameIUs(const THashMap<TInfoUnit, TInfoUnit, TInfoUnit::THashFunction>& renameMap, TExprContext& ctx,
                    const THashSet<TInfoUnit, TInfoUnit::THashFunction>& stopList = {}) override;
     virtual TString ToString(TExprContext& ctx) override;
+    virtual NJson::TJsonValue ToJson(ui32 explainFlags) override;
     virtual TString GetExplainName() const override { return "Limit"; }
 
     virtual TVector<std::reference_wrapper<TExpression>> GetExpressions() override;

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/executer_actor/kqp_executer.h>
+#include <ydb/core/kqp/opt/rbo/kqp_operator.h>
 #include <ydb/core/statistics/ut_common/ut_common.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
@@ -148,6 +149,33 @@ const NJson::TJsonValue* FindOperatorByStringFieldContaining(const NJson::TJsonV
     if (auto plans = planMap.find("Plans"); plans != planMap.end()) {
         for (const auto& child : plans->second.GetArraySafe()) {
             if (const auto* op = FindOperatorByStringFieldContaining(child, fieldName, fieldValue)) {
+                return op;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+const NJson::TJsonValue* FindOperatorByNamePrefix(const NJson::TJsonValue& planNode, const TString& namePrefix) {
+    if (!planNode.IsMap()) {
+        return nullptr;
+    }
+
+    const auto& planMap = planNode.GetMapSafe();
+    if (auto operators = planMap.find("Operators"); operators != planMap.end()) {
+        for (const auto& opNode : operators->second.GetArraySafe()) {
+            const auto& op = opNode.GetMapSafe();
+            const auto name = op.find("Name");
+            if (name != op.end() && name->second.IsString() && name->second.GetStringSafe().StartsWith(namePrefix)) {
+                return &opNode;
+            }
+        }
+    }
+
+    if (auto plans = planMap.find("Plans"); plans != planMap.end()) {
+        for (const auto& child : plans->second.GetArraySafe()) {
+            if (const auto* op = FindOperatorByNamePrefix(child, namePrefix)) {
                 return op;
             }
         }
@@ -617,6 +645,135 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
             NYdb::NConsoleClient::TQueryPlanPrinter queryPlanPrinter(NYdb::NConsoleClient::EDataFormat::PrettyTable, true, Cout, 0);
             queryPlanPrinter.Print(plan);
         }
+    }
+
+    NKikimrConfig::TAppConfig CreateExpressionPrintingTestAppConfig() {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
+        return appConfig;
+    }
+
+    void CreateExpressionPrintingTestTables(TKikimrRunner& kikimr) {
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/foo` (
+                id Int64 NOT NULL,
+                b Int64,
+                primary key(id)
+            );
+
+            CREATE TABLE `/Root/bar` (
+                id Int64 NOT NULL,
+                c Int64,
+                primary key(id)
+            );
+        )").GetValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    class TExpressionPrintingTestContext {
+    public:
+        TExpressionPrintingTestContext()
+            : AppConfig(CreateExpressionPrintingTestAppConfig())
+            , Kikimr(NKqp::TKikimrSettings(AppConfig).SetWithSampleTables(false))
+            , Session(CreateSession())
+        {
+        }
+
+        NYdb::NQuery::TSession& GetSession() {
+            return Session;
+        }
+
+    private:
+        NYdb::NQuery::TSession CreateSession() {
+            CreateExpressionPrintingTestTables(Kikimr);
+            return CreateQuerySession(Kikimr);
+        }
+
+    private:
+        NKikimrConfig::TAppConfig AppConfig;
+        TKikimrRunner Kikimr;
+        NYdb::NQuery::TSession Session;
+    };
+
+    Y_UNIT_TEST(ExplainExpressionPrintingSimpleQuery) {
+        TExpressionPrintingTestContext testContext;
+        auto plan = ExecuteExplain(testContext.GetSession(), R"(
+            PRAGMA YqlSelect = 'force';
+            SELECT id + 1 AS next_id
+            FROM `/Root/foo`
+            WHERE b > 10
+            LIMIT 3;
+        )");
+
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* mapOp = FindOperatorByNamePrefix(simplifiedPlan, "Map [");
+        const auto* filterOp = FindOperatorByNamePrefix(simplifiedPlan, "Filter");
+        const auto* limitOp = FindOperatorByNamePrefix(simplifiedPlan, "Limit");
+        UNIT_ASSERT_C(mapOp, plan);
+        UNIT_ASSERT_C(filterOp, plan);
+        UNIT_ASSERT_C(limitOp, plan);
+
+        const auto mapName = GetStringField(*mapOp, "Name");
+        UNIT_ASSERT_C(mapName.Contains("next_id:") && mapName.Contains("id + 1"), plan);
+        const auto predicate = GetStringField(*filterOp, "Predicate");
+        UNIT_ASSERT_C(predicate.Contains("b > 10"), plan);
+        UNIT_ASSERT_VALUES_EQUAL_C(GetStringField(*limitOp, "Limit"), "3", plan);
+    }
+
+    Y_UNIT_TEST(ExplainExpressionPrintingJoinPredicate) {
+        TExpressionPrintingTestContext testContext;
+        auto plan = ExecuteExplain(testContext.GetSession(), R"(
+            PRAGMA YqlSelect = 'force';
+            SELECT count(*)
+            FROM `/Root/foo` AS t1
+            INNER JOIN `/Root/bar` AS t2
+                ON t1.id = t2.id AND t1.b < t2.c;
+        )");
+
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* joinOp = FindOperatorByStringField(simplifiedPlan, "JoinKind", "Inner");
+        UNIT_ASSERT_C(joinOp, plan);
+        const auto condition = GetStringField(*joinOp, "Condition");
+        UNIT_ASSERT_C(condition.Contains("id") && condition.Contains(" = "), plan);
+
+        const auto* residualFilterOp = FindOperatorByNamePrefix(simplifiedPlan, "Filter");
+        UNIT_ASSERT_C(residualFilterOp, plan);
+        const auto residualPredicate = GetStringField(*residualFilterOp, "Predicate");
+        UNIT_ASSERT_C(residualPredicate.Contains("b") && residualPredicate.Contains(" < ") && residualPredicate.Contains("c"), plan);
+    }
+
+    Y_UNIT_TEST(ExplainExpressionPrintingJoinFilters) {
+        NYql::TExprContext exprCtx;
+        TPlanProps planProps;
+        const auto pos = NYql::TPositionHandle();
+        const auto filter = MakeBinaryPredicate(
+            "<",
+            MakeColumnAccess(TInfoUnit("t1.b"), pos, &exprCtx, &planProps),
+            MakeColumnAccess(TInfoUnit("t2.c"), pos, &exprCtx, &planProps)
+        );
+        TOpJoin join(
+            MakeIntrusive<TOpEmptySource>(pos),
+            MakeIntrusive<TOpEmptySource>(pos),
+            pos,
+            "Inner",
+            {{TInfoUnit("t1.id"), TInfoUnit("t2.id")}},
+            {filter}
+        );
+
+        const auto joinJson = join.ToJson(0);
+        const auto condition = GetStringField(joinJson, "Condition");
+        UNIT_ASSERT_C(condition.Contains("t1.id = t2.id"), condition);
+        const auto& joinOpMap = joinJson.GetMapSafe();
+        const auto filtersIt = joinOpMap.find("Filters");
+        UNIT_ASSERT_C(filtersIt != joinOpMap.end() && filtersIt->second.IsArray(), joinJson.GetStringRobust());
+        const auto& filters = filtersIt->second.GetArraySafe();
+        UNIT_ASSERT_VALUES_EQUAL_C(filters.size(), 1, joinJson.GetStringRobust());
+        UNIT_ASSERT_C(filters[0].IsString(), joinJson.GetStringRobust());
+        const auto joinFilter = filters[0].GetStringSafe();
+        UNIT_ASSERT_C(joinFilter.Contains("t1.b < t2.c"), joinFilter);
     }
 
     bool HasParam(const std::string& ast, const std::string& param) {


### PR DESCRIPTION
This introduces a pretty printer for `TExpression`, which allows for many of the **YQL**-based expressions to be printed in short form directly in explain. If pretty printer does not support some parts of the printed expression, this falls back to printing `<expr depends on: ... list of argumens ...>`, which is, I believe, enough for most cases and better than printing full **YQL AST**.