### PR TITLE
Handle OUT_OF_SPACE during compaction

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/out_of_space.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/out_of_space.cpp
@@ -15,6 +15,7 @@ Y_UNIT_TEST_SUITE(OutOfSpace) {
         env.Sim(TDuration::Seconds(30));
 
         const ui32 groupId = env.GetGroups().front();
+        auto info = env.GetGroupInfo(groupId);
 
         const TActorId edge = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
         size_t size = 65536;
@@ -37,16 +38,29 @@ Y_UNIT_TEST_SUITE(OutOfSpace) {
             size = size * 9 / 8;
             ++index;
         }
-        for (const TLogoBlobID& id : success) {
-            runtime->WrapInActorContext(edge, [&] {
-                SendToBSProxy(edge, groupId, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(), NKikimrBlobStorage::FastRead));
-            });
-            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(edge, false);
-            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
-            UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
-            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Responses[0].Status, NKikimrProto::OK);
-            UNIT_ASSERT_EQUAL(res->Get()->Responses[0].Buffer.ConvertToString(), FastGenDataForLZ4(id.BlobSize()));
-        }
+
+        auto checkReadable = [&] {
+            for (const TLogoBlobID& id : success) {
+                runtime->WrapInActorContext(edge, [&] {
+                    SendToBSProxy(edge, groupId, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(), NKikimrBlobStorage::FastRead));
+                });
+                auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(edge, false);
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
+                UNIT_ASSERT_VALUES_EQUAL(res->Get()->Responses[0].Status, NKikimrProto::OK);
+                UNIT_ASSERT_EQUAL(res->Get()->Responses[0].Buffer.ConvertToString(), FastGenDataForLZ4(id.BlobSize()));
+            }
+        };
+
+        checkReadable();
+
+        const TActorId vdiskActorId = info->GetActorId(0);
+        runtime->Send(new IEventHandle(vdiskActorId, edge, new TEvBlobStorage::TEvVCompact(info->GetVDiskId(0),
+            NKikimrBlobStorage::TEvVCompact::ASYNC)), edge.NodeId());
+        env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVCompactResult>(edge, false);
+        env.Sim(TDuration::MilliSeconds(1));
+
+        checkReadable();
     }
 
 }

