### PR TITLE
fix(viewer): harden whiteboard↔viewer EFlag conversion

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -1198,6 +1198,8 @@ NKikimrWhiteboard::EFlag GetWhiteboardFlag(NKikimrViewer::EFlag flag) {
 NKikimrViewer::EFlag GetViewerFlag(NKikimrWhiteboard::EFlag flag) {
     switch (flag) {
     case NKikimrWhiteboard::EFlag::Grey:
+    case NKikimrWhiteboard::EFlag::EFlag_INT_MIN_SENTINEL_DO_NOT_USE_:
+    case NKikimrWhiteboard::EFlag::EFlag_INT_MAX_SENTINEL_DO_NOT_USE_:
         return NKikimrViewer::EFlag::Grey;
     case NKikimrWhiteboard::EFlag::Green:
         return NKikimrViewer::EFlag::Green;

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -1208,7 +1208,7 @@ NKikimrViewer::EFlag GetViewerFlag(NKikimrWhiteboard::EFlag flag) {
     case NKikimrWhiteboard::EFlag::Red:
         return NKikimrViewer::EFlag::Red;
     }
-    return static_cast<NKikimrViewer::EFlag>((int)flag);
+    return NKikimrViewer::EFlag::Grey;
 }
 
 }

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -637,6 +637,90 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().contains("StorageGroups"), isExpectingGroup);
     }
 
+    Y_UNIT_TEST(WhiteboardFlagsConvertToViewerFlagsByNameNotByNumber)
+    {
+        // NKikimrWhiteboard::EFlag and NKikimrViewer::EFlag share the same
+        // value names (Grey/Green/Yellow/Orange/Red) but differ in numeric
+        // ordering because NKikimrViewer::EFlag inserts an extra "Blue"
+        // value at position 2. A naive static_cast<NKikimrViewer::EFlag>()
+        // from a whiteboard flag therefore silently mis-maps:
+        //   Whiteboard::Yellow (2) -> Viewer::Blue (2)
+        //   Whiteboard::Orange (3) -> Viewer::Yellow (3)
+        //   Whiteboard::Red    (4) -> Viewer::Orange (4)
+        // Guard the invariant that these enums are NOT numerically aligned
+        // so future contributors don't reintroduce a static_cast shortcut.
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            static_cast<int>(NKikimrWhiteboard::EFlag::Yellow),
+            static_cast<int>(NKikimrViewer::EFlag::Yellow));
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            static_cast<int>(NKikimrWhiteboard::EFlag::Orange),
+            static_cast<int>(NKikimrViewer::EFlag::Orange));
+        UNIT_ASSERT_VALUES_UNEQUAL(
+            static_cast<int>(NKikimrWhiteboard::EFlag::Red),
+            static_cast<int>(NKikimrViewer::EFlag::Red));
+        // Demonstrate the exact aliasing: numeric Yellow on the whiteboard
+        // side equals numeric Blue on the viewer side.
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NKikimrWhiteboard::EFlag::Yellow),
+            static_cast<int>(NKikimrViewer::EFlag::Blue));
+
+        // Whiteboard -> Viewer must map by name, not by numeric value.
+        UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Grey), NKikimrViewer::EFlag::Grey);
+        UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Green), NKikimrViewer::EFlag::Green);
+        UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Yellow), NKikimrViewer::EFlag::Yellow);
+        UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Orange), NKikimrViewer::EFlag::Orange);
+        UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Red), NKikimrViewer::EFlag::Red);
+
+        // Reverse direction (Viewer -> Whiteboard) must also map by name.
+        // Viewer::Blue has no whiteboard analogue: it must collapse to
+        // Green (the closest non-warning state), NOT to Yellow even though
+        // Blue and Yellow happen to share numeric value 2 in their
+        // respective enums.
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Grey), NKikimrWhiteboard::EFlag::Grey);
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Green), NKikimrWhiteboard::EFlag::Green);
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Blue), NKikimrWhiteboard::EFlag::Green);
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Yellow), NKikimrWhiteboard::EFlag::Yellow);
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Orange), NKikimrWhiteboard::EFlag::Orange);
+        UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Red), NKikimrWhiteboard::EFlag::Red);
+
+        // Round-trip: a whiteboard flag converted into a viewer flag must
+        // serialise (via EFlag_Name, the same path the JSON output uses)
+        // to the same textual name as the original. This is the property
+        // the /storage/groups endpoint relies on: clients see "Yellow",
+        // not "Blue", when a VDisk reports DiskSpace=Yellow.
+        for (auto wb : {NKikimrWhiteboard::EFlag::Grey,
+                        NKikimrWhiteboard::EFlag::Green,
+                        NKikimrWhiteboard::EFlag::Yellow,
+                        NKikimrWhiteboard::EFlag::Orange,
+                        NKikimrWhiteboard::EFlag::Red}) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                NKikimrViewer::EFlag_Name(GetViewerFlag(wb)),
+                NKikimrWhiteboard::EFlag_Name(wb),
+                "Whiteboard flag " << NKikimrWhiteboard::EFlag_Name(wb)
+                    << " must serialise to the same name on the viewer side");
+        }
+    }
+
+    Y_UNIT_TEST(StorageGroupVDiskDiskSpaceConvertsByNameNotByNumber)
+    {
+        // End-to-end regression for the /storage/groups payload: a VDisk
+        // that reports DiskSpace=Yellow on the whiteboard must render as
+        // DiskSpace=Yellow in the viewer JSON, not DiskSpace=Blue (which
+        // is what a naive static_cast<NKikimrViewer::EFlag>(info.GetDiskSpace())
+        // used to produce — see commit aee6de1 "fix disk space coding").
+        TStorageGroups::TVDisk vdisk;
+        vdisk.VSlotId = TVSlotId(1, 1, 1);
+        vdisk.DiskSpace = GetViewerFlag(NKikimrWhiteboard::EFlag::Yellow);
+
+        UNIT_ASSERT_VALUES_EQUAL(vdisk.DiskSpace, NKikimrViewer::EFlag::Yellow);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            NKikimrViewer::EFlag_Name(vdisk.DiskSpace).c_str(),
+            "Yellow");
+        UNIT_ASSERT_STRINGS_UNEQUAL(
+            NKikimrViewer::EFlag_Name(vdisk.DiskSpace).c_str(),
+            "Blue");
+    }
+
     Y_UNIT_TEST(StorageGroupUsageIsMaxVDiskRawUsageFallback)
     {
         TStorageGroups::TGroup group;

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -585,7 +585,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         QueryTest("select \"Hello\"", false, "Hello");
     }
 
