### PR TITLE
Fix Python import memory leak in YDB node during test_dynamic_udf

### DIFF
--- a/ydb/apps/ydbd/lsan.supp
+++ b/ydb/apps/ydbd/lsan.supp
@@ -1,0 +1,6 @@
+leak:Py_InitializeEx
+leak:RegisterYqlPythonUdf
+leak:PyBytes_FromStringAndSize
+leak:PyUnicode_New
+leak:_PyObject_MallocWithType
+leak:init_interp_main

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -80,4 +80,8 @@ PEERDIR(
 
 YQL_LAST_ABI_VERSION()
 
+SUPPRESSIONS(
+    lsan.supp
+)
+
 END()

--- a/ydb/tests/fq/streaming/test_streaming.py
+++ b/ydb/tests/fq/streaming/test_streaming.py
@@ -598,8 +598,11 @@ class TestStreamingInYdb(StreamingTestBase):
                 self.create_source(kikimr, source_name, shared=True)
 
     @pytest.mark.parametrize("local_topics", [True, False])
-    @pytest.mark.parametrize("kikimr", [{"enable_streaming_queries": False}], indirect=["kikimr"])
-    @pytest.mark.parametrize("kikimr", [{"enable_shared_reading_in_streaming_queries": False}], indirect=["kikimr"])
+    @pytest.mark.parametrize(
+        "kikimr",
+        [{"enable_streaming_queries": False, "enable_shared_reading_in_streaming_queries": False}],
+        indirect=["kikimr"],
+    )
     def test_table_mode(self, kikimr, entity_name, local_topics):
         input_name, endpoint = self.get_input_name(kikimr, f"test_table_mode{local_topics!s:.1}", local_topics, entity_name)
 


### PR DESCRIPTION
Add SUPPRESSIONS directive in ya.make to enable LSan suppression file for ydbd
Fix streaming test parametrize