--- a/ydb/core/blobstorage/ut_blobstorage/sync.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/sync.cpp
@@ -127,8 +127,8 @@ Y_UNIT_TEST_SUITE(BlobStorageSync) {
          *    distinct TEvSyncLogFreeChunk events for the same chunkIdx.
          */
         TEnvironmentSetup env{{
-            .NodeCount = 1,
-            .Erasure = TBlobStorageGroupType::ErasureNone,
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::ErasureMirror3of4,
             .VDiskConfigPreprocessor = [](TVDiskConfig& config) {
                 config.MaxLogoBlobDataSize = 8_KB;
                 config.MinHugeBlobInBytes = 4_KB;

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
@@ -613,42 +613,47 @@ namespace NKikimr {
             //       of log messages
 
             // handle commit msg differently
-            if (msg->FreshSegment) {
-                TStringStream dbg;
-                dbg << "{commiter# fresh"
-                    << " firstLsn# "<< msg->FreshSegment->GetFirstLsn()
-                    << " lastLsn# " << msg->FreshSegment->GetLastLsn()
-                    << "}";
+            if (msg->FreshCompaction) {
+                if (msg->Aborted) {
 
-                // update compacted lsn
-                const ui64 lastLsnFromFresh = msg->FreshSegment->GetLastLsn();
-                if (lastLsnFromFresh > 0)
-                    RTCtx->LevelIndex->UpdateCompactedLsn(lastLsnFromFresh);
-                // check huge blobs
-                if (Config->CheckHugeBlobs) {
-                    TDiskPartVec checkVec = THullOpUtil::FindRemovedHugeBlobsAfterFreshCompaction(
-                        HullDs->HullCtx->VCtx->VDiskLogPrefix, ctx, msg->FreshSegment, msg->SegVec);
-                    CheckRemovedHugeBlobs(ctx, msg->FreedHugeBlobs, checkVec, false);
-                    LogRemovedHugeBlobs(ctx, msg->FreedHugeBlobs, false);
+                } else {
+                    TStringStream dbg;
+                    dbg << "{commiter# fresh"
+                        << " firstLsn# "<< msg->FreshSegment->GetFirstLsn()
+                        << " lastLsn# " << msg->FreshSegment->GetLastLsn()
+                        << "}";
+
+                    // update compacted lsn
+                    const ui64 lastLsnFromFresh = msg->FreshSegment->GetLastLsn();
+                    if (lastLsnFromFresh > 0)
+                        RTCtx->LevelIndex->UpdateCompactedLsn(lastLsnFromFresh);
+                    // check huge blobs
+                    if (Config->CheckHugeBlobs) {
+                        TDiskPartVec checkVec = THullOpUtil::FindRemovedHugeBlobsAfterFreshCompaction(
+                            HullDs->HullCtx->VCtx->VDiskLogPrefix, ctx, msg->FreshSegment, msg->SegVec);
+                        CheckRemovedHugeBlobs(ctx, msg->FreedHugeBlobs, checkVec, false);
+                        LogRemovedHugeBlobs(ctx, msg->FreedHugeBlobs, false);
+                    }
+                    // remove fresh segment
+                    RTCtx->LevelIndex->FreshCompactionSstCreated(std::move(msg->FreshSegment));
+
+                    // put new sstable into zero level
+                    if (msg->SegVec.Get()) {
+                        for (auto &seg : msg->SegVec->Segments)
+                            RTCtx->LevelIndex->InsertSstAtLevel0(seg, HullDs->HullCtx);
+                    }
+
+                    // run fresh committer
+                    auto committer = std::make_unique<TAsyncFreshCommitter>(HullLogCtx, HullDbCommitterCtx, RTCtx->LevelIndex,
+                            ctx.SelfID, std::move(msg->CommitChunks), std::move(msg->ReservedChunks),
+                            std::move(msg->FreedHugeBlobs), std::move(msg->AllocatedHugeBlobs), dbg.Str(), wId);
+                    auto aid = ctx.RegisterWithSameMailbox(committer.release());
+                    ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
                 }
-                // remove fresh segment
-                RTCtx->LevelIndex->FreshCompactionSstCreated(std::move(msg->FreshSegment));
-
-                // put new sstable into zero level
-                if (msg->SegVec.Get()) {
-                    for (auto &seg : msg->SegVec->Segments)
-                        RTCtx->LevelIndex->InsertSstAtLevel0(seg, HullDs->HullCtx);
-                }
-
-                // run fresh committer
-                auto committer = std::make_unique<TAsyncFreshCommitter>(HullLogCtx, HullDbCommitterCtx, RTCtx->LevelIndex,
-                        ctx.SelfID, std::move(msg->CommitChunks), std::move(msg->ReservedChunks),
-                        std::move(msg->FreedHugeBlobs), std::move(msg->AllocatedHugeBlobs), dbg.Str(), wId);
-                auto aid = ctx.RegisterWithSameMailbox(committer.release());
-                ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
             } else {
                 Y_VERIFY_S(RTCtx->LevelIndex->GetCompState() == TLevelIndexBase::StateCompInProgress,
-                    HullDs->HullCtx->VCtx->VDiskLogPrefix);
+                    HullDs->HullCtx->VCtx->VDiskLogPrefix << "CompState# " <<
+                    TLevelIndexBase::LevelCompStateToStr(RTCtx->LevelIndex->GetCompState()));
 
                 // assign VolatileOrderId for any new SSTables at level 0 to allow merging them to level 0 below
                 if (const auto& cs = CompactionTask->CompactSsts; cs.TargetLevel == 0 && msg->SegVec.Get()) {

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompact.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompact.h
@@ -34,6 +34,7 @@ namespace NKikimr {
         TDiskPartVec AllocatedHugeBlobs;
         // was the compaction process aborted by some reason?
         bool Aborted = false;
+        bool FreshCompaction = false;
 
         THullChange() = default;
     };
@@ -229,6 +230,12 @@ namespace NKikimr {
 
         void HandleYardResponse(NPDisk::TEvChunkReserveResult::TPtr& ev, const TActorContext& ctx) {
             --PendingResponses;
+            if (ev->Get()->Status == NKikimrProto::OUT_OF_SPACE) {
+                IsAborting = true;
+                const bool flag = FinalizeIfAborting(ctx);
+                Y_ABORT_UNLESS(flag);
+                return;
+            }
             CHECK_PDISK_RESPONSE(HullCtx->VCtx, ev, ctx);
             if (FinalizeIfAborting(ctx)) {
                 return;
@@ -277,13 +284,15 @@ namespace NKikimr {
             const auto& reservedChunks = IsAborting ? Worker.GetAllocatedChunks() : Worker.GetReservedChunks();
             msg->ReservedChunks = {reservedChunks.begin(), reservedChunks.end()};
 
-            // huge blobs to free
-            LOG_LOG(ctx, IsAborting ? NLog::PRI_ERROR : NLog::PRI_INFO, NKikimrServices::BS_HULLCOMP,
-                       VDISKP(HullCtx->VCtx->VDiskLogPrefix,
-                            "%s: Compaction job (%" PRIu64 ") finished (freedHugeBlobs): fresh# %s freedHugeBlobs# %" PRIu64,
-                            PDiskSignatureForHullDbKey<TKey>().ToString().data(), CompactionID,
-                            (FreshSegment ? "true" : "false"),
-                            ui64(Worker.GetFreedHugeBlobs().Size())));
+            LOG_LOG_S(ctx, IsAborting ? NLog::PRI_ERROR : NLog::PRI_INFO, NKikimrServices::BS_HULLCOMP,
+                HullCtx->VCtx->VDiskLogPrefix << PDiskSignatureForHullDbKey<TKey>().ToString() << ": Compaction job ("
+                << CompactionID << ") finished: FreshSegment# " << (FreshSegment ? "true" : "false")
+                << " FreedHugeBlobs# " << Worker.GetFreedHugeBlobs().Size()
+                << " AllocatedHugeBlobs# " << Worker.GetAllocatedHugeBlobs().Size()
+                << " CommitChunks# " << FormatList(Worker.GetCommitChunks())
+                << " Stats# " << Worker.Statistics.ToString()
+                << " IsAborting# " << (IsAborting ? "true" : "false"));
+
             msg->FreedHugeBlobs = IsAborting ? TDiskPartVec() : Worker.GetFreedHugeBlobs();
             msg->AllocatedHugeBlobs = IsAborting ? TDiskPartVec() : Worker.GetAllocatedHugeBlobs();
 
@@ -299,15 +308,7 @@ namespace NKikimr {
             msg->SegVec = IsAborting ? nullptr : std::move(Result);
             msg->FreshSegment = IsAborting ? nullptr : FreshSegment;
             msg->Aborted = IsAborting;
-
-            Worker.Statistics.FinishTime = TAppData::TimeProvider->Now();
-            LOG_INFO(ctx, NKikimrServices::BS_HULLCOMP,
-                       VDISKP(HullCtx->VCtx->VDiskLogPrefix,
-                             "%s: Compaction job (%" PRIu64 ") finished: fresh# %s chunks# %" PRIu32 " stat# %s "
-                             "IsAborting# %s",
-                             PDiskSignatureForHullDbKey<TKey>().ToString().data(),
-                             CompactionID, (FreshSegment ? "true" : "false"), ui32(msg->CommitChunks.size()),
-                             Worker.Statistics.ToString().data(), IsAborting ? "true" : "false"));
+            msg->FreshCompaction = static_cast<bool>(FreshSegment);
 
             ctx.Send(LIActor, msg.release());
             TThis::Die(ctx);

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactworker.h
@@ -232,19 +232,15 @@ namespace NKikimr {
             // time stat
             TInstant CreationTime;
             TInstant StartTime;
-            TInstant FinishTime;
 
             TStatistics(THullCtxPtr hullCtx)
                 : HullCtx(hullCtx)
                 , CreationTime(TAppData::TimeProvider->Now())
-                , StartTime()
-                , FinishTime()
             {}
 
             TString ToString() const {
                 TStringStream str;
                 str << "{WaitTime# " << (StartTime - CreationTime).ToString()
-                    << " GetNextItemTime# " << (FinishTime - StartTime).ToString()
                     << " BytesRead# " << BytesRead << " ReadIOPS# " << ReadIOPS
                     << " BytesWritten# " << BytesWritten << " WriteIOPS# " << WriteIOPS
                     << " ItemsWritten# " << ItemsWritten

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -141,11 +141,17 @@ namespace NKikimr {
             // HANDLERS
             ////////////////////////////////////////////////////////////////////////
             void Handle(TEvSyncLogPut::TPtr &ev, const TActorContext &ctx) {
+                if (SlCtx->VCtx->Top->GType.GetErasure() == TBlobStorageGroupType::ErasureNone) {
+                    return;
+                }
                 KeepState.PutMany(ev->Get()->GetRecs().GetData(), ev->Get()->GetRecs().GetSize());
                 PerformActions(ctx);
             }
 
             void Handle(TEvSyncLogPutSst::TPtr& ev, const TActorContext& ctx) {
+                if (SlCtx->VCtx->Top->GType.GetErasure() == TBlobStorageGroupType::ErasureNone) {
+                    return;
+                }
                 KeepState.PutLevelSegment(ev->Get()->LevelSegment.Get());
                 PerformActions(ctx);
             }

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -284,7 +284,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         testConfig.RecoveryLogCutterFirstDuration = TDuration::Hours(1);
         testConfig.RecoveryLogCutterRegularDuration = TDuration::Hours(1);
         testConfig.PDiskPathSuffix = "synclog_real_live_bpd77.dat";
-        auto storage = SetupRealPDiskAndRealVDisk(runtime, TBlobStorageGroupType::ErasureNone, testConfig);
+        auto storage = SetupRealPDiskAndRealVDisk(runtime, TBlobStorageGroupType::ErasureMirror3of4, testConfig);
         const auto& info = storage.Info;
         const TActorId edge = storage.Edge;
         const TActorId putQueue = storage.PutQueue;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Handle OUT\_OF\_SPACE during compaction

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows correct aborting of compaction when space suddenly exhausts.
