### PR TITLE
Fix use-after-free and prohibit dry-run distconf enable scenario

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -463,7 +463,7 @@ namespace NKikimr::NStorage {
             bool AutomaticBootstrap = false;
         };
         TProcessCollectConfigsResult ProcessCollectConfigs(TEvGather::TCollectConfigs *res,
-            std::optional<TStringBuf> selfAssemblyUUID, bool dryRun = false);
+            std::optional<TString> selfAssemblyUUID, bool dryRun = false);
 
         void ProcessProposeStorageConfig(TEvGather::TProposeStorageConfig *res);
 

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -182,7 +182,7 @@ namespace NKikimr::NStorage {
     }
 
     TDistributedConfigKeeper::TProcessCollectConfigsResult TDistributedConfigKeeper::ProcessCollectConfigs(
-            TEvGather::TCollectConfigs *res, std::optional<TStringBuf> selfAssemblyUUID, bool dryRun) {
+            TEvGather::TCollectConfigs *res, std::optional<TString> selfAssemblyUUID, bool dryRun) {
         TStringStream err;
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -420,8 +420,7 @@ namespace NKikimr::NStorage {
                         selfAssemblyUUID.emplace(CurrentSelfAssemblyUUID.value());
                     } else {
                         // in dry run mode, use a temporary UUID without modifying state
-                        const TString tempUUID = CreateGuidAsString();
-                        selfAssemblyUUID.emplace(tempUUID);
+                        selfAssemblyUUID.emplace(CreateGuidAsString());
                     }
                 }
                 propositionBase.emplace(*baseConfig);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -386,6 +386,9 @@ namespace NKikimr::NStorage {
 
         // check if we are enabling distconf by this operation and handle it accordingly
         if (!Self->SelfManagementEnabled && ProposedStorageConfig.GetSelfManagementConfig().GetEnabled()) {
+            if (IsDryRun) {
+                throw TExError() << "DryRun is not supported when enabling distconf";
+            }
             ControllerOp = EControllerOp::ENABLE_DISTCONF;
             TryEnableDistconf(); // collect quorum of configs first to see if we have to do rolling restart of the cluster
         } else {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix use-after-free and prohibit dry-run distconf enable scenario

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
