### PR TITLE
Better bucket selection in aggregation

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
@@ -65,6 +65,12 @@ using THashPtr = NUdf::THashType(*)(const NUdf::TUnboxedValuePod*);
 using TEqualsFunc = std::function<bool(const NUdf::TUnboxedValuePod*, const NUdf::TUnboxedValuePod*)>;
 using THashFunc = std::function<NUdf::THashType(const NUdf::TUnboxedValuePod*)>;
 
+static ui64 GetSelfHash(void* self) {
+    char buf[sizeof(void*)];
+    WriteUnaligned<void*>(buf, self);
+    return CityHash64(buf, sizeof(buf));
+}
+
 struct TSegmentedArena
 {
     // TODO: Account for MKQL-specific headers
@@ -987,7 +993,9 @@ protected:
         ui64 bucketId = 0;
         ui64 hash = Hasher(tempKey);
         if (EnableSpilling) {
-            bucketId = (hash * 11400714819323198485llu) & ((1ull << BucketBits) - 1);
+            // Lower 16 bits are used by the hash shuffle connection to distribute keys among tasks, so we can't use these (even with the hash seed)
+            // Another solution would be to rehash using a different function but shifted bits are uniform enough
+            bucketId = ((hash * 11400714819323198485llu) >> 16) & ((1ull << BucketBits) - 1ull);
         }
 
         if (!SpillingStack.empty()) {
@@ -1140,7 +1148,7 @@ public:
         , Nodes(nodes)
         , WideFieldsIndex(wideFieldsIndex)
         , KeyTypes(keyTypes)
-        , Hasher(THashFunc(TWideUnboxedHasher(KeyTypes)))
+        , Hasher(THashFunc(TWideUnboxedHasher(KeyTypes, GetSelfHash(this))))
         , Equals(TWideUnboxedEqual(KeyTypes))
         , Draining(false)
         , SourceEmpty(false)

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
@@ -65,10 +65,9 @@ using THashPtr = NUdf::THashType(*)(const NUdf::TUnboxedValuePod*);
 using TEqualsFunc = std::function<bool(const NUdf::TUnboxedValuePod*, const NUdf::TUnboxedValuePod*)>;
 using THashFunc = std::function<NUdf::THashType(const NUdf::TUnboxedValuePod*)>;
 
-static ui64 GetSelfHash(void* self) {
-    char buf[sizeof(void*)];
-    WriteUnaligned<void*>(buf, self);
-    return CityHash64(buf, sizeof(buf));
+static ui64 GetInstanceSeed(void* self) {
+    // Used to return CityHash64(self) but looks like that's unnecessary: we put the seed through regular and then Fibonacci hashing anyway
+    return reinterpret_cast<ui64>(self);
 }
 
 struct TSegmentedArena
@@ -1148,7 +1147,7 @@ public:
         , Nodes(nodes)
         , WideFieldsIndex(wideFieldsIndex)
         , KeyTypes(keyTypes)
-        , Hasher(THashFunc(TWideUnboxedHasher(KeyTypes, GetSelfHash(this))))
+        , Hasher(THashFunc(TWideUnboxedHasher(KeyTypes, GetInstanceSeed(this))))
         , Equals(TWideUnboxedEqual(KeyTypes))
         , Draining(false)
         , SourceEmpty(false)

--- a/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
@@ -36,6 +36,7 @@ struct TDqRobinHoodBatchRequestItem {
 
 
 // TODO: only POD key & payloads are now supported
+// This modification doesn't mix per-instance random SelfHash into the hash value; please do it in your Hasher instead
 template <typename TKey, typename TEqual, typename THash, typename TAllocator>
 class TDqRobinHoodHashSet {
 public:
@@ -67,13 +68,12 @@ public:
         }
     };
 
-    explicit TDqRobinHoodHashSet(THash hash, TEqual equal, const ui64 initialCapacity = 1u << 8)
+    explicit TDqRobinHoodHashSet(THash hash, TEqual equal, const ui64 initialCapacity)
         : HashLocal_(std::move(hash))
         , EqualLocal_(std::move(equal))
         , Capacity_(initialCapacity)
         , CapacityShift_(32 - MostSignificantBit(initialCapacity))
         , Allocator_()
-        , SelfHash_(GetSelfHash(this))
     {
         Y_ENSURE((Capacity_ & (Capacity_ - 1)) == 0);
         Init();
@@ -195,7 +195,7 @@ private:
 
     Y_FORCE_INLINE char* MakeIterator(const ui32 hash, char* data, ui32 capacityShift) {
         // https://web.archive.org/web/20180620004325/https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
-        ui32 bucket = static_cast<ui32>(((SelfHash_ ^ static_cast<ui64>(hash)) * 11400714819323198485ull)) >> capacityShift;
+        ui32 bucket = static_cast<ui32>((static_cast<ui64>(hash) * 11400714819323198485ull)) >> capacityShift;
         char* ptr = data + GetCellSize() * bucket;
         return ptr;
     }
@@ -322,12 +322,6 @@ private:
         ptr = (ptr == end) ? begin : ptr;
     }
 
-    static ui64 GetSelfHash(void* self) {
-        char buf[sizeof(void*)];
-        WriteUnaligned<void*>(buf, self);
-        return CityHash64(buf, sizeof(buf));
-    }
-
 protected:
     void Init() {
         Allocate(Capacity_, Data_, DataEnd_);
@@ -350,7 +344,6 @@ private:
     ui64 Capacity_;
     ui32 CapacityShift_;
     TAllocator Allocator_;
-    const ui64 SelfHash_;
     char* Data_ = nullptr;
     char* DataEnd_ = nullptr;
 };

--- a/ydb/library/yql/dq/comp_nodes/type_utils.h
+++ b/ydb/library/yql/dq/comp_nodes/type_utils.h
@@ -28,20 +28,21 @@ struct TWideUnboxedEqual {
 };
 
 struct TWideUnboxedHasher {
-    TWideUnboxedHasher(const TKeyTypes& types)
-        : Types(types)
+    TWideUnboxedHasher(const TKeyTypes& types, const ui64 seed = 0ULL)
+        : Seed(seed)
+        , Types(types)
     {}
 
     NUdf::THashType operator()(const NUdf::TUnboxedValuePod* values) const {
         if (Types.size() == 1U) {
             if (const auto v = *values) {
-                return NUdf::GetValueHash(Types.front().first, v);
+                return CombineHashes(Seed, NUdf::GetValueHash(Types.front().first, v));
             } else {
                 return HashOfNull;
             }
         }
 
-        NUdf::THashType hash = 0ULL;
+        NUdf::THashType hash = Seed;
         for (const auto& type : Types) {
             if (const auto v = *values++) {
                 hash = CombineHashes(hash, NUdf::GetValueHash(type.first, v));
@@ -52,6 +53,8 @@ struct TWideUnboxedHasher {
         return hash;
     }
 
+private:
+    const ui64 Seed;
     const TKeyTypes& Types;
 };
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The key hash value modulo number of buckets is used to select spilling buckets. The exact same hash value is used to distribute keys among tasks, so there's a strong possibility of unwanted correlation between task and bucket IDs. Let's just use a different subset of hash bits for bucket selection. Also added a random-ish hash seed value (but it won't help by itself in the simplest case when there's just one column to hash).