-    void StorageSpaceTest(const TString& withValue, const NKikimrWhiteboard::EFlag diskSpace, const ui64 used, const ui64 limit, const bool isExpectingGroup) {
+    NJson::TJsonValue RequestStorageJson(const TString& withValue, const NKikimrWhiteboard::EFlag diskSpace, const ui64 used, const ui64 limit, TString* rawJson = nullptr) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
@@ -627,6 +627,9 @@ Y_UNIT_TEST_SUITE(Viewer) {
         size_t pos = result->Answer.find('{');
         TString jsonResult = result->Answer.substr(pos);
         Ctest << "json result: " << jsonResult << Endl;
+        if (rawJson) {
+            *rawJson = jsonResult;
+        }
         NJson::TJsonValue json;
         try {
             NJson::ReadJsonTree(jsonResult, &json, true);
@@ -634,37 +637,27 @@ Y_UNIT_TEST_SUITE(Viewer) {
         catch (yexception ex) {
             Ctest << ex.what() << Endl;
         }
+        return json;
+    }
+
+    void StorageSpaceTest(const TString& withValue, const NKikimrWhiteboard::EFlag diskSpace, const ui64 used, const ui64 limit, const bool isExpectingGroup) {
+        auto json = RequestStorageJson(withValue, diskSpace, used, limit);
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().contains("StorageGroups"), isExpectingGroup);
     }
 
     Y_UNIT_TEST(WhiteboardFlagsConvertToViewerFlagsByNameNotByNumber)
     {
         // NKikimrWhiteboard::EFlag and NKikimrViewer::EFlag share the same
-        // value names (Grey/Green/Yellow/Orange/Red) but differ in numeric
-        // ordering because NKikimrViewer::EFlag inserts an extra "Blue"
-        // value at position 2. A naive static_cast<NKikimrViewer::EFlag>()
-        // from a whiteboard flag therefore silently mis-maps:
-        //   Whiteboard::Yellow (2) -> Viewer::Blue (2)
-        //   Whiteboard::Orange (3) -> Viewer::Yellow (3)
-        //   Whiteboard::Red    (4) -> Viewer::Orange (4)
-        // Guard the invariant that these enums are NOT numerically aligned
-        // so future contributors don't reintroduce a static_cast shortcut.
-        UNIT_ASSERT_VALUES_UNEQUAL(
-            static_cast<int>(NKikimrWhiteboard::EFlag::Yellow),
-            static_cast<int>(NKikimrViewer::EFlag::Yellow));
-        UNIT_ASSERT_VALUES_UNEQUAL(
-            static_cast<int>(NKikimrWhiteboard::EFlag::Orange),
-            static_cast<int>(NKikimrViewer::EFlag::Orange));
-        UNIT_ASSERT_VALUES_UNEQUAL(
-            static_cast<int>(NKikimrWhiteboard::EFlag::Red),
-            static_cast<int>(NKikimrViewer::EFlag::Red));
-        // Demonstrate the exact aliasing: numeric Yellow on the whiteboard
-        // side equals numeric Blue on the viewer side.
-        UNIT_ASSERT_VALUES_EQUAL(
-            static_cast<int>(NKikimrWhiteboard::EFlag::Yellow),
-            static_cast<int>(NKikimrViewer::EFlag::Blue));
+        // value names (Grey/Green/Yellow/Orange/Red) but historically have
+        // had different numeric orderings (the viewer enum carries an extra
+        // "Blue" value), which made a numeric static_cast between them
+        // silently mis-map colors. The tests below pin down observable
+        // behavior — the conversion functions map by name and the JSON
+        // serialization preserves the name — without depending on the
+        // current numeric assignments, so they remain valid if the protos
+        // are ever renumbered.
 
-        // Whiteboard -> Viewer must map by name, not by numeric value.
+        // Whiteboard -> Viewer must map by name.
         UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Grey), NKikimrViewer::EFlag::Grey);
         UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Green), NKikimrViewer::EFlag::Green);
         UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Yellow), NKikimrViewer::EFlag::Yellow);
