### PR TITLE
[NEW RBO] Fix inline join filters rule

### DIFF
--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
@@ -334,7 +334,7 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
             cols.insert(cols.begin(), rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end());
             keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(new TOptimizerStatistics::TKeyColumns(cols));
         } else {
-            keyColumns = leftStats.KeyColumns;
+            keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>();
         }
     }
 

--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
@@ -329,7 +329,7 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
     } else if (rightKeyColumns) {
         keyColumns = rightStats.KeyColumns;
     } else {
-        if (leftStats.KeyColumns->Data.size() && rightStats.KeyColumns->Data.size()) {
+        if (leftStats.KeyColumns && leftStats.KeyColumns->Data.size() && rightStats.KeyColumns && rightStats.KeyColumns->Data.size()) {
             TVector<TString> cols = leftStats.KeyColumns->Data;
             cols.insert(cols.begin(), rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end());
             keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(new TOptimizerStatistics::TKeyColumns(cols));

--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
@@ -329,6 +329,9 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
     } else if (rightKeyColumns) {
         keyColumns = rightStats.KeyColumns;
     } else {
+        // FIXME: the correct thing to do is to append the keys in case of non-PK join, however this
+        // needs to be done more efficiently, otherwise it severily slows down the optimizer
+        /*
         if (leftStats.KeyColumns && leftStats.KeyColumns->Data.size() && rightStats.KeyColumns && rightStats.KeyColumns->Data.size()) {
             TVector<TString> cols = leftStats.KeyColumns->Data;
             cols.insert(cols.begin(), rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end());
@@ -336,6 +339,8 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
         } else {
             keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>();
         }
+        */
+        keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>();
     }
 
     auto result = TOptimizerStatistics(outputType, newCard, newNCols, newByteSize, cost, keyColumns);

--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
@@ -323,8 +323,20 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
         cost += rightStats.Nrows;
     }
 
-    auto result = TOptimizerStatistics(outputType, newCard, newNCols, newByteSize, cost,
-                                       leftKeyColumns ? leftStats.KeyColumns : (rightKeyColumns ? rightStats.KeyColumns : TIntrusivePtr<TOptimizerStatistics::TKeyColumns>()));
+    TIntrusivePtr<TOptimizerStatistics::TKeyColumns> keyColumns;
+    if (leftKeyColumns) {
+        keyColumns = leftStats.KeyColumns;
+    } else if (rightKeyColumns) {
+        keyColumns = rightStats.KeyColumns;
+    } else {
+        if (leftStats.KeyColumns->Data.size() && rightStats.KeyColumns->Data.size()) {
+            TVector<TString> cols = leftStats.KeyColumns->Data;
+            cols.insert(cols.begin(), rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end());
+            keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(new TOptimizerStatistics::TKeyColumns(cols));
+        }
+    }
+
+    auto result = TOptimizerStatistics(outputType, newCard, newNCols, newByteSize, cost, keyColumns);
     result.Selectivity = selectivity;
     return result;
 }

--- a/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
+++ b/ydb/core/kqp/opt/cbo/cbo_optimizer_new.cpp
@@ -333,6 +333,8 @@ TOptimizerStatistics TBaseProviderContext::ComputeJoinStats(
             TVector<TString> cols = leftStats.KeyColumns->Data;
             cols.insert(cols.begin(), rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end());
             keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(new TOptimizerStatistics::TKeyColumns(cols));
+        } else {
+            keyColumns = leftStats.KeyColumns;
         }
     }
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/kqp/opt/cbo/cbo_optimizer_new.h>
 #include <ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.h>
 #include <ydb/core/kqp/opt/cbo/solver/kqp_opt_stat_kqp.h>
