### PR TITLE
EXT-1049 VDisk local recovery and initial sync operation broker

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -787,6 +787,10 @@ struct TEvBlobStorage {
         EvPhantomFlagStorageCommitData,
         EvPhantomFlagStorageDrop,
         EvSyncerFullSyncDiskCancelled,
+        EvAcquireVDiskOperationToken,
+        EvVDiskOperationToken,
+        EvReleaseVDiskOperationToken,
+        EvStartupDataSyncDone,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/base/services/blobstorage_service_id.h
+++ b/ydb/core/base/services/blobstorage_service_id.h
@@ -116,6 +116,16 @@ inline TActorId MakeBlobStorageSyncBrokerID() {
     return TActorId(0, TStringBuf(x, 12));
 }
 
+inline TActorId MakeBlobStorageStartupDataSyncBrokerID() {
+    char x[12] = {'b', 's', 's', 't', 'd', 's', 'y', 'n', 'b', 'r', 'k', 'r'};
+    return TActorId(0, TStringBuf(x, 12));
+}
+
+inline TActorId MakeBlobStorageLocalRecoveryBrokerID() {
+    char x[12] = {'b', 's', 'l', 'o', 'c', 'r', 'e', 'c', 'b', 'r', 'k', 'r'};
+    return TActorId(0, TStringBuf(x, 12));
+}
+
 inline TActorId MakeBlobStorageCompBrokerID() {
     char x[12] = {'b', 's', 'c', 'o', 'm', 'p', 'b', 'r', 'o', 'k', 'e', 'r'};
     return TActorId(0, TStringBuf(x, 12));

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -13,6 +13,7 @@
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h>
 #include <ydb/core/blobstorage/pdisk/drivedata_serializer.h>
 #include <ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactbroker.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h>
 #include <ydb/core/blobstorage/vdisk/repl/blobstorage_replbroker.h>
 #include <ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_broker.h>
 #include <ydb/library/pdisk_io/file_params.h>
@@ -59,6 +60,10 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , ThrottlingMaxOccupancyPerMille(950, 1, 1000)
     , ThrottlingMinLogChunkCount(100, 1, 100000)
     , ThrottlingMaxLogChunkCount(130, 1, 100000)
+    , MaxInProgressStartupDataSyncCount(0, 0, 10000)
+    , MaxInProgressStartupDataSyncPerPDiskCount(0, 0, 10000)
+    , MaxInProgressLocalRecoveryCount(0, 0, 10000)
+    , MaxInProgressLocalRecoveryPerPDiskCount(0, 0, 10000)
     , MaxInProgressSyncCount(0, 0, 1000)
     , EnablePhantomFlagStorage(1, 0, 1)
     , EnablePersistentPhantomFlagStorage(0, 0, 1)
@@ -437,6 +442,11 @@ void TNodeWarden::Bootstrap() {
         TControlBoard::RegisterSharedControl(PhantomFlagStorageLimitPerVDiskBytes, icb->VDiskControls.PhantomFlagStorageLimitPerVDiskBytes);
         TControlBoard::RegisterSharedControl(EnableChunkKeeper, icb->VDiskControls.EnableChunkKeeper);
 
+        TControlBoard::RegisterSharedControl(MaxInProgressStartupDataSyncCount, icb->VDiskControls.MaxInProgressStartupDataSyncCount);
+        TControlBoard::RegisterSharedControl(MaxInProgressStartupDataSyncPerPDiskCount, icb->VDiskControls.MaxInProgressStartupDataSyncPerPDiskCount);
+        TControlBoard::RegisterSharedControl(MaxInProgressLocalRecoveryCount, icb->VDiskControls.MaxInProgressLocalRecoveryCount);
+        TControlBoard::RegisterSharedControl(MaxInProgressLocalRecoveryPerPDiskCount, icb->VDiskControls.MaxInProgressLocalRecoveryPerPDiskCount);
+
         TControlBoard::RegisterSharedControl(MaxCommonLogChunksHDD, icb->PDiskControls.MaxCommonLogChunksHDD);
         TControlBoard::RegisterSharedControl(MaxCommonLogChunksSSD, icb->PDiskControls.MaxCommonLogChunksSSD);
         TControlBoard::RegisterSharedControl(CommonStaticLogChunks, icb->PDiskControls.CommonStaticLogChunks);
@@ -495,6 +505,12 @@ void TNodeWarden::Bootstrap() {
 
     const ui64 maxBytes = replBrokerConfig.GetMaxInFlightReadBytes();
     actorSystem->RegisterLocalService(MakeBlobStorageReplBrokerID(), Register(CreateReplBrokerActor(maxBytes)));
+
+    actorSystem->RegisterLocalService(MakeBlobStorageLocalRecoveryBrokerID(), Register(
+        CreateVDiskOperationBrokerActor(MaxInProgressLocalRecoveryCount, MaxInProgressLocalRecoveryPerPDiskCount)));
+
+    actorSystem->RegisterLocalService(MakeBlobStorageStartupDataSyncBrokerID(), Register(
+        CreateVDiskOperationBrokerActor(MaxInProgressStartupDataSyncCount, MaxInProgressStartupDataSyncPerPDiskCount)));
 
     actorSystem->RegisterLocalService(MakeBlobStorageSyncBrokerID(), Register(
         CreateSyncBrokerActor(MaxInProgressSyncCount)));

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -240,6 +240,10 @@ namespace NKikimr::NStorage {
         TControlWrapper ThrottlingMinLogChunkCount;
         TControlWrapper ThrottlingMaxLogChunkCount;
 
+        TControlWrapper MaxInProgressStartupDataSyncCount;
+        TControlWrapper MaxInProgressStartupDataSyncPerPDiskCount;
+        TControlWrapper MaxInProgressLocalRecoveryCount;
+        TControlWrapper MaxInProgressLocalRecoveryPerPDiskCount;
         TControlWrapper MaxInProgressSyncCount;
         TControlWrapper EnablePhantomFlagStorage;
         TControlWrapper EnablePersistentPhantomFlagStorage;

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -21,6 +21,12 @@ void TNodeWarden::Handle(NMon::TEvHttpInfo::TPtr &ev) {
     if (cgi.Get("page") == "distconf") {
         TActivationContext::Send(ev->Forward(DistributedConfigKeeperId));
         return;
+    } else if (cgi.Get("page") == "localrecoverybroker") {
+        TActivationContext::Send(ev->Forward(MakeBlobStorageLocalRecoveryBrokerID()));
+        return;
+    } else if (cgi.Get("page") == "startupdatasyncbroker") {
+        TActivationContext::Send(ev->Forward(MakeBlobStorageStartupDataSyncBrokerID()));
+        return;
     }
 
     TStringBuf pathInfo = ev->Get()->Request.GetPathInfo();
@@ -105,6 +111,12 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
             DIV() {
                 out << "<a href=\"?page=distconf\">Distributed Config Keeper</a>";
             }
+        }
+
+        TAG(TH3) { out << "VDisk Brokers"; }
+        DIV() {
+            out << "<a href=\"?page=localrecoverybroker\">VDisk Local Recovery Broker</a><br>";
+            out << "<a href=\"?page=startupdatasyncbroker\">VDisk Startup Data Sync Broker</a>";
         }
 
         TAG(TH3) { out << "StorageConfig"; }

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -59,6 +59,7 @@ PEERDIR(
     ydb/core/blobstorage/ddisk
     ydb/core/blobstorage/groupinfo
     ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/vdisk/localrecovery
     ydb/core/blobstorage/vdisk
     ydb/core/control/lib
     ydb/library/actors/retro_tracing

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -573,6 +573,11 @@ config:
                 ADD_ICB_CONTROL(VDiskControls.EnableDeepScrubbing, false, false, true, Settings.EnableDeepScrubbing);
                 ADD_ICB_CONTROL(VDiskControls.HullCompThrottlerBytesRate, 0, 0, 10737418240, 0);
                 ADD_ICB_CONTROL(VDiskControls.DefragThrottlerBytesRate, 0, 0, 10'000'000'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxInProgressStartupDataSyncCount, 0, 0, 10'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxInProgressStartupDataSyncPerPDiskCount, 0, 0, 10'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxInProgressLocalRecoveryCount, 0, 0, 10'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxInProgressLocalRecoveryPerPDiskCount, 0, 0, 10'000, 0);
+                ADD_ICB_CONTROL(VDiskControls.MaxInProgressSyncCount, 0, 0, 1'000, 0);
                 ADD_ICB_CONTROL(VDiskControls.MaxChunksToDefragInflight, 10, 1, 50, 10);
                 ADD_ICB_CONTROL(VDiskControls.DefaultHugeGarbagePerMille, 300, 0, 1000, 300);
                 ADD_ICB_CONTROL(PDiskControls.MaxActiveCompactionsPerPDisk, 0, 0, 1'000'000, 0);

--- a/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
@@ -16,15 +16,6 @@
 
 namespace {
 
-    constexpr const char* MaxInProgressLocalRecoveryCountControl =
-        "VDiskControls.MaxInProgressLocalRecoveryCount";
-    constexpr const char* MaxInProgressLocalRecoveryPerPDiskCountControl =
-        "VDiskControls.MaxInProgressLocalRecoveryPerPDiskCount";
-    constexpr const char* MaxInProgressStartupDataSyncCountControl =
-        "VDiskControls.MaxInProgressStartupDataSyncCount";
-    constexpr const char* MaxInProgressStartupDataSyncPerPDiskCountControl =
-        "VDiskControls.MaxInProgressStartupDataSyncPerPDiskCount";
-
     constexpr ui32 NumGroups = 8;
     constexpr ui32 MinExpectedVDisksOnRestartedNode = 6;
     constexpr ui32 StartupBacklogTargetVDisks = 3;
@@ -54,35 +45,19 @@ namespace {
         ui64 MaxInProgressStartupDataSyncPerPDiskCount = 0;
     };
 
-    void SetNodeControl(TTestActorSystem& runtime, ui32 nodeId, const TString& controlName, i64 value,
-            i64 defaultValue = 0, i64 minValue = 0, i64 maxValue = 1'000)
-    {
-        TAppData* appData = runtime.GetNode(nodeId)->AppData.get();
-        TAtomic currentValue = 0;
-        bool exists = false;
-        appData->Icb->GetValue(controlName, currentValue, exists);
-
-        if (exists) {
-            TAtomic prevValue = 0;
-            appData->Icb->SetValue(controlName, value, prevValue);
-        } else {
-            TControlWrapper control(defaultValue, minValue, maxValue);
-            appData->Icb->RegisterSharedControl(control, controlName);
-            control = value;
-        }
-    }
-
     void ConfigureBrokerControls(TEnvironmentSetup& env, ui32 nodeId,
             ui64 maxInProgressLocalRecoveryCount, ui64 maxInProgressLocalRecoveryPerPDiskCount,
             ui64 maxInProgressStartupDataSyncCount, ui64 maxInProgressStartupDataSyncPerPDiskCount)
     {
-        SetNodeControl(*env.Runtime, nodeId, MaxInProgressLocalRecoveryCountControl, maxInProgressLocalRecoveryCount);
-        SetNodeControl(*env.Runtime, nodeId, MaxInProgressLocalRecoveryPerPDiskCountControl,
-            maxInProgressLocalRecoveryPerPDiskCount);
-        SetNodeControl(*env.Runtime, nodeId, MaxInProgressStartupDataSyncCountControl,
-            maxInProgressStartupDataSyncCount);
-        SetNodeControl(*env.Runtime, nodeId, MaxInProgressStartupDataSyncPerPDiskCountControl,
-            maxInProgressStartupDataSyncPerPDiskCount);
+        auto& icb = *env.Runtime->GetNode(nodeId)->AppData->Icb;
+        TControlBoard::SetValue(maxInProgressLocalRecoveryCount,
+            icb.VDiskControls.MaxInProgressLocalRecoveryCount);
+        TControlBoard::SetValue(maxInProgressLocalRecoveryPerPDiskCount,
+            icb.VDiskControls.MaxInProgressLocalRecoveryPerPDiskCount);
+        TControlBoard::SetValue(maxInProgressStartupDataSyncCount,
+            icb.VDiskControls.MaxInProgressStartupDataSyncCount);
+        TControlBoard::SetValue(maxInProgressStartupDataSyncPerPDiskCount,
+            icb.VDiskControls.MaxInProgressStartupDataSyncPerPDiskCount);
     }
 
     template<typename TPredicate>

--- a/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
@@ -116,15 +116,21 @@ namespace {
     void SendBrokerAcquire(TEnvironmentSetup& env, const TActorId& ownerActorId,
             const TActorId& brokerServiceId, const TActorId& vdiskServiceId)
     {
+        const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
+        Y_UNUSED(nodeId);
+        Y_UNUSED(vslotId);
         env.Runtime->Send(new IEventHandle(brokerServiceId, ownerActorId,
-            new TEvAcquireVDiskOperationToken(vdiskServiceId)), ownerActorId.NodeId());
+            new TEvAcquireVDiskOperationToken(vdiskServiceId, pdiskId)), ownerActorId.NodeId());
     }
 
     void SendBrokerRelease(TEnvironmentSetup& env, const TActorId& ownerActorId,
             const TActorId& brokerServiceId, const TActorId& vdiskServiceId)
     {
+        const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
+        Y_UNUSED(nodeId);
+        Y_UNUSED(vslotId);
         env.Runtime->Send(new IEventHandle(brokerServiceId, ownerActorId,
-            new TEvReleaseVDiskOperationToken(vdiskServiceId)), ownerActorId.NodeId());
+            new TEvReleaseVDiskOperationToken(vdiskServiceId, pdiskId)), ownerActorId.NodeId());
     }
 
     void WaitForBrokerToken(TEnvironmentSetup& env, const TActorId& ownerActorId, TStringBuf message) {
@@ -470,10 +476,7 @@ namespace {
                         break;
                     }
                     auto* msg = ev->Get<TEvAcquireVDiskOperationToken>();
-                    const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(msg->VDiskServiceId);
-                    Y_UNUSED(nodeId);
-                    Y_UNUSED(vslotId);
-                    OnQuery(ev->Sender, msg->VDiskServiceId, pdiskId);
+                    OnQuery(ev->Sender, msg->VDiskServiceId, msg->PDiskId);
                     break;
                 }
 
@@ -489,10 +492,7 @@ namespace {
                         break;
                     }
                     auto* msg = ev->Get<TEvReleaseVDiskOperationToken>();
-                    const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(msg->VDiskServiceId);
-                    Y_UNUSED(nodeId);
-                    Y_UNUSED(vslotId);
-                    OnRelease(msg->VDiskServiceId, pdiskId);
+                    OnRelease(msg->VDiskServiceId, msg->PDiskId);
                     break;
                 }
             }

--- a/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
@@ -1,0 +1,1041 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/common.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h>
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h>
+#include <ydb/core/blobstorage/vdisk/syncer/syncer_job_task.h>
+#include <ydb/core/blobstorage/vdisk/syncer/syncer_job_actor.h>
+#include <ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.h>
+
+#include <algorithm>
+#include <optional>
+#include <utility>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+
+namespace {
+
+    constexpr const char* MaxInProgressLocalRecoveryCountControl =
+        "VDiskControls.MaxInProgressLocalRecoveryCount";
+    constexpr const char* MaxInProgressLocalRecoveryPerPDiskCountControl =
+        "VDiskControls.MaxInProgressLocalRecoveryPerPDiskCount";
+    constexpr const char* MaxInProgressStartupDataSyncCountControl =
+        "VDiskControls.MaxInProgressStartupDataSyncCount";
+    constexpr const char* MaxInProgressStartupDataSyncPerPDiskCountControl =
+        "VDiskControls.MaxInProgressStartupDataSyncPerPDiskCount";
+
+    constexpr ui32 NumGroups = 8;
+    constexpr ui32 MinExpectedVDisksOnRestartedNode = 6;
+    constexpr ui32 StartupBacklogTargetVDisks = 3;
+    constexpr ui32 StartupBacklogBlobsPerGroup = 8;
+    constexpr ui32 StartupBacklogBlobSize = 512;
+    constexpr ui32 WaitIterations = 180;
+    const TDuration WaitStep = TDuration::Seconds(1);
+
+    struct TTargetVDisk {
+        ui32 GroupId = 0;
+        TVDiskID VDiskId;
+        TActorId VDiskActorId;
+        ui32 PDiskId = 0;
+    };
+
+    struct TPerPDiskSelection {
+        ui32 FocusPDiskId = 0;
+        TVector<TTargetVDisk> FocusTargets;
+        TTargetVDisk OtherTarget;
+        TVector<TTargetVDisk> StartupTargets;
+    };
+
+    struct TBrokerControls {
+        ui64 MaxInProgressLocalRecoveryCount = 0;
+        ui64 MaxInProgressLocalRecoveryPerPDiskCount = 0;
+        ui64 MaxInProgressStartupDataSyncCount = 0;
+        ui64 MaxInProgressStartupDataSyncPerPDiskCount = 0;
+    };
+
+    void SetNodeControl(TTestActorSystem& runtime, ui32 nodeId, const TString& controlName, i64 value,
+            i64 defaultValue = 0, i64 minValue = 0, i64 maxValue = 1'000)
+    {
+        TAppData* appData = runtime.GetNode(nodeId)->AppData.get();
+        TAtomic currentValue = 0;
+        bool exists = false;
+        appData->Icb->GetValue(controlName, currentValue, exists);
+
+        if (exists) {
+            TAtomic prevValue = 0;
+            appData->Icb->SetValue(controlName, value, prevValue);
+        } else {
+            TControlWrapper control(defaultValue, minValue, maxValue);
+            appData->Icb->RegisterSharedControl(control, controlName);
+            control = value;
+        }
+    }
+
+    void ConfigureBrokerControls(TEnvironmentSetup& env, ui32 nodeId,
+            ui64 maxInProgressLocalRecoveryCount, ui64 maxInProgressLocalRecoveryPerPDiskCount,
+            ui64 maxInProgressStartupDataSyncCount, ui64 maxInProgressStartupDataSyncPerPDiskCount)
+    {
+        SetNodeControl(*env.Runtime, nodeId, MaxInProgressLocalRecoveryCountControl, maxInProgressLocalRecoveryCount);
+        SetNodeControl(*env.Runtime, nodeId, MaxInProgressLocalRecoveryPerPDiskCountControl,
+            maxInProgressLocalRecoveryPerPDiskCount);
+        SetNodeControl(*env.Runtime, nodeId, MaxInProgressStartupDataSyncCountControl,
+            maxInProgressStartupDataSyncCount);
+        SetNodeControl(*env.Runtime, nodeId, MaxInProgressStartupDataSyncPerPDiskCountControl,
+            maxInProgressStartupDataSyncPerPDiskCount);
+    }
+
+    template<typename TPredicate>
+    void WaitUntil(TEnvironmentSetup& env, TPredicate&& predicate, TStringBuf message) {
+        for (ui32 i = 0; i < WaitIterations && !predicate(); ++i) {
+            env.Sim(WaitStep);
+        }
+        UNIT_ASSERT_C(predicate(), message);
+    }
+
+    TString FormatActorIdList(const TVector<TActorId>& items) {
+        TStringBuilder sb;
+        sb << "[";
+        bool first = true;
+        for (const auto& item : items) {
+            if (!first) {
+                sb << ", ";
+            }
+            first = false;
+            sb << item;
+        }
+        sb << "]";
+        return sb;
+    }
+
+    TString FormatActorIdSet(const THashSet<TActorId>& items) {
+        TVector<TActorId> ordered(items.begin(), items.end());
+        Sort(ordered);
+        return FormatActorIdList(ordered);
+    }
+
+    void WriteStartupBacklogWhileNodeDown(TEnvironmentSetup& env, const TVector<TTargetVDisk>& targets) {
+        const TActorId edge = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+
+        for (size_t targetIdx = 0; targetIdx < targets.size(); ++targetIdx) {
+            for (ui32 step = 1; step <= StartupBacklogBlobsPerGroup; ++step) {
+                const TLogoBlobID blobId(300'000 + targetIdx, 1, step, 0, StartupBacklogBlobSize, 0);
+                TString data = MakeData(StartupBacklogBlobSize, step);
+
+                env.Runtime->WrapInActorContext(edge, [&] {
+                    SendToBSProxy(edge, targets[targetIdx].GroupId,
+                        new TEvBlobStorage::TEvPut(blobId, std::move(data), TInstant::Max()));
+                });
+
+                auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(edge, false, TInstant::Max());
+                UNIT_ASSERT_VALUES_EQUAL_C(res->Get()->Status, NKikimrProto::OK,
+                    "groupId# " << targets[targetIdx].GroupId
+                    << " blobId# " << blobId);
+            }
+        }
+
+        env.Runtime->DestroyActor(edge);
+        env.Sim(TDuration::Seconds(10));
+    }
+
+    void SendBrokerAcquire(TEnvironmentSetup& env, const TActorId& ownerActorId,
+            const TActorId& brokerServiceId, const TActorId& vdiskServiceId)
+    {
+        env.Runtime->Send(new IEventHandle(brokerServiceId, ownerActorId,
+            new TEvAcquireVDiskOperationToken(vdiskServiceId)), ownerActorId.NodeId());
+    }
+
+    void SendBrokerRelease(TEnvironmentSetup& env, const TActorId& ownerActorId,
+            const TActorId& brokerServiceId, const TActorId& vdiskServiceId)
+    {
+        env.Runtime->Send(new IEventHandle(brokerServiceId, ownerActorId,
+            new TEvReleaseVDiskOperationToken(vdiskServiceId)), ownerActorId.NodeId());
+    }
+
+    void WaitForBrokerToken(TEnvironmentSetup& env, const TActorId& ownerActorId, TStringBuf message) {
+        auto* res = env.WaitForEdgeActorEvent<TEvVDiskOperationToken>(ownerActorId, false, env.Now() + TDuration::Seconds(30)).Get();
+        UNIT_ASSERT_C(res, message);
+    }
+
+    void RestartVDisk(TEnvironmentSetup& env, const TTargetVDisk& target) {
+        const TActorId edge = env.Runtime->AllocateEdgeActor(target.VDiskActorId.NodeId(), __FILE__, __LINE__);
+        env.Runtime->Send(new IEventHandle(
+            MakeBlobStorageNodeWardenID(target.VDiskActorId.NodeId()),
+            edge,
+            new TEvBlobStorage::TEvAskRestartVDisk(target.PDiskId, target.VDiskId)),
+            target.VDiskActorId.NodeId());
+        env.Runtime->DestroyActor(edge);
+    }
+
+    void WaitForVDisksToGetRunning(TEnvironmentSetup& env, const TVector<TTargetVDisk>& targets) {
+        for (const auto& target : targets) {
+            env.WaitForVDiskToGetRunning(target.VDiskId, target.VDiskActorId);
+        }
+    }
+
+    struct TRestartScenario {
+        TEnvironmentSetup Env;
+        ui32 RestartedNodeId = 0;
+        TVector<TTargetVDisk> RestartedNodeVDisks;
+        TVector<TTargetVDisk> StartupTargets;
+        TPerPDiskSelection PerPDiskSelection;
+
+        TRestartScenario()
+            : Env(TEnvironmentSetup::TSettings{
+                .NodeCount = 9,
+                .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+            })
+        {
+            Env.Runtime->SetLogPriority(NKikimrServices::BS_VDISK_SCRUB, NLog::PRI_ERROR);
+            Env.CreateBoxAndPool(0, NumGroups);
+            Env.Sim(TDuration::Seconds(30));
+
+            SelectTargets();
+        }
+
+        ui32 SelectPeerNodeForGroup(ui32 groupId) {
+            THashSet<ui32> nodes;
+            const auto groupInfo = Env.GetGroupInfo(groupId);
+            for (ui32 i = 0; i < groupInfo->GetTotalVDisksNum(); ++i) {
+                const ui32 nodeId = groupInfo->GetActorId(i).NodeId();
+                if (nodeId != RestartedNodeId && nodeId != Env.Settings.ControllerNodeId && nodes.emplace(nodeId).second) {
+                    return nodeId;
+                }
+            }
+
+            UNIT_FAIL("failed to choose peer node for group"
+                << " groupId# " << groupId);
+
+            return 0;
+        }
+
+    private:
+        TVector<TTargetVDisk> SelectStartupTargets(const TVector<TTargetVDisk>& vdisks) {
+            UNIT_ASSERT_C(vdisks.size() >= StartupBacklogTargetVDisks,
+                "expected enough VDisks for startup backlog targets; vdisks# " << vdisks.size());
+
+            TVector<TTargetVDisk> targets;
+            targets.reserve(StartupBacklogTargetVDisks);
+            for (ui32 i = 0; i < StartupBacklogTargetVDisks; ++i) {
+                targets.push_back({
+                    .GroupId = vdisks[i].GroupId,
+                    .VDiskId = vdisks[i].VDiskId,
+                    .VDiskActorId = vdisks[i].VDiskActorId,
+                    .PDiskId = vdisks[i].PDiskId,
+                });
+            }
+            return targets;
+        }
+
+        TPerPDiskSelection SelectPerPDiskTargets(const TVector<TTargetVDisk>& vdisks) {
+            THashMap<ui32, TVector<TTargetVDisk>> byPDisk;
+            for (const auto& item : vdisks) {
+                byPDisk[item.PDiskId].push_back(item);
+            }
+
+            ui32 focusPDiskId = 0;
+            size_t maxVDisksOnPDisk = 0;
+            for (const auto& [pdiskId, items] : byPDisk) {
+                if (items.size() >= 2 && items.size() > maxVDisksOnPDisk) {
+                    focusPDiskId = pdiskId;
+                    maxVDisksOnPDisk = items.size();
+                }
+            }
+
+            UNIT_ASSERT_C(focusPDiskId,
+                "expected at least two VDisks on the same PDisk to test per-PDisk broker limits");
+
+            TVector<TTargetVDisk> focusTargets = byPDisk[focusPDiskId];
+            TTargetVDisk otherTarget;
+            bool foundOtherTarget = false;
+            for (const auto& item : vdisks) {
+                if (item.PDiskId != focusPDiskId) {
+                    otherTarget = item;
+                    foundOtherTarget = true;
+                    break;
+                }
+            }
+
+            UNIT_ASSERT_C(foundOtherTarget,
+                "expected at least one more VDisk on another PDisk to distinguish per-node from per-PDisk limit");
+
+            TPerPDiskSelection selection;
+            selection.FocusPDiskId = focusPDiskId;
+            selection.FocusTargets.push_back(focusTargets[0]);
+            selection.FocusTargets.push_back(focusTargets[1]);
+            selection.OtherTarget = otherTarget;
+            selection.StartupTargets = {
+                {
+                    .GroupId = focusTargets[0].GroupId,
+                    .VDiskId = focusTargets[0].VDiskId,
+                    .VDiskActorId = focusTargets[0].VDiskActorId,
+                    .PDiskId = focusTargets[0].PDiskId,
+                },
+                {
+                    .GroupId = focusTargets[1].GroupId,
+                    .VDiskId = focusTargets[1].VDiskId,
+                    .VDiskActorId = focusTargets[1].VDiskActorId,
+                    .PDiskId = focusTargets[1].PDiskId,
+                },
+                {
+                    .GroupId = otherTarget.GroupId,
+                    .VDiskId = otherTarget.VDiskId,
+                    .VDiskActorId = otherTarget.VDiskActorId,
+                    .PDiskId = otherTarget.PDiskId,
+                },
+            };
+            return selection;
+        }
+
+        void SelectTargets() {
+            NKikimrBlobStorage::TBaseConfig config = Env.FetchBaseConfig();
+            ui32 controllerNodeId = Env.Settings.ControllerNodeId;
+            THashMap<ui32, TVector<TTargetVDisk>> vdisksPerNode;
+            for (const auto& vslot : config.GetVSlot()) {
+                const auto& slotId = vslot.GetVSlotId();
+                const ui32 nodeId = slotId.GetNodeId();
+                if (nodeId == controllerNodeId) {
+                    continue;
+                }
+
+                vdisksPerNode[nodeId].push_back({
+                    .GroupId = vslot.GetGroupId(),
+                    .VDiskId = TVDiskID(
+                        vslot.GetGroupId(),
+                        vslot.GetGroupGeneration(),
+                        vslot.GetFailRealmIdx(),
+                        vslot.GetFailDomainIdx(),
+                        vslot.GetVDiskIdx()),
+                    .VDiskActorId = MakeBlobStorageVDiskID(slotId.GetNodeId(), slotId.GetPDiskId(), slotId.GetVSlotId()),
+                    .PDiskId = slotId.GetPDiskId(),
+                });
+            }
+
+            ui32 selectedNodeId = 0;
+            size_t maxVDisks = 0;
+            for (auto& [nodeId, vdisks] : vdisksPerNode) {
+                if (vdisks.size() > maxVDisks) {
+                    selectedNodeId = nodeId;
+                    maxVDisks = vdisks.size();
+                }
+            }
+
+            UNIT_ASSERT_C(selectedNodeId, "failed to choose node to restart");
+            auto it = vdisksPerNode.find(selectedNodeId);
+            UNIT_ASSERT(it != vdisksPerNode.end());
+
+            RestartedNodeId = selectedNodeId;
+            TVector<TTargetVDisk>& restartedNodeVDisks = it->second;
+            RestartedNodeVDisks = restartedNodeVDisks;
+
+            UNIT_ASSERT_C(restartedNodeVDisks.size() >= MinExpectedVDisksOnRestartedNode,
+                "expected many VDisks on restarted node; restartedNodeId# " << RestartedNodeId
+                << " vdisks# " << restartedNodeVDisks.size());
+
+            StartupTargets = SelectStartupTargets(restartedNodeVDisks);
+            PerPDiskSelection = SelectPerPDiskTargets(restartedNodeVDisks);
+        }
+    };
+
+    void RestartNodeForBrokerTest(TRestartScenario& scenario, const TBrokerControls& controls,
+            const TVector<TTargetVDisk>* startupBacklogTargets = nullptr)
+    {
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId,
+            controls.MaxInProgressLocalRecoveryCount,
+            controls.MaxInProgressLocalRecoveryPerPDiskCount,
+            controls.MaxInProgressStartupDataSyncCount,
+            controls.MaxInProgressStartupDataSyncPerPDiskCount);
+        scenario.Env.StopNode(scenario.RestartedNodeId);
+        scenario.Env.Sim(TDuration::Seconds(5));
+        if (startupBacklogTargets) {
+            WriteStartupBacklogWhileNodeDown(scenario.Env, *startupBacklogTargets);
+        }
+        scenario.Env.StartNode(scenario.RestartedNodeId);
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId,
+            controls.MaxInProgressLocalRecoveryCount,
+            controls.MaxInProgressLocalRecoveryPerPDiskCount,
+            controls.MaxInProgressStartupDataSyncCount,
+            controls.MaxInProgressStartupDataSyncPerPDiskCount);
+    }
+
+    struct TVDiskTokenInfo {
+        TActorId VDiskActorId;
+        ui32 PDiskId = 0;
+    };
+
+    enum class ECompletionEventType {
+        YardInitResult,
+        StartupDataSyncDone,
+    };
+
+    struct TBrokerCaptureBase {
+        const TActorId BrokerServiceId;
+        const ECompletionEventType CompletionEventType;
+        THashMap<TActorId, TVDiskTokenInfo> VDiskByOwnerActor;
+        THashMap<TActorId, ui32> PDiskIdByVDiskActor;
+        THashSet<TActorId> QueriedVDisks;
+        TVector<TActorId> GrantedVDisks;
+        TVector<TActorId> ReleasedVDisks;
+        std::optional<ui32> FocusPDiskId;
+        std::optional<TActorId> SelectedOwnerActor;
+        bool ShouldStashSelectedCompletionEvent = true;
+        std::unique_ptr<IEventHandle> StashedCompletionEvent;
+
+        explicit TBrokerCaptureBase(TActorId brokerServiceId, ECompletionEventType completionEventType,
+                std::optional<ui32> focusPDiskId = std::nullopt)
+            : BrokerServiceId(brokerServiceId)
+            , CompletionEventType(completionEventType)
+            , FocusPDiskId(focusPDiskId)
+        {}
+
+        void OnQuery(const TActorId& ownerActor, const TActorId& vdiskActorId, ui32 pdiskId) {
+            VDiskByOwnerActor[ownerActor] = {vdiskActorId, pdiskId};
+            PDiskIdByVDiskActor[vdiskActorId] = pdiskId;
+            QueriedVDisks.insert(vdiskActorId);
+        }
+
+        void OnGrant(const TActorId& ownerActor) {
+            const auto it = VDiskByOwnerActor.find(ownerActor);
+            UNIT_ASSERT(it != VDiskByOwnerActor.end());
+            GrantedVDisks.push_back(it->second.VDiskActorId);
+            // Per-node scenarios may pick the first granted owner arbitrarily.
+            // Per-PDisk scenarios must pick an owner on the focus PDisk so that
+            // the stashed completion event blocks the specific PDisk lane under test.
+            if (!SelectedOwnerActor && (!FocusPDiskId || it->second.PDiskId == *FocusPDiskId)) {
+                SelectedOwnerActor = ownerActor;
+            }
+        }
+
+        void OnRelease(const TActorId& vdiskActorId, ui32 pdiskId) {
+            PDiskIdByVDiskActor[vdiskActorId] = pdiskId;
+            ReleasedVDisks.push_back(vdiskActorId);
+        }
+
+        size_t CountQueriedOnPDisk(ui32 pdiskId) const {
+            return std::count_if(QueriedVDisks.begin(), QueriedVDisks.end(), [&](const TActorId& vdiskActorId) {
+                const auto it = PDiskIdByVDiskActor.find(vdiskActorId);
+                return it != PDiskIdByVDiskActor.end() && it->second == pdiskId;
+            });
+        }
+
+        size_t CountGrantedOnPDisk(ui32 pdiskId) const {
+            return std::count_if(GrantedVDisks.begin(), GrantedVDisks.end(), [&](const TActorId& vdiskActorId) {
+                const auto it = PDiskIdByVDiskActor.find(vdiskActorId);
+                return it != PDiskIdByVDiskActor.end() && it->second == pdiskId;
+            });
+        }
+
+        bool HasAnotherGrantedOnPDisk(ui32 pdiskId, const TActorId& excludedVDiskActorId) const {
+            return std::any_of(GrantedVDisks.begin(), GrantedVDisks.end(), [&](const TActorId& vdiskActorId) {
+                const auto it = PDiskIdByVDiskActor.find(vdiskActorId);
+                return vdiskActorId != excludedVDiskActorId && it != PDiskIdByVDiskActor.end() && it->second == pdiskId;
+            });
+        }
+
+        bool HasReleasedVDisk(const TActorId& vdiskActorId) const {
+            return std::find(ReleasedVDisks.begin(), ReleasedVDisks.end(), vdiskActorId) != ReleasedVDisks.end();
+        }
+
+        bool HasOneGrantedAndAnotherWaitingPerNode() const {
+            return StashedCompletionEvent && SelectedOwnerActor
+                && QueriedVDisks.size() >= 2
+                && GrantedVDisks.size() == 1;
+        }
+
+        bool HasOneGrantedAndAnotherWaitingPerPDisk() const {
+            // Besides observing contention on the focus PDisk, require one more grant overall.
+            // This proves that only the focus PDisk lane is throttled, while another PDisk can still progress.
+            return FocusPDiskId && StashedCompletionEvent && SelectedOwnerActor
+                && CountQueriedOnPDisk(*FocusPDiskId) >= 2
+                && CountGrantedOnPDisk(*FocusPDiskId) == 1
+                && GrantedVDisks.size() >= 2;
+        }
+
+        TActorId SelectedVDiskActor() const {
+            UNIT_ASSERT(SelectedOwnerActor);
+            const auto it = VDiskByOwnerActor.find(*SelectedOwnerActor);
+            UNIT_ASSERT(it != VDiskByOwnerActor.end());
+            return it->second.VDiskActorId;
+        }
+
+        ui32 SelectedPDiskId() const {
+            UNIT_ASSERT(SelectedOwnerActor);
+            const auto it = VDiskByOwnerActor.find(*SelectedOwnerActor);
+            UNIT_ASSERT(it != VDiskByOwnerActor.end());
+            return it->second.PDiskId;
+        }
+
+        void StashIfSelected(std::unique_ptr<IEventHandle>& ev) {
+            if (ShouldStashSelectedCompletionEvent && SelectedOwnerActor && ev->Recipient == *SelectedOwnerActor
+                    && !StashedCompletionEvent) {
+                StashedCompletionEvent = std::move(ev);
+            }
+        }
+
+        bool IsSelectedCompletionEvent(ui32 eventType, const TActorId& recipient) const {
+            if (!SelectedOwnerActor || recipient != *SelectedOwnerActor || StashedCompletionEvent) {
+                return false;
+            }
+
+            switch (CompletionEventType) {
+                case ECompletionEventType::YardInitResult:
+                    return eventType == NPDisk::TEvYardInitResult::EventType;
+
+                case ECompletionEventType::StartupDataSyncDone:
+                    return eventType == TEvStartupDataSyncDone::EventType;
+            }
+
+            return false;
+        }
+
+        bool Handle(std::unique_ptr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvAcquireVDiskOperationToken::EventType: {
+                    if (ev->Recipient != BrokerServiceId) {
+                        break;
+                    }
+                    auto* msg = ev->Get<TEvAcquireVDiskOperationToken>();
+                    const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(msg->VDiskServiceId);
+                    Y_UNUSED(nodeId);
+                    Y_UNUSED(vslotId);
+                    OnQuery(ev->Sender, msg->VDiskServiceId, pdiskId);
+                    break;
+                }
+
+                case TEvVDiskOperationToken::EventType:
+                    if (!VDiskByOwnerActor.contains(ev->Recipient)) {
+                        break;
+                    }
+                    OnGrant(ev->Recipient);
+                    break;
+
+                case TEvReleaseVDiskOperationToken::EventType: {
+                    if (ev->Recipient != BrokerServiceId) {
+                        break;
+                    }
+                    auto* msg = ev->Get<TEvReleaseVDiskOperationToken>();
+                    const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(msg->VDiskServiceId);
+                    Y_UNUSED(nodeId);
+                    Y_UNUSED(vslotId);
+                    OnRelease(msg->VDiskServiceId, pdiskId);
+                    break;
+                }
+            }
+
+            if (IsSelectedCompletionEvent(ev->GetTypeRewrite(), ev->Recipient)) {
+                if (ShouldStashSelectedCompletionEvent) {
+                    StashIfSelected(ev);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        void ResumeStashedEvent(TEnvironmentSetup& env) {
+            UNIT_ASSERT(StashedCompletionEvent);
+            ShouldStashSelectedCompletionEvent = false;
+            auto* raw = StashedCompletionEvent.release();
+            const TActorId recipient = raw->Recipient;
+            const bool delivered = env.Runtime->WrapInActorContext(recipient, [&](IActor* actor) {
+                TAutoPtr<IEventHandle> ev(raw);
+                actor->Receive(ev);
+            });
+            UNIT_ASSERT_C(delivered, "failed to deliver stashed event to actor; recipient# " << recipient);
+        }
+    };
+
+    struct TScopedCaptureFilter {
+        using TFilterFunction = decltype(std::declval<TTestActorSystem>().FilterFunction);
+
+        TEnvironmentSetup& Env;
+        TFilterFunction PrevFilter;
+
+        template<typename TCapture>
+        TScopedCaptureFilter(TEnvironmentSetup& env, TCapture& capture)
+            : Env(env)
+            , PrevFilter(env.Runtime->FilterFunction)
+        {
+            Env.Runtime->FilterFunction = [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) {
+                if (capture.Handle(ev)) {
+                    return PrevFilter ? PrevFilter(nodeId, ev) : true;
+                }
+                return false;
+            };
+        }
+
+        ~TScopedCaptureFilter() {
+            Env.Runtime->FilterFunction = PrevFilter;
+        }
+    };
+
+    struct TLocalRecoveryCapture : TBrokerCaptureBase {
+        explicit TLocalRecoveryCapture(std::optional<ui32> focusPDiskId = std::nullopt)
+            : TBrokerCaptureBase(MakeBlobStorageLocalRecoveryBrokerID(),
+                ECompletionEventType::YardInitResult, focusPDiskId)
+        {}
+
+        void FailSelectedYardInit(TEnvironmentSetup& env) {
+            UNIT_ASSERT(StashedCompletionEvent);
+            ShouldStashSelectedCompletionEvent = false;
+            const TActorId recipient = StashedCompletionEvent->Recipient;
+            const TActorId sender = StashedCompletionEvent->Sender;
+            StashedCompletionEvent.reset();
+            const bool delivered = env.Runtime->WrapInActorContext(recipient, [&](IActor* actor) {
+                TAutoPtr<IEventHandle> ev(new IEventHandle(recipient, sender,
+                    new NPDisk::TEvYardInitResult(NKikimrProto::CORRUPTED, "local recovery broker test error")));
+                actor->Receive(ev);
+            });
+            UNIT_ASSERT_C(delivered, "failed to inject TEvYardInitResult into actor; recipient# " << recipient);
+        }
+    };
+
+    struct TStartupDataSyncCapture : TBrokerCaptureBase {
+        explicit TStartupDataSyncCapture(std::optional<ui32> focusPDiskId = std::nullopt)
+            : TBrokerCaptureBase(MakeBlobStorageStartupDataSyncBrokerID(),
+                ECompletionEventType::StartupDataSyncDone, focusPDiskId)
+        {}
+
+        void PoisonSelectedSyncer(TEnvironmentSetup& env) const {
+            UNIT_ASSERT(SelectedOwnerActor);
+            env.Runtime->Send(new IEventHandle(TEvents::TSystem::PoisonPill, 0, *SelectedOwnerActor, {}, nullptr, 0),
+                SelectedOwnerActor->NodeId());
+        }
+    };
+
+    struct TStartupDataSyncJobDoneCapture : TStartupDataSyncCapture {
+        std::unique_ptr<IEventHandle> StashedSyncerJobDone;
+
+        TStartupDataSyncJobDoneCapture() {
+            ShouldStashSelectedCompletionEvent = false;
+        }
+
+        bool Handle(std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvSyncerJobDone::EventType && SelectedOwnerActor && !StashedSyncerJobDone) {
+                StashedSyncerJobDone = std::move(ev);
+                return false;
+            }
+
+            return TStartupDataSyncCapture::Handle(ev);
+        }
+
+        void ResumeStashedSyncerJobDone(TEnvironmentSetup& env) {
+            UNIT_ASSERT(StashedSyncerJobDone);
+            auto* raw = StashedSyncerJobDone.release();
+            const TActorId recipient = raw->Recipient;
+            const bool delivered = env.Runtime->WrapInActorContext(recipient, [&](IActor* actor) {
+                TAutoPtr<IEventHandle> ev(raw);
+                actor->Receive(ev);
+            });
+            UNIT_ASSERT_C(delivered, "failed to deliver stashed TEvSyncerJobDone to actor; recipient# " << recipient);
+        }
+    };
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(VDiskStartupBrokers) {
+
+    // Active startup data sync owner dies; the broker frees its token and grants a new owner.
+    Y_UNIT_TEST(StartupDataSyncBrokerAllowsNewOwnerAfterActiveOwnerDies) {
+        TRestartScenario scenario;
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId, 0, 0, 1, 0);
+
+        const TActorId brokerServiceId = MakeBlobStorageStartupDataSyncBrokerID();
+        const TActorId vdiskServiceId = scenario.StartupTargets.front().VDiskActorId;
+        const TActorId firstOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+        const TActorId secondOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+
+        SendBrokerAcquire(scenario.Env, firstOwnerActorId, brokerServiceId, vdiskServiceId);
+        WaitForBrokerToken(scenario.Env, firstOwnerActorId,
+            "expected first owner to get startup data sync token");
+
+        scenario.Env.Runtime->DestroyActor(firstOwnerActorId);
+        scenario.Env.Sim(TDuration::Seconds(1));
+
+        SendBrokerAcquire(scenario.Env, secondOwnerActorId, brokerServiceId, vdiskServiceId);
+        WaitForBrokerToken(scenario.Env, secondOwnerActorId,
+            "expected new owner to get startup data sync token after previous owner died");
+    }
+
+    // Queued startup data sync owner dies; a replacement waits and receives the token after release.
+    Y_UNIT_TEST(StartupDataSyncBrokerAllowsNewOwnerAfterWaitingOwnerDies) {
+        TRestartScenario scenario;
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId, 0, 0, 1, 0);
+
+        const TActorId brokerServiceId = MakeBlobStorageStartupDataSyncBrokerID();
+        const TActorId holderVDiskServiceId = scenario.StartupTargets[0].VDiskActorId;
+        const TActorId queuedVDiskServiceId = scenario.StartupTargets[1].VDiskActorId;
+        const TActorId holderActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+        const TActorId staleWaitingOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+        const TActorId replacementWaitingOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+
+        SendBrokerAcquire(scenario.Env, holderActorId, brokerServiceId, holderVDiskServiceId);
+        WaitForBrokerToken(scenario.Env, holderActorId,
+            "expected holder actor to get startup data sync token");
+
+        SendBrokerAcquire(scenario.Env, staleWaitingOwnerActorId, brokerServiceId, queuedVDiskServiceId);
+        scenario.Env.Sim(TDuration::Seconds(1));
+        scenario.Env.Runtime->DestroyActor(staleWaitingOwnerActorId);
+        scenario.Env.Sim(TDuration::Seconds(1));
+
+        SendBrokerAcquire(scenario.Env, replacementWaitingOwnerActorId, brokerServiceId, queuedVDiskServiceId);
+        SendBrokerRelease(scenario.Env, holderActorId, brokerServiceId, holderVDiskServiceId);
+        WaitForBrokerToken(scenario.Env, replacementWaitingOwnerActorId,
+            "expected replacement owner to get startup data sync token after stale waiting owner died");
+    }
+
+    // Dead queued owner is skipped when activated, so the next queued owner is not stuck.
+    Y_UNIT_TEST(StartupDataSyncBrokerDoesNotHangWhenQueuedOwnerDiesBeforeActivation) {
+        TRestartScenario scenario;
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId, 0, 0, 1, 0);
+
+        const TActorId brokerServiceId = MakeBlobStorageStartupDataSyncBrokerID();
+        const TActorId holderVDiskServiceId = scenario.StartupTargets[0].VDiskActorId;
+        const TActorId staleQueuedVDiskServiceId = scenario.StartupTargets[1].VDiskActorId;
+        const TActorId nextQueuedVDiskServiceId = scenario.StartupTargets[2].VDiskActorId;
+        const TActorId holderActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+        const TActorId staleQueuedOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+        const TActorId nextQueuedOwnerActorId = scenario.Env.Runtime->AllocateEdgeActor(scenario.RestartedNodeId, __FILE__, __LINE__);
+
+        SendBrokerAcquire(scenario.Env, holderActorId, brokerServiceId, holderVDiskServiceId);
+        WaitForBrokerToken(scenario.Env, holderActorId,
+            "expected holder actor to get startup data sync token");
+
+        // Queue one VDisk behind the holder and then kill its owner before the queue reaches it.
+        // After the holder releases token, the broker will try to activate this stale queue entry.
+        // Without TrackDelivery + Undelivered cleanup this dead entry would keep the only token forever.
+        SendBrokerAcquire(scenario.Env, staleQueuedOwnerActorId, brokerServiceId, staleQueuedVDiskServiceId);
+        SendBrokerAcquire(scenario.Env, nextQueuedOwnerActorId, brokerServiceId, nextQueuedVDiskServiceId);
+        scenario.Env.Sim(TDuration::Seconds(1));
+        scenario.Env.Runtime->DestroyActor(staleQueuedOwnerActorId);
+        scenario.Env.Sim(TDuration::Seconds(1));
+
+        SendBrokerRelease(scenario.Env, holderActorId, brokerServiceId, holderVDiskServiceId);
+        WaitForBrokerToken(scenario.Env, nextQueuedOwnerActorId,
+            "expected next queued owner to get startup data sync token after stale queued owner dies");
+    }
+
+    // After the initial local-recovery wave is drained, later VDisk restarts still respect broker limits.
+    Y_UNIT_TEST(LocalRecoveryBrokerSerializesLateVDiskStartsAfterInitialStartup) {
+        TRestartScenario scenario;
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryCount = 1});
+        WaitForVDisksToGetRunning(scenario.Env, scenario.RestartedNodeVDisks);
+
+        TLocalRecoveryCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+
+        RestartVDisk(scenario.Env, scenario.RestartedNodeVDisks[0]);
+        RestartVDisk(scenario.Env, scenario.RestartedNodeVDisks[1]);
+
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected late VDisk restart to hold local recovery token while another late VDisk is waiting");
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.GrantedVDisks.size(), 1,
+            "expected only one local recovery token for late VDisk restart before unblocking first VDisk");
+
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] { return capture.GrantedVDisks.size() >= 2; },
+            "expected second late VDisk to get local recovery token after the first one proceeds");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != firstVDiskActorId,
+            "expected local recovery broker to hand token to another late VDisk after release;"
+            << " firstVDiskActorId# " << firstVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // After the initial startup data sync wave is drained, later VDisk restarts still respect broker limits.
+    Y_UNIT_TEST(StartupDataSyncBrokerSerializesLateVDiskStartsAfterInitialStartup) {
+        TRestartScenario scenario;
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1}, &scenario.StartupTargets);
+        WaitForVDisksToGetRunning(scenario.Env, scenario.RestartedNodeVDisks);
+
+        TStartupDataSyncCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+
+        RestartVDisk(scenario.Env, scenario.RestartedNodeVDisks[0]);
+        RestartVDisk(scenario.Env, scenario.RestartedNodeVDisks[1]);
+
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected late VDisk restart to hold startup data sync token while another late VDisk is waiting");
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.GrantedVDisks.size(), 1,
+            "expected only one startup data sync token for late VDisk restart before unblocking first VDisk");
+
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] { return capture.GrantedVDisks.size() >= 2; },
+            "expected second late VDisk to get startup data sync token after the first one completes");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != firstVDiskActorId,
+            "expected startup data sync broker to hand token to another late VDisk after release;"
+            << " firstVDiskActorId# " << firstVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // Node-wide local recovery limit allows one VDisk at a time and hands off after completion.
+    Y_UNIT_TEST(LocalRecoveryBrokerSerializesStartupPerNode) {
+        TRestartScenario scenario;
+        TLocalRecoveryCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryCount = 1});
+
+        // Wait until two VDisks have reached the broker, but only one token is granted.
+        // The selected owner's completion event is stashed to keep that state stable.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected one VDisk to hold local recovery token while another VDisk is already waiting");
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.GrantedVDisks.size(), 1,
+            "expected only one local recovery token before unblocking first VDisk; queriedVDisks# "
+            << capture.QueriedVDisks.size());
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] { return capture.GrantedVDisks.size() >= 2; },
+            "expected another VDisk to get local recovery token after the first one proceeds");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != firstVDiskActorId,
+            "expected local recovery broker to hand token to another VDisk after release;"
+            << " firstVDiskActorId# " << firstVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // Failed local recovery owner releases its node-wide token for another VDisk.
+    Y_UNIT_TEST(LocalRecoveryBrokerReleasesTokenOnStartupFailurePerNode) {
+        TRestartScenario scenario;
+        TLocalRecoveryCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryCount = 1});
+
+        // Observe the throttled state first, then fail the selected owner and verify token handoff.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected one VDisk to hold local recovery token while another VDisk is waiting");
+
+        const TActorId failedVDiskActorId = capture.SelectedVDiskActor();
+        capture.FailSelectedYardInit(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(failedVDiskActorId) && capture.GrantedVDisks.size() >= 2;
+        }, "expected failed local recovery owner to release token and let another VDisk proceed");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != failedVDiskActorId,
+            "expected local recovery broker to pass token to another VDisk after startup failure;"
+            << " failedVDiskActorId# " << failedVDiskActorId
+            << " secondGrantedVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // Per-PDisk local recovery limit blocks one PDisk while another PDisk keeps progressing.
+    Y_UNIT_TEST(LocalRecoveryBrokerSerializesStartupPerPDisk) {
+        TRestartScenario scenario;
+        TLocalRecoveryCapture capture(scenario.PerPDiskSelection.FocusPDiskId);
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryPerPDiskCount = 1});
+
+        // For per-PDisk throttling we require two things:
+        // 1. another VDisk on the same PDisk is already waiting;
+        // 2. a VDisk on a different PDisk is still allowed to proceed.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerPDisk(); },
+            "expected one VDisk on focus PDisk to hold local recovery token while another VDisk on the same PDisk waits");
+
+        const ui32 focusPDiskId = scenario.PerPDiskSelection.FocusPDiskId;
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.CountGrantedOnPDisk(focusPDiskId), 1,
+            "expected exactly one local recovery token on focus PDisk before release");
+        UNIT_ASSERT_C(capture.GrantedVDisks.size() >= 2,
+            "expected another PDisk to continue while focus PDisk is blocked; focusPDiskId# " << focusPDiskId);
+
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasAnotherGrantedOnPDisk(focusPDiskId, firstVDiskActorId);
+        }, "expected another VDisk on focus PDisk to get token after the first one proceeds");
+    }
+
+    // Failed local recovery owner releases its per-PDisk token for another VDisk on that PDisk.
+    Y_UNIT_TEST(LocalRecoveryBrokerReleasesTokenOnStartupFailurePerPDisk) {
+        TRestartScenario scenario;
+        TLocalRecoveryCapture capture(scenario.PerPDiskSelection.FocusPDiskId);
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryPerPDiskCount = 1});
+
+        // Observe the per-PDisk throttled state first, then fail the selected owner and verify token handoff.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerPDisk(); },
+            "expected one VDisk on focus PDisk to hold local recovery token while another VDisk on the same PDisk waits");
+
+        const ui32 focusPDiskId = scenario.PerPDiskSelection.FocusPDiskId;
+        const TActorId failedVDiskActorId = capture.SelectedVDiskActor();
+        capture.FailSelectedYardInit(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(failedVDiskActorId)
+                && capture.HasAnotherGrantedOnPDisk(focusPDiskId, failedVDiskActorId);
+        }, "expected failed local recovery owner to release token for another VDisk on the same PDisk");
+    }
+
+    // Node-wide startup data sync limit allows one Syncer at a time and hands off after completion.
+    Y_UNIT_TEST(StartupDataSyncBrokerSerializesStartupDataSyncPerNode) {
+        TRestartScenario scenario;
+        TStartupDataSyncCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1}, &scenario.StartupTargets);
+
+        // Wait until two Syncers have reached the broker, but only one token is granted.
+        // The selected owner's completion event is stashed to keep that state stable.
+        for (ui32 i = 0; i < WaitIterations && !capture.HasOneGrantedAndAnotherWaitingPerNode(); ++i) {
+            scenario.Env.Sim(WaitStep);
+        }
+        UNIT_ASSERT_C(capture.HasOneGrantedAndAnotherWaitingPerNode(),
+            "expected one Syncer to hold startup data sync token while another VDisk is already waiting"
+            << "; queried# " << capture.QueriedVDisks.size()
+            << " queried_vdisks# " << FormatActorIdSet(capture.QueriedVDisks)
+            << " granted# " << capture.GrantedVDisks.size()
+            << " granted_vdisks# " << FormatActorIdList(capture.GrantedVDisks)
+            << " released# " << capture.ReleasedVDisks.size()
+            << " released_vdisks# " << FormatActorIdList(capture.ReleasedVDisks)
+            << " selected_owner# " << (capture.SelectedOwnerActor ? capture.SelectedOwnerActor->ToString() : TString("<none>"))
+            << " stashed# " << bool(capture.StashedCompletionEvent));
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.GrantedVDisks.size(), 1,
+            "expected only one startup data sync token before releasing first Syncer; queriedVDisks# "
+            << capture.QueriedVDisks.size());
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] { return capture.GrantedVDisks.size() >= 2; },
+            "expected another VDisk to get startup data sync token after the first one completes startup wave");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != firstVDiskActorId,
+            "expected startup data sync broker to pass token to another VDisk after startup wave completion;"
+            << " firstVDiskActorId# " << firstVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // Dead Syncer releases its node-wide startup data sync token for another VDisk.
+    Y_UNIT_TEST(StartupDataSyncBrokerReleasesTokenWhenSyncerDiesPerNode) {
+        TRestartScenario scenario;
+        TStartupDataSyncCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1}, &scenario.StartupTargets);
+
+        // Observe the throttled state first, then kill the selected Syncer and verify token handoff.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected one Syncer to hold startup data sync token while another VDisk is already waiting");
+
+        const TActorId failedVDiskActorId = capture.SelectedVDiskActor();
+        capture.PoisonSelectedSyncer(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(failedVDiskActorId) && capture.GrantedVDisks.size() >= 2;
+        }, "expected startup data sync token to be released when the owning Syncer dies");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != failedVDiskActorId,
+            "expected startup data sync broker to pass token to another VDisk after Syncer death;"
+            << " failedVDiskActorId# " << failedVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]);
+    }
+
+    // Startup data sync token stays held until the initial due sync job result is applied.
+    Y_UNIT_TEST(StartupDataSyncBrokerKeepsTokenUntilInitialDueSyncAttemptCompletes) {
+        TRestartScenario scenario;
+        TStartupDataSyncJobDoneCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1});
+
+        WaitUntil(scenario.Env, [&] { return capture.StashedSyncerJobDone != nullptr; },
+            "expected first startup sync job to finish while startup data sync token is still held");
+
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.GrantedVDisks.size(), 1,
+            "startup data sync token must not be released before the initial due sync attempt is applied;"
+            << " granted_vdisks# " << FormatActorIdList(capture.GrantedVDisks)
+            << " released_vdisks# " << FormatActorIdList(capture.ReleasedVDisks));
+        UNIT_ASSERT_C(capture.ReleasedVDisks.empty(),
+            "startup data sync token was released before the initial due sync attempt was applied;"
+            << " released_vdisks# " << FormatActorIdList(capture.ReleasedVDisks));
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        capture.ResumeStashedSyncerJobDone(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(firstVDiskActorId) && capture.GrantedVDisks.size() >= 2;
+        }, "expected startup data sync token to be released after the initial due sync attempt is applied");
+    }
+
+    // Offline peer does not keep the node-wide startup data sync token held forever.
+    Y_UNIT_TEST(StartupDataSyncBrokerReleasesTokenWhenPeerIsOfflinePerNode) {
+        TRestartScenario scenario;
+        const ui32 offlinePeerNodeId = scenario.SelectPeerNodeForGroup(scenario.StartupTargets.front().GroupId);
+        TStartupDataSyncCapture capture;
+        TScopedCaptureFilter guard(scenario.Env, capture);
+
+        // Keep one startup data sync peer offline and verify that the first Syncer still
+        // eventually completes its startup wave, releases the token, and lets another
+        // VDisk proceed instead of blocking the broker forever.
+        scenario.Env.StopNode(offlinePeerNodeId);
+        scenario.Env.Sim(TDuration::Seconds(5));
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1}, &scenario.StartupTargets);
+
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerNode(); },
+            "expected one Syncer to hold startup data sync token while another VDisk is already waiting");
+
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        capture.ResumeStashedEvent(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(firstVDiskActorId) && capture.GrantedVDisks.size() >= 2;
+        }, "expected startup data sync token to be released even when one peer is offline");
+
+        UNIT_ASSERT_C(capture.GrantedVDisks[1] != firstVDiskActorId,
+            "expected startup data sync broker to pass token to another VDisk after an offline-peer attempt;"
+            << " firstVDiskActorId# " << firstVDiskActorId
+            << " secondVDiskActorId# " << capture.GrantedVDisks[1]
+            << " offlinePeerNodeId# " << offlinePeerNodeId);
+    }
+
+    // Per-PDisk startup data sync limit blocks one PDisk while another PDisk keeps progressing.
+    Y_UNIT_TEST(StartupDataSyncBrokerSerializesStartupDataSyncPerPDisk) {
+        TRestartScenario scenario;
+        TStartupDataSyncCapture capture(scenario.PerPDiskSelection.FocusPDiskId);
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncPerPDiskCount = 1},
+            &scenario.PerPDiskSelection.StartupTargets);
+
+        // For per-PDisk throttling we require two things:
+        // 1. another Syncer on the same PDisk is already waiting;
+        // 2. a Syncer on a different PDisk is still allowed to proceed.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerPDisk(); },
+            "expected one Syncer on focus PDisk to hold startup data sync token while another VDisk on the same PDisk waits");
+
+        const ui32 focusPDiskId = scenario.PerPDiskSelection.FocusPDiskId;
+        const TActorId firstVDiskActorId = capture.SelectedVDiskActor();
+        UNIT_ASSERT_VALUES_EQUAL_C(capture.CountGrantedOnPDisk(focusPDiskId), 1,
+            "expected exactly one startup data sync token on focus PDisk before release");
+        UNIT_ASSERT_C(capture.GrantedVDisks.size() >= 2,
+            "expected another PDisk to continue startup data sync while focus PDisk is blocked; focusPDiskId# "
+            << focusPDiskId);
+
+        capture.ResumeStashedEvent(scenario.Env);
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasAnotherGrantedOnPDisk(focusPDiskId, firstVDiskActorId);
+        }, "expected another VDisk on focus PDisk to get startup data sync token after the first one completes");
+    }
+
+    // Dead Syncer releases its per-PDisk startup data sync token for another VDisk on that PDisk.
+    Y_UNIT_TEST(StartupDataSyncBrokerReleasesTokenWhenSyncerDiesPerPDisk) {
+        TRestartScenario scenario;
+        TStartupDataSyncCapture capture(scenario.PerPDiskSelection.FocusPDiskId);
+        TScopedCaptureFilter guard(scenario.Env, capture);
+        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncPerPDiskCount = 1},
+            &scenario.PerPDiskSelection.StartupTargets);
+
+        // Observe the per-PDisk throttled state first, then kill the selected Syncer and verify token handoff.
+        WaitUntil(scenario.Env, [&] { return capture.HasOneGrantedAndAnotherWaitingPerPDisk(); },
+            "expected one Syncer on focus PDisk to hold startup data sync token while another VDisk on the same PDisk waits");
+
+        const ui32 focusPDiskId = scenario.PerPDiskSelection.FocusPDiskId;
+        const TActorId failedVDiskActorId = capture.SelectedVDiskActor();
+        capture.PoisonSelectedSyncer(scenario.Env);
+
+        WaitUntil(scenario.Env, [&] {
+            return capture.HasReleasedVDisk(failedVDiskActorId)
+                && capture.HasAnotherGrantedOnPDisk(focusPDiskId, failedVDiskActorId);
+        }, "expected startup data sync token to be released for another VDisk on the same PDisk when Syncer dies");
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/startup_brokers.cpp
@@ -148,10 +148,38 @@ namespace {
         env.Runtime->DestroyActor(edge);
     }
 
