### PR TITLE
26-1-1-13-hotfix: Fix data corruption during export/import

### DIFF
--- a/ydb/core/tx/datashard/export_s3_buffer.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer.cpp
@@ -23,6 +23,7 @@
 
 #include <contrib/libs/zstd/include/zstd.h>
 
+#include <functional>
 
 namespace NKikimr::NDataShard {
 
@@ -75,6 +76,7 @@ private:
 };
 
 class TS3Buffer: public NExportScan::IBuffer {
+    using TChecksumCreator = std::function<NBackup::IChecksum*()>;
     using TTagToColumn = IExport::TTableColumns;
     using TTagToIndex = THashMap<ui32, ui32>; // index in IScan::TRow
 
@@ -95,7 +97,7 @@ private:
     bool Collect(const NTable::IScan::TRow& row, IOutputStream& out);
     virtual TMaybe<TBuffer> Flush(bool last);
 
-    static NBackup::IChecksum* CreateChecksum(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings);
+    static TChecksumCreator GenChecksumCreator(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings);
     static TZStdCompressionProcessor* CreateCompression(const TMaybe<TS3ExportBufferSettings::TCompressionSettings>& settings);
 
 private:
@@ -111,6 +113,7 @@ protected:
     ui64 BytesRead = 0;
     TBuffer Buffer;
 
+    TChecksumCreator ChecksumCreator;
     NBackup::IChecksum::TPtr Checksum;
     TZStdCompressionProcessor::TPtr Compression;
     TMaybe<NBackup::TEncryptedFileSerializer> Encryption;
@@ -123,7 +126,8 @@ TS3Buffer::TS3Buffer(TS3ExportBufferSettings&& settings)
     , RowsLimit(settings.MaxRows)
     , MinBytes(settings.MinBytes)
     , MaxBytes(settings.MaxBytes)
-    , Checksum(CreateChecksum(settings.ChecksumSettings))
+    , ChecksumCreator(GenChecksumCreator(settings.ChecksumSettings))
+    , Checksum(ChecksumCreator())
     , Compression(CreateCompression(settings.CompressionSettings))
 {
     if (settings.EncryptionSettings) {
@@ -135,14 +139,16 @@ TS3Buffer::TS3Buffer(TS3ExportBufferSettings&& settings)
     }
 }
 
-NBackup::IChecksum* TS3Buffer::CreateChecksum(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings) {
-    if (settings) {
-        switch (settings->ChecksumType) {
-        case TS3ExportBufferSettings::TChecksumSettings::EChecksumType::Sha256:
-            return NBackup::CreateChecksum();
+std::function<NBackup::IChecksum*()> TS3Buffer::GenChecksumCreator(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings) {
+    return [settings]() -> NBackup::IChecksum* {
+        if (settings) {
+            switch (settings->ChecksumType) {
+            case TS3ExportBufferSettings::TChecksumSettings::EChecksumType::Sha256:
+                return NBackup::CreateChecksum();
+            }
         }
-    }
-    return nullptr;
+        return nullptr;
+    };
 }
 
 TZStdCompressionProcessor* TS3Buffer::CreateCompression(const TMaybe<TS3ExportBufferSettings::TCompressionSettings>& settings) {
@@ -329,6 +335,10 @@ IEventBase* TS3Buffer::PrepareEvent(bool last, NExportScan::IBuffer::TStats& sta
 void TS3Buffer::Clear() {
     Rows = 0;
     BytesRead = 0;
+    Buffer = TBuffer();
+    if (Checksum) {
+        Checksum.reset(ChecksumCreator());
+    }
     if (Compression) {
         Compression->Clear();
     }
@@ -407,8 +417,10 @@ TMaybe<TBuffer> TZStdCompressionProcessor::Flush() {
         } while (res != DONE);
     }
 
+    auto buffer = std::exchange(Buffer, TBuffer());
+
     Reset();
-    return std::exchange(Buffer, TBuffer());
+    return buffer;
 }
 
 TZStdCompressionProcessor::ECompressionResult TZStdCompressionProcessor::Compress(ZSTD_inBuffer* input, ZSTD_EndDirective endOp) {
@@ -433,6 +445,7 @@ void TZStdCompressionProcessor::Reset() {
     ZSTD_CCtx_reset(Context.Get(), ZSTD_reset_session_only);
     ZSTD_CCtx_refCDict(Context.Get(), NULL);
     ZSTD_CCtx_setParameter(Context.Get(), ZSTD_c_compressionLevel, CompressionLevel);
+    Buffer = TBuffer();
 }
 
 } // anonymous

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -319,6 +319,87 @@ namespace {
             return {};
         }
 
+        ui64 ExportWithRetryInjection(ui64 txId, const TString& compression = "", ui64 minWriteBatchSize = 1) {
+            Runtime().SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_DEBUG);
+
+            THolder<IEventHandle> injectResult;
+            auto prevObserver = Runtime().SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvDataShard::EvProposeTransaction: {
+                        auto& record = ev->Get<TEvDataShard::TEvProposeTransaction>()->Record;
+                        if (record.GetTxKind() != NKikimrTxDataShard::ETransactionKind::TX_KIND_SCHEME) {
+                            return TTestActorRuntime::EEventAction::PROCESS;
+                        }
+
+                        NKikimrTxDataShard::TFlatSchemeTransaction schemeTx;
+                        UNIT_ASSERT(schemeTx.ParseFromString(record.GetTxBody()));
+
+                        if (schemeTx.HasBackup()) {
+                            schemeTx.MutableBackup()->MutableScanSettings()->SetRowsBatchSize(1);
+                            schemeTx.MutableBackup()->MutableS3Settings()->MutableLimits()->SetMinWriteBatchSize(minWriteBatchSize);
+                            record.SetTxBody(schemeTx.SerializeAsString());
+                        }
+
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    }
+
+                    case NWrappers::NExternalStorage::EvUploadPartResponse: {
+                        if (injectResult) {
+                            return TTestActorRuntime::EEventAction::PROCESS;
+                        }
+
+                        auto response = MakeHolder<NWrappers::NExternalStorage::TEvUploadPartResponse>(
+                            std::nullopt,
+                            Aws::Utils::Outcome<Aws::S3::Model::UploadPartResult, Aws::S3::S3Error>(
+                                Aws::Client::AWSError<Aws::S3::S3Errors>(Aws::S3::S3Errors::SLOW_DOWN, true)
+                            )
+                        );
+                        injectResult = MakeHolder<IEventHandle>(ev->Recipient, ev->Sender, response.Release(), ev->Flags, ev->Cookie);
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+
+                    default: {
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    }
+                }
+            });
+
+            TString compressionLine;
+            if (compression) {
+                compressionLine = Sprintf(R"(compression: "%s")", compression.c_str());
+            }
+
+            const auto exportId = ++txId;
+            TestExport(Runtime(), exportId, "/MyRoot", Sprintf(R"(
+                ExportToS3Settings {
+                  endpoint: "localhost:%d"
+                  scheme: HTTP
+                  number_of_retries: 10
+                  items {
+                    source_path: "/MyRoot/Table"
+                    destination_prefix: ""
+                  }
+                  %s
+                }
+            )", S3Port(), compressionLine.c_str()));
+
+            if (!injectResult) {
+                TDispatchOptions opts;
+                opts.FinalEvents.emplace_back([&injectResult](IEventHandle&) -> bool {
+                    return bool(injectResult);
+                });
+                Runtime().DispatchEvents(opts);
+            }
+
+            Runtime().SetObserverFunc(prevObserver);
+            Runtime().Send(injectResult.Release(), 0, true);
+
+            Env().TestWaitNotification(Runtime(), exportId);
+            TestGetExport(Runtime(), exportId, "/MyRoot");
+
+            return txId;
+        }
+
         void TearDown(NUnitTest::TTestContext&) override {
             if (S3ServerMock) {
                 S3ServerMock = Nothing();
@@ -4218,4 +4299,75 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
         TestIcb();
     }
 
+    Y_UNIT_TEST(ShouldNotCorruptBufferOnRetry) {
+        EnvOptions().EnableChecksumsExport(true);
+        Env();
+        ui64 txId = 100;
+
+        TestCreateTable(Runtime(), ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        Env().TestWaitNotification(Runtime(), txId);
+
+        UpdateRow(Runtime(), "Table", 1, "valueA");
+        UpdateRow(Runtime(), "Table", 2, "valueB");
+
+        txId = ExportWithRetryInjection(txId);
+
+        const auto* data = S3Mock().GetData().FindPtr("/data_00.csv");
+        UNIT_ASSERT(data);
+
+        const TString expected = "1,\"valueA\"\n2,\"valueB\"\n";
+        UNIT_ASSERT_VALUES_EQUAL_C(*data, expected, "Buffer corruption detected");
+    }
+
+    Y_UNIT_TEST(ShouldNotCorruptCompressedBufferOnRetry) {
+        EnvOptions().EnableChecksumsExport(true);
+        Env();
+        ui64 txId = 100;
+
+        TestCreateTable(Runtime(), ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        Env().TestWaitNotification(Runtime(), txId);
+
+        auto generateValue = [](size_t size, ui32 seed) {
+            TString result;
+            result.reserve(size);
+            for (size_t i = 0; i < size; ++i) {
+                seed = seed * 1103515245 + 12345;
+                result.push_back('a' + (seed >> 16) % 26);
+            }
+            return result;
+        };
+        const TString value1 = generateValue(256'000, 1);
+        const TString value2 = generateValue(256'000, 2);
+        WriteRow(Runtime(), ++txId, "/MyRoot/Table", 0, 1, value1);
+        Env().TestWaitNotification(Runtime(), txId);
+        WriteRow(Runtime(), ++txId, "/MyRoot/Table", 0, 2, value2);
+        Env().TestWaitNotification(Runtime(), txId);
+
+        txId = ExportWithRetryInjection(txId, "zstd");
+
+        const auto importId = ++txId;
+        TestImport(Runtime(), importId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Restored"
+              }
+            }
+        )", S3Port()));
+        Env().TestWaitNotification(Runtime(), importId);
+
+        TestGetImport(Runtime(), importId, "/MyRoot", Ydb::StatusIds::SUCCESS);
+    }
 }

--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -207,11 +207,11 @@ bool TS3Mock::TRequest::HttpServeList(const TReplyParams& params, TStringBuf buc
 
 bool TS3Mock::TRequest::HttpServeWrite(const TReplyParams& params, TStringBuf path, const TCgiParameters& queryParams) {
     TString content;
-    ui64 length;
+    ui64 length = 0;
 
     if (params.Input.GetContentLength(length)) {
         content = TString::Uninitialized(length);
-        params.Input.Read(content.Detach(), length);
+        params.Input.Load(content.Detach(), length);
     } else {
         content = params.Input.ReadAll();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix `Data corruption detected` error during import from backups with compression

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Исправлена ошибка с невалидным буффером в экспорте, возникающая при ретраях.
- Исправлена ошибка с невалидным буффером в экспорте со сжатием, возникающая при ретраях.
- Исправлена ошибка с невалидными чексуммами в экспорте, возникающая при ретраях (добавлена в этом pr-е так как иначе падал импорт в тесте с компрессией).

Тест `ShouldNotCorruptBufferOnRetry`: без фикса `(*data == expected) failed: ("2,\"valueB\"\n1,\"valueA\"\n2,\"valueB\"\n" != "1,\"valueA\"\n2,\"valueB\"\n") Buffer corruption detected`

Тест `ShouldNotCorruptCompressedBufferOnRetry`: без фикса `error: /data_00.csv.zst: cannot process data: Data corruption detected`

Original PR: https://github.com/ydb-platform/ydb/pull/40167