### PR TITLE
Reduce deep scrubbing cpu costs

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1586,23 +1586,27 @@ struct TEvBlobStorage {
         TInstant Deadline;
         NKikimrBlobStorage::EGetHandleClass GetHandleClass;
         bool SingleLine;    // Print DataInfo in single line
+        bool OmitDataInfoUnlessError;
 
         TEvCheckIntegrity(TCloneEventPolicy, const TEvCheckIntegrity& origin)
             : Id(origin.Id)
             , Deadline(origin.Deadline)
             , GetHandleClass(origin.GetHandleClass)
             , SingleLine(origin.SingleLine)
+            , OmitDataInfoUnlessError(origin.OmitDataInfoUnlessError)
         {}
 
         TEvCheckIntegrity(
                 const TLogoBlobID& id,
                 TInstant deadline,
                 NKikimrBlobStorage::EGetHandleClass getHandleClass,
-                bool singleLine = false)
+                bool singleLine = false,
+                bool omitDataInfoUnlessError = false)
             : Id(id)
             , Deadline(deadline)
             , GetHandleClass(getHandleClass)
             , SingleLine(singleLine)
+            , OmitDataInfoUnlessError(omitDataInfoUnlessError)
         {}
 
         TString Print(bool /*isFull*/) const {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
@@ -192,9 +192,8 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         }
 
         const bool omitDataInfo = OmitDataInfoUnlessError
-            && PendingResult->PlacementStatus != TEvCheckIntegrityResult::PS_BLOB_IS_LOST
-            && PendingResult->PlacementStatus != TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE
-            && PendingResult->DataStatus != TEvCheckIntegrityResult::DS_ERROR;
+            && PendingResult->PlacementStatus == TEvCheckIntegrityResult::PS_OK
+            && PendingResult->DataStatus == TEvCheckIntegrityResult::DS_OK;
         if (!omitDataInfo) {
             TStringStream str;
             str << "Disks:" << separator;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_check_integrity_get.cpp
@@ -13,6 +13,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
     const TInstant Deadline;
     const NKikimrBlobStorage::EGetHandleClass GetHandleClass;
     const bool SingleLine;
+    const bool OmitDataInfoUnlessError;
 
     TGroupQuorumTracker QuorumTracker;
 
@@ -24,7 +25,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
     bool HasErrorDisks = false;
 
     ui32 VGetsInFlight = 0;
-    THashMap<ui32, TString> VGetsResults;
+    THashMap<ui32, TAutoPtr<TEvBlobStorage::TEvVGetResult>> VGetsResults;
 
     using TEvCheckIntegrityResult = TEvBlobStorage::TEvCheckIntegrityResult;
     std::unique_ptr<TEvCheckIntegrityResult> PendingResult;
@@ -109,7 +110,6 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
 
         TEvBlobStorage::TEvVGetResult* msg = ev->Get();
         const ui32 idxInSubgroup = Info->GetIdxInSubgroup(vDiskId, Id.Hash());
-        VGetsResults[idxInSubgroup] = msg->ToString();
 
         switch (NKikimrProto::EReplyStatus newStatus = QuorumTracker.ProcessReply(vDiskId, status)) {
             case NKikimrProto::ERROR:
@@ -132,6 +132,8 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         } else {
             HasErrorDisks = true;
         }
+
+        VGetsResults[idxInSubgroup] = ev->Release();
 
         if (!VGetsInFlight) {
             Analyze();
@@ -189,19 +191,32 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
             PendingResult->DataStatus = TEvCheckIntegrityResult::DS_ERROR;
         }
 
-        TStringStream str;
-        str << "Disks:" << separator;
-        for (ui32 diskIdx = 0; diskIdx < Info->Type.BlobSubgroupSize(); ++diskIdx) {
-            auto vDiskIdShort = Info->GetTopology().GetVDiskInSubgroup(diskIdx, Id.Hash());
-            str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort);
-            if (auto it = VGetsResults.find(diskIdx); it != VGetsResults.end()) {
-                str << " " << it->second;
+        const bool omitDataInfo = OmitDataInfoUnlessError
+            && PendingResult->PlacementStatus != TEvCheckIntegrityResult::PS_BLOB_IS_LOST
+            && PendingResult->PlacementStatus != TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE
+            && PendingResult->DataStatus != TEvCheckIntegrityResult::DS_ERROR;
+        if (!omitDataInfo) {
+            TStringStream str;
+            str << "Disks:" << separator;
+            for (ui32 diskIdx = 0; diskIdx < Info->Type.BlobSubgroupSize(); ++diskIdx) {
+                auto vDiskIdShort = Info->GetTopology().GetVDiskInSubgroup(diskIdx, Id.Hash());
+                str << diskIdx << ": " << Info->CreateVDiskID(vDiskIdShort);
+                if (auto it = VGetsResults.find(diskIdx); it != VGetsResults.end()) {
+                    const auto& msg = *it->second;
+                    str << " " << NKikimrProto::EReplyStatus_Name(msg.Record.GetStatus());
+                    for (const auto& result : msg.Record.GetResult()) {
+                        str << " {Part " << LogoBlobIDFromLogoBlobID(result.GetBlobID()).PartId()
+                            << " " << NKikimrProto::EReplyStatus_Name(result.GetStatus())
+                            << " " << result.GetSize() << "/" << result.GetFullDataSize()
+                            << "}";
+                    }
+                }
+                str << separator;
             }
-            str << separator;
-        }
 
-        PendingResult->DataInfo = str.Str();
-        PendingResult->DataInfo += partsState.DataInfo;
+            PendingResult->DataInfo = str.Str();
+            PendingResult->DataInfo += partsState.DataInfo;
+        }
 
         ReplyAndDie(NKikimrProto::OK);
     }
