### PR TITLE
Fix flaky test_simple_analytics_query: retry stop_query during COMPLE…

### DIFF
--- a/ydb/tests/fq/http_api/test_http_api.py
+++ b/ydb/tests/fq/http_api/test_http_api.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pytest
 import re
+import time
 import yaml
 from yaml.loader import SafeLoader
 
@@ -103,7 +104,17 @@ class TestHttpApi(TestBase):
 
             assert client.get_query_status(query_id) in ["STARTING", "RUNNING", "COMPLETED", "COMPLETING"]
 
-            response = client.stop_query(query_id)
+            # `select 1` after restart may be in the transient COMPLETING state, which
+            # rejects stop_query until the query reaches a terminal status.
+            for _ in range(10):
+                try:
+                    response = client.stop_query(query_id)
+                    break
+                except YQHttpClientException as e:
+                    if e.details and "COMPLETING" in str(e.details):
+                        time.sleep(0.1)
+                        continue
+                    raise
             assert response.status_code == 204
 
     def test_empty_query(self):

--- a/ydb/tests/fq/http_api/test_http_api.py
+++ b/ydb/tests/fq/http_api/test_http_api.py
@@ -115,6 +115,8 @@ class TestHttpApi(TestBase):
                         time.sleep(0.1)
                         continue
                     raise
+            else:
+                pytest.fail("stop_query did not succeed after 10 retries while query remained in COMPLETING state")
             assert response.status_code == 204
 
     def test_empty_query(self):


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category
Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Fixes #40335

After restart, `select 1` can briefly sit in the transient COMPLETING state before reaching COMPLETED. stop_query is rejected in that window, causing sporadic failures. Retry the call until the query reaches a terminal status.
