### PR TITLE
wm: change permission for resource pool sys view to match create/alter

### DIFF
--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
@@ -66,7 +66,7 @@ private:
         if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
             ReplyEmptyAndDie();
         }
-        Register(NKqp::NWorkload::CreateDatabaseFetcherActor(SelfId(), TenantName, UserToken, NACLib::EAccessRights::GenericFull));
+        Register(NKqp::NWorkload::CreateDatabaseFetcherActor(SelfId(), TenantName, UserToken, NACLib::EAccessRights::GenericUse));
     }
 
     void Handle(NKqp::NWorkload::TEvFetchDatabaseResponse::TPtr& ev) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `.sys/resource_pool_classifiers` sys view required `GenericFull` permissions on the database, which includes `CreateDatabase | DropDatabase` rights. This was inconsistent with the create/alter/drop classifier path that only requires `GenericUse`.

As a result, users who could successfully create resource pool classifiers were unable to view them via the sys view, getting:
"Error: You don't have access permissions for database <path>". Changed the ACL check in the sys view scan actor from `GenericFull` to `GenericUse` to align with the classifier management path.