### PR TITLE
Unit tests for reproducing TLI detection failure

### DIFF
--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -4,6 +4,8 @@
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/library/actors/wilson/test_util/fake_wilson_uploader.h>
+#include <ydb/core/testlib/actors/wait_events.h>
+#include <ydb/core/tx/time_cast/time_cast.h>
 
 #include <algorithm>
 #include <memory>
@@ -634,6 +636,75 @@ namespace {
 
         void CreateAndSeedTablesWithSecondKey(int count) {
             CreateAndSeedTablesWithSecondKeyInSession(*BreakerSession, count);
+        }
+    };
+
+    // NQuery-based test context (primary API for all tests) not using the real threads
+    struct TTliThreadlessTestContext {
+        TKikimrRunner Kikimr;
+        TQueryClient Client;
+        TSession Session;
+        TSession VictimSession;
+
+        TTliThreadlessTestContext(TStringStream& ss, bool logEnabled = true)
+            : Kikimr(MakeKikimrSettings(ss).SetUseRealThreads(false))
+            , Client(Kikimr.RunCall([&] () { return Kikimr.GetQueryClient(); }))
+            , Session(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
+            , VictimSession(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
+        {
+            ConfigureKikimrForTli(Kikimr, logEnabled);
+        }
+
+        void CreateTable(const TString& tableName) {
+            NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
+                return Session.ExecuteQuery(Sprintf(R"(CREATE TABLE `%s` (Key Uint64, Value String, PRIMARY KEY (Key));)", tableName.c_str()),
+                    TTxControl::NoTx()).GetValueSync();
+            }));
+        }
+
+        void SeedTable(const TString& tableName, const TVector<std::pair<ui64, TString>>& rows) {
+            for (const auto& [key, value] : rows) {
+                NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
+                    return Session.ExecuteQuery(Sprintf("UPSERT INTO `%s` (Key, Value) VALUES (%luu, \"%s\")", tableName.c_str(), key, value.c_str()),
+                        TTxControl::BeginTx().CommitTx()).GetValueSync();
+                }));
+            }
+        }
+
+        void CreateAndSeedTables(int count) {
+            for (int i = 1; i <= count; ++i) {
+                const TString tablePath = NumberedTablePath(i);
+                CreateTable(tablePath);
+                SeedTable(tablePath, {{1, Sprintf("Init%d", i)}});
+            }
+        }
+
+        void CreateAndSeedTablesWithSecondKey(int count) {
+            for (int i = 1; i <= count; ++i) {
+                const TString tablePath = NumberedTablePath(i);
+                CreateTable(tablePath);
+                SeedTable(tablePath, {{1, Sprintf("Init%d", i)}, {2, Sprintf("Init%d_2", i)}});
+            }
+        }
+
+        void ExecuteQuery(const TString& query, bool sync = true) {
+            if (sync) {
+                TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate>(*Kikimr.GetTestServer().GetRuntime()).Wait();
+            }
+            NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
+                return Session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
+            }));
+        }
+
+        std::optional<TTransaction> BeginTx(TSession& session, const TString& query) {
+            auto result = Kikimr.RunCall([&] () { return session.ExecuteQuery(query, TTxControl::BeginTx()).GetValueSync(); });
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            return result.GetTransaction();
+        }
+
+        std::pair<EStatus, TString> CommitTxWithIssues(TTransaction& tx) {
+            auto result = Kikimr.RunCall([&] () { return tx.Commit().GetValueSync(); });
+            return {result.GetStatus(), result.GetIssues().ToString()};
         }
     };
 
@@ -1692,74 +1763,6 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         VerifyTliIssueAndLogs(issues, ss, breakerQueryText, victimQueryText, victimCommitText);
     }
 
