### PR TITLE
cli: add support for resource pool

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,6 @@
-* Added CPU Time satistics to becnhmarks run commands.
+* Added CPU Time statistics to benchmarks run commands.
+* `ydb sql`: add `--resource-pool` option
+* `ydb` interactive mode add `SET resource_pool` command
 
 ## 2.31.0 ##
 

--- a/ydb/apps/ydb/ut/sql_resource_pool.cpp
+++ b/ydb/apps/ydb/ut/sql_resource_pool.cpp
@@ -28,7 +28,12 @@ Y_UNIT_TEST_SUITE(SqlResourcePool) {
     }
 
     Y_UNIT_TEST(ShouldFailWithoutValue) {
-        // --resource-pool without a value should fail with a CLI parse error.
-        RunYdb({"sql", "--resource-pool", "-s", "SELECT 1"}, {}, true, true, {}, 1);
+        // --resource-pool at the end without a value triggers "must have arg" error.
+        try {
+            RunYdb({"sql", "-s", "SELECT 1", "--resource-pool"}, {});
+            UNIT_FAIL("Expected RunYdb to throw when --resource-pool has no value");
+        } catch (const yexception& e) {
+            UNIT_ASSERT_STRING_CONTAINS(e.what(), "option --resource-pool must have arg");
+        }
     }
 }

--- a/ydb/apps/ydb/ut/sql_resource_pool.cpp
+++ b/ydb/apps/ydb/ut/sql_resource_pool.cpp
@@ -1,0 +1,34 @@
+#include "run_ydb.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/string/strip.h>
+
+Y_UNIT_TEST_SUITE(SqlResourcePool) {
+    Y_UNIT_TEST(ShouldWorkOnDefaultPool) {
+        // The "default" resource pool always exists when workload manager is enabled.
+        TString output = RunYdb({"sql", "--resource-pool", "default", "-s", "SELECT 42 AS value"}, {});
+        UNIT_ASSERT_STRING_CONTAINS(output, "42");
+    }
+
+    Y_UNIT_TEST(ShouldFailOnInvalidPool) {
+        // A non-existent pool must cause the query to fail.
+        // RunYdb with default expectedExitCode=0 throws yexception whose message
+        // includes stderr, so we can check the error text.
+        try {
+            RunYdb(
+                {"sql", "--resource-pool", "nonexistent_pool_12345", "-s", "SELECT 42 AS value"},
+                {}
+            );
+            UNIT_FAIL("Expected RunYdb to throw for non-existent resource pool");
+        } catch (const yexception& e) {
+            UNIT_ASSERT_STRING_CONTAINS(e.what(), "exitcode: 1");
+            UNIT_ASSERT_STRING_CONTAINS(e.what(), "Resource pool nonexistent_pool_12345 not found");
+        }
+    }
+
+    Y_UNIT_TEST(ShouldFailWithoutValue) {
+        // --resource-pool without a value should fail with a CLI parse error.
+        RunYdb({"sql", "--resource-pool", "-s", "SELECT 1"}, {}, true, true, {}, 1);
+    }
+}

--- a/ydb/apps/ydb/ut/ya.make
+++ b/ydb/apps/ydb/ut/ya.make
@@ -22,6 +22,7 @@ SRCS(
     mock_env.cpp
     parse_command_line.cpp
     run_ydb.cpp
+    sql_resource_pool.cpp
     supported_codecs.cpp
     supported_codecs_fixture.cpp
     workload-topic.cpp

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -141,6 +141,9 @@ public:
         NQuery::TExecuteQuerySettings settings;
         settings.StatsMode(CollectStatsMode);
         settings.ConcurrentResultSets(false);
+        if (!ResourcePool.empty()) {
+            settings.ResourcePool(ResourcePool);
+        }
 
         try {
             TExecuteGenericQuery executeRunner(SqlLazyDriver->Get());
@@ -195,6 +198,11 @@ private:
         })));
 
         elements.emplace_back(CreateListItem(hbox({
+            keyword("SET resource_pool = "), CreateEntityName("POOL_NAME"),
+            text(": set resource pool for workload manager (empty string to reset).")
+        })));
+
+        elements.emplace_back(CreateListItem(hbox({
             keyword("EXPLAIN"), text(" ["), keyword("AST"), text("] "), CreateEntityName("SQL_QUERY"),
             text(": execute query in explain mode and optionally print AST.")
         })));
