### PR TITLE
[EXT-2222] OIDC wrong cookie prefix

### DIFF
--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -119,11 +119,11 @@ TString CreateNameYdbOidcCookie(TStringBuf suffix) {
 }
 
 TString CreateNameSessionCookie(TStringBuf key) {
-    return "__Host_" + TOpenIdConnectSettings::SESSION_COOKIE + "_" + HexEncode(key);
+    return "__Host-" + TOpenIdConnectSettings::SESSION_COOKIE + "_" + HexEncode(key);
 }
 
 TString CreateNameImpersonatedCookie(TStringBuf key) {
-    return "__Host_" + TOpenIdConnectSettings::IMPERSONATED_COOKIE + "_" + HexEncode(key);
+    return "__Host-" + TOpenIdConnectSettings::IMPERSONATED_COOKIE + "_" + HexEncode(key);
 }
 
 const TString& GetAuthCallbackUrl() {

--- a/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
@@ -23,11 +23,11 @@ def direct_bearer_headers(token=TEST_IAM_TOKEN):
 
 
 def session_cookie_name(client_id=TEST_CLIENT_ID):
-    return f"__Host_session_cookie_{client_id.encode().hex().upper()}"
+    return f"__Host-session_cookie_{client_id.encode().hex().upper()}"
 
 
 def impersonated_cookie_name(client_id=TEST_CLIENT_ID):
-    return f"__Host_impersonated_cookie_{client_id.encode().hex().upper()}"
+    return f"__Host-impersonated_cookie_{client_id.encode().hex().upper()}"
 
 
 def encoded_cookie_value(token):
@@ -201,7 +201,7 @@ def authenticate_session(oidc_proxy_full_flow_env, start_path):
 
     assert callback_response.status_code == 302, callback_response.text
     assert callback_response.headers["Location"] == start_path, callback_response.headers
-    assert "__Host_session_cookie_" in callback_response.headers["Set-Cookie"], callback_response.headers["Set-Cookie"]
+    assert "__Host-session_cookie_" in callback_response.headers["Set-Cookie"], callback_response.headers["Set-Cookie"]
 
     return callback_response.headers["Set-Cookie"].split(";", 1)[0]
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Browser rules are looking for `__Host-` prefix in cookies for theirs logic, but in OIDC we use `__Host_` instead.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change invalidates previously issued cookies and will force a one-time re-authentication after rollout. We consider that acceptable and do not expect other issues.
