### PR TITLE
[Backport stable-26-1-1] PR #35735: enhance error handling for invalid acl change

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -374,7 +374,7 @@ bool TViewerPipeClient::IsSuccess(const TEvTxUserProxy::TEvProposeTransactionSta
 }
 
 TString TViewerPipeClient::GetError(const TEvTxUserProxy::TEvProposeTransactionStatus& ev) {
-    return TStringBuilder() << ev.Record.GetStatus();
+    return TStringBuilder() << NTxProxy::TResultStatus::Str(static_cast<NTxProxy::TResultStatus::EStatus>(ev.Record.GetStatus()));
 }
 
 bool TViewerPipeClient::IsSuccess(const NKqp::TEvGetScriptExecutionOperationResponse& ev) {
@@ -874,6 +874,22 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     return response;
 }
 
+TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> TViewerPipeClient::MakeRequestSchemeCacheNavigateWithoutToken(TPathId pathId, ui64 cookie) {
+    THolder<NSchemeCache::TSchemeCacheNavigate> request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+    NSchemeCache::TSchemeCacheNavigate::TEntry entry;
+    entry.TableId.PathId = pathId;
+    entry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
+    entry.RedirectRequired = false;
+    entry.ShowPrivatePath = true;
+    entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
+    request->ResultSet.emplace_back(entry);
+    auto response = MakeRequest<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release()), 0 /*flags*/, cookie);
+    if (response.Span) {
+        response.Span.Attribute("path_id", pathId.ToString());
+    }
+    return response;
+}
+
 TViewerPipeClient::TRequestResponse<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>
     TViewerPipeClient::MakeRequestSchemeShardDescribe(TTabletId schemeShardId, const TString& path, const NKikimrSchemeOp::TDescribeOptions& options, ui64 cookie) {
     auto request = std::make_unique<NSchemeShard::TEvSchemeShard::TEvDescribeScheme>();
@@ -1174,9 +1190,17 @@ void TViewerPipeClient::HandleResolveResource(TEvTxProxySchemeCache::TEvNavigate
             ResourceBoardInfoResponse = MakeRequestStateStorageEndpointsLookup(SharedDatabase);
             --DataRequests; // don't count this request
         } else {
-            AddEvent("Failed to resolve database - shared database not found");
-            Direct = true;
-            Bootstrap(); // retry bootstrap without redirect this time
+            if (CheckDatabase) {
+                if (ResourceNavigateResponse->GetError() == "AccessDenied") {
+                    ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Forbidden"), ResourceNavigateResponse->GetError());
+                } else {
+                    ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Failed to resolve shared database"), ResourceNavigateResponse->GetError());
+                }
+            } else {
+                AddEvent("Failed to resolve database - shared database not found");
+                Direct = true;
+                Bootstrap(); // retry bootstrap without redirect this time
+            }
         }
     }
 }
@@ -1187,7 +1211,9 @@ void TViewerPipeClient::HandleResolveDatabase(TEvTxProxySchemeCache::TEvNavigate
         if (DatabaseNavigateResponse->IsOk()) {
             TSchemeCacheNavigate::TEntry& entry(DatabaseNavigateResponse->Get()->Request->ResultSet.front());
             if (entry.DomainInfo && entry.DomainInfo->ResourcesDomainKey && entry.DomainInfo->DomainKey != entry.DomainInfo->ResourcesDomainKey) {
-                ResourceNavigateResponse = MakeRequestSchemeCacheNavigate(TPathId(entry.DomainInfo->ResourcesDomainKey));
+                // we successfully resolved serverless database using user's token, now resolve shared database without token
+                // because users of serverless databases don't have direct access to shared database
+                ResourceNavigateResponse = MakeRequestSchemeCacheNavigateWithoutToken(TPathId(entry.DomainInfo->ResourcesDomainKey));
                 --DataRequests; // don't count this request
                 Become(&TViewerPipeClient::StateResolveResource);
             } else {
@@ -1196,9 +1222,17 @@ void TViewerPipeClient::HandleResolveDatabase(TEvTxProxySchemeCache::TEvNavigate
                 --DataRequests; // don't count this request
             }
         } else {
-            AddEvent("Failed to resolve database - not found");
-            Direct = true;
-            Bootstrap(); // retry bootstrap without redirect this time
+            if (CheckDatabase) {
+                if (DatabaseNavigateResponse->GetError() == "AccessDenied") {
+                    ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Forbidden"), DatabaseNavigateResponse->GetError());
+                } else {
+                    ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Failed to resolve database"), DatabaseNavigateResponse->GetError());
+                }
+            } else {
+                AddEvent("Failed to resolve database - not found");
+                Direct = true;
+                Bootstrap(); // retry bootstrap without redirect this time
+            }
         }
     }
 }
