### PR TITLE
26-1: schemeshard: optimize split/merge in-memory update

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -465,6 +465,12 @@ enum ECumulativeCounters {
     COUNTER_FORCED_COMPACTION_LOANED = 139        [(CounterOpts) = {Name: "ForcedCompactionLoaned"}];
 
     COUNTER_FINISHED_OPS_TxPrepareIndexValidation = 140 [(CounterOpts) = {Name: "FinishedOps/PrepareIndexValidation"}];
+
+    // Partitions skipped (not rewritten) during split/merge due to partial persistence.
+    // Together with COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN, gives the savings ratio.
+    COUNTER_SPLIT_MERGE_PARTITIONS_SKIPPED  = 141 [(CounterOpts) = {Name: "SplitMergePartitionsSkipped"}];
+    // Partitions actually rewritten during split/merge (those at or after the split point).
+    COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN = 142 [(CounterOpts) = {Name: "SplitMergePartitionsRewritten"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -285,5 +285,7 @@ message TFeatureFlags {
     optional bool EnableNodeShutdownHints = 257 [default = false];
     optional bool ForbidDiscoveryInnerDbPaths = 259 [default = false];
     optional bool EnableStreamingQueryDisposition = 260 [default = false];
+    // Skip persisting partition rows that are not affected by a split/merge operation.
+    optional bool EnableSplitMergePartialPersistence = 261 [default = true];
     optional bool EnableLocalMinMaxIndex = 262 [default = false];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.cpp
@@ -479,10 +479,8 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
                 continue;
             }
 
-            const auto& shardToPartition = tableInfo->GetShard2PartitionIdx();
-            Y_ABORT_UNLESS(shardToPartition.contains(shardIdx));
-            const ui64 partitionIdx = shardToPartition.at(shardIdx);
-            Y_ABORT_UNLESS(partitionIdx < tableInfo->GetPartitions().size());
+            const TTableShardInfo* partition = tableInfo->GetPartitionStore().FindPtr(shardIdx);
+            Y_ABORT_UNLESS(partition);
 
             TDuration next = ProcessCondEraseResponse(ctx, tablePathId, tableInfo, shardIdx, record, now);
 
@@ -493,7 +491,7 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
                 });
                 it->second.AffectedShards.emplace_back(TCondEraseAffectedShard{
                     .ShardIdx = shardIdx,
-                    .PartitionIdx = partitionIdx,
+                    .Partition = partition,
                     .TabletId = tabletId,
                     .Next = next,
                 });
@@ -505,7 +503,7 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
             const auto& tableInfo = item.TableInfo;
             for (const auto& i : item.AffectedShards) {
                 {
-                    const auto& lag = tableInfo->GetPartitions().at(i.PartitionIdx).LastCondEraseLag;
+                    const auto& lag = i.Partition->LastCondEraseLag;
                     if (lag) {
                         Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
                     } else {
@@ -517,7 +515,7 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
                 tableInfo->UpdateNextCondErase(i.ShardIdx, now, i.Next);
 
                 {
-                    const auto& lag = tableInfo->GetPartitions().at(i.PartitionIdx).LastCondEraseLag;
+                    const auto& lag = i.Partition->LastCondEraseLag;
                     Y_ABORT_UNLESS(lag.Defined());
                     Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
                 }
@@ -530,7 +528,9 @@ struct TSchemeShard::TTxScheduleConditionalErase : public TTransactionBase<TSche
             const auto& tableInfo = item.TableInfo;
             const auto& affectedShards = item.AffectedShards;
             for (const auto& i : affectedShards) {
-                Self->PersistTablePartitionCondErase(db, tablePathId, i.PartitionIdx, tableInfo);
+                Self->PersistTablePartitionCondErase(db, tablePathId, i.Partition, tableInfo);
+                //NOTE: i.Partition TTableShardInfo pointer is used (and should be used)
+                // only within Execute(), this is the last reference
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
+++ b/ydb/core/tx/schemeshard/schemeshard__conditional_erase.h
@@ -12,7 +12,7 @@ namespace NKikimr::NSchemeShard {
 
 struct TCondEraseAffectedShard {
     TShardIdx ShardIdx;
-    ui64 PartitionIdx;
+    const TTableShardInfo* Partition;
     TTabletId TabletId;
     TDuration Next;
 };

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2474,7 +2474,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 const ui64 partitionId = rowSet.GetValue<Schema::TablePartitionStats::PartitionId>();
                 Y_ABORT_UNLESS(partitionId < tableInfo->GetPartitions().size());
 
-                const TShardIdx shardIdx = tableInfo->GetPartitions()[partitionId].ShardIdx;
+                const TShardIdx shardIdx = tableInfo->GetPartitions()[partitionId]->ShardIdx;
                 Y_ABORT_UNLESS(shardIdx != InvalidShardIdx);
 
                 if (Self->ShardInfos.contains(shardIdx)) {

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -1356,7 +1356,7 @@ private:
                                     str << "path is dropped or is not a table";
                                 } else {
                                     const TTableInfo::TPtr table = Self->Tables.at(pathId);
-                                    str << (table->GetShard2PartitionIdx().contains(shardIdx) ? "Active" : "Inactive");
+                                    str << (table->GetPartitionStore().contains(shardIdx) ? "Active" : "Inactive");
                                 }
                             }
                         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
@@ -192,9 +192,9 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
         boundaries.reserve(partitions.size() - 1);
 
         for (ui32 i = 0; i < partitions.size(); ++i) {
-            const auto& partition = partitions.at(i);
+            const auto* partition = partitions.at(i);
             if (i != partitions.size() - 1) {
-                boundaries.push_back(partition.EndOfRange);
+                boundaries.push_back(partition->EndOfRange);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -190,9 +190,8 @@ void PrepareChanges(TOperationId opId, TPathElement::TPtr path, TTableInfo::TPtr
             ? TTxState::CreateParts
             : TTxState::ConfigureParts;
 
-    txState.Shards.reserve(table->GetPartitions().size());
-    for (const auto& shard : table->GetPartitions()) {
-        auto shardIdx = shard.ShardIdx;
+    txState.Shards.reserve(table->GetPartitionStore().size());
+    for (auto& [shardIdx, shard] : table->GetPartitionStore()) {
         TShardInfo& shardInfo = context.SS->ShardInfos[shardIdx];
 
         auto shardOp = commonShardOp;
@@ -392,9 +391,10 @@ public:
         if (table->IsTTLEnabled() && ttlIt == context.SS->TTLEnabledTables.end()) {
             context.SS->TTLEnabledTables[pathId] = table;
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
+            table->ScheduleAllCondErase();
 
             const auto now = context.Ctx.Now();
-            for (auto& shard : table->GetPartitions()) {
+            for (const auto& [_, shard] : table->GetPartitionStore()) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
@@ -404,8 +404,9 @@ public:
         } else if (!table->IsTTLEnabled() && ttlIt != context.SS->TTLEnabledTables.end()) {
             context.SS->TTLEnabledTables.erase(ttlIt);
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Sub(1);
+            table->ClearCondEraseSchedule();
 
-            for (auto& shard : table->GetPartitions()) {
+            for (const auto& [_, shard] : table->GetPartitionStore()) {
                 if (auto& lag = shard.LastCondEraseLag) {
                     context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
                     lag.Clear();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
@@ -246,9 +246,9 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
             boundaries.reserve(partitions.size() - 1);
 
             for (ui32 i = 0; i < partitions.size(); ++i) {
-                const auto& partition = partitions.at(i);
+                const auto* partition = partitions.at(i);
                 if (i != partitions.size() - 1) {
-                    boundaries.push_back(partition.EndOfRange);
+                    boundaries.push_back(partition->EndOfRange);
                 }
             }
 
@@ -295,9 +295,9 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
                         const auto& indexPartitions = indexTable->GetPartitions();
                         indexBoundaries.reserve(indexPartitions.size() - 1);
                         for (ui32 i = 0; i < indexPartitions.size(); ++i) {
-                            const auto& partition = indexPartitions.at(i);
+                            const auto* partition = indexPartitions.at(i);
                             if (i != indexPartitions.size() - 1) {
-                                indexBoundaries.push_back(partition.EndOfRange);
+                                indexBoundaries.push_back(partition->EndOfRange);
                             }
                         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_restore_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_restore_common.h
@@ -233,7 +233,7 @@ public:
             }
         }
     }
-    
+
     static void CollectStats(TOperationId operationId, const TEvColumnShard::TEvNotifyTxCompletionResult::TPtr& ev, TOperationContext& context) {
         const auto& evRecord = ev->Get()->Record;
         if (!evRecord.HasOpResult() || !evRecord.GetOpResult().HasSuccess()) {
@@ -664,9 +664,8 @@ public:
         TTxState& txState = context.SS->CreateTx(OperationId, TxType, path->PathId);
 
         txState.Shards.reserve(table->GetPartitions().size());
-        for (const auto& shard : table->GetPartitions()) {
-            auto shardIdx = shard.ShardIdx;
-            txState.Shards.emplace_back(shardIdx, ETabletType::DataShard, TTxState::ConfigureParts);
+        for (const auto* shard : table->GetPartitions()) {
+            txState.Shards.emplace_back(shard->ShardIdx, ETabletType::DataShard, TTxState::ConfigureParts);
         }
 
         NIceDb::TNiceDb db(context.GetDB());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -735,8 +735,8 @@ bool CheckPartitioningChangedForTableModificationImpl(TTxState &txState, TOperat
     TTableInfo::TPtr table = context.SS->Tables.at(txState.TargetPathId);
 
     THashSet<TShardIdx> shardIdxsLeft;
-    for (auto& shard : table->GetPartitions()) {
-        shardIdxsLeft.insert(shard.ShardIdx);
+    for (const auto* shard : table->GetPartitions()) {
+        shardIdxsLeft.insert(shard->ShardIdx);
     }
 
     for (auto& shardOp : txState.Shards) {
@@ -863,8 +863,8 @@ void UpdatePartitioningForTableModification(TOperationId operationId, TTxState &
     }
 
     // Fill new list of tx shards
-    for (auto& shard : table->GetPartitions()) {
-        auto shardIdx = shard.ShardIdx;
+    for (const auto* shard : table->GetPartitions()) {
+        auto shardIdx = shard->ShardIdx;
         Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shardIdx));
         auto& shardInfo = context.SS->ShardInfos.at(shardIdx);
 
@@ -908,8 +908,8 @@ bool SourceTablePartitioningChangedForCopyTable(const TTxState &txState, TOperat
     const TTableInfo::TPtr srcTableInfo = *context.SS->Tables.FindPtr(txState.SourcePathId);
 
     THashSet<TShardIdx> srcShardIdxsLeft;
-    for (const auto& p : srcTableInfo->GetPartitions()) {
-        srcShardIdxsLeft.insert(p.ShardIdx);
+    for (const auto* p : srcTableInfo->GetPartitions()) {
+        srcShardIdxsLeft.insert(p->ShardIdx);
     }
 
     for (const auto& shard : txState.Shards) {
@@ -957,7 +957,6 @@ void UpdatePartitioningForCopyTable(TOperationId operationId, TTxState &txState,
             context.SS->ShardInfos.erase(shard.Idx);
             domainInfo->RemoveInternalShard(shard.Idx, context.SS);
             context.SS->DecrementPathDbRefCount(pathId, "remove shard from txState");
-            context.SS->OnShardRemoved(shard.Idx);
         }
     }
     txState.Shards.clear();
@@ -1006,7 +1005,7 @@ void UpdatePartitioningForCopyTable(TOperationId operationId, TTxState &txState,
     for (const auto& part : newPartitioning) {
         newShardsIdx.push_back(part.ShardIdx);
     }
-    context.SS->SetPartitioning(txState.TargetPathId, dstTableInfo, std::move(newPartitioning));
+    context.SS->CopyPartitioning(txState.TargetPathId, dstTableInfo, std::move(newPartitioning));
     if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
         context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
     }
@@ -1022,15 +1021,15 @@ void UpdatePartitioningForCopyTable(TOperationId operationId, TTxState &txState,
     context.SS->PersistUpdateNextPathId(db);
     context.SS->PersistUpdateNextShardIdx(db);
     // Persist new shards info
-    for (const auto& shard : dstTableInfo->GetPartitions()) {
-        Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.ShardIdx), "shard info is set before");
-        const auto tabletType = context.SS->ShardInfos[shard.ShardIdx].TabletType;
-        context.SS->PersistShardMapping(db, shard.ShardIdx, InvalidTabletId, txState.TargetPathId, operationId.GetTxId(), tabletType);
-        context.SS->PersistChannelsBinding(db, shard.ShardIdx, channelsBinding);
+    for (const auto* shard : dstTableInfo->GetPartitions()) {
+        Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard->ShardIdx), "shard info is set before");
+        const auto tabletType = context.SS->ShardInfos[shard->ShardIdx].TabletType;
+        context.SS->PersistShardMapping(db, shard->ShardIdx, InvalidTabletId, txState.TargetPathId, operationId.GetTxId(), tabletType);
+        context.SS->PersistChannelsBinding(db, shard->ShardIdx, channelsBinding);
 
         if (storePerShardConfig) {
-            dstTableInfo->PerShardPartitionConfig[shard.ShardIdx].CopyFrom(perShardConfig);
-            context.SS->PersistAddTableShardPartitionConfig(db, shard.ShardIdx, perShardConfig);
+            dstTableInfo->PerShardPartitionConfig[shard->ShardIdx].CopyFrom(perShardConfig);
+            context.SS->PersistAddTableShardPartitionConfig(db, shard->ShardIdx, perShardConfig);
         }
     }
 
@@ -1038,14 +1037,22 @@ void UpdatePartitioningForCopyTable(TOperationId operationId, TTxState &txState,
 }
 
 TVector<TTableShardInfo> ApplyPartitioningCopyTable(const TShardInfo &templateDatashardInfo, TTableInfo::TPtr srcTableInfo, TTxState &txState, TSchemeShard *ss) {
-    TVector<TTableShardInfo> dstPartitions = srcTableInfo->GetPartitions();
+    // Build a mutable copy of src partitions for the dst table.
+    TVector<TTableShardInfo> dstPartitions;
+    {
+        const auto& srcParts = srcTableInfo->GetPartitions();
+        dstPartitions.reserve(srcParts.size());
+        for (const auto* p : srcParts) {
+            dstPartitions.push_back(*p);
+        }
+    }
 
     // Source table must not be altered or drop while we are performing copying. So we put it into a special state.
     ui64 count = dstPartitions.size();
     txState.Shards.reserve(count*2);
     for (ui64 i = 0; i < count; ++i) {
         // Source shards need to get "Send parts" transaction
-        auto srcShardIdx = srcTableInfo->GetPartitions()[i].ShardIdx;
+        auto srcShardIdx = srcTableInfo->GetPartitions()[i]->ShardIdx;
         Y_ABORT_UNLESS(ss->ShardInfos.contains(srcShardIdx), "Source table shard not found");
         auto srcTabletId = ss->ShardInfos[srcShardIdx].TabletID;
         Y_ABORT_UNLESS(srcTabletId != InvalidTabletId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_pq.cpp
@@ -465,21 +465,21 @@ bool TConfigureParts::ProgressState(TOperationContext& context) {
         const auto& partitions = table->GetPartitions();
 
         for (ui32 i = 0; i < partitions.size(); ++i) {
-            const auto& cur = partitions.at(i);
+            const auto* cur = partitions.at(i);
 
-            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(cur.ShardIdx));
-            const auto& shard = context.SS->ShardInfos.at(cur.ShardIdx);
+            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(cur->ShardIdx));
+            const auto& shard = context.SS->ShardInfos.at(cur->ShardIdx);
 
             auto& mg = *bootstrapConfig->AddExplicitMessageGroups();
             mg.SetId(NPQ::NSourceIdEncoding::EncodeSimple(ToString(shard.TabletID)));
 
             if (i != partitions.size() - 1) {
-                mg.MutableKeyRange()->SetToBound(cur.EndOfRange);
+                mg.MutableKeyRange()->SetToBound(cur->EndOfRange);
             }
 
             if (i) {
-                const auto& prev = partitions.at(i - 1);
-                mg.MutableKeyRange()->SetFromBound(prev.EndOfRange);
+                const auto* prev = partitions.at(i - 1);
+                mg.MutableKeyRange()->SetFromBound(prev->EndOfRange);
             }
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -84,10 +84,10 @@ public:
         const ui64 dstSchemaVersion = NEW_TABLE_ALTER_VERSION;
 
         for (ui32 i = 0; i < dstTableInfo->GetPartitions().size(); ++i) {
-            TShardIdx srcShardIdx = srcTableInfo->GetPartitions()[i].ShardIdx;
+            TShardIdx srcShardIdx = srcTableInfo->GetPartitions()[i]->ShardIdx;
             TTabletId srcDatashardId = context.SS->ShardInfos[srcShardIdx].TabletID;
 
-            TShardIdx dstShardIdx = dstTableInfo->GetPartitions()[i].ShardIdx;
+            TShardIdx dstShardIdx = dstTableInfo->GetPartitions()[i]->ShardIdx;
             TTabletId dstDatashardId = context.SS->ShardInfos[dstShardIdx].TabletID;
 
             auto seqNo = context.SS->StartRound(*txState);
@@ -257,7 +257,7 @@ public:
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
 
             const auto now = context.Ctx.Now();
-            for (auto& shard : table->GetPartitions()) {
+            for (const auto& [_, shard] : table->GetPartitionStore()) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
@@ -848,14 +848,14 @@ public:
         if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
             context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
         }
-        for (const auto& shard : tableInfo->GetPartitions()) {
-            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.ShardIdx), "shard info is set before");
+        for (const auto& [shardIdx, shard] : tableInfo->GetPartitionStore()) {
+            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shardIdx), "shard info is set before");
             if (storePerShardConfig) {
-                tableInfo->PerShardPartitionConfig[shard.ShardIdx].CopyFrom(perShardConfig);
+                tableInfo->PerShardPartitionConfig[shardIdx].CopyFrom(perShardConfig);
             }
         }
 
-        Y_ABORT_UNLESS(tableInfo->GetPartitions().back().EndOfRange.empty(), "End of last range must be +INF");
+        Y_ABORT_UNLESS(tableInfo->GetPartitions().back()->EndOfRange.empty(), "End of last range must be +INF");
 
         context.SS->Tables[newTable->PathId] = tableInfo;
         context.SS->IncrementPathDbRefCount(newTable->PathId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -887,9 +887,9 @@ bool FillBoundaries(const TTableInfo& table, const NKikimrSchemeOp::TCreateCdcSt
         boundaries.reserve(partitions.size() - 1);
 
         for (ui32 i = 0; i < partitions.size(); ++i) {
-            const auto& partition = partitions.at(i);
+            const auto* partition = partitions.at(i);
             if (i != partitions.size() - 1) {
-                boundaries.push_back(partition.EndOfRange);
+                boundaries.push_back(partition->EndOfRange);
             }
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
@@ -58,9 +58,9 @@ TVector<ISubOperation::TPtr> CreateNewContinuousBackup(TOperationId opId, const 
     boundaries.reserve(partitions.size() - 1);
 
     for (ui32 i = 0; i < partitions.size(); ++i) {
-        const auto& partition = partitions.at(i);
+        const auto* partition = partitions.at(i);
         if (i != partitions.size() - 1) {
-            boundaries.push_back(partition.EndOfRange);
+            boundaries.push_back(partition->EndOfRange);
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -324,7 +324,7 @@ public:
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
 
             const auto now = context.Ctx.Now();
-            for (auto& shard : table->GetPartitions()) {
+            for (const auto& [_, shard] : table->GetPartitionStore()) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
@@ -692,7 +692,7 @@ public:
 
         ApplyPartitioning(OperationId.GetTxId(), newTable->PathId, tableInfo, txState, channelsBinding, context.SS, partitions);
 
-        Y_ABORT_UNLESS(tableInfo->GetPartitions().back().EndOfRange.empty(), "End of last range must be +INF");
+        Y_ABORT_UNLESS(tableInfo->GetPartitions().back()->EndOfRange.empty(), "End of last range must be +INF");
 
         if (tableInfo->IsAsyncReplica()) {
             newTable->SetAsyncReplica(true);
@@ -726,16 +726,16 @@ public:
         context.SS->PersistUpdateNextPathId(db);
         context.SS->PersistUpdateNextShardIdx(db);
         // Persist new shards info
-        for (const auto& shard : tableInfo->GetPartitions()) {
-            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shard.ShardIdx), "shard info is set before");
-            auto tabletType = context.SS->ShardInfos[shard.ShardIdx].TabletType;
-            const auto& bindedChannels = context.SS->ShardInfos[shard.ShardIdx].BindedChannels;
-            context.SS->PersistShardMapping(db, shard.ShardIdx, InvalidTabletId, newTable->PathId, OperationId.GetTxId(), tabletType);
-            context.SS->PersistChannelsBinding(db, shard.ShardIdx, bindedChannels);
+        for (const auto& [shardIdx, shard] : tableInfo->GetPartitionStore()) {
+            Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shardIdx), "shard info is set before");
+            auto tabletType = context.SS->ShardInfos[shardIdx].TabletType;
+            const auto& bindedChannels = context.SS->ShardInfos[shardIdx].BindedChannels;
+            context.SS->PersistShardMapping(db, shardIdx, InvalidTabletId, newTable->PathId, OperationId.GetTxId(), tabletType);
+            context.SS->PersistChannelsBinding(db, shardIdx, bindedChannels);
 
             if (storePerShardConfig) {
-                tableInfo->PerShardPartitionConfig[shard.ShardIdx].CopyFrom(perShardConfig);
-                context.SS->PersistAddTableShardPartitionConfig(db, shard.ShardIdx, perShardConfig);
+                tableInfo->PerShardPartitionConfig[shardIdx].CopyFrom(perShardConfig);
+                context.SS->PersistAddTableShardPartitionConfig(db, shardIdx, perShardConfig);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
@@ -584,8 +584,8 @@ public:
         Y_ABORT_UNLESS(context.SS->Tables.contains(path.Base()->PathId));
         TTableInfo::TPtr table = context.SS->Tables.at(path.Base()->PathId);
         Y_ABORT_UNLESS(table->GetPartitions().size());
-        for (auto& shard : table->GetPartitions()) {
-            auto shardIdx = shard.ShardIdx;
+        for (const auto* shard : table->GetPartitions()) {
+            auto shardIdx = shard->ShardIdx;
             context.MemChanges.GrabShard(context.SS, shardIdx);
             context.DbChanges.PersistShard(shardIdx);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_incremental_restore_finalize.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_incremental_restore_finalize.cpp
@@ -113,8 +113,8 @@ class TIncrementalRestoreFinalizeOp: public TSubOperationWithContext {
                 // which runs after coordinator confirmation, ensuring consistency if datashard proposals fail.
 
                 // Add all shards of this table to txState
-                for (const auto& shard : table->GetPartitions()) {
-                    auto shardIdx = shard.ShardIdx;
+                for (const auto* shard : table->GetPartitions()) {
+                    auto shardIdx = shard->ShardIdx;
                     if (!txState->ShardsInProgress.contains(shardIdx)) {
                         txState->Shards.emplace_back(shardIdx, ETabletType::DataShard, TTxState::ConfigureParts);
                         txState->ShardsInProgress.insert(shardIdx);
@@ -141,8 +141,8 @@ class TIncrementalRestoreFinalizeOp: public TSubOperationWithContext {
                 TPathId tablePathId;
                 for (const auto& pathId : implTablesToUpdate) {
                     auto table = context.SS->Tables.at(pathId);
-                    for (const auto& partition : table->GetPartitions()) {
-                        if (partition.ShardIdx == shardIdx) {
+                    for (const auto* partition : table->GetPartitions()) {
+                        if (partition->ShardIdx == shardIdx) {
                             tablePathId = pathId;
                             break;
                         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -83,8 +83,8 @@ public:
             if (srcPath->IsTable()) {
                 const auto& srcTable = context.SS->Tables.at(srcPath->PathId);
                 shardIdxs.reserve(srcTable->GetPartitions().size());
-                for (const auto& shard : srcTable->GetPartitions()) {
-                    shardIdxs.emplace_back(shard.ShardIdx);
+                for (const auto* shard : srcTable->GetPartitions()) {
+                    shardIdxs.emplace_back(shard->ShardIdx);
                 }
             } else if (srcPath->IsColumnTable()) {
                 const auto& srcTable =context.SS->ColumnTables.GetVerified(srcPath.Base()->PathId);
@@ -282,7 +282,14 @@ public:
             context.SS->Tables[dstPath.Base()->PathId] = tableInfo;
             context.SS->PersistTable(db, dstPath.Base()->PathId);
             context.SS->PersistTablePartitionStats(db, dstPath.Base()->PathId, tableInfo);
-            context.SS->SetPartitioning(dstPath.Base()->PathId, tableInfo, TVector<TTableShardInfo>(tableInfo->GetPartitions()));
+            {
+                TVector<TTableShardInfo> newParts;
+                newParts.reserve(tableInfo->GetPartitions().size());
+                for (const auto* p : tableInfo->GetPartitions()) {
+                    newParts.push_back(*p);
+                }
+                context.SS->MovePartitioning(dstPath.Base()->PathId, tableInfo, std::move(newParts));
+            }
         } else if (srcPath->IsColumnTable()) {
             auto srcTable = context.SS->ColumnTables.GetVerified(srcPath.Base()->PathId);
             auto tableInfo = context.SS->ColumnTables.BuildNew(dstPath.Base()->PathId, srcTable.GetPtr());
@@ -505,9 +512,9 @@ public:
                 context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
 
                 const auto now = context.Ctx.Now();
-                for (auto& shard : tableInfo->GetPartitions()) {
-                    auto& lag = shard.LastCondEraseLag;
-                    lag = now - shard.LastCondErase;
+                for (auto* shard : tableInfo->GetPartitions()) {
+                    auto& lag = shard->LastCondEraseLag;
+                    lag = now - shard->LastCondErase;
                     context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
@@ -204,7 +204,8 @@ public:
         LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                    DebugHint() << " HandleReply TEvSplitAck"
                                << ", at schemeshard: " << ssId
-                               << ", message: " << ev->Get()->Record.ShortDebugString());
+                               << ", OperationCookie: " << ev->Get()->Record.GetOperationCookie()
+                               << ", TabletId: " << ev->Get()->Record.GetTabletId());
 
         NIceDb::TNiceDb db(context.GetDB());
 
@@ -244,63 +245,68 @@ public:
         Y_ABORT_UNLESS(tableInfo);
 
         // Replace all Src datashard(s) with Dst datashard(s)
-        TVector<TTableShardInfo> newPartitioning;
         TVector<TShardIdx> newShardsIdx;
-        THashSet<TShardIdx> allSrcShardIdxs;
+        TVector<TShardIdx> allSrcShardIdxs;
+        // Pre-build the dst partition list in a single pass over txState->Shards.
+        TVector<TTableShardInfo> dstPartitions;
+        const auto now = context.Ctx.Now();
         for (const auto& txShard : txState->Shards) {
-            if (txShard.Operation == TTxState::TransferData)
-                allSrcShardIdxs.insert(txShard.Idx);
+            if (txShard.Operation == TTxState::TransferData) {
+                allSrcShardIdxs.push_back(txShard.Idx);
+            } else if (txShard.Operation == TTxState::CreateParts) {
+                //NOTE: proper dst order in txState->Shards is determined at operation start
+                // and preserved schemeshard restarts
+                Y_ABORT_UNLESS(context.SS->ShardInfos.contains(txShard.Idx));
+                TTableShardInfo dst(txShard.Idx, txShard.RangeEnd);
+                if (tableInfo->IsTTLEnabled()) {
+                    auto& lag = dst.LastCondEraseLag;
+                    Y_DEBUG_ABORT_UNLESS(!lag.Defined());
+                    lag = now - dst.LastCondErase;
+                    context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
+                }
+                newShardsIdx.push_back(dst.ShardIdx);
+                dstPartitions.push_back(std::move(dst));
+            }
         }
 
-        bool dstAdded = false;
-        const auto now = context.Ctx.Now();
-        for (const auto& shard : tableInfo->GetPartitions()) {
-            if (allSrcShardIdxs.contains(shard.ShardIdx)) {
-                if (auto& lag = shard.LastCondEraseLag) {
-                    context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
-                    lag.Clear();
-                }
-
-                if (dstAdded) {
-                    continue;
-                }
-
-                for (const auto& txShard : txState->Shards) {
-                    if (txShard.Operation != TTxState::CreateParts)
-                        continue;
-
-                    // TODO: make sure dst are sorted by range end
-                    Y_ABORT_UNLESS(context.SS->ShardInfos.contains(txShard.Idx));
-                    TTableShardInfo dst(txShard.Idx, txShard.RangeEnd);
-
-                    if (tableInfo->IsTTLEnabled()) {
-                        auto& lag = dst.LastCondEraseLag;
-                        Y_DEBUG_ABORT_UNLESS(!lag.Defined());
-
-                        lag = now - dst.LastCondErase;
-                        context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
+        // Clear TTL lag counters for src shards (O(k) instead of O(N)).
+        if (tableInfo->IsTTLEnabled()) {
+            for (const TShardIdx& srcIdx : allSrcShardIdxs) {
+                if (auto* p = tableInfo->GetPartitionStore().FindPtr(srcIdx)) {
+                    if (auto& lag = p->LastCondEraseLag) {
+                        context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
+                        lag.Clear();
                     }
-
-                    newPartitioning.push_back(dst);
-                    newShardsIdx.push_back(dst.ShardIdx);
                 }
-
-                dstAdded = true;
-            } else {
-                newPartitioning.push_back(shard);
             }
         }
 
         auto oldAggrStats = tableInfo->GetStats().Aggregated;
 
-        // Delete the whole old partitioning and persist the whole new partitioning as the indexes have changed
-        context.SS->PersistTablePartitioningDeletion(db, tableId, tableInfo);
-        context.SS->SetPartitioning(tableId, tableInfo, std::move(newPartitioning));
+        // srcFirstIdx: position of the first src shard in Partitions (O(k) via Position field).
+        ui64 srcFirstIdx = Max<ui64>(); // sentinel — will be overwritten
+        for (const TShardIdx& s : allSrcShardIdxs) {
+            const auto* p = tableInfo->GetPartitionStore().FindPtr(s);
+            Y_ABORT_UNLESS(p);
+            srcFirstIdx = Min(srcFirstIdx, p->Position);
+        }
+        Y_ABORT_UNLESS(srcFirstIdx != Max<ui64>());
+        const ui64 splitStartIdx = AppData()->FeatureFlags.GetEnableSplitMergePartialPersistence()
+            ? srcFirstIdx
+            : 0;
+
+        context.SS->PersistTablePartitioningDeletion(db, tableId, tableInfo, splitStartIdx);
+        context.SS->ApplySplitMerge(tableId, tableInfo, std::move(dstPartitions), allSrcShardIdxs, srcFirstIdx);
         if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
             context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
         }
-        context.SS->PersistTablePartitioning(db, tableId, tableInfo);
-        context.SS->PersistTablePartitionStats(db, tableId, tableInfo);
+        context.SS->PersistTablePartitioning(db, tableId, tableInfo, splitStartIdx);
+        context.SS->PersistTablePartitionStats(db, tableId, tableInfo, splitStartIdx);
+
+        // Partial persistence counters: skipped = [0, splitStartIdx), rewritten = [splitStartIdx, end).
+        const ui64 newPartitionCount = tableInfo->GetPartitions().size();
+        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_SKIPPED].Increment(splitStartIdx);
+        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN].Increment(newPartitionCount - splitStartIdx);
 
         context.SS->TabletCounters->Simple()[COUNTER_TABLE_SHARD_ACTIVE_COUNT].Sub(allSrcShardIdxs.size());
         context.SS->TabletCounters->Simple()[COUNTER_TABLE_SHARD_INACTIVE_COUNT].Add(allSrcShardIdxs.size());
@@ -551,8 +557,8 @@ public:
             ui64 piPrev = srcPartitionIdxs[i-1];
 
             if (pi != piPrev + 1) {
-                auto shardIdx = tableInfo->GetPartitions()[pi].ShardIdx;
-                auto shardIdxPrev = tableInfo->GetPartitions()[piPrev].ShardIdx;
+                auto shardIdx = tableInfo->GetPartitions()[pi]->ShardIdx;
+                auto shardIdxPrev = tableInfo->GetPartitions()[piPrev]->ShardIdx;
 
                 errStr = TStringBuilder()
                     << "Partitions are not consecutive at index " << i << " : #" << piPrev << "(" << context.SS->ShardInfos[shardIdxPrev].TabletID << ")"
@@ -564,7 +570,7 @@ public:
         TString firstRangeBegin;
         if (srcPartitionIdxs[0] != 0) {
             // Take the end of previous shard
-            firstRangeBegin = tableInfo->GetPartitions()[srcPartitionIdxs[0]-1].EndOfRange;
+            firstRangeBegin = tableInfo->GetPartitions()[srcPartitionIdxs[0]-1]->EndOfRange;
         } else {
             TVector<TCell> firstKey;
             ui32 keyColCount = 0;
@@ -583,11 +589,11 @@ public:
         TString prevRangeEnd = firstRangeBegin;
         for (ui64 pi : srcPartitionIdxs) {
             auto* srcRange = op.SplitDescription->AddSourceRanges();
-            auto shardIdx = tableInfo->GetPartitions()[pi].ShardIdx;
+            auto shardIdx = tableInfo->GetPartitions()[pi]->ShardIdx;
             srcRange->SetShardIdx(ui64(shardIdx.GetLocalId()));
             srcRange->SetTabletID(ui64(context.SS->ShardInfos[shardIdx].TabletID));
             srcRange->SetKeyRangeBegin(prevRangeEnd);
-            TString rangeEnd = tableInfo->GetPartitions()[pi].EndOfRange;
+            TString rangeEnd = tableInfo->GetPartitions()[pi]->EndOfRange;
             srcRange->SetKeyRangeEnd(rangeEnd);
             prevRangeEnd = rangeEnd;
         }
@@ -599,7 +605,7 @@ public:
         auto idx = context.SS->RegisterShardInfo(datashardInfo);
 
         ui64 lastSrcPartition = srcPartitionIdxs.back();
-        TString lastRangeEnd = tableInfo->GetPartitions()[lastSrcPartition].EndOfRange;
+        TString lastRangeEnd = tableInfo->GetPartitions()[lastSrcPartition]->EndOfRange;
 
         TTxState::TShardOperation dstShardOp(idx, ETabletType::DataShard, TTxState::CreateParts);
         dstShardOp.RangeEnd = lastRangeEnd;
@@ -631,7 +637,7 @@ public:
             return false;
         }
 
-        auto srcShardIdx = tableInfo->GetPartitions()[srcPartitionIdx].ShardIdx;
+        auto srcShardIdx = tableInfo->GetPartitions()[srcPartitionIdx]->ShardIdx;
         const auto forceShardSplitSettings = context.SS->SplitSettings.GetForceShardSplitSettings();
 
         if (tableInfo->GetExpectedPartitionCount() + count - 1 > tableInfo->GetMaxPartitionsCount() &&
@@ -660,19 +666,19 @@ public:
         }
 
         // Last dst shard ends where src shard used to end
-        rangeEnds.push_back(tableInfo->GetPartitions()[srcPartitionIdx].EndOfRange);
+        rangeEnds.push_back(tableInfo->GetPartitions()[srcPartitionIdx]->EndOfRange);
 
         op.SplitDescription = std::make_shared<NKikimrTxDataShard::TSplitMergeDescription>();
         auto* srcRange = op.SplitDescription->AddSourceRanges();
         srcRange->SetShardIdx(ui64(srcShardIdx.GetLocalId()));
         srcRange->SetTabletID(ui64(context.SS->ShardInfos[srcShardIdx].TabletID));
-        srcRange->SetKeyRangeEnd(tableInfo->GetPartitions()[srcPartitionIdx].EndOfRange);
+        srcRange->SetKeyRangeEnd(tableInfo->GetPartitions()[srcPartitionIdx]->EndOfRange);
 
         // Check that ranges are sorted in ascending order
         TVector<TCell> prevKey;
         if (srcPartitionIdx != 0) {
             // Take the end of previous shard
-            TSerializedCellVec key(tableInfo->GetPartitions()[srcPartitionIdx-1].EndOfRange);
+            TSerializedCellVec key(tableInfo->GetPartitions()[srcPartitionIdx-1]->EndOfRange);
             prevKey.assign(key.GetCells().begin(), key.GetCells().end());
         } else {
             // Or start from (NULL, NULL, .., NULL)
@@ -731,7 +737,7 @@ public:
         TString firstRangeBegin;
         if (srcPartitionIdxs[0] != 0) {
             // Take the end of previous shard
-            firstRangeBegin = tableInfo->GetPartitions()[srcPartitionIdxs[0]-1].EndOfRange;
+            firstRangeBegin = tableInfo->GetPartitions()[srcPartitionIdxs[0]-1]->EndOfRange;
         } else {
             TVector<TCell> firstKey;
             ui32 keyColCount = 0;
@@ -750,11 +756,11 @@ public:
         TString prevRangeEnd = firstRangeBegin;
         for (ui64 pi : srcPartitionIdxs) {
             auto* srcRange = op.SplitDescription->AddSourceRanges();
-            auto shardIdx = tableInfo->GetPartitions()[pi].ShardIdx;
+            auto shardIdx = tableInfo->GetPartitions()[pi]->ShardIdx;
             srcRange->SetShardIdx(ui64(shardIdx.GetLocalId()));
             srcRange->SetTabletID(ui64(context.SS->ShardInfos[shardIdx].TabletID));
             srcRange->SetKeyRangeBegin(prevRangeEnd);
-            TString rangeEnd = tableInfo->GetPartitions()[pi].EndOfRange;
+            TString rangeEnd = tableInfo->GetPartitions()[pi]->EndOfRange;
             srcRange->SetKeyRangeEnd(rangeEnd);
             prevRangeEnd = rangeEnd;
         }
@@ -766,7 +772,7 @@ public:
         auto idx = context.SS->RegisterShardInfo(datashardInfo);
 
         ui64 lastSrcPartition = srcPartitionIdxs.back();
-        TString lastRangeEnd = tableInfo->GetPartitions()[lastSrcPartition].EndOfRange;
+        TString lastRangeEnd = tableInfo->GetPartitions()[lastSrcPartition]->EndOfRange;
 
         TTxState::TShardOperation dstShardOp(idx, ETabletType::DataShard, TTxState::CreateParts);
         dstShardOp.RangeEnd = lastRangeEnd;
@@ -880,7 +886,18 @@ public:
             return result;
         }
 
-        const THashMap<TShardIdx, ui64>& shardIdx2partition = tableInfo->GetShard2PartitionIdx();
+        // Duplication check: no internal path produces duplicates,
+        // but manual request via ydb cli can contain anything.
+        {
+            THashSet<ui64> seen;
+            for (const auto i : info.GetSourceTabletId()) {
+                if (!seen.insert(i).second) {
+                    TString errMsg = TStringBuilder() << "Duplicate SourceTabletId: " << i;
+                    setResultError(NKikimrScheme::StatusInvalidParameter, errMsg);
+                    return result;
+                }
+            }
+        }
 
         TVector<ui64> srcPartitionIdxs;
         i64 totalSrcPartCount = 0;
@@ -903,7 +920,9 @@ public:
                 return result;
             }
 
-            if (!shardIdx2partition.contains(srcShardIdx)) {
+            const auto* partition = tableInfo->GetPartitionStore().FindPtr(srcShardIdx);
+
+            if (partition == nullptr) {
                 TString errMsg = TStringBuilder()
                     << "shard doesn't present at schemeshard at table"
                     << ", tablet: " << srcTabletId
@@ -913,7 +932,7 @@ public:
                 return result;
             }
 
-            if (context.SS->ShardInfos.FindPtr(srcShardIdx)->PathId != path.Base()->PathId || !shardIdx2partition.contains(srcShardIdx)) {
+            if (context.SS->ShardInfos.FindPtr(srcShardIdx)->PathId != path.Base()->PathId) {
                 TString errMsg = TStringBuilder() << "TabletId " << srcTabletId << " is not a partition of table " << info.GetTablePath();
                 setResultError(NKikimrScheme::StatusInvalidParameter, errMsg);
                 return result;
@@ -937,7 +956,7 @@ public:
                 totalSrcPartCount += stats->PartCount;
             }
 
-            auto pi = shardIdx2partition.at(srcShardIdx);
+            const auto pi = partition->Position;
             Y_VERIFY_S(pi < tableInfo->GetPartitions().size(), "pi: " << pi << " partitions.size: " << tableInfo->GetPartitions().size());
             srcPartitionIdxs.push_back(pi);
         }
@@ -1001,7 +1020,7 @@ public:
 
         // Fill Src shards for tx
         for (ui64 pi : srcPartitionIdxs) {
-            auto srcShardIdx = tableInfo->GetPartitions()[pi].ShardIdx;
+            auto srcShardIdx = tableInfo->GetPartitions()[pi]->ShardIdx;
             op.Shards.emplace_back(srcShardIdx, ETabletType::DataShard, TTxState::TransferData);
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
@@ -293,8 +293,8 @@ public:
             TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxTruncateTable, tablePath.Base()->PathId);
             txState.State = TTxState::ConfigureParts;
 
-            for (const auto& shard : table->GetPartitions()) {
-                auto shardIdx = shard.ShardIdx;
+            for (const auto* shard : table->GetPartitions()) {
+                auto shardIdx = shard->ShardIdx;
                 context.MemChanges.GrabShard(context.SS, shardIdx);
                 context.DbChanges.PersistShard(shardIdx);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
@@ -239,16 +239,16 @@ public:
         }
 
         for (ui32 partNum = 0; partNum < tableInfo->GetPartitions().size(); ++partNum) {
-            const TTableShardInfo& partition = tableInfo->GetPartitions().at(partNum);
+            const TTableShardInfo* partition = tableInfo->GetPartitions().at(partNum);
 
             auto partDescr = descr.AddPartitions();
             partDescr->SetId(partNum);
-            partDescr->SetRangeEnd(partition.EndOfRange);
-            partDescr->MutableShardIdx()->SetOwnerId(partition.ShardIdx.GetOwnerId());
-            partDescr->MutableShardIdx()->SetLocalId(ui64(partition.ShardIdx.GetLocalId()));
-            if (tableInfo->PerShardPartitionConfig.contains(partition.ShardIdx)) {
+            partDescr->SetRangeEnd(partition->EndOfRange);
+            partDescr->MutableShardIdx()->SetOwnerId(partition->ShardIdx.GetOwnerId());
+            partDescr->MutableShardIdx()->SetLocalId(ui64(partition->ShardIdx.GetLocalId()));
+            if (tableInfo->PerShardPartitionConfig.contains(partition->ShardIdx)) {
                 TString partitionConfig;
-                Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->PerShardPartitionConfig.at(partition.ShardIdx).SerializeToString(&partitionConfig);
+                Y_PROTOBUF_SUPPRESS_NODISCARD tableInfo->PerShardPartitionConfig.at(partition->ShardIdx).SerializeToString(&partitionConfig);
                 partDescr->SetPartitionConfig(partitionConfig);
             }
         }
@@ -326,8 +326,8 @@ public:
                 *event->Record.MutableTable() = DescribeTable(context, pathId);
 
                 TTableInfo::TPtr tableInfo = context.SS->Tables.at(pathId);
-                for (auto part: tableInfo->GetPartitions()) {
-                    TShardIdx shardIdx = part.ShardIdx;
+                for (const auto* part: tableInfo->GetPartitions()) {
+                    TShardIdx shardIdx = part->ShardIdx;
                     *migrateShards->Add() = DescribeShard(context, shardIdx);
                 }
 
@@ -855,8 +855,8 @@ public:
                 {
                     Y_ABORT_UNLESS(context.SS->Tables.contains(pId));
                     TTableInfo::TPtr table = context.SS->Tables.at(pId);
-                    for (auto item: table->GetPartitions()) {
-                        auto shardIdx = item.ShardIdx;
+                    for (const auto* item: table->GetPartitions()) {
+                        auto shardIdx = item->ShardIdx;
                         const auto& shardInfo = context.SS->ShardInfos.at(shardIdx);
 
                         bool inserted = false;

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -523,26 +523,22 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
         return true;
     }
 
-    const auto& shardToPartition = table->GetShard2PartitionIdx();
-    if (table->IsTTLEnabled() && shardToPartition.contains(shardIdx)) {
-        const ui64 partitionIdx = shardToPartition.at(shardIdx);
-        const auto& partitions = table->GetPartitions();
+    if (table->IsTTLEnabled()) {
+        if (auto* p = table->GetPartitionStore().FindPtr(shardIdx)) {
+            auto& lag = p->LastCondEraseLag;
 
-        Y_ABORT_UNLESS(partitionIdx < partitions.size());
-        auto& shardInfo = partitions.at(partitionIdx);
-        auto& lag = shardInfo.LastCondEraseLag;
+            if (lag) {
+                Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
+            }
 
-        if (lag) {
-            Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
+            if (now >= p->LastCondErase) {
+                lag = now - p->LastCondErase;
+            } else {
+                lag = TDuration::Zero();
+            }
+
+            Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
         }
-
-        if (now >= shardInfo.LastCondErase) {
-            lag = now - shardInfo.LastCondErase;
-        } else {
-            lag = TDuration::Zero();
-        }
-
-        Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
     }
 
     const TTableIndexInfo* index = Self->Indexes.Value(pathElement->ParentPathId, nullptr).Get();

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -33,7 +33,7 @@ static std::tuple<NTableIndex::NKMeans::TClusterId, NTableIndex::NKMeans::TClust
     const auto count = kmeans.ChildCount();
     NTableIndex::NKMeans::TClusterId step = 1;
     auto parts = count;
-    auto shards = tableInfo.GetShard2PartitionIdx().size();
+    auto shards = tableInfo.GetPartitionStore().size();
     if (!buildInfo.KMeans.NeedsAnotherLevel() || count <= 1 || shards <= 1) {
         return {1, 1, 1};
     }
@@ -354,9 +354,9 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
         // This also means that we can directly copy split boundaries from the main table!
         const auto& tableInfo = ss->Tables.at(buildInfo.TablePathId);
         size_t parts = tableInfo->GetPartitions().size();
-        for (const auto& x: tableInfo->GetPartitions()) {
+        for (const auto* x: tableInfo->GetPartitions()) {
             if (--parts > 0) {
-                op.AddSplitBoundary()->SetSerializedKeyPrefix(x.EndOfRange);
+                op.AddSplitBoundary()->SetSerializedKeyPrefix(x->EndOfRange);
             }
         }
         LOG_NOTICE_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX,
@@ -1984,8 +1984,8 @@ private:
         std::vector<const TSerializedTableRange*> sortedRanges;
         sortedRanges.reserve(buildInfo.Shards.size());
         Y_ENSURE(buildInfo.Shards.size() == table->GetPartitions().size());
-        for (const auto& x: table->GetPartitions()) {
-            auto it = buildInfo.Shards.find(x.ShardIdx);
+        for (const auto* x: table->GetPartitions()) {
+            auto it = buildInfo.Shards.find(x->ShardIdx);
             Y_ENSURE(it != buildInfo.Shards.end());
             Y_ENSURE(it->second.Status == NKikimrIndexBuilder::EBuildStatus::DONE);
             sortedRanges.emplace_back(&it->second.Range);
@@ -2449,25 +2449,25 @@ public:
 
         buildInfo.Cluster2Shards.clear();
         for (const auto& x: table->GetPartitions()) {
-            Y_ENSURE(Self->ShardInfos.contains(x.ShardIdx));
-            TSerializedCellVec bound{x.EndOfRange};
+            Y_ENSURE(Self->ShardInfos.contains(x->ShardIdx));
+            TSerializedCellVec bound{x->EndOfRange};
             if (!buildInfo.IsValidatingUniqueIndex()) {
                 shardRange.To = bound;
             }
             if (buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildVectorIndex &&
                 buildInfo.KMeans.State != TIndexBuildInfo::TKMeans::Filter) {
-                LOG_D("InitiateShard " << x.ShardIdx << " range " << buildInfo.KMeans.RangeToDebugStr(shardRange));
-                buildInfo.AddParent(shardRange, x.ShardIdx);
+                LOG_D("InitiateShard " << x->ShardIdx << " range " << buildInfo.KMeans.RangeToDebugStr(shardRange));
+                buildInfo.AddParent(shardRange, x->ShardIdx);
             } else {
-                LOG_D("InitiateShard " << x.ShardIdx);
+                LOG_D("InitiateShard " << x->ShardIdx);
             }
-            auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildShardStatus{std::move(shardRange), ""});
+            auto [it, emplaced] = buildInfo.Shards.emplace(x->ShardIdx, TIndexBuildShardStatus{std::move(shardRange), ""});
             Y_ENSURE(emplaced);
             if (!buildInfo.IsValidatingUniqueIndex()) {
                 shardRange.From = std::move(bound);
             }
 
-            Self->PersistBuildIndexShardStatusInitiate(db, BuildId, x.ShardIdx, it->second);
+            Self->PersistBuildIndexShardStatusInitiate(db, BuildId, x->ShardIdx, it->second);
         }
 
         return true;

--- a/ydb/core/tx/schemeshard/schemeshard_cdc_stream_scan.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_cdc_stream_scan.cpp
@@ -183,11 +183,11 @@ private:
 
         if (streamInfo->ScanShards.empty()) {
             NIceDb::TNiceDb db(txc.DB);
-            for (const auto& shard : table->GetPartitions()) {
+            for (const auto* shard : table->GetPartitions()) {
                 const auto status = TCdcStreamInfo::TShardStatus(NKikimrTxDataShard::TEvCdcStreamScanResponse::PENDING);
-                streamInfo->ScanShards.emplace(shard.ShardIdx, status);
-                streamInfo->PendingShards.insert(shard.ShardIdx);
-                Self->PersistCdcStreamScanShardStatus(db, streamPathId, shard.ShardIdx, status);
+                streamInfo->ScanShards.emplace(shard->ShardIdx, status);
+                streamInfo->PendingShards.insert(shard->ShardIdx);
+                Self->PersistCdcStreamScanShardStatus(db, streamPathId, shard->ShardIdx, status);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
@@ -135,8 +135,8 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
 
         for (const auto& tablePathId : info->TablesToCompact) {
             auto tableInfo = Self->Tables.at(tablePathId);
-            for (const auto& shardInfo : tableInfo->GetPartitions()) {
-                shardsToCompact.emplace_back(shardInfo.ShardIdx, tablePathId);
+            for (const auto* shardInfo : tableInfo->GetPartitions()) {
+                shardsToCompact.emplace_back(shardInfo->ShardIdx, tablePathId);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -902,13 +902,13 @@ bool TSchemeShard::GetBindingsRooms(
 
 bool TSchemeShard::GetBindingsRoomsChanges(
         const TPathId domainId,
-        const TVector<TTableShardInfo>& partitions,
+        const TVector<TTableShardInfo*>& partitions,
         const NKikimrSchemeOp::TPartitionConfig& partitionConfig,
         TBindingsRoomsChanges& changes,
         TString& errStr)
 {
-    for (const auto& shard : partitions) {
-        const auto& shardInfo = ShardInfos.at(shard.ShardIdx);
+    for (const auto* shard : partitions) {
+        const auto& shardInfo = ShardInfos.at(shard->ShardIdx);
         if (!shardInfo.BindedChannels) {
             // Shard has no existing channel bindings, better leave untouched!
             continue;
@@ -2777,15 +2777,15 @@ void TSchemeShard::PersistChannelsBinding(NIceDb::TNiceDb& db, const TShardIdx s
     }
 }
 
-void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo) {
-    for (ui64 pi = 0; pi < tableInfo->GetPartitions().size(); ++pi) {
-        const auto& partition = tableInfo->GetPartitions()[pi];
-        if (IsLocalId(pathId) && IsLocalId(partition.ShardIdx)) {
+void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
+    for (ui64 pi = startIdx; pi < tableInfo->GetPartitions().size(); ++pi) {
+        const auto* partition = tableInfo->GetPartitions()[pi];
+        if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
             db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Update(
-                NIceDb::TUpdate<Schema::TablePartitions::RangeEnd>(partition.EndOfRange),
-                NIceDb::TUpdate<Schema::TablePartitions::DatashardIdx>(partition.ShardIdx.GetLocalId()),
-                NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(partition.LastCondErase.GetValue()),
-                NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(partition.NextCondErase.GetValue()));
+                NIceDb::TUpdate<Schema::TablePartitions::RangeEnd>(partition->EndOfRange),
+                NIceDb::TUpdate<Schema::TablePartitions::DatashardIdx>(partition->ShardIdx.GetLocalId()),
+                NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(partition->LastCondErase.GetValue()),
+                NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(partition->NextCondErase.GetValue()));
         } else {
             if (IsLocalId(pathId)) {
                 // Incompatible change 1:
@@ -2795,11 +2795,11 @@ void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId p
                 BumpIncompatibleChanges(db, 1);
             }
             db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Update(
-                NIceDb::TUpdate<Schema::MigratedTablePartitions::RangeEnd>(partition.EndOfRange),
-                NIceDb::TUpdate<Schema::MigratedTablePartitions::OwnerShardIdx>(partition.ShardIdx.GetOwnerId()),
-                NIceDb::TUpdate<Schema::MigratedTablePartitions::LocalShardIdx>(partition.ShardIdx.GetLocalId()),
-                NIceDb::TUpdate<Schema::MigratedTablePartitions::LastCondErase>(partition.LastCondErase.GetValue()),
-                NIceDb::TUpdate<Schema::MigratedTablePartitions::NextCondErase>(partition.NextCondErase.GetValue()));
+                NIceDb::TUpdate<Schema::MigratedTablePartitions::RangeEnd>(partition->EndOfRange),
+                NIceDb::TUpdate<Schema::MigratedTablePartitions::OwnerShardIdx>(partition->ShardIdx.GetOwnerId()),
+                NIceDb::TUpdate<Schema::MigratedTablePartitions::LocalShardIdx>(partition->ShardIdx.GetLocalId()),
+                NIceDb::TUpdate<Schema::MigratedTablePartitions::LastCondErase>(partition->LastCondErase.GetValue()),
+                NIceDb::TUpdate<Schema::MigratedTablePartitions::NextCondErase>(partition->NextCondErase.GetValue()));
         }
     }
     if (IsLocalId(pathId)) {
@@ -2811,9 +2811,9 @@ void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId p
     }
 }
 
-void TSchemeShard::PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo) {
+void TSchemeShard::PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
     const auto& partitions = tableInfo->GetPartitions();
-    for (ui64 pi = 0; pi < partitions.size(); ++pi) {
+    for (ui64 pi = startIdx; pi < partitions.size(); ++pi) {
         if (IsLocalId(pathId)) {
             db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Delete();
         }
@@ -2822,21 +2822,20 @@ void TSchemeShard::PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const T
     }
 }
 
-void TSchemeShard::PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, ui64 id, const TTableInfo::TPtr tableInfo) {
-    const auto& partition = tableInfo->GetPartitions()[id];
-
-    if (IsLocalId(pathId) && IsLocalId(partition.ShardIdx)) {
+void TSchemeShard::PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, const TTableShardInfo* partition, [[maybe_unused]] const TTableInfo::TPtr tableInfo) {
+    const ui64 id = partition->Position;
+    if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
         db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, id).Update(
-            NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(partition.LastCondErase.GetValue()),
-            NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(partition.NextCondErase.GetValue()));
+            NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(partition->LastCondErase.GetValue()),
+            NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(partition->NextCondErase.GetValue()));
     } else {
         if (IsLocalId(pathId)) {
             // Incompatible change 1 (see above)
             BumpIncompatibleChanges(db, 1);
         }
         db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, id).Update(
-            NIceDb::TUpdate<Schema::MigratedTablePartitions::LastCondErase>(partition.LastCondErase.GetValue()),
-            NIceDb::TUpdate<Schema::MigratedTablePartitions::NextCondErase>(partition.NextCondErase.GetValue()));
+            NIceDb::TUpdate<Schema::MigratedTablePartitions::LastCondErase>(partition->LastCondErase.GetValue()),
+            NIceDb::TUpdate<Schema::MigratedTablePartitions::NextCondErase>(partition->NextCondErase.GetValue()));
     }
 }
 
@@ -2910,34 +2909,35 @@ void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId
         return;
     }
 
-    const auto& shardToPartition = tableInfo->GetShard2PartitionIdx();
-    if (!shardToPartition.contains(shardIdx)) {
+    const TTableShardInfo* p = tableInfo->GetPartitionStore().FindPtr(shardIdx);
+    if (!p) {
         return;
     }
 
     const auto& tableStats = tableInfo->GetStats();
-    if (!tableStats.PartitionStats.contains(shardIdx)) {
+    const auto* statsPtr = tableStats.PartitionStats.FindPtr(shardIdx);
+    if (!statsPtr) {
         return;
     }
 
-    const ui64 partitionId = shardToPartition.at(shardIdx);
-    const auto& stats = tableStats.PartitionStats.at(shardIdx);
-    PersistTablePartitionStats(db, tableId, partitionId, stats);
+    PersistTablePartitionStats(db, tableId, p->Position, *statsPtr);
 }
 
-void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo) {
+void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
     if (!AppData()->FeatureFlags.GetEnablePersistentPartitionStats()) {
         return;
     }
 
     const auto& tableStats = tableInfo->GetStats();
+    const auto& partitions = tableInfo->GetPartitions();
 
-    for (const auto& [shardIdx, pi] : tableInfo->GetShard2PartitionIdx()) {
+    for (ui64 pi = startIdx; pi < partitions.size(); ++pi) {
+        const TShardIdx shardIdx = partitions[pi]->ShardIdx;
         if (!tableStats.PartitionStats.contains(shardIdx)) {
             continue;
         }
-
-        PersistTablePartitionStats(db, tableId, pi, tableStats.PartitionStats.at(shardIdx));
+        const auto& stats = tableStats.PartitionStats.at(shardIdx);
+        PersistTablePartitionStats(db, tableId, pi, stats);
     }
 }
 
@@ -4505,8 +4505,8 @@ void TSchemeShard::PersistRemoveTable(NIceDb::TNiceDb& db, TPathId pathId, const
         db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pNo).Delete();
         db.Table<Schema::TablePartitionStats>().Key(pathId.OwnerId, pathId.LocalPathId, pNo).Delete();
 
-        const auto& shardInfo = tableInfo->GetPartitions().at(pNo);
-        if (auto& lag = shardInfo.LastCondEraseLag) {
+        const auto* shardInfo = tableInfo->GetPartitions().at(pNo);
+        if (auto& lag = shardInfo->LastCondEraseLag) {
             TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
             lag.Clear();
         }
@@ -4548,8 +4548,8 @@ void TSchemeShard::PersistRemoveTable(NIceDb::TNiceDb& db, TPathId pathId, const
     }
 
     // sanity check: by this time compaction queue and metrics must be updated already
-    for (const auto& p: tableInfo->GetPartitions()) {
-        OnShardRemoved(p.ShardIdx);
+    for (const auto& [shardIdx, p] : tableInfo->GetPartitionStore()) {
+        OnShardRemoved(shardIdx);
     }
 
     Tables.erase(pathId);
@@ -7751,14 +7751,14 @@ void TSchemeShard::FillTableDescription(TPathId tableId, ui32 partitionIdx, ui64
     const TTableInfo::TPtr tinfo = Tables.at(tableId);
 
     TString rangeBegin = (partitionIdx != 0)
-        ? tinfo->GetPartitions()[partitionIdx-1].EndOfRange
+        ? tinfo->GetPartitions()[partitionIdx-1]->EndOfRange
         : TString();
-    TString rangeEnd = tinfo->GetPartitions()[partitionIdx].EndOfRange;
+    TString rangeEnd = tinfo->GetPartitions()[partitionIdx]->EndOfRange;
 
     // For uniform partitioning we include range start and exclude range end
     FillTableDescriptionForShardIdx(
         tableId,
-        tinfo->GetPartitions()[partitionIdx].ShardIdx,
+        tinfo->GetPartitions()[partitionIdx]->ShardIdx,
         tableDescr,
         std::move(rangeBegin),
         std::move(rangeEnd),
@@ -7842,7 +7842,8 @@ void TSchemeShard::SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, T
     shardIndices.reserve(newPartitioning.size());
     for (auto& info : newPartitioning) {
         shardIndices.push_back(
-            std::make_pair(ui64(info.ShardIdx.GetOwnerId()), ui64(info.ShardIdx.GetLocalId())));
+            std::make_pair(ui64(info.ShardIdx.GetOwnerId()), ui64(info.ShardIdx.GetLocalId()))
+        );
     }
 
     auto path = TPath::Init(pathId, this);
@@ -7850,37 +7851,97 @@ void TSchemeShard::SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, T
     ev->ShardIndices.swap(shardIndices);
     Send(SysPartitionStatsCollector, ev.Release());
 
+    tableInfo->SetPartitioning(std::move(newPartitioning));
+}
+
+void TSchemeShard::MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
+    TVector<std::pair<ui64, ui64>> shardIndices;
+    shardIndices.reserve(newPartitioning.size());
+    for (auto& info : newPartitioning) {
+        shardIndices.push_back(
+            std::make_pair(ui64(info.ShardIdx.GetOwnerId()), ui64(info.ShardIdx.GetLocalId()))
+        );
+    }
+    auto path = TPath::Init(pathId, this);
+    auto ev = MakeHolder<NSysView::TEvSysView::TEvSetPartitioning>(GetDomainKey(pathId), pathId, path.PathString());
+    ev->ShardIndices.swap(shardIndices);
+    Send(SysPartitionStatsCollector, ev.Release());
+
     if (!tableInfo->IsBackup) {
-        // partitions updated:
-        // 1. We need to remove some parts from compaction queues.
-        // 2. We need to add new ones to the queues. Since we can safely enqueue already
-        // enqueued parts, we simple enqueue each part in newPartitioning
-        THashSet<TShardIdx> newPartitioningSet;
-        newPartitioningSet.reserve(newPartitioning.size());
-        const auto& oldPartitioning = tableInfo->GetPartitions();
-
-        TInstant now = AppData()->TimeProvider->Now();
-        for (const auto& p: newPartitioning) {
-            if (!oldPartitioning.empty())
-                newPartitioningSet.insert(p.ShardIdx);
-
-            const auto& partitionStats = tableInfo->GetStats().PartitionStats;
+        const auto& partitionStats = tableInfo->GetStats().PartitionStats;
+        const TInstant now = AppData()->TimeProvider->Now();
+        for (const auto& p : newPartitioning) {
             auto it = partitionStats.find(p.ShardIdx);
             if (it != partitionStats.end()) {
                 EnqueueBackgroundCompaction(p.ShardIdx, it->second);
                 UpdateShardMetrics(p.ShardIdx, it->second, now);
             }
         }
+        // No OnShardRemoved — same physical shards, just a new path.
+    }
 
-        for (const auto& p: oldPartitioning) {
-            if (!newPartitioningSet.contains(p.ShardIdx)) {
-                // note that queues might not contain the shard
-                OnShardRemoved(p.ShardIdx);
+    tableInfo->MovePartitioning(std::move(newPartitioning));
+}
+
+void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
+    TVector<std::pair<ui64, ui64>> shardIndices;
+    shardIndices.reserve(newPartitioning.size());
+    for (auto& info : newPartitioning) {
+        shardIndices.push_back(
+            std::make_pair(ui64(info.ShardIdx.GetOwnerId()), ui64(info.ShardIdx.GetLocalId()))
+        );
+    }
+    auto path = TPath::Init(pathId, this);
+    auto ev = MakeHolder<NSysView::TEvSysView::TEvSetPartitioning>(GetDomainKey(pathId), pathId, path.PathString());
+    ev->ShardIndices.swap(shardIndices);
+    Send(SysPartitionStatsCollector, ev.Release());
+
+    if (!tableInfo->IsBackup) {
+        for (const auto& [shardIdx, p] : tableInfo->GetPartitionStore()) {
+            OnShardRemoved(shardIdx); // note that queues might not contain the shard
+        }
+        // No EnqueueBackgroundCompaction — new shards have no stats yet.
+    }
+
+    tableInfo->CopyPartitioning(std::move(newPartitioning));
+}
+
+void TSchemeShard::ApplySplitMerge(
+    TPathId pathId,
+    TTableInfo::TPtr tableInfo,
+    TVector<TTableShardInfo>&& dstPartitions,
+    const TVector<TShardIdx>& removedShards,
+    ui64 splitStartIdx
+) {
+    const TInstant now = AppData()->TimeProvider->Now();
+    if (!tableInfo->IsBackup) {
+        for (const TShardIdx& shardIdx : removedShards) {
+            OnShardRemoved(shardIdx);
+        }
+        // New dst shards have no stats yet; they are enqueued on their first EvPeriodicTableStats.
+        const auto& partitionStats = tableInfo->GetStats().PartitionStats;
+        for (const auto& dst : dstPartitions) {
+            auto it = partitionStats.find(dst.ShardIdx);
+            if (it != partitionStats.end()) {
+                EnqueueBackgroundCompaction(dst.ShardIdx, it->second);
+                UpdateShardMetrics(dst.ShardIdx, it->second, now);
             }
         }
     }
 
-    tableInfo->SetPartitioning(std::move(newPartitioning));
+    tableInfo->ApplySplitMerge(std::move(dstPartitions), removedShards, splitStartIdx, now);
+
+    TVector<std::pair<ui64, ui64>> shardIndices;
+    shardIndices.reserve(tableInfo->GetPartitions().size());
+    for (const auto* info : tableInfo->GetPartitions()) {
+        shardIndices.push_back(
+            std::make_pair(ui64(info->ShardIdx.GetOwnerId()), ui64(info->ShardIdx.GetLocalId()))
+        );
+    }
+    auto path = TPath::Init(pathId, this);
+    auto ev = MakeHolder<NSysView::TEvSysView::TEvSetPartitioning>(GetDomainKey(pathId), pathId, path.PathString());
+    ev->ShardIndices.swap(shardIndices);
+    Send(SysPartitionStatsCollector, ev.Release());
 }
 
 void TSchemeShard::OnShardRemoved(const TShardIdx& shardIdx) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -632,7 +632,7 @@ public:
      */
     bool GetBindingsRoomsChanges(
             const TPathId domainId,
-            const TVector<TTableShardInfo>& partitions,
+            const TVector<TTableShardInfo*>& partitions,
             const NKikimrSchemeOp::TPartitionConfig& partitionConfig,
             TBindingsRoomsChanges& changes,
             TString& errStr);
@@ -756,6 +756,17 @@ public:
     void SetPartitioning(TPathId pathId, TOlapStoreInfo::TPtr storeInfo);
     void SetPartitioning(TPathId pathId, TColumnTableInfo::TPtr tableInfo);
     void SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning);
+    // MoveTable: same physical shards, new path — preserves Stats, enqueues compaction.
+    void MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning);
+    // CopyTable: all-new shard IDs — calls OnShardRemoved for old shards, rebuilds Stats.
+    void CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning);
+    void ApplySplitMerge(
+        TPathId pathId,
+        TTableInfo::TPtr tableInfo,
+        TVector<TTableShardInfo>&& dstPartitions,
+        const TVector<TShardIdx>& removedShards,
+        ui64 splitStartIdx
+    );
     void OnShardRemoved(const TShardIdx& shardIdx);
     auto BuildStatsForCollector(TPathId tableId, TShardIdx shardIdx, TTabletId datashardId, ui32 followerId,
         TMaybe<ui32> nodeId, TMaybe<ui64> startTime, const TPartitionStats& stats, const TActorContext& ctx);
@@ -799,12 +810,12 @@ public:
     void PersistRemoveTx(NIceDb::TNiceDb& db, const TOperationId opId, const TTxState& txState);
     void PersistTable(NIceDb::TNiceDb &db, const TPathId pathId);
     void PersistChannelsBinding(NIceDb::TNiceDb& db, const TShardIdx shardId, const TChannelsBindings& bindedChannels);
-    void PersistTablePartitioning(NIceDb::TNiceDb &db, const TPathId pathId, const TTableInfo::TPtr tableInfo);
-    void PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId tableId, const TTableInfo::TPtr tableInfo);
-    void PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, ui64 id, const TTableInfo::TPtr tableInfo);
+    void PersistTablePartitioning(NIceDb::TNiceDb &db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    void PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    void PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, const TTableShardInfo* partition, const TTableInfo::TPtr tableInfo);
     void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, ui64 partitionId, const TPartitionStats& stats);
     void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TShardIdx& shardIdx, const TTableInfo::TPtr tableInfo);
-    void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo);
+    void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
     void PersistTableCreated(NIceDb::TNiceDb& db, const TPathId tableId);
     void PersistTableAlterVersion(NIceDb::TNiceDb &db, const TPathId pathId, const TTableInfo::TPtr tableInfo);
     void PersistClearAlterTableFull(NIceDb::TNiceDb& db, const TPathId& pathId);

--- a/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
@@ -614,7 +614,7 @@ void TSchemeShard::CreateIncrementalRestoreOperation(
                 if (itemPath.IsResolved() && itemPath.Base()->IsTable()) {
                     auto tableInfo = Tables.FindPtr(itemPath.Base()->PathId);
                     if (tableInfo) {
-                        for (const auto& [shardIdx, partitionIdx] : (*tableInfo)->GetShard2PartitionIdx()) {
+                        for (const auto& [shardIdx, _] : (*tableInfo)->GetPartitionStore()) {
                             tableOpState.ExpectedShards.insert(shardIdx);
                             stateIt->second.InvolvedShards.insert(shardIdx);
                         }
@@ -884,7 +884,7 @@ void TSchemeShard::CreateSingleIndexRestoreOperation(
 
         if (Tables.contains(indexImplTablePathId)) {
             auto indexImplTable = Tables.at(indexImplTablePathId);
-            for (const auto& [shardIdx, partitionIdx] : indexImplTable->GetShard2PartitionIdx()) {
+            for (const auto& [shardIdx, _] : indexImplTable->GetPartitionStore()) {
                 indexOpState.ExpectedShards.insert(shardIdx);
                 stateIt->second.InvolvedShards.insert(shardIdx);
             }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1778,81 +1778,259 @@ void TTableInfo::DeserializeAlterExtraData(const TString& str) {
 #endif
 
 void TTableInfo::SetPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
-    THashMap<TShardIdx, TPartitionStats> newPartitionStats;
-    TPartitionStats newAggregatedStats;
-    newAggregatedStats.PartCount = newPartitioning.size();
-    ui64 cpuTotal = 0;
-    THashSet<TShardIdx> newUpdatedStats;
+    Y_ENSURE(PartitionStore.empty());
+    Y_ENSURE(Partitions.empty());
+    Y_ENSURE(SplitOpsInFlight.empty());
 
-    for (const auto& np : newPartitioning) {
-        auto idx = np.ShardIdx;
-        auto& newStats(newPartitionStats[idx]);
-        newStats = Stats.PartitionStats.contains(idx) ? Stats.PartitionStats[idx] : TPartitionStats();
-        newAggregatedStats.RowCount += newStats.RowCount;
-        newAggregatedStats.DataSize += newStats.DataSize;
-        newAggregatedStats.IndexSize += newStats.IndexSize;
-        newAggregatedStats.ByKeyFilterSize += newStats.ByKeyFilterSize;
-        for (const auto& [poolKind, newStoragePoolStats] : newStats.StoragePoolsStats) {
-            auto& [dataSize, indexSize] = newAggregatedStats.StoragePoolsStats[poolKind];
-            dataSize += newStoragePoolStats.DataSize;
-            indexSize += newStoragePoolStats.IndexSize;
-        }
-        newAggregatedStats.InFlightTxCount += newStats.InFlightTxCount;
-        cpuTotal += newStats.GetCurrentRawCpuUsage();
-        newAggregatedStats.Memory += newStats.Memory;
-        newAggregatedStats.Network += newStats.Network;
-        newAggregatedStats.Storage += newStats.Storage;
-        newAggregatedStats.ReadThroughput += newStats.ReadThroughput;
-        newAggregatedStats.WriteThroughput += newStats.WriteThroughput;
-        newAggregatedStats.ReadIops += newStats.ReadIops;
-        newAggregatedStats.WriteIops += newStats.WriteIops;
-
-        if (Stats.PartitionStats.contains(idx) && Stats.UpdatedStats.contains(idx)) {
-            newUpdatedStats.insert(idx);
-        }
+    for (const auto& p : newPartitioning) {
+        Stats.PartitionStats.emplace(p.ShardIdx, TPartitionStats{});
     }
-    newAggregatedStats.SetCurrentRawCpuUsage(cpuTotal, AppData()->TimeProvider->Now());
-    newAggregatedStats.LastAccessTime = Stats.Aggregated.LastAccessTime;
-    newAggregatedStats.LastUpdateTime = Stats.Aggregated.LastUpdateTime;
+    Stats.Aggregated.PartCount = newPartitioning.size();
+    ExpectedPartitionCount = newPartitioning.size();
 
-    newAggregatedStats.ImmediateTxCompleted = Stats.Aggregated.ImmediateTxCompleted;
-    newAggregatedStats.PlannedTxCompleted = Stats.Aggregated.PlannedTxCompleted;
-    newAggregatedStats.TxRejectedByOverload = Stats.Aggregated.TxRejectedByOverload;
-    newAggregatedStats.TxRejectedBySpace = Stats.Aggregated.TxRejectedBySpace;
-
-    newAggregatedStats.RowUpdates = Stats.Aggregated.RowUpdates;
-    newAggregatedStats.RowDeletes = Stats.Aggregated.RowDeletes;
-    newAggregatedStats.RowReads = Stats.Aggregated.RowReads;
-    newAggregatedStats.RangeReads = Stats.Aggregated.RangeReads;
-    newAggregatedStats.RangeReadRows = Stats.Aggregated.RangeReadRows;
-
-    newAggregatedStats.LocksAcquired = Stats.Aggregated.LocksAcquired;
-    newAggregatedStats.LocksWholeShard = Stats.Aggregated.LocksWholeShard;
-    newAggregatedStats.LocksBroken = Stats.Aggregated.LocksBroken;
-
-    if (SplitOpsInFlight.empty()) {
-        ExpectedPartitionCount = newPartitioning.size();
+    PartitionStore.reserve(newPartitioning.size());
+    Partitions.reserve(newPartitioning.size());
+    for (auto& p : newPartitioning) {
+        const TShardIdx idx = p.ShardIdx;
+        auto [it, _] = PartitionStore.emplace(idx, std::move(p));
+        Partitions.push_back(&it->second);
     }
+    newPartitioning.clear();
 
-    if (Partitions.empty()) {
-        Y_ENSURE(SplitOpsInFlight.empty());
-    }
-
-    Stats.PartitionStats.swap(newPartitionStats);
-    Stats.Aggregated = newAggregatedStats;
-    Stats.UpdatedStats.swap(newUpdatedStats);
-    Partitions.swap(newPartitioning);
     PreserializedTablePartitions.clear();
     PreserializedTablePartitionsNoKeys.clear();
     PreserializedTableSplitBoundaries.clear();
 
-    CondEraseSchedule.clear();
-    InFlightCondErase.clear();
-    Shard2PartitionIdx.clear();
-    for (ui32 i = 0; i < Partitions.size(); ++i) {
-        Shard2PartitionIdx[Partitions[i].ShardIdx] = i;
-        CondEraseSchedule.push(Partitions.begin() + i);
+    // Only schedule TTL sweeps when TTL is actually enabled — non-TTL tables
+    // don't need entries in CondEraseSchedule at all.
+    if (IsTTLEnabled()) {
+        for (auto* p : Partitions) {
+            CondEraseSchedule.PushRaw(p->NextCondErase, p->ShardIdx);
+        }
+        CondEraseSchedule.BuildHeap();
     }
+
+    for (ui64 i = 0; i < Partitions.size(); ++i) {
+        Partitions[i]->Position = i;
+    }
+
+    VerifyConsistency();
+}
+
+void TTableInfo::MovePartitioning(TVector<TTableShardInfo>&& newPartitioning) {
+    // Same shard set as before — Stats are already correct (caller is a DeepCopy).
+    Y_ABORT_UNLESS(newPartitioning.size() == PartitionStore.size());
+
+    THashMap<TShardIdx, TTableShardInfo> newStore;
+    newStore.reserve(newPartitioning.size());
+    TPartitionsVec newOrder;
+    newOrder.reserve(newPartitioning.size());
+    for (auto& p : newPartitioning) {
+        const TShardIdx idx = p.ShardIdx;
+        auto [it, _] = newStore.emplace(idx, std::move(p));
+        newOrder.push_back(&it->second);
+    }
+    newPartitioning.clear();
+    PartitionStore = std::move(newStore);
+    Partitions = std::move(newOrder);
+
+    // Discard any in-flight TTL state and reschedule all shards.
+    if (IsTTLEnabled()) {
+        ClearCondEraseSchedule();
+        ScheduleAllCondErase();
+    }
+
+    for (ui64 i = 0; i < Partitions.size(); ++i) {
+        Partitions[i]->Position = i;
+    }
+
+    PreserializedTablePartitions.clear();
+    PreserializedTablePartitionsNoKeys.clear();
+    PreserializedTableSplitBoundaries.clear();
+
+    VerifyConsistency();
+}
+
+void TTableInfo::CopyPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
+    // Precondition: per-shard sums in Aggregated (RowCount, DataSize, ...) are still zero.
+    // They only change when a datashard reports stats, and UpdatePartitioningForCopyTable
+    // (our only caller) asserts every dst shard has TabletID == InvalidTabletId.
+    Y_ABORT_UNLESS(Stats.Aggregated.RowCount == 0 && Stats.Aggregated.DataSize == 0);
+    Stats.PartitionStats.clear();
+    Stats.UpdatedStats.clear();
+    Stats.Aggregated.PartCount = newPartitioning.size();
+    Y_ABORT_UNLESS(SplitOpsInFlight.empty());
+    ExpectedPartitionCount = newPartitioning.size();
+
+    THashMap<TShardIdx, TTableShardInfo> newStore;
+    newStore.reserve(newPartitioning.size());
+    TPartitionsVec newOrder;
+    newOrder.reserve(newPartitioning.size());
+    for (auto& p : newPartitioning) {
+        const TShardIdx idx = p.ShardIdx;
+        auto [it, _] = newStore.emplace(idx, std::move(p));
+        newOrder.push_back(&it->second);
+        Stats.PartitionStats.emplace(idx, TPartitionStats{});
+    }
+    newPartitioning.clear();
+    PartitionStore = std::move(newStore);
+    Partitions = std::move(newOrder);
+
+    if (IsTTLEnabled()) {
+        ClearCondEraseSchedule();
+        ScheduleAllCondErase();
+    }
+
+    for (ui64 i = 0; i < Partitions.size(); ++i) {
+        Partitions[i]->Position = i;
+    }
+
+    PreserializedTablePartitions.clear();
+    PreserializedTablePartitionsNoKeys.clear();
+    PreserializedTableSplitBoundaries.clear();
+
+    VerifyConsistency();
+}
+
+void TTableInfo::ApplySplitMerge(
+    TVector<TTableShardInfo>&& dstPartitions,
+    const TVector<TShardIdx>& removedShards,
+    ui64 splitFirstIdx,
+    TInstant now
+) {
+    const ui64 kRemoved = removedShards.size();
+    const ui64 kAdded = dstPartitions.size();
+
+    // Src shards are contiguous at [splitFirstIdx, splitFirstIdx + kRemoved).
+    Y_ABORT_UNLESS(splitFirstIdx < Partitions.size());
+    const ui64 splitEndIdx = splitFirstIdx + kRemoved;
+    Y_ABORT_UNLESS(splitEndIdx <= Partitions.size());
+    for (const TShardIdx& s : removedShards) {
+        const auto* p = PartitionStore.FindPtr(s);
+        Y_ABORT_UNLESS(p && p->Position >= splitFirstIdx && p->Position < splitEndIdx);
+    }
+
+    // Stats: subtract src shards, initialise dst shards
+    Stats.RemoveShardStats(removedShards, now);
+    for (const auto& dst : dstPartitions) {
+        Stats.PartitionStats.emplace(dst.ShardIdx, TPartitionStats{});
+    }
+    const ui64 newPartitionCount = Partitions.size() - kRemoved + kAdded;
+    Stats.Aggregated.PartCount = newPartitionCount;
+    if (SplitOpsInFlight.empty()) {
+        ExpectedPartitionCount = newPartitionCount;
+    }
+
+    // PartitionStore: erase src, insert dst
+    for (const TShardIdx& s : removedShards) {
+        PartitionStore.erase(s);
+    }
+    TVector<TTableShardInfo*> dstPtrs;
+    dstPtrs.reserve(kAdded);
+    for (auto& dst : dstPartitions) {
+        const TShardIdx idx = dst.ShardIdx;
+        auto [it, _] = PartitionStore.emplace(idx, std::move(dst));
+        dstPtrs.push_back(&it->second);
+    }
+    dstPartitions.clear();
+
+    // CondEraseSchedule: erase src, schedule dst
+    for (const TShardIdx& s : removedShards) {
+        InFlightCondErase.erase(s);
+        CondEraseSchedule.Erase(s);
+    }
+    if (IsTTLEnabled()) {
+        for (auto* dst : dstPtrs) {
+            CondEraseSchedule.Push(dst->NextCondErase, dst->ShardIdx);
+        }
+    }
+
+    // Partitions (pointer vector): erase src ptrs, insert dst ptrs
+    // Moving raw pointers is cheap and does not affect the pointed-to objects.
+    // Update Position for newly-inserted dst shards and all right-shifted survivors.
+    Partitions.erase(Partitions.begin() + splitFirstIdx, Partitions.begin() + splitEndIdx);
+    Partitions.insert(Partitions.begin() + splitFirstIdx, dstPtrs.begin(), dstPtrs.end());
+    for (ui64 i = splitFirstIdx; i < Partitions.size(); ++i) {
+        Partitions[i]->Position = i;
+    }
+
+    PreserializedTablePartitions.clear();
+    PreserializedTablePartitionsNoKeys.clear();
+    PreserializedTableSplitBoundaries.clear();
+
+    VerifyConsistency();
+}
+
+void TTableInfo::VerifyConsistency() const {
+    Y_ABORT_UNLESS(PartitionStore.size() == Partitions.size());
+    Y_ABORT_UNLESS(Stats.PartitionStats.size() == Partitions.size());
+    Y_ABORT_UNLESS(Stats.Aggregated.PartCount == Partitions.size());
+
+    for (size_t i = 0; i < Partitions.size(); ++i) {
+        const TTableShardInfo* p = Partitions[i];
+        Y_ABORT_UNLESS(p);
+        // Pointer must come from PartitionStore (same address).
+        Y_ABORT_UNLESS(PartitionStore.FindPtr(p->ShardIdx) == p);
+        Y_ABORT_UNLESS(Stats.PartitionStats.contains(p->ShardIdx));
+        if (i + 1 < Partitions.size()) {
+            Y_ABORT_UNLESS(!p->EndOfRange.empty());
+        }
+        // Position must reflect actual index in Partitions.
+        Y_ABORT_UNLESS(p->Position == i);
+    }
+
+    Y_ABORT_UNLESS(CondEraseSchedule.IsValidHeap());
+
+    if (IsTTLEnabled()) {
+        // Each live shard is either waiting in CondEraseSchedule or currently
+        // being erased (popped into InFlightCondErase by AddInFlightCondErase).
+        Y_ABORT_UNLESS(CondEraseSchedule.Container().size() + InFlightCondErase.size() == Partitions.size());
+        for (const auto* p : Partitions) {
+            Y_ABORT_UNLESS(CondEraseSchedule.Contains(p->ShardIdx) || InFlightCondErase.contains(p->ShardIdx));
+        }
+    } else {
+        Y_ABORT_UNLESS(CondEraseSchedule.Empty());
+        Y_ABORT_UNLESS(InFlightCondErase.empty());
+    }
+}
+
+void TTableAggregatedStats::RemoveShardStats(const TVector<TShardIdx>& keys, TInstant now) {
+    auto saturating_sub = [](ui64& value, const ui64 delta) {
+        value = ((value > delta) ? value - delta : 0);
+    };
+    ui64 removedCpu = 0;
+    for (const TShardIdx& key : keys) {
+        auto it = PartitionStats.find(key);
+        if (it == PartitionStats.end()) {
+            continue;
+        }
+        const TPartitionStats& s = it->second;
+        saturating_sub(Aggregated.RowCount, s.RowCount);
+        saturating_sub(Aggregated.DataSize, s.DataSize);
+        saturating_sub(Aggregated.IndexSize, s.IndexSize);
+        saturating_sub(Aggregated.ByKeyFilterSize, s.ByKeyFilterSize);
+        for (const auto& [poolKind, poolStats] : s.StoragePoolsStats) {
+            if (auto* agg = Aggregated.StoragePoolsStats.FindPtr(poolKind)) {
+                saturating_sub(agg->DataSize, poolStats.DataSize);
+                saturating_sub(agg->IndexSize, poolStats.IndexSize);
+            }
+        }
+        saturating_sub(Aggregated.InFlightTxCount, s.InFlightTxCount);
+        removedCpu += s.GetCurrentRawCpuUsage();
+        saturating_sub(Aggregated.Memory, s.Memory);
+        saturating_sub(Aggregated.Network, s.Network);
+        saturating_sub(Aggregated.Storage, s.Storage);
+        saturating_sub(Aggregated.ReadThroughput, s.ReadThroughput);
+        saturating_sub(Aggregated.WriteThroughput, s.WriteThroughput);
+        saturating_sub(Aggregated.ReadIops, s.ReadIops);
+        saturating_sub(Aggregated.WriteIops, s.WriteIops);
+        UpdatedStats.erase(key);
+        PartitionStats.erase(key);
+    }
+    const ui64 newCpu = static_cast<ui64>(
+        std::max<i64>(0, static_cast<i64>(Aggregated.GetCurrentRawCpuUsage()) - static_cast<i64>(removedCpu))
+    );
+    Aggregated.SetCurrentRawCpuUsage(newCpu, now);
 }
 
 void TTableInfo::UpdateShardStats(TDiskSpaceUsageDelta* diskSpaceUsageDelta, TShardIdx datashardIdx, const TPartitionStats& newStats, TInstant now) {
@@ -2211,11 +2389,11 @@ bool TTableInfo::CheckCanMergePartitions(const TSplitSettings& splitSettings,
         return false;
     }
 
-    if (!Shard2PartitionIdx.contains(shardIdx)) {
+    const TTableShardInfo* partitionInfo = PartitionStore.FindPtr(shardIdx);
+    if (!partitionInfo) {
         return false;
     }
-
-    i64 partitionIdx = *Shard2PartitionIdx.FindPtr(shardIdx);
+    const i64 partitionIdx = static_cast<i64>(partitionInfo->Position);
 
     shardsToMerge.clear();
     ui64 totalSize = 0;
@@ -2237,7 +2415,7 @@ bool TTableInfo::CheckCanMergePartitions(const TSplitSettings& splitSettings,
         << " " << shardMergeReason;
 
     for (i64 pi = partitionIdx - 1; pi >= 0; --pi) {
-        if (!TryAddShardToMerge(splitSettings, forceShardSplitSettings, GetPartitions()[pi].ShardIdx, shardsToMerge, partOwners, totalSize, totalLoad, cpuMergeThreshold, mainTableForIndex, now, shardMergeReason)) {
+        if (!TryAddShardToMerge(splitSettings, forceShardSplitSettings, GetPartitions()[pi]->ShardIdx, shardsToMerge, partOwners, totalSize, totalLoad, cpuMergeThreshold, mainTableForIndex, now, shardMergeReason)) {
             break;
         }
     }
@@ -2245,7 +2423,7 @@ bool TTableInfo::CheckCanMergePartitions(const TSplitSettings& splitSettings,
     Reverse(shardsToMerge.begin(), shardsToMerge.end());
 
     for (ui64 pi = partitionIdx + 1; pi < GetPartitions().size(); ++pi) {
-        if (!TryAddShardToMerge(splitSettings, forceShardSplitSettings, GetPartitions()[pi].ShardIdx, shardsToMerge, partOwners, totalSize, totalLoad, cpuMergeThreshold, mainTableForIndex, now, shardMergeReason)) {
+        if (!TryAddShardToMerge(splitSettings, forceShardSplitSettings, GetPartitions()[pi]->ShardIdx, shardsToMerge, partOwners, totalSize, totalLoad, cpuMergeThreshold, mainTableForIndex, now, shardMergeReason)) {
             break;
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -199,6 +199,7 @@ struct TTableShardInfo {
     TInstant LastCondErase;
     TInstant NextCondErase;
     mutable TMaybe<TDuration> LastCondEraseLag;
+    ui64 Position = 0;  // index in TTableInfo::Partitions; maintained by TTableInfo, not persisted
 
     // TODO: remove this ctor. It's used for vector.resize() that is not clear.
     TTableShardInfo() = default;
@@ -543,6 +544,11 @@ struct TTableAggregatedStats {
         const TShardIdx& shardIdx,
         const TPartitionStats& newStats
     );
+
+    // Subtracts current-state metrics of each shard from Aggregated
+    // and removes each shard from PartitionStats/UpdatedStats.
+    // Silently skips shards not in PartitionStats.
+    void RemoveShardStats(const TVector<TShardIdx>& keys, TInstant now);
 };
 
 struct TAggregatedStats : public TTableAggregatedStats {
@@ -552,6 +558,143 @@ struct TAggregatedStats : public TTableAggregatedStats {
 };
 
 struct TSubDomainInfo;
+
+// Indexed min-heap keyed by TShardIdx.
+// Pos map enables O(log N) targeted Erase (O(1) position lookup + O(log N) sift).
+class TCondEraseSchedule {
+public:
+    using TEntry = std::pair<TInstant, TShardIdx>;
+
+    void Push(TInstant t, const TShardIdx& shardIdx) {
+        Y_ABORT_UNLESS(!Contains(shardIdx));
+        const ui32 i = Heap.size();
+        Heap.push_back({t, shardIdx});
+        Pos[shardIdx] = i;
+        SiftUp(i);
+    }
+
+    // Batch load: call PushRaw for each entry, then BuildHeap once — O(N) total.
+    void PushRaw(TInstant t, const TShardIdx& shardIdx) {
+        Heap.push_back({t, shardIdx});
+    }
+    void BuildHeap() {
+        std::make_heap(Heap.begin(), Heap.end(), TGreater{});
+        Pos.clear();
+        Pos.reserve(Heap.size());
+        for (ui32 i = 0; i < Heap.size(); ++i) {
+            Pos[Heap[i].second] = i;
+        }
+    }
+
+    void Pop() {
+        Y_ABORT_UNLESS(!Heap.empty());
+        Pos.erase(Heap[0].second);
+        if (Heap.size() > 1) {
+            Heap[0] = std::move(Heap.back());
+            Pos[Heap[0].second] = 0;
+        }
+        Heap.pop_back();
+        if (!Heap.empty()) {
+            SiftDown(0);
+        }
+    }
+
+    // O(log N) targeted removal; no-op if shardIdx not present.
+    void Erase(const TShardIdx& shardIdx) {
+        auto posIt = Pos.find(shardIdx);
+        if (posIt == Pos.end()) {
+            return;
+        }
+        const ui32 i = posIt->second;
+        Pos.erase(posIt);
+        const ui32 last = Heap.size() - 1;
+        if (i < last) {
+            Heap[i] = std::move(Heap[last]);
+            Pos[Heap[i].second] = i;
+            Heap.pop_back();
+            SiftUp(i);
+            SiftDown(i);
+        } else {
+            Heap.pop_back();
+        }
+    }
+
+    bool Empty() const {
+        return Heap.empty();
+    }
+    bool Contains(const TShardIdx& shardIdx) const {
+        return Pos.contains(shardIdx);
+    }
+    void Clear() {
+        Heap.clear(); Pos.clear();
+    }
+    const TEntry& Top() const {
+        Y_ABORT_UNLESS(!Heap.empty());
+        return Heap[0];
+    }
+    const TVector<TEntry>& Container() const {
+        return Heap;
+    }
+
+    bool IsValidHeap() const {
+        if (Pos.size() != Heap.size()) {
+            return false;
+        }
+        for (ui32 i = 0; i < Heap.size(); ++i) {
+            auto it = Pos.find(Heap[i].second);
+            if (it == Pos.end() || it->second != i) {
+                return false;
+            }
+        }
+        return std::is_heap(Heap.begin(), Heap.end(), TGreater{});
+    }
+
+private:
+    struct TGreater {
+        bool operator()(const TEntry& a, const TEntry& b) const {
+            return a.first > b.first;
+        }
+    };
+
+    void SwapAt(ui32 i, ui32 j) {
+        std::swap(Heap[i], Heap[j]);
+        Pos[Heap[i].second] = i;
+        Pos[Heap[j].second] = j;
+    }
+
+    void SiftUp(ui32 i) {
+        while (i > 0) {
+            const ui32 p = (i - 1) >> 1;
+            if (Heap[p].first <= Heap[i].first) {
+                break;
+            }
+            SwapAt(i, p);
+            i = p;
+        }
+    }
+
+    void SiftDown(ui32 i) {
+        const ui32 n = Heap.size();
+        while (true) {
+            ui32 best = i;
+            const ui32 l = 2*i + 1, r = l + 1;
+            if (l < n && Heap[l].first < Heap[best].first) {
+                best = l;
+            }
+            if (r < n && Heap[r].first < Heap[best].first) {
+                best = r;
+            }
+            if (best == i) {
+                break;
+            }
+            SwapAt(i, best);
+            i = best;
+        }
+    }
+
+    TVector<TEntry> Heap;
+    THashMap<TShardIdx, ui32> Pos;
+};
 
 struct TTableInfo : public TSimpleRefCount<TTableInfo> {
     using TPtr = TIntrusivePtr<TTableInfo>;
@@ -736,19 +879,13 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
     }
 
 private:
-    using TPartitionsVec = TVector<TTableShardInfo>;
+    using TPartitionsVec = TVector<TTableShardInfo*>;
 
-    struct TSortByNextCondErase {
-        using TIterator = TPartitionsVec::iterator;
-
-        bool operator()(TIterator left, TIterator right) const {
-            return left->NextCondErase > right->NextCondErase;
-        }
-    };
-
-    TPartitionsVec Partitions;
-    THashMap<TShardIdx, ui64> Shard2PartitionIdx; // shardIdx -> index in Partitions
-    TPriorityQueue<TPartitionsVec::iterator, TVector<TPartitionsVec::iterator>, TSortByNextCondErase> CondEraseSchedule;
+    // Stable-address store: THashMap uses separate chaining, so element references
+    // survive insert.  Also serves as the O(1) ShardIdx lookup index.
+    THashMap<TShardIdx, TTableShardInfo> PartitionStore;
+    TPartitionsVec Partitions;  // ordered by EndOfRange; raw ptrs into PartitionStore
+    TCondEraseSchedule CondEraseSchedule;
     THashMap<TShardIdx, TActorId> InFlightCondErase; // shard to pipe client
     mutable TMaybe<ui32> TTLColumnId;
     THashSet<TOperationId> SplitOpsInFlight;
@@ -758,18 +895,8 @@ private:
     TAggregatedStats Stats;
     bool ShardsStatsDetached = false;
 
-    TPartitionsVec::iterator FindPartition(const TShardIdx& shardIdx) {
-        auto it = Shard2PartitionIdx.find(shardIdx);
-        if (it == Shard2PartitionIdx.end()) {
-            return Partitions.end();
-        }
-
-        const auto partitionIdx = it->second;
-        if (partitionIdx >= Partitions.size()) {
-            return Partitions.end();
-        }
-
-        return Partitions.begin() + partitionIdx;
+    TTableShardInfo* FindPartition(const TShardIdx& shardIdx) {
+        return PartitionStore.FindPtr(shardIdx);
     }
 
 public:
@@ -789,11 +916,15 @@ public:
 
     static TTableInfo::TPtr DeepCopy(const TTableInfo& other) {
         TTableInfo::TPtr copy(new TTableInfo(other));
-        // rebuild conditional erase schedule since it uses iterators
-        copy->CondEraseSchedule.clear();
-        for (ui32 i = 0; i < copy->Partitions.size(); ++i) {
-            copy->CondEraseSchedule.push(copy->Partitions.begin() + i);
+        // Partitions holds raw pointers into PartitionStore; after the value copy
+        // they point into other's store — rebuild them to point into the copy's.
+        copy->Partitions.resize(other.Partitions.size());
+        for (ui64 i = 0; i < other.Partitions.size(); ++i) {
+            copy->Partitions[i] = copy->PartitionStore.FindPtr(other.Partitions[i]->ShardIdx);
+            Y_ABORT_UNLESS(copy->Partitions[i]);
         }
+
+        copy->VerifyConsistency();
 
         return copy;
     }
@@ -900,8 +1031,20 @@ public:
 #endif
 
     void SetPartitioning(TVector<TTableShardInfo>&& newPartitioning);
+    // Rebuild PartitionStore/Partitions from newPartitioning; Stats are already correct
+    // (caller is a DeepCopy of a table with the same physical shard set).
+    void MovePartitioning(TVector<TTableShardInfo>&& newPartitioning);
+    // Rebuild PartitionStore/Partitions and Stats from scratch for all-new shard IDs
+    // (caller is a fresh dst table whose old placeholder shards had zero stats).
+    void CopyPartitioning(TVector<TTableShardInfo>&& newPartitioning);
 
-    const TVector<TTableShardInfo>& GetPartitions() const {
+    // O(N) consistency check across Partitions, PartitionStore, Stats, and CondEraseSchedule.
+    void VerifyConsistency() const;
+
+    // In-place split/merge: replaces the contiguous src shard range with dst shards.
+    void ApplySplitMerge(TVector<TTableShardInfo>&& dstPartitions, const TVector<TShardIdx>& removedShards, ui64 splitFirstIdx, TInstant now);
+
+    const TVector<TTableShardInfo*>& GetPartitions() const {
         return Partitions;
     }
 
@@ -942,8 +1085,8 @@ public:
         return SplitOpsInFlight;
     }
 
-    const THashMap<TShardIdx, ui64>& GetShard2PartitionIdx() const {
-        return Shard2PartitionIdx;
+    const THashMap<TShardIdx, TTableShardInfo>& GetPartitionStore() const {
+        return PartitionStore;
     }
 
     ui64 GetExpectedPartitionCount() const {
@@ -1173,11 +1316,27 @@ public:
     }
 
     const TTableShardInfo* GetScheduledCondEraseShard() const {
-        if (CondEraseSchedule.empty()) {
+        if (CondEraseSchedule.Empty()) {
             return nullptr;
         }
+        const TShardIdx& shardIdx = CondEraseSchedule.Top().second;
+        const auto* p = PartitionStore.FindPtr(shardIdx);
+        Y_ABORT_UNLESS(p);
+        return p;
+    }
 
-        return CondEraseSchedule.top();
+    // Schedule any partition not already in the schedule or in-flight.
+    void ScheduleAllCondErase() {
+        for (const auto* p : Partitions) {
+            if (!CondEraseSchedule.Contains(p->ShardIdx) && !InFlightCondErase.contains(p->ShardIdx)) {
+                CondEraseSchedule.Push(p->NextCondErase, p->ShardIdx);
+            }
+        }
+    }
+
+    void ClearCondEraseSchedule() {
+        CondEraseSchedule.Clear();
+        InFlightCondErase.clear();
     }
 
     const auto& GetInFlightCondErase() const {
@@ -1193,26 +1352,26 @@ public:
         Y_ENSURE(shardInfo && shardIdx == shardInfo->ShardIdx);
 
         InFlightCondErase[shardIdx] = TActorId();
-        CondEraseSchedule.pop();
+        CondEraseSchedule.Pop();
     }
 
     void RescheduleCondErase(const TShardIdx& shardIdx) {
         Y_ENSURE(InFlightCondErase.contains(shardIdx));
 
-        auto it = FindPartition(shardIdx);
-        Y_ENSURE(it != Partitions.end());
+        auto* p = FindPartition(shardIdx);
+        Y_ENSURE(p);
 
-        CondEraseSchedule.push(it);
+        CondEraseSchedule.Push(p->NextCondErase, shardIdx);
         InFlightCondErase.erase(shardIdx);
     }
 
     void UpdateNextCondErase(const TShardIdx& shardIdx, const TInstant& now, const TDuration& next) {
-        auto it = FindPartition(shardIdx);
-        Y_ENSURE(it != Partitions.end());
+        auto* p = FindPartition(shardIdx);
+        Y_ENSURE(p);
 
-        it->LastCondErase = now;
-        it->NextCondErase = now + next;
-        it->LastCondEraseLag = TDuration::Zero();
+        p->LastCondErase = now;
+        p->NextCondErase = now + next;
+        p->LastCondEraseLag = TDuration::Zero();
     }
 
     bool IsUsingSequence(const TString& name) {

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -315,8 +315,8 @@ void FillTableBoundaries(
     // Number of split boundaries equals to number of partitions - 1
     result->Reserve(tableInfo.GetPartitions().size() - 1);
     for (ui32 pi = 0; pi < tableInfo.GetPartitions().size() - 1; ++pi) {
-        const auto& p = tableInfo.GetPartitions()[pi];
-        TSerializedCellVec endKey(p.EndOfRange);
+        const auto* p = tableInfo.GetPartitions()[pi];
+        TSerializedCellVec endKey(p->EndOfRange);
         auto boundary = result->Add()->MutableKeyPrefix();
         for (ui32 ki = 0;  ki < endKey.GetCells().size(); ++ki){
             const auto& c = endKey.GetCells()[ki];
@@ -334,9 +334,9 @@ void FillTablePartitions(
     bool includeKeys
 ) {
     result->Reserve(tableInfo.GetPartitions().size());
-    for (auto& p : tableInfo.GetPartitions()) {
-        const auto& tabletId = ui64(shardInfos.at(p.ShardIdx).TabletID);
-        const auto& key = p.EndOfRange;
+    for (const auto* p : tableInfo.GetPartitions()) {
+        const auto& tabletId = ui64(shardInfos.at(p->ShardIdx).TabletID);
+        const auto& key = p->EndOfRange;
 
         auto part = result->Add();
         part->SetDatashardId(tabletId);
@@ -424,8 +424,8 @@ void TPathDescriber::DescribeTable(const TActorContext& ctx, TPathId pathId, TPa
     if (returnPartitionStats) {
         NKikimrSchemeOp::TPathDescription& pathDescription = *Result->Record.MutablePathDescription();
         pathDescription.MutableTablePartitionStats()->Reserve(tableInfo.GetPartitions().size());
-        for (auto& p : tableInfo.GetPartitions()) {
-            const auto* stats = tableInfo.GetStats().PartitionStats.FindPtr(p.ShardIdx);
+        for (const auto* p : tableInfo.GetPartitions()) {
+            const auto* stats = tableInfo.GetStats().PartitionStats.FindPtr(p->ShardIdx);
             Y_ABORT_UNLESS(stats);
             auto pbStats = pathDescription.AddTablePartitionStats();
             FillTableStats(pbStats, *stats);

--- a/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
@@ -1,0 +1,630 @@
+#include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+namespace {
+
+TVector<TTableShardInfo> MakeShards(ui32 n, ui64 ownerId = 1) {
+    TVector<TTableShardInfo> v;
+    v.reserve(n);
+    for (ui32 i = 0; i < n; ++i) {
+        TString range = (i + 1 < n) ? TString(1, char(i + 1)) : TString{};
+        v.emplace_back(TShardIdx(ownerId, i), range);
+    }
+    return v;
+}
+
+TTableInfo::TPtr MakeTable() {
+    return TTableInfo::TPtr(new TTableInfo());
+}
+
+void EnableTTL(TTableInfo& info) {
+    info.MutableTTLSettings().MutableEnabled()->SetColumnName("ts");
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TTableInfoTest) {
+
+// --- SetPartitioning ---
+
+Y_UNIT_TEST(SetPartitioning_BasicStructure) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    const auto& parts = info->GetPartitions();
+    UNIT_ASSERT_VALUES_EQUAL(parts.size(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().PartitionStats.size(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.PartCount, 3u);
+    for (ui32 i = 0; i < 3; ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(parts[i]->Position, i);
+    }
+    // No TTL — schedule must be empty.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+}
+
+Y_UNIT_TEST(SetPartitioning_WithTTL) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+    info->SetPartitioning(MakeShards(4));
+
+    // VerifyConsistency inside SetPartitioning checks schedule size == partition count.
+    // With no shards in-flight, all 4 must be in the schedule.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 4u);
+}
+
+Y_UNIT_TEST(SetPartitioning_ExpectedPartitionCount) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(5));
+    UNIT_ASSERT_VALUES_EQUAL(info->GetExpectedPartitionCount(), 5u);
+}
+
+// --- MovePartitioning ---
+
+Y_UNIT_TEST(MovePartitioning_PreservesStats) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    THashSet<TShardIdx> before;
+    for (const auto& [idx, _] : info->GetStats().PartitionStats) {
+        before.insert(idx);
+    }
+
+    info->MovePartitioning(MakeShards(3));
+
+    // Same shard indices must remain in Stats.
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().PartitionStats.size(), 3u);
+    for (const auto& [idx, _] : info->GetStats().PartitionStats) {
+        UNIT_ASSERT_C(before.contains(idx), "Unexpected shard in stats after MovePartitioning");
+    }
+}
+
+Y_UNIT_TEST(MovePartitioning_PreservesStatsValues) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    // Inject non-zero stats into shard 1.
+    TPartitionStats s;
+    s.SeqNo = TMessageSeqNo{1, 0};
+    s.RowCount = 42;
+    s.DataSize = 1000;
+    TDiskSpaceUsageDelta delta;
+    info->UpdateShardStats(&delta, TShardIdx(1, 1), s, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 42u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.DataSize, 1000u);
+
+    info->MovePartitioning(MakeShards(3));
+
+    // Stats values must survive the move — MovePartitioning must not touch PartitionStats.
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().PartitionStats.at(TShardIdx(1, 1)).RowCount, 42u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().PartitionStats.at(TShardIdx(1, 1)).DataSize, 1000u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 42u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.DataSize, 1000u);
+}
+
+Y_UNIT_TEST(MovePartitioning_RebuildsPositions) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+    info->MovePartitioning(MakeShards(3));
+
+    const auto& parts = info->GetPartitions();
+    for (ui32 i = 0; i < parts.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(parts[i]->Position, i);
+    }
+}
+
+Y_UNIT_TEST(MovePartitioning_TTL_ClearsInFlight) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+
+    // Shard 0 gets NextCondErase=0 so it will be heap-top.
+    TVector<TTableShardInfo> shards;
+    shards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 0);
+    shards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 1000);
+    shards.emplace_back(TShardIdx(1, 2), TString{},          0, 2000);
+    info->SetPartitioning(std::move(shards));
+
+    // Move the earliest shard into in-flight.
+    const auto* top = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(top);
+    info->AddInFlightCondErase(top->ShardIdx);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetInFlightCondErase().size(), 1u);
+
+    TVector<TTableShardInfo> newShards;
+    newShards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 0);
+    newShards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 1000);
+    newShards.emplace_back(TShardIdx(1, 2), TString{},          0, 2000);
+    info->MovePartitioning(std::move(newShards));
+
+    // In-flight must be cleared; VerifyConsistency checks all 3 are scheduled.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+}
+
+// --- CopyPartitioning ---
+
+Y_UNIT_TEST(CopyPartitioning_ClearsOldStats) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3, 1));  // ownerId=1
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().PartitionStats.size(), 3u);
+
+    // Copy with entirely different ShardIdx (ownerId=2).
+    info->CopyPartitioning(MakeShards(3, 2));
+
+    const auto& stats = info->GetStats().PartitionStats;
+    UNIT_ASSERT_VALUES_EQUAL(stats.size(), 3u);
+    for (const auto& [idx, _] : stats) {
+        UNIT_ASSERT_VALUES_EQUAL(idx.GetOwnerId(), (ui64)2);
+    }
+}
+
+Y_UNIT_TEST(CopyPartitioning_ResetsPartCount) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+    info->CopyPartitioning(MakeShards(5));
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.PartCount, 5u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 5u);
+}
+
+Y_UNIT_TEST(CopyPartitioning_TTL_ReschedulesNewShards) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+    info->SetPartitioning(MakeShards(2, 1));
+
+    info->CopyPartitioning(MakeShards(3, 2));
+
+    // VerifyConsistency inside CopyPartitioning checks all 3 new shards are scheduled.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 3u);
+}
+
+// --- ApplySplitMerge ---
+
+Y_UNIT_TEST(ApplySplitMerge_Split_1to2) {
+    auto info = MakeTable();
+    // Shards: A(1/0, '\x01'), B(1/1, '\x02'), C(1/2, '')
+    info->SetPartitioning(MakeShards(3));
+
+    // Split B (position 1) into B1 and B2.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 0);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 0);
+    TVector<TShardIdx> removed = {TShardIdx(1, 1)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/1, TInstant::Zero());
+
+    const auto& parts = info->GetPartitions();
+    UNIT_ASSERT_VALUES_EQUAL(parts.size(), 4u);
+    for (ui32 i = 0; i < parts.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(parts[i]->Position, i);
+    }
+    const auto& stats = info->GetStats().PartitionStats;
+    UNIT_ASSERT(!stats.contains(TShardIdx(1, 1)));   // B gone
+    UNIT_ASSERT(stats.contains(TShardIdx(2, 0)));    // B1 present
+    UNIT_ASSERT(stats.contains(TShardIdx(2, 1)));    // B2 present
+    UNIT_ASSERT(stats.contains(TShardIdx(1, 0)));    // A preserved
+    UNIT_ASSERT(stats.contains(TShardIdx(1, 2)));    // C preserved
+}
+
+Y_UNIT_TEST(ApplySplitMerge_Merge_2to1) {
+    auto info = MakeTable();
+    // Shards: A(1/0, '\x01'), B(1/1, '\x02'), C(1/2, '')
+    info->SetPartitioning(MakeShards(3));
+
+    // Merge A+B into AB.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x02'), 0, 0);
+    TVector<TShardIdx> removed = {TShardIdx(1, 0), TShardIdx(1, 1)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    const auto& parts = info->GetPartitions();
+    UNIT_ASSERT_VALUES_EQUAL(parts.size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(parts[0]->Position, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(parts[1]->Position, 1u);
+    const auto& stats = info->GetStats().PartitionStats;
+    UNIT_ASSERT(!stats.contains(TShardIdx(1, 0)));   // A gone
+    UNIT_ASSERT(!stats.contains(TShardIdx(1, 1)));   // B gone
+    UNIT_ASSERT(stats.contains(TShardIdx(2, 0)));    // AB present
+    UNIT_ASSERT(stats.contains(TShardIdx(1, 2)));    // C preserved
+}
+
+Y_UNIT_TEST(ApplySplitMerge_RightShiftPositions) {
+    auto info = MakeTable();
+    // Shards: A(1/0), B(1/1), C(1/2), D(1/3)
+    info->SetPartitioning(MakeShards(4));
+
+    // Split A (position 0) into A1+A2 — B, C, D shift right by 1.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 0);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 0);
+    TVector<TShardIdx> removed = {TShardIdx(1, 0)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    const auto& parts = info->GetPartitions();
+    UNIT_ASSERT_VALUES_EQUAL(parts.size(), 5u);
+    for (ui32 i = 0; i < parts.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL(parts[i]->Position, i);
+    }
+}
+
+Y_UNIT_TEST(ApplySplitMerge_AggregatedStatsSubtracted) {
+    auto info = MakeTable();
+    // Shards: A(1/0), B(1/1), C(1/2)
+    info->SetPartitioning(MakeShards(3));
+
+    // Inject stats into A and B.
+    TDiskSpaceUsageDelta delta;
+    TPartitionStats sA;
+    sA.SeqNo = TMessageSeqNo{1, 0};
+    sA.RowCount = 100;
+    sA.DataSize = 500;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), sA, TInstant::Zero());
+
+    TPartitionStats sB;
+    sB.SeqNo = TMessageSeqNo{1, 0};
+    sB.RowCount = 200;
+    sB.DataSize = 300;
+    info->UpdateShardStats(&delta, TShardIdx(1, 1), sB, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 300u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.DataSize, 800u);
+
+    // Merge A+B into AB — RemoveShardStats must subtract A and B from Aggregated.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x02'), 0, 0);
+    TVector<TShardIdx> removed = {TShardIdx(1, 0), TShardIdx(1, 1)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    // AB starts with zero stats, so Aggregated should reflect only the removal.
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.DataSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 2u);
+}
+
+Y_UNIT_TEST(ApplySplitMerge_TTL_SrcInFlightCleared) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+
+    // Shard 0 gets NextCondErase=0 so it will be heap-top.
+    TVector<TTableShardInfo> shards;
+    shards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 0);
+    shards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 1000);
+    shards.emplace_back(TShardIdx(1, 2), TString{},          0, 2000);
+    info->SetPartitioning(std::move(shards));
+
+    const auto* top = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(top);
+    const TShardIdx inFlightShard = top->ShardIdx;
+    info->AddInFlightCondErase(inFlightShard);
+
+    // Split the in-flight shard (position 0).
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 500);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 600);
+    TVector<TShardIdx> removed = {inFlightShard};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    // The in-flight entry for the src shard must be cleared.
+    UNIT_ASSERT(!info->GetInFlightCondErase().contains(inFlightShard));
+    // VerifyConsistency confirms all 4 remaining shards are covered by the schedule.
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 4u);
+}
+
+Y_UNIT_TEST(ApplySplitMerge_TTL_SrcInSchedule) {
+    // Complement to ApplySplitMerge_TTL_SrcInFlightCleared: exercises the path
+    // where the src shard is in CondEraseSchedule (not in-flight) when the split arrives.
+    auto info = MakeTable();
+    EnableTTL(*info);
+
+    TVector<TTableShardInfo> shards;
+    shards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 0);
+    shards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 1000);
+    shards.emplace_back(TShardIdx(1, 2), TString{},          0, 2000);
+    info->SetPartitioning(std::move(shards));
+
+    // All 3 shards are in CondEraseSchedule, none in-flight.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 500);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 600);
+    TVector<TShardIdx> removed = {TShardIdx(1, 0)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    // VerifyConsistency checks all 4 resulting shards are covered by schedule.
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 4u);
+}
+
+// --- DeepCopy ---
+
+Y_UNIT_TEST(DeepCopy_PointersAreIndependent) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    auto copy = TTableInfo::DeepCopy(*info);
+
+    // Mutate the original — split middle shard.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 0);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 0);
+    info->ApplySplitMerge(std::move(dst), {TShardIdx(1, 1)}, /*splitFirstIdx=*/1, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 4u);
+
+    // Copy must be unaffected — its pointers still reach its own PartitionStore.
+    UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 3u);
+    copy->VerifyConsistency();
+}
+
+Y_UNIT_TEST(DeepCopy_PreservesStats) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    TDiskSpaceUsageDelta delta;
+    TPartitionStats s;
+    s.SeqNo = TMessageSeqNo{1, 0};
+    s.RowCount = 77;
+    info->UpdateShardStats(&delta, TShardIdx(1, 1), s, TInstant::Zero());
+
+    auto copy = TTableInfo::DeepCopy(*info);
+
+    UNIT_ASSERT_VALUES_EQUAL(copy->GetStats().PartitionStats.at(TShardIdx(1, 1)).RowCount, 77u);
+    UNIT_ASSERT_VALUES_EQUAL(copy->GetStats().Aggregated.RowCount, 77u);
+}
+
+Y_UNIT_TEST(DeepCopy_WithTTL) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+    info->SetPartitioning(MakeShards(4));
+
+    // Move one shard to in-flight before copy.
+    const auto* top = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(top);
+    info->AddInFlightCondErase(top->ShardIdx);
+
+    auto copy = TTableInfo::DeepCopy(*info);
+
+    // VerifyConsistency is called inside DeepCopy, but verify the state explicitly.
+    UNIT_ASSERT_VALUES_EQUAL(copy->GetInFlightCondErase().size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 4u);
+    copy->VerifyConsistency();
+}
+
+// --- TTL state machine ---
+
+Y_UNIT_TEST(TTL_RescheduleCycle) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+
+    TVector<TTableShardInfo> shards;
+    shards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 0);
+    shards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 1000);
+    shards.emplace_back(TShardIdx(1, 2), TString{},          0, 2000);
+    info->SetPartitioning(std::move(shards));
+
+    const auto* top = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(top);
+    const TShardIdx dispatched = top->ShardIdx;
+    info->AddInFlightCondErase(dispatched);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetInFlightCondErase().size(), 1u);
+
+    // Reschedule back — simulates the "nothing to erase" response path.
+    info->RescheduleCondErase(dispatched);
+    UNIT_ASSERT(info->GetInFlightCondErase().empty());
+
+    // VerifyConsistency confirms all 3 are in the schedule.
+    info->VerifyConsistency();
+}
+
+Y_UNIT_TEST(TTL_ScheduleOrdering) {
+    auto info = MakeTable();
+    EnableTTL(*info);
+
+    // Shard 1/1 has the earliest NextCondErase (5000 < 10000 < 20000).
+    TVector<TTableShardInfo> shards;
+    shards.emplace_back(TShardIdx(1, 0), TString(1, '\x01'), 0, 10000);
+    shards.emplace_back(TShardIdx(1, 1), TString(1, '\x02'), 0, 5000);
+    shards.emplace_back(TShardIdx(1, 2), TString{},          0, 20000);
+    info->SetPartitioning(std::move(shards));
+
+    const auto* top = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(top);
+    UNIT_ASSERT_VALUES_EQUAL(top->ShardIdx, TShardIdx(1, 1));
+    info->AddInFlightCondErase(TShardIdx(1, 1));
+
+    // After work, reschedule with a much later NextCondErase.
+    info->UpdateNextCondErase(TShardIdx(1, 1), TInstant::FromValue(50000), TDuration::Seconds(1));
+    info->RescheduleCondErase(TShardIdx(1, 1));
+
+    // Shard 1/0 (NextCondErase=10000) must now be next.
+    const auto* newTop = info->GetScheduledCondEraseShard();
+    UNIT_ASSERT(newTop);
+    UNIT_ASSERT_VALUES_EQUAL(newTop->ShardIdx, TShardIdx(1, 0));
+}
+
+// --- UpdateShardStats ---
+
+Y_UNIT_TEST(UpdateShardStats_StaleDropped) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(2));
+
+    TDiskSpaceUsageDelta delta;
+    TPartitionStats current;
+    current.SeqNo = TMessageSeqNo{1, 5};
+    current.RowCount = 100;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), current, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 100u);
+
+    // Older SeqNo — must be silently dropped.
+    TPartitionStats stale;
+    stale.SeqNo = TMessageSeqNo{1, 3};
+    stale.RowCount = 999;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), stale, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 100u);
+}
+
+Y_UNIT_TEST(UpdateShardStats_GenerationRollover) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(2));
+
+    TDiskSpaceUsageDelta delta;
+
+    // Generation 1: tablet has processed 100 transactions.
+    TPartitionStats gen1;
+    gen1.SeqNo = TMessageSeqNo{1, 0};
+    gen1.ImmediateTxCompleted = 100;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), gen1, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.ImmediateTxCompleted, 100u);
+
+    // Generation 2: tablet restarted, its own counter reset to 10.
+    // Aggregated must preserve the gen1 count and add gen2 from a zero baseline.
+    TPartitionStats gen2;
+    gen2.SeqNo = TMessageSeqNo{2, 0};
+    gen2.ImmediateTxCompleted = 10;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), gen2, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.ImmediateTxCompleted, 110u);
+}
+
+// --- RemoveShardStats ---
+
+Y_UNIT_TEST(RemoveShardStats_NormalSubtraction) {
+    TTableAggregatedStats stats;
+    const TShardIdx shard{1, 0};
+
+    TPartitionStats s;
+    s.RowCount = 100;
+    s.DataSize = 500;
+    s.IndexSize = 50;
+    s.ByKeyFilterSize = 10;
+    s.Memory = 200;
+    s.Network = 30;
+    s.Storage = 1000;
+    s.ReadThroughput = 100;
+    s.WriteThroughput = 200;
+    s.ReadIops = 5;
+    s.WriteIops = 7;
+    s.InFlightTxCount = 3;
+    stats.PartitionStats[shard] = s;
+    stats.Aggregated.RowCount = 100;
+    stats.Aggregated.DataSize = 500;
+    stats.Aggregated.IndexSize = 50;
+    stats.Aggregated.ByKeyFilterSize = 10;
+    stats.Aggregated.Memory = 200;
+    stats.Aggregated.Network = 30;
+    stats.Aggregated.Storage = 1000;
+    stats.Aggregated.ReadThroughput = 100;
+    stats.Aggregated.WriteThroughput = 200;
+    stats.Aggregated.ReadIops = 5;
+    stats.Aggregated.WriteIops = 7;
+    stats.Aggregated.InFlightTxCount = 3;
+
+    stats.RemoveShardStats({shard}, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.RowCount, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.DataSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.IndexSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.ByKeyFilterSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.Memory, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.Network, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.Storage, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.ReadThroughput, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.WriteThroughput, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.ReadIops, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.WriteIops, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.InFlightTxCount, 0u);
+    UNIT_ASSERT(!stats.PartitionStats.contains(shard));
+}
+
+Y_UNIT_TEST(RemoveShardStats_SaturatesAtZero) {
+    // Shard stats exceed the aggregate (invariant drift). Must clamp to 0, not wrap.
+    TTableAggregatedStats stats;
+    const TShardIdx shard{1, 0};
+
+    TPartitionStats s;
+    s.RowCount = 200;
+    s.DataSize = 600;
+    s.Memory = 999;
+    stats.PartitionStats[shard] = s;
+    stats.Aggregated.RowCount = 100;
+    stats.Aggregated.DataSize = 500;
+    stats.Aggregated.Memory = 0;
+
+    stats.RemoveShardStats({shard}, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.RowCount, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.DataSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.Memory, 0u);
+}
+
+Y_UNIT_TEST(RemoveShardStats_UnknownKeyIsNoop) {
+    TTableAggregatedStats stats;
+    stats.Aggregated.RowCount = 42;
+
+    stats.RemoveShardStats({TShardIdx{9, 9}}, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.RowCount, 42u);
+}
+
+Y_UNIT_TEST(RemoveShardStats_MultipleKeys) {
+    TTableAggregatedStats stats;
+    const TShardIdx sA{1, 0};
+    const TShardIdx sB{1, 1};
+
+    TPartitionStats sa;
+    sa.RowCount = 100;
+    TPartitionStats sb;
+    sb.RowCount = 200;
+    stats.PartitionStats[sA] = sa;
+    stats.PartitionStats[sB] = sb;
+    stats.Aggregated.RowCount = 300;
+
+    stats.RemoveShardStats({sA, sB}, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(stats.Aggregated.RowCount, 0u);
+    UNIT_ASSERT(!stats.PartitionStats.contains(sA));
+    UNIT_ASSERT(!stats.PartitionStats.contains(sB));
+}
+
+Y_UNIT_TEST(RemoveShardStats_StoragePoolStats_Subtracted) {
+    TTableAggregatedStats stats;
+    const TShardIdx shard{1, 0};
+
+    TPartitionStats s;
+    s.StoragePoolsStats["hdd"] = {.DataSize = 100, .IndexSize = 50};
+    stats.PartitionStats[shard] = s;
+    stats.Aggregated.StoragePoolsStats["hdd"] = {.DataSize = 200, .IndexSize = 100};
+
+    stats.RemoveShardStats({shard}, TInstant::Zero());
+
+    const auto& pool = stats.Aggregated.StoragePoolsStats.at("hdd");
+    UNIT_ASSERT_VALUES_EQUAL(pool.DataSize, 100u);
+    UNIT_ASSERT_VALUES_EQUAL(pool.IndexSize, 50u);
+}
+
+Y_UNIT_TEST(RemoveShardStats_StoragePoolStats_UnknownPoolNotInserted) {
+    // Pool present on the shard but absent from the aggregate must not create a zero entry.
+    TTableAggregatedStats stats;
+    const TShardIdx shard{1, 0};
+
+    TPartitionStats s;
+    s.StoragePoolsStats["nvme"] = {.DataSize = 100, .IndexSize = 50};
+    stats.PartitionStats[shard] = s;
+
+    stats.RemoveShardStats({shard}, TInstant::Zero());
+
+    UNIT_ASSERT(!stats.Aggregated.StoragePoolsStats.contains("nvme"));
+}
+
+}

--- a/ydb/core/tx/schemeshard/ut_base/ya.make
+++ b/ydb/core/tx/schemeshard/ut_base/ya.make
@@ -26,6 +26,7 @@ SRCS(
     ut_counters.cpp
     ut_info_types.cpp
     ut_table_decimal_types.cpp
+    ut_table_info.cpp
     ut_table_pg_types.cpp
     ut_commit_redo_limit.cpp
 )

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5568,6 +5568,59 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         env.TestWaitNotification(runtime, txId);
     }
 
+    Y_UNIT_TEST(ShouldImportMultiPartitionTable) {
+        // Check that shard iteration order is correct.
+        // With 3 partitions the iteration order could differ from partition order,
+        // routing file-0 data ("a..." rows) to the shard covering "c..."
+        // and producing "key is out of range" failures.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        const auto data = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+            partitioning_settings { min_partitions_count: 1 }
+            partition_at_keys {
+              split_points {
+                type { tuple_type { elements { optional_type { item { type_id: UTF8 } } } } }
+                value { items { text_value: "b" } }
+              }
+              split_points {
+                type { tuple_type { elements { optional_type { item { type_id: UTF8 } } } } }
+                value { items { text_value: "c" } }
+              }
+            }
+        )", {{"a", 1}, {"b", 1}, {"c", 1}});
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(data), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", port));
+        env.TestWaitNotification(runtime, txId);
+
+        TestGetImport(runtime, txId, "/MyRoot");
+    }
+
     Y_UNIT_TEST(ViewCreationRetry) {
         TTestBasicRuntime runtime;
         auto options = TTestEnvOptions()

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -468,6 +468,125 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitBySizeTest) {
         // test requires more txids than cached at start
     }
 
+    Y_UNIT_TEST(MergeNonFirstPartitions) {
+        // Merging non-first partitions (positions 1 and 2) with partial persistence
+        // disabled (splitStartIdx=0).  ApplySplitMerge uses srcFirstIdx=1 for the
+        // src range; partition 0 must be unchanged.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        // 3 partitions: (-inf,"A"), ["A","B"), ["B",+inf)
+        // shards: FakeHiveTablets+0, +1, +2
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "A" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "B" } } } }
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    SizeToSplit: 100500
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"A", "B", ""})});
+
+        // With the flag off, splitStartIdx=0 for persistence; ApplySplitMerge
+        // still uses srcFirstIdx=1 as the src-shard position.
+        runtime.GetAppData().FeatureFlags.SetEnableSplitMergePartialPersistence(false);
+
+        // Merge partitions 1 and 2 (the non-first ones).
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+            SourceTabletId: %lu
+            SourceTabletId: %lu
+        )", TTestTxConfig::FakeHiveTablets + 1, TTestTxConfig::FakeHiveTablets + 2));
+        env.TestWaitNotification(runtime, txId);
+
+        // Partition 0 must be unchanged; partitions 1+2 merged into one.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"A", ""})});
+    }
+
+    Y_UNIT_TEST_FLAG(UnchangedPartitionStatsKeptAfterSplit, EnableSplitMergePartialPersistence) {
+        // Stats for partitions at positions >= splitStartIdx survive a schemeshard
+        // restart.  Exercised with both partial-persistence on and off.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        opts.DisableStatsBatching(true);
+        opts.DataShardStatsReportIntervalSeconds(0);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableSplitMergePartialPersistence(EnableSplitMergePartialPersistence);
+        // EnablePersistentPartitionStats is checked at call time, so setting it
+        // before any stats arrive is sufficient — no tablet restart needed.
+        runtime.GetAppData().FeatureFlags.SetEnablePersistentPartitionStats(true);
+
+        // 3 partitions: (-inf,100)→F+0, [100,200)→F+1, [200,+inf)→F+2 (C).
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 100 } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 200 } } } }
+            PartitionConfig {
+                PartitioningPolicy {
+                    SizeToSplit: 100500
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Block stats events.  Patch DataSize for shard C (F+2) to a sentinel so
+        // we can distinguish "stats row present" from "stats missing → default 0".
+        constexpr ui64 kShardCDataSize = 99999;
+        const ui64 shardCTabletId = TTestTxConfig::FakeHiveTablets + 2;
+        TBlockEvents<TEvDataShard::TEvPeriodicTableStats> statsBlocker(runtime);
+
+        runtime.WaitFor("stats from all 3 shards", [&]{ return statsBlocker.size() >= 3; });
+
+        for (auto& ev : statsBlocker) {
+            auto* msg = ev->Get();
+            if (msg->Record.GetDatashardId() == shardCTabletId) {
+                msg->Record.MutableTableStats()->SetDataSize(kShardCDataSize);
+            }
+        }
+        statsBlocker.Unblock(3);
+        // The 3 unblocked events are now ahead of the split proposal in the
+        // dispatch queue, so TestSplitTable's internal dispatch processes them
+        // first.  All further stats remain blocked so schemeshard cannot
+        // refresh C's stats from a fresh datashard report.
+
+        // Split F+1 (position 1) at key 150 → B1(pos=1), B2(pos=2).
+        // C shifts from position 2 to position 3.
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+            SourceTabletId: %lu
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 150 } } } }
+        )", TTestTxConfig::FakeHiveTablets + 1));
+        env.TestWaitNotification(runtime, txId);
+
+        GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Stats are still blocked: schemeshard has only what it loaded from local DB.
+        NKikimrSchemeOp::TDescribeOptions descOpts;
+        descOpts.SetReturnPartitioningInfo(true);
+        descOpts.SetReturnPartitionStats(true);
+        auto describe = DescribePath(runtime, "/MyRoot/Table", descOpts);
+        const auto& partStats = describe.GetPathDescription().GetTablePartitionStats();
+        UNIT_ASSERT_VALUES_EQUAL((size_t)partStats.size(), 4u);
+        // C is now at position 3; its stats row must be present in the DB.
+        UNIT_ASSERT_VALUES_EQUAL(partStats[3].GetDataSize(), kShardCDataSize);
+    }
+
     Y_UNIT_TEST(MergeIndexTableShards) {
         TTestBasicRuntime runtime;
 
@@ -665,6 +784,51 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitBySizeTest) {
 
     Y_UNIT_TEST(Make20MergeOperationsWithoutLimit) {
         AsyncMergeWithInflyLimit(20, 0);
+    }
+
+    Y_UNIT_TEST(SequentialSplitFirstShard) {
+        // Split the first (leftmost) shard 19 times to produce 20 partitions.
+        // Each split inserts a new shard at position 0, incrementing Position
+        // of all existing shards by 1.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    SizeToSplit: 100500
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Each iteration splits shard 0 at "key%02u" for i = 19, 18, ..., 01.
+        // Because "key01" < "key02" < ... < "key19" lexicographically, the new
+        // boundary is always less than all previous ones, keeping shard 0 as
+        // the leftmost shard throughout.
+        for (ui32 i = 19; i >= 1; --i) {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            const auto& parts = describe.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_VALUES_EQUAL((ui32)parts.size(), 20 - i);
+
+            const ui64 firstTabletId = parts[0].GetDatashardId();
+            TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "key%02u" } } } }
+            )", firstTabletId, i));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionCount(20)});
     }
 
 }
@@ -2376,5 +2540,29 @@ Y_UNIT_TEST_SUITE(TSchemeShardMergeByLoad) {
             true /* shouldSendReadRequests */,
             false /* expectTableToBeMerged */
         );
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardSplitMergeValidation) {
+    Y_UNIT_TEST(SplitWithDuplicateSourceTabletId) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "Key" Type: "Uint64"}
+            Columns { Name: "Value" Type: "Utf8"}
+            KeyColumnNames: ["Key"]
+            UniformPartitionsCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Try to split with duplicate SourceTabletId - should fail with StatusInvalidParameter
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", R"(
+            SourceTabletId: 72075186233409546
+            SourceTabletId: 72075186233409546
+        )", {{NKikimrScheme::StatusInvalidParameter, "Duplicate SourceTabletId"}});
     }
 }

--- a/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
+++ b/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_private.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
@@ -893,6 +894,209 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
         runtime.Send(delayed.Release(), 0, true);
         WaitForCondErase(runtime, TEvCondEraseResp::ProtoRecordType::SCHEME_ERROR);
+    }
+
+    Y_UNIT_TEST(SplitDuringInFlightCondErase) {
+        // Regression: VerifyConsistency() asserted CondEraseSchedule.size() ==
+        // Partitions.size(), which fails when one shard has a TTL erase in-flight
+        // (AddInFlightCondErase pops it from CondEraseSchedule) while a *different*
+        // shard is split. The correct invariant is
+        //   CondEraseSchedule.size() + InFlightCondErase.size() == Partitions.size().
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Two partitions: (-inf,100) → FakeHiveTablets+0, [100,+inf) → FakeHiveTablets+1.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts"  Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 100 } } } }
+            TTLSettings { Enabled { ColumnName: "ts" } }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Intercept the first TEvConditionalEraseRowsRequest.
+        // The TTL min-heap fires FakeHiveTablets+0 first (smaller ShardIdx), so
+        // FakeHiveTablets+0 ends up in InFlightCondErase while FakeHiveTablets+1
+        // remains in CondEraseSchedule.
+        THolder<IEventHandle> blocked;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!blocked && ev->GetTypeRewrite() == TEvCondEraseReq::EventType) {
+                blocked.Reset(ev.Release());
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        runtime.AdvanceCurrentTime(TDuration::Hours(1));
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&blocked](IEventHandle&) { return bool(blocked); });
+            runtime.DispatchEvents(opts);
+        }
+        runtime.SetObserverFunc(prevObserver);
+
+        // Split FakeHiveTablets+1 (still in CondEraseSchedule, not in-flight).
+        // ApplySplitMerge calls VerifyConsistency at the end. State after split:
+        //   Partitions = [F+0, dst1, dst2]  (size 3)
+        //   CondEraseSchedule = {dst1, dst2} (size 2)
+        //   InFlightCondErase = {F+0}        (size 1)
+        // Old broken check: 2 == 3 → abort. Fixed check: 2 + 1 == 3 → ok.
+        TestSplitTable(runtime, ++txId, "/MyRoot/TTLTable", Sprintf(R"(
+            SourceTabletId: %lu
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 150 } } } }
+        )", TTestTxConfig::FakeHiveTablets + 1));
+        env.TestWaitNotification(runtime, txId);
+
+        // Release the held erase so FakeHiveTablets+0 can respond.
+        runtime.Send(blocked.Release(), 0, true);
+        WaitForCondErase(runtime);
+    }
+
+    Y_UNIT_TEST(MoveTableDuringInFlightCondErase) {
+        // MovePartitioning (called during MoveTable) clears InFlightCondErase and
+        // reschedules all partitions.  After the move, the shard is in CondEraseSchedule
+        // and fires exactly one erase request in the next TTL cycle.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts"  Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings { Enabled { ColumnName: "ts" SysSettings { MaxShardsInFlight: 0 } } }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Block the erase request so the shard enters InFlightCondErase.
+        THolder<IEventHandle> blocked;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!blocked && ev->GetTypeRewrite() == TEvCondEraseReq::EventType) {
+                blocked.Reset(ev.Release());
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        runtime.AdvanceCurrentTime(TDuration::Hours(1));
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&blocked](IEventHandle&) { return bool(blocked); });
+            runtime.DispatchEvents(opts);
+        }
+        runtime.SetObserverFunc(prevObserver);
+
+        // Move the table while the shard is in InFlightCondErase.
+        TestMoveTable(runtime, ++txId, "/MyRoot/TTLTable", "/MyRoot/TTLTableMoved");
+        env.TestWaitNotification(runtime, txId);
+
+        // Drop the blocked request; after repartitioning the shard is in CondEraseSchedule.
+        blocked.Reset();
+
+        // Count erase requests emitted in the next TTL cycle.
+        ui32 extraRequests = 0;
+        auto countObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvCondEraseReq::EventType) {
+                ++extraRequests;
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        runtime.AdvanceCurrentTime(TDuration::Hours(1));
+        runtime.DispatchEvents({}, TDuration::Seconds(10));
+        runtime.SetObserverFunc(countObserver);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(extraRequests, 1,
+            "Shard must be rescheduled on the destination table after MoveTable");
+    }
+
+    Y_UNIT_TEST(DisableTTLClearsPendingCondErase) {
+        // ClearCondEraseSchedule() must also clear InFlightCondErase when TTL is
+        // disabled.  If it does not, re-enabling TTL leaves a stale entry in
+        // InFlightCondErase while ScheduleAllCondErase() repopulates
+        // CondEraseSchedule with the same shard.  TTxRunConditionalErase then
+        // checks InFlightCondErase.size() >= MaxShardsInFlight and skips the
+        // request — no TEvConditionalEraseRowsRequest is ever sent.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Single partition, MaxShardsInFlight=1 so one stale InFlightCondErase
+        // entry is enough to block all subsequent erase requests.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTable"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "ts"  Type: "Timestamp" }
+            KeyColumnNames: ["key"]
+            TTLSettings {
+                Enabled {
+                    ColumnName: "ts"
+                    SysSettings { MaxShardsInFlight: 1 }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Hold one erase request so the shard lands in InFlightCondErase.
+        THolder<IEventHandle> blocked;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!blocked && ev->GetTypeRewrite() == TEvCondEraseReq::EventType) {
+                blocked.Reset(ev.Release());
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        runtime.AdvanceCurrentTime(TDuration::Hours(1));
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&blocked](IEventHandle&) { return bool(blocked); });
+            runtime.DispatchEvents(opts);
+        }
+        runtime.SetObserverFunc(prevObserver);
+        // Drop the request — datashard never sees it, no response will arrive.
+        blocked.Reset();
+
+        // Disable TTL.  Must clear InFlightCondErase, not only CondEraseSchedule.
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTable"
+            TTLSettings { Disabled {} }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Re-enable TTL.  ScheduleAllCondErase() repopulates CondEraseSchedule.
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "TTLTable"
+            TTLSettings {
+                Enabled {
+                    ColumnName: "ts"
+                    SysSettings { MaxShardsInFlight: 1 }
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // After re-enabling TTL, the erase request must arrive within the first
+        // scheduler cycle.  ScheduleConditionalEraseRun always posts the next
+        // wakeup at +1 minute, so a 10-second deadline is enough to catch the
+        // already-past-due timer, but not enough to spin through repeated retries.
+        // In the bug case InFlightCondErase.size() >= MaxShardsInFlight (1 >= 1)
+        // blocks every TTxRunConditionalErase attempt; no request is ever sent;
+        // the next timer lands outside the 10-second window; DispatchEvents
+        // returns at quiescence instantly, and UNIT_ASSERT_C fires immediately.
+        TBlockEvents<TEvCondEraseReq> eraseReqs(runtime);
+        runtime.AdvanceCurrentTime(TDuration::Hours(1));
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&eraseReqs](IEventHandle&) { return !eraseReqs.empty(); });
+            runtime.DispatchEvents(opts, TDuration::Seconds(10));
+        }
+        UNIT_ASSERT_C(!eraseReqs.empty(), "TTL erase was blocked — InFlightCondErase was not cleared on disable");
     }
 
     Y_UNIT_TEST(ShouldCheckQuotas) {


### PR DESCRIPTION
Cherry-pick from `main`:
- 873abc2997b, https://github.com/ydb-platform/ydb/pull/38803

Changes:
- Layered optimization of HandleReply(TEvSplitAck) and related paths. No DB schema changes.

Issues: #37067.
