### PR TITLE
TEvLockRows: implement SkipAbsent

### DIFF
--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -209,6 +209,10 @@ message TEvLockRows {
     // When true rows already locked by other transactions are skipped without
     // waiting for conflicting transactions to commit or abort.
     optional bool SkipLocked = 7;
+    // When true, keys that are absent or deleted in the latest version are skipped
+    // and not locked. If the skipped key was modified/deleted above the snapshot,
+    // its index will NOT appear in the ModifiedKeys result field.
+    optional bool SkipAbsent = 13;
 
     // Destination global table id, must include SchemaVersion to detect schema changes
     optional TTableId TableId = 8;
@@ -268,8 +272,11 @@ message TEvLockRowsResult {
     // A list of row indexes from the request which have been successfully locked
     repeated uint32 LockedKeys = 6 [packed = true];
 
-    // A list of row indexes from the request which have been skipped when SkipLocked is true
-    repeated uint32 SkippedKeys = 7 [packed = true];
+    // A list of row indexes from the request which have been skipped because SkipLocked is true
+    repeated uint32 SkippedLockedKeys = 7 [packed = true];
+
+    // A list of row indexes from the request which have been skipped because SkipAbsent is true
+    repeated uint32 SkippedAbsentKeys = 9 [packed = true];
 
     // A list of row indexes from the request which have been modified since the specified Snapshot
     repeated uint32 ModifiedKeys = 8 [packed = true];

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -392,7 +392,7 @@ namespace NTable {
                 if (chain->Rop != ERowOp::Absent) {
                     auto* commitVersion = committedTransactions.Find(chain->RowVersion.TxId);
                     if (commitVersion) {
-                        return { *commitVersion, chain->RowVersion.TxId };
+                        return { *commitVersion, chain->RowVersion.TxId, chain->Rop };
                     }
                     transactionObserver.OnSkipUncommitted(chain->RowVersion.TxId);
                 }
@@ -403,7 +403,7 @@ namespace NTable {
                 CurrentVersion = chain;
             }
 
-            return chain->RowVersion;
+            return { chain->RowVersion, 0, chain->Rop };
         }
 
         bool IsValid() const

--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -1120,7 +1120,7 @@ namespace NTable {
                     const auto* commitVersion = committedTransactions.Find(txId);
                     if (commitVersion) {
                         // Found a committed delta
-                        return { *commitVersion, txId };
+                        return { *commitVersion, txId, data->GetRop() };
                     }
                     // Skip an uncommitted delta
                     transactionObserver.OnSkipUncommitted(txId);
@@ -1140,11 +1140,15 @@ namespace NTable {
 
             if (!SkipEraseVersion && data->IsErased()) {
                 // Return erase version of this row
-                return data->GetMaxVersion(info);
+                return { data->GetMaxVersion(info), 0, data->GetRop() };
             }
 
             // Otherwise either row version or part version is the first committed version
-            return data->IsVersioned() ? data->GetMinVersion(info) : Part->MinRowVersion;
+            return {
+                data->IsVersioned() ? data->GetMinVersion(info) : Part->MinRowVersion,
+                0,
+                data->GetRop()
+            };
         }
 
         bool IsDelta() const noexcept

--- a/ydb/core/tablet_flat/flat_row_eggs.h
+++ b/ydb/core/tablet_flat/flat_row_eggs.h
@@ -92,13 +92,15 @@ namespace NTable {
     struct TSkipToCommittedResult {
         TRowVersion RowVersion = TRowVersion::Min();
         ui64 RowTxId = 0;
+        ERowOp RowOp = ERowOp::Absent;
         bool Valid = false;
 
         TSkipToCommittedResult() = default;
 
-        TSkipToCommittedResult(const TRowVersion& rowVersion, ui64 rowTxId = 0)
+        TSkipToCommittedResult(const TRowVersion& rowVersion, ui64 rowTxId, ERowOp rowOp)
             : RowVersion(rowVersion)
             , RowTxId(rowTxId)
+            , RowOp(rowOp)
             , Valid(true)
         {}
 
@@ -111,6 +113,7 @@ namespace NTable {
         EReady Ready;
         TRowVersion RowVersion = TRowVersion::Min();
         ui64 RowTxId = 0;
+        ERowOp RowOp = ERowOp::Absent;
         ELockMode LockMode = ELockMode::None;
         ui64 LockTxId = 0;
 
@@ -122,12 +125,7 @@ namespace NTable {
             : Ready(result ? EReady::Data : EReady::Gone)
             , RowVersion(result.RowVersion)
             , RowTxId(result.RowTxId)
-        { }
-
-        explicit TSelectRowVersionResult(const TRowVersion& rowVersion, ui64 rowTxId = 0)
-            : Ready(EReady::Data)
-            , RowVersion(rowVersion)
-            , RowTxId(rowTxId)
+            , RowOp(result.RowOp)
         { }
 
         explicit operator bool() const {

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -1655,6 +1655,7 @@ TSelectRowVersionResult TTable::SelectRowVersionByKeyPrefix(
             if (ready != NTable::EReady::Gone) {
                 res.RowVersion = iter->GetRowVersion();
                 res.RowTxId = iter->GetDeltaTxId();
+                res.RowOp = iter->Row().GetRowState();
             }
             return res;
         }
@@ -1664,6 +1665,7 @@ TSelectRowVersionResult TTable::SelectRowVersionByKeyPrefix(
             res.Ready = NTable::EReady::Data;
             res.RowVersion = iter->GetRowVersion();
             res.RowTxId = iter->GetDeltaTxId();
+            res.RowOp = iter->Row().GetRowState();
         }
     }
     if (ready == NTable::EReady::Page) {

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -646,6 +646,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
                 if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
                     success->Record.AddSkippedAbsentKeys(processedKeys);
+                    runtimeLock.Reset();
                     ++processedKeys;
                     continue;
                 }
@@ -683,7 +684,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     ++processedKeys;
                 };
 
-                auto finishSkipped = [&]() {
+                auto finishSkippedLocked = [&]() {
                     success->Record.AddSkippedLockedKeys(processedKeys);
                     runtimeLock.Reset();
                     ++processedKeys;
@@ -771,7 +772,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
 
                 // Don't bother waiting in skipLocked mode when current owner conflicts with us
                 if (skipLocked && currentOwner && !IsCompatibleRowLockMode(currentLockMode, lockMode)) {
-                    finishSkipped();
+                    finishSkippedLocked();
                     continue;
                 }
 
@@ -787,7 +788,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     Y_ENSURE(runtimeLock.IsValid());
                     if (!runtimeLock.IsOwner()) {
                         if (skipLocked) {
-                            finishSkipped();
+                            finishSkippedLocked();
                             continue;
                         }
 

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -305,6 +305,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
     const ui32 lockNodeId = msg->Record.GetLockNodeId();
     const TTableId tableId = msg->GetTableId();
     const bool skipLocked = msg->Record.GetSkipLocked();
+    const bool skipAbsent = msg->Record.GetSkipAbsent();
 
     {
         NKikimrTxDataShard::TEvProposeTransactionResult::EStatus rejectStatus;
@@ -643,6 +644,12 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     return ETxLockRows::Restart;
                 }
 
+                if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
+                    success->Record.AddSkippedAbsentKeys(processedKeys);
+                    ++processedKeys;
+                    continue;
+                }
+
                 // Undecided volatile transactions will have non-zero VolatileVersion
                 // We don't wait until they are decided and return a modified flag
                 // instead. A subsequent re-read will wait for the decision.
@@ -677,7 +684,7 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                 };
 
                 auto finishSkipped = [&]() {
-                    success->Record.AddSkippedKeys(processedKeys);
+                    success->Record.AddSkippedLockedKeys(processedKeys);
                     runtimeLock.Reset();
                     ++processedKeys;
                 };

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -2080,6 +2080,80 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         UNIT_ASSERT(responseStatusStats[NKikimrDataEvents::TEvLockRowsResult::STATUS_DEADLOCK] > 0);
     }
 
+    Y_UNIT_TEST(RowSkips) {
+        TPortManager pm;
+
+        auto [runtime, server, sender] = TestCreateServer(pm);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 100), (2, 200), (3, 300);
+            )"),
+            "<empty>");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        TTestPipe pipe(runtime, shards.at(0));
+
+        TLockHandle lock1(123, runtime.GetActorSystem(0));
+        TLockHandle lock2(234, runtime.GetActorSystem(0));
+        TLockRowsHelper lockRows(runtime, pipe);
+
+        TWaitGraphInterceptor waitGraph(runtime);
+
+        // Acquire snapshot for the second lock request.
+        auto snapshot = AcquireReadSnapshot(runtime, "/Root");
+
+        // Lock key 2 by lock 123.
+        auto req1 = lockRows.SendRequest(lock1, tableId, TKeysBuilder().Add(2).Build());
+        lockRows.ExpectResult(req1);
+
+        // Delete key 3.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                DELETE FROM `/Root/table` WHERE key = 3;
+            )"),
+            "<empty>");
+
+        // Try locking keys 1, 2, 3, 4 by lock 234.
+        auto req2 = lockRows.SendRequest(
+            lock2, tableId, TKeysBuilder().Add(1).Add(2).Add(3).Add(4).Build(),
+            [&](NEvents::TDataEvents::TEvLockRows* ev) {
+                ev->Record.MutableSnapshot()->SetStep(snapshot.Step);
+                ev->Record.MutableSnapshot()->SetTxId(snapshot.TxId);
+                ev->Record.SetSkipLocked(true);
+                ev->Record.SetSkipAbsent(true);
+            });
+        auto res = lockRows.ExpectResult(req2);
+
+        // Key 1 was locked
+        const auto& locked = res->Record.GetLockedKeys();
+        UNIT_ASSERT_VALUES_EQUAL(locked.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(locked[0], 0);
+
+        // Key 2 was skipped because it was previously locked by req1
+        const auto& skippedLocked = res->Record.GetSkippedLockedKeys();
+        UNIT_ASSERT_VALUES_EQUAL(skippedLocked.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(skippedLocked[0], 1);
+
+        // Key 3 was skipped because it was deleted, and key 4 was skipped because it was absent.
+        const auto& skippedAbsent = res->Record.GetSkippedAbsentKeys();
+        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent[0], 2);
+        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent[1], 3);
+
+        // Key 3 was deleted after the snapshot, but it is not in ModifiedKeys because we skipped it.
+        UNIT_ASSERT_VALUES_EQUAL(res->Record.GetModifiedKeys().size(), 0);
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)
 
 } // namespace NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implement SkipAbsent flag (intended for use in UPDATEs) that doesn't lock keys that are absent or have been deleted. This mimics postgresql behavior - keys that have been deleted after WHERE evaluation but before locking attempt, are not locked.

Old behavior (SkipAbsent = false) is intended for use in INSERTs / unique index updates.

Fixes https://github.com/ydb-platform/ydb/issues/40420