### PR TITLE
Fix WBadDep in compute/yt unit tests after #40413

### DIFF
--- a/ydb/library/yql/dq/actors/compute/ut/large/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/large/ya.make
@@ -27,7 +27,6 @@ PEERDIR(
     ydb/library/yql/dq/transform
     ydb/library/yql/providers/dq/task_runner
     ydb/library/yql/public/ydb_issue
-    yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/minikql/computation
     yql/essentials/providers/common/comp_nodes
     yql/essentials/public/udf/service/stub

--- a/ydb/library/yql/dq/actors/compute/ut/large/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/large/ya.make
@@ -27,10 +27,8 @@ PEERDIR(
     ydb/library/yql/dq/transform
     ydb/library/yql/providers/dq/task_runner
     ydb/library/yql/public/ydb_issue
-    yql/essentials/minikql/comp_nodes
-    yql/essentials/minikql/comp_nodes/no_llvm
+    yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/minikql/computation
-    yql/essentials/minikql/invoke_builtins
     yql/essentials/providers/common/comp_nodes
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy

--- a/ydb/library/yql/dq/actors/compute/ut/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/ya.make
@@ -31,10 +31,8 @@ PEERDIR(
     ydb/library/yql/dq/transform
     ydb/library/yql/providers/dq/task_runner
     ydb/library/yql/public/ydb_issue
-    yql/essentials/minikql/comp_nodes
-    yql/essentials/minikql/comp_nodes/no_llvm
+    yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/minikql/computation
-    yql/essentials/minikql/invoke_builtins
     yql/essentials/providers/common/comp_nodes
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy

--- a/ydb/library/yql/dq/actors/compute/ut/ya.make
+++ b/ydb/library/yql/dq/actors/compute/ut/ya.make
@@ -31,7 +31,6 @@ PEERDIR(
     ydb/library/yql/dq/transform
     ydb/library/yql/providers/dq/task_runner
     ydb/library/yql/public/ydb_issue
-    yql/essentials/minikql/comp_nodes/llvm16
     yql/essentials/minikql/computation
     yql/essentials/providers/common/comp_nodes
     yql/essentials/public/udf/service/stub

--- a/ydb/library/yql/providers/yt/actors/ut/ya.make
+++ b/ydb/library/yql/providers/yt/actors/ut/ya.make
@@ -1,10 +1,9 @@
 UNITTEST_FOR(ydb/library/yql/providers/yt/actors)
 
 PEERDIR(
-    yt/yql/providers/yt/codec/codegen/no_llvm
-    yt/yql/providers/yt/comp_nodes/no_llvm
+    yt/yql/providers/yt/codec/codegen/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/gateway/file
-    yql/essentials/minikql/codegen/no_llvm
     ydb/library/actors/testlib
     yql/essentials/public/udf
     library/cpp/testing/unittest

--- a/ydb/library/yql/providers/yt/actors/ut/ya.make
+++ b/ydb/library/yql/providers/yt/actors/ut/ya.make
@@ -1,6 +1,8 @@
 UNITTEST_FOR(ydb/library/yql/providers/yt/actors)
 
 PEERDIR(
+    yt/yql/providers/yt/codec/codegen/llvm16
+    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/gateway/file
     ydb/library/actors/testlib
     yql/essentials/public/udf

--- a/ydb/library/yql/providers/yt/actors/ut/ya.make
+++ b/ydb/library/yql/providers/yt/actors/ut/ya.make
@@ -1,8 +1,6 @@
 UNITTEST_FOR(ydb/library/yql/providers/yt/actors)
 
 PEERDIR(
-    yt/yql/providers/yt/codec/codegen/llvm16
-    yt/yql/providers/yt/comp_nodes/llvm16
     yt/yql/providers/yt/gateway/file
     ydb/library/actors/testlib
     yql/essentials/public/udf


### PR DESCRIPTION
Fix `WBadDep` introduced by #40413: remove `no_llvm` PEERDIR entries from
unit test build configurations that conflict with `llvm16` variants now
pulled in transitively via `dq/runtime → dq/comp_nodes → comp_nodes/llvm16`.



### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
