### PR TITLE
asan fix: accesing counters only from compute actor.

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/composite/yql_pq_composite_read_session.cpp
@@ -787,6 +787,7 @@ public:
         Y_VALIDATE(update(SuspendedPartitions) + update(PendingPartitions) + update(ReadyPartitions) + update(IdlePartitions) == 1, "Unexpected partition state");
 
         RefreshPartitionsState(minReadTimeBefore);
+        UpdateMetrics();
     }
 
     void AdvanceExternalTime(TInstant readTime) final {
@@ -895,8 +896,6 @@ private:
         if (*minReadTimeBefore != GetMinimalLocalReadTime()) {
             MinReadTimeChangedSignal.Signal();
         }
-
-        UpdateMetrics();
     }
 
     void DistributePartitionSession(const TPartitionKey& key) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category 
Not for changelog (changelog entry is not required)

### Description for reviewers 
 #40341

This pull request makes a small adjustment to the `TCompositeTopicReadSession` class to improve when metrics are updated during partition state changes. The main change is moving the call to `UpdateMetrics()` from the end of the `AdvancePartitionState` method to immediately after refreshing the partition state, ensuring metrics are updated at the correct point in the process.

Most important change:

* Moved the call to `UpdateMetrics()` so that metrics are updated right after `RefreshPartitionsState` in the `AdvancePartitionState` method, and removed its previous call location from `AdvanceExternalTime` for more accurate metric reporting. [[1]](diffhunk://#diff-53feeb64c5a56fbaf5108f1a4a9d62da4835758570fb0f05fa438a96f9c5d7faR790) [[2]](diffhunk://#diff-53feeb64c5a56fbaf5108f1a4a9d62da4835758570fb0f05fa438a96f9c5d7faL898-L899)those who read this PR -->

...
