### PR TITLE
Forbid requests with empty database to static nodes P.3

### DIFF
--- a/ydb/services/fq/private_grpc.cpp
+++ b/ydb/services/fq/private_grpc.cpp
@@ -28,7 +28,7 @@ void TGRpcFqPrivateTaskService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logge
 #endif
 
 #define SETUP_FQ_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, fq_internal, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, fq_internal, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_FQ_METHOD(PingTask, DoFqPrivatePingTaskRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());
     SETUP_FQ_METHOD(GetTask, DoFqPrivateGetTaskRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::NonModifying());

--- a/ydb/services/fq/ut_integration/fq_ut.cpp
+++ b/ydb/services/fq/ut_integration/fq_ut.cpp
@@ -852,7 +852,11 @@ Y_UNIT_TEST_SUITE(PrivateApi) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driver = TDriver(TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin")
+        );
         ::NFq::TPrivateClient client(driver);
         const TString historyId = "id";
         const TString folderId = "folder_id";
@@ -881,7 +885,11 @@ Y_UNIT_TEST_SUITE(PrivateApi) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driver = TDriver(TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin")
+        );
         ::NFq::TPrivateClient client(driver);
         {
             Fq::Private::GetTaskRequest req;
@@ -905,7 +913,11 @@ Y_UNIT_TEST_SUITE(PrivateApi) {
         TKikimrWithGrpcAndRootSchema server({}, {}, {}, true);
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
-        auto driver = TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken("root@builtin"));
+        auto driver = TDriver(TDriverConfig()
+            .SetEndpoint(location)
+            .SetDatabase("/Root")
+            .SetAuthToken("root@builtin")
+        );
         ::NFq::TPrivateClient client(driver);
         const auto instanceId = CreateGuidAsString();
         {

--- a/ydb/services/fq/ydb_over_fq.cpp
+++ b/ydb/services/fq/ydb_over_fq.cpp
@@ -32,7 +32,7 @@ void TGRpcYdbOverFqService::InitService(grpc::ServerCompletionQueue *cq, NYdbGrp
         requestType,                                                \
         YDB_API_DEFAULT_COUNTER_BLOCK(ydb_over_fq, methodName),     \
         auditMode,                                                  \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                   \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                 \
         COMMON,                                                     \
         operationCallClass,                                         \
         GRpcRequestProxyId_,                                        \

--- a/ydb/services/monitoring/grpc_service.cpp
+++ b/ydb/services/monitoring/grpc_service.cpp
@@ -27,7 +27,7 @@ void TGRpcMonitoringService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) 
         requestType,                                                                                     \
         YDB_API_DEFAULT_COUNTER_BLOCK(monitoring, methodName),                                           \
         auditMode,                                                                                       \
-        EEmptyDatabaseMode::EmptyDatabaseAllowed,                                                        \
+        EEmptyDatabaseMode::EmptyDatabaseForbidden,                                                      \
         COMMON,                                                                                          \
         operationCallClass,                                                                              \
         GRpcRequestProxyId_,                                                                             \

--- a/ydb/services/ydb/ydb_dummy.cpp
+++ b/ydb/services/ydb/ydb_dummy.cpp
@@ -177,7 +177,7 @@ void TGRpcYdbDummyService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
                     new TEvBiStreamPingRequest(
                         context,
                         NGRpcService::TRequestAuxSettings{
-                            .EmptyDatabaseMode = EEmptyDatabaseMode::EmptyDatabaseAllowed
+                            .EmptyDatabaseMode = EEmptyDatabaseMode::EmptyDatabaseForbidden
                         }
                     )
                 );

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -298,6 +298,7 @@ Y_UNIT_TEST_SUITE(TGRpcClientLowTest) {
         TString location = TStringBuilder() << "localhost:" << grpc;
         auto clientConfig = NGRpcProxy::TGRpcClientConfig(location);
         NYdbGrpc::TCallMeta meta;
+        meta.Aux.push_back({YDB_DATABASE_HEADER, "/Root"});
         meta.Aux.push_back({YDB_AUTH_TICKET_HEADER, "root@builtin"});
         {
             using TRequest = Draft::Dummy::PingRequest;


### PR DESCRIPTION
Requests with empty database name were forbidden for next grpc services:

- FqPrivateTaskService
- TableOverFqService
- SchemeOverFqService
- MonitoringService