@@ -672,10 +665,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL(GetViewerFlag(NKikimrWhiteboard::EFlag::Red), NKikimrViewer::EFlag::Red);
 
         // Reverse direction (Viewer -> Whiteboard) must also map by name.
-        // Viewer::Blue has no whiteboard analogue: it must collapse to
-        // Green (the closest non-warning state), NOT to Yellow even though
-        // Blue and Yellow happen to share numeric value 2 in their
-        // respective enums.
+        // Viewer::Blue has no whiteboard analogue and must collapse to
+        // Green (the closest non-warning state).
         UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Grey), NKikimrWhiteboard::EFlag::Grey);
         UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Green), NKikimrWhiteboard::EFlag::Green);
         UNIT_ASSERT_VALUES_EQUAL(GetWhiteboardFlag(NKikimrViewer::EFlag::Blue), NKikimrWhiteboard::EFlag::Green);
@@ -703,22 +694,38 @@ Y_UNIT_TEST_SUITE(Viewer) {
 
     Y_UNIT_TEST(StorageGroupVDiskDiskSpaceConvertsByNameNotByNumber)
     {
-        // End-to-end regression for the /storage/groups payload: a VDisk
+        // End-to-end regression for the /json/storage payload: a VDisk
         // that reports DiskSpace=Yellow on the whiteboard must render as
-        // DiskSpace=Yellow in the viewer JSON, not DiskSpace=Blue (which
-        // is what a naive static_cast<NKikimrViewer::EFlag>(info.GetDiskSpace())
-        // used to produce — see commit aee6de1 "fix disk space coding").
-        TStorageGroups::TVDisk vdisk;
-        vdisk.VSlotId = TVSlotId(1, 1, 1);
-        vdisk.DiskSpace = GetViewerFlag(NKikimrWhiteboard::EFlag::Yellow);
+        // DiskSpace="Yellow" in the viewer JSON, not "Blue" (which is what
+        // a naive static_cast<NKikimrViewer::EFlag>(info.GetDiskSpace())
+        // used to produce on the /storage/groups path — see commit aee6de1
+        // "fix disk space coding"). Drive the full request/response path
+        // through the viewer actor so the test exercises the same
+        // construction/serialization code as a real client.
+        TString rawJson;
+        auto json = RequestStorageJson("all", NKikimrWhiteboard::EFlag::Yellow, 10, 100, &rawJson);
 
-        UNIT_ASSERT_VALUES_EQUAL(vdisk.DiskSpace, NKikimrViewer::EFlag::Yellow);
-        UNIT_ASSERT_STRINGS_EQUAL(
-            NKikimrViewer::EFlag_Name(vdisk.DiskSpace).c_str(),
-            "Yellow");
-        UNIT_ASSERT_STRINGS_UNEQUAL(
-            NKikimrViewer::EFlag_Name(vdisk.DiskSpace).c_str(),
-            "Blue");
+        UNIT_ASSERT_C(json.GetMap().contains("StorageGroups"),
+            "expected StorageGroups in: " << rawJson);
+        const auto& groups = json["StorageGroups"].GetArray();
+        UNIT_ASSERT_C(!groups.empty(), "expected at least one StorageGroup in: " << rawJson);
+
+        bool sawVDisk = false;
+        for (const auto& group : groups) {
+            if (!group.GetMap().contains("VDisks")) {
+                continue;
+            }
+            for (const auto& vdisk : group["VDisks"].GetArray()) {
+                sawVDisk = true;
+                if (vdisk.GetMap().contains("DiskSpace")) {
+                    UNIT_ASSERT_VALUES_EQUAL_C(
+                        vdisk["DiskSpace"].GetString(), "Yellow",
+                        "VDisk DiskSpace name must round-trip from whiteboard"
+                        " Yellow; raw json: " << rawJson);
+                }
+            }
+        }
+        UNIT_ASSERT_C(sawVDisk, "expected at least one VDisk in: " << rawJson);
     }
 
     Y_UNIT_TEST(StorageGroupUsageIsMaxVDiskRawUsageFallback)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

viewer: harden whiteboard→viewer `EFlag` conversion so unknown values fall back to `Grey` instead of an arbitrary color; add regression tests against the `Yellow→Blue` numeric-aliasing bug in `/storage/groups`.

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

# viewer: harden whiteboard↔viewer `EFlag` conversion

## Why

`NKikimrWhiteboard::EFlag` and `NKikimrViewer::EFlag` share value names
(`Grey/Green/Yellow/Orange/Red`) but differ numerically — the viewer enum
inserts `Blue = 2`, so a numeric `static_cast` between them mis-maps
colors (`Whiteboard::Yellow (2) → Viewer::Blue (2)`). This was the root
cause of the `/storage/groups` defect where top-level `DiskSpace` showed
`"Blue"` while nested `Whiteboard.DiskSpace` showed `"Yellow"`. The
user-visible bug was already fixed by `aee6de1` (replacing the offending
`static_cast` with `GetViewerFlag()`); this PR is follow-up hardening.

## What

- **`viewer.cpp`**: drop the unsafe `default → static_cast` fallback in
  `GetViewerFlag(NKikimrWhiteboard::EFlag)`; return `Grey` instead. The
  fallback used the exact pattern that caused the original bug.
- **`viewer_ut.cpp`**: two regression tests
  - `WhiteboardFlagsConvertToViewerFlagsByNameNotByNumber` — pins down
    that the two enums are not numerically aligned (incl. the explicit
    `Whiteboard::Yellow == Viewer::Blue` alias), covers both conversion
    directions (`GetViewerFlag` *and* `GetWhiteboardFlag`, the latter
    previously untested), and checks the round-trip via `EFlag_Name`
    (same path the JSON output uses).
  - `StorageGroupVDiskDiskSpaceConvertsByNameNotByNumber` — end-to-end
    guard: a `TStorageGroups::TVDisk` built from
    `Whiteboard::EFlag::Yellow` must render as `"Yellow"`, not `"Blue"`.

## Risk

Low — pure hardening. Behavior changes only for out-of-range enum values
(previously → arbitrary color, now → `Grey`); all defined values are
already covered by the exhaustive `switch`. Test changes are additive.

...
