### PR TITLE
[NEW RBO] Fixed a bug with statistics request to a bad table

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -370,7 +370,7 @@ void TOpAggregate::ComputeMetadata(TRBOContext& ctx, TPlanProps& planProps) {
     TString alias = "_aggregate";
     int duplicateId = Props.Metadata->ColumnLineage.AddAlias(alias, alias);
     for (const auto & iu : GetOutputIUs()) {
-        Props.Metadata->ColumnLineage.AddMapping(iu, TColumnLineageEntry(alias, alias, iu.GetColumnName(), duplicateId));
+        Props.Metadata->ColumnLineage.AddMapping(iu, TColumnLineageEntry(alias, "", iu.GetColumnName(), duplicateId));
     }
 }
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -215,7 +215,7 @@ void TKqpNewRBOTransformer::CollectTablesAndColumnsNames(const TExpression& expr
 
     for (const auto& column : colNames) {
         const auto it = mapping.find(column.GetFullName());
-        if (it != mapping.end()) {
+        if (it != mapping.end() && it->second.TableName != "") {
             const auto& tableName = it->second.TableName;
             const auto& colName = it->second.ColumnName;
             CMColumnsByTableName[tableName].insert(colName);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -2113,7 +2113,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         RunTPC_YqlBenchmark(EBenchType::TPCDS, /*columnstore=*/true, {1,  2,  3,  4, 7,  11, 13, 15, 19, 21, 22, 25, 26, 29, 30, 32, 33, 34, 37, 42, 43, 46, 48,
                                                                      50, 52, 55, 56, 59, 60, 61, 62, 64, 65, 66, 68, 71, 72, 73, 74, 78, 79, 81, 82, 84, 85, 90, 91, 92, 96, 99},
                            {}, /*new rbo=*/true, /*printStatus=*/true, /*compareResults=*/true);
-    }
+    } 
 
     void InsertIntoSchema0(NYdb::NTable::TTableClient& db, std::string tableName, ui32 numRows) {
         NYdb::TValueBuilder rows;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

We created a "fake" alias for the output of aggregate, but also created a fake table name, which was then used to request column statistics. Changed that to an empty table name and added a check when requesting statistics

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