-    // Test: Concurrent UPSERT...SELECT transactions - expected cancellation of victim transaction does not happen.
-    // This test does not use real threads and due to a lower step resolution always reproduces a bug with detecting TLI conflicts
-    // if MVCC versions of victim and breaker happen to be the same.
-    Y_UNIT_TEST(ConcurrentUpsertSelectRaceThreadless) {
-        const TString victimUpsertSelect = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) "
-                                           "SELECT Key, \"VictimModified\" AS Value FROM `/Root/Tenant1/Table1` "
-                                           "WHERE Key = 1u";
-
-        const TString breakerUpsert = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) VALUES (1u, \"BreakerValue\")";
-
-        TStringStream ss;
-        struct TTliThreadlessTestContext {
-            TKikimrRunner Kikimr;
-            TQueryClient Client;
-            TSession Session;
-            TSession VictimSession;
-
-            TTliThreadlessTestContext(TStringStream& ss, bool logEnabled = true)
-                : Kikimr(MakeKikimrSettings(ss).SetUseRealThreads(false))
-                , Client(Kikimr.RunCall([&] () { return Kikimr.GetQueryClient(); }))
-                , Session(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
-                , VictimSession(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
-            {
-                ConfigureKikimrForTli(Kikimr, logEnabled);
-            }
-            void CreateAndSeedTables(int count) {
-                CreateAndSeedTablesInSession(Session, count);
-            }
-
-            void ExecuteQuery(const TString& query) {
-                NKqp::AssertSuccessResult(Session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync());
-            }
-        };
-
-        TTliThreadlessTestContext ctx(ss);
-
-        EStatus status;
-        TBasicString<char> issues;
-
-        auto future = ctx.Kikimr.RunInThreadPool([&] () {
-            ctx.CreateAndSeedTables(1);
-
-            auto victimTx = BeginTx(ctx.VictimSession, victimUpsertSelect);
-
-            // if this line is uncommented, leading to a waiting for a step update, the test succeeds
-            //
-            // TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate>(*ctx.Kikimr.GetTestServer().GetRuntime()).Wait();
-            //
-            // in order to compile with the previous line, add the following headers:
-            //
-            // #include <ydb/core/testlib/actors/wait_events.h>
-            // #include <ydb/core/tx/time_cast/time_cast.h>
-
-            ctx.ExecuteQuery(breakerUpsert);
-
-            std::tie(status, issues) = CommitTxWithIssues(*victimTx);
-        });
-
-        auto& runtime = *ctx.Kikimr.GetTestServer().GetRuntime();
-        TDispatchOptions opts;
-        opts.FinalEvents.emplace_back(
-            [&](IEventHandle&) { return status != EStatus::STATUS_UNDEFINED; });
-        runtime.DispatchEvents(opts);
-
-        runtime.WaitFuture(future);
-
-        UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
-    }
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -1382,6 +1382,45 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         VerifyTliIssueAndLogs(issues, ss, breakerUpsert, victimUpsertSelect);
     }
 
+    // Test: Concurrent UPSERT...SELECT transactions - replicates user's production scenario
+    // Tests that BreakerQuerySpanId and VictimQuerySpanId linkage is maintained even with
+    // OLTP sink + UPSERT...SELECT where locks may be created lazily (deferred lock creation).
+    Y_UNIT_TEST(ConcurrentUpsertSelectThreadless) {
+        TStringStream ss;
+        auto ctx = std::make_unique<TTliThreadlessTestContext>(ss);
+        ctx->CreateAndSeedTables(1);
+
+        // Seed with initial data in the key range 1-10
+        for (ui64 i = 2; i <= 10; ++i) {
+            ctx->SeedTable("/Root/Tenant1/Table1", {{i, Sprintf("Initial%lu", i)}});
+        }
+
+        // Victim transaction: UPSERT...SELECT that reads and writes keys 1-5
+        const TString victimUpsertSelect = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) "
+                                           "SELECT Key, \"VictimModified\" AS Value FROM `/Root/Tenant1/Table1` "
+                                           "WHERE Key >= 1u AND Key <= 5u";
+
+        // Breaker transaction: simple UPSERT to key 3 (overlaps with victim's range)
+        const TString breakerUpsert = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) VALUES (3u, \"BreakerValue\")";
+
+        // Victim: start transaction with UPSERT...SELECT (reads keys 1-5, then writes them)
+        // Note: with OLTP sink, the lock is NOT created immediately here (deferred lock creation)
+        auto victimTx = ctx->BeginTx(ctx->VictimSession, victimUpsertSelect);
+
+        // Breaker: write to key 3
+        // At this point, victim's lock doesn't exist yet (deferred lock creation)
+        // The breaker's write is tracked for later TLI linkage via RecentWritesForTli cache
+        ctx->ExecuteQuery(breakerUpsert);
+
+        // Victim: try to commit - should be aborted due to MVCC conflict detection
+        auto [status, issues] = ctx->CommitTxWithIssues(*victimTx);
+        UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
+        ctx.reset();
+
+        // Verify issue and TLI logs using common verification function
+        VerifyTliIssueAndLogs(issues, ss, breakerUpsert, victimUpsertSelect);
+    }
+
     // ==================== 2-Node Tests ====================
     // These tests use a 2-node environment:
     // - Node 0: victim KQP session

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -671,7 +671,7 @@ namespace {
             Kikimr.RunCall([&] () { return CreateAndSeedTablesWithSecondKeyInSession(Session, count); });
         }
 
