### PR TITLE
DataShard: PESSIMISTIC_NONE lock mode

### DIFF
--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -60,7 +60,7 @@ NTable::EReady TDataShardUserDb::SelectRow(
         GetReadTxMap(tableId),
         GetReadTxObserver(tableId));
 
-    if (LockMode != ELockMode::OptimisticSnapshotIsolation && stats.InvisibleRowSkips > 0) {
+    if (LockMode == ELockMode::Optimistic && stats.InvisibleRowSkips > 0) {
         if (LockTxId) {
             Self.SysLocksTable().BreakSetLocks();
         }
@@ -232,7 +232,7 @@ void TDataShardUserDb::UpdateRow(
     Y_ENSURE(localTableId != 0, "Unexpected UpdateRow for an unknown table");
 
     if (!RowExists(tableId, key)) {
-        if (LockTxId && LockMode != ELockMode::OptimisticSnapshotIsolation) {
+        if (LockTxId && LockMode == ELockMode::Optimistic) {
             // We don't perform an update, but this key may be modified later
             // by a different transaction. Make sure we set the read lock to
             // guard against that.
@@ -1068,7 +1068,7 @@ void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) {
             Self.SysLocksTable().BreakSetLocks();
         }
         MvccReadConflict = true;
-    } else if (rowVersion > SnapshotVersion) {
+    } else if (rowVersion > SnapshotVersion && LockMode == ELockMode::OptimisticSnapshotIsolation) {
         // During commit we read at the current mvcc version, however we may
         // notice there have been changes between the snapshot and current
         // commit version. This is not necessarily an error, but indicates

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -261,6 +261,7 @@ public:
     enum class ELockMode : ui32 {
         Optimistic = 0,
         OptimisticSnapshotIsolation = 1,
+        PessimisticNone = 6,
     };
 
 private:

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -138,7 +138,7 @@ Y_UNIT_TEST(PessimisticNoneModeWriteWrite) {
     )");
 
     // Commit along with writing to key 1. This is where PESSIMISTIC_NONE differs
-    // from OPTIMISTIC_SNAPSHOT_ISOLATION:  Since this key is modifed between
+    // from OPTIMISTIC_SNAPSHOT_ISOLATION:  Since this key is modified between
     // the snapshot and commit timestamps, with the snapshot isolation it would abort,
     // but PESSIMISTIC_NONE allows blind writes.
     UNIT_ASSERT_VALUES_EQUAL(
@@ -201,7 +201,7 @@ Y_UNIT_TEST(PessimisticNoneModeWriteWriteUncommitted) {
     UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 2u);
     UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.back().GetHasWrites(), true);
 
-    // Make an uncommitted write in tx1 to key 2
+    // Make an uncommitted write in tx2 to key 2
     UNIT_ASSERT_VALUES_EQUAL(
         tx2.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 202)),
         "OK");

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -1,0 +1,96 @@
+#include "datashard_ut_common_kqp.h"
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h>
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/protos/query_stats.pb.h>
+
+namespace NKikimr {
+
+using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace NKikimr::NDataShard::NTxHelpers;
+using namespace Tests;
+
+Y_UNIT_TEST_SUITE(DataShardReadCommitted) {
+
+std::tuple<TTestActorRuntime&, Tests::TServer::TPtr, TActorId> TestCreateServer(const TServerSettings& serverSettings) {
+    Tests::TServer::TPtr server = new TServer(serverSettings);
+    auto& runtime = *server->GetRuntime();
+    auto sender = runtime.AllocateEdgeActor();
+
+    runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+    InitRoot(server, sender);
+
+    return {runtime, server, sender};
+}
+
+Y_UNIT_TEST(PessimisticNoneModeSimple) {
+    // PESSIMISTIC_NONE reads don't set locks but can read writes from the same tx.
+
+    TPortManager pm;
+    NKikimrConfig::TAppConfig app;
+    TServerSettings serverSettings(pm.GetPort(2134));
+    serverSettings.SetDomainName("Root")
+        .SetUseRealThreads(false)
+        .SetAppConfig(app);
+
+    auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+    TDisableDataShardLogBatching disableDataShardLogBatching;
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSchemeExec(runtime, R"(
+            CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+        )"),
+        "SUCCESS"
+    );
+
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (1, 100), (2, 200);
+    )");
+
+    const auto tableId = ResolveTableId(server, sender, "/Root/table");
+    UNIT_ASSERT(tableId);
+    const auto shards = GetTableShards(server, sender, "/Root/table");
+    UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+    TTransactionState tx(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+
+    // Read doesn't acquire locks
+    UNIT_ASSERT_VALUES_EQUAL(tx.ReadKey(tableId, shards[0], 1), "1, 100\n");
+    UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 0);
+
+    // Write to key 1, this shouldn't break anything
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (1, 101);
+    )");
+
+    // Lock key 2 and write to it with the same lock id.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx.LockRows(tableId, shards.at(0), {2}),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 1);
+
+    // Write with the same LockTxId to another key
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 201)),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 2);
+
+    tx.ResetSnapshot();
+    UNIT_ASSERT_VALUES_EQUAL(tx.ReadRange(tableId, shards[0], 1, 2), "1, 101\n2, 201\n");
+    UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 2);
+
+    // Check that we can commit the tx.
+    UNIT_ASSERT_VALUES_EQUAL(tx.WriteCommit(tableId, shards.at(0)), "OK");
+
+    // Check that other txs see the update
+    TTransactionState tx2(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+    UNIT_ASSERT_VALUES_EQUAL(tx2.ReadKey(tableId, shards[0], 2), "2, 201\n");
+    UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.size(), 0);
+}
+
+} // Y_UNIT_TEST_SUITE(DataShardReadCommitted)
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -78,6 +78,7 @@ Y_UNIT_TEST(PessimisticNoneModeSimple) {
         "OK");
     UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 2);
 
+    // Read with the new snapshot. Check that the read sees the committed update.
     tx.ResetSnapshot();
     UNIT_ASSERT_VALUES_EQUAL(tx.ReadRange(tableId, shards[0], 1, 2), "1, 101\n2, 201\n");
     UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 2);
