### PR TITLE
Fix SpaceColor to EFlag mapping in viewer

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_outofspace.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_outofspace.cpp
@@ -24,17 +24,19 @@ namespace NKikimr {
             case TSpaceColor::CYAN:
                 return NKikimrWhiteboard::EFlag::Green;
             case TSpaceColor::LIGHT_YELLOW:
-            case TSpaceColor::YELLOW:
-            case TSpaceColor::LIGHT_ORANGE:
                 return NKikimrWhiteboard::EFlag::Yellow;
+            case TSpaceColor::YELLOW:
+                return NKikimrWhiteboard::EFlag::Orange;
+            case TSpaceColor::LIGHT_ORANGE:
             case TSpaceColor::PRE_ORANGE:
             case TSpaceColor::ORANGE:
                 return NKikimrWhiteboard::EFlag::Orange;
             case TSpaceColor::RED:
             case TSpaceColor::BLACK:
+                return NKikimrWhiteboard::EFlag::Red;
             case NKikimrBlobStorage::TPDiskSpaceColor_E_TPDiskSpaceColor_E_INT_MIN_SENTINEL_DO_NOT_USE_:
             case NKikimrBlobStorage::TPDiskSpaceColor_E_TPDiskSpaceColor_E_INT_MAX_SENTINEL_DO_NOT_USE_:
-                return NKikimrWhiteboard::EFlag::Red;
+                return NKikimrWhiteboard::EFlag::Grey;
         }
     }
 

--- a/ydb/core/blobstorage/vdisk/common/vdisk_outofspace_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_outofspace_ut.cpp
@@ -1,6 +1,7 @@
 #include "defs.h"
 #include "vdisk_outofspace.h"
 #include <library/cpp/testing/unittest/registar.h>
+#include <ydb/core/protos/whiteboard_flags.pb.h>
 #include <util/generic/ptr.h>
 #include <util/stream/null.h>
 #include <util/system/thread.h>
@@ -37,6 +38,33 @@ namespace NKikimr {
             state.Update(4, flags | NKikimrBlobStorage::StatusDiskSpaceOrange);
             state.Update(5, flags | NKikimrBlobStorage::StatusDiskSpaceLightYellowMove);
             UNIT_ASSERT_EQUAL(state.GetGlobalColor(), TSpaceColor::ORANGE);
+        }
+
+        Y_UNIT_TEST(ToWhiteboardFlag) {
+            using EFlag = NKikimrWhiteboard::EFlag;
+
+            struct TCase {
+                TSpaceColor::E Color;
+                EFlag Expected;
+            };
+
+            const TCase cases[] = {
+                {TSpaceColor::GREEN, EFlag::Green},
+                {TSpaceColor::CYAN, EFlag::Green},
+                {TSpaceColor::LIGHT_YELLOW, EFlag::Yellow},
+                {TSpaceColor::YELLOW, EFlag::Orange},
+                {TSpaceColor::LIGHT_ORANGE, EFlag::Orange},
+                {TSpaceColor::PRE_ORANGE, EFlag::Orange},
+                {TSpaceColor::ORANGE, EFlag::Orange},
+                {TSpaceColor::RED, EFlag::Red},
+                {TSpaceColor::BLACK, EFlag::Red},
+            };
+
+            for (const auto& testCase : cases) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    TOutOfSpaceState::ToWhiteboardFlag(testCase.Color),
+                    testCase.Expected);
+            }
         }
     }
 

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -1426,8 +1426,9 @@ NKikimrViewer::EFlag GetViewerFlag(NKikimrWhiteboard::EFlag flag) {
         return NKikimrViewer::EFlag::Orange;
     case NKikimrWhiteboard::EFlag::Red:
         return NKikimrViewer::EFlag::Red;
+    default:
+        return NKikimrViewer::EFlag::Grey;
     }
-    return static_cast<NKikimrViewer::EFlag>((int)flag);
 }
 
 }

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -497,15 +497,6 @@ public:
             Used = allocated;
             Limit = limit;
             Usage = Limit ? 100.0 * Used / Limit : 0;
