### PR TITLE
Switch on EnableSkipMessagesWithObsoleteTimestamp feature flag 

### DIFF
--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2167,6 +2167,7 @@ Y_UNIT_TEST(TestMaxTimeLagRewind) {
             CmdWrite(0, "sourceid0", data, tc, false, {}, i == 0);
             tc.Runtime->UpdateCurrentTime(tc.Runtime->GetCurrentTime() + TDuration::Minutes(1));
         }
+        tc.Runtime->UpdateCurrentTime(tc.Runtime->GetCurrentTime() + TDuration::Seconds(5));
         const auto ts = tc.Runtime->GetCurrentTime();
 
         CmdRead(0, 0, 1, Max<i32>(), 1, false, tc, {0});
@@ -2178,8 +2179,8 @@ Y_UNIT_TEST(TestMaxTimeLagRewind) {
                 (ts - TDuration::Minutes(3)).MilliSeconds());
         CmdRead(0, 22, 1, Max<i32>(), 1, false, tc, {22}, 0,
                 (ts - TDuration::Minutes(3)).MilliSeconds());
-        CmdRead(0, 4, 1, Max<i32>(), 1, false, tc, {34}, 0,
-                (ts - TDuration::Seconds(1)).MilliSeconds());
+        CmdRead(0, 4, 1, Max<i32>(), 0, false, tc, {34}, 0, (ts - TDuration::Seconds(1)).MilliSeconds());
+        CmdRead(0, 4, 1, Max<i32>(), 1, false, tc, {28}, 0, (ts - TDuration::Seconds(80)).MilliSeconds());
 
         PQTabletPrepare({.readFromTimestampsMs=(ts - TDuration::Seconds(1)).MilliSeconds()},
                         {{"aaa", true}}, tc);

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -229,7 +229,7 @@ message TFeatureFlags {
     optional bool EnableSetColumnConstraint = 202 [default = false];
     optional bool EnableSchemaSecrets = 203 [default = true];
     optional bool EnableTableCacheModes = 204 [default = true];
-    optional bool EnableSkipMessagesWithObsoleteTimestamp = 205 [default = false];
+    optional bool EnableSkipMessagesWithObsoleteTimestamp = 205 [default = true];
     optional bool EnableStreamingQueries = 206 [default = true];
     optional bool EnableTinyDisks = 207 [default = false];
     optional bool EnableMetricsLevel = 208 [default = true];


### PR DESCRIPTION
LOGBROKER-9908
YDBOPS-14549

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