@@ -85,10 +86,145 @@ Y_UNIT_TEST(PessimisticNoneModeSimple) {
     // Check that we can commit the tx.
     UNIT_ASSERT_VALUES_EQUAL(tx.WriteCommit(tableId, shards.at(0)), "OK");
 
-    // Check that other txs see the update
+    // Check that other txs see the update from tx.
     TTransactionState tx2(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
     UNIT_ASSERT_VALUES_EQUAL(tx2.ReadKey(tableId, shards[0], 2), "2, 201\n");
     UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.size(), 0);
+}
+
+Y_UNIT_TEST(PessimisticNoneModeWriteWrite) {
+    // PESSIMISTIC_NONE allows blind writes over committed updates (the expectation is that
+    // they are prevented separately via the TEvLockRows mechanism).
+
+    TPortManager pm;
+    NKikimrConfig::TAppConfig app;
+    TServerSettings serverSettings(pm.GetPort(2134));
+    serverSettings.SetDomainName("Root")
+        .SetUseRealThreads(false)
+        .SetAppConfig(app);
+
+    auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+    TDisableDataShardLogBatching disableDataShardLogBatching;
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSchemeExec(runtime, R"(
+            CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+        )"),
+        "SUCCESS"
+    );
+
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (1, 100), (2, 200);
+    )");
+
+    const auto tableId = ResolveTableId(server, sender, "/Root/table");
+    UNIT_ASSERT(tableId);
+    const auto shards = GetTableShards(server, sender, "/Root/table");
+    UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+    TTransactionState tx(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+
+    // Start tx by reading key 1, this should not acquire locks, but will acquire
+    // a snapshot.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx.ReadKey(tableId, shards.at(0), 1),
+        "1, 100\n");
+    UNIT_ASSERT_VALUES_EQUAL(tx.Locks.size(), 0u);
+
+    // Write to key 2, which would be with version above the tx1 snapshot
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (2, 201);
+    )");
+
+    // Commit along with writing to key 1. This is where PESSIMISTIC_NONE differs
+    // from OPTIMISTIC_SNAPSHOT_ISOLATION:  Since this key is modifed between
+    // the snapshot and commit timestamps, with the snapshot isolation it would abort,
+    // but PESSIMISTIC_NONE allows blind writes.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx.WriteCommit(tableId, shards.at(0), TWriteOperation::Upsert(2, 202)),
+        "OK");
+
+    // Check that tx committed successfully.
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSimpleExec(runtime, R"(
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )"),
+        "{ items { int32_value: 1 } items { int32_value: 100 } }, "
+        "{ items { int32_value: 2 } items { int32_value: 202 } }");
+}
+
+Y_UNIT_TEST(PessimisticNoneModeWriteWriteUncommitted) {
+    // PESSIMISTIC_NONE uncommitted writes still conflict to uphold the
+    // "first written, first committed" localdb uncommitted writes invariant.
+
+    TPortManager pm;
+    NKikimrConfig::TAppConfig app;
+    TServerSettings serverSettings(pm.GetPort(2134));
+    serverSettings.SetDomainName("Root")
+        .SetUseRealThreads(false)
+        .SetAppConfig(app);
+
+    auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+    TDisableDataShardLogBatching disableDataShardLogBatching;
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSchemeExec(runtime, R"(
+            CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+        )"),
+        "SUCCESS"
+    );
+
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (1, 100), (2, 200);
+    )");
+
+    const auto tableId = ResolveTableId(server, sender, "/Root/table");
+    UNIT_ASSERT(tableId);
+    const auto shards = GetTableShards(server, sender, "/Root/table");
+    UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+    TTransactionState tx1(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+    TTransactionState tx2(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+
+    // Make an uncommitted write in tx1 to keys 1 and 2
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.Write(tableId, shards.at(0), TWriteOperation::Upsert(1, 101)),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.back().GetHasWrites(), true);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 201)),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.back().GetHasWrites(), true);
+
+    // Make an uncommitted write in tx1 to key 2
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 202)),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.back().GetHasWrites(), true);
+
+    // Commit tx2, it must succeed
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.WriteCommit(tableId, shards.at(0)),
+        "OK");
+
+    // Try committing tx1, it must be broken now
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.WriteCommit(tableId, shards.at(0)),
+        "ERROR: STATUS_LOCKS_BROKEN");
+
+    // We should not observe a commit by tx1.
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSimpleExec(runtime, R"(
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )"),
+        "{ items { int32_value: 1 } items { int32_value: 100 } }, "
+        "{ items { int32_value: 2 } items { int32_value: 202 } }");
 }
 
 } // Y_UNIT_TEST_SUITE(DataShardReadCommitted)

--- a/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot_isolation.cpp
@@ -1,15 +1,15 @@
 #include "datashard_ut_common_kqp.h"
-#include <ydb/core/tx/data_events/payload_helper.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/protos/query_stats.pb.h>
-#include <ydb/core/tx/long_tx_service/public/lock_handle.h>
 
 namespace NKikimr {
 
 using namespace NKikimr::NDataShard;
 using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace NKikimr::NDataShard::NTxHelpers;
 using namespace NSchemeShard;
 using namespace Tests;
 
@@ -27,437 +27,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         return {runtime, server, sender};
     }
 