@@ -236,6 +244,8 @@ private:
             Cerr << Colors.Red() << "\nMissing variable value for \"SET\" special command." << Colors.OldColor() << Endl;
         } else if (to_lower(TString(tokens[1].data)) == "stats") {
             TrySetCollectStatsMode(tokens);
+        } else if (to_lower(TString(tokens[1].data)) == "resource_pool") {
+            TrySetResourcePool(tokens);
         } else {
             Cerr << Colors.Red() << "\nUnknown variable name \"" << tokens[1].data << "\" for \"SET\" special command." << Colors.OldColor() << Endl;
         }
@@ -259,10 +269,24 @@ private:
         CollectStatsMode = *statsMode;
     }
 
+    void TrySetResourcePool(const std::vector<TLexer::TToken>& tokens) {
+        size_t tokensSize = tokens.size();
+        Y_VALIDATE(tokensSize >= 4, "Not enough tokens for \"SET resource_pool\" special command.");
+
+        if (tokensSize > 4) {
+            Cerr << Colors.Red() << "\nVariable value for \"SET resource_pool\" special command should contain exactly one token." << Colors.OldColor() << Endl;
+            return;
+        }
+
+        ResourcePool = std::string(tokens[3].data);
+        Cout << "Resource pool set to \"" << ResourcePool << "\"." << Endl;
+    }
+
 private:
     TQueryPlanPrinter QueryPlanPrinter;
     TLazyDriver::TPtr SqlLazyDriver;
     NQuery::EStatsMode CollectStatsMode = NQuery::EStatsMode::None;
+    std::string ResourcePool;
     bool EnableAiInteractive;
 };
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -53,9 +53,16 @@ void TCommandSql::Config(TConfig& config) {
         .RequiredArgument("[String]").Hidden().DefaultValue("none").StoreResult(&Progress);
     config.Opts->AddLongOption("diagnostics-file", "Path to file where the diagnostics will be saved.")
         .RequiredArgument("[String]").StoreResult(&ExecSettings.DiagnosticsFile);
-    config.Opts->AddLongOption("resource-pool", "Explicit resource pool for workload manager")
-        .RequiredArgument("[String]")
-        .StoreResult(&ResourcePool);
+    if (config.HelpCommandVerbosityLevel >= 2) {
+        config.Opts->AddLongOption("resource-pool", "Explicit resource pool for workload manager")
+            .RequiredArgument("[String]")
+            .StoreResult(&ResourcePool);
+    } else {
+        config.Opts->AddLongOption("resource-pool")
+            .RequiredArgument("[String]")
+            .Hidden()
+            .StoreResult(&ResourcePool);
+    }
     config.Opts->AddLongOption("syntax", "Query syntax [yql, pg]")
         .RequiredArgument("[String]")
         .Hidden()

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -53,6 +53,9 @@ void TCommandSql::Config(TConfig& config) {
         .RequiredArgument("[String]").Hidden().DefaultValue("none").StoreResult(&Progress);
     config.Opts->AddLongOption("diagnostics-file", "Path to file where the diagnostics will be saved.")
         .RequiredArgument("[String]").StoreResult(&ExecSettings.DiagnosticsFile);
+    config.Opts->AddLongOption("resource-pool", "Explicit resource pool for workload manager")
+        .RequiredArgument("[String]")
+        .StoreResult(&ResourcePool);
     config.Opts->AddLongOption("syntax", "Query syntax [yql, pg]")
         .RequiredArgument("[String]")
         .Hidden()
@@ -169,6 +172,10 @@ int TCommandSql::RunCommand(TConfig& config) {
     }
 
     ExecSettings.Settings.Syntax(SyntaxType);
+
+    if (!ResourcePool.empty()) {
+        ExecSettings.Settings.ResourcePool(std::string(ResourcePool));
+    }
 
     if (!Parameters.empty() || InputParamStream) {
         // Execute query with parameters

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.h
@@ -26,6 +26,7 @@ private:
     TString Query;
     TString QueryFile;
     TString Progress;
+    TString ResourcePool;
     TExecuteGenericQuery::TSettings ExecSettings;
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- `ydb sql`:  add `--resource-pool` option
- `ydb` interactive mode add `SET resource_pool` command

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

New parameter allows to route the query to the specified resource pool. Example:

```bash
ydb sql --resource-pool my_pool -s "SELECT 1"
```
While running in interactive mode with 'SET' command user can set a resource pool that will be used to run the next queries.

```
SET resource_pool = my_pool
SELECT 1
```