### PR TITLE
wm: ignore unavailability event from scheme

### DIFF
--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -248,6 +248,7 @@ public:
         hFunc(TEvPrivate::TEvStopPoolHandlerResponse, Handle);
         hFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
         IgnoreFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated);
+        IgnoreFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable);
     )
 
 private:


### PR DESCRIPTION
### Changelog entry

- Ignore TEvWatchNotifyUnavailable from the SchemeCache by WorkloadManager

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Ignore TEvWatchNotifyUnavailable from the SchemeCache as WM does not require any actions for this event.

fixes: [37949](https://github.com/ydb-platform/ydb/issues/37949)