### PR TITLE
Fix "File is corrupted" error during export with encryption

### DIFF
--- a/ydb/core/backup/common/encryption.cpp
+++ b/ydb/core/backup/common/encryption.cpp
@@ -404,6 +404,8 @@ TEncryptedFileSerializer::TEncryptedFileSerializer(TString algorithm, TEncryptio
 {
 }
 
+TEncryptedFileSerializer::TEncryptedFileSerializer(TEncryptedFileSerializer&&) noexcept = default;
+TEncryptedFileSerializer& TEncryptedFileSerializer::operator=(TEncryptedFileSerializer&&) noexcept = default;
 TEncryptedFileSerializer::~TEncryptedFileSerializer() = default;
 
 TBuffer TEncryptedFileSerializer::AddBlock(TStringBuf data, bool last) {

--- a/ydb/core/backup/common/encryption.h
+++ b/ydb/core/backup/common/encryption.h
@@ -183,7 +183,8 @@ struct TEncryptionKey {
 // Has streaming interface
 class TEncryptedFileSerializer {
 public:
-    TEncryptedFileSerializer(TEncryptedFileSerializer&&) = default;
+    TEncryptedFileSerializer(TEncryptedFileSerializer&&) noexcept;
+    TEncryptedFileSerializer& operator=(TEncryptedFileSerializer&&) noexcept;
     TEncryptedFileSerializer(TString algorithm, TEncryptionKey key, TEncryptionIV iv);
     ~TEncryptedFileSerializer();
 

--- a/ydb/core/tx/datashard/export_s3_buffer.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer.cpp
@@ -77,6 +77,7 @@ private:
 
 class TS3Buffer: public NExportScan::IBuffer {
     using TChecksumCreator = std::function<NBackup::IChecksum*()>;
+    using TEncryptionCreator = std::function<TMaybe<NBackup::TEncryptedFileSerializer>()>;
     using TTagToColumn = IExport::TTableColumns;
     using TTagToIndex = THashMap<ui32, ui32>; // index in IScan::TRow
 
@@ -98,6 +99,7 @@ private:
     virtual TMaybe<TBuffer> Flush(bool last);
 
     static TChecksumCreator GenChecksumCreator(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings);
+    static TEncryptionCreator GenEncryptionCreator(const TMaybe<TS3ExportBufferSettings::TEncryptionSettings>& settings);
     static TZStdCompressionProcessor* CreateCompression(const TMaybe<TS3ExportBufferSettings::TCompressionSettings>& settings);
 
 private:
@@ -116,6 +118,7 @@ protected:
     TChecksumCreator ChecksumCreator;
     NBackup::IChecksum::TPtr Checksum;
     TZStdCompressionProcessor::TPtr Compression;
+    TEncryptionCreator EncryptionCreator;
     TMaybe<NBackup::TEncryptedFileSerializer> Encryption;
 
     TString ErrorString;
@@ -129,14 +132,9 @@ TS3Buffer::TS3Buffer(TS3ExportBufferSettings&& settings)
     , ChecksumCreator(GenChecksumCreator(settings.ChecksumSettings))
     , Checksum(ChecksumCreator())
     , Compression(CreateCompression(settings.CompressionSettings))
+    , EncryptionCreator(GenEncryptionCreator(settings.EncryptionSettings))
+    , Encryption(EncryptionCreator())
 {
-    if (settings.EncryptionSettings) {
-        Encryption.ConstructInPlace(
-            std::move(settings.EncryptionSettings->Algorithm),
-            std::move(settings.EncryptionSettings->Key),
-            std::move(settings.EncryptionSettings->IV)
-        );
-    }
 }
 
 std::function<NBackup::IChecksum*()> TS3Buffer::GenChecksumCreator(const TMaybe<TS3ExportBufferSettings::TChecksumSettings>& settings) {
@@ -148,6 +146,15 @@ std::function<NBackup::IChecksum*()> TS3Buffer::GenChecksumCreator(const TMaybe<
             }
         }
         return nullptr;
+    };
+}
+
+TS3Buffer::TEncryptionCreator TS3Buffer::GenEncryptionCreator(const TMaybe<TS3ExportBufferSettings::TEncryptionSettings>& settings) {
+    return [settings]() -> TMaybe<NBackup::TEncryptedFileSerializer> {
+        if (settings) {
+            return NBackup::TEncryptedFileSerializer(settings->Algorithm, settings->Key, settings->IV);
+        }
+        return Nothing();
     };
 }
 
@@ -342,6 +349,7 @@ void TS3Buffer::Clear() {
     if (Compression) {
         Compression->Clear();
     }
+    // Encryption = EncryptionCreator();
 }
 
 bool TS3Buffer::IsFilled() const {

--- a/ydb/core/tx/datashard/export_s3_buffer.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer.cpp
@@ -349,7 +349,7 @@ void TS3Buffer::Clear() {
     if (Compression) {
         Compression->Clear();
     }
-    // Encryption = EncryptionCreator();
+    Encryption = EncryptionCreator();
 }
 
 bool TS3Buffer::IsFilled() const {

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -319,8 +319,12 @@ namespace {
             return {};
         }
 
-        ui64 ExportWithRetryInjection(ui64 txId, const TString& compression = "", ui64 minWriteBatchSize = 1) {
+        ui64 ExportWithRetryInjection(ui64 txId, const TString& compression = "", const TString& encryptionBlock = "", ui64 minWriteBatchSize = 1) {
             Runtime().SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_DEBUG);
+
+            if (encryptionBlock) {
+                Runtime().GetAppData().FeatureFlags.SetEnableEncryptedExport(true);
+            }
 
             THolder<IEventHandle> injectResult;
             auto prevObserver = Runtime().SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
@@ -369,6 +373,11 @@ namespace {
                 compressionLine = Sprintf(R"(compression: "%s")", compression.c_str());
             }
 
+            TString extraSettings;
+            if (compressionLine || encryptionBlock) {
+                extraSettings = compressionLine + "\n" + encryptionBlock;
+            }
+
             const auto exportId = ++txId;
             TestExport(Runtime(), exportId, "/MyRoot", Sprintf(R"(
                 ExportToS3Settings {
@@ -381,7 +390,7 @@ namespace {
                   }
                   %s
                 }
-            )", S3Port(), compressionLine.c_str()));
+            )", S3Port(), extraSettings.c_str()));
 
             if (!injectResult) {
                 TDispatchOptions opts;
@@ -4542,5 +4551,48 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `ExternalTable` (
         Env().TestWaitNotification(Runtime(), importId);
 
         TestGetImport(Runtime(), importId, "/MyRoot", Ydb::StatusIds::SUCCESS);
+    }
+
+    Y_UNIT_TEST(ShouldNotCorruptEncryptedBufferOnRetry) {
+        Env();
+        Runtime().GetAppData().FeatureFlags.SetEnableEncryptedExport(true);
+        Runtime().SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_DEBUG);
+        ui64 txId = 100;
+
+        TestCreateTable(Runtime(), ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        Env().TestWaitNotification(Runtime(), txId);
+
+        UpdateRow(Runtime(), "Table", 1, "valueA");
+        UpdateRow(Runtime(), "Table", 2, "valueB");
+
+        txId = ExportWithRetryInjection(txId, "",
+        R"(
+            destination_prefix: "export1"
+              encryption_settings {
+                encryption_algorithm: "AES-128-GCM"
+                symmetric_key {
+                    key: "0123456789012345"
+                }
+              }
+        )");
+
+        const auto* data = S3Mock().GetData().FindPtr("/export1/001/data_00.csv.enc");
+        UNIT_ASSERT(data);
+
+        TBuffer decryptedData;
+        NBackup::TEncryptionIV iv;
+        UNIT_ASSERT_NO_EXCEPTION(std::tie(decryptedData, iv) = NBackup::TEncryptedFileDeserializer::DecryptFullFile(
+            NBackup::TEncryptionKey("0123456789012345"),
+            TBuffer(data->data(), data->size())
+        ));
+
+        const TString expected = "1,\"valueA\"\n2,\"valueB\"\n";
+        const TString decrypted(decryptedData.Data(), decryptedData.Size());
+        UNIT_ASSERT_VALUES_EQUAL_C(decrypted, expected, "Encrypted buffer corruption detected");
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix `File is corrupted` error during export with encryption

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Без очистки шифрования тест выдает `Backup::TEncryptedFileDeserializer::DecryptFullFile( NBackup::TEncryptionKey("0123456789012345"), TBuffer(data->data(), data->size()) ) throws 
Exception message: (yexception) File is corrupted:`.

Этот pr является продолжением фиксов  в https://github.com/ydb-platform/ydb/issues/40088
