### PR TITLE
Fix handshake broker over-crediting Capacity on waiter cancel

### DIFF
--- a/ydb/library/actors/interconnect/handshake_broker.h
+++ b/ydb/library/actors/interconnect/handshake_broker.h
@@ -111,14 +111,18 @@ namespace NActors {
 
         void Handle(TEvHandshakeBrokerFree::TPtr& ev) {
             const TActorId sender = ev->Sender;
-            if (!PermittedLeases.erase(sender)) {
+            if (PermittedLeases.erase(sender)) {
+                // An actual slot was freed, hand it to the next waiter (or
+                // credit Capacity back). Only do this when a permitted lease
+                // was released -- a canceled waiter never consumed a slot.
+                PermitNext();
+            } else {
                 // Lease was not permitted yet, remove sender from Waiters queue
                 const auto it = WaiterLookup.find(sender);
                 Y_ABORT_UNLESS(it != WaiterLookup.end());
                 Waiters.erase(it->second);
                 WaiterLookup.erase(it);
             }
-            PermitNext();
         }
 
     public:

--- a/ydb/library/actors/interconnect/ut/handshake_broker_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/handshake_broker_ut.cpp
@@ -1,0 +1,67 @@
+#include <ydb/library/actors/interconnect/handshake_broker.h>
+#include <ydb/library/actors/interconnect/events_local.h>
+#include <ydb/library/actors/testlib/test_runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+
+Y_UNIT_TEST_SUITE(HandshakeBroker) {
+
+    // Regression test for the over-credit bug in THandshakeBroker.
+    //
+    // When a waiter (a Take that was queued because Capacity == 0) is
+    // canceled by sending Free before it ever received Permit, the broker
+    // still calls PermitNext(). With an empty Waiters queue, PermitNext
+    // falls into its `else { Capacity += 1; }` branch and credits a slot
+    // that was never actually consumed — letting a subsequent Take be
+    // granted while all original leases are still outstanding.
+    //
+    // With inflightLimit = 2 the bug allows 3 simultaneous permits.
+    Y_UNIT_TEST(CapacityIsNotOverCreditedOnWaiterCancel) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const ui32 inflightLimit = 2;
+        const TActorId brokerId = runtime.Register(CreateHandshakeBroker(inflightLimit));
+
+        const TActorId a = runtime.AllocateEdgeActor();
+        const TActorId b = runtime.AllocateEdgeActor();
+        const TActorId c = runtime.AllocateEdgeActor();
+        const TActorId d = runtime.AllocateEdgeActor();
+
+        // A and B take both available slots. Capacity becomes 0.
+        runtime.Send(new IEventHandle(brokerId, a, new TEvHandshakeBrokerTake()));
+        runtime.Send(new IEventHandle(brokerId, b, new TEvHandshakeBrokerTake()));
+        UNIT_ASSERT(runtime.GrabEdgeEvent<TEvHandshakeBrokerPermit>(a, TDuration::Seconds(5)));
+        UNIT_ASSERT(runtime.GrabEdgeEvent<TEvHandshakeBrokerPermit>(b, TDuration::Seconds(5)));
+
+        // C asks for a slot — none available, C is queued in Waiters.
+        runtime.Send(new IEventHandle(brokerId, c, new TEvHandshakeBrokerTake()));
+
+        // C is canceled before it ever got a Permit. No slot was actually
+        // consumed by C, so this Free must not change Capacity.
+        runtime.Send(new IEventHandle(brokerId, c, new TEvHandshakeBrokerFree()));
+
+        // D asks for a slot. A and B still hold their leases, so D must
+        // wait — it must NOT receive a Permit.
+        runtime.Send(new IEventHandle(brokerId, d, new TEvHandshakeBrokerTake()));
+
+        bool dGotPermit = false;
+        try {
+            auto permit = runtime.GrabEdgeEvent<TEvHandshakeBrokerPermit>(d, TDuration::Seconds(1));
+            if (permit) {
+                dGotPermit = true;
+            }
+        } catch (const TEmptyEventQueueException&) {
+            // expected: no Permit is on the way to D
+        }
+        UNIT_ASSERT_C(!dGotPermit,
+            "D received a Permit while A and B still hold leases — broker over-credited "
+            "Capacity after a queued waiter was canceled");
+
+        // Sanity check: once A releases, D should then be permitted.
+        runtime.Send(new IEventHandle(brokerId, a, new TEvHandshakeBrokerFree()));
+        UNIT_ASSERT(runtime.GrabEdgeEvent<TEvHandshakeBrokerPermit>(d, TDuration::Seconds(5)));
+    }
+}

--- a/ydb/library/actors/interconnect/ut/ya.make
+++ b/ydb/library/actors/interconnect/ut/ya.make
@@ -12,6 +12,7 @@ SRCS(
     channel_scheduler_ut.cpp
     connection_checker_ut.cpp
     event_holder_pool_ut.cpp
+    handshake_broker_ut.cpp
     interconnect_ut.cpp
     large.cpp
     outgoing_stream_ut.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category 
Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
THandshakeBroker::Handle(TEvHandshakeBrokerFree) unconditionally called
PermitNext(). When the freed actor was a queued waiter that never received
a Permit, no slot was consumed, but PermitNext() still fell into its
`else { Capacity += 1; }` branch and credited a phantom slot. Repeated
waiter cancellations (timeouts, poisons) drifted Capacity upward and
defeated OutgoingHandshakeInflightLimit.

Only call PermitNext() when a permitted lease was actually released.