-        void ExecuteQuery(const TString& query, bool waitForMediatorStep = true) {
+        void ExecuteQuery(const TString& query, bool waitForMediatorStep = false) {
             if (waitForMediatorStep) {
                 NActors::TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate> waiter(*Kikimr.GetTestServer().GetRuntime());
                 waiter.Wait(TDuration::Seconds(5));
@@ -1397,7 +1397,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         // Breaker: write to key 3
         // At this point, victim's lock doesn't exist yet (deferred lock creation)
         // The breaker's write is tracked for later TLI linkage via RecentWritesForTli cache
-        ctx->ExecuteQuery(breakerUpsert);
+        ctx->ExecuteQuery(breakerUpsert, true);
 
         // Victim: try to commit - should be aborted due to MVCC conflict detection
         auto [status, issues] = ctx->CommitTxWithIssues(victimTx);

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -1692,57 +1692,6 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         VerifyTliIssueAndLogs(issues, ss, breakerQueryText, victimQueryText, victimCommitText);
     }
 
-    // Test: Concurrent UPSERT...SELECT transactions - sometimes, expected cancellation of victim transaction does not happen.
-    // The path to reproduce a problem is as follows:
-    // - upon start of the service coordinator queues the reduced resolution step update, aligned on a 1000ms boundary;
-    // - just before BeginTx for a victim is issued, coordinator adjusts it's step to an aligned value and pushes it as a mediator step to the DataShard;
-    // - BeginTx requests read snapshot, receives current mediator step and schedules step update because less than 1ms has passed since previous update;
-    // - breaker also uses current mediator step for it's MVCC version because less than 1ms has passed since previous update;
-    // - both, the victim and a breaker, have same MVCC version {step/u64max} because both are immidiate;
-    // - due to an equal MVCC versions TLI conflict is not detected and both operations succeed.
-    Y_UNIT_TEST(ConcurrentUpsertSelectRace) {
-        const TString victimUpsertSelect = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) "
-                                           "SELECT Key, \"VictimModified\" AS Value FROM `/Root/Tenant1/Table1` "
-                                           "WHERE Key = 1u";
-
-        const TString breakerUpsert = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) VALUES (1u, \"BreakerValue\")";
-
-        const size_t resolution = 1000; // reduced step resolution
-        const size_t shift = 50; // time shift used to offset step off the clock
-        const size_t delays_limit = 10; // size of a delay averaging set
-        size_t delays[delays_limit]; // delays seen between victim's BeginTx and breaker query
-        size_t delays_count = 0; // number of delays seen between victim's BeginTx and breaker query
-        for (;;) {
-            TStringStream ss;
-            TTliTestContext ctx(ss);
-
-            ctx.CreateAndSeedTables(1);
-            if (delays_count) { // try to align a victim's BeginTx timestamp to reproduce a fail scenario
-                auto now = TAppData::TimeProvider->Now().MilliSeconds();
-                auto count = std::min(delays_count, delays_limit);
-                auto delay = std::accumulate(delays, delays + count, 0) / count; // average delay
-                auto aligned = (now + resolution - 1) / resolution * resolution; // aligned mediator step
-                auto drift = delays_count % 3 - 1; // some randomness
-                auto until = aligned - shift - delay + drift; // timepoint to sleep until
-                while (until < now) { // double check it's not in the past
-                    until += resolution;
-                }   
-                auto sleep = until - now;
-                Sleep(TDuration::MilliSeconds(sleep)); // breaker query should begin just after the step update
-            }
-            auto begin_ts = TAppData::TimeProvider->Now().MilliSeconds();
-            auto victimTx = BeginTx(ctx.VictimSession, victimUpsertSelect);
-            auto breaker_ts = TAppData::TimeProvider->Now().MilliSeconds();
-            ctx.ExecuteQuery(breakerUpsert);
-            auto [status, issues] = CommitTxWithIssues(*victimTx);
-
-            UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
-
-            delays[delays_count % delays_limit] = breaker_ts - begin_ts; // save delay
-            delays_count++;
-        }
-    }
-
     // Test: Concurrent UPSERT...SELECT transactions - expected cancellation of victim transaction does not happen.
     // This test does not use real threads and due to a lower step resolution always reproduces a bug with detecting TLI conflicts
     // if MVCC versions of victim and breaker happen to be the same.
@@ -1791,7 +1740,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
             //
             // TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate>(*ctx.Kikimr.GetTestServer().GetRuntime()).Wait();
             //
-            // in order to compile the previous line, add the following headers:
+            // in order to compile with the previous line, add the following headers:
             //
             // #include <ydb/core/testlib/actors/wait_events.h>
             // #include <ydb/core/tx/time_cast/time_cast.h>

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -639,14 +639,14 @@ namespace {
         }
     };
 