-    ui64 AllocateTxId(TTestActorRuntime& runtime, const TActorId& sender) {
-        ui32 nodeId = sender.NodeId();
-        ui32 nodeIndex = nodeId - runtime.GetNodeId(0);
-        runtime.Send(new IEventHandle(MakeTxProxyID(), sender, new TEvTxUserProxy::TEvAllocateTxId), nodeIndex, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvAllocateTxIdResult>(sender);
-        auto* msg = ev->Get();
-        return msg->TxId;
-    }
-
-    TRowVersion AcquireSnapshot(TTestActorRuntime& runtime, const TActorId& sender, const TString& databaseName = "/Root") {
-        ui32 nodeId = sender.NodeId();
-        ui32 nodeIndex = nodeId - runtime.GetNodeId(0);
-        auto* req = new NLongTxService::TEvLongTxService::TEvAcquireReadSnapshot(databaseName);
-        runtime.Send(new IEventHandle(NLongTxService::MakeLongTxServiceID(nodeId), sender, req), nodeIndex, true);
-        auto ev = runtime.GrabEdgeEventRethrow<TEvLongTxService::TEvAcquireReadSnapshotResult>(sender);
-        auto* msg = ev->Get();
-        UNIT_ASSERT_VALUES_EQUAL(msg->Status, Ydb::StatusIds::SUCCESS);
-        return msg->Snapshot;
-    }
-
-    NLongTxService::TLockHandle MakeLockHandle(TTestActorRuntime& runtime, ui64 lockId, ui32 nodeIndex = 0) {
-        return NLongTxService::TLockHandle(lockId, runtime.GetActorSystem(nodeIndex));
-    }
-
-    TString FormatReadResult(const TEvDataShard::TEvReadResult* msg) {
-        TStringBuilder sb;
-        if (msg->Record.GetStatus().GetCode() == Ydb::StatusIds::SUCCESS) {
-            size_t count = msg->GetRowsCount();
-            for (size_t i = 0; i < count; ++i) {
-                auto cells = msg->GetCells(i);
-                for (size_t j = 0; j < cells.size(); ++j) {
-                    if (j != 0) {
-                        sb << ", ";
-                    }
-                    sb << cells[j].AsValue<i32>();
-                }
-                sb << "\n";
-            }
-        } else {
-            sb << "ERROR: " << msg->Record.GetStatus().GetCode();
-        }
-        return sb;
-    }
-
-    struct TKeyValue {
-        i32 Key;
-        i32 Value;
-    };
-
-    struct TOperation {
-        NKikimrDataEvents::TEvWrite::TOperation::EOperationType Type;
-        TVector<TKeyValue> Rows;
-
-        void ApplyTo(const TTableId& tableId, NEvents::TDataEvents::TEvWrite* req) {
-            TVector<TCell> cells;
-            cells.reserve(Rows.size() * 2);
-            for (const auto& row : Rows) {
-                cells.push_back(TCell::Make(row.Key));
-                cells.push_back(TCell::Make(row.Value));
-            }
-
-            TSerializedCellMatrix matrix(cells, Rows.size(), 2);
-            TString blobData = matrix.ReleaseBuffer();
-
-            ui64 payloadIndex = NKikimr::NEvWrite::TPayloadWriter<NKikimr::NEvents::TDataEvents::TEvWrite>(*req).AddDataToPayload(std::move(blobData));
-            req->AddOperation(Type, tableId, { 1, 2 }, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
-        }
-
-        static TOperation Upsert(i32 key, i32 value) {
-            return Upsert({ { key, value } });
-        }
-
-        static TOperation Upsert(TVector<TKeyValue> rows) {
-            return TOperation{
-                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
-                std::move(rows),
-            };
-        }
-
-        static TOperation Insert(i32 key, i32 value) {
-            return Insert({ { key, value } } );
-        }
-
-        static TOperation Insert(TVector<TKeyValue> rows) {
-            return TOperation{
-                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
-                std::move(rows),
-            };
-        }
-    };
-
-    class TTransactionState {
-    public:
-        TTransactionState(TTestActorRuntime& runtime)
-            : Runtime(runtime)
-        {
-            Sender = Runtime.AllocateEdgeActor();
-            LockTxId = AllocateTxId(Runtime, Sender);
-            LockNodeId = Sender.NodeId();
-            LockHandle = MakeLockHandle(Runtime, LockTxId, LockNodeId - Runtime.GetNodeId(0));
-        }
-
-        struct TReadPromise {
-            TTransactionState& State;
-            TActorId Sender;
-            TActorId LastSender = TActorId();
-            ui64 LastSeqNo = 0;
-
-            void SendAck(ui64 maxRows = Max<ui64>(), ui64 maxBytes = Max<ui64>()) {
-                auto* msg = new TEvDataShard::TEvReadAck();
-                msg->Record.SetReadId(0);
-                msg->Record.SetSeqNo(LastSeqNo);
-                msg->Record.SetMaxRows(maxRows);
-                msg->Record.SetMaxBytes(maxBytes);
-                ui32 nodeIndex = Sender.NodeId() - State.Runtime.GetNodeId(0);
-                State.Runtime.Send(new IEventHandle(LastSender, Sender, msg), nodeIndex, true);
-            }
-
-            std::unique_ptr<TEvDataShard::TEvReadResult> NextResult(TDuration simTimeout = TDuration::Max()) {
-                auto ev = State.Runtime.GrabEdgeEventRethrow<TEvDataShard::TEvReadResult>(Sender, simTimeout);
-                if (!ev) {
-                    return nullptr;
-                }
-                LastSender = ev->Sender;
-                std::unique_ptr<TEvDataShard::TEvReadResult> msg(ev->Release().Release());
-                LastSeqNo = msg->Record.GetSeqNo();
-                for (const auto& lock : msg->Record.GetTxLocks()) {
-                    State.Locks.push_back(lock);
-                }
-                for (const auto& lock : msg->Record.GetBrokenTxLocks()) {
-                    State.Locks.push_back(lock);
-                }
-                return msg;
-            }
-
-            TString NextString(TDuration simTimeout = TDuration::Max()) {
-                auto msg = NextResult(simTimeout);
-                if (!msg) {
-                    return "<timeout>";
-                }
-                auto status = msg->Record.GetStatus().GetCode();
-                if (status != Ydb::StatusIds::SUCCESS) {
-                    return TStringBuilder() << "ERROR: " << status;
-                }
-                TString res = FormatReadResult(msg.get());
-                if (msg->Record.GetFinished()) {
-                    res += "<end>";
-                }
-                return res;
-            }
-
-            TString AllString() {
-                TString res;
-                for (;;) {
-                    auto msg = NextResult();
-                    auto status = msg->Record.GetStatus().GetCode();
-                    if (status != Ydb::StatusIds::SUCCESS) {
-                        res += TStringBuilder() << "ERROR: " << status;
-                        break;
-                    }
-                    res += FormatReadResult(msg.get());
-                    if (msg->Record.GetFinished()) {
-                        break;
-                    }
-                    SendAck();
-                }
-                return res;
-            }
-        };
-
-        TReadPromise SendReadKey(const TTableId& tableId, ui64 shardId, i32 key) {
-            if (!Snapshot) {
-                Snapshot = AcquireSnapshot(Runtime, Sender);
-            }
-
-            TActorId sender = Runtime.AllocateEdgeActor();
-            ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
-
-            auto* req = new TEvDataShard::TEvRead();
-            req->Record.SetReadId(0);
-            req->Record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
-            req->Record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
-            req->Record.MutableTableId()->SetSchemaVersion(tableId.SchemaVersion);
-            req->Record.MutableSnapshot()->SetStep(Snapshot->Step);
-            req->Record.MutableSnapshot()->SetTxId(Snapshot->TxId);
-            req->Record.SetLockTxId(LockTxId);
-            req->Record.SetLockNodeId(LockNodeId);
-            req->Record.SetLockMode(NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
-            req->Record.AddColumns(1);
-            req->Record.AddColumns(2);
-            req->Record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-
-            TVector<TCell> cells;
-            cells.emplace_back(TCell::Make(key));
-            req->Keys.emplace_back(cells);
-
-            Runtime.SendToPipe(shardId, sender, req, nodeIndex);
-            return { *this, sender };
-        }
-
-        TString ReadKey(const TTableId& tableId, ui64 shardId, i32 key) {
-            auto promise = SendReadKey(tableId, shardId, key);
-            return promise.AllString();
-        }
-
-        TReadPromise SendReadRange(const TTableId& tableId, ui64 shardId, i32 minKey, i32 maxKey, ui64 maxRowsQuota = Max<ui64>()) {
-            if (!Snapshot) {
-                Snapshot = AcquireSnapshot(Runtime, Sender);
-            }
-
-            TActorId sender = Runtime.AllocateEdgeActor();
-            ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
-
-            auto* req = new TEvDataShard::TEvRead();
-            req->Record.SetReadId(0);
-            req->Record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
-            req->Record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
-            req->Record.MutableTableId()->SetSchemaVersion(tableId.SchemaVersion);
-            req->Record.MutableSnapshot()->SetStep(Snapshot->Step);
-            req->Record.MutableSnapshot()->SetTxId(Snapshot->TxId);
-            req->Record.SetLockTxId(LockTxId);
-            req->Record.SetLockNodeId(LockNodeId);
-            req->Record.SetLockMode(NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
-            req->Record.AddColumns(1);
-            req->Record.AddColumns(2);
-            req->Record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-            req->Record.SetMaxRowsInResult(1);
-            req->Record.SetMaxRows(maxRowsQuota);
-
-            TVector<TCell> minCells, maxCells;
-            minCells.emplace_back(TCell::Make(minKey));
-            maxCells.emplace_back(TCell::Make(maxKey));
-            req->Ranges.emplace_back(minCells, true, maxCells, true);
-
-            Runtime.SendToPipe(shardId, sender, req, nodeIndex);
-            return { *this, sender };
-        }
-
-        TString ReadRange(const TTableId& tableId, ui64 shardId, i32 minKey, i32 maxKey) {
-            auto promise = SendReadRange(tableId, shardId, minKey, maxKey);
-            return promise.AllString();
-        }
-
-        bool HasLockConflicts(ui64 shardId) const {
-            const NKikimrDataEvents::TLock* prev = nullptr;
-            for (auto it = Locks.begin(); it != Locks.end(); ++it) {
-                if (it->GetDataShard() == shardId) {
-                    if (prev) {
-                        if (prev->GetGeneration() != it->GetGeneration()) {
-                            return true;
-                        }
-                        if (prev->GetCounter() != it->GetCounter()) {
-                            return true;
-                        }
-                    }
-                    prev = &*it;
-                }
-            }
-            return false;
-        }
-
-        const NKikimrDataEvents::TLock* FindLastLock(ui64 shardId) const {
-            for (auto it = Locks.rbegin(); it != Locks.rend(); ++it) {
-                if (it->GetDataShard() == shardId) {
-                    return &*it;
-                }
-            }
-            return nullptr;
-        }
-
-        struct TWritePromise {
-            TTransactionState& State;
-            TActorId Sender;
-
-            std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> NextResult(TDuration simTimeout = TDuration::Max()) {
-                auto ev = State.Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(Sender, simTimeout);
-                if (!ev) {
-                    return nullptr;
-                }
-                std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> msg(ev->Release().Release());
-                for (const auto& lock : msg->Record.GetTxLocks()) {
-                    State.Locks.push_back(lock);
-                }
-                return msg;
-            }
-
-            TString NextString(TDuration simTimeout = TDuration::Max()) {
-                auto msg = NextResult(simTimeout);
-                if (!msg) {
-                    return "<timeout>";
-                }
-                auto status = msg->Record.GetStatus();
-                if (status != NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED) {
-                    return TStringBuilder() << "ERROR: " << status;
-                }
-                return "OK";
-            }
-        };
-
-        template<class... TOps>
-        TWritePromise SendWrite(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto sender = Runtime.AllocateEdgeActor();
-            ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
-
-            auto* req = new NEvents::TDataEvents::TEvWrite(0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
-            req->Record.SetLockTxId(LockTxId);
-            req->Record.SetLockNodeId(LockNodeId);
-            req->Record.SetLockMode(NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
-            if (Snapshot) {
-                req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
-                req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
-            }
-
-            (..., ops.ApplyTo(tableId, req));
-
-            Runtime.SendToPipe(shardId, sender, req, nodeIndex);
-            return { *this, sender };
-        }
-
-        template<class... TOps>
-        TString Write(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto promise = SendWrite(tableId, shardId, std::forward<TOps>(ops)...);
-            return promise.NextString();
-        }
-
-        template<class... TOps>
-        TWritePromise SendWriteCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto sender = Runtime.AllocateEdgeActor();
-            ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
-
-            auto* req = new NEvents::TDataEvents::TEvWrite(0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
-            req->Record.SetLockMode(NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
-            if (Snapshot) {
-                req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
-                req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
-            }
-
-            // Try to find the last known lock state
-            if (const auto* pLock = FindLastLock(shardId)) {
-                req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
-                req->Record.MutableLocks()->AddSendingShards(shardId);
-                req->Record.MutableLocks()->AddReceivingShards(shardId);
-                *req->Record.MutableLocks()->AddLocks() = *pLock;
-            }
-
-            (..., ops.ApplyTo(tableId, req));
-
-            Runtime.SendToPipe(shardId, sender, req, nodeIndex);
-            return { *this, sender };
-        }
-
-        template<class... TOps>
-        TString WriteCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto promise = SendWriteCommit(tableId, shardId, std::forward<TOps>(ops)...);
-            return promise.NextString();
-        }
-
-        void InitCommit(std::vector<ui64> participants) {
-            CommitTxId = AllocateTxId(Runtime, Sender);
-            Participants = std::move(participants);
-        }
-
-        template<class... TOps>
-        TWritePromise SendPrepareCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto sender = Runtime.AllocateEdgeActor();
-            ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
-
-            auto* req = new NEvents::TDataEvents::TEvWrite(CommitTxId, NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE);
-            req->Record.SetLockMode(NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
-            if (Snapshot) {
-                req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
-                req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
-            }
-
-            req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
-            for (ui64 participant : Participants) {
-                req->Record.MutableLocks()->AddSendingShards(participant);
-                req->Record.MutableLocks()->AddReceivingShards(participant);
-            }
-            if (const auto* pLock = FindLastLock(shardId)) {
-                *req->Record.MutableLocks()->AddLocks() = *pLock;
-            }
-
-            (..., ops.ApplyTo(tableId, req));
-
-            Runtime.SendToPipe(shardId, sender, req, nodeIndex);
-            return { *this, sender };
-        }
-
-        template<class... TOps>
-        TWritePromise PrepareCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
-            auto promise = SendPrepareCommit(tableId, shardId, std::forward<TOps>(ops)...);
-            auto msg = promise.NextResult();
-            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), NKikimrDataEvents::TEvWriteResult::STATUS_PREPARED);
-            MinStep = Max(MinStep, msg->Record.GetMinStep());
-            MaxStep = Min(MaxStep, msg->Record.GetMaxStep());
-            for (ui64 coordinator : msg->Record.GetDomainCoordinators()) {
-                Coordinator = coordinator;
-            }
-            return promise;
-        }
-
-        void SendPlan() {
-            UNIT_ASSERT(Coordinator != 0);
-            UNIT_ASSERT(MinStep <= MaxStep);
-            UNIT_ASSERT(!Participants.empty());
-            SendProposeToCoordinator(
-                Runtime, Sender, Participants, {
-                    .TxId = CommitTxId,
-                    .Coordinator = Coordinator,
-                    .MinStep = MinStep,
-                    .MaxStep = MaxStep,
-                    .Volatile = true,
-                });
-        }
-
-    public:
-        TTestActorRuntime& Runtime;
-        TActorId Sender;
-        ui64 LockTxId = 0;
-        ui32 LockNodeId = 0;
-        NLongTxService::TLockHandle LockHandle;
-        std::optional<TRowVersion> Snapshot;
-        ui64 Counter = 0;
-        std::vector<NKikimrDataEvents::TLock> Locks;
-        std::vector<ui64> Participants;
-        ui64 CommitTxId = 0;
-        ui64 MinStep = 0;
-        ui64 MaxStep = Max<ui64>();
-        ui64 Coordinator = 0;
-    };
+    using TOperation = NKikimr::NDataShard::NTxHelpers::TWriteOperation;
 
     Y_UNIT_TEST(ReadWriteNoLocksNoConflict) {
         TPortManager pm;
@@ -487,7 +57,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -542,7 +112,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -590,7 +160,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -646,7 +216,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -654,7 +224,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             "1, 1001\n");
         UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 0u);
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Make an uncommitted write in tx2 to key 2
         UNIT_ASSERT_VALUES_EQUAL(
@@ -717,7 +287,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -781,7 +351,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -838,7 +408,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -896,7 +466,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -910,7 +480,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx2.InitCommit(shards);
         auto write1 = tx2.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx2.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -972,7 +542,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -986,7 +556,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx2.InitCommit(shards);
         auto write1 = tx2.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx2.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1062,7 +632,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1076,7 +646,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx2.InitCommit(shards);
         auto write1 = tx2.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx2.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1139,7 +709,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1153,7 +723,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx2.InitCommit(shards);
         auto write1 = tx2.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx2.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1225,7 +795,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx1.InitCommit(shards);
         auto write1 = tx1.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx1.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1234,7 +804,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         runtime.WaitFor("blocked readsets", [&]{ return blockedReadSets.size() >= 2; });
         blockedReadSets.Stop();
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1300,7 +870,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx1.InitCommit(shards);
         auto write1 = tx1.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx1.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1309,7 +879,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         runtime.WaitFor("blocked readsets", [&]{ return blockedReadSets.size() >= 2; });
         blockedReadSets.Stop();
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1372,7 +942,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
             return !(msg->Record.GetFlags() & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET);
         });
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
         tx1.InitCommit(shards);
         auto write1 = tx1.PrepareCommit(tableId, shards.at(0), TOperation::Upsert(2, 2001));
         auto write2 = tx1.PrepareCommit(tableId, shards.at(1), TOperation::Upsert(11, 2002));
@@ -1381,7 +951,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         runtime.WaitFor("blocked readsets", [&]{ return blockedReadSets.size() >= 2; });
         blockedReadSets.Stop();
 
-        TTransactionState tx2(runtime);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1440,7 +1010,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1488,7 +1058,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Start transaction by reading key 1, this should not acquire locks
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1536,7 +1106,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Read range, we should observe initial values
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1604,8 +1174,8 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
-        TTransactionState tx2(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Make an uncommitted write to key 2 in tx1
         UNIT_ASSERT_VALUES_EQUAL(
@@ -1666,8 +1236,8 @@ Y_UNIT_TEST_SUITE(DataShardSnapshotIsolation) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
 
-        TTransactionState tx1(runtime);
-        TTransactionState tx2(runtime);
+        TTransactionState tx1(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
+        TTransactionState tx2(runtime, NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION);
 
         // Make an uncommitted write to key 2 in tx1
         UNIT_ASSERT_VALUES_EQUAL(

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -63,11 +63,7 @@ TValidatedWriteTx::TValidatedWriteTx(TDataShard* self, ui64 globalTxId, TInstant
     }
 
     if (record.HasLockMode()) {
-        auto lockMode = record.GetLockMode();
-        if (lockMode == NKikimrDataEvents::PESSIMISTIC_NONE) {
-            lockMode = NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION;
-        }
-        LockMode = TDataShardUserDb::ELockMode(lockMode);
+        LockMode = TDataShardUserDb::ELockMode(record.GetLockMode());
     }
 
     OverloadSubscribe = record.HasOverloadSubscribe() ? record.GetOverloadSubscribe() : std::optional<ui64>{};

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -2934,7 +2934,7 @@ ui64 AsyncTruncateTable(
     return RunSchemeTx(*server->GetRuntime(), std::move(request), sender);
 }
 
-TString FormatReadResult(const TEvDataShard::TEvReadResult* msg) {
+TString FormatIntReadResult(const TEvDataShard::TEvReadResult* msg) {
     TStringBuilder sb;
     if (msg->Record.GetStatus().GetCode() == Ydb::StatusIds::SUCCESS) {
         size_t count = msg->GetRowsCount();

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -2934,4 +2934,24 @@ ui64 AsyncTruncateTable(
     return RunSchemeTx(*server->GetRuntime(), std::move(request), sender);
 }
 
+TString FormatReadResult(const TEvDataShard::TEvReadResult* msg) {
+    TStringBuilder sb;
+    if (msg->Record.GetStatus().GetCode() == Ydb::StatusIds::SUCCESS) {
+        size_t count = msg->GetRowsCount();
+        for (size_t i = 0; i < count; ++i) {
+            auto cells = msg->GetCells(i);
+            for (size_t j = 0; j < cells.size(); ++j) {
+                if (j != 0) {
+                    sb << ", ";
+                }
+                sb << cells[j].AsValue<i32>();
+            }
+            sb << "\n";
+        }
+    } else {
+        sb << "ERROR: " << msg->Record.GetStatus().GetCode();
+    }
+    return sb;
+}
+
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -1035,7 +1035,7 @@ std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(
     TActorId clientId = {},
     TDuration timeout = TDuration::Max());
 
-TString FormatReadResult(const TEvDataShard::TEvReadResult* msg);
+TString FormatIntReadResult(const TEvDataShard::TEvReadResult* msg);
 
 TString ReadTable(
     Tests::TServer::TPtr server,

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -1035,6 +1035,8 @@ std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(
     TActorId clientId = {},
     TDuration timeout = TDuration::Max());
 
+TString FormatReadResult(const TEvDataShard::TEvReadResult* msg);
+
 TString ReadTable(
     Tests::TServer::TPtr server,
     std::span<const ui64> tabletIds,

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -202,6 +202,60 @@ const NKikimrDataEvents::TLock* TTransactionState::FindLastLock(ui64 shardId) co
     return nullptr;
 }
 
+std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult>
+TTransactionState::TLockRowsPromise::NextResult(TDuration simTimeout) {
+    auto ev = State.Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvLockRowsResult>(
+        Sender, simTimeout);
+    if (!ev) {
+        return nullptr;
+    }
+    std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult> msg(ev->Release().Release());
+    for (const auto& lock : msg->Record.GetLocks()) {
+        State.Locks.push_back(lock);
+    }
+    return msg;
+}
+
+TString TTransactionState::TLockRowsPromise::NextString(TDuration simTimeout) {
+    auto msg = NextResult(simTimeout);
+    if (!msg) {
+        return "<timeout>";
+    }
+    auto status = msg->Record.GetStatus();
+    if (status != NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS) {
+        return TStringBuilder() << "ERROR: " << status;
+    }
+    return "OK";
+}
+
+TTransactionState::TLockRowsPromise TTransactionState::SendLockRows(
+    const TTableId& tableId, ui64 shardId, const TVector<i32>& keys,
+    NKikimrDataEvents::ELockMode lockMode) {
+        auto sender = Runtime.AllocateEdgeActor();
+        ui32 nodeIdx = sender.NodeId() - Runtime.GetNodeId(0);
+
+        ui64 requestId = 0;
+        auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(requestId);
+        req->Record.SetLockId(LockTxId);
+        req->Record.SetLockNodeId(LockNodeId);
+        req->Record.SetLockMode(lockMode);
+        req->SetTableId(tableId);
+        req->Record.AddColumnIds(1);
+
+        req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+        TVector<TCell> cells;
+        cells.reserve(keys.size());
+        for (const auto& key : keys) {
+            cells.push_back(TCell::Make(key));
+        }
+        TSerializedCellMatrix matrix(cells, keys.size(), 1);
+        req->SetCellMatrix(matrix.ReleaseBuffer());
+
+        Runtime.SendToPipe(shardId, sender, req.release(), nodeIdx);
+        return { *this, sender };
+}
+
+
 std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> TTransactionState::TWritePromise::NextResult(TDuration simTimeout) {
     auto ev = State.Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(Sender, simTimeout);
     if (!ev) {

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -1,0 +1,248 @@
+#include "datashard_ut_common_tx.h"
+
+namespace NKikimr::NDataShard::NTxHelpers {
+
+ui64 AllocateTxId(TTestActorRuntime& runtime, const TActorId& sender) {
+    ui32 nodeId = sender.NodeId();
+    ui32 nodeIndex = nodeId - runtime.GetNodeId(0);
+    runtime.Send(new IEventHandle(MakeTxProxyID(), sender, new TEvTxUserProxy::TEvAllocateTxId), nodeIndex, true);
+    auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvAllocateTxIdResult>(sender);
+    auto* msg = ev->Get();
+    return msg->TxId;
+}
+
+TRowVersion AcquireSnapshot(TTestActorRuntime& runtime, const TActorId& sender, const TString& databaseName) {
+    ui32 nodeId = sender.NodeId();
+    ui32 nodeIndex = nodeId - runtime.GetNodeId(0);
+    auto* req = new NLongTxService::TEvLongTxService::TEvAcquireReadSnapshot(databaseName);
+    runtime.Send(new IEventHandle(NLongTxService::MakeLongTxServiceID(nodeId), sender, req), nodeIndex, true);
+    auto ev = runtime.GrabEdgeEventRethrow<TEvLongTxService::TEvAcquireReadSnapshotResult>(sender);
+    auto* msg = ev->Get();
+    UNIT_ASSERT_VALUES_EQUAL(msg->Status, Ydb::StatusIds::SUCCESS);
+    return msg->Snapshot;
+}
+
+NLongTxService::TLockHandle MakeLockHandle(TTestActorRuntime& runtime, ui64 lockId, ui32 nodeIndex) {
+    return NLongTxService::TLockHandle(lockId, runtime.GetActorSystem(nodeIndex));
+}
+
+void TWriteOperation::ApplyTo(const TTableId& tableId, NEvents::TDataEvents::TEvWrite* req) {
+    TVector<TCell> cells;
+    cells.reserve(Rows.size() * 2);
+    for (const auto& row : Rows) {
+        cells.push_back(TCell::Make(row.Key));
+        cells.push_back(TCell::Make(row.Value));
+    }
+
+    TSerializedCellMatrix matrix(cells, Rows.size(), 2);
+    TString blobData = matrix.ReleaseBuffer();
+
+    ui64 payloadIndex = NKikimr::NEvWrite::TPayloadWriter<NKikimr::NEvents::TDataEvents::TEvWrite>(*req).AddDataToPayload(std::move(blobData));
+    req->AddOperation(Type, tableId, { 1, 2 }, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
+}
+
+TTransactionState::TTransactionState(TTestActorRuntime& runtime, NKikimrDataEvents::ELockMode lockMode)
+    : Runtime(runtime)
+    , LockMode(lockMode)
+{
+    Sender = Runtime.AllocateEdgeActor();
+    LockTxId = AllocateTxId(Runtime, Sender);
+    LockNodeId = Sender.NodeId();
+    LockHandle = MakeLockHandle(Runtime, LockTxId, LockNodeId - Runtime.GetNodeId(0));
+}
+
+void TTransactionState::TReadPromise::SendAck(ui64 maxRows, ui64 maxBytes) {
+    auto* msg = new TEvDataShard::TEvReadAck();
+    msg->Record.SetReadId(0);
+    msg->Record.SetSeqNo(LastSeqNo);
+    msg->Record.SetMaxRows(maxRows);
+    msg->Record.SetMaxBytes(maxBytes);
+    ui32 nodeIndex = Sender.NodeId() - State.Runtime.GetNodeId(0);
+    State.Runtime.Send(new IEventHandle(LastSender, Sender, msg), nodeIndex, true);
+}
+
+std::unique_ptr<TEvDataShard::TEvReadResult> TTransactionState::TReadPromise::NextResult(TDuration simTimeout) {
+    auto ev = State.Runtime.GrabEdgeEventRethrow<TEvDataShard::TEvReadResult>(Sender, simTimeout);
+    if (!ev) {
+        return nullptr;
+    }
+    LastSender = ev->Sender;
+    std::unique_ptr<TEvDataShard::TEvReadResult> msg(ev->Release().Release());
+    LastSeqNo = msg->Record.GetSeqNo();
+    for (const auto& lock : msg->Record.GetTxLocks()) {
+        State.Locks.push_back(lock);
+    }
+    for (const auto& lock : msg->Record.GetBrokenTxLocks()) {
+        State.Locks.push_back(lock);
+    }
+    return msg;
+}
+
+TString TTransactionState::TReadPromise::NextString(TDuration simTimeout) {
+    auto msg = NextResult(simTimeout);
+    if (!msg) {
+        return "<timeout>";
+    }
+    auto status = msg->Record.GetStatus().GetCode();
+    if (status != Ydb::StatusIds::SUCCESS) {
+        return TStringBuilder() << "ERROR: " << status;
+    }
+    TString res = FormatReadResult(msg.get());
+    if (msg->Record.GetFinished()) {
+        res += "<end>";
+    }
+    return res;
+}
+
+TString TTransactionState::TReadPromise::AllString() {
+    TString res;
+    for (;;) {
+        auto msg = NextResult();
+        auto status = msg->Record.GetStatus().GetCode();
+        if (status != Ydb::StatusIds::SUCCESS) {
+            res += TStringBuilder() << "ERROR: " << status;
+            break;
+        }
+        res += FormatReadResult(msg.get());
+        if (msg->Record.GetFinished()) {
+            break;
+        }
+        SendAck();
+    }
+    return res;
+}
+
+TTransactionState::TReadPromise TTransactionState::SendReadKey(const TTableId& tableId, ui64 shardId, i32 key) {
+    if (!Snapshot) {
+        Snapshot = AcquireSnapshot(Runtime, Sender);
+    }
+
+    TActorId sender = Runtime.AllocateEdgeActor();
+    ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+    auto* req = new TEvDataShard::TEvRead();
+    req->Record.SetReadId(0);
+    req->Record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
+    req->Record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
+    req->Record.MutableTableId()->SetSchemaVersion(tableId.SchemaVersion);
+    req->Record.MutableSnapshot()->SetStep(Snapshot->Step);
+    req->Record.MutableSnapshot()->SetTxId(Snapshot->TxId);
+    req->Record.SetLockTxId(LockTxId);
+    req->Record.SetLockNodeId(LockNodeId);
+    req->Record.SetLockMode(LockMode);
+    req->Record.AddColumns(1);
+    req->Record.AddColumns(2);
+    req->Record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+
+    TVector<TCell> cells;
+    cells.emplace_back(TCell::Make(key));
+    req->Keys.emplace_back(cells);
+
+    Runtime.SendToPipe(shardId, sender, req, nodeIndex);
+    return { *this, sender };
+}
+
+TTransactionState::TReadPromise TTransactionState::SendReadRange(const TTableId& tableId, ui64 shardId, i32 minKey, i32 maxKey, ui64 maxRowsQuota) {
+    if (!Snapshot) {
+        Snapshot = AcquireSnapshot(Runtime, Sender);
+    }
+
+    TActorId sender = Runtime.AllocateEdgeActor();
+    ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+    auto* req = new TEvDataShard::TEvRead();
+    req->Record.SetReadId(0);
+    req->Record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
+    req->Record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
+    req->Record.MutableTableId()->SetSchemaVersion(tableId.SchemaVersion);
+    req->Record.MutableSnapshot()->SetStep(Snapshot->Step);
+    req->Record.MutableSnapshot()->SetTxId(Snapshot->TxId);
+    req->Record.SetLockTxId(LockTxId);
+    req->Record.SetLockNodeId(LockNodeId);
+    req->Record.SetLockMode(LockMode);
+    req->Record.AddColumns(1);
+    req->Record.AddColumns(2);
+    req->Record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+    req->Record.SetMaxRowsInResult(1);
+    req->Record.SetMaxRows(maxRowsQuota);
+
+    TVector<TCell> minCells, maxCells;
+    minCells.emplace_back(TCell::Make(minKey));
+    maxCells.emplace_back(TCell::Make(maxKey));
+    req->Ranges.emplace_back(minCells, true, maxCells, true);
+
+    Runtime.SendToPipe(shardId, sender, req, nodeIndex);
+    return { *this, sender };
+}
+
+bool TTransactionState::HasLockConflicts(ui64 shardId) const {
+    const NKikimrDataEvents::TLock* prev = nullptr;
+    for (auto it = Locks.begin(); it != Locks.end(); ++it) {
+        if (it->GetDataShard() == shardId) {
+            if (prev) {
+                if (prev->GetGeneration() != it->GetGeneration()) {
+                    return true;
+                }
+                if (prev->GetCounter() != it->GetCounter()) {
+                    return true;
+                }
+            }
+            prev = &*it;
+        }
+    }
+    return false;
+}
+
+const NKikimrDataEvents::TLock* TTransactionState::FindLastLock(ui64 shardId) const {
+    for (auto it = Locks.rbegin(); it != Locks.rend(); ++it) {
+        if (it->GetDataShard() == shardId) {
+            return &*it;
+        }
+    }
+    return nullptr;
+}
+
+std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> TTransactionState::TWritePromise::NextResult(TDuration simTimeout) {
+    auto ev = State.Runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(Sender, simTimeout);
+    if (!ev) {
+        return nullptr;
+    }
+    std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> msg(ev->Release().Release());
+    for (const auto& lock : msg->Record.GetTxLocks()) {
+        State.Locks.push_back(lock);
+    }
+    return msg;
+}
+
+TString TTransactionState::TWritePromise::NextString(TDuration simTimeout) {
+    auto msg = NextResult(simTimeout);
+    if (!msg) {
+        return "<timeout>";
+    }
+    auto status = msg->Record.GetStatus();
+    if (status != NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED) {
+        return TStringBuilder() << "ERROR: " << status;
+    }
+    return "OK";
+}
+
+void TTransactionState::InitCommit(std::vector<ui64> participants) {
+    CommitTxId = AllocateTxId(Runtime, Sender);
+    Participants = std::move(participants);
+}
+
+void TTransactionState::SendPlan() {
+    UNIT_ASSERT(Coordinator != 0);
+    UNIT_ASSERT(MinStep <= MaxStep);
+    UNIT_ASSERT(!Participants.empty());
+    SendProposeToCoordinator(
+        Runtime, Sender, Participants, {
+            .TxId = CommitTxId,
+            .Coordinator = Coordinator,
+            .MinStep = MinStep,
+            .MaxStep = MaxStep,
+            .Volatile = true,
+        });
+}
+
+}

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -1,5 +1,7 @@
 #include "datashard_ut_common_tx.h"
 
+#include <ydb/core/tx/data_events/payload_helper.h>
+
 namespace NKikimr::NDataShard::NTxHelpers {
 
 ui64 AllocateTxId(TTestActorRuntime& runtime, const TActorId& sender) {
@@ -87,7 +89,7 @@ TString TTransactionState::TReadPromise::NextString(TDuration simTimeout) {
     if (status != Ydb::StatusIds::SUCCESS) {
         return TStringBuilder() << "ERROR: " << status;
     }
-    TString res = FormatReadResult(msg.get());
+    TString res = FormatIntReadResult(msg.get());
     if (msg->Record.GetFinished()) {
         res += "<end>";
     }
@@ -103,7 +105,7 @@ TString TTransactionState::TReadPromise::AllString() {
             res += TStringBuilder() << "ERROR: " << status;
             break;
         }
-        res += FormatReadResult(msg.get());
+        res += FormatIntReadResult(msg.get());
         if (msg->Record.GetFinished()) {
             break;
         }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -222,7 +222,6 @@ public:
     ui32 LockNodeId = 0;
     NLongTxService::TLockHandle LockHandle;
     std::optional<TRowVersion> Snapshot;
-    ui64 Counter = 0;
     std::vector<NKikimrDataEvents::TLock> Locks;
     std::vector<ui64> Participants;
     ui64 CommitTxId = 0;

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -1,0 +1,215 @@
+#pragma once
+
+#include "datashard_ut_common.h"
+#include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/datashard/datashard_impl.h>
+
+#include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/tx/long_tx_service/public/lock_handle.h>
+#include <ydb/core/tx/data_events/payload_helper.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NDataShard::NTxHelpers {
+
+ui64 AllocateTxId(TTestActorRuntime& runtime, const TActorId& sender);
+
+TRowVersion AcquireSnapshot(TTestActorRuntime& runtime, const TActorId& sender, const TString& databaseName = "/Root");
+
+NLongTxService::TLockHandle MakeLockHandle(TTestActorRuntime& runtime, ui64 lockId, ui32 nodeIndex = 0);
+
+struct TWriteOperation {
+    struct TKeyValue {
+        i32 Key;
+        i32 Value;
+    };
+
+    NKikimrDataEvents::TEvWrite::TOperation::EOperationType Type;
+    TVector<TKeyValue> Rows;
+
+    void ApplyTo(const TTableId& tableId, NEvents::TDataEvents::TEvWrite* req);
+
+    static TWriteOperation Upsert(i32 key, i32 value) {
+        return Upsert({ { key, value } });
+    }
+
+    static TWriteOperation Upsert(TVector<TKeyValue> rows) {
+        return TWriteOperation{
+            NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
+            std::move(rows),
+        };
+    }
+
+    static TWriteOperation Insert(i32 key, i32 value) {
+        return Insert({ { key, value } } );
+    }
+
+    static TWriteOperation Insert(TVector<TKeyValue> rows) {
+        return TWriteOperation{
+            NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+            std::move(rows),
+        };
+    }
+};
+
+class TTransactionState {
+public:
+    TTransactionState(TTestActorRuntime&, NKikimrDataEvents::ELockMode);
+
+    struct TReadPromise {
+        TTransactionState& State;
+        TActorId Sender;
+        TActorId LastSender = TActorId();
+        ui64 LastSeqNo = 0;
+
+        void SendAck(ui64 maxRows = Max<ui64>(), ui64 maxBytes = Max<ui64>());
+        std::unique_ptr<TEvDataShard::TEvReadResult> NextResult(TDuration simTimeout = TDuration::Max());
+        TString NextString(TDuration simTimeout = TDuration::Max());
+        TString AllString();
+    };
+
+    TReadPromise SendReadKey(const TTableId& tableId, ui64 shardId, i32 key);
+
+    TString ReadKey(const TTableId& tableId, ui64 shardId, i32 key) {
+        auto promise = SendReadKey(tableId, shardId, key);
+        return promise.AllString();
+    }
+
+    TReadPromise SendReadRange(const TTableId& tableId, ui64 shardId, i32 minKey, i32 maxKey, ui64 maxRowsQuota = Max<ui64>());
+
+    TString ReadRange(const TTableId& tableId, ui64 shardId, i32 minKey, i32 maxKey) {
+        auto promise = SendReadRange(tableId, shardId, minKey, maxKey);
+        return promise.AllString();
+    }
+
+    bool HasLockConflicts(ui64 shardId) const;
+    const NKikimrDataEvents::TLock* FindLastLock(ui64 shardId) const;
+
+    struct TWritePromise {
+        TTransactionState& State;
+        TActorId Sender;
+
+        std::unique_ptr<NEvents::TDataEvents::TEvWriteResult> NextResult(TDuration simTimeout = TDuration::Max());
+        TString NextString(TDuration simTimeout = TDuration::Max());
+    };
+
+    template<class... TOps>
+    TWritePromise SendWrite(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto sender = Runtime.AllocateEdgeActor();
+        ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+        auto* req = new NEvents::TDataEvents::TEvWrite(0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
+        req->Record.SetLockTxId(LockTxId);
+        req->Record.SetLockNodeId(LockNodeId);
+        req->Record.SetLockMode(LockMode);
+        if (Snapshot) {
+            req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
+            req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
+        }
+
+        (..., ops.ApplyTo(tableId, req));
+
+        Runtime.SendToPipe(shardId, sender, req, nodeIndex);
+        return { *this, sender };
+    }
+
+    template<class... TOps>
+    TString Write(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto promise = SendWrite(tableId, shardId, std::forward<TOps>(ops)...);
+        return promise.NextString();
+    }
+
+    template<class... TOps>
+    TWritePromise SendWriteCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto sender = Runtime.AllocateEdgeActor();
+        ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+        auto* req = new NEvents::TDataEvents::TEvWrite(0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
+        req->Record.SetLockMode(LockMode);
+        if (Snapshot) {
+            req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
+            req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
+        }
+
+        // Try to find the last known lock state
+        if (const auto* pLock = FindLastLock(shardId)) {
+            req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req->Record.MutableLocks()->AddSendingShards(shardId);
+            req->Record.MutableLocks()->AddReceivingShards(shardId);
+            *req->Record.MutableLocks()->AddLocks() = *pLock;
+        }
+
+        (..., ops.ApplyTo(tableId, req));
+
+        Runtime.SendToPipe(shardId, sender, req, nodeIndex);
+        return { *this, sender };
+    }
+
+    template<class... TOps>
+    TString WriteCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto promise = SendWriteCommit(tableId, shardId, std::forward<TOps>(ops)...);
+        return promise.NextString();
+    }
+
+    void InitCommit(std::vector<ui64> participants);
+
+    template<class... TOps>
+    TWritePromise SendPrepareCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto sender = Runtime.AllocateEdgeActor();
+        ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+        auto* req = new NEvents::TDataEvents::TEvWrite(CommitTxId, NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE);
+        req->Record.SetLockMode(LockMode);
+        if (Snapshot) {
+            req->Record.MutableMvccSnapshot()->SetStep(Snapshot->Step);
+            req->Record.MutableMvccSnapshot()->SetTxId(Snapshot->TxId);
+        }
+
+        req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+        for (ui64 participant : Participants) {
+            req->Record.MutableLocks()->AddSendingShards(participant);
+            req->Record.MutableLocks()->AddReceivingShards(participant);
+        }
+        if (const auto* pLock = FindLastLock(shardId)) {
+            *req->Record.MutableLocks()->AddLocks() = *pLock;
+        }
+
+        (..., ops.ApplyTo(tableId, req));
+
+        Runtime.SendToPipe(shardId, sender, req, nodeIndex);
+        return { *this, sender };
+    }
+
+    template<class... TOps>
+    TWritePromise PrepareCommit(const TTableId& tableId, ui64 shardId, TOps&&... ops) {
+        auto promise = SendPrepareCommit(tableId, shardId, std::forward<TOps>(ops)...);
+        auto msg = promise.NextResult();
+        UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), NKikimrDataEvents::TEvWriteResult::STATUS_PREPARED);
+        MinStep = Max(MinStep, msg->Record.GetMinStep());
+        MaxStep = Min(MaxStep, msg->Record.GetMaxStep());
+        for (ui64 coordinator : msg->Record.GetDomainCoordinators()) {
+            Coordinator = coordinator;
+        }
+        return promise;
+    }
+
+    void SendPlan();
+
+public:
+    TTestActorRuntime& Runtime;
+    NKikimrDataEvents::ELockMode LockMode;
+    TActorId Sender;
+    ui64 LockTxId = 0;
+    ui32 LockNodeId = 0;
+    NLongTxService::TLockHandle LockHandle;
+    std::optional<TRowVersion> Snapshot;
+    ui64 Counter = 0;
+    std::vector<NKikimrDataEvents::TLock> Locks;
+    std::vector<ui64> Participants;
+    ui64 CommitTxId = 0;
+    ui64 MinStep = 0;
+    ui64 MaxStep = Max<ui64>();
+    ui64 Coordinator = 0;
+};
+
+}

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -1,14 +1,9 @@
 #pragma once
 
 #include "datashard_ut_common.h"
-#include <ydb/core/tx/datashard/datashard.h>
-#include <ydb/core/tx/datashard/datashard_impl.h>
 
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/tx/long_tx_service/public/lock_handle.h>
-#include <ydb/core/tx/data_events/payload_helper.h>
-
-#include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr::NDataShard::NTxHelpers {
 

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -82,8 +82,32 @@ public:
         return promise.AllString();
     }
 
+    void ResetSnapshot() {
+        Snapshot = {};
+    }
+
     bool HasLockConflicts(ui64 shardId) const;
     const NKikimrDataEvents::TLock* FindLastLock(ui64 shardId) const;
+
+    struct TLockRowsPromise {
+        TTransactionState& State;
+        TActorId Sender;
+
+        std::unique_ptr<NEvents::TDataEvents::TEvLockRowsResult> NextResult(
+            TDuration simTimeout = TDuration::Max());
+        TString NextString(TDuration simTimeout = TDuration::Max());
+    };
+
+    TLockRowsPromise SendLockRows(
+        const TTableId& tableId, ui64 shardId, const TVector<i32>& keys,
+        NKikimrDataEvents::ELockMode lockMode = NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+
+    TString LockRows(
+            const TTableId& tableId, ui64 shardId, const TVector<i32>& keys,
+            NKikimrDataEvents::ELockMode lockMode = NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE) {
+        auto promise = SendLockRows(tableId, shardId, keys, lockMode);
+        return promise.NextString();
+    }
 
     struct TWritePromise {
         TTransactionState& State;

--- a/ydb/core/tx/datashard/ut_common/ya.make
+++ b/ydb/core/tx/datashard/ut_common/ya.make
@@ -11,6 +11,8 @@ YQL_LAST_ABI_VERSION()
 SRCS(
     datashard_ut_common.cpp
     datashard_ut_common.h
+    datashard_ut_common_tx.cpp
+    datashard_ut_common_tx.h
 )
 
 END()

--- a/ydb/core/tx/datashard/ut_read_committed/ya.make
+++ b/ydb/core/tx/datashard/ut_read_committed/ya.make
@@ -1,0 +1,33 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(2)
+
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    yql/essentials/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/src/client/result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_read_committed.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -339,6 +339,7 @@ RECURSE_FOR_TESTS(
     ut_object_storage_listing
     ut_order
     ut_range_ops
+    ut_read_committed
     ut_read_iterator
     ut_read_table
     ut_reassign


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implement PESSIMISTIC_NONE lock mode needed for the read committed isolation level.

For reads this mode is exactly the same as OPTIMISTIC_SNAPSHOT_ISOLATION - locks are not set, the read fails only if we get inconsistent result from the snapshot.

For writes, the expectation is that they are done in 2 stages: first a TEvLockRows request is sent, that locks the row with an exclusive lock and checks for conflicts, and then a TEvWrite with the PESSIMISTIC_NONE lock mode. The write itself therefore doesn't need to do much, so we only check the "first written, first committed" localdb invariant for uncommitted writes.

Fixes https://github.com/ydb-platform/ydb/issues/36680

