### PR TITLE
Fix local-ydb TLS certificate regeneration in Docker

### DIFF
--- a/ydb/docs/en/core/reference/docker/configuration.md
+++ b/ydb/docs/en/core/reference/docker/configuration.md
@@ -8,6 +8,7 @@
 | -- | -- | -- | -- |
 | [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0` or `1` | `1` | Enable the `grpcs://` protocol (gRPC over TLS) |
 | [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_data` | Data path with TLS certificates for the `grpcs://` connection |
+| [`YDB_GRPC_TLS_USE_EXISTING_CERTS`](https://GitHub.com/ydb-platform/ydb/blob/main/ydb/public/tools/lib/cmds/__init__.py#L262) | `true` or `false` | `false` | Reuse `ca.pem`, `cert.pem`, and `key.pem` from `YDB_GRPC_TLS_DATA_PATH` instead of generating new certificates. All three files are required. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP port of [Embedded UI](../../reference/embedded-ui/index.md) |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC port |
 | [`IC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L179) | `int` | `19001` | [Interconnect](../../concepts/glossary.md#interconnect) port |

--- a/ydb/docs/ru/core/reference/docker/configuration.md
+++ b/ydb/docs/ru/core/reference/docker/configuration.md
@@ -8,6 +8,7 @@
 | -- | -- | -- | -- |
 | [`YDB_GRPC_ENABLE_TLS`](https://GitHub.com/ydb-platform/ydb/blob/c113fcffa7b1a20ad8dcb1b1760ae5bfa25370ca/ydb/public/tools/lib/cmds/__init__.py#L258) | `0` или `1` | `1` | Включает использование TLS для gRPC соединений. |
 | [`YDB_GRPC_TLS_DATA_PATH`](https://GitHub.com/ydb-platform/ydb/blob/8fefc809c83829d8d8b886e82534d009de4c8826/ydb/public/tools/lib/cmds/__init__.py#L291) | `string` | `/ydb_data` | Путь до директории с TLS сертификатами для gRPC соединений. |
+| [`YDB_GRPC_TLS_USE_EXISTING_CERTS`](https://GitHub.com/ydb-platform/ydb/blob/main/ydb/public/tools/lib/cmds/__init__.py#L262) | `true` или `false` | `false` | Использует `ca.pem`, `cert.pem` и `key.pem` из `YDB_GRPC_TLS_DATA_PATH` вместо генерации новых сертификатов. Требуются все три файла. |
 | [`MON_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L170) | `int` | `8765` | HTTP-порт [встроенного веб-интерфейса {{ ydb-short-name }}](../../reference/embedded-ui/index.md). |
 | [`GRPC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L174) | `int` | `2136` | gRPC порт. |
 | [`IC_PORT`](https://GitHub.com/ydb-platform/ydb/blob/8dde59cd0af86737d07a1cd8ff19811a2bd2b663/ydb/tests/library/harness/kikimr_port_allocator.py#L179) | `int` | `19001` | Порт интерконнекта. |

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -259,6 +259,10 @@ def enable_tls():
     return os.getenv('YDB_GRPC_ENABLE_TLS') == 'true'
 
 
+def use_existing_grpc_tls_data():
+    return os.getenv('YDB_GRPC_TLS_USE_EXISTING_CERTS') == 'true'
+
+
 def is_tiny_mode():
     return os.getenv('YDB_TINY_MODE') == 'true'
 
@@ -349,6 +353,7 @@ def deploy(arguments):
     if enable_tls():
         optionals.update({'grpc_tls_data_path': grpc_tls_data_path(arguments)})
         optionals.update({'grpc_ssl_enable': enable_tls()})
+        optionals.update({'use_existing_grpc_tls_data': use_existing_grpc_tls_data()})
     pdisk_store_path = arguments.ydb_working_dir if arguments.ydb_working_dir else None
 
     enable_feature_flags = arguments.enabled_feature_flags.copy()  # type: typing.List[str]

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -70,8 +70,11 @@ def _get_grpc_host():
     return "[::]"
 
 
-def _grpc_tls_data_has_any_file(ca_path, cert_path, key_path):
-    return any(os.path.isfile(path) for path in (ca_path, cert_path, key_path))
+def _normalize_grpc_tls_data_path(grpc_tls_data_path):
+    if grpc_tls_data_path is not None and not grpc_tls_data_path.strip():
+        raise ValueError("grpc_tls_data_path must not be empty")
+
+    return grpc_tls_data_path
 
 
 def _read_grpc_tls_data(ca_path, cert_path, key_path):
@@ -174,6 +177,7 @@ class KikimrConfigGenerator(object):
             enable_audit_log=False,
             audit_log_config=None,
             grpc_tls_data_path=None,
+            use_existing_grpc_tls_data=False,
             fq_config_path=None,
             public_http_config_path=None,
             public_http_config=None,
@@ -267,20 +271,14 @@ class KikimrConfigGenerator(object):
         self.__grpc_tls_ca = None
         self.__grpc_tls_key = None
         self.__grpc_tls_cert = None
-        self.__grpc_tls_write_data = False
         self._pdisks_info = []
         if self.__grpc_ssl_enable:
-            grpc_tls_data_path_is_explicit = grpc_tls_data_path is not None
+            grpc_tls_data_path = _normalize_grpc_tls_data_path(grpc_tls_data_path)
             self.__grpc_tls_data_path = grpc_tls_data_path or yatest.common.output_path()
-            use_existing_grpc_tls_certs = (
-                grpc_tls_data_path_is_explicit
-                and _grpc_tls_data_has_any_file(
-                    self.grpc_tls_ca_path,
-                    self.grpc_tls_cert_path,
-                    self.grpc_tls_key_path,
-                )
-            )
-            if use_existing_grpc_tls_certs:
+            if use_existing_grpc_tls_data:
+                if grpc_tls_data_path is None:
+                    raise RuntimeError("Existing gRPC TLS data requires grpc_tls_data_path")
+
                 self.__grpc_tls_ca, self.__grpc_tls_cert, self.__grpc_tls_key = _read_grpc_tls_data(
                     self.grpc_tls_ca_path,
                     self.grpc_tls_cert_path,
@@ -291,7 +289,7 @@ class KikimrConfigGenerator(object):
                 self.__grpc_tls_ca = cert_pem
                 self.__grpc_tls_key = key_pem
                 self.__grpc_tls_cert = cert_pem
-                self.__grpc_tls_write_data = True
+                self.write_tls_data()
 
         self.monitoring_tls_cert_path = None
         self.monitoring_tls_key_path = None
@@ -895,11 +893,16 @@ class KikimrConfigGenerator(object):
         self.__binary_paths = binary_paths
 
     def write_tls_data(self):
-        if self.__grpc_ssl_enable and self.__grpc_tls_write_data:
+        if self.__grpc_ssl_enable:
             for fpath, data in (
                 (self.grpc_tls_ca_path, self.grpc_tls_ca), (self.grpc_tls_cert_path, self.grpc_tls_cert),
                 (self.grpc_tls_key_path, self.grpc_tls_key)
             ):
+                if os.path.isfile(fpath):
+                    with open(fpath, 'rb') as f:
+                        if f.read() == data:
+                            continue
+
                 with open(fpath, 'wb') as f:
                     f.write(data)
 

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -70,6 +70,29 @@ def _get_grpc_host():
     return "[::]"
 
 
+def _grpc_tls_data_has_any_file(ca_path, cert_path, key_path):
+    return any(os.path.isfile(path) for path in (ca_path, cert_path, key_path))
+
+
+def _read_grpc_tls_data(ca_path, cert_path, key_path):
+    missing_paths = [path for path in (ca_path, cert_path, key_path) if not os.path.isfile(path)]
+    if missing_paths:
+        raise RuntimeError(
+            "Existing gRPC TLS data requires ca.pem, cert.pem and key.pem, missing: {}".format(
+                ", ".join(missing_paths)
+            )
+        )
+
+    with open(ca_path, 'rb') as ca_file:
+        ca = ca_file.read()
+    with open(cert_path, 'rb') as cert_file:
+        cert = cert_file.read()
+    with open(key_path, 'rb') as key_file:
+        key = key_file.read()
+
+    return ca, cert, key
+
+
 def _load_default_yaml(default_tablet_node_ids, ydb_domain_name, static_erasure, log_configs, default_log_level):
     if default_log_level is None:
         ydb_default_log_level = int(LogLevels.from_string(os.getenv("YDB_DEFAULT_LOG_LEVEL", "NOTICE")))
@@ -244,13 +267,31 @@ class KikimrConfigGenerator(object):
         self.__grpc_tls_ca = None
         self.__grpc_tls_key = None
         self.__grpc_tls_cert = None
+        self.__grpc_tls_write_data = False
         self._pdisks_info = []
         if self.__grpc_ssl_enable:
+            grpc_tls_data_path_is_explicit = grpc_tls_data_path is not None
             self.__grpc_tls_data_path = grpc_tls_data_path or yatest.common.output_path()
-            cert_pem, key_pem = tls_tools.generate_selfsigned_cert(_get_fqdn())
-            self.__grpc_tls_ca = cert_pem
-            self.__grpc_tls_key = key_pem
-            self.__grpc_tls_cert = cert_pem
+            use_existing_grpc_tls_certs = (
+                grpc_tls_data_path_is_explicit
+                and _grpc_tls_data_has_any_file(
+                    self.grpc_tls_ca_path,
+                    self.grpc_tls_cert_path,
+                    self.grpc_tls_key_path,
+                )
+            )
+            if use_existing_grpc_tls_certs:
+                self.__grpc_tls_ca, self.__grpc_tls_cert, self.__grpc_tls_key = _read_grpc_tls_data(
+                    self.grpc_tls_ca_path,
+                    self.grpc_tls_cert_path,
+                    self.grpc_tls_key_path,
+                )
+            else:
+                cert_pem, key_pem = tls_tools.generate_selfsigned_cert(_get_fqdn())
+                self.__grpc_tls_ca = cert_pem
+                self.__grpc_tls_key = key_pem
+                self.__grpc_tls_cert = cert_pem
+                self.__grpc_tls_write_data = True
 
         self.monitoring_tls_cert_path = None
         self.monitoring_tls_key_path = None
@@ -854,7 +895,7 @@ class KikimrConfigGenerator(object):
         self.__binary_paths = binary_paths
 
     def write_tls_data(self):
-        if self.__grpc_ssl_enable:
+        if self.__grpc_ssl_enable and self.__grpc_tls_write_data:
             for fpath, data in (
                 (self.grpc_tls_ca_path, self.grpc_tls_ca), (self.grpc_tls_cert_path, self.grpc_tls_cert),
                 (self.grpc_tls_key_path, self.grpc_tls_key)

--- a/ydb/tests/library/ut/kikimr_config.py
+++ b/ydb/tests/library/ut/kikimr_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 from yql.essentials.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
@@ -64,3 +66,44 @@ def test_kikimr_config_generator_nbs_disabled():
 
     # Check that NBS config is not present when disabled
     assert "nbs_config" not in yaml_config
+
+
+def test_kikimr_config_generator_uses_existing_grpc_tls_data(tmp_path):
+    tls_data_path = tmp_path / "tls"
+    tls_data_path.mkdir()
+
+    ca = b"existing-ca"
+    cert = b"existing-cert"
+    key = b"existing-key"
+    (tls_data_path / "ca.pem").write_bytes(ca)
+    (tls_data_path / "cert.pem").write_bytes(cert)
+    (tls_data_path / "key.pem").write_bytes(key)
+
+    cfg_gen = KikimrConfigGenerator(
+        grpc_ssl_enable=True,
+        grpc_tls_data_path=str(tls_data_path),
+    )
+    cfg_gen.write_tls_data()
+
+    assert cfg_gen.grpc_tls_ca == ca
+    assert cfg_gen.grpc_tls_cert == cert
+    assert cfg_gen.grpc_tls_key == key
+    assert (tls_data_path / "ca.pem").read_bytes() == ca
+    assert (tls_data_path / "cert.pem").read_bytes() == cert
+    assert (tls_data_path / "key.pem").read_bytes() == key
+
+
+def test_kikimr_config_generator_rejects_partial_existing_grpc_tls_data(tmp_path):
+    tls_data_path = tmp_path / "tls"
+    tls_data_path.mkdir()
+
+    cert = b"existing-cert"
+    (tls_data_path / "cert.pem").write_bytes(cert)
+
+    with pytest.raises(RuntimeError, match="missing: .*ca\\.pem.*key\\.pem"):
+        KikimrConfigGenerator(
+            grpc_ssl_enable=True,
+            grpc_tls_data_path=str(tls_data_path),
+        )
+
+    assert (tls_data_path / "cert.pem").read_bytes() == cert

--- a/ydb/tests/library/ut/kikimr_config.py
+++ b/ydb/tests/library/ut/kikimr_config.py
@@ -82,6 +82,7 @@ def test_kikimr_config_generator_uses_existing_grpc_tls_data(tmp_path):
     cfg_gen = KikimrConfigGenerator(
         grpc_ssl_enable=True,
         grpc_tls_data_path=str(tls_data_path),
+        use_existing_grpc_tls_data=True,
     )
     cfg_gen.write_tls_data()
 
@@ -104,6 +105,40 @@ def test_kikimr_config_generator_rejects_partial_existing_grpc_tls_data(tmp_path
         KikimrConfigGenerator(
             grpc_ssl_enable=True,
             grpc_tls_data_path=str(tls_data_path),
+            use_existing_grpc_tls_data=True,
         )
 
     assert (tls_data_path / "cert.pem").read_bytes() == cert
+
+
+def test_kikimr_config_generator_generates_grpc_tls_data_without_reuse_flag(tmp_path):
+    tls_data_path = tmp_path / "tls"
+    tls_data_path.mkdir()
+
+    cfg_gen = KikimrConfigGenerator(
+        grpc_ssl_enable=True,
+        grpc_tls_data_path=str(tls_data_path),
+    )
+
+    assert cfg_gen.grpc_tls_ca
+    assert cfg_gen.grpc_tls_cert
+    assert cfg_gen.grpc_tls_key
+    assert (tls_data_path / "ca.pem").read_bytes() == cfg_gen.grpc_tls_ca
+    assert (tls_data_path / "cert.pem").read_bytes() == cfg_gen.grpc_tls_cert
+    assert (tls_data_path / "key.pem").read_bytes() == cfg_gen.grpc_tls_key
+
+
+def test_kikimr_config_generator_rejects_empty_grpc_tls_data_path():
+    with pytest.raises(ValueError, match="grpc_tls_data_path must not be empty"):
+        KikimrConfigGenerator(
+            grpc_ssl_enable=True,
+            grpc_tls_data_path="",
+        )
+
+
+def test_kikimr_config_generator_rejects_existing_grpc_tls_data_without_path():
+    with pytest.raises(RuntimeError, match="requires grpc_tls_data_path"):
+        KikimrConfigGenerator(
+            grpc_ssl_enable=True,
+            use_existing_grpc_tls_data=True,
+        )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

  Fixed local YDB Docker startup with pre-provided gRPC TLS certificates. When certificates are prepared before `local_ydb deploy`, for example by a `/
  preinit.d` script, local YDB no longer regenerates and overwrites `ca.pem`, `cert.pem`, and `key.pem` in `YDB_GRPC_TLS_DATA_PATH`.

  ### Changelog category <!-- remove all except one -->

  * Bugfix

  ### Description for reviewers <!-- (optional) description for those who read this PR -->

  Fixes #16737.

  Before this change, Docker users could provide TLS certificates before startup, for example by copying them from `/input_certs` to `/ydb_certs` in a
  `/preinit.d` script. `local_ydb deploy` still generated a new self-signed certificate and overwrote the files in `/ydb_certs`, so the running
  container used a different certificate than the one provided by the user.

  The fix makes `KikimrConfigGenerator` reuse existing TLS files from an explicitly provided `grpc_tls_data_path` instead of regenerating them. If only
  part of the TLS file set exists, startup fails instead of mixing existing and generated TLS data.

  Manual validation performed:

  1. Built a Linux `local_ydb` binary with the fix.
  2. Reused `ydbplatform/local-ydb:latest` and replaced only `/local_ydb` with the rebuilt binary for local verification.
  3. Started the container with a `/preinit.d` script that copies `ca.pem`, `cert.pem`, and `key.pem` from `/input_certs` to `/ydb_certs`.
  4. Verified that the certificates are preserved after `local_ydb deploy`:

  ```bash
  openssl x509 -in input_certs/cert.pem -noout -fingerprint -sha256
  openssl x509 -in ydb_certs/cert.pem -noout -fingerprint -sha256

  cmp input_certs/cert.pem ydb_certs/cert.pem
  cmp input_certs/ca.pem ydb_certs/ca.pem
  cmp input_certs/key.pem ydb_certs/key.pem

  Result: fingerprints match, and cmp reports no differences for ca.pem, cert.pem, and key.pem.