### PR TITLE
generic provider: improve error handling

### DIFF
--- a/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
@@ -85,10 +85,11 @@ namespace NYql::NDq {
 
     private:
         // clang-format off
-        STRICT_STFUNC(StateFunc,
+        STRICT_STFUNC_EXC(StateFunc,
                       hFunc(TEvReadSplitsIterator, Handle);
                       hFunc(TEvReadSplitsPart, Handle);
                       hFunc(TEvReadSplitsFinished, Handle);
+                      , ExceptionFunc(std::exception, HandleException)
         )
         // clang-format on
 
@@ -167,7 +168,7 @@ namespace NYql::NDq {
                     response.error());
             }
 
-            YQL_ENSURE(response.arrow_ipc_streaming().size(), "empty data");
+            YQL_ENSURE(response.arrow_ipc_streaming().size(), "empty data from connector");
 
             // Preserve stream message to return it to ComputeActor later
             LastReadSplitsResponse_ = std::move(ev->Get()->Response);
@@ -247,6 +248,16 @@ namespace NYql::NDq {
             }
             IngressStats_.Chunks++;
             IngressStats_.Resume();
+        }
+
+        void HandleException(const std::exception& e) {
+            YQL_CLOG(ERROR, ProviderGeneric) << "ActorId=" << SelfId() << " Got unexpected exception: " << e.what();
+
+            NotifyComputeActorWithIssue(
+                TActivationContext::ActorSystem(),
+                ComputeActorId_,
+                InputIndex_,
+                TIssue(TStringBuilder() << "Internal error. Got unexpected exception: " << e.what()));
         }
 
         void NotifyComputeActorWithData() {

--- a/ydb/library/yql/providers/generic/connector/libcpp/error.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/error.h
@@ -18,17 +18,7 @@ namespace NYql::NConnector {
             return true;
         }
 
-        const NApi::TError& error = response.error();
-
-        YQL_ENSURE(error.status() != Ydb::StatusIds_StatusCode::StatusIds_StatusCode_STATUS_CODE_UNSPECIFIED,
-                   "error status code is not initialized");
-
-        auto ok = error.status() == Ydb::StatusIds_StatusCode::StatusIds_StatusCode_SUCCESS;
-        if (ok) {
-            YQL_ENSURE(error.issues_size() == 0, "request succeeded, but issues are not empty");
-        }
-
-        return ok;
+        return response.error().status() == Ydb::StatusIds_StatusCode::StatusIds_StatusCode_SUCCESS;
     }
 
     TIssues ErrorToIssues(const NApi::TError& error, TString prefix = "");


### PR DESCRIPTION
connector client: don't throw from IsSuccess
while we can catch exceptions, users hardly expect that IsSuccess method will throw on unusual status code from external systems
generic read: handle exceptions

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


