### PR TITLE
publish minSnapshotForNewScans on scans

### DIFF
--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -198,20 +198,26 @@ ui64 TColumnShard::GetOutdatedStep() const {
     return step;
 }
 
+void TColumnShard::PublishMinSnapshotForNewScans(const IScanSnapshotGuard& guard) const {
+    const auto minSnapshot = guard.GetMinSnapshotForNewReads();
+    Counters.GetRequestsTracingCounters()->OnDefaultMinSnapshotInstant(TInstant::MilliSeconds(minSnapshot.GetPlanStep()));
+}
+
 NOlap::TSnapshot TColumnShard::GetMinSnapshotForNewReads() const {
     auto guard = CreateScanSnapshotGuard(GetOutdatedStep(), CurrentSchemeShardId, LastCleanupSnapshot, InFlightReadsTracker, TablesManager);
-    auto minSnapshot = guard->GetMinSnapshotForNewReads();
-    Counters.GetRequestsTracingCounters()->OnDefaultMinSnapshotInstant(TInstant::MilliSeconds(minSnapshot.GetPlanStep()));
-    return minSnapshot;
+    PublishMinSnapshotForNewScans(*guard);
+    return guard->GetMinSnapshotForNewReads();
 }
 
 bool TColumnShard::MayStartScanAt(const NOlap::TSnapshot& snapshot, const NColumnShard::TSchemeShardLocalPathId& schemeShardLocalPathId) const {
     auto guard = CreateScanSnapshotGuard(GetOutdatedStep(), CurrentSchemeShardId, LastCleanupSnapshot, InFlightReadsTracker, TablesManager);
+    PublishMinSnapshotForNewScans(*guard);
     return guard->MayStartScanAt(snapshot, schemeShardLocalPathId);
 }
 
 std::unique_ptr<NOlap::ISnapshotHolders> TColumnShard::GetSnapshotHolders() const {
     auto guard = CreateScanSnapshotGuard(GetOutdatedStep(), CurrentSchemeShardId, LastCleanupSnapshot, InFlightReadsTracker, TablesManager);
+    PublishMinSnapshotForNewScans(*guard);
     return guard->BuildSnapshotHolders();
 }
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -123,6 +123,7 @@ class TTxBlobsWritingFailed;
 class TWriteTasksQueue;
 class TWriteTask;
 class TCommitOperation;
