### PR TITLE
Mute: fast unmute track - handle gh errors

### DIFF
--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -285,7 +285,11 @@ def remove_label_from_issue(issue_id, label_name):
 
 
 def fetch_issue_label_names(issue_numbers):
-    """Return ``{issue_number: {label_name, ...}}`` from GitHub GraphQL."""
+    """Return ``{issue_number: {label_name_lower, ...}}`` from GitHub GraphQL.
+
+    Names are lowercased and trimmed so callers can compare against lowercase
+    label constants without re-normalizing on each site.
+    """
     result = {}
     numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
     if not numbers:
@@ -309,7 +313,7 @@ def fetch_issue_label_names(issue_numbers):
             node = repo_data.get(f'n{number}') or {}
             labels = (node.get('labels') or {}).get('nodes') or []
             result[number] = {
-                str(label.get('name') or '').strip()
+                str(label.get('name') or '').strip().lower()
                 for label in labels
                 if (label or {}).get('name')
             }
@@ -401,6 +405,9 @@ def fetch_issue_project_statuses(issue_numbers):
 
     target_project_number = int(PROJECT_ID)
     chunk_size = 50
+    # ``projectItems(first: 10)`` covers all realistic cases (we expect 1 — the
+    # configured manual-unmute project) while keeping the GraphQL response and
+    # complexity budget small for a 50-issue chunk.
     for i in range(0, len(numbers), chunk_size):
         chunk = numbers[i : i + chunk_size]
         subqueries = []
