### PR TITLE
Optimize retry count for errors at the NFS export completion stage

### DIFF
--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -652,14 +652,14 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
         }
 
         if (CanRetry(error)) {
-            if (error.GetExceptionName() == "FsUploadSessionLost") {
+            if (error.GetExceptionName() == "FsCompleteMultipartUploadFailed") {
                 ForceNewUpload = true;
             }
             UploadId.Clear(); // force getting info after restart
             Retry();
         } else {
             Error = TStringBuilder() << "S3 error: " << error;
-            this->PassAway();
+            PassAway();
         }
     }
 
@@ -682,7 +682,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
             Y_ENSURE(Error);
             Error = TStringBuilder() << *Error << " Additionally, 'AbortMultipartUpload' has failed: "
                 << error;
-            this->PassAway();
+            PassAway();
         }
     }
 
@@ -735,7 +735,7 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader<TSettings>> {
                 return;
             }
 
-            this->PassAway();
+            PassAway();
         } else {
             if (success) {
                 this->Send(DataShard, new TEvDataShard::TEvChangeS3UploadStatus(this->SelfId(), TxId,

--- a/ydb/core/wrappers/fs_storage.cpp
+++ b/ydb/core/wrappers/fs_storage.cpp
@@ -93,10 +93,10 @@ private:
     }
 
     template<typename TEvResponse>
-    auto CreateOutcome(Aws::S3::S3Errors errorType, const TString& errorMessage, bool retryable) {
+    auto CreateOutcome(Aws::S3::S3Errors errorType, const TString& exceptionName, const TString& errorMessage, bool retryable) {
         Aws::Client::AWSError<Aws::S3::S3Errors> awsError(
             errorType,
-            "FsStorageError",
+            exceptionName,
             errorMessage,
             retryable
         );
@@ -110,10 +110,11 @@ private:
             const NActors::TActorId& sender,
             const TString& errorMessage,
             Aws::S3::S3Errors errorType = Aws::S3::S3Errors::INTERNAL_FAILURE,
-            bool retryable = false)
+            bool retryable = false,
+            const TString& exceptionName = "FsStorageError")
     {
         std::unique_ptr<TEvResponse> response;
-        response = std::make_unique<TEvResponse>(CreateOutcome<TEvResponse>(errorType, errorMessage, retryable));
+        response = std::make_unique<TEvResponse>(CreateOutcome<TEvResponse>(errorType, exceptionName, errorMessage, retryable));
         this->Send(sender, response.release());
     }
 
@@ -123,10 +124,11 @@ private:
             const TString& key,
             const TString& errorMessage,
             Aws::S3::S3Errors errorType = Aws::S3::S3Errors::INTERNAL_FAILURE,
-            bool retryable = false)
+            bool retryable = false,
+            const TString& exceptionName = "FsStorageError")
     {
         std::unique_ptr<TEvResponse> response;
-        response = std::make_unique<TEvResponse>(key, CreateOutcome<TEvResponse>(errorType, errorMessage, retryable));
+        response = std::make_unique<TEvResponse>(key, CreateOutcome<TEvResponse>(errorType, exceptionName, errorMessage, retryable));
         this->Send(sender, response.release());
     }
 
@@ -137,10 +139,11 @@ private:
             const std::pair<ui64, ui64>& range,
             const TString& errorMessage,
             Aws::S3::S3Errors errorType = Aws::S3::S3Errors::INTERNAL_FAILURE,
-            bool retryable = false)
+            bool retryable = false,
+            const TString& exceptionName = "FsStorageError")
     {
         std::unique_ptr<TEvResponse> response;
-        response = std::make_unique<TEvResponse>(key, range, CreateOutcome<TEvResponse>(errorType, errorMessage, retryable));
+        response = std::make_unique<TEvResponse>(key, range, CreateOutcome<TEvResponse>(errorType, exceptionName, errorMessage, retryable));
         this->Send(sender, response.release());
     }
 
@@ -249,6 +252,7 @@ public:
             session.File.Write(body.data(), body.size());
             session.File.Flush();
             session.File.Close();
+
             ReplySuccess<TEvPutObjectResponse>(ev->Sender, key);
         } catch (const TSystemError& ex) {
             if (!HandleFileLockError<TEvPutObjectResponse>(ex, ev->Sender, key, "PutObject")) {
@@ -590,18 +594,12 @@ public:
             const TString incompleteKey = GetIncompletePath(key.c_str());
             auto it = ActiveUploads.find(uploadId);
             if (it == ActiveUploads.end()) {
-                // Upload session not found - likely due to actor restart
-                // Return retryable error to force datashard to retry with cleared uploadId
-                Aws::Client::AWSError<Aws::S3::S3Errors> awsError(
-                    Aws::S3::S3Errors::INTERNAL_FAILURE,
-                    "FsUploadSessionLost",
+                ReplyError<TEvCompleteMultipartUploadResponse>(ev->Sender, key,
                     TStringBuilder() << "Upload session not found: uploadId# " << uploadId,
-                    true // retryable
+                    Aws::S3::S3Errors::INTERNAL_FAILURE, 
+                    true /* retryable */, 
+                    "FsCompleteMultipartUploadFailed"
                 );
-                Aws::S3::S3Error error(std::move(awsError));
-                Aws::Utils::Outcome<Aws::S3::Model::CompleteMultipartUploadResult, Aws::S3::S3Error> outcome(std::move(error));
-                auto response = std::make_unique<TEvCompleteMultipartUploadResponse>(key, std::move(outcome));
-                this->Send(ev->Sender, response.release());
                 return;
             }
 
@@ -618,9 +616,11 @@ public:
                 NFs::Remove(incompleteKey);
                 ActiveUploads.erase(it);
 
-                ReplyError<TEvCompleteMultipartUploadResponse>(
-                    ev->Sender, key, errorMsg,
-                    Aws::S3::S3Errors::INTERNAL_FAILURE, true /* retryable */);
+                ReplyError<TEvCompleteMultipartUploadResponse>(ev->Sender, key, errorMsg, 
+                    Aws::S3::S3Errors::INTERNAL_FAILURE, 
+                    true /* retryable */, 
+                    "FsCompleteMultipartUploadFailed"
+                );
                 return;
             }
             FsyncParentDir(key);

--- a/ydb/core/wrappers/fs_storage_ut.cpp
+++ b/ydb/core/wrappers/fs_storage_ut.cpp
@@ -739,8 +739,8 @@ public:
             UNIT_ASSERT(result.GetError().ShouldRetry());
             TString exceptionName(result.GetError().GetExceptionName().data(),
                 result.GetError().GetExceptionName().size());
-            UNIT_ASSERT_C(exceptionName == "FsUploadSessionLost",
-                TStringBuilder() << "Expected 'FsUploadSessionLost', got: " << exceptionName);
+            UNIT_ASSERT_C(exceptionName == "FsCompleteMultipartUploadFailed",
+                TStringBuilder() << "Expected 'FsCompleteMultipartUploadFailed', got: " << exceptionName);
         }
 
         TString newUploadId;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Убран лишний ретрай при ошибки rename в `CompleteMultipartUpload` (ранее требовалось 2, теперь 1).
- Небольшой рефакторинг формирования ошибок в `fs_storage.cpp`