+class IScanSnapshotGuard;
 
 namespace NLoading {
 class TTxControllerInitializer;
@@ -587,6 +588,7 @@ private:
     void SendWaitPlanStep(ui64 step);
     void RescheduleWaitingReads();
     NOlap::TSnapshot GetMaxReadVersion() const;
+    void PublishMinSnapshotForNewScans(const IScanSnapshotGuard& guard) const;
     NOlap::TSnapshot GetMinSnapshotForNewReads() const;
     bool MayStartScanAt(const NOlap::TSnapshot& snapshot, const NColumnShard::TSchemeShardLocalPathId& schemeShardLocalPathId) const;
     std::unique_ptr<NOlap::ISnapshotHolders> GetSnapshotHolders() const;

--- a/ydb/core/tx/columnshard/scan_snapshot_guard.cpp
+++ b/ydb/core/tx/columnshard/scan_snapshot_guard.cpp
@@ -9,44 +9,48 @@
 namespace NKikimr::NColumnShard {
 namespace {
 
+NOlap::TSnapshot BuildLocalMinSnapshotForNewReads(const ui64 passedStep, const NOlap::TSnapshot& lastCleanupSnapshot) {
+    const ui64 delayMillisec = NYDBTest::TControllers::GetColumnShardController()->GetMaxReadStaleness().MilliSeconds();
+    const ui64 minReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
+    return std::max(NOlap::TSnapshot(minReadStep, 0), lastCleanupSnapshot);
+}
+
 class TLocalScanSnapshotGuard: public IScanSnapshotGuard {
 private:
-    const ui64 PassedStep;
-    const NOlap::TSnapshot LastCleanupSnapshot;
     const TInFlightReadsTracker& InFlightReadsTracker;
+    const NOlap::TSnapshot MinSnapshotForNewReads;
 
 public:
     TLocalScanSnapshotGuard(
         const ui64 passedStep, const NOlap::TSnapshot& lastCleanupSnapshot, const TInFlightReadsTracker& inFlightReadsTracker)
-        : PassedStep(passedStep)
-        , LastCleanupSnapshot(lastCleanupSnapshot)
-        , InFlightReadsTracker(inFlightReadsTracker)
+        : InFlightReadsTracker(inFlightReadsTracker)
+        , MinSnapshotForNewReads(BuildLocalMinSnapshotForNewReads(passedStep, lastCleanupSnapshot))
     {
     }
 
     NOlap::TSnapshot GetMinSnapshotForNewReads() const override {
-        const ui64 delayMillisec = NYDBTest::TControllers::GetColumnShardController()->GetMaxReadStaleness().MilliSeconds();
-        const ui64 minReadStep = (PassedStep > delayMillisec ? PassedStep - delayMillisec : 0);
-        return std::max(NOlap::TSnapshot(minReadStep, 0), LastCleanupSnapshot);
+        return MinSnapshotForNewReads;
     }
 
     bool MayStartScanAt(const NOlap::TSnapshot& snapshot, const TSchemeShardLocalPathId&) const override {
-        return GetMinSnapshotForNewReads() <= snapshot || InFlightReadsTracker.HasLiveSnapshot(snapshot);
+        return MinSnapshotForNewReads <= snapshot || InFlightReadsTracker.HasLiveSnapshot(snapshot);
     }
 
     std::unique_ptr<NOlap::ISnapshotHolders> BuildSnapshotHolders() const override {
-        auto minSnapshotForNewReads = GetMinSnapshotForNewReads();
-        auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(minSnapshotForNewReads);
-        return std::make_unique<NOlap::TLegacySnapshotHolders>(minSnapshotForNewReads, std::move(inFlightTxs));
+        auto inFlightTxs = InFlightReadsTracker.GetLiveSnapshots(MinSnapshotForNewReads);
+        return std::make_unique<NOlap::TLegacySnapshotHolders>(MinSnapshotForNewReads, std::move(inFlightTxs));
     }
 };
 
 class TRegistryNotReadySnapshotGuard: public IScanSnapshotGuard {
+private:
+    const NOlap::TSnapshot MinSnapshotForNewReads = NOlap::TSnapshot::Zero();
+
 public:
     NOlap::TSnapshot GetMinSnapshotForNewReads() const override {
         // Strictly safe mode while snapshots locking is enabled but registry is not materialized yet:
         // no portion is considered removable by snapshot age.
-        return NOlap::TSnapshot::Zero();
+        return MinSnapshotForNewReads;
     }
 
     bool MayStartScanAt(const NOlap::TSnapshot&, const TSchemeShardLocalPathId&) const override {
@@ -56,61 +60,62 @@ public:
 
     std::unique_ptr<NOlap::ISnapshotHolders> BuildSnapshotHolders() const override {
         // Keep everything until registry materializes to preserve correctness.
-        return std::make_unique<NOlap::TLegacySnapshotHolders>(GetMinSnapshotForNewReads(), std::vector<NOlap::TSnapshot>{});
+        return std::make_unique<NOlap::TLegacySnapshotHolders>(MinSnapshotForNewReads, std::vector<NOlap::TSnapshot>{});
     }
 };
 
+NOlap::TSnapshot BuildRegistryMinSnapshotForNewReads(const ui64 passedStep, const NOlap::TSnapshot& lastCleanupSnapshot,
+    const TTrueAtomicSharedPtr<IImmutableSnapshotRegistry>& registry, const NKikimrConfig::TLongTxServiceConfig& longTxConfig) {
+    // How long it may take for a snapshot from the most remote node to reach this columnshard
+    // in the worst case by default:
+    //   promotion delay (120s) + exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 170s.
+    // 10 seconds delta is the agreed conservative estimate:
+    //   4 messages * log_10(100k nodes) * 0.5s (ping time between the nodes) = 10s.
+
+    // But, in fact, the registry is not ready right after the node start, it takes it a while to materialize.
+    // During this period of materialization the shard keeps all portions (do not delete anything), see `TRegistryNotReadySnapshotGuard`.
+    // A practical upper estimate of this additional startup "no-delete" window with default config:
+    // exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 50s
+    // Therefore the total default conservative duration of keeping removed portions is roughly:
+    //   170s (steady-state delay window) + 50s (startup materialization period) = ~220 seconds.
+    // That is at most for how long we will keep removed portions by default.
+    const ui64 delaySeconds = longTxConfig.GetLocalSnapshotPromotionTimeSeconds() + longTxConfig.GetSnapshotsExchangeIntervalSeconds() +
+                              longTxConfig.GetSnapshotsRegistryUpdateIntervalSeconds() + 10;
+    const ui64 delayMillisec = TDuration::Seconds(delaySeconds).MilliSeconds();
+    const ui64 serviceMinReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
+
+    NOlap::TSnapshot minSnapshot = std::max(NOlap::TSnapshot(serviceMinReadStep, 0), lastCleanupSnapshot);
+    // Registry border may be older than the calculated delay window.
+    // In that case we use the older border to preserve correctness.
+    const TRowVersion border = registry->GetBorder();
+    return std::min(minSnapshot, NOlap::TSnapshot(border.Step, border.TxId));
+}
+
 class TRegistryScanSnapshotGuard: public IScanSnapshotGuard {
 private:
-    const ui64 PassedStep;
     const ui64 SchemeShardId;
-    const NOlap::TSnapshot LastCleanupSnapshot;
     const NOlap::IPathIdTranslator& PathIdTranslator;
     const TTrueAtomicSharedPtr<IImmutableSnapshotRegistry> Registry;
-    const NKikimrConfig::TLongTxServiceConfig& LongTxConfig;
+    const NOlap::TSnapshot MinSnapshotForNewReads;
 
 public:
     TRegistryScanSnapshotGuard(const ui64 passedStep, const ui64 schemeShardId, const NOlap::TSnapshot& lastCleanupSnapshot,
         const NOlap::IPathIdTranslator& pathIdTranslator, TTrueAtomicSharedPtr<IImmutableSnapshotRegistry> registry,
         const NKikimrConfig::TLongTxServiceConfig& longTxConfig)
-        : PassedStep(passedStep)
-        , SchemeShardId(schemeShardId)
-        , LastCleanupSnapshot(lastCleanupSnapshot)
+        : SchemeShardId(schemeShardId)
         , PathIdTranslator(pathIdTranslator)
         , Registry(std::move(registry))
-        , LongTxConfig(longTxConfig)
+        , MinSnapshotForNewReads(BuildRegistryMinSnapshotForNewReads(passedStep, lastCleanupSnapshot, Registry, longTxConfig))
     {
         AFL_VERIFY(Registry);
     }
 
     NOlap::TSnapshot GetMinSnapshotForNewReads() const override {
-        // How long it may take for a snapshot from the most remote node to reach this columnshard
-        // in the worst case by default:
-        //   promotion delay (120s) + exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 170s.
-        // 10 seconds delta is the agreed conservative estimate:
-        //   4 messages * log_10(100k nodes) * 0.5s (ping time between the nodes) = 10s.
-
-        // But, in fact, the registry is not ready right after the node start, it takes it a while to materialize.
-        // During this period of materialization the shard keeps all portions (do not delete anything), see `TRegistryNotReadySnapshotGuard`.
-        // A practical upper estimate of this additional startup "no-delete" window with default config:
-        // exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 50s
-        // Therefore the total default conservative duration of keeping removed portions is roughly:
-        //   170s (steady-state delay window) + 50s (startup materialization period) = ~220 seconds.
-        // That is at most for how long we will keep removed portions by default.
-        const ui64 delaySeconds = LongTxConfig.GetLocalSnapshotPromotionTimeSeconds() + LongTxConfig.GetSnapshotsExchangeIntervalSeconds() +
-                                  LongTxConfig.GetSnapshotsRegistryUpdateIntervalSeconds() + 10;
-        const ui64 delayMillisec = TDuration::Seconds(delaySeconds).MilliSeconds();
-        const ui64 serviceMinReadStep = (PassedStep > delayMillisec ? PassedStep - delayMillisec : 0);
-
-        NOlap::TSnapshot minSnapshot = std::max(NOlap::TSnapshot(serviceMinReadStep, 0), LastCleanupSnapshot);
-        // Registry border may be older than the calculated delay window.
-        // In that case we use the older border to preserve correctness.
-        const TRowVersion border = Registry->GetBorder();
-        return std::min(minSnapshot, NOlap::TSnapshot(border.Step, border.TxId));
+        return MinSnapshotForNewReads;
     }
 
     bool MayStartScanAt(const NOlap::TSnapshot& snapshot, const TSchemeShardLocalPathId& schemeShardLocalPathId) const override {
-        if (GetMinSnapshotForNewReads() <= snapshot) {
+        if (MinSnapshotForNewReads <= snapshot) {
             return true;
         }
 
@@ -120,7 +125,7 @@ public:
     }
 
     std::unique_ptr<NOlap::ISnapshotHolders> BuildSnapshotHolders() const override {
-        return std::make_unique<NOlap::TRegistrySnapshotHolders>(GetMinSnapshotForNewReads(), Registry, SchemeShardId, PathIdTranslator);
+        return std::make_unique<NOlap::TRegistrySnapshotHolders>(MinSnapshotForNewReads, Registry, SchemeShardId, PathIdTranslator);
     }
 };
 


### PR DESCRIPTION
Currently, columnshards publish MinSnapshotForNewScans to the sensors only on writes.

This pr make them publish it on scans too.