### PR TITLE
sdk & pq provider: set and use TReadSessionSettings TraceId

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/topic_session.cpp
@@ -517,6 +517,7 @@ NYdb::NTopic::TReadSessionSettings TTopicSession::GetReadSessionSettings(const T
         << ", BufferSize " << BufferSize << ", GetConsumerMode " << Config.GetConsumerMode());
 
     auto settings = NYdb::NTopic::TReadSessionSettings()
+        .TraceId(LogPrefix)
         .AppendTopics(topicReadSettings)
         .MaxMemoryUsageBytes(BufferSize)
         .ReadFromTimestamp(minTime)

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -826,6 +826,7 @@ private:
 
         auto settings = NYdb::NTopic::TReadSessionSettings();
         settings
+            .TraceId(LogPrefix)
             .AppendTopics(topicReadSettings)
             .MaxMemoryUsageBytes(BufferSize)
             .ReadFromTimestamp(StartingMessageTimestamp)

--- a/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
@@ -171,7 +171,7 @@ TDirectReadSessionManager::~TDirectReadSessionManager() {
 }
 
 TStringBuilder TDirectReadSessionManager::GetLogPrefix() const {
-    return TStringBuilder() << static_cast<const void*>(this) << " TDirectReadSessionManager ServerSessionId=" << ServerSessionId << " ";
+    return TStringBuilder() << static_cast<const void*>(this) << " TDirectReadSessionManager ServerSessionId=" << ServerSessionId << " TraceId=" << ReadSessionSettings.TraceId_ << " ";
 }
 
 TDirectReadSessionContextPtr TDirectReadSessionManager::CreateDirectReadSession(TNodeId nodeId) {
@@ -830,7 +830,7 @@ void TDirectReadSession::ReadFromProcessorImpl(TDeferredActions<false>& deferred
 }
 
 TStringBuilder TDirectReadSession::GetLogPrefix() const {
-    return TStringBuilder() << static_cast<const void*>(this) << " TDirectReadSession ServerSessionId=" << ServerSessionId << " NodeId=" << NodeId << " ";
+    return TStringBuilder() << static_cast<const void*>(this) << " TDirectReadSession ServerSessionId=" << ServerSessionId << " NodeId=" << NodeId << " TraceId=" << ReadSessionSettings.TraceId_ << " ";
 }
 
 void TDirectReadSession::InitImpl(TDeferredActions<false>& deferred) {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
@@ -1970,7 +1970,7 @@ void TProducer::GetSessionClosedEventAndDie(WrappedWriteSessionPtr wrappedSessio
 }
 
 TStringBuilder TProducer::LogPrefix() {
-    return TStringBuilder() << " Id: " << Id << " Epoch: " << Epoch.load() << " " << "TraceId: " << Settings.TraceId_;
+    return TStringBuilder() << " Id: " << Id << " Epoch: " << Epoch.load() << " TraceId: " << Settings.TraceId_ << " ";
 }
 
 void TProducer::NextEpoch() {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/producer.cpp
@@ -1970,7 +1970,7 @@ void TProducer::GetSessionClosedEventAndDie(WrappedWriteSessionPtr wrappedSessio
 }
 
 TStringBuilder TProducer::LogPrefix() {
-    return TStringBuilder() << " Id: " << Id << " Epoch: " << Epoch.load() << " ";
+    return TStringBuilder() << " Id: " << Id << " Epoch: " << Epoch.load() << " " << "TraceId: " << Settings.TraceId_;
 }
 
 void TProducer::NextEpoch() {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -251,7 +251,7 @@ void TReadSession::ClearAllEvents() {
 }
 
 TStringBuilder TReadSession::GetLogPrefix() const {
-     return TStringBuilder() << GetDatabaseLogPrefix(DbDriverState->Database) << "[" << SessionId << "] ";
+     return TStringBuilder() << GetDatabaseLogPrefix(DbDriverState->Database) << "[" << SessionId << "] [" << Settings.TraceId_ << "]";
 }
 
 void TReadSession::MakeCountersIfNeeded() {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -251,7 +251,7 @@ void TReadSession::ClearAllEvents() {
 }
 
 TStringBuilder TReadSession::GetLogPrefix() const {
-     return TStringBuilder() << GetDatabaseLogPrefix(DbDriverState->Database) << "[" << SessionId << "] [" << Settings.TraceId_ << "]";
+     return TStringBuilder() << GetDatabaseLogPrefix(DbDriverState->Database) << "[" << SessionId << "] [" << Settings.TraceId_ << "] ";
 }
 
 void TReadSession::MakeCountersIfNeeded() {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -265,7 +265,7 @@ TSingleClusterReadSessionImpl<UseMigrationProtocol>::~TSingleClusterReadSessionI
 
 template<bool UseMigrationProtocol>
 TStringBuilder TSingleClusterReadSessionImpl<UseMigrationProtocol>::GetLogPrefix() const {
-    return TStringBuilder() << GetDatabaseLogPrefix(Database) << "[" << SessionId << "] [" << ClusterName << "] [" << Settings.TraceId_ << "]";
+    return TStringBuilder() << GetDatabaseLogPrefix(Database) << "[" << SessionId << "] [" << ClusterName << "] [" << Settings.TraceId_ << "] ";
 }
 
 template<bool UseMigrationProtocol>

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -265,7 +265,7 @@ TSingleClusterReadSessionImpl<UseMigrationProtocol>::~TSingleClusterReadSessionI
 
 template<bool UseMigrationProtocol>
 TStringBuilder TSingleClusterReadSessionImpl<UseMigrationProtocol>::GetLogPrefix() const {
-    return TStringBuilder() << GetDatabaseLogPrefix(Database) << "[" << SessionId << "] [" << ClusterName << "] ";
+    return TStringBuilder() << GetDatabaseLogPrefix(Database) << "[" << SessionId << "] [" << ClusterName << "] [" << Settings.TraceId_ << "]";
 }
 
 template<bool UseMigrationProtocol>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Similar: #14477
Can break some log processing tools, but log format is not part of any specification, should be within expectations.
Optional parts:
I'm not sure if `direct_reader` may be used by pq provider, so it was that just-in-case.
And `producer` change is just for completeness (I'm not aware if anything sets TraceId there).