### PR TITLE
Enabled HideAuthenticationFailureReasons by default

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -305,7 +305,7 @@ message TDomainsConfig {
         optional bool DisableBuiltinSecurity = 19;
         optional bool DisableBuiltinGroups = 20;
         optional bool DisableBuiltinAccess = 21;
-        optional bool HideAuthenticationFailureReasons = 22 [default = false];
+        optional bool HideAuthenticationFailureReasons = 22 [default = true];
     }
 
     repeated TDomain Domain = 1;


### PR DESCRIPTION
Enabled after switching on production clusters