### PR TITLE
Fix requests stucking in DSQueue after external cancellation

### DIFF
--- a/ydb/core/base/blobstorage_relevance.cpp
+++ b/ydb/core/base/blobstorage_relevance.cpp
@@ -8,8 +8,14 @@ TMessageRelevance::TMessageRelevance(const TMessageRelevanceOwner& onwer,
     , ExternalWatcher(external)
 {}
 
-bool TMessageRelevance::IsRelevant() const {
-    return !InternalWatcher.expired() && (!ExternalWatcher || !ExternalWatcher->expired());
+TMessageRelevance::EStatus TMessageRelevance::GetStatus() const {
+    if (InternalWatcher.expired()) {
+        return EStatus::CancelledInternally;
+    }
+    if (ExternalWatcher && ExternalWatcher->expired()) {
+        return EStatus::CancelledExternally;
+    }
+    return EStatus::Relevant;
 }
 
 } // namespace NKikimr

--- a/ydb/core/base/blobstorage_relevance.h
+++ b/ydb/core/base/blobstorage_relevance.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <util/system/types.h>
 
 namespace NKikimr {
 
@@ -11,10 +12,17 @@ using TMessageRelevanceWatcher = std::weak_ptr<TMessageRelevanceTracker>;
 
 class TMessageRelevance {
 public:
+    enum class EStatus : ui8 {
+        Relevant = 0,
+        CancelledInternally = 1,
+        CancelledExternally = 2,
+    };
+
+public:
     TMessageRelevance() = default;
     TMessageRelevance(const TMessageRelevanceOwner& owner,
             std::optional<TMessageRelevanceWatcher> external = std::nullopt);
-    bool IsRelevant() const;
+    EStatus GetStatus() const;
 
 private:
     // tracks request actor state and cancels request when actor dies

--- a/ydb/core/blobstorage/backpressure/event.h
+++ b/ydb/core/blobstorage/backpressure/event.h
@@ -92,8 +92,11 @@ public:
         Discard();
     }
 
-    bool Relevant() const {
-        return !Tracker || Tracker->IsRelevant();
+    TMessageRelevance::EStatus GetRelevanceStatus() const {
+        if (!Tracker) {
+            return TMessageRelevance::EStatus::Relevant;
+        }
+        return Tracker->GetStatus();
     }
 
     ui32 GetByteSize() const {

--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -191,9 +191,23 @@ void TBlobStorageQueue::SendToVDisk(const TActorContext& ctx, const TActorId& re
             break;
         }
 
-        if (!item.Event.Relevant()) {
+        bool isRelevant = true;
+        switch (item.Event.GetRelevanceStatus()) {
+        case TMessageRelevance::EStatus::CancelledExternally:
+            // signal to make DSProxy finalize event processing
+            ReplyWithError(item, NKikimrProto::ERROR, "external cancellation", ctx);
+            [[fallthrough]];
+        case TMessageRelevance::EStatus::CancelledInternally:
+            isRelevant = false;
             ++*QueueItemsPruned;
             it = EraseItem(Queues.Waiting, it);
+            break;
+        default:
+            // event is relevant
+            break;
+        }
+
+        if (!isRelevant) {
             continue;
         }
 
@@ -253,13 +267,15 @@ bool TBlobStorageQueue::OnResponse(ui64 msgId, ui64 sequenceId, ui64 cookie, TAc
     Y_ABORT_UNLESS(InFlightCost >= it->Cost);
     InFlightCost -= it->Cost;
 
-    const bool relevant = it->Event.Relevant();
+    const bool dsproxyAwaitingResponse =
+            it->Event.GetRelevanceStatus() == TMessageRelevance::EStatus::Relevant ||
+            it->Event.GetRelevanceStatus() == TMessageRelevance::EStatus::CancelledExternally;
 
     *outSender = it->Event.GetSender();
     *outCookie = it->Event.GetCookie();
     *processingTime = TDuration::Seconds(it->ProcessingTimer.Passed());
     LWTRACK(DSQueueVPutResultRecieved, it->Event.GetOrbit(), processingTime->SecondsFloat() * 1e3,
-            it->Event.GetByteSize(), !relevant);
+            it->Event.GetByteSize(), !dsproxyAwaitingResponse);
 
     InFlightLookup.erase(lookupIt);
     auto span = std::exchange(it->Span, {});
@@ -272,7 +288,7 @@ bool TBlobStorageQueue::OnResponse(ui64 msgId, ui64 sequenceId, ui64 cookie, TAc
     }
 
     ++*QueueItemsProcessed;
-    return relevant;
+    return dsproxyAwaitingResponse;
 }
 
 void TBlobStorageQueue::Unwind(ui64 failedMsgId, ui64 failedSequenceId, ui64 expectedMsgId, ui64 expectedSequenceId) {
@@ -287,7 +303,7 @@ void TBlobStorageQueue::Unwind(ui64 failedMsgId, ui64 failedSequenceId, ui64 exp
         const ui32 erased = InFlightLookup.erase(std::make_pair(x->SequenceId, x->MsgId));
         Y_ABORT_UNLESS(erased);
         cost += x->Cost; // count item's cost
-        if (!x->Event.Relevant()) {
+        if (x->Event.GetRelevanceStatus() == TMessageRelevance::EStatus::CancelledInternally) {
             if (x == it) {
                 ++it; // advance starting iterator as the item pointed to is being erased
             }
@@ -320,7 +336,7 @@ void TBlobStorageQueue::DrainQueue(NKikimrProto::EReplyStatus status, const TStr
 
     auto flushQueue = [&](TItemList& queue) {
         for (auto it = queue.begin(); it != queue.end(); it = EraseItem(queue, it)) {
-            if (it->Event.Relevant()) {
+            if (it->Event.GetRelevanceStatus() != TMessageRelevance::EStatus::CancelledInternally) {
                 ReplyWithError(*it, status, errorReason, ctx);
             }
         }

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
@@ -504,8 +504,8 @@ private:
         TActorId sender;
         ui64 cookie = 0;
         TDuration processingTime;
-        bool isOk = Queue.OnResponse(msgId, sequenceId, ev->Cookie, &sender, &cookie, &processingTime);
-        if (isOk) {
+        bool dsproxyAwaitingResponse = Queue.OnResponse(msgId, sequenceId, ev->Cookie, &sender, &cookie, &processingTime);
+        if (dsproxyAwaitingResponse) {
             NWilson::TTraceId traceId = std::move(ev->TraceId);
             ctx.Send(sender, ev->Release().Release(), 0, cookie, std::move(traceId));
         }
@@ -513,7 +513,7 @@ private:
             << " sequenceId# " << sequenceId << " msgId# " << msgId
             << " status# " << NKikimrProto::EReplyStatus_Name(status)
             << " processingTime# " << processingTime
-            << " isOk# " << isOk);
+            << " dsproxyAwaitingResponse# " << dsproxyAwaitingResponse);
 
         Pump(ctx);
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -303,7 +303,8 @@ public:
     static double GetTotalTimeMs(const NKikimrBlobStorage::TTimestamps& timestamps);
     static double GetVDiskTimeMs(const NKikimrBlobStorage::TTimestamps& timestamps);
 
-    bool CheckForExternalCancellation();
+    bool CancelIfIrrelevant();
+    bool CheckForExternalCancellation() const;
 
 private:
     void CheckPostponedQueue();

--- a/ydb/core/blobstorage/dsproxy/dsproxy_mon.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_mon.cpp
@@ -19,6 +19,7 @@ TBlobStorageGroupProxyMon::TBlobStorageGroupProxyMon(const TIntrusivePtr<::NMoni
     , EventGroup(Counters->GetSubgroup("subsystem", "event"))
     , HandoffGroup(Counters->GetSubgroup("subsystem", "handoff"))
     , ActiveRequestsGroup(Counters->GetSubgroup("subsystem", "requests"))
+    , CancellationGroup(Counters->GetSubgroup("subsystem", "cancellation"))
 {
     if (info) {
         const TBlobStorageGroupInfo::TDynamicInfo& dyn = info->GetDynamicInfo();
@@ -117,6 +118,9 @@ TBlobStorageGroupProxyMon::TBlobStorageGroupProxyMon(const TIntrusivePtr<::NMoni
     RespStatPatch.emplace(respStatGroup->GetSubgroup("request", "patch"));
     RespStatAssimilate.emplace(respStatGroup->GetSubgroup("request", "assimilate"));
     RespStatCheckIntegrity.emplace(respStatGroup->GetSubgroup("request", "checkIntegrity"));
+
+    CancelledEvents = CancellationGroup->GetCounter("CancelledEvents");
+    TimeoutedCancelledEvents = CancellationGroup->GetCounter("TimeoutedCancelledEvents");
 }
 
 void TBlobStorageGroupProxyMon::BecomeFull() {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_mon.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_mon.cpp
@@ -119,8 +119,7 @@ TBlobStorageGroupProxyMon::TBlobStorageGroupProxyMon(const TIntrusivePtr<::NMoni
     RespStatAssimilate.emplace(respStatGroup->GetSubgroup("request", "assimilate"));
     RespStatCheckIntegrity.emplace(respStatGroup->GetSubgroup("request", "checkIntegrity"));
 
-    CancelledEvents = CancellationGroup->GetCounter("CancelledEvents");
-    TimeoutedCancelledEvents = CancellationGroup->GetCounter("TimeoutedCancelledEvents");
+    CancelledEvents = CancellationGroup->GetCounter("CancelledEvents", true);
 }
 
 void TBlobStorageGroupProxyMon::BecomeFull() {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
@@ -271,7 +271,6 @@ public:
     // cancellation
     TIntrusivePtr<::NMonitoring::TDynamicCounters> CancellationGroup;
     ::NMonitoring::TDynamicCounters::TCounterPtr CancelledEvents;
-    ::NMonitoring::TDynamicCounters::TCounterPtr TimeoutedCancelledEvents;
 
     TRequestMonGroup& GetRequestMonGroup(ERequestType request) {
         switch (request) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
@@ -202,11 +202,6 @@ protected:
     TRequestMonGroup GetBlockGroup;
     TRequestMonGroup CheckIntegrityGroup;
 
-    // cancellation
-    TIntrusivePtr<::NMonitoring::TDynamicCounters> CancellationGroup;
-    ::NMonitoring::TDynamicCounters::TCounterPtr CancelledEvents;
-    ::NMonitoring::TDynamicCounters::TCounterPtr TimeoutedCancelledEvents;
-
 public:
     TBlobStorageGroupProxyTimeStats TimeStats;
 
@@ -272,6 +267,11 @@ public:
     ::NMonitoring::TDynamicCounters::TCounterPtr VPatchContinueFailed;
     ::NMonitoring::TDynamicCounters::TCounterPtr VPatchPartPlacementVerifyFailed;
     ::NMonitoring::TDynamicCounters::TCounterPtr PatchesWithFallback;
+
+    // cancellation
+    TIntrusivePtr<::NMonitoring::TDynamicCounters> CancellationGroup;
+    ::NMonitoring::TDynamicCounters::TCounterPtr CancelledEvents;
+    ::NMonitoring::TDynamicCounters::TCounterPtr TimeoutedCancelledEvents;
 
     TRequestMonGroup& GetRequestMonGroup(ERequestType request) {
         switch (request) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_mon.h
@@ -202,6 +202,11 @@ protected:
     TRequestMonGroup GetBlockGroup;
     TRequestMonGroup CheckIntegrityGroup;
 
+    // cancellation
+    TIntrusivePtr<::NMonitoring::TDynamicCounters> CancellationGroup;
+    ::NMonitoring::TDynamicCounters::TCounterPtr CancelledEvents;
+    ::NMonitoring::TDynamicCounters::TCounterPtr TimeoutedCancelledEvents;
+
 public:
     TBlobStorageGroupProxyTimeStats TimeStats;
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -314,7 +314,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
                 GetVDiskTimeMs(record.GetTimestamps()));
         }
 
-        if (CheckForExternalCancellation()) {
+        if (CancelIfIrrelevant()) {
             return;
         }
 
@@ -394,7 +394,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
             }
         }
 
-        if (CheckForExternalCancellation()) {
+        if (CancelIfIrrelevant()) {
             return;
         }
 
@@ -828,7 +828,7 @@ public:
             << " Not answered in "
             << (TActivationContext::Monotonic() - RequestStartTime) << " seconds");
 
-        if (CheckForExternalCancellation()) {
+        if (CancelIfIrrelevant()) {
             return;
         }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -867,6 +867,9 @@ namespace NKikimr {
 
             case TEvBlobStorage::EvDeadline: {
                 ErrorReason = "Deadline timer hit";
+                if (CheckForExternalCancellation()) {
+                    Mon->TimeoutedCancelledEvent->Inc();
+                }
                 ReplyAndDie(NKikimrProto::DEADLINE);
                 return true;
             }
@@ -1137,12 +1140,17 @@ namespace NKikimr {
         return true;
     }
 
-    bool TBlobStorageGroupRequestActor::CheckForExternalCancellation() {
-        if (ExternalRelevanceWatcher && ExternalRelevanceWatcher->expired()) {
+    bool TBlobStorageGroupRequestActor::CancelIfIrrelevant() {
+        if (CheckForExternalCancellation()) {
+            Mon->CancelledEvents->Inc();
             ReplyAndDie(NKikimrProto::ERROR);
             return true;
         }
         return false;
+    }
+
+    bool TBlobStorageGroupRequestActor::CheckForExternalCancellation() {
+        return ExternalRelevanceWatcher && ExternalRelevanceWatcher->expired();
     }
 
     void TBlobStorageGroupProxy::Handle(TEvGetQueuesInfo::TPtr ev) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -868,7 +868,7 @@ namespace NKikimr {
             case TEvBlobStorage::EvDeadline: {
                 ErrorReason = "Deadline timer hit";
                 if (CheckForExternalCancellation()) {
-                    Mon->TimeoutedCancelledEvent->Inc();
+                    Mon->TimeoutedCancelledEvents->Inc();
                 }
                 ReplyAndDie(NKikimrProto::DEADLINE);
                 return true;
@@ -1149,7 +1149,7 @@ namespace NKikimr {
         return false;
     }
 
-    bool TBlobStorageGroupRequestActor::CheckForExternalCancellation() {
+    bool TBlobStorageGroupRequestActor::CheckForExternalCancellation() const {
         return ExternalRelevanceWatcher && ExternalRelevanceWatcher->expired();
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1140,6 +1140,7 @@ namespace NKikimr {
     bool TBlobStorageGroupRequestActor::CancelIfIrrelevant() {
         if (CheckForExternalCancellation()) {
             Mon->CancelledEvents->Inc();
+            ErrorReason = "external cancellation";
             ReplyAndDie(NKikimrProto::ERROR);
             return true;
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -867,9 +867,6 @@ namespace NKikimr {
 
             case TEvBlobStorage::EvDeadline: {
                 ErrorReason = "Deadline timer hit";
-                if (CheckForExternalCancellation()) {
-                    Mon->TimeoutedCancelledEvents->Inc();
-                }
                 ReplyAndDie(NKikimrProto::DEADLINE);
                 return true;
             }

--- a/ydb/core/blobstorage/ut_blobstorage/cancellation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/cancellation.cpp
@@ -10,6 +10,35 @@
 Y_UNIT_TEST_SUITE(Cancellation) {
     using TTestCtx = TTestCtxBase;
 
+    ui64 GetCancellationCounter(TTestCtx& ctx, const TString& name) {
+        ui64 value = 0;
+        const TString groupName = Sprintf("%09" PRIu32, ctx.GroupId);
+        for (ui32 nodeId = 1; nodeId <= ctx.NodeCount; ++nodeId) {
+            auto* appData = ctx.Env->Runtime->GetNode(nodeId)->AppData.get();
+            value += GetServiceCounters(appData->Counters, "dsproxy")
+                ->GetSubgroup("blobstorageproxy", groupName)
+                ->GetSubgroup("subsystem", "cancellation")
+                ->GetCounter(name)->Val();
+        }
+        return value;
+    }
+
+    void SendCancellablePut(TTestCtx& ctx, TMessageRelevanceOwner owner, TInstant deadline = TInstant::Max()) {
+        TString data = MakeData(10);
+        TLogoBlobID blobId(1, 1, 1, 1, data.size(), 1);
+        auto* ev = new TEvBlobStorage::TEvPut(
+            TEvBlobStorage::TEvPut::TParameters{
+                .BlobId = blobId,
+                .Buffer = TRope(data),
+                .Deadline = deadline,
+                .ExternalRelevanceWatcher = owner,
+            }
+        );
+        ctx.Env->Runtime->WrapInActorContext(ctx.Edge, [&] {
+            SendToBSProxy(ctx.Edge, ctx.GroupId, ev);
+        });
+    }
+
     Y_UNIT_TEST(CancelPut) {
         TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
         TTestCtx ctx({
@@ -32,25 +61,56 @@ Y_UNIT_TEST_SUITE(Cancellation) {
             return true;
         };
 
-        {
-            TString data = MakeData(10);
-            TLogoBlobID blobId(1, 1, 1, 1, data.size(), 1);
-            TEvBlobStorage::TEvPut* ev = new TEvBlobStorage::TEvPut(
-                TEvBlobStorage::TEvPut::TParameters{
-                    .BlobId = blobId,
-                    .Buffer = TRope(data),
-                    .Deadline = TInstant::Max(),
-                    .ExternalRelevanceWatcher = owner,
-                }
-            );
-            owner.reset();
-            ctx.Env->Runtime->WrapInActorContext(ctx.Edge, [&] {
-                SendToBSProxy(ctx.Edge, ctx.GroupId, ev);
-            });
-        }
+        const ui64 cancelledEvents = GetCancellationCounter(ctx, "CancelledEvents");
+        const ui64 timeoutedCancelledEvents = GetCancellationCounter(ctx, "TimeoutedCancelledEvents");
+
+        SendCancellablePut(ctx, owner);
+        owner.reset();
 
         auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(ctx.Edge, false,
                 TAppData::TimeProvider->Now() + TDuration::Seconds(65));
         UNIT_ASSERT(res);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents + 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "TimeoutedCancelledEvents"), timeoutedCancelledEvents);
+    }
+
+    Y_UNIT_TEST(CancelPutByDeadline) {
+        TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TTestCtx ctx({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+            .MaxPutTimeoutDSProxy = TDuration::Minutes(10),
+        });
+
+        ctx.Initialize();
+        ctx.AllocateEdgeActorOnSpecificNode(ctx.NodeCount);
+
+        TMessageRelevanceOwner owner = std::make_shared<TMessageRelevanceTracker>();
+        bool deadlineInjected = false;
+
+        ctx.Env->Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) -> bool {
+            if (!deadlineInjected && ev->GetTypeRewrite() == TEvBlobStorage::TEvVPut::EventType) {
+                deadlineInjected = true;
+                owner.reset();
+                ctx.Env->Runtime->Send(new IEventHandle(TEvBlobStorage::EvDeadline, 0, ev->Sender,
+                    MakeBlobStorageProxyID(ctx.GroupId), nullptr, 0), ev->Sender.NodeId());
+                return false;
+            }
+            return true;
+        };
+
+        const ui64 cancelledEvents = GetCancellationCounter(ctx, "CancelledEvents");
+        const ui64 timeoutedCancelledEvents = GetCancellationCounter(ctx, "TimeoutedCancelledEvents");
+
+        SendCancellablePut(ctx, owner, TAppData::TimeProvider->Now() + TDuration::Minutes(10));
+
+        auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(ctx.Edge, false,
+                TAppData::TimeProvider->Now() + TDuration::Seconds(5));
+        UNIT_ASSERT(deadlineInjected);
+        UNIT_ASSERT(res);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::DEADLINE);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "TimeoutedCancelledEvents"), timeoutedCancelledEvents + 1);
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/cancellation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/cancellation.cpp
@@ -18,7 +18,7 @@ Y_UNIT_TEST_SUITE(Cancellation) {
             value += GetServiceCounters(appData->Counters, "dsproxy")
                 ->GetSubgroup("blobstorageproxy", groupName)
                 ->GetSubgroup("subsystem", "cancellation")
-                ->GetCounter(name)->Val();
+                ->GetCounter(name, true)->Val();
         }
         return value;
     }
@@ -62,7 +62,6 @@ Y_UNIT_TEST_SUITE(Cancellation) {
         };
 
         const ui64 cancelledEvents = GetCancellationCounter(ctx, "CancelledEvents");
-        const ui64 timeoutedCancelledEvents = GetCancellationCounter(ctx, "TimeoutedCancelledEvents");
 
         SendCancellablePut(ctx, owner);
         owner.reset();
@@ -72,10 +71,8 @@ Y_UNIT_TEST_SUITE(Cancellation) {
         UNIT_ASSERT(res);
         UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
         UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents + 1);
-        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "TimeoutedCancelledEvents"), timeoutedCancelledEvents);
     }
-
-    Y_UNIT_TEST(CancelPutByDeadline) {
+    Y_UNIT_TEST(ExternalCancellationTerminatesInTime) {
         TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
         TTestCtx ctx({
             .NodeCount = erasure.BlobSubgroupSize() + 1,
@@ -87,30 +84,91 @@ Y_UNIT_TEST_SUITE(Cancellation) {
         ctx.AllocateEdgeActorOnSpecificNode(ctx.NodeCount);
 
         TMessageRelevanceOwner owner = std::make_shared<TMessageRelevanceTracker>();
-        bool deadlineInjected = false;
+        bool cancelledInBackpressure = false;
 
         ctx.Env->Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) -> bool {
-            if (!deadlineInjected && ev->GetTypeRewrite() == TEvBlobStorage::TEvVPut::EventType) {
-                deadlineInjected = true;
-                owner.reset();
-                ctx.Env->Runtime->Send(new IEventHandle(TEvBlobStorage::EvDeadline, 0, ev->Sender,
-                    MakeBlobStorageProxyID(ctx.GroupId), nullptr, 0), ev->Sender.NodeId());
-                return false;
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvVPut::EventType) {
+                if (!cancelledInBackpressure) {
+                    cancelledInBackpressure = true;
+                    owner.reset();
+                }
+                if (ev->Sender.NodeId() != ev->Recipient.NodeId()) {
+                    UNIT_FAIL("Externally cancelled TEvVPut was sent to VDisk, event# " << ev->Sender << "->" <<
+                            ev->Recipient << " " << ev->ToString());
+                }
             }
             return true;
         };
 
         const ui64 cancelledEvents = GetCancellationCounter(ctx, "CancelledEvents");
-        const ui64 timeoutedCancelledEvents = GetCancellationCounter(ctx, "TimeoutedCancelledEvents");
 
-        SendCancellablePut(ctx, owner, TAppData::TimeProvider->Now() + TDuration::Minutes(10));
+        SendCancellablePut(ctx, owner);
 
         auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(ctx.Edge, false,
                 TAppData::TimeProvider->Now() + TDuration::Seconds(5));
-        UNIT_ASSERT(deadlineInjected);
-        UNIT_ASSERT(res);
-        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::DEADLINE);
-        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents);
-        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "TimeoutedCancelledEvents"), timeoutedCancelledEvents + 1);
+        UNIT_ASSERT(cancelledInBackpressure);
+        UNIT_ASSERT_C(res, "Externally cancelled request did not terminate in time");
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents + 1);
+    }
+
+    Y_UNIT_TEST(ExternalCancellationAfterAllSubrequestsSentTerminatesInTime) {
+        TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TTestCtx ctx({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+            .MaxPutTimeoutDSProxy = TDuration::Minutes(10),
+        });
+
+        ctx.Initialize();
+        ctx.AllocateEdgeActorOnSpecificNode(ctx.NodeCount);
+
+        TMessageRelevanceOwner owner = std::make_shared<TMessageRelevanceTracker>();
+        const ui32 expectedSubrequests = erasure.TotalPartCount();
+        ui32 subrequestsSent = 0;
+        bool allSubrequestsSent = false;
+        bool releaseResults = false;
+        std::vector<std::pair<ui32, std::unique_ptr<IEventHandle>>> detainedResults;
+
+        ctx.Env->Runtime->FilterFunction = [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) -> bool {
+            switch (ev->GetTypeRewrite()) {
+                case TEvBlobStorage::TEvVPut::EventType:
+                    if (ev->Sender.NodeId() != ev->Recipient.NodeId() && ++subrequestsSent == expectedSubrequests) {
+                        allSubrequestsSent = true;
+                        owner.reset();
+                    }
+                    return true;
+
+                case TEvBlobStorage::TEvVPutResult::EventType:
+                    if (!releaseResults) {
+                        detainedResults.emplace_back(nodeId, std::move(ev));
+                        return false;
+                    }
+                    return true;
+
+                default:
+                    return true;
+            }
+        };
+
+        const ui64 cancelledEvents = GetCancellationCounter(ctx, "CancelledEvents");
+
+        SendCancellablePut(ctx, owner);
+
+        while (!allSubrequestsSent || detainedResults.empty()) {
+            ctx.Env->Sim(TDuration::MilliSeconds(100));
+        }
+
+        releaseResults = true;
+        for (auto& [nodeId, ev] : detainedResults) {
+            ctx.Env->Runtime->Send(ev.release(), nodeId);
+        }
+        detainedResults.clear();
+
+        auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(ctx.Edge, false,
+                TAppData::TimeProvider->Now() + TDuration::Seconds(5));
+        UNIT_ASSERT_C(res, "Request cancelled after all subrequests were sent did not terminate in time");
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
+        UNIT_ASSERT_VALUES_EQUAL(GetCancellationCounter(ctx, "CancelledEvents"), cancelledEvents + 1);
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make DSQueue reply back to DSProxy when it processes a request cancelled externally. Add a counter for the external cancellation logic.

### Changelog category <!-- remove all except one -->

* Improvement