-    void WaitForVDisksToGetRunning(TEnvironmentSetup& env, const TVector<TTargetVDisk>& targets) {
-        for (const auto& target : targets) {
-            env.WaitForVDiskToGetRunning(target.VDiskId, target.VDiskActorId);
+    bool IsVDiskRunning(TEnvironmentSetup& env, const TTargetVDisk& target) {
+        const TActorId edge = env.Runtime->AllocateEdgeActor(target.VDiskActorId.NodeId(), __FILE__, __LINE__);
+        env.Runtime->Send(new IEventHandle(
+            target.VDiskActorId,
+            edge,
+            new TEvBlobStorage::TEvVStatus(target.VDiskId),
+            IEventHandle::FlagTrackDelivery),
+            edge.NodeId());
+
+        auto res = env.Runtime->WaitForEdgeActorEvent({edge});
+        env.Runtime->DestroyActor(edge);
+        if (auto* msg = res->CastAsLocal<TEvBlobStorage::TEvVStatusResult>()) {
+            const auto& record = msg->Record;
+            return record.GetStatus() == NKikimrProto::OK && record.GetJoinedGroup() && record.GetReplicated();
+        } else if (auto* msg = res->CastAsLocal<TEvents::TEvUndelivered>()) {
+            Y_ABORT_UNLESS(msg->SourceType == TEvBlobStorage::EvVStatus);
+            return false;
+        } else {
+            Y_ABORT();
         }
+    }
+
+    void WaitForVDisksToGetRunning(TEnvironmentSetup& env, const TVector<TTargetVDisk>& targets) {
+        THashSet<TActorId> running;
+        WaitUntil(env, [&] {
+            for (const auto& target : targets) {
+                if (!running.contains(target.VDiskActorId) && IsVDiskRunning(env, target)) {
+                    running.insert(target.VDiskActorId);
+                }
+            }
+            return running.size() == targets.size();
+        }, "expected VDisks to get running");
     }
 
     struct TRestartScenario {
@@ -693,8 +721,9 @@ Y_UNIT_TEST_SUITE(VDiskStartupBrokers) {
     // After the initial local-recovery wave is drained, later VDisk restarts still respect broker limits.
     Y_UNIT_TEST(LocalRecoveryBrokerSerializesLateVDiskStartsAfterInitialStartup) {
         TRestartScenario scenario;
-        RestartNodeForBrokerTest(scenario, {.MaxInProgressLocalRecoveryCount = 1});
+        RestartNodeForBrokerTest(scenario, {});
         WaitForVDisksToGetRunning(scenario.Env, scenario.RestartedNodeVDisks);
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId, 1, 0, 0, 0);
 
         TLocalRecoveryCapture capture;
         TScopedCaptureFilter guard(scenario.Env, capture);
@@ -722,8 +751,9 @@ Y_UNIT_TEST_SUITE(VDiskStartupBrokers) {
     // After the initial startup data sync wave is drained, later VDisk restarts still respect broker limits.
     Y_UNIT_TEST(StartupDataSyncBrokerSerializesLateVDiskStartsAfterInitialStartup) {
         TRestartScenario scenario;
-        RestartNodeForBrokerTest(scenario, {.MaxInProgressStartupDataSyncCount = 1}, &scenario.StartupTargets);
+        RestartNodeForBrokerTest(scenario, {}, &scenario.StartupTargets);
         WaitForVDisksToGetRunning(scenario.Env, scenario.RestartedNodeVDisks);
+        ConfigureBrokerControls(scenario.Env, scenario.RestartedNodeId, 0, 0, 1, 0);
 
         TStartupDataSyncCapture capture;
         TScopedCaptureFilter guard(scenario.Env, capture);

--- a/ydb/core/blobstorage/ut_blobstorage/ut_startup_brokers/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_startup_brokers/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
+
+    FORK_SUBTESTS()
+
+    SIZE(MEDIUM)
+
+    SRCS(
+        startup_brokers.cpp
+    )
+
+    PEERDIR(
+        ydb/core/blobstorage/ut_blobstorage/lib
+    )
+
+END()

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -79,6 +79,7 @@ RECURSE_FOR_TESTS(
     ut_donor
     ut_group_reconfiguration
     ut_huge
+    ut_startup_brokers
     ut_read_only_vdisk
     ut_osiris
     ut_phantom_blobs

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
@@ -105,13 +105,13 @@ namespace NKikimr {
                 return !nodeLimit || Active.size() < nodeLimit;
             }
 
-            bool CanActivate(ui32 pdiskId) const {
-                if (!HasNodeCapacity()) {
-                    return false;
-                }
-
+            bool HasPDiskCapacity(ui32 pdiskId) const {
                 const ui64 perPDiskLimit = GetPerPDiskLimit();
                 return !perPDiskLimit || GetActiveOnPDisk(pdiskId) < perPDiskLimit;
+            }
+
+            bool CanActivate(ui32 pdiskId) const {
+                return HasNodeCapacity() && HasPDiskCapacity(pdiskId);
             }
 
             auto FindWaiting(const TActorId& vdiskServiceId) {
@@ -162,11 +162,11 @@ namespace NKikimr {
             }
 
             void ProcessQueue() {
-                for (auto it = WaitQueue.begin(); it != WaitQueue.end() && HasNodeCapacity(); ) {
-                    if (CanActivate(it->PDiskId)) {
-                        auto next = std::next(it);
-                        auto entry = DequeueWaiting(it);
-                        it = next;
+                auto it = WaitQueue.begin();
+                while (it != WaitQueue.end() && HasNodeCapacity()) {
+                    if (HasPDiskCapacity(it->PDiskId)) {
+                        auto current = it++;
+                        auto entry = DequeueWaiting(current);
                         Activate(std::move(entry));
                     } else {
                         ++it;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
@@ -1,0 +1,555 @@
+#include "vdisk_operation_broker.h"
+#include "vdisk_log.h"
+
+#include <ydb/core/base/services/blobstorage_service_id.h>
+#include <ydb/core/control/immediate_control_board_wrapper.h>
+#include <ydb/library/actors/core/mon.h>
+
+#include <library/cpp/monlib/service/pages/templates.h>
+#include <util/string/builder.h>
+
+#include <algorithm>
+#include <list>
+#include <unordered_map>
+
+namespace NKikimr {
+
+    namespace {
+
+        class TVDiskOperationBroker
+            : public TActorBootstrapped<TVDiskOperationBroker>
+        {
+            using TThis = TVDiskOperationBroker;
+
+            struct TEntry {
+                TActorId VDiskServiceId;
+                ui32 PDiskId = 0;
+                TActorId OwnerActorId;
+            };
+
+            TControlWrapper MaxInProgressCount;
+            TControlWrapper MaxInProgressPerPDiskCount;
+            std::unordered_map<TActorId, TEntry> Active;
+            std::unordered_map<ui32, ui32> ActivePerPDisk;
+            std::list<TEntry> WaitQueue;
+            std::unordered_map<TActorId, std::list<TEntry>::iterator> WaitingIndex;
+
+            static TString MakePDiskActorPageUrl(ui32 nodeId, ui32 pdiskId) {
+                return Sprintf("/node/%" PRIu32 "/actors/pdisks/pdisk%09" PRIu32, nodeId, pdiskId);
+            }
+
+            static TString MakeVDiskActorPageUrl(const TActorId& vdiskServiceId) {
+                const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
+                return Sprintf("/node/%" PRIu32 "/actors/vdisks/vdisk%09" PRIu32 "_%09" PRIu32,
+                    nodeId, pdiskId, vslotId);
+            }
+
+            static void RenderActorPageLink(IOutputStream& str, const TString& url, TStringBuf title) {
+                str << "<a href=\"" << url << "\">" << title << "</a>";
+            }
+
+            static void RenderActorPageLink(IOutputStream& str, const TString& url, ui32 id) {
+                str << "<a href=\"" << url << "\">" << id << "</a>";
+            }
+
+            ui64 GetNodeLimit() const {
+                return static_cast<ui64>(MaxInProgressCount);
+            }
+
+            ui64 GetPerPDiskLimit() const {
+                return static_cast<ui64>(MaxInProgressPerPDiskCount);
+            }
+
+            ui32 GetActiveOnPDisk(ui32 pdiskId) const {
+                if (const auto it = ActivePerPDisk.find(pdiskId); it != ActivePerPDisk.end()) {
+                    return it->second;
+                }
+                return 0;
+            }
+
+            ui32 GetLocalNodeIdForPages() const {
+                if (!Active.empty()) {
+                    return Active.begin()->first.NodeId();
+                }
+                if (!WaitQueue.empty()) {
+                    return WaitQueue.front().VDiskServiceId.NodeId();
+                }
+                return 0;
+            }
+
+            bool CanActivate(ui32 pdiskId) const {
+                const ui64 nodeLimit = GetNodeLimit();
+                if (nodeLimit && Active.size() >= nodeLimit) {
+                    return false;
+                }
+
+                const ui64 perPDiskLimit = GetPerPDiskLimit();
+                return !perPDiskLimit || GetActiveOnPDisk(pdiskId) < perPDiskLimit;
+            }
+
+            auto FindWaiting(const TActorId& vdiskServiceId) {
+                if (const auto it = WaitingIndex.find(vdiskServiceId); it != WaitingIndex.end()) {
+                    return it->second;
+                }
+                return WaitQueue.end();
+            }
+
+            auto EnqueueWaiting(TEntry&& entry) {
+                WaitQueue.emplace_back(std::move(entry));
+                const auto it = std::prev(WaitQueue.end());
+                WaitingIndex.emplace(it->VDiskServiceId, it);
+                return it;
+            }
+
+            TEntry DequeueWaiting(std::list<TEntry>::iterator it) {
+                TEntry entry = std::move(*it);
+                WaitingIndex.erase(entry.VDiskServiceId);
+                WaitQueue.erase(it);
+                return entry;
+            }
+
+            void EraseWaiting(std::list<TEntry>::iterator it) {
+                WaitingIndex.erase(it->VDiskServiceId);
+                WaitQueue.erase(it);
+            }
+
+            void SendToken(const TEntry& entry) {
+                this->Send(entry.OwnerActorId, new TEvVDiskOperationToken, IEventHandle::FlagTrackDelivery);
+            }
+
+            void Activate(TEntry&& entry) {
+                SendToken(entry);
+                ++ActivePerPDisk[entry.PDiskId];
+                Active.emplace(entry.VDiskServiceId, std::move(entry));
+            }
+
+            void Deactivate(typename std::unordered_map<TActorId, TEntry>::iterator it) {
+                const ui32 pdiskId = it->second.PDiskId;
+                Active.erase(it);
+
+                auto activeByPDisk = ActivePerPDisk.find(pdiskId);
+                Y_ABORT_UNLESS(activeByPDisk != ActivePerPDisk.end() && activeByPDisk->second);
+                if (--activeByPDisk->second == 0) {
+                    ActivePerPDisk.erase(activeByPDisk);
+                }
+            }
+
+            void ProcessQueue() {
+                const ui64 nodeLimit = GetNodeLimit();
+
+                bool progress = true;
+                while (progress && (!nodeLimit || Active.size() < nodeLimit)) {
+                    progress = false;
+                    for (auto it = WaitQueue.begin(); it != WaitQueue.end() && (!nodeLimit || Active.size() < nodeLimit); ) {
+                        if (CanActivate(it->PDiskId)) {
+                            auto next = std::next(it);
+                            auto entry = DequeueWaiting(it);
+                            it = next;
+                            Activate(std::move(entry));
+                            progress = true;
+                        } else {
+                            ++it;
+                        }
+                    }
+                }
+            }
+
+            size_t GrantAllWaitingOnce() {
+                size_t numGranted = 0;
+                while (!WaitQueue.empty()) {
+                    auto entry = DequeueWaiting(WaitQueue.begin());
+                    Activate(std::move(entry));
+                    ++numGranted;
+                }
+
+                LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                    "GrantAllWaitingOnce"
+                    << ", broker service id: " << this->SelfId()
+                    << ", granted waiting VDisks: " << numGranted
+                    << ", active: " << Active.size()
+                    << ", waiting: " << WaitQueue.size());
+                return numGranted;
+            }
+
+        public:
+            static constexpr auto ActorActivityType() {
+                return NKikimrServices::TActivity::NODE_WARDEN;
+            }
+
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvAcquireVDiskOperationToken, Handle)
+                hFunc(TEvReleaseVDiskOperationToken, Handle)
+                hFunc(TEvents::TEvUndelivered, Handle)
+                hFunc(TEvents::TEvWakeup, Handle)
+                hFunc(NMon::TEvHttpInfo, Handle)
+            )
+
+            explicit TVDiskOperationBroker(const TControlWrapper& maxInProgressCount,
+                    const TControlWrapper& maxInProgressPerPDiskCount)
+                : MaxInProgressCount(maxInProgressCount)
+                , MaxInProgressPerPDiskCount(maxInProgressPerPDiskCount)
+            {}
+
+            void Bootstrap() {
+                this->Become(&TThis::StateFunc, TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+            }
+
+            void Handle(TEvAcquireVDiskOperationToken::TPtr& ev) {
+                const auto vdiskServiceId = ev->Get()->VDiskServiceId;
+                const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
+                Y_UNUSED(nodeId);
+                Y_UNUSED(vslotId);
+                const auto actorId = ev->Sender;
+
+                if (const auto it = Active.find(vdiskServiceId); it != Active.end()) {
+                    Y_ABORT_UNLESS(it->second.PDiskId == pdiskId);
+                    if (it->second.OwnerActorId != actorId) {
+                        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvAcquireVDiskOperationToken"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << vdiskServiceId
+                            << ", PDiskId: " << pdiskId
+                            << ", stale active owner actor id: " << it->second.OwnerActorId
+                            << ", new owner actor id: " << actorId
+                            << ", action: update active owner");
+                        it->second.OwnerActorId = actorId;
+                    }
+                    SendToken(it->second);
+
+                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                        "TEvAcquireVDiskOperationToken"
+                        << ", broker service id: " << this->SelfId()
+                        << ", VDisk service id: " << vdiskServiceId
+                        << ", PDiskId: " << pdiskId
+                        << ", actor id: " << actorId
+                        << ", token sent, active: " << Active.size()
+                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                        << ", waiting: " << WaitQueue.size());
+                    return;
+                }
+
+                if (const auto it = FindWaiting(vdiskServiceId); it != WaitQueue.end()) {
+                    Y_ABORT_UNLESS(it->PDiskId == pdiskId);
+                    if (it->OwnerActorId != actorId) {
+                        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvAcquireVDiskOperationToken"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << vdiskServiceId
+                            << ", PDiskId: " << pdiskId
+                            << ", stale waiting owner actor id: " << it->OwnerActorId
+                            << ", new owner actor id: " << actorId
+                            << ", action: update waiting owner");
+                        it->OwnerActorId = actorId;
+                    }
+
+                    if (CanActivate(pdiskId)) {
+                        auto entry = DequeueWaiting(it);
+                        Activate(std::move(entry));
+
+                        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvAcquireVDiskOperationToken"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << vdiskServiceId
+                            << ", PDiskId: " << pdiskId
+                            << ", actor id: " << actorId
+                            << ", token sent from queue, active: " << Active.size()
+                            << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                            << ", waiting: " << WaitQueue.size());
+                        return;
+                    }
+
+                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                        "TEvAcquireVDiskOperationToken"
+                        << ", broker service id: " << this->SelfId()
+                        << ", VDisk service id: " << vdiskServiceId
+                        << ", PDiskId: " << pdiskId
+                        << ", actor id: " << actorId
+                        << ", enqueued, active: " << Active.size()
+                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                        << ", waiting: " << WaitQueue.size());
+                    return;
+                }
+
+                if (CanActivate(pdiskId)) {
+                    TEntry entry{vdiskServiceId, pdiskId, actorId};
+                    Activate(std::move(entry));
+
+                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                        "TEvAcquireVDiskOperationToken"
+                        << ", broker service id: " << this->SelfId()
+                        << ", VDisk service id: " << vdiskServiceId
+                        << ", PDiskId: " << pdiskId
+                        << ", actor id: " << actorId
+                        << ", token sent, active: " << Active.size()
+                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                        << ", waiting: " << WaitQueue.size());
+                    return;
+                }
+
+                EnqueueWaiting(TEntry{vdiskServiceId, pdiskId, actorId});
+
+                LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                    "TEvAcquireVDiskOperationToken"
+                    << ", broker service id: " << this->SelfId()
+                    << ", VDisk service id: " << vdiskServiceId
+                    << ", PDiskId: " << pdiskId
+                    << ", actor id: " << actorId
+                    << ", enqueued, active: " << Active.size()
+                    << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                    << ", waiting: " << WaitQueue.size());
+            }
+
+            void Handle(TEvReleaseVDiskOperationToken::TPtr& ev) {
+                const auto vdiskServiceId = ev->Get()->VDiskServiceId;
+                const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
+                Y_UNUSED(nodeId);
+                Y_UNUSED(vslotId);
+                const auto actorId = ev->Sender;
+
+                if (const auto it = Active.find(vdiskServiceId); it != Active.end()) {
+                    Y_ABORT_UNLESS(it->second.PDiskId == pdiskId);
+                    if (it->second.OwnerActorId != actorId) {
+                        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvReleaseVDiskOperationToken"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << vdiskServiceId
+                            << ", PDiskId: " << pdiskId
+                            << ", stale active owner actor id: " << actorId
+                            << ", current owner actor id: " << it->second.OwnerActorId
+                            << ", action: ignore stale release");
+                        return;
+                    }
+                    Deactivate(it);
+                    ProcessQueue();
+
+                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                        "TEvReleaseVDiskOperationToken"
+                        << ", broker service id: " << this->SelfId()
+                        << ", VDisk service id: " << vdiskServiceId
+                        << ", PDiskId: " << pdiskId
+                        << ", actor id: " << actorId
+                        << ", token released, active: " << Active.size()
+                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                        << ", waiting: " << WaitQueue.size());
+                    return;
+                }
+
+                if (const auto it = FindWaiting(vdiskServiceId); it != WaitQueue.end()) {
+                    Y_ABORT_UNLESS(it->PDiskId == pdiskId);
+                    if (it->OwnerActorId != actorId) {
+                        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvReleaseVDiskOperationToken"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << vdiskServiceId
+                            << ", PDiskId: " << pdiskId
+                            << ", stale waiting owner actor id: " << actorId
+                            << ", current queued owner actor id: " << it->OwnerActorId
+                            << ", action: ignore stale release");
+                        return;
+                    }
+                    EraseWaiting(it);
+
+                    LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                        "TEvReleaseVDiskOperationToken"
+                        << ", broker service id: " << this->SelfId()
+                        << ", VDisk service id: " << vdiskServiceId
+                        << ", PDiskId: " << pdiskId
+                        << ", actor id: " << actorId
+                        << ", removed from queue, active: " << Active.size()
+                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
+                        << ", waiting: " << WaitQueue.size());
+                    return;
+                }
+
+                LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                    "TEvReleaseVDiskOperationToken"
+                    << ", broker service id: " << this->SelfId()
+                    << ", VDisk service id: " << vdiskServiceId
+                    << ", PDiskId: " << pdiskId
+                    << ", actor id: " << actorId
+                    << ", action: ignore release for unknown VDisk");
+            }
+
+            void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+                if (ev->Get()->SourceType != TEvVDiskOperationToken::EventType) {
+                    return;
+                }
+
+                const auto actorId = ev->Sender;
+                for (auto it = Active.begin(); it != Active.end(); ++it) {
+                    if (it->second.OwnerActorId == actorId) {
+                        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
+                            "TEvUndelivered"
+                            << ", broker service id: " << this->SelfId()
+                            << ", VDisk service id: " << it->second.VDiskServiceId
+                            << ", PDiskId: " << it->second.PDiskId
+                            << ", owner actor id: " << actorId
+                            << ", source type: " << ev->Get()->SourceType
+                            << ", reason: " << ev->Get()->Reason
+                            << ", action: drop active token owner and process queue");
+                        Deactivate(it);
+                        ProcessQueue();
+                        return;
+                    }
+                }
+            }
+
+            void Handle(TEvents::TEvWakeup::TPtr&) {
+                ProcessQueue();
+                this->Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+            }
+
+            void Handle(NMon::TEvHttpInfo::TPtr& ev) {
+                const auto& request = ev->Get()->Request;
+                const auto& cgi = request.GetParams();
+                TString actionMessage;
+                if (request.GetMethod() == HTTP_METHOD_POST) {
+                    const auto& post = request.GetPostParams();
+                    if (post.Get("broker_action") == "grant_all_waiting_once") {
+                        const size_t numGranted = GrantAllWaitingOnce();
+                        actionMessage = TStringBuilder()
+                            << "Emergency action executed: granted tokens to " << numGranted << " waiting VDisk(s).";
+                    }
+                } else if (cgi.Get("broker_action") == "grant_all_waiting_once") {
+                    actionMessage = "Emergency action was not executed: grant_all_waiting_once requires POST.";
+                }
+
+                TStringStream str;
+                TString nodeLimit = GetNodeLimit() ? ToString(GetNodeLimit()) : "unlimited";
+                TString perPDiskLimit = GetPerPDiskLimit() ? ToString(GetPerPDiskLimit()) : "unlimited";
+                HTML(str) {
+                    if (!actionMessage.empty()) {
+                        DIV_CLASS("alert alert-warning") {
+                            str << actionMessage;
+                        }
+                        str << "<script>"
+                               "if (window.history && window.history.replaceState) {"
+                               "const url = new URL(window.location.href);"
+                               "url.searchParams.delete('broker_action');"
+                               "window.history.replaceState({}, '', url.toString());"
+                               "}"
+                               "</script>";
+                    }
+
+                    DIV_CLASS("panel panel-info") {
+                        DIV_CLASS("panel-body") {
+                            str << "Broker Service Id: " << this->SelfId() << "<br>";
+                            str << "Node Limit: " << nodeLimit << "<br>";
+                            str << "Per-PDisk Limit: " << perPDiskLimit << "<br>";
+                            str << "Active VDisks: " << Active.size() << "<br>";
+                            str << "Waiting VDisks: " << WaitQueue.size();
+                        }
+
+                        DIV_CLASS("panel-body") {
+                            STRONG() { str << "Emergency actions"; }
+                            str << "<br>";
+                            str << "Use this only as a manual recovery tool when you suspect a broker bug or a stuck waiter.";
+                            str << "<br><br>";
+                            str << "<form method=\"POST\">";
+                            str << "<input type=\"hidden\" name=\"broker_action\" value=\"grant_all_waiting_once\">";
+                            str << "<button type=\"submit\" class=\"btn btn-warning\">Grant tokens to all waiting VDisks once</button>";
+                            str << "</form>";
+                        }
+
+                        DIV_CLASS("panel-body") {
+                            STRONG() {str << "Active per PDisk";}
+                            str << "<br>";
+                            if (ActivePerPDisk.empty()) {
+                                str << "empty";
+                            } else {
+                                TABLE_CLASS("table table-condensed") {
+                                    TABLEHEAD() {
+                                        TABLER() {
+                                            TABLEH() {str << "PDiskId";}
+                                            TABLEH() {str << "Active VDisks";}
+                                        }
+                                    }
+                                    TABLEBODY() {
+                                        const ui32 nodeId = GetLocalNodeIdForPages();
+                                        for (const auto& [pdiskId, count] : ActivePerPDisk) {
+                                            TABLER() {
+                                                TABLED() { RenderActorPageLink(str, MakePDiskActorPageUrl(nodeId, pdiskId), pdiskId); }
+                                                TABLED() {str << count;}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        DIV_CLASS("panel-body") {
+                            STRONG() {str << "Active";}
+                            str << "<br>";
+                            if (Active.empty()) {
+                                str << "empty";
+                            } else {
+                                TABLE_CLASS("table table-condensed") {
+                                    TABLEHEAD() {
+                                        TABLER() {
+                                            TABLEH() {str << "VDiskServiceId";}
+                                            TABLEH() {str << "VDisk page";}
+                                            TABLEH() {str << "PDisk page";}
+                                            TABLEH() {str << "PDiskId";}
+                                            TABLEH() {str << "OwnerActorId";}
+                                        }
+                                    }
+                                    TABLEBODY() {
+                                        for (const auto& [vdiskServiceId, entry] : Active) {
+                                            TABLER() {
+                                                TABLED() {str << vdiskServiceId;}
+                                                TABLED() { RenderActorPageLink(str, MakeVDiskActorPageUrl(vdiskServiceId), "page"); }
+                                                TABLED() { RenderActorPageLink(str, MakePDiskActorPageUrl(vdiskServiceId.NodeId(), entry.PDiskId), "page"); }
+                                                TABLED() {str << entry.PDiskId;}
+                                                TABLED() {str << entry.OwnerActorId;}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        DIV_CLASS("panel-body") {
+                            STRONG() {str << "Waiting";}
+                            str << "<br>";
+                            if (WaitQueue.empty()) {
+                                str << "empty";
+                            } else {
+                                TABLE_CLASS("table table-condensed") {
+                                    TABLEHEAD() {
+                                        TABLER() {
+                                            TABLEH() {str << "VDiskServiceId";}
+                                            TABLEH() {str << "VDisk page";}
+                                            TABLEH() {str << "PDisk page";}
+                                            TABLEH() {str << "PDiskId";}
+                                            TABLEH() {str << "OwnerActorId";}
+                                        }
+                                    }
+                                    TABLEBODY() {
+                                        for (const auto& item : WaitQueue) {
+                                            TABLER() {
+                                                TABLED() {str << item.VDiskServiceId;}
+                                                TABLED() { RenderActorPageLink(str, MakeVDiskActorPageUrl(item.VDiskServiceId), "page"); }
+                                                TABLED() { RenderActorPageLink(str, MakePDiskActorPageUrl(item.VDiskServiceId.NodeId(), item.PDiskId), "page"); }
+                                                TABLED() {str << item.PDiskId;}
+                                                TABLED() {str << item.OwnerActorId;}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                this->Send(ev->Sender, new NMon::TEvHttpInfoRes(str.Str(), ev->Get()->SubRequestId));
+            }
+        };
+
+    } // anonymous namespace
+
+    IActor* CreateVDiskOperationBrokerActor(const TControlWrapper& maxInProgressCount,
+            const TControlWrapper& maxInProgressPerPDiskCount) {
+        return new TVDiskOperationBroker(maxInProgressCount, maxInProgressPerPDiskCount);
+    }
+
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <list>
+#include <optional>
 #include <unordered_map>
 
 namespace NKikimr {
@@ -78,9 +79,34 @@ namespace NKikimr {
                 return 0;
             }
 
-            bool CanActivate(ui32 pdiskId) const {
+            TString BuildLogString(
+                    const TActorId& vdiskServiceId = TActorId(),
+                    std::optional<ui32> pdiskId = std::nullopt,
+                    const TActorId& senderActorId = TActorId()) const {
+                TStringBuilder str;
+                str << "broker service id: " << this->SelfId()
+                    << ", active: " << Active.size()
+                    << ", waiting: " << WaitQueue.size();
+                if (vdiskServiceId != TActorId()) {
+                    str << ", VDisk service id: " << vdiskServiceId;
+                }
+                if (pdiskId) {
+                    str << ", PDiskId: " << *pdiskId
+                        << ", active on PDisk: " << GetActiveOnPDisk(*pdiskId);
+                }
+                if (senderActorId != TActorId()) {
+                    str << ", sender actor id: " << senderActorId;
+                }
+                return str;
+            }
+
+            bool HasNodeCapacity() const {
                 const ui64 nodeLimit = GetNodeLimit();
-                if (nodeLimit && Active.size() >= nodeLimit) {
+                return !nodeLimit || Active.size() < nodeLimit;
+            }
+
+            bool CanActivate(ui32 pdiskId) const {
+                if (!HasNodeCapacity()) {
                     return false;
                 }
 
@@ -136,21 +162,14 @@ namespace NKikimr {
             }
 
             void ProcessQueue() {
-                const ui64 nodeLimit = GetNodeLimit();
-
-                bool progress = true;
-                while (progress && (!nodeLimit || Active.size() < nodeLimit)) {
-                    progress = false;
-                    for (auto it = WaitQueue.begin(); it != WaitQueue.end() && (!nodeLimit || Active.size() < nodeLimit); ) {
-                        if (CanActivate(it->PDiskId)) {
-                            auto next = std::next(it);
-                            auto entry = DequeueWaiting(it);
-                            it = next;
-                            Activate(std::move(entry));
-                            progress = true;
-                        } else {
-                            ++it;
-                        }
+                for (auto it = WaitQueue.begin(); it != WaitQueue.end() && HasNodeCapacity(); ) {
+                    if (CanActivate(it->PDiskId)) {
+                        auto next = std::next(it);
+                        auto entry = DequeueWaiting(it);
+                        it = next;
+                        Activate(std::move(entry));
+                    } else {
+                        ++it;
                     }
                 }
             }
@@ -165,10 +184,8 @@ namespace NKikimr {
 
                 LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                     "GrantAllWaitingOnce"
-                    << ", broker service id: " << this->SelfId()
-                    << ", granted waiting VDisks: " << numGranted
-                    << ", active: " << Active.size()
-                    << ", waiting: " << WaitQueue.size());
+                    << ", " << BuildLogString()
+                    << ", granted waiting VDisks: " << numGranted);
                 return numGranted;
             }
 
@@ -204,9 +221,7 @@ namespace NKikimr {
 
             void Handle(TEvAcquireVDiskOperationToken::TPtr& ev) {
                 const auto vdiskServiceId = ev->Get()->VDiskServiceId;
-                const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
-                Y_UNUSED(nodeId);
-                Y_UNUSED(vslotId);
+                const ui32 pdiskId = ev->Get()->PDiskId;
                 const auto actorId = ev->Sender;
 
                 if (const auto it = Active.find(vdiskServiceId); it != Active.end()) {
@@ -214,9 +229,7 @@ namespace NKikimr {
                     if (it->second.OwnerActorId != actorId) {
                         LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvAcquireVDiskOperationToken"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << vdiskServiceId
-                            << ", PDiskId: " << pdiskId
+                            << ", " << BuildLogString(vdiskServiceId, pdiskId)
                             << ", stale active owner actor id: " << it->second.OwnerActorId
                             << ", new owner actor id: " << actorId
                             << ", action: update active owner");
@@ -226,13 +239,8 @@ namespace NKikimr {
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvAcquireVDiskOperationToken"
-                        << ", broker service id: " << this->SelfId()
-                        << ", VDisk service id: " << vdiskServiceId
-                        << ", PDiskId: " << pdiskId
-                        << ", actor id: " << actorId
-                        << ", token sent, active: " << Active.size()
-                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                        << ", waiting: " << WaitQueue.size());
+                        << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                        << ", token sent");
                     return;
                 }
 
@@ -241,9 +249,7 @@ namespace NKikimr {
                     if (it->OwnerActorId != actorId) {
                         LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvAcquireVDiskOperationToken"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << vdiskServiceId
-                            << ", PDiskId: " << pdiskId
+                            << ", " << BuildLogString(vdiskServiceId, pdiskId)
                             << ", stale waiting owner actor id: " << it->OwnerActorId
                             << ", new owner actor id: " << actorId
                             << ", action: update waiting owner");
@@ -256,25 +262,15 @@ namespace NKikimr {
 
                         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvAcquireVDiskOperationToken"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << vdiskServiceId
-                            << ", PDiskId: " << pdiskId
-                            << ", actor id: " << actorId
-                            << ", token sent from queue, active: " << Active.size()
-                            << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                            << ", waiting: " << WaitQueue.size());
+                            << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                            << ", queued request activated");
                         return;
                     }
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvAcquireVDiskOperationToken"
-                        << ", broker service id: " << this->SelfId()
-                        << ", VDisk service id: " << vdiskServiceId
-                        << ", PDiskId: " << pdiskId
-                        << ", actor id: " << actorId
-                        << ", enqueued, active: " << Active.size()
-                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                        << ", waiting: " << WaitQueue.size());
+                        << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                        << ", queued request still waiting");
                     ScheduleProcessQueueWakeup();
                     return;
                 }
@@ -285,13 +281,8 @@ namespace NKikimr {
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvAcquireVDiskOperationToken"
-                        << ", broker service id: " << this->SelfId()
-                        << ", VDisk service id: " << vdiskServiceId
-                        << ", PDiskId: " << pdiskId
-                        << ", actor id: " << actorId
-                        << ", token sent, active: " << Active.size()
-                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                        << ", waiting: " << WaitQueue.size());
+                        << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                        << ", token sent");
                     return;
                 }
 
@@ -299,21 +290,14 @@ namespace NKikimr {
 
                 LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                     "TEvAcquireVDiskOperationToken"
-                    << ", broker service id: " << this->SelfId()
-                    << ", VDisk service id: " << vdiskServiceId
-                    << ", PDiskId: " << pdiskId
-                    << ", actor id: " << actorId
-                    << ", enqueued, active: " << Active.size()
-                    << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                    << ", waiting: " << WaitQueue.size());
+                    << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                    << ", enqueued");
                 ScheduleProcessQueueWakeup();
             }
 
             void Handle(TEvReleaseVDiskOperationToken::TPtr& ev) {
                 const auto vdiskServiceId = ev->Get()->VDiskServiceId;
-                const auto [nodeId, pdiskId, vslotId] = DecomposeVDiskServiceId(vdiskServiceId);
-                Y_UNUSED(nodeId);
-                Y_UNUSED(vslotId);
+                const ui32 pdiskId = ev->Get()->PDiskId;
                 const auto actorId = ev->Sender;
 
                 if (const auto it = Active.find(vdiskServiceId); it != Active.end()) {
@@ -321,9 +305,7 @@ namespace NKikimr {
                     if (it->second.OwnerActorId != actorId) {
                         LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvReleaseVDiskOperationToken"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << vdiskServiceId
-                            << ", PDiskId: " << pdiskId
+                            << ", " << BuildLogString(vdiskServiceId, pdiskId)
                             << ", stale active owner actor id: " << actorId
                             << ", current owner actor id: " << it->second.OwnerActorId
                             << ", action: ignore stale release");
@@ -335,13 +317,8 @@ namespace NKikimr {
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvReleaseVDiskOperationToken"
-                        << ", broker service id: " << this->SelfId()
-                        << ", VDisk service id: " << vdiskServiceId
-                        << ", PDiskId: " << pdiskId
-                        << ", actor id: " << actorId
-                        << ", token released, active: " << Active.size()
-                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                        << ", waiting: " << WaitQueue.size());
+                        << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                        << ", token released");
                     return;
                 }
 
@@ -350,9 +327,7 @@ namespace NKikimr {
                     if (it->OwnerActorId != actorId) {
                         LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvReleaseVDiskOperationToken"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << vdiskServiceId
-                            << ", PDiskId: " << pdiskId
+                            << ", " << BuildLogString(vdiskServiceId, pdiskId)
                             << ", stale waiting owner actor id: " << actorId
                             << ", current queued owner actor id: " << it->OwnerActorId
                             << ", action: ignore stale release");
@@ -362,22 +337,14 @@ namespace NKikimr {
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvReleaseVDiskOperationToken"
-                        << ", broker service id: " << this->SelfId()
-                        << ", VDisk service id: " << vdiskServiceId
-                        << ", PDiskId: " << pdiskId
-                        << ", actor id: " << actorId
-                        << ", removed from queue, active: " << Active.size()
-                        << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
-                        << ", waiting: " << WaitQueue.size());
+                        << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
+                        << ", removed from queue");
                     return;
                 }
 
                 LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                     "TEvReleaseVDiskOperationToken"
-                    << ", broker service id: " << this->SelfId()
-                    << ", VDisk service id: " << vdiskServiceId
-                    << ", PDiskId: " << pdiskId
-                    << ", actor id: " << actorId
+                    << ", " << BuildLogString(vdiskServiceId, pdiskId, actorId)
                     << ", action: ignore release for unknown VDisk");
             }
 
@@ -391,9 +358,7 @@ namespace NKikimr {
                     if (it->second.OwnerActorId == actorId) {
                         LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                             "TEvUndelivered"
-                            << ", broker service id: " << this->SelfId()
-                            << ", VDisk service id: " << it->second.VDiskServiceId
-                            << ", PDiskId: " << it->second.PDiskId
+                            << ", " << BuildLogString(it->second.VDiskServiceId, it->second.PDiskId)
                             << ", owner actor id: " << actorId
                             << ", source type: " << ev->Get()->SourceType
                             << ", reason: " << ev->Get()->Reason

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.cpp
@@ -33,6 +33,7 @@ namespace NKikimr {
             std::unordered_map<ui32, ui32> ActivePerPDisk;
             std::list<TEntry> WaitQueue;
             std::unordered_map<TActorId, std::list<TEntry>::iterator> WaitingIndex;
+            bool ProcessQueueWakeupScheduled = false;
 
             static TString MakePDiskActorPageUrl(ui32 nodeId, ui32 pdiskId) {
                 return Sprintf("/node/%" PRIu32 "/actors/pdisks/pdisk%09" PRIu32, nodeId, pdiskId);
@@ -171,6 +172,13 @@ namespace NKikimr {
                 return numGranted;
             }
 
+            void ScheduleProcessQueueWakeup() {
+                if (!ProcessQueueWakeupScheduled && !WaitQueue.empty()) {
+                    this->Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+                    ProcessQueueWakeupScheduled = true;
+                }
+            }
+
         public:
             static constexpr auto ActorActivityType() {
                 return NKikimrServices::TActivity::NODE_WARDEN;
@@ -191,7 +199,7 @@ namespace NKikimr {
             {}
 
             void Bootstrap() {
-                this->Become(&TThis::StateFunc, TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+                this->Become(&TThis::StateFunc);
             }
 
             void Handle(TEvAcquireVDiskOperationToken::TPtr& ev) {
@@ -267,6 +275,7 @@ namespace NKikimr {
                         << ", enqueued, active: " << Active.size()
                         << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
                         << ", waiting: " << WaitQueue.size());
+                    ScheduleProcessQueueWakeup();
                     return;
                 }
 
@@ -297,6 +306,7 @@ namespace NKikimr {
                     << ", enqueued, active: " << Active.size()
                     << ", active on PDisk: " << GetActiveOnPDisk(pdiskId)
                     << ", waiting: " << WaitQueue.size());
+                ScheduleProcessQueueWakeup();
             }
 
             void Handle(TEvReleaseVDiskOperationToken::TPtr& ev) {
@@ -321,6 +331,7 @@ namespace NKikimr {
                     }
                     Deactivate(it);
                     ProcessQueue();
+                    ScheduleProcessQueueWakeup();
 
                     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::BS_NODE,
                         "TEvReleaseVDiskOperationToken"
@@ -389,14 +400,16 @@ namespace NKikimr {
                             << ", action: drop active token owner and process queue");
                         Deactivate(it);
                         ProcessQueue();
+                        ScheduleProcessQueueWakeup();
                         return;
                     }
                 }
             }
 
             void Handle(TEvents::TEvWakeup::TPtr&) {
+                ProcessQueueWakeupScheduled = false;
                 ProcessQueue();
-                this->Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+                ScheduleProcessQueueWakeup();
             }
 
             void Handle(NMon::TEvHttpInfo::TPtr& ev) {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ydb/core/base/blobstorage.h>
+
+namespace NKikimr {
+
+    struct TEvAcquireVDiskOperationToken
+        : public TEventLocal<TEvAcquireVDiskOperationToken, TEvBlobStorage::EvAcquireVDiskOperationToken>
+    {
+        TActorId VDiskServiceId;
+
+        explicit TEvAcquireVDiskOperationToken(const TActorId& vdiskServiceId)
+            : VDiskServiceId(vdiskServiceId)
+        {}
+    };
+
+    struct TEvVDiskOperationToken
+        : public TEventLocal<TEvVDiskOperationToken, TEvBlobStorage::EvVDiskOperationToken>
+    {};
+
+    struct TEvReleaseVDiskOperationToken
+        : public TEventLocal<TEvReleaseVDiskOperationToken, TEvBlobStorage::EvReleaseVDiskOperationToken>
+    {
+        TActorId VDiskServiceId;
+
+        explicit TEvReleaseVDiskOperationToken(const TActorId& vdiskServiceId)
+            : VDiskServiceId(vdiskServiceId)
+        {}
+    };
+
+    class TControlWrapper;
+
+    IActor* CreateVDiskOperationBrokerActor(const TControlWrapper& maxInProgressCount,
+        const TControlWrapper& maxInProgressPerPDiskCount);
+
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h
@@ -8,9 +8,11 @@ namespace NKikimr {
         : public TEventLocal<TEvAcquireVDiskOperationToken, TEvBlobStorage::EvAcquireVDiskOperationToken>
     {
         TActorId VDiskServiceId;
+        ui32 PDiskId = 0;
 
-        explicit TEvAcquireVDiskOperationToken(const TActorId& vdiskServiceId)
+        TEvAcquireVDiskOperationToken(const TActorId& vdiskServiceId, ui32 pdiskId)
             : VDiskServiceId(vdiskServiceId)
+            , PDiskId(pdiskId)
         {}
     };
 
@@ -22,9 +24,11 @@ namespace NKikimr {
         : public TEventLocal<TEvReleaseVDiskOperationToken, TEvBlobStorage::EvReleaseVDiskOperationToken>
     {
         TActorId VDiskServiceId;
+        ui32 PDiskId = 0;
 
-        explicit TEvReleaseVDiskOperationToken(const TActorId& vdiskServiceId)
+        TEvReleaseVDiskOperationToken(const TActorId& vdiskServiceId, ui32 pdiskId)
             : VDiskServiceId(vdiskServiceId)
+            , PDiskId(pdiskId)
         {}
     };
 

--- a/ydb/core/blobstorage/vdisk/common/ya.make
+++ b/ydb/core/blobstorage/vdisk/common/ya.make
@@ -54,6 +54,7 @@ SRCS(
     vdisk_mongroups.h
     vdisk_outofspace.cpp
     vdisk_outofspace.h
+    vdisk_operation_broker.cpp
     vdisk_performance_params.cpp
     vdisk_performance_params.h
     vdisk_pdisk_error.h
@@ -65,6 +66,7 @@ SRCS(
     vdisk_response.cpp
     vdisk_response.h
     vdisk_syncneighbors.h
+    vdisk_operation_broker.h
 )
 
 END()

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -756,6 +756,12 @@ namespace NKikimr {
                             ctx.SelfID.ToString().data(), yardInitDelay.SecondsFloat()));
         }
 
+        void ContinueYardInit(const TActorContext &ctx) {
+            SendYardInit(ctx, TDuration::Zero());
+            Become(&TThis::StateInitialize);
+            VDiskMonGroup.VDiskLocalRecoveryState() = TDbMon::TDbLocalRecovery::YardInit;
+        }
+
         void Bootstrap(const TActorContext &ctx) {
             LOG_NOTICE(ctx, BS_LOCALRECOVERY,
                        VDISKP(LocRecCtx->VCtx->VDiskLogPrefix, "LocalRecovery START"));
@@ -766,18 +772,14 @@ namespace NKikimr {
 
         void Handle(TEvVDiskOperationToken::TPtr&, const TActorContext& ctx) {
             Y_ABORT_UNLESS(LocalRecoveryTokenRequested);
-            SendYardInit(ctx, TDuration::Zero());
-            Become(&TThis::StateInitialize);
-            VDiskMonGroup.VDiskLocalRecoveryState() = TDbMon::TDbLocalRecovery::YardInit;
+            ContinueYardInit(ctx);
         }
 
         void HandleBrokerUndelivered(TEvents::TEvUndelivered::TPtr& ev, const TActorContext& ctx) {
             if (ev->Get()->SourceType == TEvAcquireVDiskOperationToken::EventType) {
                 // No localrecovery broker service. Continue without it.
                 LocalRecoveryTokenRequested = false;
-                SendYardInit(ctx, TDuration::Zero());
-                Become(&TThis::StateInitialize);
-                VDiskMonGroup.VDiskLocalRecoveryState() = TDbMon::TDbLocalRecovery::YardInit;
+                ContinueYardInit(ctx);
             }
         }
 

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -1,5 +1,6 @@
 #include "localrecovery_public.h"
 #include "localrecovery_logreplay.h"
+#include <ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h>
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_lsnmngr.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/recovery/hulldb_recovery.h>
@@ -80,6 +81,7 @@ namespace NKikimr {
         TVDiskIncarnationGuid VDiskIncarnationGuid;
         std::shared_ptr<TRopeArena> Arena;
         NMonGroup::TVDiskStateGroup VDiskMonGroup;
+        bool LocalRecoveryTokenRequested = false;
         bool HullLogoBlobsDBInitialized = false;
         bool HullBlocksDBInitialized = false;
         bool HullBarriersDBInitialized = false;
@@ -99,6 +101,24 @@ namespace NKikimr {
         bool DatabaseStateLoaded() const {
             return HullLogoBlobsDBInitialized && HullBlocksDBInitialized &&
             HullBarriersDBInitialized && SyncLogInitialized;
+        }
+
+        void QueryToken(const TActorContext& ctx) {
+            Y_ABORT_UNLESS(!LocalRecoveryTokenRequested);
+            ctx.Send(MakeBlobStorageLocalRecoveryBrokerID(),
+                new TEvAcquireVDiskOperationToken(MakeBlobStorageVDiskID(
+                    SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId)),
+                IEventHandle::FlagTrackDelivery);
+            LocalRecoveryTokenRequested = true;
+        }
+
+        void ReleaseToken(const TActorContext& ctx) {
+            if (LocalRecoveryTokenRequested) {
+                ctx.Send(MakeBlobStorageLocalRecoveryBrokerID(),
+                    new TEvReleaseVDiskOperationToken(MakeBlobStorageVDiskID(
+                        SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId)));
+                LocalRecoveryTokenRequested = false;
+            }
         }
 
         void SignalErrorAndDie(const TActorContext &ctx, NKikimrProto::EReplyStatus status, const TString &reason) {
@@ -130,6 +150,7 @@ namespace NKikimr {
                                                 {},
                                                 nullptr,
                                                 false));
+            ReleaseToken(ctx);
             Die(ctx);
         }
 
@@ -166,6 +187,7 @@ namespace NKikimr {
                                                               std::move(MetadataEntryPoint),
                                                               std::move(LocRecCtx->ChunkKeeperData),
                                                               HasMetadata));
+            ReleaseToken(ctx);
             Die(ctx);
         }
 
@@ -738,9 +760,25 @@ namespace NKikimr {
             LOG_NOTICE(ctx, BS_LOCALRECOVERY,
                        VDISKP(LocRecCtx->VCtx->VDiskLogPrefix, "LocalRecovery START"));
 
+            QueryToken(ctx);
+            Become(&TThis::StateAwaitToken);
+        }
+
+        void Handle(TEvVDiskOperationToken::TPtr&, const TActorContext& ctx) {
+            Y_ABORT_UNLESS(LocalRecoveryTokenRequested);
             SendYardInit(ctx, TDuration::Zero());
             Become(&TThis::StateInitialize);
             VDiskMonGroup.VDiskLocalRecoveryState() = TDbMon::TDbLocalRecovery::YardInit;
+        }
+
+        void HandleBrokerUndelivered(TEvents::TEvUndelivered::TPtr& ev, const TActorContext& ctx) {
+            if (ev->Get()->SourceType == TEvAcquireVDiskOperationToken::EventType) {
+                // No localrecovery broker service. Continue without it.
+                LocalRecoveryTokenRequested = false;
+                SendYardInit(ctx, TDuration::Zero());
+                Become(&TThis::StateInitialize);
+                VDiskMonGroup.VDiskLocalRecoveryState() = TDbMon::TDbLocalRecovery::YardInit;
+            }
         }
 
         void Handle(THullIndexLoaded::TPtr &ev, const TActorContext &ctx) {
@@ -775,6 +813,7 @@ namespace NKikimr {
 
         void HandlePoison(const TActorContext &ctx) {
             ActiveActors.KillAndClear(ctx);
+            ReleaseToken(ctx);
             Die(ctx);
         }
 
@@ -785,6 +824,13 @@ namespace NKikimr {
             ctx.Send(ev->Sender, new NMon::TEvHttpInfoRes(str.Str(), TDbMon::LocalRecovInfoId));
         }
 
+
+        STRICT_STFUNC(StateAwaitToken,
+            HFunc(TEvVDiskOperationToken, Handle)
+            HFunc(TEvents::TEvUndelivered, HandleBrokerUndelivered)
+            CFunc(NActors::TEvents::TSystem::PoisonPill, HandlePoison)
+            HFunc(NMon::TEvHttpInfo, Handle)
+        )
 
         STRICT_STFUNC(StateInitialize,
             HFunc(NPDisk::TEvYardInitResult, Handle)

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -107,7 +107,8 @@ namespace NKikimr {
             Y_ABORT_UNLESS(!LocalRecoveryTokenRequested);
             ctx.Send(MakeBlobStorageLocalRecoveryBrokerID(),
                 new TEvAcquireVDiskOperationToken(MakeBlobStorageVDiskID(
-                    SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId)),
+                    SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId),
+                    Config->BaseInfo.PDiskId),
                 IEventHandle::FlagTrackDelivery);
             LocalRecoveryTokenRequested = true;
         }
@@ -116,7 +117,8 @@ namespace NKikimr {
             if (LocalRecoveryTokenRequested) {
                 ctx.Send(MakeBlobStorageLocalRecoveryBrokerID(),
                     new TEvReleaseVDiskOperationToken(MakeBlobStorageVDiskID(
-                        SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId)));
+                        SkeletonId.NodeId(), Config->BaseInfo.PDiskId, Config->BaseInfo.VDiskSlotId),
+                        Config->BaseInfo.PDiskId));
                 LocalRecoveryTokenRequested = false;
             }
         }
@@ -778,6 +780,8 @@ namespace NKikimr {
         void HandleBrokerUndelivered(TEvents::TEvUndelivered::TPtr& ev, const TActorContext& ctx) {
             if (ev->Get()->SourceType == TEvAcquireVDiskOperationToken::EventType) {
                 // No localrecovery broker service. Continue without it.
+                LOG_WARN(ctx, BS_LOCALRECOVERY,
+                    VDISKP(LocRecCtx->VCtx->VDiskLogPrefix, "LocalRecovery broker is not available, continuing without it"));
                 LocalRecoveryTokenRequested = false;
                 ContinueYardInit(ctx);
             }

--- a/ydb/core/blobstorage/vdisk/localrecovery/ya.make
+++ b/ydb/core/blobstorage/vdisk/localrecovery/ya.make
@@ -3,7 +3,9 @@ LIBRARY()
 PEERDIR(
     ydb/core/base
     ydb/core/blobstorage/pdisk
+    ydb/core/blobstorage/vdisk/common
     ydb/core/blobstorage/vdisk/hulldb
+    ydb/core/control
     ydb/core/protos
 )
 

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
@@ -204,7 +204,7 @@ namespace NKikimr {
         void QueryStartupDataSyncToken(const TActorContext& ctx) {
             Y_ABORT_UNLESS(!StartupDataSyncTokenRequested);
             ctx.Send(MakeBlobStorageStartupDataSyncBrokerID(),
-                new TEvAcquireVDiskOperationToken(GetVDiskServiceId()),
+                new TEvAcquireVDiskOperationToken(GetVDiskServiceId(), SyncerCtx->Config->BaseInfo.PDiskId),
                 IEventHandle::FlagTrackDelivery);
             StartupDataSyncTokenRequested = true;
         }
@@ -212,7 +212,7 @@ namespace NKikimr {
         void ReleaseStartupDataSyncToken(const TActorContext& ctx) {
             if (StartupDataSyncTokenRequested) {
                 ctx.Send(MakeBlobStorageStartupDataSyncBrokerID(),
-                    new TEvReleaseVDiskOperationToken(GetVDiskServiceId()));
+                    new TEvReleaseVDiskOperationToken(GetVDiskServiceId(), SyncerCtx->Config->BaseInfo.PDiskId));
                 StartupDataSyncTokenRequested = false;
             }
         }
@@ -402,6 +402,8 @@ namespace NKikimr {
         void HandleStartupDataSyncBrokerUndelivered(TEvents::TEvUndelivered::TPtr& ev, const TActorContext& ctx) {
             if (ev->Get()->SourceType == TEvAcquireVDiskOperationToken::EventType) {
                 // No startup data sync broker service. Continue without it.
+                LOG_WARN(ctx, BS_SYNCER,
+                    VDISKP(SyncerCtx->VCtx->VDiskLogPrefix, "Startup data sync broker is not available, continuing without it"));
                 StartupDataSyncTokenRequested = false;
                 Become(&TThis::StandardModeStateFunc);
                 StartScheduler(ctx);

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/blobstorage/base/html.h>
 #include <ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h>
 #include <ydb/core/blobstorage/vdisk/common/blobstorage_status.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_operation_broker.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_public_events.h>
 
@@ -174,6 +175,7 @@ namespace NKikimr {
         TActorId GuidRecoveryId;
         TActorId RecoverLostDataId;
         TVector<TActorId> PropagatorIds;
+        bool StartupDataSyncTokenRequested = false;
         EPhase Phase = TPhaseVal::PhaseNone;
         TActiveActors ActiveActors;
         std::unique_ptr<NSyncer::TOutcome> GuidRecovOutcome;
@@ -190,6 +192,38 @@ namespace NKikimr {
             ActiveActors.Insert(CommitterId, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
             // Sync VDisk Guid
             SyncGuid(ctx);
+        }
+
+        TActorId GetVDiskServiceId() const {
+            return MakeBlobStorageVDiskID(
+                SyncerCtx->VCtx->NodeId,
+                SyncerCtx->Config->BaseInfo.PDiskId,
+                SyncerCtx->Config->BaseInfo.VDiskSlotId);
+        }
+
+        void QueryStartupDataSyncToken(const TActorContext& ctx) {
+            Y_ABORT_UNLESS(!StartupDataSyncTokenRequested);
+            ctx.Send(MakeBlobStorageStartupDataSyncBrokerID(),
+                new TEvAcquireVDiskOperationToken(GetVDiskServiceId()),
+                IEventHandle::FlagTrackDelivery);
+            StartupDataSyncTokenRequested = true;
+        }
+
+        void ReleaseStartupDataSyncToken(const TActorContext& ctx) {
+            if (StartupDataSyncTokenRequested) {
+                ctx.Send(MakeBlobStorageStartupDataSyncBrokerID(),
+                    new TEvReleaseVDiskOperationToken(GetVDiskServiceId()));
+                StartupDataSyncTokenRequested = false;
+            }
+        }
+
+        void StartScheduler(const TActorContext& ctx) {
+            Y_ABORT_UNLESS(!SchedulerId);
+            LOG_DEBUG(ctx, BS_SYNCER,
+                VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
+                    "%s: Creating syncer scheduler on node %d", __PRETTY_FUNCTION__, SelfId().NodeId()));
+            SchedulerId = ctx.Register(CreateSyncerSchedulerActor(SyncerCtx, GInfo, SyncerData, CommitterId, SelfId()));
+            ActiveActors.Insert(SchedulerId, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -347,24 +381,55 @@ namespace NKikimr {
             ctx.Send(SyncerData->NotifyId,
                      new TEvSyncGuidRecoveryDone(NKikimrProto::OK, LocalSyncerState.DbBirthLsn));
             SyncerData->Neighbors->DbBirthLsn = LocalSyncerState.DbBirthLsn;
-            Become(&TThis::StandardModeStateFunc);
+            Phase = TPhaseVal::PhaseStandardMode;
             if (!SyncerCtx->Config->BaseInfo.ReadOnly) {
-                LOG_DEBUG(ctx, BS_SYNCER,
-                    VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
-                        "%s: Creating syncer scheduler on node %d", __PRETTY_FUNCTION__, SelfId().NodeId()));
-                SchedulerId = ctx.Register(CreateSyncerSchedulerActor(SyncerCtx, GInfo, SyncerData, CommitterId));
-                ActiveActors.Insert(SchedulerId, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
+                Become(&TThis::AwaitStartupDataSyncTokenStateFunc);
+                QueryStartupDataSyncToken(ctx);
             } else {
+                Become(&TThis::StandardModeStateFunc);
                 LOG_WARN(ctx, BS_SYNCER,
                     VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
                         "%s: Skipping scheduler start due to read-only", __PRETTY_FUNCTION__));
             }
-            Phase = TPhaseVal::PhaseStandardMode;
         }
+
+        void Handle(TEvVDiskOperationToken::TPtr&, const TActorContext& ctx) {
+            Y_ABORT_UNLESS(StartupDataSyncTokenRequested);
+            Become(&TThis::StandardModeStateFunc);
+            StartScheduler(ctx);
+        }
+
+        void HandleStartupDataSyncBrokerUndelivered(TEvents::TEvUndelivered::TPtr& ev, const TActorContext& ctx) {
+            if (ev->Get()->SourceType == TEvAcquireVDiskOperationToken::EventType) {
+                // No startup data sync broker service. Continue without it.
+                StartupDataSyncTokenRequested = false;
+                Become(&TThis::StandardModeStateFunc);
+                StartScheduler(ctx);
+            }
+        }
+
+        void Handle(TEvStartupDataSyncDone::TPtr&, const TActorContext& ctx) {
+            ReleaseStartupDataSyncToken(ctx);
+        }
+
+        STRICT_STFUNC(AwaitStartupDataSyncTokenStateFunc,
+            HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
+            HFunc(TEvSyncerCommitDone, Handle)
+            HFunc(TEvVDiskOperationToken, Handle)
+            HFunc(TEvents::TEvUndelivered, HandleStartupDataSyncBrokerUndelivered)
+            HFunc(NMon::TEvHttpInfo, Handle)
+            HFunc(TEvLocalStatus, Handle)
+            HFunc(NPDisk::TEvCutLog, Handle)
+            HFunc(TEvents::TEvGone, Handle)
+            HFunc(TEvents::TEvPoisonPill, HandlePoison)
+            HFunc(TEvSublogLine, Handle)
+            HFunc(TEvVGenerationChange, ReadyModeHandle)
+        )
 
         STRICT_STFUNC(StandardModeStateFunc,
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
+            HFunc(TEvStartupDataSyncDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -516,13 +581,18 @@ namespace NKikimr {
 
         // This handler is called when TSyncerHttpInfoActor is finished
         void Handle(TEvents::TEvGone::TPtr &ev, const TActorContext &ctx) {
-            Y_UNUSED(ctx);
             ActiveActors.Erase(ev->Sender);
+            if (ev->Sender == SchedulerId) {
+                SchedulerId = TActorId();
+                // If scheduler is gone, we should release startup data sync token to avoid being stuck.
+                ReleaseStartupDataSyncToken(ctx);
+            }
         }
 
         void HandlePoison(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx) {
             Y_UNUSED(ev);
             ActiveActors.KillAndClear(ctx);
+            ReleaseStartupDataSyncToken(ctx);
             Die(ctx);
         }
 

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
@@ -192,7 +192,6 @@ namespace NKikimr {
         {}
     };
 
-
     ////////////////////////////////////////////////////////////////////////////
     // TSyncerScheduler
     ////////////////////////////////////////////////////////////////////////////
@@ -222,7 +221,10 @@ namespace NKikimr {
         TActiveActors ActiveActors;
         const TDuration SyncTimeInterval;
         TActorId CommitterId;
+        TActorId NotifyId;
         bool Scheduled;
+        THashSet<ui32> StartupDataSyncPeers;
+        bool StartupDataSyncDoneReported = false;
         std::shared_ptr<TSjCtx> JobCtx;
 
         bool FullSyncGatherMode = false;
@@ -243,6 +245,12 @@ namespace NKikimr {
                 public TEventLocal<TEvFullSyncGatherTimeout, EvFullSyncGatherTimeout> {};
         };
 
+        void ReportStartupDataSyncDone(const TActorContext& ctx) {
+            if (!StartupDataSyncDoneReported) {
+                StartupDataSyncDoneReported = true;
+                ctx.Send(NotifyId, new TEvStartupDataSyncDone);
+            }
+        }
 
         void ActualizeUnsyncedDisksNum() {
             unsigned unsyncedDisks = 0;
@@ -262,8 +270,11 @@ namespace NKikimr {
                 if (!x.Myself) {
                     Y_DEBUG_ABORT_UNLESS(x.Get().PeerSyncState.LastSyncStatus != TSyncStatusVal::Running);
                     SchedulerQueue.push(&x);
+                    StartupDataSyncPeers.insert(x.OrderNumber);
                 }
             }
+
+            ActualizeUnsyncedDisksNum();
 
             // if we haven't found any neighbors to sync with, notify skeleton
             if (SchedulerQueue.empty()) {
@@ -271,6 +282,10 @@ namespace NKikimr {
             } else {
                 // start sync immediately
                 Schedule(ctx);
+            }
+
+            if (StartupDataSyncPeers.empty()) {
+                ReportStartupDataSyncDone(ctx);
             }
         }
 
@@ -300,6 +315,10 @@ namespace NKikimr {
             auto interval = fullRecovery ? TDuration::Seconds(0) : SyncTimeInterval;
             SyncerData->Neighbors->ApplyChanges(vDiskId, peerSyncState, interval);
             ActualizeUnsyncedDisksNum();
+            const ui32 orderNumber = GInfo->GetOrderNumber(task.VDiskId);
+            if (StartupDataSyncPeers.erase(orderNumber) && StartupDataSyncPeers.empty()) {
+                ReportStartupDataSyncDone(ctx);
+            }
             SchedulerQueue.push(&(*SyncerData->Neighbors)[vDiskId]);
             Schedule(ctx);
         }
@@ -527,7 +546,8 @@ namespace NKikimr {
         TSyncerScheduler(const TIntrusivePtr<TSyncerContext> &sc,
                          const TIntrusivePtr<TBlobStorageGroupInfo> &info,
                          const TIntrusivePtr<TSyncerData> &syncerData,
-                         const TActorId &committerId)
+                         const TActorId &committerId,
+                         const TActorId &notifyId)
             : TActorBootstrapped<TSyncerScheduler>()
             , SyncerContext(sc)
             , GInfo(info)
@@ -536,6 +556,7 @@ namespace NKikimr {
             , ActiveActors()
             , SyncTimeInterval(SyncerContext->Config->SyncTimeInterval)
             , CommitterId(committerId)
+            , NotifyId(notifyId)
             , Scheduled(false)
             , JobCtx(TSjCtx::Create(SyncerContext, GInfo))
         {}
@@ -548,8 +569,9 @@ namespace NKikimr {
     IActor* CreateSyncerSchedulerActor(const TIntrusivePtr<TSyncerContext> &sc,
                                        const TIntrusivePtr<TBlobStorageGroupInfo> &info,
                                        const TIntrusivePtr<TSyncerData> &syncerData,
-                                       const TActorId &committerId) {
-        return new TSyncerScheduler(sc, info, syncerData, committerId);
+                                       const TActorId &committerId,
+                                       const TActorId &notifyId) {
+        return new TSyncerScheduler(sc, info, syncerData, committerId, notifyId);
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
@@ -315,7 +315,7 @@ namespace NKikimr {
             auto interval = fullRecovery ? TDuration::Seconds(0) : SyncTimeInterval;
             SyncerData->Neighbors->ApplyChanges(vDiskId, peerSyncState, interval);
             ActualizeUnsyncedDisksNum();
-            const ui32 orderNumber = GInfo->GetOrderNumber(task.VDiskId);
+            const ui32 orderNumber = GInfo->GetOrderNumber(vDiskId);
             if (StartupDataSyncPeers.erase(orderNumber) && StartupDataSyncPeers.empty()) {
                 ReportStartupDataSyncDone(ctx);
             }

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.cpp
@@ -315,7 +315,7 @@ namespace NKikimr {
             auto interval = fullRecovery ? TDuration::Seconds(0) : SyncTimeInterval;
             SyncerData->Neighbors->ApplyChanges(vDiskId, peerSyncState, interval);
             ActualizeUnsyncedDisksNum();
-            const ui32 orderNumber = GInfo->GetOrderNumber(vDiskId);
+            const ui32 orderNumber = GInfo->GetOrderNumber(TVDiskIdShort(vDiskId));
             if (StartupDataSyncPeers.erase(orderNumber) && StartupDataSyncPeers.empty()) {
                 ReportStartupDataSyncDone(ctx);
             }

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.h
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_scheduler.h
@@ -2,7 +2,16 @@
 
 #include "defs.h"
 
+#include <ydb/core/base/blobstorage.h>
+
 namespace NKikimr {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TEvStartupDataSyncDone
+    ////////////////////////////////////////////////////////////////////////////
+    struct TEvStartupDataSyncDone
+        : public TEventLocal<TEvStartupDataSyncDone, TEvBlobStorage::EvStartupDataSyncDone>
+    {};
 
     ////////////////////////////////////////////////////////////////////////////
     // SYNCER ACTOR CREATOR
@@ -13,6 +22,7 @@ namespace NKikimr {
     IActor* CreateSyncerSchedulerActor(const TIntrusivePtr<TSyncerContext> &sc,
                                        const TIntrusivePtr<TBlobStorageGroupInfo> &info,
                                        const TIntrusivePtr<TSyncerData> &syncerData,
-                                       const TActorId &committerId);
+                                       const TActorId &committerId,
+                                       const TActorId &notifyId);
 
 } // NKikimr

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1867,6 +1867,30 @@ message TImmediateControlsConfig {
             MaxValue: 1,
             DefaultValue: 0,
         }];
+
+        optional uint64 MaxInProgressStartupDataSyncCount = 43 [(ControlOptions) = {
+            Description: "Maximum number of simultaneous startup data sync processes; 0 means no limit",
+            MinValue: 0,
+            MaxValue: 10000,
+            DefaultValue: 0 }];
+
+        optional uint64 MaxInProgressStartupDataSyncPerPDiskCount = 44 [(ControlOptions) = {
+            Description: "Maximum number of simultaneous startup data sync processes per PDisk; 0 means no limit",
+            MinValue: 0,
+            MaxValue: 10000,
+            DefaultValue: 0 }];
+
+        optional uint64 MaxInProgressLocalRecoveryCount = 45 [(ControlOptions) = {
+            Description: "Maximum number of simultaneous local recovery processes; 0 means no limit",
+            MinValue: 0,
+            MaxValue: 10000,
+            DefaultValue: 0 }];
+
+        optional uint64 MaxInProgressLocalRecoveryPerPDiskCount = 46 [(ControlOptions) = {
+            Description: "Maximum number of simultaneous local recovery processes per PDisk; 0 means no limit",
+            MinValue: 0,
+            MaxValue: 10000,
+            DefaultValue: 0 }];
     }
 
     message TTabletControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added VDisk operation brokers to throttle local recovery and startup data sync by node and by PDisk, with new immediate controls and monitoring pages. 


### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
