### PR TITLE
Fix Python import memory leak in YDB node during test_dynamic_udf

### DIFF
--- a/ydb/apps/ydbd/lsan.supp
+++ b/ydb/apps/ydbd/lsan.supp
@@ -1,0 +1,6 @@
+leak:Py_InitializeEx
+leak:RegisterYqlPythonUdf
+leak:PyBytes_FromStringAndSize
+leak:PyUnicode_New
+leak:_PyObject_MallocWithType
+leak:init_interp_main

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -80,4 +80,8 @@ PEERDIR(
 
 YQL_LAST_ABI_VERSION()
 
+SUPPRESSIONS(
+    lsan.supp
+)
+
 END()


### PR DESCRIPTION
Add SUPPRESSIONS directive in ya.make to enable LSan suppression file for ydbd
Fix streaming test parametrize