+#include <ydb/core/kqp/opt/rbo/kqp_rbo_utils.h>
 
 /***
  * All the methods to compute metadata and statistics are collected in this file
@@ -14,22 +15,6 @@ using namespace NKikimr;
 using namespace NKikimr::NKqp;
 using namespace NYql;
 using namespace NYql::NDq;
-TVector<TInfoUnit> ConvertKeyColumns(TIntrusivePtr<NKikimr::NKqp::TOptimizerStatistics::TKeyColumns> keyColumns, const TVector<TInfoUnit>& outputColumns) {
-    if (!keyColumns) {
-        return {};
-    }
-
-    TVector<TInfoUnit> result;
-    for (const auto& key : keyColumns->Data) {
-        auto it = std::find_if(outputColumns.begin(), outputColumns.end(), [&key](const TInfoUnit& iu) {
-            return key == iu.GetColumnName();
-        });
-
-        Y_ENSURE(it != outputColumns.end(), TStringBuilder() << "Cannot convert key column: " << key);
-        result.push_back(*it);
-    }
-    return result;
-}
 
 void ComputeAlisesForJoin(const TIntrusivePtr<IOperator>& left, const TIntrusivePtr<IOperator>& right, TVector<TString>& leftAliases,
                           TVector<TString>& rightAliases, TVector<TString>& unionOfAliases) {
@@ -59,6 +44,34 @@ void ComputeAlisesForJoin(const TIntrusivePtr<IOperator>& left, const TIntrusive
     std::sort(rightAliases.begin(), rightAliases.end());
     std::set_union(leftAliasSet.begin(), leftAliasSet.end(), rightAliasSet.begin(), rightAliasSet.end(),
             std::back_inserter(unionOfAliases));
+}
+
+TVector<TInfoUnit> ComputeKeysAfterJoin(TOpJoin* join) {
+    auto leftKeys = join->GetLeftInput()->Props.Metadata->KeyColumns;
+    if (join->JoinKind == "LeftSemi" || join->JoinKind == "LeftOnly") {
+        return leftKeys;
+    }
+
+    auto rightKeys = join->GetRightInput()->Props.Metadata->KeyColumns;
+    if (join->JoinKind == "RightSemi" || join->JoinKind == "RightOnly") {
+        return rightKeys;
+    }
+    
+    if (leftKeys.empty() || rightKeys.empty()) {
+        return {};
+    }
+
+    if(IUSetDiff(leftKeys, rightKeys).empty()) {
+        return rightKeys;
+    }
+    else if (IUSetDiff(rightKeys, leftKeys).empty()) {
+        return leftKeys;
+    }
+    else {
+        auto concatKeys = leftKeys;
+        AddUnique<TInfoUnit>(rightKeys, concatKeys);
+        return concatKeys;
+    }
 }
 }
 
@@ -442,7 +455,7 @@ void TOpJoin::ComputeMetadata(TRBOContext& ctx, TPlanProps& planProps) {
         FindCardHint(unionOfAliases, *hints.BytesHints));
 
     Props.Metadata->ColumnsCount = GetLeftInput()->Props.Metadata->ColumnsCount + GetRightInput()->Props.Metadata->ColumnsCount;
-    Props.Metadata->KeyColumns = ConvertKeyColumns(CBOStats.KeyColumns, GetOutputIUs());
+    Props.Metadata->KeyColumns = ComputeKeysAfterJoin(this);
     Props.Metadata->StorageType = CBOStats.StorageType;
     Props.Metadata->Type = CBOStats.Type;
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -25,7 +25,7 @@ TVector<TInfoUnit> ConvertKeyColumns(TIntrusivePtr<NKikimr::NKqp::TOptimizerStat
             return key == iu.GetColumnName();
         });
 
-        Y_ENSURE(it != outputColumns.end());
+        Y_ENSURE(it != outputColumns.end(), TStringBuilder() << "Cannot convert key column: " << key);
         result.push_back(*it);
     }
     return result;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -68,7 +68,7 @@ class TInlineSimpleInExistsSubplanRule : public ISimplifiedRule {
  */
 class TInlineJoinFiltersRule : public ISimplifiedRule {
   public:
-    TInlineJoinFiltersRule() : ISimplifiedRule("Inline join filters", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata, true) {}
+    TInlineJoinFiltersRule() : ISimplifiedRule("Inline join filters", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata) {}
 
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
@@ -121,7 +121,7 @@ class TPushFilterUnderMapRule : public ISimplifiedRule {
  */
 class TPushFilterIntoJoinRule : public ISimplifiedRule {
   public:
-    TPushFilterIntoJoinRule() : ISimplifiedRule("Push filter into join", ERuleProperties::RequireParents, true) {}
+    TPushFilterIntoJoinRule() : ISimplifiedRule("Push filter into join", ERuleProperties::RequireParents) {}
 
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -68,7 +68,7 @@ class TInlineSimpleInExistsSubplanRule : public ISimplifiedRule {
  */
 class TInlineJoinFiltersRule : public ISimplifiedRule {
   public:
-    TInlineJoinFiltersRule() : ISimplifiedRule("Inline join filters", ERuleProperties::RequireParents) {}
+    TInlineJoinFiltersRule() : ISimplifiedRule("Inline join filters", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata, true) {}
 
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
@@ -121,7 +121,7 @@ class TPushFilterUnderMapRule : public ISimplifiedRule {
  */
 class TPushFilterIntoJoinRule : public ISimplifiedRule {
   public:
-    TPushFilterIntoJoinRule() : ISimplifiedRule("Push filter into join", ERuleProperties::RequireParents) {}
+    TPushFilterIntoJoinRule() : ISimplifiedRule("Push filter into join", ERuleProperties::RequireParents, true) {}
 
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
@@ -59,13 +59,14 @@ TInfoUnit TRBOMetadata::MapColumn(const TInfoUnit& key) {
 }
 
 TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps& props, bool withStatsAndCosts) {
-    TVector<TInfoUnit> keyColumns;
-    return BuildOptimizerStatistics(props, withStatsAndCosts, keyColumns);
-}
-
-TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps& props, bool withStatsAndCosts, const TVector<TInfoUnit>& keyColumns) {
+    TVector<TInfoUnit> mappedKeyColumns;
     TVector<TString> keyColumnNames;
-    for (const auto& iu: (keyColumns.empty() ? props.Metadata->KeyColumns : keyColumns)) {
+
+    for (const auto& col : props.Metadata->KeyColumns) {
+        mappedKeyColumns.push_back(props.Metadata->MapColumn(col));
+    }
+
+    for (const auto& iu: mappedKeyColumns) {
         keyColumnNames.push_back(iu.GetColumnName());
     }
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.h
@@ -114,7 +114,6 @@ public:
 };
 
 TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps & props, bool withStatsAndCosts);
-TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps & props, bool withStatsAndCosts, const TVector<TInfoUnit>& keyColumns);
 
 }
 }

--- a/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
@@ -167,12 +167,7 @@ std::shared_ptr<TJoinOptimizerNode> ConvertJoinTree(TIntrusivePtr<TOpCBOTree>& c
             childAliases.push_back("#fake_alias" + std::to_string(fakeAliasId++));
         }
 
-        TVector<TInfoUnit> mappedKeyColumns;
-        for (const auto& col : child->Props.Metadata->KeyColumns) {
-            mappedKeyColumns.push_back(cboTree->TreeRoot->Props.Metadata->MapColumn(col));
-        }
-
-        auto stats = BuildOptimizerStatistics(child->Props, true, mappedKeyColumns);
+        auto stats = BuildOptimizerStatistics(child->Props, true);
         auto relNode = std::make_shared<TRBORelOptimizerNode>(childAliases, stats, child);
         rels.push_back(relNode);
         nodeMap.insert({child.get(), relNode});

--- a/ydb/core/kqp/opt/rbo/rules/inline_join_filters.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_join_filters.cpp
@@ -53,6 +53,16 @@ TIntrusivePtr<TOpMap> MakeMapFromRenames(TIntrusivePtr<IOperator> input,
     return MakeIntrusive<TOpMap>(input, pos, mapElements, true);
 }
 
+bool CheckNonNullKeys(const TIntrusivePtr<IOperator> &input, const TVector<TInfoUnit>& columns) {
+    auto itemType = input->Type->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>();
+    for (const auto & column : columns) {
+        auto columnType = itemType->FindItemType(column.GetFullName());
+        if (columnType->IsOptionalOrNull()) {
+            return false;
+        }
+    }
+    return true;
+}
 
 }
 
@@ -119,7 +129,20 @@ TIntrusivePtr<IOperator> TInlineJoinFiltersRule::SimpleMatchAndApply(const TIntr
 
     auto renameMap = MakeRenameMap(topCommonIUs, props.InternalVarIdx);
     auto map = MakeMapFromRenames(newFilter, renameMap, join->Pos, &ctx.ExprCtx, &props);
-    auto newJoinKeys = RemapJoinKeysRightSide(join->JoinKeys, renameMap);
+
+    // The join will be on the keys of lhs, we just need to check that all the keys are non-null
+    // We don't support nullable keys at this stage
+    auto keyColumns = join->GetLeftInput()->Props.Metadata->KeyColumns;
+    Y_ENSURE(!keyColumns.empty(), "Cannot inline a join filter because key columns are missing");
+
+    Y_ENSURE(CheckNonNullKeys(join->GetLeftInput(), keyColumns), "Key columns cannot be optional when inlining join filter");
+
+    TVector<std::pair<TInfoUnit, TInfoUnit>> newJoinKeys;
+    for (const auto & column : keyColumns) {
+        newJoinKeys.push_back(std::make_pair(column, column));
+    }
+
+    newJoinKeys = RemapJoinKeysRightSide(newJoinKeys, renameMap);
     auto result = MakeIntrusive<TOpJoin>(join->GetLeftInput(), map, join->Pos, join->JoinKind, newJoinKeys);
     
     return result;

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -2115,6 +2115,14 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
                            {}, /*new rbo=*/true, /*printStatus=*/true, /*compareResults=*/true);
     }
 