-    // NQuery-based test context (primary API for all tests) not using the real threads
-    struct TTliThreadlessTestContext {
+    // Test context with manual event dispatching for better control over order of query execution.
+    struct TTliManualDispatchTestContext {
         TKikimrRunner Kikimr;
         TQueryClient Client;
         TSession Session;
         TSession VictimSession;
 
-        TTliThreadlessTestContext(TStringStream& ss, bool logEnabled = true)
+        TTliManualDispatchTestContext(TStringStream& ss, bool logEnabled = true)
             : Kikimr(MakeKikimrSettings(ss).SetUseRealThreads(false))
             , Client(Kikimr.RunCall([&] () { return Kikimr.GetQueryClient(); }))
             , Session(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
@@ -671,8 +671,8 @@ namespace {
             Kikimr.RunCall([&] () { return CreateAndSeedTablesWithSecondKeyInSession(Session, count); });
         }
 
-        void ExecuteQuery(const TString& query, bool sync = true) {
-            if (sync) {
+        void ExecuteQuery(const TString& query, bool waitForMediatorStep = true) {
+            if (waitForMediatorStep) {
                 NActors::TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate> waiter(*Kikimr.GetTestServer().GetRuntime());
                 waiter.Wait(TDuration::Seconds(5));
             }
@@ -1372,9 +1372,9 @@ Y_UNIT_TEST_SUITE(KqpTli) {
     // Test: Concurrent UPSERT...SELECT transactions - replicates user's production scenario
     // Tests that BreakerQuerySpanId and VictimQuerySpanId linkage is maintained even with
     // OLTP sink + UPSERT...SELECT where locks may be created lazily (deferred lock creation).
-    Y_UNIT_TEST(ConcurrentUpsertSelectThreadless) {
+    Y_UNIT_TEST(ConcurrentUpsertSelectManualDispatch) {
         TStringStream ss;
-        auto ctx = std::make_unique<TTliThreadlessTestContext>(ss);
+        auto ctx = std::make_unique<TTliManualDispatchTestContext>(ss);
         ctx->CreateAndSeedTables(1);
 
         // Seed with initial data in the key range 1-10

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -1692,6 +1692,125 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         VerifyTliIssueAndLogs(issues, ss, breakerQueryText, victimQueryText, victimCommitText);
     }
 
+    // Test: Concurrent UPSERT...SELECT transactions - sometimes, expected cancellation of victim transaction does not happen.
+    // The path to reproduce a problem is as follows:
+    // - upon start of the service coordinator queues the reduced resolution step update, aligned on a 1000ms boundary;
+    // - just before BeginTx for a victim is issued, coordinator adjusts it's step to an aligned value and pushes it as a mediator step to the DataShard;
+    // - BeginTx requests read snapshot, receives current mediator step and schedules step update because less than 1ms has passed since previous update;
+    // - breaker also uses current mediator step for it's MVCC version because less than 1ms has passed since previous update;
+    // - both, the victim and a breaker, have same MVCC version {step/u64max} because both are immidiate;
+    // - due to an equal MVCC versions TLI conflict is not detected and both operations succeed.
+    Y_UNIT_TEST(ConcurrentUpsertSelectRace) {
+        const TString victimUpsertSelect = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) "
+                                           "SELECT Key, \"VictimModified\" AS Value FROM `/Root/Tenant1/Table1` "
+                                           "WHERE Key = 1u";
+
+        const TString breakerUpsert = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) VALUES (1u, \"BreakerValue\")";
+
+        const size_t resolution = 1000; // reduced step resolution
+        const size_t shift = 50; // time shift used to offset step off the clock
+        const size_t delays_limit = 10; // size of a delay averaging set
+        size_t delays[delays_limit]; // delays seen between victim's BeginTx and breaker query
+        size_t delays_count = 0; // number of delays seen between victim's BeginTx and breaker query
+        for (;;) {
+            TStringStream ss;
+            TTliTestContext ctx(ss);
+
+            ctx.CreateAndSeedTables(1);
+            if (delays_count) { // try to align a victim's BeginTx timestamp to reproduce a fail scenario
+                auto now = TAppData::TimeProvider->Now().MilliSeconds();
+                auto count = std::min(delays_count, delays_limit);
+                auto delay = std::accumulate(delays, delays + count, 0) / count; // average delay
+                auto aligned = (now + resolution - 1) / resolution * resolution; // aligned mediator step
+                auto drift = delays_count % 3 - 1; // some randomness
+                auto until = aligned - shift - delay + drift; // timepoint to sleep until
+                while (until < now) { // double check it's not in the past
+                    until += resolution;
+                }   
+                auto sleep = until - now;
+                Sleep(TDuration::MilliSeconds(sleep)); // breaker query should begin just after the step update
+            }
+            auto begin_ts = TAppData::TimeProvider->Now().MilliSeconds();
+            auto victimTx = BeginTx(ctx.VictimSession, victimUpsertSelect);
+            auto breaker_ts = TAppData::TimeProvider->Now().MilliSeconds();
+            ctx.ExecuteQuery(breakerUpsert);
+            auto [status, issues] = CommitTxWithIssues(*victimTx);
+
+            UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
+
+            delays[delays_count % delays_limit] = breaker_ts - begin_ts; // save delay
+            delays_count++;
+        }
+    }
+
+    // Test: Concurrent UPSERT...SELECT transactions - expected cancellation of victim transaction does not happen.
+    // This test does not use real threads and due to a lower step resolution always reproduces a bug with detecting TLI conflicts
+    // if MVCC versions of victim and breaker happen to be the same.
+    Y_UNIT_TEST(ConcurrentUpsertSelectRaceThreadless) {
+        const TString victimUpsertSelect = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) "
+                                           "SELECT Key, \"VictimModified\" AS Value FROM `/Root/Tenant1/Table1` "
+                                           "WHERE Key = 1u";
+
+        const TString breakerUpsert = "UPSERT INTO `/Root/Tenant1/Table1` (Key, Value) VALUES (1u, \"BreakerValue\")";
+
+        TStringStream ss;
+        struct TTliThreadlessTestContext {
+            TKikimrRunner Kikimr;
+            TQueryClient Client;
+            TSession Session;
+            TSession VictimSession;
+
+            TTliThreadlessTestContext(TStringStream& ss, bool logEnabled = true)
+                : Kikimr(MakeKikimrSettings(ss).SetUseRealThreads(false))
+                , Client(Kikimr.RunCall([&] () { return Kikimr.GetQueryClient(); }))
+                , Session(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
+                , VictimSession(Kikimr.RunCall([&] () { return Client.GetSession().GetValueSync().GetSession(); }))
+            {
+                ConfigureKikimrForTli(Kikimr, logEnabled);
+            }
+            void CreateAndSeedTables(int count) {
+                CreateAndSeedTablesInSession(Session, count);
+            }
+
+            void ExecuteQuery(const TString& query) {
+                NKqp::AssertSuccessResult(Session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync());
+            }
+        };
+
+        TTliThreadlessTestContext ctx(ss);
+
+        EStatus status;
+        TBasicString<char> issues;
+
+        auto future = ctx.Kikimr.RunInThreadPool([&] () {
+            ctx.CreateAndSeedTables(1);
+
+            auto victimTx = BeginTx(ctx.VictimSession, victimUpsertSelect);
+
+            // if this line is uncommented, leading to a waiting for a step update, the test succeeds
+            //
+            // TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate>(*ctx.Kikimr.GetTestServer().GetRuntime()).Wait();
+            //
+            // in order to compile the previous line, add the following headers:
+            //
+            // #include <ydb/core/testlib/actors/wait_events.h>
+            // #include <ydb/core/tx/time_cast/time_cast.h>
+
+            ctx.ExecuteQuery(breakerUpsert);
+
+            std::tie(status, issues) = CommitTxWithIssues(*victimTx);
+        });
+
+        auto& runtime = *ctx.Kikimr.GetTestServer().GetRuntime();
+        TDispatchOptions opts;
+        opts.FinalEvents.emplace_back(
+            [&](IEventHandle&) { return status != EStatus::STATUS_UNDEFINED; });
+        runtime.DispatchEvents(opts);
+
+        runtime.WaitFuture(future);
+
+        UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
+    }
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
+++ b/ydb/core/kqp/ut/tli/kqp_tli_ut.cpp
@@ -656,50 +656,37 @@ namespace {
         }
 
         void CreateTable(const TString& tableName) {
-            NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
-                return Session.ExecuteQuery(Sprintf(R"(CREATE TABLE `%s` (Key Uint64, Value String, PRIMARY KEY (Key));)", tableName.c_str()),
-                    TTxControl::NoTx()).GetValueSync();
-            }));
+            Kikimr.RunCall([&] () { return CreateTableInSession(Session, tableName); });
         }
 
         void SeedTable(const TString& tableName, const TVector<std::pair<ui64, TString>>& rows) {
-            for (const auto& [key, value] : rows) {
-                NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
-                    return Session.ExecuteQuery(Sprintf("UPSERT INTO `%s` (Key, Value) VALUES (%luu, \"%s\")", tableName.c_str(), key, value.c_str()),
-                        TTxControl::BeginTx().CommitTx()).GetValueSync();
-                }));
-            }
+            Kikimr.RunCall([&] () { return SeedTableInSession(Session, tableName, rows); });
         }
 
         void CreateAndSeedTables(int count) {
-            for (int i = 1; i <= count; ++i) {
-                const TString tablePath = NumberedTablePath(i);
-                CreateTable(tablePath);
-                SeedTable(tablePath, {{1, Sprintf("Init%d", i)}});
-            }
+            Kikimr.RunCall([&] () { return CreateAndSeedTablesInSession(Session, count); });
         }
 
         void CreateAndSeedTablesWithSecondKey(int count) {
-            for (int i = 1; i <= count; ++i) {
-                const TString tablePath = NumberedTablePath(i);
-                CreateTable(tablePath);
-                SeedTable(tablePath, {{1, Sprintf("Init%d", i)}, {2, Sprintf("Init%d_2", i)}});
-            }
+            Kikimr.RunCall([&] () { return CreateAndSeedTablesWithSecondKeyInSession(Session, count); });
         }
 
         void ExecuteQuery(const TString& query, bool sync = true) {
             if (sync) {
-                TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate>(*Kikimr.GetTestServer().GetRuntime()).Wait();
+                NActors::TWaitForFirstEvent<TEvMediatorTimecast::TEvUpdate> waiter(*Kikimr.GetTestServer().GetRuntime());
+                waiter.Wait(TDuration::Seconds(5));
             }
             NKqp::AssertSuccessResult(Kikimr.RunCall([&] () {
                 return Session.ExecuteQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
             }));
         }
 
-        std::optional<TTransaction> BeginTx(TSession& session, const TString& query) {
+        TTransaction BeginTx(TSession& session, const TString& query) {
             auto result = Kikimr.RunCall([&] () { return session.ExecuteQuery(query, TTxControl::BeginTx()).GetValueSync(); });
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            return result.GetTransaction();
+            auto tx = result.GetTransaction();
+            UNIT_ASSERT(tx);
+            return *tx;
         }
 
         std::pair<EStatus, TString> CommitTxWithIssues(TTransaction& tx) {
@@ -1392,7 +1379,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
 
         // Seed with initial data in the key range 1-10
         for (ui64 i = 2; i <= 10; ++i) {
-            ctx->SeedTable("/Root/Tenant1/Table1", {{i, Sprintf("Initial%lu", i)}});
+            ctx->SeedTable("/Root/Tenant1/Table1", {{i, Sprintf("Initial%" PRIu64, i)}});
         }
 
         // Victim transaction: UPSERT...SELECT that reads and writes keys 1-5
@@ -1413,7 +1400,7 @@ Y_UNIT_TEST_SUITE(KqpTli) {
         ctx->ExecuteQuery(breakerUpsert);
 
         // Victim: try to commit - should be aborted due to MVCC conflict detection
-        auto [status, issues] = ctx->CommitTxWithIssues(*victimTx);
+        auto [status, issues] = ctx->CommitTxWithIssues(victimTx);
         UNIT_ASSERT_VALUES_EQUAL(status, EStatus::ABORTED);
         ctx.reset();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Unit test for reproducing TLI detection in more controlled environment

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Introducing a new version of existing ConcurrentUpsertSelect unit test based on a  manual event dispatcher.
This version uses an explicit wait for a mediator step update ensuring stable ordering of victim/breaker queries regarding a more relaxed consistency model during a single shard operations.
