### PR TITLE
[NEW RBO] Fix aggregate compute metadata leaking key columns

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -350,23 +350,23 @@ void TOpAggregate::ComputeMetadata(TRBOContext& ctx, TPlanProps& planProps) {
         return;
     }
 
-    Props.Metadata = GetInput()->Props.Metadata;
+    const auto& inputMetadata = *GetInput()->Props.Metadata;
 
+    Props.Metadata = TRBOMetadata();
+
+    Props.Metadata->StorageType = inputMetadata.StorageType;
     // Compute logical cardinality info. Its the same as input cardinality, except in the case
     // where the group-by list is empty, then we always produce a single tuple
-    if (KeyColumns.empty()) {
-        Props.Metadata->LogicalCard = ELogicalCardinality::One;
-    }
-
+    Props.Metadata->LogicalCard = KeyColumns.empty() ? ELogicalCardinality::One : inputMetadata.LogicalCard;
     Props.Metadata->Type = EStatisticsType::BaseTable;
     Props.Metadata->KeyColumns = KeyColumns;
     Props.Metadata->ColumnsCount = GetOutputIUs().size();
 
     Props.Metadata->ShuffledByColumns = {};
 
-    // Aggregate acts list a source in terms of lineage
-    // FIXME: We currently delete all lineage of columns before Aggregate, maybe this is suboptimal in some future cases?
-    Props.Metadata->ColumnLineage = {};
+    // Aggregate acts like a source in terms of lineage.
+    // FIXME: We currently delete all lineage of columns before Aggregate,
+    // maybe this is suboptimal in some future cases?
     TString alias = "_aggregate";
     int duplicateId = Props.Metadata->ColumnLineage.AddAlias(alias, alias);
     for (const auto & iu : GetOutputIUs()) {

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -4646,6 +4646,52 @@ foo_0.join_id = foo_6.id AND foo_0.join_id = foo_7.id AND foo_0.join_id = foo_8.
 
     */
 
+    // Regression: Aggregate::ComputeMetadata was copying input metadata instead of starting
+    // fresh, leaking its KeyColumns into the input Map. Repros with TPCH Q21 pattern.
+    Y_UNIT_TEST(AggregateKeyColumnsNotLeakedToInputMap) {
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableTableServiceConfig()->SetEnableNewRBO(true);
+        appConfig.MutableTableServiceConfig()->SetAllowOlapDataQuery(true);
+        appConfig.MutableTableServiceConfig()->SetEnableFallbackToYqlOptimizer(false);
+        appConfig.MutableTableServiceConfig()->SetDefaultLangVer(NYql::GetMaxLangVersion());
+        appConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+        TKikimrRunner kikimr(NKqp::TKikimrSettings(appConfig).SetWithSampleTables(false));
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto schemeResult = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE `/Root/items` (
+                order_id Int64 NOT NULL,
+                line_id  Int64 NOT NULL,
+                sup_id   Int64 NOT NULL,
+                late     Int64 NOT NULL,
+                PRIMARY KEY (order_id, line_id)
+            ) WITH (Store = Column);
+        )").GetValueSync();
+        UNIT_ASSERT_C(schemeResult.IsSuccess(), schemeResult.GetIssues().ToString());
+
+        auto queryClient = kikimr.GetQueryClient();
+        auto querySession = queryClient.GetSession().GetValueSync().GetSession();
+        auto result = querySession.ExecuteQuery(R"(
+            SELECT i1.sup_id, COUNT(*) AS cnt
+            FROM `/Root/items` AS i1
+            WHERE i1.late = 1
+              AND EXISTS (
+                  SELECT * FROM `/Root/items` AS i2
+                  WHERE i2.order_id = i1.order_id AND i2.sup_id != i1.sup_id
+              )
+              AND NOT EXISTS (
+                  SELECT * FROM `/Root/items` AS i3
+                  WHERE i3.order_id = i1.order_id AND i3.sup_id != i1.sup_id AND i3.late = 1
+              )
+            GROUP BY i1.sup_id
+            ORDER BY cnt DESC, i1.sup_id;
+        )", NYdb::NQuery::TTxControl::NoTx(),
+            NYdb::NQuery::TExecuteQuerySettings().ExecMode(NQuery::EExecMode::Explain))
+            .ExtractValueSync();
+
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
 }
 
 } // namespace NKqp


### PR DESCRIPTION
This PR fixes weird Lineage and incorrect KeyColumns due to copying of metadata inside TOpAggregate as observed in TPCH 21:

```
Map [s_name: supplier.s_name, numwait: numwait] Project
 Type: BaseTable, ColumnsCount: 2, Storage: N/A, KeyCols: [.s_name], Lineage: {numwait: <ColName: __kqp_agg_result_agg_col_1, Alias: _aggregate, Table: _aggregate, DuplicateNo: 0>, s_name: <ColName: s_name, Alias: _aggregate, Table: _aggregate, DuplicateNo: 0>, }
  Map [numwait: __kqp_agg_result_agg_col_1, supplier.s_name: supplier.s_name] Project
   Type: BaseTable, ColumnsCount: 2, Storage: N/A, KeyCols: [supplier.s_name], Lineage: {numwait: <ColName: __kqp_agg_result_agg_col_1, Alias: _aggregate, Table: _aggregate, DuplicateNo: 0>, supplier.s_name: <ColName: s_name, Alias: _aggregate, Table: _aggregate, DuplicateNo: 0>, }
    Aggregate [__kqp_agg_result_agg_col_1: count(__kqp_agg_input_agg_expr_0) [supplier.s_name]] Undefined
```