@@ -210,7 +225,7 @@ class TBlobStorageGroupCheckIntegrityRequest : public TBlobStorageGroupRequestAc
         ++*Mon->NodeMon->RestartCheckIntegrity;
 
         auto ev = std::make_unique<TEvBlobStorage::TEvCheckIntegrity>(
-            Id, Deadline, GetHandleClass, SingleLine);
+            Id, Deadline, GetHandleClass, SingleLine, OmitDataInfoUnlessError);
         ev->RestartCounter = counter;
         return ev;
     }
@@ -230,6 +245,7 @@ public:
         , Deadline(params.Common.Event->Deadline)
         , GetHandleClass(params.Common.Event->GetHandleClass)
         , SingleLine(params.Common.Event->SingleLine)
+        , OmitDataInfoUnlessError(params.Common.Event->OmitDataInfoUnlessError)
         , QuorumTracker(Info.Get())
     {}
 

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_check_integrity_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_check_integrity_ut.cpp
@@ -261,6 +261,23 @@ Y_UNIT_TEST(PlacementRecoverable4of6) {
         TEvCheckIntegrityResult::DS_OK);
 }
 
+Y_UNIT_TEST(PlacementRecoverableAllPartsAtTheSameSlot) {
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto& gm = fx.TestState->GetGroupMock();
+
+    auto blobId = fx.MakeBlobId(200001);
+    for (int i = 1; i <= 6; i++) {
+        gm.PutPartAtSlot(blobId, 0, i, fx.TestState->BlobData);
+    }
+    fx.SendCheckIntegrity(blobId);
+    fx.TestState->HandleVGetsWithMock(fx.SubgroupSize());
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), blobId,
+        TEvCheckIntegrityResult::PS_BLOB_IS_RECOVERABLE,
+        TEvCheckIntegrityResult::DS_OK);
+}
+
 Y_UNIT_TEST(PlacementBlobIsLost) {
     // Part 4 is missing, part 3 is duplicated
     TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
@@ -342,6 +359,28 @@ Y_UNIT_TEST(DataCorruptionTwoParts) {
 
     TAutoPtr<IEventHandle> h;
     AssertResultOk(fx.GrabResult(h), id,
+        TEvCheckIntegrityResult::PS_OK,
+        TEvCheckIntegrityResult::DS_ERROR);
+}
+
+Y_UNIT_TEST(DataCorruptionInconsistentParts) {
+    TFixture fx(TBlobStorageGroupType::Erasure4Plus2Block);
+    auto& gm = fx.TestState->GetGroupMock();
+
+    auto blobId = fx.MakeBlobId(200001);
+    for (ui32 slot = 0; slot < fx.SubgroupSize(); slot++) {
+        for (int part = 1; part <= 6; part++) {
+            gm.PutPartAtSlot(blobId, slot, part, fx.TestState->BlobData);
+            if (slot >= 3) {
+                gm.CorruptPart(blobId, slot, part);
+            }
+        }
+    }
+    fx.SendCheckIntegrity(blobId);
+    fx.TestState->HandleVGetsWithMock(fx.SubgroupSize());
+
+    TAutoPtr<IEventHandle> h;
+    AssertResultOk(fx.GrabResult(h), blobId,
         TEvCheckIntegrityResult::PS_OK,
         TEvCheckIntegrityResult::DS_ERROR);
 }

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
@@ -252,7 +252,7 @@ namespace NKikimr {
 
     void TScrubCoroImpl::CheckIntegrity(const TLogoBlobID& blobId, bool isHuge) {
         SendToBSProxy(SelfActorId, Info->GroupID, new TEvBlobStorage::TEvCheckIntegrity(blobId, TInstant::Max(),
-                NKikimrBlobStorage::EGetHandleClass::LowRead, true));
+                NKikimrBlobStorage::EGetHandleClass::LowRead, true, true));
         auto res = WaitForPDiskEvent<TEvBlobStorage::TEvCheckIntegrityResult>();
 
         TErasureType::EErasureSpecies erasure = Info->Type.GetErasure();

--- a/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/scrub_actor.cpp
@@ -252,7 +252,8 @@ namespace NKikimr {
 
     void TScrubCoroImpl::CheckIntegrity(const TLogoBlobID& blobId, bool isHuge) {
         SendToBSProxy(SelfActorId, Info->GroupID, new TEvBlobStorage::TEvCheckIntegrity(blobId, TInstant::Max(),
-                NKikimrBlobStorage::EGetHandleClass::LowRead, true, true));
+                NKikimrBlobStorage::EGetHandleClass::LowRead,
+                /*singleLine*/ true, /*omitDataInfoUnlessError*/ true));
         auto res = WaitForPDiskEvent<TEvBlobStorage::TEvCheckIntegrityResult>();
 
         TErasureType::EErasureSpecies erasure = Info->Type.GetErasure();


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Follow-up (performance fixup) for #39488 
- Reduce deep scrubbing cpu costs by eliminating unnecessary string manipulations
- Remove sensitive data from TEvCheckIntegrityResult DataInfo
- Extend ut cases, see full test log: https://nda.ya.ru/t/9TJwS-_y7bz3aH

Example output:

```
./ut/test-results/unittest/chunk0/testing_out_stuff/TDSProxyCheckIntegrityMirror3dc.PlacementOk2Plus2DuringDcOutage.err
TEvCheckIntegrityResult { Id# [300011:1:1:0:0:1024:0] Status# OK ErrorReason#  Erasure# mirror-3-dc PlacementStatus# PS_OK DataStatus# DS_OK DataInfo# Disks:
0: [0:1:2:2:0] OK {Part 1 OK 1024/1024}
1: [0:1:0:2:0] OK {Part 1 OK 1024/1024}
2: [0:1:1:2:0] ERROR {Part 0 ERROR 0/1024}
3: [0:1:2:0:0] OK {Part 1 OK 1024/1024}
4: [0:1:0:0:0] OK {Part 1 OK 1024/1024}
5: [0:1:1:0:0] ERROR {Part 0 ERROR 0/1024}
6: [0:1:2:1:0] OK {Part 0 NODATA 0/0}
7: [0:1:0:1:0] OK {Part 0 NODATA 0/0}
8: [0:1:1:1:0] ERROR {Part 0 ERROR 0/1024}
Layout info:
ver0 disks [ 4 1 3 0 ]
 }
```