### PR TITLE
Fix macOS build: guard sched_getcpu() by _linux_ instead of __GNUC__

### DIFF
--- a/ydb/library/actors/memory_log/memlog.cpp
+++ b/ydb/library/actors/memory_log/memlog.cpp
@@ -85,7 +85,7 @@ unsigned TMemoryLog::GetSelfCpu() noexcept {
     int acpiID = (b >> 24);
     return acpiID;
 
-#elif defined(__GNUC__)
+#elif defined(_linux_)
     return sched_getcpu();
 #else
     return 0;


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
sched_getcpu() is a Linux/glibc-specific function. Clang on macOS also defines __GNUC__ for GCC compatibility, so after the __CNUC__ typo fix in #40269 the macOS build started hitting this branch and failing to compile. Guard by _linux_ to match the actual platform requirement.

Check for MacOS: https://github.com/ydb-platform/ydb/actions/runs/26155381608
Check for Win (JIC): https://github.com/ydb-platform/ydb/actions/runs/26155435139