+    Y_UNIT_TEST(TPCH_YQL_11) {
+        RunTPC_YqlTest(EBenchType::TPCH, 11, true, true);
+    }
+
+    Y_UNIT_TEST(TPCH_YQL_21) {
+        RunTPC_YqlTest(EBenchType::TPCH, 21, true, true);
+    }
+
     void InsertIntoSchema0(NYdb::NTable::TTableClient& db, std::string tableName, ui32 numRows) {
         NYdb::TValueBuilder rows;
         rows.BeginList();

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -2115,14 +2115,6 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
                            {}, /*new rbo=*/true, /*printStatus=*/true, /*compareResults=*/true);
     }
 
-    Y_UNIT_TEST(TPCH_YQL_11) {
-        RunTPC_YqlTest(EBenchType::TPCH, 11, true, true);
-    }
-
-    Y_UNIT_TEST(TPCH_YQL_21) {
-        RunTPC_YqlTest(EBenchType::TPCH, 21, true, true);
-    }
-
     void InsertIntoSchema0(NYdb::NTable::TTableClient& db, std::string tableName, ui32 numRows) {
         NYdb::TValueBuilder rows;
         rows.BeginList();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Join Filter inlining was implemented incorrectly, now we do the inner join with a filter to handle join filters, and then join back with the left side on the keys of the left side

Fixed a bug with key computation for intermediate results as well


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