-            if (Usage >= 95) {
-                DiskSpace = std::max(DiskSpace, NKikimrViewer::EFlag::Red);
-            } else if (Usage >= 90) {
-                DiskSpace = std::max(DiskSpace, NKikimrViewer::EFlag::Orange);
-            } else if (Usage >= 85) {
-                DiskSpace = std::max(DiskSpace, NKikimrViewer::EFlag::Yellow);
-            } else {
-                DiskSpace = std::max(DiskSpace, NKikimrViewer::EFlag::Green);
-            }
         }
 
         void CalcCapacityMetrics() {
@@ -2657,6 +2648,7 @@ public:
         storageGroupProperties["MaxVDiskSlotUsage"]["description"] = "max VDisk.VDiskSlotUsage across VDisks in this group";
         storageGroupProperties["MaxNormalizedOccupancy"]["description"] = "max VDisk.NormalizedOccupancy across VDisks in this group";
         storageGroupProperties["MaxVDiskRawUsage"]["description"] = "max VDisk.RawUsage across VDisks in this group";
+        storageGroupProperties["CapacityAlert"]["description"] = "worst VDisk.CapacityAlert in this group";
         return node;
     }
 };

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -585,7 +585,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         QueryTest("select \"Hello\"", false, "Hello");
     }
 
-    void StorageSpaceTest(const TString& withValue, const NKikimrWhiteboard::EFlag diskSpace, const ui64 used, const ui64 limit, const bool isExpectingGroup) {
+    void StorageSpaceTest(const TString& withValue, const NKikimrWhiteboard::EFlag diskSpace, const ui64 used, const ui64 limit,
+            const bool isExpectingGroup, const std::optional<TString> expectedGroupDiskSpace = {}) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
@@ -635,25 +636,64 @@ Y_UNIT_TEST_SUITE(Viewer) {
             Ctest << ex.what() << Endl;
         }
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().contains("StorageGroups"), isExpectingGroup);
+
+        if (isExpectingGroup) {
+            const auto& storageGroups = json["StorageGroups"].GetArray();
+            UNIT_ASSERT_VALUES_EQUAL(storageGroups.size(), 1);
+            const auto& group = storageGroups[0];
+            if (expectedGroupDiskSpace) {
+                UNIT_ASSERT(group.GetMap().contains("DiskSpace"));
+                UNIT_ASSERT_VALUES_EQUAL(group["DiskSpace"].GetString(), *expectedGroupDiskSpace);
+            } else {
+                UNIT_ASSERT(!group.GetMap().contains("DiskSpace"));
+            }
+        }
     }
 
     Y_UNIT_TEST(StorageGroupOutputWithoutFilterNoDepends)
     {
-        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Green, 10, 100, true);
-        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Red, 90, 100, true);
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Green, 10, 100, true, "Green");
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Red, 90, 100, true, "Red");
     }
 
     Y_UNIT_TEST(StorageGroupOutputWithSpaceCheckDependsOnVDiskSpaceStatus)
     {
         StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 10, 100, false);
-        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Red, 10, 100, true);
+        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Red, 10, 100, true, "Red");
     }
 
     Y_UNIT_TEST(StorageGroupOutputWithSpaceCheckDependsOnUsage)
     {
         StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 70, 100, false);
-        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 80, 100, true);
-        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 90, 100, true);
+        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 80, 100, true, "Green");
+        StorageSpaceTest("space", NKikimrWhiteboard::EFlag::Green, 90, 100, true, "Green");
+    }
+
+    Y_UNIT_TEST(StorageGroupOutputFlagMatchesWorstVDiskFlag)
+    {
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Grey, 10, 100, true, std::nullopt);
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Green, 10, 100, true, "Green");
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Yellow, 10, 100, true, "Yellow");
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Orange, 10, 100, true, "Orange");
+        StorageSpaceTest("all", NKikimrWhiteboard::EFlag::Red, 10, 100, true, "Red");
+    }
+
+    Y_UNIT_TEST(StorageGroupDiskSpaceDoesNotDependOnUsage)
+    {
+        TStorageGroups::TGroup group;
+        auto& vdisk = group.VDisks.emplace_back();
+        vdisk.VSlotId = TVSlotId(1, 1, 1);
+        vdisk.AllocatedSize = 99;
+        vdisk.AvailableSize = 1;
+        vdisk.DiskSpace = NKikimrViewer::EFlag::Green;
+
+        TStorageGroups::TPDisk pdisk;
+        pdisk.EnforcedDynamicSlotSize = 100;
+
+        group.CalcAvailableAndDiskSpace({{TPDiskId(1, 1), pdisk}});
+
+        UNIT_ASSERT_DOUBLES_EQUAL(group.Usage, 99.0, 1e-6);
+        UNIT_ASSERT_VALUES_EQUAL(NKikimrViewer::EFlag_Name(group.DiskSpace), "Green");
     }
 
     Y_UNIT_TEST(StorageGroupUsageWithDynamicSlotSize)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Enforce the consistent mapping from TPDiskSpaceColor::E (9 colors) to EFlag (green/yellow/orange/red)
- Fix the mapping itself
- Close https://github.com/ydb-platform/ydb-embedded-ui/issues/3667