### PR TITLE
Add stack memory pool for coroutine actors. NBYDB-2174 (#40175)

### DIFF
--- a/ydb/library/actors/core/actor_coroutine.cpp
+++ b/ydb/library/actors/core/actor_coroutine.cpp
@@ -3,6 +3,7 @@
 
 #include <util/system/sanitizers.h>
 #include <util/system/type_name.h>
+#include <util/system/filemap.h>
 #include <util/system/info.h>
 #include <util/system/protect.h>
 
@@ -17,21 +18,65 @@ namespace NActors {
 #endif
         return size;
     }
+
+    class TLegacyStackMem : public IStackMem {
+    public:
+        explicit TLegacyStackMem(size_t sz)
+            : Alloc(sz)
+        {
+#ifndef NDEBUG
+            ProtectMemory(STACK_GROW_DOWN ? Begin() : End() - PageSize, PageSize, EProtectMemoryMode::PM_NONE);
+#endif
+        }
+
+        char* Begin() noexcept override {
+            return Alloc.Begin();
+        }
+
+        char* End() noexcept override {
+            return Alloc.End();
+        }
+
+    private:
+        TMappedAllocation Alloc;
+    };
+
+    static TArrayRef<char> GetStackRange(const std::unique_ptr<IStackMem>& stack) {
+        Y_ABORT_UNLESS(stack);
+        return TArrayRef(stack->Begin(), stack->End());
+    }
 #endif
 
     TActorCoroImpl::TActorCoroImpl(size_t stackSize, bool allowUnhandledDtor)
-        : AllowUnhandledDtor(allowUnhandledDtor)
 #if !CORO_THROUGH_THREADS
-        , Stack(AlignStackSize(stackSize))
-        , FiberClosure{this, TArrayRef(Stack.Begin(), Stack.End())}
-        , FiberContext(FiberClosure)
+        : TActorCoroImpl(std::make_unique<TLegacyStackMem>(AlignStackSize(stackSize)), allowUnhandledDtor)
+#else
+        : AllowUnhandledDtor(allowUnhandledDtor)
 #endif
     {
         Y_UNUSED(stackSize);
-#if !CORO_THROUGH_THREADS && !defined(NDEBUG)
-        ProtectMemory(STACK_GROW_DOWN ? Stack.Begin() : Stack.End() - PageSize, PageSize, EProtectMemoryMode::PM_NONE);
-#endif
     }
+
+    TActorCoroImpl::TActorCoroImpl(TUsePooledStack stack, bool allowUnhandledDtor)
+#if !CORO_THROUGH_THREADS
+        : TActorCoroImpl(
+            TStackMemPool::GetMemPool(TStackMemPool::TPageBucket::Bytes(stack.StackSize))->Allocate(),
+            allowUnhandledDtor)
+#else
+        : TActorCoroImpl(stack.StackSize, allowUnhandledDtor)
+#endif
+    {
+    }
+
+#if !CORO_THROUGH_THREADS
+    TActorCoroImpl::TActorCoroImpl(std::unique_ptr<IStackMem> stack, bool allowUnhandledDtor)
+        : AllowUnhandledDtor(allowUnhandledDtor)
+        , Stack(std::move(stack))
+        , FiberClosure{this, GetStackRange(Stack)}
+        , FiberContext(FiberClosure)
+    {
+    }
+#endif
 
     void TActorCoroImpl::Destroy() {
         if (!Finished) { // only resume when we have bootstrapped and Run() was entered and not yet finished; in other case simply terminate

--- a/ydb/library/actors/core/actor_coroutine.h
+++ b/ydb/library/actors/core/actor_coroutine.h
@@ -2,16 +2,27 @@
 
 #include <util/system/context.h>
 #include <util/system/event.h>
-#include <util/system/filemap.h>
-
 #include "actor_bootstrapped.h"
+#include "coro_stack_pool.h"
 #include "event_local.h"
 
+#include <memory>
 #include <thread>
 
 namespace NActors {
 
     class TActorCoro;
+
+    struct TUsePooledStack {
+        ui32 StackSize;
+    };
+
+    template <ui32 StackSize>
+    constexpr TUsePooledStack UsePooledStack() noexcept {
+        static_assert(StackSize && ((StackSize & (StackSize - 1u)) == 0));
+        static_assert(StackSize < (1 << 20));
+        return {StackSize};
+    }
 
 #ifndef CORO_THROUGH_THREADS
 #   ifdef _tsan_enabled_
@@ -31,7 +42,7 @@ namespace NActors {
         TActivationContext *ActivationContext = nullptr;
         std::thread WorkerThread;
 #else
-        TMappedAllocation Stack;
+        std::unique_ptr<IStackMem> Stack;
         TContClosure FiberClosure;
         TExceptionSafeContext FiberContext;
         TExceptionSafeContext* ActorSystemContext = nullptr;
@@ -99,6 +110,10 @@ namespace NActors {
 
     public:
         TActorCoroImpl(size_t stackSize, bool allowUnhandledDtor = false);
+        TActorCoroImpl(TUsePooledStack stack, bool allowUnhandledDtor = false);
+#if !CORO_THROUGH_THREADS
+        TActorCoroImpl(std::unique_ptr<IStackMem> stack, bool allowUnhandledDtor = false);
+#endif
         // specify stackSize explicitly for each actor; don't forget about overflow control gap
 
         virtual ~TActorCoroImpl() = default;

--- a/ydb/library/actors/core/coro_stack_pool.cpp
+++ b/ydb/library/actors/core/coro_stack_pool.cpp
@@ -1,0 +1,306 @@
+#include "coro_stack_pool.h"
+
+#include <util/generic/yexception.h>
+#include <util/system/context.h>
+#include <util/system/info.h>
+#include <util/system/yassert.h>
+
+#include <library/cpp/threading/queue/mpmc_unordered_ring.h>
+
+#include <array>
+#include <atomic>
+#include <algorithm>
+#include <bit>
+#include <cerrno>
+#include <cstring>
+#include <mutex>
+#include <vector>
+
+#if defined(_unix_) || defined(_darwin_)
+#include <sys/mman.h>
+#elif defined(_win_)
+#include <Windows.h>
+#else
+#error TStackMemPool requires mmap or VirtualAlloc
+#endif
+
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+namespace NActors {
+
+static const size_t PageSize = NSystemInfo::GetPageSize();
+static constexpr ui32 MaxStackPageBits = 20;
+static constexpr size_t LocalCacheLimitBytes = 1 * 1024 * 1024;
+static constexpr size_t GlobalExchangeLimitBytes = 64 * 1024 * 1024;
+
+// The stack memory layout and mprotect test cover only downward-growing stacks.
+// Revisit guard placement before enabling upward-growing stacks.
+static_assert(STACK_GROW_DOWN == 1, "TStackMemPool requires downward-growing stacks");
+
+static struct {
+    std::mutex Mutex;
+    std::array<std::atomic<TStackMemPool*>, MaxStackPageBits> Pools;
+} StackMemPoolRegistry;
+
+static size_t GetMappingSize(TStackMemPool::TPageBucket pageBucket) noexcept {
+    return pageBucket.Size() + PageSize;
+}
+
+static size_t GetCacheLimit(size_t limitBytes, TStackMemPool::TPageBucket pageBucket) noexcept {
+    // TODO: Precompute limits per page bucket to avoid division in the local cache put path.
+    return std::max<size_t>(1, limitBytes / GetMappingSize(pageBucket));
+}
+
+static char* AllocateStackMemMapping(size_t mappingSize) {
+#if defined(_unix_) || defined(_darwin_)
+    char* mapping = static_cast<char*>(mmap(nullptr, mappingSize, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    Y_ABORT_UNLESS(mapping != MAP_FAILED, "mmap failed for coroutine stack memory, mappingSize# %zu errno# %d (%s)",
+        mappingSize, errno, std::strerror(errno));
+    return mapping;
+#elif defined(_win_)
+    char* mapping = static_cast<char*>(VirtualAlloc(nullptr, mappingSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
+    Y_ABORT_UNLESS(mapping, "VirtualAlloc failed for coroutine stack memory, mappingSize# %zu lastError# %lu",
+        mappingSize, GetLastError());
+    return mapping;
+#endif
+}
+
+static void FreeStackMemMapping(char* mapping, size_t mappingSize) noexcept {
+#if defined(_unix_) || defined(_darwin_)
+    Y_ABORT_UNLESS(munmap(mapping, mappingSize) == 0);
+#elif defined(_win_)
+    (void)mappingSize;
+    Y_ABORT_UNLESS(VirtualFree(mapping, 0, MEM_RELEASE));
+#endif
+}
+
+static char* GetStackMemMappingBegin(char* stackMem) noexcept {
+    return stackMem - PageSize;
+}
+
+static void ProtectStackMemGuard(char* mapping) noexcept {
+#if defined(_unix_) || defined(_darwin_)
+    Y_ABORT_UNLESS(mprotect(mapping, PageSize, PROT_NONE) == 0,
+        "mprotect failed for coroutine stack guard page, errno# %d (%s)", errno, std::strerror(errno));
+#elif defined(_win_)
+    DWORD oldProtect = 0;
+    Y_ABORT_UNLESS(VirtualProtect(mapping, PageSize, PAGE_NOACCESS, &oldProtect),
+        "VirtualProtect failed for coroutine stack guard page, lastError# %lu", GetLastError());
+#endif
+}
+
+static char* AllocateStackMem(TStackMemPool::TPageBucket pageBucket) {
+    const size_t mappingSize = GetMappingSize(pageBucket);
+    char* mapping = AllocateStackMemMapping(mappingSize);
+    char* stackMem = mapping + PageSize;
+    ProtectStackMemGuard(mapping);
+
+    return stackMem;
+}
+
+static void FreeStackMem(TStackMemPool::TPageBucket pageBucket, char* stackMem) noexcept {
+    if (!stackMem) {
+        return;
+    }
+
+    FreeStackMemMapping(GetStackMemMappingBegin(stackMem), GetMappingSize(pageBucket));
+}
+
+struct TStackMemChain {
+    char* TryPop() noexcept {
+        if (StackMems.empty()) {
+            return nullptr;
+        }
+
+        char* stackMem = StackMems.back();
+        StackMems.pop_back();
+        return stackMem;
+    }
+
+    bool Push(char* stackMem, size_t limit) noexcept {
+        if (StackMems.size() >= limit) {
+            return false;
+        }
+
+        StackMems.push_back(stackMem);
+        return true;
+    }
+
+    void Clear(TStackMemPool::TPageBucket pageBucket) noexcept {
+        for (char* stackMem : StackMems) {
+            FreeStackMem(pageBucket, stackMem);
+        }
+        StackMems.clear();
+    }
+
+    std::vector<char*> StackMems;
+};
+
+struct TGlobalStackExchange {
+    struct TLockFreeChain {
+        explicit TLockFreeChain(size_t limit)
+            : StackMems(limit)
+        {}
+
+        char* TryPop() noexcept {
+            return static_cast<char*>(StackMems.Pop());
+        }
+
+        bool Push(char* stackMem) noexcept {
+            return StackMems.Push(stackMem);
+        }
+
+        void Clear(TStackMemPool::TPageBucket pageBucket) noexcept {
+            while (char* stackMem = TryPop()) {
+                FreeStackMem(pageBucket, stackMem);
+            }
+
+            ui64 last = 0;
+            while (char* stackMem = static_cast<char*>(StackMems.UnsafeScanningPop(&last))) {
+                FreeStackMem(pageBucket, stackMem);
+            }
+        }
+
+        NThreading::TMPMCUnorderedRing StackMems;
+    };
+
+    TGlobalStackExchange() {
+        for (size_t i = 0; i < Chains.size(); ++i) {
+            Chains[i] = std::make_unique<TLockFreeChain>(
+                GetCacheLimit(GlobalExchangeLimitBytes, TStackMemPool::TPageBucket{static_cast<ui32>(i)}));
+        }
+    }
+
+    ~TGlobalStackExchange() {
+        for (size_t i = 0; i < Chains.size(); ++i) {
+            Chains[i]->Clear(TStackMemPool::TPageBucket{static_cast<ui32>(i)});
+        }
+    }
+
+    char* Allocate(TStackMemPool::TPageBucket pageBucket) noexcept {
+        return Chains[pageBucket.Index]->TryPop();
+    }
+
+    bool Put(TStackMemPool::TPageBucket pageBucket, char* stackMem) noexcept {
+        return Chains[pageBucket.Index]->Push(stackMem);
+    }
+
+    std::array<std::unique_ptr<TLockFreeChain>, MaxStackPageBits> Chains;
+};
+
+static TGlobalStackExchange GlobalExchange;
+
+struct TStackMemPoolCache {
+    ~TStackMemPoolCache() {
+        for (size_t i = 0; i < Chains.size(); ++i) {
+            Chains[i].Clear(TStackMemPool::TPageBucket{static_cast<ui32>(i)});
+        }
+    }
+
+    char* Allocate(TStackMemPool::TPageBucket pageBucket) noexcept {
+        if (char* stackMem = Chains[pageBucket.Index].TryPop()) {
+            return stackMem;
+        }
+
+        return GlobalExchange.Allocate(pageBucket);
+    }
+
+    void Put(TStackMemPool::TPageBucket pageBucket, char* stackMem) noexcept {
+        if (!Chains[pageBucket.Index].Push(stackMem, GetCacheLimit(LocalCacheLimitBytes, pageBucket))) {
+            if (!GlobalExchange.Put(pageBucket, stackMem)) {
+                FreeStackMem(pageBucket, stackMem);
+            }
+        }
+    }
+
+    void Free(TStackMemPool::TPageBucket pageBucket, char* stackMem) noexcept {
+        if (!stackMem) {
+            return;
+        }
+
+        Put(pageBucket, stackMem);
+    }
+
+    std::array<TStackMemChain, MaxStackPageBits> Chains;
+};
+
+static thread_local TStackMemPoolCache LocalCache;
+
+class TStackMem final : public IStackMem {
+public:
+    TStackMem(char* stackMem, TStackMemPool::TPageBucket pageBucket) noexcept
+        : StackMem(stackMem)
+        , PageBucket(pageBucket)
+    {}
+
+    ~TStackMem() override {
+        LocalCache.Free(PageBucket, StackMem);
+    }
+
+    char* Begin() noexcept override {
+        return StackMem;
+    }
+
+    char* End() noexcept override {
+        return StackMem + PageBucket.Size();
+    }
+
+private:
+    char* StackMem;
+    const TStackMemPool::TPageBucket PageBucket;
+};
+
+TStackMemPool::TPageBucket TStackMemPool::TPageBucket::Bytes(ui32 sz) {
+    if (sz == 0 || (sz & (sz - 1u))) {
+        ythrow yexception() << "The stack size must be power of 2";
+    }
+
+    const ui32 pages = (sz + PageSize - 1) / PageSize;
+    const ui32 bucketIndex = std::bit_width(pages - 1);
+
+    if (bucketIndex >= MaxStackPageBits) {
+        ythrow yexception() << "The stack requires too large page bucket: " << bucketIndex;
+    }
+
+    return TPageBucket{bucketIndex};
+}
+
+size_t TStackMemPool::TPageBucket::Size() const noexcept {
+    return PageSize << Index;
+}
+
+
+TStackMemPool* TStackMemPool::GetMemPool(TPageBucket pageBucket) noexcept {
+    Y_ABORT_UNLESS(pageBucket.Index < MaxStackPageBits);
+    TStackMemPool* pool = StackMemPoolRegistry.Pools[pageBucket.Index].load(std::memory_order_acquire);
+    if (pool) {
+        return pool;
+    }
+
+    std::lock_guard<std::mutex> guard(StackMemPoolRegistry.Mutex);
+    pool = StackMemPoolRegistry.Pools[pageBucket.Index].load(std::memory_order_relaxed);
+    if (!pool) {
+        pool = new TStackMemPool(pageBucket);
+        StackMemPoolRegistry.Pools[pageBucket.Index].store(pool, std::memory_order_release);
+    }
+
+    return pool;
+}
+
+TStackMemPool::TStackMemPool(TPageBucket pageBucket) noexcept
+    : PageBucket(pageBucket)
+{}
+
+std::unique_ptr<IStackMem> TStackMemPool::Allocate() {
+    char* stackMem = LocalCache.Allocate(PageBucket);
+    if (!stackMem) {
+        stackMem = AllocateStackMem(PageBucket);
+    }
+
+    return std::unique_ptr<IStackMem>(new TStackMem(stackMem, PageBucket));
+}
+
+}

--- a/ydb/library/actors/core/coro_stack_pool.h
+++ b/ydb/library/actors/core/coro_stack_pool.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <util/generic/noncopyable.h>
+#include <util/system/types.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace NActors {
+
+class IStackMem {
+public:
+    virtual ~IStackMem() = default;
+
+    virtual char* Begin() noexcept = 0;
+    virtual char* End() noexcept = 0;
+};
+
+
+class TStackMemPool : public NNonCopyable::TNonCopyable {
+public:
+    struct TPageBucket {
+        static TPageBucket Bytes(ui32 sz);
+        size_t Size() const noexcept;
+        ui32 Index;
+    };
+
+    static TStackMemPool* GetMemPool(TPageBucket pageBucket) noexcept;
+    std::unique_ptr<IStackMem> Allocate();
+private:
+    explicit TStackMemPool(TPageBucket pageBucket) noexcept;
+
+private:
+    const TPageBucket PageBucket;
+};
+
+
+}

--- a/ydb/library/actors/core/ut/actor_coroutine_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_coroutine_ut.cpp
@@ -8,6 +8,10 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/system/sanitizers.h>
+#include <util/system/hp_timer.h>
+#include <util/string/cast.h>
+
+#include <cstdlib>
 
 using namespace NActors;
 
@@ -16,7 +20,9 @@ Y_UNIT_TEST_SUITE(ActorCoro) {
         Begin = EventSpaceBegin(TEvents::ES_USERSPACE),
         Request,
         Response,
-        Enough
+        Enough,
+        ChainMessage,
+        ChainMessageReceived
     };
 
     struct TEvRequest: public TEventLocal<TEvRequest, Request> {
@@ -27,6 +33,51 @@ Y_UNIT_TEST_SUITE(ActorCoro) {
 
     struct TEvEnough: public TEventLocal<TEvEnough, Enough> {
     };
+
+    struct TEvChainMessage: public TEventLocal<TEvChainMessage, ChainMessage> {
+        ui32 Step = 0;
+
+        explicit TEvChainMessage(ui32 step)
+            : Step(step)
+        {}
+    };
+
+    struct TEvChainMessageReceived: public TEventLocal<TEvChainMessageReceived, ChainMessageReceived> {
+        ui32 Step = 0;
+
+        explicit TEvChainMessageReceived(ui32 step)
+            : Step(step)
+        {}
+    };
+
+    ui32 GetCoroutineActorChainLength() {
+        if (const char* value = std::getenv("ACTOR_COROUTINE_CHAIN_LENGTH")) {
+            return FromString<ui32>(value);
+        }
+        return 10000;
+    }
+
+    ui32 GetCoroutineActorChainExecutorThreads() {
+        if (const char* value = std::getenv("ACTOR_COROUTINE_CHAIN_EXECUTOR_THREADS")) {
+            return FromString<ui32>(value);
+        }
+        return 4;
+    }
+
+    enum class EChainCoroStackKind {
+        Legacy,
+#if !CORO_THROUGH_THREADS
+        StackPool,
+#endif
+    };
+
+    template <EChainCoroStackKind StackKind>
+    class TChainCoroActor;
+
+    struct TChainCoroCompletion;
+
+    template <EChainCoroStackKind StackKind>
+    IActor* CreateChainCoroActor(TChainCoroCompletion& completion, ui32 step, ui32 chainLength);
 
     class TBasicResponderActor: public TActorBootstrapped<TBasicResponderActor> {
         TDeque<TActorId> RespondTo;
@@ -61,6 +112,93 @@ Y_UNIT_TEST_SUITE(ActorCoro) {
             Die(ctx);
         }
     };
+
+    static constexpr ui32 ChainCoroStackSize = 64 * 1024;
+
+    struct TChainCoroCompletion {
+        explicit TChainCoroCompletion(ui32 chainCount) {
+            AtomicSet(RemainingChains, chainCount);
+        }
+
+        void CompleteChain() {
+            if (AtomicDecrement(RemainingChains) == 0) {
+                DoneEvent.Signal();
+            }
+        }
+
+        void Wait() {
+            DoneEvent.WaitI();
+        }
+
+    private:
+        TManualEvent DoneEvent;
+        TAtomic RemainingChains = 0;
+    };
+
+    template <EChainCoroStackKind StackKind>
+    struct TChainCoroStackArg;
+
+    template <>
+    struct TChainCoroStackArg<EChainCoroStackKind::Legacy> {
+        static size_t Create() {
+            return ChainCoroStackSize;
+        }
+    };
+
+#if !CORO_THROUGH_THREADS
+    template <>
+    struct TChainCoroStackArg<EChainCoroStackKind::StackPool> {
+        static TUsePooledStack Create() {
+            return UsePooledStack<ChainCoroStackSize>();
+        }
+    };
+#endif
+
+    template <EChainCoroStackKind StackKind>
+    class TChainCoroActor: public TActorCoroImpl {
+        TChainCoroCompletion& Completion;
+        const ui32 Step;
+        const ui32 ChainLength;
+
+    public:
+        TChainCoroActor(TChainCoroCompletion& completion, ui32 step, ui32 chainLength)
+            : TActorCoroImpl(TChainCoroStackArg<StackKind>::Create())
+            , Completion(completion)
+            , Step(step)
+            , ChainLength(chainLength)
+        {}
+
+        void Run() override {
+            if (Step) {
+                THolder<IEventHandle> ev = WaitForEvent();
+                UNIT_ASSERT_VALUES_EQUAL(ev->GetTypeRewrite(), TEvChainMessage::EventType);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Get<TEvChainMessage>()->Step, Step);
+                Send(ev->Sender, new TEvChainMessageReceived(Step));
+            }
+
+            if (Step == ChainLength) {
+                return;
+            }
+
+            const ui32 nextStep = Step + 1;
+            const TActorId nextActor = Register(CreateChainCoroActor<StackKind>(Completion, nextStep, ChainLength));
+            Send(nextActor, new TEvChainMessage(nextStep));
+
+            THolder<IEventHandle> ev = WaitForEvent();
+            UNIT_ASSERT_VALUES_EQUAL(ev->GetTypeRewrite(), TEvChainMessageReceived::EventType);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get<TEvChainMessageReceived>()->Step, nextStep);
+            UNIT_ASSERT_C(ev->Sender == nextActor, "TEvChainMessageReceived sender mismatch");
+
+            if (nextStep == ChainLength) {
+                Completion.CompleteChain();
+            }
+        }
+    };
+
+    template <EChainCoroStackKind StackKind>
+    IActor* CreateChainCoroActor(TChainCoroCompletion& completion, ui32 step, ui32 chainLength) {
+        return new TActorCoro(MakeHolder<TChainCoroActor<StackKind>>(completion, step, chainLength));
+    }
 
     class TCoroActor: public TActorCoroImpl {
         TManualEvent& DoneEvent;
@@ -142,4 +280,82 @@ Y_UNIT_TEST_SUITE(ActorCoro) {
     Y_UNIT_TEST(PoisonPill) {
         Check(MakeHolder<TEvents::TEvPoisonPill>());
     }
+
+    template <EChainCoroStackKind StackKind>
+    void RunActorCreationChains(const char* name, ui32 chainCount) {
+        if (NSan::TSanIsOn()) {
+            return;
+        }
+
+        const ui32 chainLength = GetCoroutineActorChainLength();
+        const ui32 executorThreads = GetCoroutineActorChainExecutorThreads();
+        UNIT_ASSERT_C(chainLength > 0, "ACTOR_COROUTINE_CHAIN_LENGTH must be greater than zero");
+        UNIT_ASSERT_C(executorThreads > 0, "ACTOR_COROUTINE_CHAIN_EXECUTOR_THREADS must be greater than zero");
+        UNIT_ASSERT_C(chainCount > 0, "chainCount must be greater than zero");
+
+        THolder<TActorSystemSetup> setup = MakeHolder<TActorSystemSetup>();
+        setup->NodeId = 0;
+        setup->ExecutorsCount = 1;
+        setup->Executors.Reset(new TAutoPtr<IExecutorPool>[setup->ExecutorsCount]);
+        setup->Executors[0] = new TBasicExecutorPool(0, executorThreads, 10, "basic");
+        setup->Scheduler = new TBasicSchedulerThread;
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TChainCoroCompletion completion(chainCount);
+
+        THPTimer timer;
+        timer.Reset();
+        for (ui32 chain = 0; chain < chainCount; ++chain) {
+            actorSystem.Register(CreateChainCoroActor<StackKind>(completion, 0, chainLength));
+        }
+        completion.Wait();
+        const double elapsedUs = timer.Passed() * 1000000.0;
+        const double perChainStepUs = elapsedUs / chainLength;
+
+        Cerr << name
+             << " length# " << chainLength
+             << " chains# " << chainCount
+             << " executor_threads# " << executorThreads
+             << " elapsed_us# " << elapsedUs
+             << " per_chain_step_us# " << perChainStepUs
+             << Endl;
+
+        actorSystem.Stop();
+    }
+
+    Y_UNIT_TEST(ActorCreationChainLegacy) {
+        RunActorCreationChains<EChainCoroStackKind::Legacy>("ActorCreationChainLegacy", 1);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainLegacyParallel4) {
+        RunActorCreationChains<EChainCoroStackKind::Legacy>("ActorCreationChainLegacyParallel4", 4);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainLegacyParallel16) {
+        RunActorCreationChains<EChainCoroStackKind::Legacy>("ActorCreationChainLegacyParallel16", 16);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainLegacyParallel64) {
+        RunActorCreationChains<EChainCoroStackKind::Legacy>("ActorCreationChainLegacyParallel64", 64);
+    }
+
+#if !CORO_THROUGH_THREADS
+    Y_UNIT_TEST(ActorCreationChainStackPool) {
+        RunActorCreationChains<EChainCoroStackKind::StackPool>("ActorCreationChainStackPool", 1);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainStackPoolParallel4) {
+        RunActorCreationChains<EChainCoroStackKind::StackPool>("ActorCreationChainStackPoolParallel4", 4);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainStackPoolParallel16) {
+        RunActorCreationChains<EChainCoroStackKind::StackPool>("ActorCreationChainStackPoolParallel16", 16);
+    }
+
+    Y_UNIT_TEST(ActorCreationChainStackPoolParallel64) {
+        RunActorCreationChains<EChainCoroStackKind::StackPool>("ActorCreationChainStackPoolParallel64", 64);
+    }
+#endif
 }

--- a/ydb/library/actors/core/ut_mprotect/mprotect_ut.cpp
+++ b/ydb/library/actors/core/ut_mprotect/mprotect_ut.cpp
@@ -1,0 +1,105 @@
+#include <ydb/library/actors/core/coro_stack_pool.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/context.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <csignal>
+#include <cstring>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr ui32 StackSize = 64 * 1024;
+
+enum class ETouchMode {
+    Read,
+    Write,
+};
+
+enum class ETouchRange {
+    InBounds,
+    GuardPage,
+};
+
+volatile char Sink = 0;
+
+char* ShiftAddress(char* address, std::intptr_t offset) noexcept {
+    return reinterpret_cast<char*>(reinterpret_cast<std::intptr_t>(address) + offset);
+}
+
+char* GetTouchAddress(NActors::IStackMem& stackMem, ETouchRange range) noexcept {
+    return range == ETouchRange::GuardPage ? ShiftAddress(stackMem.Begin(), -1) : stackMem.Begin();
+}
+
+void TouchStackMem(ETouchRange range, ETouchMode mode) {
+    auto stackMem = NActors::TStackMemPool::GetMemPool(
+        NActors::TStackMemPool::TPageBucket::Bytes(StackSize))->Allocate();
+    volatile char* address = GetTouchAddress(*stackMem, range);
+
+    switch (mode) {
+        case ETouchMode::Read:
+            Sink ^= *address;
+            break;
+        case ETouchMode::Write:
+            *address = 1;
+            break;
+    }
+}
+
+void ResetFaultSignalHandlers() noexcept {
+    // The unittest runner may install crash handlers; the child must die with the default fault signal.
+    (void)std::signal(SIGSEGV, SIG_DFL);
+    (void)std::signal(SIGBUS, SIG_DFL);
+}
+
+int RunInChild(ETouchRange range, ETouchMode mode) {
+    const pid_t pid = fork();
+    UNIT_ASSERT_C(pid >= 0, "fork failed: " << std::strerror(errno));
+
+    if (pid == 0) {
+        ResetFaultSignalHandlers();
+        TouchStackMem(range, mode);
+        _exit(0);
+    }
+
+    int status = 0;
+    pid_t waited = 0;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+
+    UNIT_ASSERT_C(waited == pid, "waitpid failed: " << std::strerror(errno));
+    return status;
+}
+
+void AssertChildExitedNormally(ETouchRange range, ETouchMode mode) {
+    const int status = RunInChild(range, mode);
+    UNIT_ASSERT_C(WIFEXITED(status), "child did not exit normally, status# " << status);
+    UNIT_ASSERT_VALUES_EQUAL(WEXITSTATUS(status), 0);
+}
+
+void AssertChildWasKilled(ETouchRange range, ETouchMode mode) {
+    const int status = RunInChild(range, mode);
+    UNIT_ASSERT_C(WIFSIGNALED(status), "child was expected to be killed, status# " << status);
+    const int signal = WTERMSIG(status);
+    UNIT_ASSERT_C(signal == SIGSEGV || signal == SIGBUS, "unexpected child signal# " << signal);
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(CoroStackPoolMProtect) {
+    Y_UNIT_TEST(InBoundsAccessSurvives) {
+        AssertChildExitedNormally(ETouchRange::InBounds, ETouchMode::Read);
+        AssertChildExitedNormally(ETouchRange::InBounds, ETouchMode::Write);
+    }
+
+    Y_UNIT_TEST(GuardPageAccessKillsChild) {
+        AssertChildWasKilled(ETouchRange::GuardPage, ETouchMode::Read);
+        AssertChildWasKilled(ETouchRange::GuardPage, ETouchMode::Write);
+    }
+}

--- a/ydb/library/actors/core/ut_mprotect/mprotect_ut_win.cpp
+++ b/ydb/library/actors/core/ut_mprotect/mprotect_ut_win.cpp
@@ -1,0 +1,219 @@
+#include <ydb/library/actors/core/coro_stack_pool.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/string.h>
+#include <util/system/context.h>
+#include <util/system/error.h>
+
+#include <Windows.h>
+
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr ui32 StackSize = 64 * 1024;
+constexpr const char* ChildEnvName = "YDB_CORO_STACK_POOL_MPROTECT_CHILD";
+
+enum class ETouchMode {
+    Read,
+    Write,
+};
+
+enum class ETouchRange {
+    InBounds,
+    GuardPage,
+};
+
+volatile char Sink = 0;
+
+char* ShiftAddress(char* address, std::intptr_t offset) noexcept {
+    return reinterpret_cast<char*>(reinterpret_cast<std::intptr_t>(address) + offset);
+}
+
+char* GetTouchAddress(NActors::IStackMem& stackMem, ETouchRange range) noexcept {
+    return range == ETouchRange::GuardPage ? ShiftAddress(stackMem.Begin(), -1) : stackMem.Begin();
+}
+
+void TouchStackMem(ETouchRange range, ETouchMode mode) {
+    auto stackMem = NActors::TStackMemPool::GetMemPool(
+        NActors::TStackMemPool::TPageBucket::Bytes(StackSize))->Allocate();
+    volatile char* address = GetTouchAddress(*stackMem, range);
+
+    switch (mode) {
+        case ETouchMode::Read:
+            Sink ^= *address;
+            break;
+        case ETouchMode::Write:
+            *address = 1;
+            break;
+    }
+}
+
+const char* GetChildSpec(ETouchRange range, ETouchMode mode) noexcept {
+    if (range == ETouchRange::InBounds) {
+        return mode == ETouchMode::Read ? "in-bounds-read" : "in-bounds-write";
+    }
+
+    return mode == ETouchMode::Read ? "guard-page-read" : "guard-page-write";
+}
+
+bool TryParseChildSpec(const char* spec, ETouchRange& range, ETouchMode& mode) noexcept {
+    if (std::strcmp(spec, "in-bounds-read") == 0) {
+        range = ETouchRange::InBounds;
+        mode = ETouchMode::Read;
+        return true;
+    }
+    if (std::strcmp(spec, "in-bounds-write") == 0) {
+        range = ETouchRange::InBounds;
+        mode = ETouchMode::Write;
+        return true;
+    }
+    if (std::strcmp(spec, "guard-page-read") == 0) {
+        range = ETouchRange::GuardPage;
+        mode = ETouchMode::Read;
+        return true;
+    }
+    if (std::strcmp(spec, "guard-page-write") == 0) {
+        range = ETouchRange::GuardPage;
+        mode = ETouchMode::Write;
+        return true;
+    }
+    return false;
+}
+
+void RunChildCommandIfRequested() {
+    const char* spec = std::getenv(ChildEnvName);
+    if (!spec) {
+        return;
+    }
+
+    ETouchRange range;
+    ETouchMode mode;
+    if (!TryParseChildSpec(spec, range, mode)) {
+        ExitProcess(2);
+    }
+
+    TouchStackMem(range, mode);
+    ExitProcess(0);
+}
+
+TString QuoteCommandLineArg(const TString& arg) {
+    TString result;
+    result += '"';
+
+    size_t backslashes = 0;
+    for (char ch : arg) {
+        if (ch == '\\') {
+            ++backslashes;
+            continue;
+        }
+
+        if (ch == '"') {
+            for (size_t i = 0; i < backslashes * 2 + 1; ++i) {
+                result += '\\';
+            }
+            result += ch;
+            backslashes = 0;
+            continue;
+        }
+
+        for (size_t i = 0; i < backslashes; ++i) {
+            result += '\\';
+        }
+        backslashes = 0;
+        result += ch;
+    }
+
+    for (size_t i = 0; i < backslashes * 2; ++i) {
+        result += '\\';
+    }
+    result += '"';
+    return result;
+}
+
+TString GetCurrentExecutablePath() {
+    std::vector<char> buffer(MAX_PATH);
+    for (;;) {
+        const DWORD size = GetModuleFileNameA(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+        UNIT_ASSERT_C(size != 0, "GetModuleFileNameA failed: " << LastSystemErrorText());
+
+        if (size < buffer.size()) {
+            return TString(buffer.data(), size);
+        }
+
+        buffer.resize(buffer.size() * 2);
+    }
+}
+
+DWORD RunInChild(ETouchRange range, ETouchMode mode) {
+    UNIT_ASSERT_C(SetEnvironmentVariableA(ChildEnvName, GetChildSpec(range, mode)),
+        "SetEnvironmentVariableA failed: " << LastSystemErrorText());
+
+    STARTUPINFOA startupInfo = {};
+    startupInfo.cb = sizeof(startupInfo);
+    PROCESS_INFORMATION processInfo = {};
+
+    TString commandLine = QuoteCommandLineArg(GetCurrentExecutablePath());
+    std::vector<char> commandLineBuffer(commandLine.begin(), commandLine.end());
+    commandLineBuffer.push_back('\0');
+
+    const BOOL created = CreateProcessA(
+        nullptr,
+        commandLineBuffer.data(),
+        nullptr,
+        nullptr,
+        FALSE,
+        0,
+        nullptr,
+        nullptr,
+        &startupInfo,
+        &processInfo);
+    const DWORD createError = GetLastError();
+    SetEnvironmentVariableA(ChildEnvName, nullptr);
+
+    UNIT_ASSERT_C(created, "CreateProcessA failed: " << LastSystemErrorText(createError));
+
+    CloseHandle(processInfo.hThread);
+
+    const DWORD waitResult = WaitForSingleObject(processInfo.hProcess, INFINITE);
+    UNIT_ASSERT_C(waitResult == WAIT_OBJECT_0, "WaitForSingleObject failed: " << LastSystemErrorText());
+
+    DWORD exitCode = 0;
+    UNIT_ASSERT_C(GetExitCodeProcess(processInfo.hProcess, &exitCode),
+        "GetExitCodeProcess failed: " << LastSystemErrorText());
+    CloseHandle(processInfo.hProcess);
+
+    return exitCode;
+}
+
+void AssertChildExitedNormally(ETouchRange range, ETouchMode mode) {
+    const DWORD exitCode = RunInChild(range, mode);
+    UNIT_ASSERT_VALUES_EQUAL(exitCode, 0);
+}
+
+void AssertChildWasKilled(ETouchRange range, ETouchMode mode) {
+    const DWORD exitCode = RunInChild(range, mode);
+    UNIT_ASSERT_VALUES_EQUAL(exitCode, static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION));
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(CoroStackPoolMProtect) {
+    Y_UNIT_TEST(InBoundsAccessSurvives) {
+        RunChildCommandIfRequested();
+
+        AssertChildExitedNormally(ETouchRange::InBounds, ETouchMode::Read);
+        AssertChildExitedNormally(ETouchRange::InBounds, ETouchMode::Write);
+    }
+
+    Y_UNIT_TEST(GuardPageAccessKillsChild) {
+        RunChildCommandIfRequested();
+
+        AssertChildWasKilled(ETouchRange::GuardPage, ETouchMode::Read);
+        AssertChildWasKilled(ETouchRange::GuardPage, ETouchMode::Write);
+    }
+}

--- a/ydb/library/actors/core/ut_mprotect/ya.make
+++ b/ydb/library/actors/core/ut_mprotect/ya.make
@@ -1,0 +1,17 @@
+IF (NOT SANITIZER_TYPE)
+    UNITTEST_FOR(ydb/library/actors/core)
+
+    SIZE(SMALL)
+
+    IF (OS_WINDOWS)
+        SRCS(
+            mprotect_ut_win.cpp
+        )
+    ELSE()
+        SRCS(
+            mprotect_ut.cpp
+        )
+    ENDIF()
+
+    END()
+ENDIF()

--- a/ydb/library/actors/core/ya.make
+++ b/ydb/library/actors/core/ya.make
@@ -33,6 +33,7 @@ SRCS(
     callstack.cpp
     callstack.h
     config.h
+    coro_stack_pool.cpp
     cpu_manager.cpp
     cpu_manager.h
     defs.h
@@ -120,6 +121,7 @@ PEERDIR(
     library/cpp/svnversion
     library/cpp/time_provider
     library/cpp/threading/future
+    library/cpp/threading/queue
 )
 
 IF (SANITIZER_TYPE == "thread")
@@ -137,4 +139,5 @@ RECURSE(
 RECURSE_FOR_TESTS(
     ut
     ut_fat
+    ut_mprotect
 )

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -24,7 +24,7 @@
 #include <variant>
 
 namespace NActors {
-    static constexpr size_t StackSize = 64 * 1024; // 64k should be enough
+    static constexpr ui32 StackSize = 64 * 1024; // 64k should be enough
 
     static constexpr size_t RdmaHandshakeRegionSize = 4096;
 
@@ -382,7 +382,7 @@ namespace NActors {
     public:
         THandshakeActor(TInterconnectProxyCommon::TPtr common, const TActorId& self, const TActorId& peer,
                         ui32 nodeId, ui64 nextPacket, TString peerHostName, TSessionParams params)
-            : TActorCoroImpl(StackSize, true)
+            : TActorCoroImpl(UsePooledStack<StackSize>(), true)
             , Common(std::move(common))
             , SelfVirtualId(self)
             , PeerVirtualId(peer)
@@ -405,7 +405,7 @@ namespace NActors {
         }
 
         THandshakeActor(TInterconnectProxyCommon::TPtr common, TSocketPtr socket)
-            : TActorCoroImpl(StackSize, true)
+            : TActorCoroImpl(UsePooledStack<StackSize>(), true)
             , Common(std::move(common))
             , MainChannel(this, std::move(socket))
             , ExternalDataChannel(this, nullptr)


### PR DESCRIPTION
Introduce IStackMem/TStackMemPool and allow coroutine actors to opt into pooled stack memory via the TUsePooledStack/UsePooledStack constructor tag.

The new pool allocates guarded stack memory mappings. Keeps a small thread-local cache with a global exchange for cross-thread reuse, and uses page-size based layout with explicit support for downward-growing stacks. Unix/Darwin use mmap and Windows uses VirtualAlloc.

Switch the interconnect handshake coroutine actor to UsePooledStack<64_KB>().

Add coroutine actor chain tests for legacy and pooled stacks, including parallel 4/16/64-chain runs, and add a dedicated ut_mprotect target that checks guard-page protection in a child process.

Local relwithdebinfo checks:

per_chain_step_us results:

StackPool x1   threads=4   3.0069
StackPool x4   threads=4   5.5408
StackPool x16  threads=4   17.4798
StackPool x64  threads=4   75.2520
StackPool x64  threads=64  41.3865

Legacy    x1   threads=4    16.391
Legacy    x4   threads=4    68.983
Legacy    x16  threads=4    275.079
Legacy    x64  threads=4    1034.003
Legacy    x64  threads=64   1090.413439

(cherry picked from commit d445a990f9cdb292585c881fb0bce6c940430401)



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
