### PR TITLE
Harden DSProxy bounds checks NBYDB-2108

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover.cpp
@@ -378,6 +378,7 @@ class TBlobStorageGroupDiscoverRequest : public TBlobStorageGroupRequestActor {
 
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdisk), "incorrect VDiskId# %s", vdisk.ToString().data());
 
         Y_ABORT_UNLESS(status == NKikimrProto::OK || status == NKikimrProto::ERROR || status == NKikimrProto::VDISK_ERROR_STATE);
         if (IsIterativeDone) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
@@ -287,6 +287,7 @@ public:
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
         const TVDiskIdShort shortId(vdiskId);
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(shortId), "incorrect VDiskId# %s", shortId.ToString().data());
         ui32 index = Info->GetOrderNumber(shortId);
         Y_ABORT_UNLESS(index < VDiskWorkers.size());
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
@@ -286,7 +286,7 @@ public:
         const auto& record = ev->Record;
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
-        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", shortId.ToString().data());
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
         const TVDiskIdShort shortId(vdiskId);
         ui32 index = Info->GetOrderNumber(shortId);
         Y_ABORT_UNLESS(index < VDiskWorkers.size());

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
@@ -286,8 +286,8 @@ public:
         const auto& record = ev->Record;
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", shortId.ToString().data());
         const TVDiskIdShort shortId(vdiskId);
-        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(shortId), "incorrect VDiskId# %s", shortId.ToString().data());
         ui32 index = Info->GetOrderNumber(shortId);
         Y_ABORT_UNLESS(index < VDiskWorkers.size());
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3of4.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3of4.cpp
@@ -165,7 +165,9 @@ public:
             BlockedGeneration = record.GetBlockedGeneration();
         }
         const TVDiskID& vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
