### PR TITLE
Fix storage groups hive request ordering

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -4651,6 +4651,26 @@
             "TotalGroups": 5
         }
     ],
+    "test.TestViewer.test_viewer_groups_sort_by_vdisk_slot_usage_with_allocation_units": {
+        "with_allocation_units": {
+            "FoundGroups": 5,
+            "HasMaxVDiskSlotUsage": true,
+            "NeedFilter": false,
+            "NeedLimit": false,
+            "NeedSort": false,
+            "Problems": [],
+            "ReturnedGroups": 1
+        },
+        "without_allocation_units": {
+            "FoundGroups": 5,
+            "HasMaxVDiskSlotUsage": true,
+            "NeedFilter": false,
+            "NeedLimit": false,
+            "NeedSort": false,
+            "Problems": [],
+            "ReturnedGroups": 1
+        }
+    },
     "test.TestViewer.test_viewer_groups_with_invalid_database": {
         "status_code": 403,
         "text": "<html><body><h1>403 Forbidden</h1><p><main>: Error: Unknown database\n</p></body></html>"

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -747,6 +747,37 @@ class TestViewer(object):
         ]
 
     @classmethod
+    def test_viewer_groups_sort_by_vdisk_slot_usage_with_allocation_units(cls):
+        def request_and_check(fields_required):
+            result = cls.get_viewer("/viewer/groups", {
+                'fields_required': fields_required,
+                'sort': '-MaxVDiskSlotUsage',
+                'limit': 1,
+            })
+            assert 'status_code' not in result, result
+            assert not result.get('NeedFilter'), result
+            assert not result.get('NeedSort'), result
+            assert not result.get('NeedLimit'), result
+            assert result.get('Problems', []) == [], result
+            groups = result.get('StorageGroups', [])
+            assert len(groups) == 1, result
+            assert 'MaxVDiskSlotUsage' in groups[0], result
+            return {
+                'FoundGroups': result.get('FoundGroups'),
+                'ReturnedGroups': len(groups),
+                'HasMaxVDiskSlotUsage': 'MaxVDiskSlotUsage' in groups[0],
+                'NeedFilter': result.get('NeedFilter', False),
+                'NeedSort': result.get('NeedSort', False),
+                'NeedLimit': result.get('NeedLimit', False),
+                'Problems': result.get('Problems', []),
+            }
+
+        return {
+            'without_allocation_units': request_and_check('MaxVDiskSlotUsage'),
+            'with_allocation_units': request_and_check('AllocationUnits,MaxVDiskSlotUsage'),
+        }
+
+    @classmethod
     def test_viewer_groups_with_invalid_database(cls):
         # Test that the endpoint doesn't crash when provided with an invalid database
         result = cls.call_viewer("/viewer/groups", {

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -896,6 +896,7 @@ public:
         } if (Params.Get("with") == "space") {
             With = EWith::SpaceProblems;
             FieldsRequired.set(+EGroupFields::Available);
+            FieldsRequired.set(+EGroupFields::Usage);
             NeedFilter = true;
         }
         if (Params.Has("offset")) {
@@ -1434,7 +1435,50 @@ public:
     }
 
     bool WaitingForHive() const {
-        return HiveStorageStatsInFlight != 0 && (FieldsHive.test(+SortBy) || FieldsHive.test(+GroupBy));
+        return HiveStorageStatsInFlight != 0 && ((NeedSort && FieldsHive.test(+SortBy))
+            || (NeedGroup && FieldsHive.test(+GroupBy))
+            || (NeedFilter && !FilterGroup.empty() && FieldsHive.test(+FilterGroupBy)));
+    }
+
+    bool NeedToWaitForFieldBeforeHive(EGroupFields field) const {
+        return field != EGroupFields::COUNT && FieldsRequired.test(+field) && !FieldsAvailable.test(+field) && !FieldsHive.test(+field);
+    }
+
+    bool NeedToWaitForFilterBeforeHive() const {
+        if (!NeedFilter) {
+            return false;
+        }
+        if (!DatabaseStoragePools.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PoolName)) {
+            return true;
+        }
+        if (!FilterStoragePools.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PoolName)) {
+            return true;
+        }
+        if (!FilterNodeIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::NodeId)) {
+            return true;
+        }
+        if (!FilterPDiskIds.empty() && NeedToWaitForFieldBeforeHive(EGroupFields::PDiskId)) {
+            return true;
+        }
+        if (With == EWith::MissingDisks && NeedToWaitForFieldBeforeHive(EGroupFields::MissingDisks)) {
+            return true;
+        }
+        if (With == EWith::SpaceProblems && NeedToWaitForFieldBeforeHive(EGroupFields::Usage)) {
+            return true;
+        }
+        if (!Filter.empty() && (NeedToWaitForFieldBeforeHive(EGroupFields::PoolName) || NeedToWaitForFieldBeforeHive(EGroupFields::GroupId))) {
+            return true;
+        }
+        if (!FilterGroup.empty() && NeedToWaitForFieldBeforeHive(FilterGroupBy)) {
+            return true;
+        }
+        return false;
+    }
+
+    bool NeedToWaitBeforeCollectingHiveData() const {
+        return NeedToWaitForFilterBeforeHive()
+            || (NeedSort && NeedToWaitForFieldBeforeHive(SortBy))
+            || (NeedGroup && NeedToWaitForFieldBeforeHive(GroupBy));
     }
 
     bool TimeToAskWhiteboard() const {
@@ -1617,7 +1661,8 @@ public:
             }
         }
         if (AreBSControllerRequestsDone()) {
-            if (FieldsNeeded(FieldsHive) && !CollectedHiveData) {
+            ApplyEverything();
+            if (FieldsNeeded(FieldsHive) && !CollectedHiveData && !NeedToWaitBeforeCollectingHiveData()) {
                 CollectHiveData();
             }
             if (FieldsAvailable.test(+EGroupFields::GroupId) && FieldsNeeded(FieldsHive) && NavigateKeySetInFlight == 0 && HiveStorageStatsInFlight == 0) {
@@ -2014,6 +2059,7 @@ public:
     void BSGroupRequestDone() {
         if (--BSGroupStateRequestsInFlight == 0) {
             ProcessWhiteboardGroups();
+            ProcessResponses();
         }
         RequestDone();
     }
@@ -2022,6 +2068,7 @@ public:
         --VDiskStateRequestsInFlight;
         if (VDiskStateRequestsInFlight == 0 && PDiskStateRequestsInFlight == 0) {
             ProcessWhiteboardDisks();
+            ProcessResponses();
         }
         RequestDone();
     }
@@ -2030,6 +2077,7 @@ public:
         --PDiskStateRequestsInFlight;
         if (VDiskStateRequestsInFlight == 0 && PDiskStateRequestsInFlight == 0) {
             ProcessWhiteboardDisks();
+            ProcessResponses();
         }
         RequestDone();
     }


### PR DESCRIPTION
Fixes #40554

Summary:
- defer Hive storage stats collection for `/storage/groups` until pending non-Hive filter/sort/group dependencies are available, including whiteboard-backed `MaxVDiskSlotUsage`
- resume response processing after whiteboard group/disk data is collected so deferred Hive requests are started before the handler replies
- add a `viewer/tests` regression smoke for sorting by `MaxVDiskSlotUsage` with and without `AllocationUnits` requested

Tests:
- `git diff --check -- ydb/core/viewer/viewer_groups.h ydb/core/viewer/tests/test.py ydb/core/viewer/tests/canondata/result.json`
- `./ya make --build relwithdebinfo -tA ydb/core/viewer/tests -F '*test_viewer_groups_sort_by_vdisk_slot_usage_with_allocation_units*' 2>&1 | tail -80`
- `./ya make --build relwithdebinfo -tA ydb/core/viewer/tests -F '*test_storage_groups*' 2>&1 | tail`
- `./ya make --build relwithdebinfo -tA ydb/core/viewer/ut -F '*StorageGroup*' 2>&1 | tail`