### PR TITLE
enable SnapshotLocking in tests by default

### DIFF
--- a/ydb/core/kqp/ut/olap/combinatory/executor.cpp
+++ b/ydb/core/kqp/ut/olap/combinatory/executor.cpp
@@ -18,6 +18,7 @@ void TScriptExecutor::Execute(const TKikimrSettings& settings) {
     longTxConfig.SetLocalSnapshotPromotionTimeSeconds(1);
     longTxConfig.SetSnapshotsExchangeIntervalSeconds(1);
     longTxConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
+    kikimr.GetTestServer().GetRuntime()->GetAppData().FeatureFlags.SetEnableSnapshotsLocking(true);
     auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
     csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
     csController->SetOverrideLagForCompactionBeforeTierings(TDuration::Seconds(1));

--- a/ydb/core/kqp/ut/olap/operations/write_ut.cpp
+++ b/ydb/core/kqp/ut/olap/operations/write_ut.cpp
@@ -495,6 +495,7 @@ Y_UNIT_TEST_SUITE(KqpOlapWrite) {
         longTxConfig.SetLocalSnapshotPromotionTimeSeconds(1);
         longTxConfig.SetSnapshotsExchangeIntervalSeconds(1);
         longTxConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
+        kikimr.GetTestServer().GetRuntime()->GetAppData().FeatureFlags.SetEnableSnapshotsLocking(true);
         auto helper = TLocalHelper(kikimr);
         helper.CreateTestOlapTable();
         helper.SetForcedCompaction();

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -74,6 +74,7 @@ public:
         longTxConfig.SetLocalSnapshotPromotionTimeSeconds(1);
         longTxConfig.SetSnapshotsExchangeIntervalSeconds(1);
         longTxConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
+        TestHelper->GetRuntime().GetAppData().FeatureFlags.SetEnableSnapshotsLocking(true);
         OlapHelper.emplace(TestHelper->GetKikimr());
         TestHelper->GetRuntime().SetLogPriority(NKikimrServices::TX_TIERING, NActors::NLog::PRI_DEBUG);
         TestHelper->GetRuntime().SetLogPriority(NKikimrServices::TX_COLUMNSHARD_ACTUALIZATION, NActors::NLog::PRI_DEBUG);

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
@@ -64,6 +64,7 @@ void TTester::Setup(TTestActorRuntime& runtime) {
         holder->Set(std::move(*builder).Build());
         for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
             auto& appData = runtime.GetAppData(nodeIndex);
+            appData.FeatureFlags.SetEnableSnapshotsLocking(true);
             appData.SnapshotRegistryHolder = holder;
             appData.LongTxServiceConfig.SetLocalSnapshotPromotionTimeSeconds(1);
             appData.LongTxServiceConfig.SetSnapshotsExchangeIntervalSeconds(1);

--- a/ydb/core/tx/columnshard/ut_rw/ut_columnshard_read_write.cpp
+++ b/ydb/core/tx/columnshard/ut_rw/ut_columnshard_read_write.cpp
@@ -2764,6 +2764,7 @@ Y_UNIT_TEST_SUITE(TColumnShardTestReadWrite) {
         csDefaultControllerGuard->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
         csDefaultControllerGuard->SetOverrideBlobSplitSettings(NOlap::NSplitter::TSplitSettings());
         TTester::Setup(runtime);
+        runtime.GetAppData(0).FeatureFlags.SetEnableSnapshotsLocking(true);
 
         TActorId sender = runtime.AllocateEdgeActor();
         CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::ColumnShard), &CreateColumnShard);
@@ -2845,6 +2846,7 @@ Y_UNIT_TEST_SUITE(TColumnShardTestReadWrite) {
         csDefaultControllerGuard->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
         csDefaultControllerGuard->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Cleanup);
         TTester::Setup(runtime);
+        runtime.GetAppData(0).FeatureFlags.SetEnableSnapshotsLocking(true);
         // Keep each write in indexed-portions path and prevent merges during setup.
         TControlBoard::SetValue(1024, runtime.GetAppData(0).Icb->ColumnShardControls.MinBytesToIndex);
         runtime.GetAppData(0).FeatureFlags.SetEnableWritePortionsOnInsert(true);

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -1044,6 +1044,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
             auto builder = CreateImmutableSnapshotRegistryBuilder();
             auto holder = CreateImmutableSnapshotRegistryHolder();
             holder->Set(std::move(*builder).Build());
+            appData.FeatureFlags.SetEnableSnapshotsLocking(true);
             appData.SnapshotRegistryHolder = holder;
             appData.LongTxServiceConfig.SetLocalSnapshotPromotionTimeSeconds(1);
             appData.LongTxServiceConfig.SetSnapshotsExchangeIntervalSeconds(1);

--- a/ydb/tests/functional/statistics/test_restarts.py
+++ b/ydb/tests/functional/statistics/test_restarts.py
@@ -36,6 +36,7 @@ LONG_TX_SERVICE_CONFIG = {
 @pytest.fixture(scope="module")
 def ydb_configurator(ydb_cluster_configuration):
     config_generator = KikimrConfigGenerator(**ydb_cluster_configuration)
+    config_generator.yaml_config["feature_flags"]["enable_snapshots_locking"] = True
     # Explicitly configure snapshot registry timings for CS min-read-snapshot
     # calculation. Total service delay is up to 1+1+1+10 = 13s.
     config_generator.yaml_config["long_tx_service_config"] = LONG_TX_SERVICE_CONFIG

--- a/ydb/tests/olap/ttl_tiering/base.py
+++ b/ydb/tests/olap/ttl_tiering/base.py
@@ -43,6 +43,7 @@ class TllTieringTestBase(object):
                     "enable_write_portions_on_insert": True,
                     "enable_tiering_in_column_shard": True,
                     "enable_columnshard_bool": True,
+                    "enable_snapshots_locking": True,
                 },
                 column_shard_config={
                     "lag_for_compaction_before_tierings_ms": 0,


### PR DESCRIPTION
Enable SnapshotLocking in tests by default. We need that because SnapshotLocking is enabled by default in main and disabled by default in the stable branches. So the only way to make the tests work everywhere is to enable it explicitly.