@@ -1257,6 +1291,7 @@ void TViewerPipeClient::RedirectToDatabase(const TString& database) {
 
 bool TViewerPipeClient::NeedToRedirect(bool checkDatabaseAuth) {
     auto request = GetRequest();
+    CheckDatabase = checkDatabaseAuth;
     if (NeedRedirect && request) {
         NeedRedirect = false;
         Direct |= !request.GetHeader("X-Forwarded-From-Node").empty(); // we're already forwarding

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -48,6 +48,7 @@ protected:
     bool PassedAway = false;
     bool ReplySent = false;
     bool UseCache = false;
+    bool CheckDatabase = true;
     TDuration CachedDataMaxAge;
     TString Error;
     i32 MaxRequestsInFlight = 200;
@@ -322,6 +323,7 @@ protected:
 
     [[nodiscard]] TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> MakeRequestSchemeCacheNavigate(const TString& path, ui64 cookie = 0);
     [[nodiscard]] TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> MakeRequestSchemeCacheNavigate(TPathId pathId, ui64 cookie = 0);
+    [[nodiscard]] TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> MakeRequestSchemeCacheNavigateWithoutToken(TPathId pathId, ui64 cookie = 0);
     [[nodiscard]] TRequestResponse<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult> MakeRequestSchemeShardDescribe(TTabletId schemeShardId, const TString& path, const NKikimrSchemeOp::TDescribeOptions& options = {}, ui64 cookie = 0);
     [[nodiscard]] TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> MakeRequestSchemeCacheNavigateWithToken(
         const TString& path, ui32 access, ui64 cookie = 0);

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -3085,6 +3085,10 @@
             }
         }
     ],
+    "test.TestViewer.test_viewer_acl_write_invalid": {
+        "status_code": 403,
+        "text": "<html><body><h1>403 Forbidden</h1><p><main>: Error: Token is not in correct format\n</p></body></html>"
+    },
     "test.TestViewer.test_viewer_autocomplete": {
         "/Root": {
             "Result": {
@@ -13102,6 +13106,7 @@
             }
         ]
     },
+    "test.TestViewer.test_waiting_for_cluster_ready": {},
     "test.TestViewer.test_whoami_database": {
         "status_code": 403,
         "text": "<html><body><h1>403 Forbidden</h1></body></html>"

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -327,6 +327,10 @@ class TestViewer(object):
         print('Wait for cluster to be ready took %s seconds' % wait_time)
 
     @classmethod
+    def test_waiting_for_cluster_ready(cls):
+        return {}
+
+    @classmethod
     def test_whoami_root(cls):
         return cls.get_viewer_normalized("/viewer/whoami")
 
@@ -820,6 +824,20 @@ class TestViewer(object):
                 'database': cls.dedicated_db,
                 'path': cls.dedicated_db
             })]
+
+    @classmethod
+    def test_viewer_acl_write_invalid(cls):
+        return cls.post_viewer("/viewer/acl", {
+            'database': cls.dedicated_db,
+            'path': cls.dedicated_db
+        }, headers={
+            'Cookie': 'ydb_session_id=XXX',
+        }, body={
+            'AddAccess': [{
+                'Subject': 'userX',
+                'AccessRights': ['Full']
+            }]
+        })
 
     @classmethod
     def test_viewer_autocomplete(cls):

--- a/ydb/core/viewer/viewer_acl.h
+++ b/ydb/core/viewer/viewer_acl.h
@@ -354,6 +354,12 @@ public:
                         return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Invalid path"));
                     }
                 }
+            } else {
+                if (CacheResult.GetError() == "AccessDenied") {
+                    ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Forbidden"), CacheResult.GetError());
+                } else {
+                    ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", CacheResult.GetError()), CacheResult.GetError());
+                }
             }
             RequestDone();
         }
@@ -367,6 +373,12 @@ public:
                 ui64 schemeShardTabletId = record.GetSchemeShardTabletId();
                 auto request = std::make_unique<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>(record.GetTxId());
                 NotifyTxCompletionResult = MakeRequestToTablet<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult>(schemeShardTabletId, request.release());
+            }
+        } else {
+            if (ProposeStatus.GetError() == "AccessDenied") {
+                return ReplyAndPassAway(GETHTTPACCESSDENIED("text/plain", "Forbidden"), ProposeStatus.GetError());
+            } else {
+                return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", ProposeStatus.GetError()), ProposeStatus.GetError());
             }
         }
         RequestDone();

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -490,11 +490,19 @@ Y_UNIT_TEST_SUITE(Viewer) {
         client.CreateUser("/Root", "username", "password");
         client.GrantConnect("username");
 
+        const auto grantStatus = client.Grant("/", "Root", "username", NACLib::EAccessRights::DescribeSchema);
+        UNIT_ASSERT_EQUAL(grantStatus, NMsgBusProxy::MSTATUS_OK);
+
         const auto alterAttrsStatus = client.AlterUserAttributes("/", "Root", {
             { "folder_id", "test_folder_id" },
             { "database_id", "test_database_id" },
         });
         UNIT_ASSERT_EQUAL(alterAttrsStatus, NMsgBusProxy::MSTATUS_OK);
+    }
+
+    void GrantRead(TClient& client) {
+        GrantConnect(client);
+        client.Grant("/", "Root", "username", NACLib::EAccessRights::GenericRead);
     }
 
    TKeepAliveHttpClient::THttpCode PostOffsetCommit(TKeepAliveHttpClient& httpClient,
@@ -535,7 +543,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         server.EnableGRpc(grpcPort);
         TClient client(settings);
         client.InitRootScheme();
-        GrantConnect(client);
+        GrantRead(client);
         client.Grant("/", "Root", "username", NACLib::EAccessRights::GenericWrite);
         client.Grant("/", "Root", "username", NACLib::EAccessRights::GenericRead);
         TKeepAliveHttpClient httpClient("localhost", monPort);


### PR DESCRIPTION
Backport of https://github.com/ydb-platform/ydb/pull/35735 to `stable-26-1-1`.

Original commit cherry-picked with `-x`:
- `397e0d7216f` Enhance error handling and add new request method for scheme cache navigation without token

Conflict resolution:
- `ydb/core/viewer/json_pipe_req.cpp`: kept the stable branch retry fallback for the non-`CheckDatabase` path while applying the new `CheckDatabase` error handling from the original fix.