-        TDiskState& disk = DiskState[Info->GetOrderNumber(vdiskId)];
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
+        const ui32 orderNumber = Info->GetOrderNumber(vdiskId);
+        TDiskState& disk = DiskState[orderNumber];
         Y_DEBUG_ABORT_UNLESS(disk.VDiskId == vdiskId);
         const EDiskState prev = std::exchange(disk.State, EDiskState::IDLE);
         Y_ABORT_UNLESS(prev == EDiskState::READ_PENDING);

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
@@ -218,6 +218,7 @@ class TBlobStorageGroupGetRequest : public TBlobStorageGroupRequestActor {
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
         const TVDiskIdShort shortId(vdisk);
+        ui32 orderNumber = GetImpl.GetOrderNumber(shortId);
 
         LWTRACK(DSProxyVDiskRequestDuration, Orbit, TEvBlobStorage::EvVGet, totalSize, tabletId, vdisk.GroupID.GetRawId(), channel,
                 Info->GetFailDomainOrderNumber(shortId),
@@ -233,7 +234,6 @@ class TBlobStorageGroupGetRequest : public TBlobStorageGroupRequestActor {
                     GetVDiskTimeMs(record.GetTimestamps()));
         }
 
-        ui32 orderNumber = Info->GetOrderNumber(shortId);
         if (DiskCounters.size() <= orderNumber) {
             DiskCounters.resize(orderNumber + 1);
         }
@@ -294,6 +294,7 @@ class TBlobStorageGroupGetRequest : public TBlobStorageGroupRequestActor {
         const auto &record = ev->Get()->Record;
         const TVDiskID vDiskId = VDiskIDFromVDiskID(record.GetVDiskID());
         TVDiskIdShort shortId(vDiskId);
+        ui32 orderNumber = GetImpl.GetOrderNumber(shortId);
         const NKikimrProto::EReplyStatus status = record.GetStatus();
         NActors::NLog::EPriority priority = PriorityForStatusInbound(status);
         DSP_LOG_LOG_S(priority, "BPG30", "Handle VPuEventResult"
@@ -317,7 +318,6 @@ class TBlobStorageGroupGetRequest : public TBlobStorageGroupRequestActor {
                     GetVDiskTimeMs(record.GetTimestamps()));
         }
 
-        ui32 orderNumber = Info->GetOrderNumber(shortId);
         if (DiskCounters.size() <= orderNumber) {
             DiskCounters.resize(orderNumber + 1);
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -362,7 +362,7 @@ void TGetImpl::OnVPutResult(TLogContext &logCtx, TEvBlobStorage::TEvVPutResult &
     Y_ABORT_UNLESS(record.HasVDiskID());
     TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
     TVDiskIdShort shortId(vdisk);
-    ui32 orderNumber = Info->GetOrderNumber(shortId);
+    ui32 orderNumber = GetOrderNumber(shortId);
     const TLogoBlobID blob = LogoBlobIDFromLogoBlobID(record.GetBlobID());
 
     const NKikimrProto::EReplyStatus status = record.GetStatus();

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
@@ -159,6 +159,11 @@ public:
         return ResponseIndex;
     }
 
+    ui32 GetOrderNumber(const TVDiskIdShort& vdiskId) const {
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
+        return Info->GetOrderNumber(vdiskId);
+    }
+
     void GenerateInitialRequests(TLogContext &logCtx, TDeque<std::unique_ptr<TEvBlobStorage::TEvVGet>> &outVGets);
 
     void OnVGetResult(TLogContext &logCtx, TEvBlobStorage::TEvVGetResult &ev,
@@ -174,7 +179,7 @@ public:
         Y_ABORT_UNLESS(record.HasVDiskID());
         TVDiskID vdisk = VDiskIDFromVDiskID(record.GetVDiskID());
         TVDiskIdShort shortId(vdisk);
-        ui32 orderNumber = Info->GetOrderNumber(shortId);
+        ui32 orderNumber = GetOrderNumber(shortId);
         {
             NActors::NLog::EPriority priority = PriorityForStatusInbound(record.GetStatus());
             DSP_LOG_LOG_SX(logCtx, priority, "BPG12", "Handle TEvVGetResult"

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -244,7 +244,11 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         ++StatusResultMsgsReceived;
 
         auto& record = ev->Get()->Record;
-        const ui32 orderNumber = ev->Cookie;
+        const ui64 cookie = ev->Cookie;
+        Y_ABORT_UNLESS(cookie < IncarnationRecords.size(),
+            "unexpected TEvVStatusResult cookie# %" PRIu64 " IncarnationRecords.size# %zu",
+            cookie, IncarnationRecords.size());
+        const ui32 orderNumber = static_cast<ui32>(cookie);
         auto& incarnationRecord = IncarnationRecords[orderNumber];
         Y_ABORT_UNLESS(incarnationRecord.IncarnationGuid);
         Y_ABORT_UNLESS(incarnationRecord.ExpirationTimestamp != TMonotonic::Max());
@@ -254,7 +258,6 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         if (record.HasIncarnationGuid()) {
             HandleIncarnation(issue, orderNumber, record.GetIncarnationGuid());
         } else if (record.GetStatus() != NKikimrProto::OK) { // we can't obtain status from the vdisk; assume it has not been written
-            Y_ABORT_UNLESS(orderNumber < IncarnationRecords.size());
             IncarnationRecords[orderNumber] = {};
             PutImpl.InvalidatePartStates(orderNumber);
             ++*Mon->NodeMon->IncarnationChanges;
@@ -281,7 +284,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         Y_ABORT_UNLESS(record.HasVDiskID());
         TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
         const TVDiskIdShort shortId(vdiskId);
-        const ui32 vdisk = Info->GetOrderNumber(shortId);
+        const ui32 vdisk = PutImpl.GetOrderNumber(shortId);
         const NKikimrProto::EReplyStatus status = record.GetStatus();
         const size_t blobIdx = PutImpl.GetBlobIdx(blobId);
 
@@ -297,7 +300,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
 
         if (record.HasIncarnationGuid()) {
             // TODO: correct timestamp
-            HandleIncarnation(TActivationContext::Monotonic(), Info->GetOrderNumber(shortId), record.GetIncarnationGuid());
+            HandleIncarnation(TActivationContext::Monotonic(), vdisk, record.GetIncarnationGuid());
         }
 
         LWTRACK(DSProxyVDiskRequestDuration, Orbit, TEvBlobStorage::EvVPut, blobId.BlobSize(), blobId.TabletID(),
@@ -347,7 +350,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         Y_ABORT_UNLESS(record.HasVDiskID());
         const TVDiskID vdiskId = VDiskIDFromVDiskID(record.GetVDiskID());
         const TVDiskIdShort shortId(vdiskId);
-        const ui32 vdisk = Info->GetOrderNumber(shortId);
+        const ui32 vdisk = PutImpl.GetOrderNumber(shortId);
         const NKikimrProto::EReplyStatus status = record.GetStatus();
 
         if (TimeStatsEnabled && record.GetMsgQoS().HasExecTimeStats()) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
@@ -310,7 +310,7 @@ public:
     void ProcessResponse(TEvBlobStorage::TEvVPutResult& msg) {
         ++VPutResponses;
         ProcessResponseCommonPart(msg.Record);
-        ui32 orderNumber = Info->GetOrderNumber(TVDiskIdShort(VDiskIDFromVDiskID(msg.Record.GetVDiskID())));
+        ui32 orderNumber = GetOrderNumber(VDiskIDFromVDiskID(msg.Record.GetVDiskID()));
         ProcessResponseBlob(orderNumber, msg.Record);
         History.AddVPutResult(orderNumber, msg.Record.GetStatus(), msg.Record.GetErrorReason());
     }
@@ -318,7 +318,7 @@ public:
     void ProcessResponse(TEvBlobStorage::TEvVMultiPutResult& msg) {
         ++VMultiPutResponses;
         ProcessResponseCommonPart(msg.Record);
-        ui32 orderNumber = Info->GetOrderNumber(TVDiskIdShort(VDiskIDFromVDiskID(msg.Record.GetVDiskID())));
+        ui32 orderNumber = GetOrderNumber(VDiskIDFromVDiskID(msg.Record.GetVDiskID()));
         auto vputResult = History.CreateVPutResult(orderNumber, msg.Record.GetStatus(), msg.Record.GetErrorReason());
         for (const auto& item : msg.Record.GetItems()) {
             ProcessResponseBlob(orderNumber, item);
@@ -331,6 +331,16 @@ public:
         const auto it = BlobMap.find(id.FullID());
         Y_ABORT_UNLESS(it != BlobMap.end());
         return it->second;
+    }
+
+    ui32 GetOrderNumber(const TVDiskIdShort& vdiskId) const {
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
+        return Info->GetOrderNumber(vdiskId);
+    }
+
+    ui32 GetOrderNumber(const TVDiskID& vdiskId) const {
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
+        return Info->GetOrderNumber(vdiskId);
     }
 
 protected:

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put_impl.h
@@ -339,8 +339,14 @@ public:
     }
 
     ui32 GetOrderNumber(const TVDiskID& vdiskId) const {
-        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(vdiskId), "incorrect VDiskId# %s", vdiskId.ToString().data());
-        return Info->GetOrderNumber(vdiskId);
+        Y_ABORT_UNLESS(vdiskId.GroupID == Info->GroupID, "incorrect VDiskId# %s expected GroupId# %u",
+            vdiskId.ToString().data(), static_cast<unsigned>(Info->GroupID.GetRawId()));
+
+        // Old-generation replies may legitimately reach this path during a generation race; only
+        // the group identity and topology coordinates must match before mapping to an order number.
+        const TVDiskIdShort shortId(vdiskId);
+        Y_ABORT_UNLESS(Info->GetTopology().IsValidId(shortId), "incorrect VDiskId# %s", vdiskId.ToString().data());
+        return Info->GetOrderNumber(shortId);
     }
 
 protected:

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -207,8 +207,11 @@ namespace NKikimr {
             NKikimrBlobStorage::EPutHandleClass handleClass = ev->Get()->HandleClass;
             TEvBlobStorage::TEvPut::ETactic tactic = ev->Get()->Tactic;
             const bool reduceInterpileTraffic = ev->Get()->ReduceInterpileTraffic;
-            Y_ABORT_UNLESS((ui64)handleClass <= PutHandleClassCount);
-            Y_ABORT_UNLESS(tactic <= PutTacticCount);
+            Y_ABORT_UNLESS(NKikimrBlobStorage::EPutHandleClass_MIN <= handleClass &&
+                handleClass <= NKikimrBlobStorage::EPutHandleClass_MAX,
+                "incorrect PutHandleClass# %u", static_cast<unsigned>(handleClass));
+            Y_ABORT_UNLESS(0 <= tactic && tactic < TEvBlobStorage::TEvPut::TacticCount,
+                "incorrect PutTactic# %d", static_cast<int>(tactic));
 
             TBatchedPutQueue &batchedPuts = BatchedPuts[handleClass][tactic][reduceInterpileTraffic];
             if (batchedPuts.Queue.empty()) {

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_sequence_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_sequence_ut.cpp
@@ -560,11 +560,23 @@ Y_UNIT_TEST(TestGivenBlock42MultiPut2ItemsStatuses) {
 
 enum {
     Begin = EventSpaceBegin(TEvents::ES_USERSPACE),
-    EvRequestEnd
+    EvRequestEnd,
+    EvGenerationRaceProbeResult
 };
 
 struct TEvRequestEnd : TEventLocal<TEvRequestEnd, EvRequestEnd> {
     TEvRequestEnd() = default;
+};
+
+struct TEvGenerationRaceProbeResult : TEventLocal<TEvGenerationRaceProbeResult, EvGenerationRaceProbeResult> {
+    TString Name;
+    bool Processed = false;
+    bool HasEvent = false;
+    bool HasRecordStatus = false;
+    NKikimrProto::EReplyStatus RecordStatus = NKikimrProto::UNKNOWN;
+    bool HasItemStatus = false;
+    NKikimrProto::EReplyStatus ItemStatus = NKikimrProto::UNKNOWN;
+    bool Replied = false;
 };
 
 struct TDyingDecorator : public TTestDecorator {
@@ -584,6 +596,242 @@ struct TDyingDecorator : public TTestDecorator {
         }
     }
 };
+
+struct TGenerationRaceProbeParameters {
+    TBlobStorageGroupRequestActor::TCommonParameters<TEvBlobStorage::TEvGet> Common;
+    TBlobStorageGroupRequestActor::TTypeSpecificParameters TypeSpecific = {
+        .LogComponent = NKikimrServices::BS_PROXY_GET,
+        .Name = "DSProxy.GenerationRaceProbe",
+        .Activity = NKikimrServices::TActivity::BS_PROXY_GET_ACTOR,
+    };
+    ui32 ExpectedResults = 0;
+};
+
+class TGenerationRaceProbeActor : public TBlobStorageGroupRequestActor {
+    const TActorId EdgeActor;
+    const ui32 ExpectedResults;
+    ui32 Results = 0;
+
+public:
+    explicit TGenerationRaceProbeActor(TGenerationRaceProbeParameters& params)
+        : TBlobStorageGroupRequestActor(params)
+        , EdgeActor(params.Common.Source)
+        , ExpectedResults(params.ExpectedResults)
+    {
+        LogCtx.SuppressLog = true;
+    }
+
+    void Bootstrap() override {
+        Become(&TGenerationRaceProbeActor::StateWork);
+    }
+
+    void ReplyAndDie(NKikimrProto::EReplyStatus status) override {
+        Replied = true;
+        ReplyStatus = status;
+    }
+
+    std::unique_ptr<IEventBase> RestartQuery(ui32) override {
+        return std::make_unique<TEvBlobStorage::TEvGet>(
+            TLogoBlobID(1, 1, 1, 0, 1, 0), 0, 0, TInstant::Max(), NKikimrBlobStorage::FastRead);
+    }
+
+    ERequestType GetRequestType() const override {
+        return ERequestType::Get;
+    }
+
+    ::NMonitoring::TDynamicCounters::TCounterPtr& GetActiveCounter() const override {
+        return Mon->ActiveGet;
+    }
+
+    bool Replied = false;
+    NKikimrProto::EReplyStatus ReplyStatus = NKikimrProto::UNKNOWN;
+
+private:
+    static const char *EventName(ui32 type) {
+        switch (type) {
+#define CHECK(T) case TEvBlobStorage::T::EventType: return #T;
+            CHECK(TEvVPutResult);
+            CHECK(TEvVMultiPutResult);
+            CHECK(TEvVGetResult);
+            CHECK(TEvVBlockResult);
+            CHECK(TEvVGetBlockResult);
+            CHECK(TEvVCollectGarbageResult);
+            CHECK(TEvVGetBarrierResult);
+            CHECK(TEvVStatusResult);
+            CHECK(TEvVAssimilateResult);
+#undef CHECK
+            default:
+                return "unexpected event";
+        }
+    }
+
+    static void FillRecordStatus(TEvGenerationRaceProbeResult& result, TAutoPtr<IEventHandle>& ev) {
+        if (!ev) {
+            return;
+        }
+
+        result.HasEvent = true;
+        switch (ev->GetTypeRewrite()) {
+#define CHECK(T) \
+            case TEvBlobStorage::T::EventType: \
+                result.HasRecordStatus = true; \
+                result.RecordStatus = ev->Get<TEvBlobStorage::T>()->Record.GetStatus(); \
+                break;
+            CHECK(TEvVPutResult);
+            CHECK(TEvVBlockResult);
+            CHECK(TEvVGetBlockResult);
+            CHECK(TEvVCollectGarbageResult);
+            CHECK(TEvVGetBarrierResult);
+            CHECK(TEvVStatusResult);
+            CHECK(TEvVAssimilateResult);
+#undef CHECK
+            case TEvBlobStorage::TEvVMultiPutResult::EventType: {
+                auto *event = ev->Get<TEvBlobStorage::TEvVMultiPutResult>();
+                result.HasRecordStatus = true;
+                result.RecordStatus = event->Record.GetStatus();
+                result.HasItemStatus = event->Record.ItemsSize() > 0;
+                if (result.HasItemStatus) {
+                    result.ItemStatus = event->Record.GetItems(0).GetStatus();
+                }
+                break;
+            }
+            case TEvBlobStorage::TEvVGetResult::EventType: {
+                auto *event = ev->Get<TEvBlobStorage::TEvVGetResult>();
+                result.HasRecordStatus = true;
+                result.RecordStatus = event->Record.GetStatus();
+                result.HasItemStatus = event->Record.ResultSize() > 0;
+                if (result.HasItemStatus) {
+                    result.ItemStatus = event->Record.GetResult(0).GetStatus();
+                }
+                break;
+            }
+        }
+    }
+
+    void SendProbeResult(TAutoPtr<IEventHandle>& ev, bool processed, ui64 cookie, const char *name) {
+        auto result = std::make_unique<TEvGenerationRaceProbeResult>();
+        result->Name = name;
+        result->Processed = processed;
+        result->Replied = Replied;
+        FillRecordStatus(*result, ev);
+
+        Send(EdgeActor, result.release(), 0, cookie);
+
+        if (++Results == ExpectedResults) {
+            PassAway();
+        }
+    }
+
+    STATEFN(StateWork) {
+        const ui64 cookie = ev->Cookie;
+        const char *name = EventName(ev->GetTypeRewrite());
+        const bool processed = ProcessEvent(ev);
+        SendProbeResult(ev, processed, cookie, name);
+    }
+};
+
+template <typename TEvent>
+std::unique_ptr<TEvent> MakeOldGenerationRaceResult(const TVDiskID& vdiskId) {
+    auto event = std::make_unique<TEvent>();
+    event->Record.SetStatus(NKikimrProto::RACE);
+    VDiskIDFromVDiskID(vdiskId, event->Record.MutableVDiskID());
+    return event;
+}
+
+template <typename TEvent, typename TVerify>
+void CheckOldGenerationRaceResult(TTestBasicRuntime& runtime, const TActorId& actorId, const TActorId& edgeActor,
+        const char *name, std::unique_ptr<TEvent> event, TVerify verify) {
+    runtime.Send(new IEventHandle(actorId, edgeActor, event.release()));
+
+    TAutoPtr<IEventHandle> handle;
+    auto *result = runtime.GrabEdgeEventRethrow<TEvGenerationRaceProbeResult>(handle);
+
+    UNIT_ASSERT_VALUES_EQUAL_C(TString(name), result->Name, name);
+    UNIT_ASSERT_C(!result->Processed, name);
+    UNIT_ASSERT_C(result->HasEvent, name);
+    UNIT_ASSERT_C(result->HasRecordStatus, name);
+    UNIT_ASSERT_VALUES_EQUAL_C(NKikimrProto::ERROR, result->RecordStatus, name);
+    UNIT_ASSERT_C(!result->Replied, name);
+    verify(*result);
+}
+
+template <typename TEvent>
+void CheckOldGenerationRaceResult(TTestBasicRuntime& runtime, const TActorId& actorId, const TActorId& edgeActor,
+        const char *name, std::unique_ptr<TEvent> event) {
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, name, std::move(event),
+        [](const TEvGenerationRaceProbeResult&) {});
+}
+
+Y_UNIT_TEST(TestOldVDiskGenerationRaceIsHandledForAllCommonResultTypes) {
+    TBlobStorageGroupType type = {TErasureType::Erasure4Plus2Block};
+    TTestBasicRuntime runtime(1, false);
+    Setup(runtime, type);
+    DSProxyEnv.SetGroupGeneration(2);
+
+    auto request = std::make_unique<TEvBlobStorage::TEvGet>(
+        TLogoBlobID(1, 1, 1, 0, 1, 0), 0, 0, TInstant::Max(), NKikimrBlobStorage::FastRead);
+
+    const TActorId edgeActor = runtime.AllocateEdgeActor(0);
+    TGenerationRaceProbeParameters params{
+        .Common = {
+            .GroupInfo = DSProxyEnv.Info,
+            .GroupQueues = DSProxyEnv.GroupQueues,
+            .Mon = DSProxyEnv.Mon,
+            .Source = edgeActor,
+            .Cookie = 0,
+            .Now = TMonotonic::Now(),
+            .StoragePoolCounters = DSProxyEnv.StoragePoolCounters,
+            .RestartCounter = 0,
+            .Event = request.get(),
+            .DoSendDeathNote = false,
+        },
+        .ExpectedResults = 9,
+    };
+
+    const TActorId actorId = runtime.Register(new TGenerationRaceProbeActor(params));
+    {
+        TDispatchOptions options;
+        options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
+        runtime.DispatchEvents(options);
+    }
+    const TVDiskID oldVDiskId(DSProxyEnv.Info->GroupID, 1, 0, 0, 0);
+
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVPutResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVPutResult>(oldVDiskId));
+
+    {
+        auto event = MakeOldGenerationRaceResult<TEvBlobStorage::TEvVMultiPutResult>(oldVDiskId);
+        event->Record.AddItems()->SetStatus(NKikimrProto::RACE);
+        CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVMultiPutResult", std::move(event),
+            [](const TEvGenerationRaceProbeResult& result) {
+                UNIT_ASSERT(result.HasItemStatus);
+                UNIT_ASSERT_VALUES_EQUAL(NKikimrProto::ERROR, result.ItemStatus);
+            });
+    }
+
+    {
+        auto event = MakeOldGenerationRaceResult<TEvBlobStorage::TEvVGetResult>(oldVDiskId);
+        event->Record.AddResult()->SetStatus(NKikimrProto::RACE);
+        CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVGetResult", std::move(event),
+            [](const TEvGenerationRaceProbeResult& result) {
+                UNIT_ASSERT(result.HasItemStatus);
+                UNIT_ASSERT_VALUES_EQUAL(NKikimrProto::ERROR, result.ItemStatus);
+            });
+    }
+
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVBlockResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVBlockResult>(oldVDiskId));
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVGetBlockResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVGetBlockResult>(oldVDiskId));
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVCollectGarbageResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVCollectGarbageResult>(oldVDiskId));
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVGetBarrierResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVGetBarrierResult>(oldVDiskId));
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVStatusResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVStatusResult>(oldVDiskId));
+    CheckOldGenerationRaceResult(runtime, actorId, edgeActor, "TEvVAssimilateResult",
+        MakeOldGenerationRaceResult<TEvBlobStorage::TEvVAssimilateResult>(oldVDiskId));
+}
 
 Y_UNIT_TEST(TestGivenBlock42GroupGenerationGreaterThanVDiskGenerations) {
     return; // KIKIMR-9016


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


Turn several DSProxy paths that used unchecked topology-derived indexes into explicit fail-fast checks before indexing arrays, vectors or queue pointers.

Covered memory-corruption risks:

* malformed VDiskID coordinates in VDisk replies or generated subrequests reaching GetOrderNumber/GetFailDomainOrderNumber and indexing topology-backed state;

* out-of-range VDisk order numbers indexing DiskState, VDiskWorkers, WaitingVDiskResponseCount, DisksByOrderNumber or node-layout vectors;

* missing entries in DisksByOrderNumber leading to null queue dereference;

* invalid put handle class or tactic indexing BatchedPuts;

* TEvVStatusResult cookies larger than ui32 being truncated before indexing IncarnationRecords.



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
