### PR TITLE
Fix filestore space accounting validation. NBYDB-2183 (#39696)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_fs.cpp
@@ -368,6 +368,15 @@ THolder<TProposeResponse> TAlterFileStore::Propose(
         return result;
     }
 
+    if (!TFileStoreInfo::ValidateFileStoreConfigSpaceOverflow(
+            fs->Config.GetBlockSize(),
+            alterConfig->GetBlocksCount(),
+            errStr))
+    {
+        result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+        return result;
+    }
+
     TChannelsBindings storeChannelsBinding;
     const auto channelProfilesProcessed = ProcessChannelProfiles(
         path,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_fs.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_fs.cpp
@@ -445,15 +445,27 @@ TFileStoreInfo::TPtr TCreateFileStore::CreateFileStoreInfo(
     TFileStoreInfo::TPtr fs = new TFileStoreInfo();
 
     const auto& config = op.GetConfig();
+
     if (!config.HasBlockSize()) {
         status = NKikimrScheme::StatusSchemeError;
         errStr = "Block size is required";
         return nullptr;
     }
 
+    if (config.GetBlockSize() == 0) {
+        status = NKikimrScheme::StatusInvalidParameter;
+        errStr = "Non zero block size is required";
+        return nullptr;
+    }
+
     if (config.HasVersion()) {
         status = NKikimrScheme::StatusSchemeError;
         errStr = "Setting version is not allowed";
+        return nullptr;
+    }
+
+    if (!TFileStoreInfo::ValidateFileStoreConfigSpaceOverflow(config.GetBlockSize(), config.GetBlocksCount(), errStr)) {
+        status = NKikimrScheme::StatusInvalidParameter;
         return nullptr;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2382,6 +2382,18 @@ struct TFileStoreInfo : public TSimpleRefCount<TFileStoreInfo> {
         return space;
     }
 
+    static bool ValidateFileStoreConfigSpaceOverflow(ui64 blockSize, ui64 blockCount, TString& errStr) {
+        if (blockSize && blockCount > Max<ui64>() / blockSize) {
+            errStr = TStringBuilder()
+                << "FileStore size overflows ui64: blocks count " << blockCount
+                << " * block size " << blockSize
+                << " > " << Max<ui64>();
+            return false;
+        }
+
+        return true;
+    }
+
 private:
     TFileStoreSpace GetFileStoreSpace(const NKikimrFileStore::TConfig& config) const {
         const ui64 blockSize = config.GetBlockSize();

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -33,6 +33,13 @@ bool CheckSpaceChanged(const TSpaceLimits& limits, ui64 newValue, ui64 oldValue,
     }
 
     const ui64 diff = newValue - oldValue;
+    if (limits.Allocated > Max<ui64>() - diff) {
+        errStr = TStringBuilder()
+            << "New " << tabletType << " space overflows allocated counter" << suffix
+            << ": " << limits.Allocated << " + " << diff << " > " << Max<ui64>();
+        return false;
+    }
+
     const ui64 newAllocated = limits.Allocated + diff;
     if (newAllocated <= limits.Limit) {
         return true;

--- a/ydb/core/tx/schemeshard/ut_filestore/ut_filestore.cpp
+++ b/ydb/core/tx/schemeshard/ut_filestore/ut_filestore.cpp
@@ -1,0 +1,182 @@
+#include <ydb/core/protos/filestore_config.pb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+#include <util/generic/size_literals.h>
+
+using namespace NKikimr;
+using namespace NSchemeShardUT_Private;
+
+namespace {
+
+auto& InitCreateFileStoreConfig(
+    const TString& name,
+    NKikimrSchemeOp::TFileStoreDescription& vdescr)
+{
+    vdescr.SetName(name);
+
+    auto& config = *vdescr.MutableConfig();
+    config.SetBlockSize(4_KB);
+    config.SetBlocksCount(4096);
+    config.SetFileSystemId(name);
+    config.SetCloudId("cloud");
+    config.SetFolderId("folder");
+
+    config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+    config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+    config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+    config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
+
+    return config;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TFileStore) {
+    Y_UNIT_TEST(CreateFileStoreRejectsAllocatedSpaceOverflow) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription hugeDescr;
+        auto& hugeConfig = InitCreateFileStoreConfig("HugeFS", hugeDescr);
+        hugeConfig.SetStorageMediaKind(1);
+        hugeConfig.SetBlocksCount(Max<ui64>() / 4_KB);
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", hugeDescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        NKikimrSchemeOp::TFileStoreDescription smallDescr;
+        auto& smallConfig = InitCreateFileStoreConfig("SmallFS", smallDescr);
+        smallConfig.SetStorageMediaKind(1);
+        smallConfig.SetBlocksCount(2);
+
+        TestCreateFileStore(
+            runtime,
+            ++txId,
+            "/MyRoot",
+            smallDescr.DebugString(),
+            {NKikimrScheme::StatusPreconditionFailed});
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "HugeFS");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(SizeMultiplicationOverflowCannotBypassDomainQuota) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        constexpr ui64 quotaBlocks = 32;
+        constexpr ui64 blockSize = 4_KB;
+        const ui64 overflowBlocks = Max<ui64>() / blockSize + 1;
+
+        TestUserAttrs(
+            runtime,
+            ++txId,
+            "",
+            "MyRoot",
+            AlterUserAttrs({
+                {"__filestore_space_limit_ssd", ToString(quotaBlocks * blockSize)}
+            }));
+        env.TestWaitNotification(runtime, txId);
+
+        NKikimrSchemeOp::TFileStoreDescription overflowDescr;
+        auto& overflowConfig = InitCreateFileStoreConfig("OverflowFS", overflowDescr);
+        overflowConfig.SetStorageMediaKind(1);
+        overflowConfig.SetBlocksCount(overflowBlocks);
+
+        TestCreateFileStore(
+            runtime,
+            ++txId,
+            "/MyRoot",
+            overflowDescr.DebugString(),
+            {{NKikimrScheme::StatusInvalidParameter, "FileStore size overflows ui64"}});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/OverflowFS"), {NLs::PathNotExist});
+
+        NKikimrSchemeOp::TFileStoreDescription quotaDescr;
+        auto& quotaConfig = InitCreateFileStoreConfig("QuotaFS", quotaDescr);
+        quotaConfig.SetStorageMediaKind(1);
+        quotaConfig.SetBlocksCount(quotaBlocks);
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", quotaDescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/QuotaFS"), {
+            NLs::PathExist,
+            NLs::Finished,
+            [blockSize, quotaBlocks](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                const auto& config = record.GetPathDescription().GetFileStoreDescription().GetConfig();
+                UNIT_ASSERT_VALUES_EQUAL(config.GetBlockSize(), blockSize);
+                UNIT_ASSERT_VALUES_EQUAL(config.GetBlocksCount(), quotaBlocks);
+            }
+        });
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "QuotaFS");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(CreateFileStoreRejectsZeroBlockSize) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        auto& config = InitCreateFileStoreConfig("ZeroBlockSizeFS", descr);
+        config.SetBlockSize(0);
+        config.SetStorageMediaKind(1);
+        config.SetBlocksCount(4096);
+
+        TestCreateFileStore(
+            runtime,
+            ++txId,
+            "/MyRoot",
+            descr.DebugString(),
+            {NKikimrScheme::StatusInvalidParameter});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/ZeroBlockSizeFS"), {NLs::PathNotExist});
+    }
+
+    Y_UNIT_TEST(AlterFileStoreRejectsSizeMultiplicationOverflow) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        constexpr ui64 blockSize = 4_KB;
+        constexpr ui64 initialBlocks = 4096;
+        const ui64 overflowBlocks = Max<ui64>() / blockSize + 1;
+
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        auto& config = InitCreateFileStoreConfig("AlterOverflowFS", descr);
+        config.SetStorageMediaKind(1);
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        NKikimrSchemeOp::TFileStoreDescription alterDescr;
+        alterDescr.SetName("AlterOverflowFS");
+        auto& alterConfig = *alterDescr.MutableConfig();
+        alterConfig.SetVersion(1);
+        alterConfig.SetBlocksCount(overflowBlocks);
+
+        TestAlterFileStore(
+            runtime,
+            ++txId,
+            "/MyRoot",
+            alterDescr.DebugString(),
+            {{NKikimrScheme::StatusInvalidParameter, "FileStore size overflows ui64"}});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/AlterOverflowFS"), {
+            NLs::PathExist,
+            NLs::Finished,
+            [blockSize, initialBlocks](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+                const auto& config = record.GetPathDescription().GetFileStoreDescription().GetConfig();
+                UNIT_ASSERT_VALUES_EQUAL(config.GetBlockSize(), blockSize);
+                UNIT_ASSERT_VALUES_EQUAL(config.GetBlocksCount(), initialBlocks);
+            }
+        });
+    }
+
+}

--- a/ydb/core/tx/schemeshard/ut_filestore/ya.make
+++ b/ydb/core/tx/schemeshard/ut_filestore/ya.make
@@ -1,0 +1,23 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/testlib/default
+    ydb/core/tx
+    ydb/core/tx/schemeshard/ut_helpers
+    yql/essentials/public/udf/service/exception_policy
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ut_filestore.cpp
+)
+
+END()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -23,6 +23,7 @@ RECURSE_FOR_TESTS(
     ut_external_table_reboots
     ut_extsubdomain
     ut_extsubdomain_reboots
+    ut_filestore
     ut_filestore_reboots
     ut_index
     ut_index_build


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This commit prevents possible ui64 overflow during filestore alter/creation op.

(cherry picked from commit 7292792857709b4015034e0706db109369dafe02)
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