@@ -408,7 +415,7 @@ def fetch_issue_project_statuses(issue_numbers):
             subqueries.append(
                 f"""
                 n{n}: issue(number: {n}) {{
-                  projectItems(first: 40) {{
+                  projectItems(first: 10) {{
                     nodes {{
                       project {{ number }}
                       fieldValues(first: 20) {{
@@ -457,5 +464,3 @@ def fetch_issue_project_statuses(issue_numbers):
                 break
             result[number] = status_name
     return result
-
-

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -388,3 +388,74 @@ def fetch_issue_states(issue_numbers):
     return result
 
 
+def fetch_issue_project_statuses(issue_numbers):
+    """Return ``{issue_number: project_status_name}`` from Project V2 card fields.
+
+    Reads live status from GitHub project item, so callers are not dependent on YDB
+    export freshness.
+    """
+    result = {}
+    numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
+    if not numbers:
+        return result
+
+    target_project_number = int(PROJECT_ID)
+    chunk_size = 50
+    for i in range(0, len(numbers), chunk_size):
+        chunk = numbers[i : i + chunk_size]
+        subqueries = []
+        for n in chunk:
+            subqueries.append(
+                f"""
+                n{n}: issue(number: {n}) {{
+                  projectItems(first: 40) {{
+                    nodes {{
+                      project {{ number }}
+                      fieldValues(first: 20) {{
+                        nodes {{
+                          ... on ProjectV2ItemFieldSingleSelectValue {{
+                            field {{
+                              ... on ProjectV2SingleSelectField {{
+                                name
+                              }}
+                            }}
+                            name
+                          }}
+                        }}
+                      }}
+                    }}
+                  }}
+                }}
+                """
+            )
+
+        query = f"""
+        query {{
+            repository(owner: "{ORG_NAME}", name: "{REPO_NAME}") {{
+                {' '.join(subqueries)}
+            }}
+        }}
+        """
+        response = run_query(query)
+        repo_data = (response.get('data') or {}).get('repository') or {}
+        for number in chunk:
+            node = repo_data.get(f'n{number}') or {}
+            items = (node.get('projectItems') or {}).get('nodes') or []
+            status_name = ''
+            for item in items:
+                project_num = int((item.get('project') or {}).get('number') or -1)
+                if project_num != target_project_number:
+                    continue
+                field_nodes = (item.get('fieldValues') or {}).get('nodes') or []
+                for fv in field_nodes:
+                    field_name = (
+                        ((fv.get('field') or {}).get('name') or '').strip().lower()
+                    )
+                    if field_name == 'status':
+                        status_name = str(fv.get('name') or '')
+                        break
+                break
+            result[number] = status_name
+    return result
+
+

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -245,10 +245,10 @@ def _get_label_id(label_name):
 
 
 def add_label_to_issue(issue_id, label_name):
-    """Attach a label to issue. Idempotent — GitHub ignores duplicates."""
+    """Attach a label to issue. Returns ``True`` only on successful API call."""
     label_id = _get_label_id(label_name)
     if not label_id:
-        return
+        return False
     mutation = """
     mutation ($labelableId: ID!, $labelIds: [ID!]!) {
       addLabelsToLabelable(input: {labelableId: $labelableId, labelIds: $labelIds}) {
@@ -258,17 +258,19 @@ def add_label_to_issue(issue_id, label_name):
     """
     try:
         run_query(mutation, {'labelableId': issue_id, 'labelIds': [label_id]})
+        return True
     except Exception as exc:
         logging.warning(
             'Failed to add label %r to issue %s: %s', label_name, issue_id, exc
         )
+        return False
 
 
 def remove_label_from_issue(issue_id, label_name):
-    """Detach a label from issue. No-op if the label is not present."""
+    """Detach a label from issue. Returns ``True`` only on successful API call."""
     label_id = _get_label_id(label_name)
     if not label_id:
-        return
+        return False
     mutation = """
     mutation ($labelableId: ID!, $labelIds: [ID!]!) {
       removeLabelsFromLabelable(input: {labelableId: $labelableId, labelIds: $labelIds}) {
@@ -278,10 +280,12 @@ def remove_label_from_issue(issue_id, label_name):
     """
     try:
         run_query(mutation, {'labelableId': issue_id, 'labelIds': [label_id]})
+        return True
     except Exception as exc:
         logging.warning(
             'Failed to remove label %r from issue %s: %s', label_name, issue_id, exc
         )
+        return False
 
 
 def fetch_issue_label_names(issue_numbers):
@@ -410,9 +414,9 @@ def fetch_issue_project_statuses(issue_numbers):
 
     target_project_number = int(PROJECT_ID)
     chunk_size = 50
-    # ``projectItems(first: 10)`` covers all realistic cases (we expect 1 — the
-    # configured manual-unmute project) while keeping the GraphQL response and
-    # complexity budget small for a 50-issue chunk.
+    # Keep this aligned with ``fetch_issue_numbers_in_manual_unmute_project``
+    # to reduce the chance of missing the target project item for issues that
+    # belong to many projects.
     for i in range(0, len(numbers), chunk_size):
         chunk = numbers[i : i + chunk_size]
         subqueries = []
@@ -420,7 +424,7 @@ def fetch_issue_project_statuses(issue_numbers):
             subqueries.append(
                 f"""
                 n{n}: issue(number: {n}) {{
-                  projectItems(first: 10) {{
+                  projectItems(first: 40) {{
                     nodes {{
                       project {{ number }}
                       fieldValues(first: 20) {{

--- a/.github/scripts/tests/mute/fast_unmute_github.py
+++ b/.github/scripts/tests/mute/fast_unmute_github.py
@@ -395,8 +395,13 @@ def fetch_issue_states(issue_numbers):
 def fetch_issue_project_statuses(issue_numbers):
     """Return ``{issue_number: project_status_name}`` from Project V2 card fields.
 
-    Reads live status from GitHub project item, so callers are not dependent on YDB
-    export freshness.
+    Only issues that already have a card in the configured manual-unmute project
+    are present in the result; callers can use ``number in result`` as a proxy
+    for "is on the board". The value can be an empty string if the card exists
+    but no Status option is set.
+
+    Reads live status from GitHub project item, so callers are not dependent on
+    YDB export freshness.
     """
     result = {}
     numbers = sorted({int(n) for n in (issue_numbers or []) if n is not None})
@@ -448,11 +453,11 @@ def fetch_issue_project_statuses(issue_numbers):
         for number in chunk:
             node = repo_data.get(f'n{number}') or {}
             items = (node.get('projectItems') or {}).get('nodes') or []
-            status_name = ''
             for item in items:
                 project_num = int((item.get('project') or {}).get('number') or -1)
                 if project_num != target_project_number:
                     continue
+                status_name = ''
                 field_nodes = (item.get('fieldValues') or {}).get('nodes') or []
                 for fv in field_nodes:
                     field_name = (
@@ -461,6 +466,6 @@ def fetch_issue_project_statuses(issue_numbers):
                     if field_name == 'status':
                         status_name = str(fv.get('name') or '')
                         break
+                result[number] = status_name
                 break
-            result[number] = status_name
     return result

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -33,6 +33,7 @@ from mute.fast_unmute_github import (
     fetch_issue_closers,
     fetch_issue_label_names,
     fetch_issue_numbers_in_manual_unmute_project,
+    fetch_issue_project_statuses,
     fetch_issue_states,
     remove_label_from_issue,
     reopen_issue,
@@ -505,6 +506,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             set_manual_unmute_project_board_status(
                 issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
             )
+            remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
             add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
 
         for issue_number in issues_to_delabel:
@@ -513,6 +515,66 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
                 remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
 
     logging.info('manual_unmute_cleanup: removed %d row(s)', delete_count)
+
+
+def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_path):
+    """Repair label state for finished manual fast-unmute issues.
+
+    For CLOSED+COMPLETED issues in lookback with no active ``fast_unmute_active`` rows:
+    - remove stale ``manual-fast-unmute`` label,
+    - ensure project Status is ``Unmuted``,
+    - ensure ``fast-unmute-finished`` label is present when the issue already participates
+      in manual fast-unmute label flow (has either fast-unmute label).
+    """
+    raw_candidates = fetch_candidate_issues(
+        ydb_wrapper, issues_table_path, get_manual_unmute_issue_closed_lookback_days()
+    )
+    issue_meta = {
+        int(c['issue_number']): c.get('issue_id')
+        for c in raw_candidates
+        if c.get('issue_number') is not None and c.get('issue_id')
+    }
+    if not issue_meta:
+        return
+
+    issue_numbers = set(issue_meta.keys())
+    remaining = count_rows_per_issue(ydb_wrapper, table_path, issue_numbers)
+    live_status_by_issue = fetch_issue_project_statuses(issue_numbers)
+    labels_by_issue = fetch_issue_label_names(issue_numbers)
+
+    touched = 0
+    for issue_number in sorted(issue_numbers):
+        if remaining.get(issue_number, 0) != 0:
+            continue
+
+        labels_raw = labels_by_issue.get(issue_number) or set()
+        labels = {str(name).strip().lower() for name in labels_raw if name}
+        has_manual = MANUAL_FAST_UNMUTE_GITHUB_LABEL in labels
+        has_finished = MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL in labels
+        if not (has_manual or has_finished):
+            continue
+
+        issue_id = issue_meta.get(issue_number)
+        if not issue_id:
+            continue
+
+        project_status = str(live_status_by_issue.get(issue_number) or '').strip().lower()
+        if project_status != PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS.lower():
+            set_manual_unmute_project_board_status(
+                issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
+            )
+        if has_manual:
+            remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
+            touched += 1
+        if not has_finished:
+            add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
+            touched += 1
+
+    if touched:
+        logging.info(
+            'manual_unmute_reconcile: applied %d label repair operation(s)',
+            touched,
+        )
 
 
 def sync(ydb_wrapper):
@@ -540,5 +602,6 @@ def sync(ydb_wrapper):
         config['min_runs'],
     )
     cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path)
+    reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_path)
     if grace_table_path:
         expire_fast_unmute_grace(ydb_wrapper, grace_table_path)

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -600,11 +600,11 @@ def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_pa
                 )
                 status_flips += 1
         if has_manual:
-            remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
-            label_ops += 1
+            if remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL):
+                label_ops += 1
         if not has_finished:
-            add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
-            label_ops += 1
+            if add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL):
+                label_ops += 1
 
     if label_ops or status_flips:
         logging.info(

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -530,13 +530,18 @@ _RECONCILE_STATUS_ALLOWED_FROM = frozenset(
 def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_path):
     """Repair label/status for finished manual fast-unmute issues.
 
-    For CLOSED+COMPLETED issues in lookback that no longer have rows in
-    ``fast_unmute_active`` AND already participate in manual fast-unmute
-    label flow (have either ``manual-fast-unmute`` or ``fast-unmute-finished``):
+    For issues that:
+    - are in the lookback YDB candidate set (CLOSED+COMPLETED there), and
+    - are still CLOSED+COMPLETED on GitHub (live re-check — YDB export can lag), and
+    - no longer have rows in ``fast_unmute_active``, and
+    - already participate in manual fast-unmute label flow
+      (have either ``manual-fast-unmute`` or ``fast-unmute-finished``):
+    we
     - remove stale ``manual-fast-unmute`` label,
     - ensure ``fast-unmute-finished`` label is present,
-    - flip project Status to ``Unmuted`` only from ``Observation`` / empty
-      (we never override ``Muted`` — that's a meaningful end state).
+    - flip project Status to ``Unmuted`` (only from ``Observation`` / empty, and
+      only for issues already on the manual-unmute project board — we never add
+      cards from here and never override ``Muted``).
     """
     raw_candidates = fetch_candidate_issues(
         ydb_wrapper, issues_table_path, get_manual_unmute_issue_closed_lookback_days()
@@ -555,31 +560,45 @@ def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_pa
     if not zero_row_issues:
         return
 
-    live_status_by_issue = fetch_issue_project_statuses(zero_row_issues)
-    labels_by_issue = fetch_issue_label_names(zero_row_issues)
+    live_states = fetch_issue_states(zero_row_issues)
+    eligible_issues = {
+        n for n in zero_row_issues
+        if issue_eligible_for_manual_fast_unmute_entry(
+            (live_states.get(n) or {}).get('state'),
+            (live_states.get(n) or {}).get('state_reason'),
+        )
+    }
+    if not eligible_issues:
+        return
+
+    live_status_by_issue = fetch_issue_project_statuses(eligible_issues)
+    labels_by_issue = fetch_issue_label_names(eligible_issues)
 
     label_ops = 0
     status_flips = 0
-    for issue_number in sorted(zero_row_issues):
+    for issue_number in sorted(eligible_issues):
         labels = labels_by_issue.get(issue_number) or set()
         has_manual = MANUAL_FAST_UNMUTE_GITHUB_LABEL in labels
         has_finished = MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL in labels
         if not (has_manual or has_finished):
             continue
 
-        issue_id = issue_meta.get(issue_number)
+        issue_id = (live_states.get(issue_number) or {}).get('id') or issue_meta.get(issue_number)
         if not issue_id:
             continue
 
-        project_status = str(live_status_by_issue.get(issue_number) or '').strip().lower()
-        if (
-            project_status != PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS.lower()
-            and project_status in _RECONCILE_STATUS_ALLOWED_FROM
-        ):
-            set_manual_unmute_project_board_status(
-                issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
-            )
-            status_flips += 1
+        # Only touch project status for issues that already have a card; never
+        # implicitly add cards from the reconciler.
+        if issue_number in live_status_by_issue:
+            project_status = str(live_status_by_issue[issue_number] or '').strip().lower()
+            if (
+                project_status != PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS.lower()
+                and project_status in _RECONCILE_STATUS_ALLOWED_FROM
+            ):
+                set_manual_unmute_project_board_status(
+                    issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
+                )
+                status_flips += 1
         if has_manual:
             remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
             label_ops += 1

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -509,7 +509,9 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
             add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
 
-        for issue_number in issues_to_delabel:
+        # Success-branch issues already had the label removed above; skip them
+        # to avoid an extra round-trip to GitHub.
+        for issue_number in issues_to_delabel - success_comment_issues:
             issue_id = issue_ids.get(issue_number)
             if issue_id:
                 remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
@@ -517,14 +519,24 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
     logging.info('manual_unmute_cleanup: removed %d row(s)', delete_count)
 
 
-def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_path):
-    """Repair label state for finished manual fast-unmute issues.
+# Project statuses from which the reconciler is allowed to flip to ``Unmuted``.
+# Anything else (e.g. ``Muted`` set by abandon/TTL-fail, or a state a human picked
+# intentionally) is left alone to avoid clobbering meaningful state.
+_RECONCILE_STATUS_ALLOWED_FROM = frozenset(
+    s.lower() for s in (PROJECT_STATUS_ON_FAST_UNMUTE_REOPEN, '')
+)
 
-    For CLOSED+COMPLETED issues in lookback with no active ``fast_unmute_active`` rows:
+
+def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_path):
+    """Repair label/status for finished manual fast-unmute issues.
+
+    For CLOSED+COMPLETED issues in lookback that no longer have rows in
+    ``fast_unmute_active`` AND already participate in manual fast-unmute
+    label flow (have either ``manual-fast-unmute`` or ``fast-unmute-finished``):
     - remove stale ``manual-fast-unmute`` label,
-    - ensure project Status is ``Unmuted``,
-    - ensure ``fast-unmute-finished`` label is present when the issue already participates
-      in manual fast-unmute label flow (has either fast-unmute label).
+    - ensure ``fast-unmute-finished`` label is present,
+    - flip project Status to ``Unmuted`` only from ``Observation`` / empty
+      (we never override ``Muted`` — that's a meaningful end state).
     """
     raw_candidates = fetch_candidate_issues(
         ydb_wrapper, issues_table_path, get_manual_unmute_issue_closed_lookback_days()
@@ -539,16 +551,17 @@ def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_pa
 
     issue_numbers = set(issue_meta.keys())
     remaining = count_rows_per_issue(ydb_wrapper, table_path, issue_numbers)
-    live_status_by_issue = fetch_issue_project_statuses(issue_numbers)
-    labels_by_issue = fetch_issue_label_names(issue_numbers)
+    zero_row_issues = {n for n in issue_numbers if remaining.get(n, 0) == 0}
+    if not zero_row_issues:
+        return
 
-    touched = 0
-    for issue_number in sorted(issue_numbers):
-        if remaining.get(issue_number, 0) != 0:
-            continue
+    live_status_by_issue = fetch_issue_project_statuses(zero_row_issues)
+    labels_by_issue = fetch_issue_label_names(zero_row_issues)
 
-        labels_raw = labels_by_issue.get(issue_number) or set()
-        labels = {str(name).strip().lower() for name in labels_raw if name}
+    label_ops = 0
+    status_flips = 0
+    for issue_number in sorted(zero_row_issues):
+        labels = labels_by_issue.get(issue_number) or set()
         has_manual = MANUAL_FAST_UNMUTE_GITHUB_LABEL in labels
         has_finished = MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL in labels
         if not (has_manual or has_finished):
@@ -559,21 +572,26 @@ def reconcile_manual_fast_unmute_labels(ydb_wrapper, table_path, issues_table_pa
             continue
 
         project_status = str(live_status_by_issue.get(issue_number) or '').strip().lower()
-        if project_status != PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS.lower():
+        if (
+            project_status != PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS.lower()
+            and project_status in _RECONCILE_STATUS_ALLOWED_FROM
+        ):
             set_manual_unmute_project_board_status(
                 issue_id, PROJECT_STATUS_ON_FAST_UNMUTE_SUCCESS
             )
+            status_flips += 1
         if has_manual:
             remove_label_from_issue(issue_id, MANUAL_FAST_UNMUTE_GITHUB_LABEL)
-            touched += 1
+            label_ops += 1
         if not has_finished:
             add_label_to_issue(issue_id, MANUAL_FAST_UNMUTE_FINISHED_GITHUB_LABEL)
-            touched += 1
+            label_ops += 1
 
-    if touched:
+    if label_ops or status_flips:
         logging.info(
-            'manual_unmute_reconcile: applied %d label repair operation(s)',
-            touched,
+            'manual_unmute_reconcile: %d label op(s), %d status flip(s)',
+            label_ops,
+            status_flips,
         )
 
 

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -61,17 +61,35 @@ def truncate_issue_body(body):
     return truncated_body
 
 def handle_github_errors(response):
-    if 'errors' in response:
-        for error in response['errors']:
-            if error['type'] == 'INSUFFICIENT_SCOPES':
-                print("Error: Insufficient Scopes")
-                print("Message:", error['message'])
-                raise Exception("Insufficient scopes. Please update your token's scopes.")
-            # Handle other types of errors if necessary
-            else:
-                print("Unknown error type:", error.get('type', 'No type'))
-                print("Message:", error.get('message', 'No message available'))
-                raise Exception("GraphQL Error: " + error.get('message', 'Unknown error'))
+    errors = response.get('errors') or []
+    if not errors:
+        return
+
+    formatted_errors = []
+    has_insufficient_scopes = False
+    for raw_error in errors:
+        if isinstance(raw_error, dict):
+            error_type = (
+                raw_error.get('type')
+                or (raw_error.get('extensions') or {}).get('code')
+                or 'UNKNOWN'
+            )
+            message = raw_error.get('message') or 'Unknown error'
+        else:
+            error_type = 'UNKNOWN'
+            message = str(raw_error) if raw_error is not None else 'Unknown error'
+
+        if error_type == 'INSUFFICIENT_SCOPES':
+            has_insufficient_scopes = True
+        formatted_errors.append(f"{error_type}: {message}")
+
+    if has_insufficient_scopes:
+        raise Exception(
+            "Insufficient scopes. Please update your token's scopes. "
+            + " | ".join(formatted_errors)
+        )
+
+    raise Exception("GraphQL Error(s): " + " | ".join(formatted_errors))
 
 
 def _retry_backoff_seconds(attempt, response=None):

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -69,17 +69,22 @@ def handle_github_errors(response):
     has_insufficient_scopes = False
     for raw_error in errors:
         if isinstance(raw_error, dict):
+            extensions = raw_error.get('extensions') or {}
+            extensions_code = extensions.get('code')
             error_type = (
                 raw_error.get('type')
-                or (raw_error.get('extensions') or {}).get('code')
+                or extensions_code
                 or 'UNKNOWN'
             )
             message = raw_error.get('message') or 'Unknown error'
         else:
+            extensions_code = None
             error_type = 'UNKNOWN'
             message = str(raw_error) if raw_error is not None else 'Unknown error'
 
-        if error_type == 'INSUFFICIENT_SCOPES':
+        # GitHub returns INSUFFICIENT_SCOPES either as the top-level ``type`` or
+        # alongside ``type: FORBIDDEN`` in ``extensions.code`` — check both.
+        if 'INSUFFICIENT_SCOPES' in (error_type, extensions_code):
             has_insufficient_scopes = True
         formatted_errors.append(f"{error_type}: {message}")
 


### PR DESCRIPTION
## Что сделано

- Починил обработку ошибок GraphQL в `update_mute_issues.py` (больше не падаем на `KeyError: 'type'`).
- В success-ветке fast-unmute поменял порядок:
  - сначала снимаем `manual-fast-unmute`,
  - потом ставим `fast-unmute-finished`.
- Добавил self-heal в `fast_unmute_pipeline.py`:
  - для закрытых `COMPLETED` issue без активных fast-unmute строк
  - снимаем залипший `manual-fast-unmute`,
  - при необходимости ставим `fast-unmute-finished`,
  - дожимаем `Status -> Unmuted`.
- Для проверки статуса в self-heal теперь используем **live** данные из GitHub Project (`fast_unmute_github.py`), а не потенциально устаревший YDB snapshot.

## Зачем

Был кейс, когда из-за сбоев GitHub API метка `manual-fast-unmute` не снялась, и это блокировало создание нового mute-issue при повторном mute теста.

## Результат

Логика стала устойчивее к временным ошибкам GitHub и сама вычищает “залипшие” состояния.

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
