### PR TITLE
Fix of a typo (__CNUC__ -> __GNUC__)

### DIFF
--- a/ydb/library/actors/memory_log/memlog.cpp
+++ b/ydb/library/actors/memory_log/memlog.cpp
@@ -85,7 +85,7 @@ unsigned TMemoryLog::GetSelfCpu() noexcept {
     int acpiID = (b >> 24);
     return acpiID;
 
-#elif defined(__CNUC__)
+#elif defined(__GNUC__)
     return sched_getcpu();
 #else
     return 0;


### PR DESCRIPTION

### Changelog category <!-- remove all except one -->

Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
This pull request fixes a typo in a preprocessor directive to ensure the correct macro is used for compiler detection. 
