### PR TITLE
Fix columnshard's errors for export pipeline

### DIFF
--- a/ydb/core/tx/columnshard/backup/iscan/iscan.cpp
+++ b/ydb/core/tx/columnshard/backup/iscan/iscan.cpp
@@ -151,7 +151,9 @@ public:
     void Fail(const TString& errorMessage) {
         AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("component", "TUploaderActor")("error", errorMessage);
         Send(SubscriberActorId, new TEvPrivate::TEvBackupExportError(errorMessage));
-        Exporter->Finish(NTable::EStatus::Done);
+        if (Exporter) {
+            Exporter->Finish(NTable::EStatus::Done);
+        }
         PassAway();
     }
 

--- a/ydb/core/tx/columnshard/export/actor/export_actor.cpp
+++ b/ydb/core/tx/columnshard/export/actor/export_actor.cpp
@@ -145,7 +145,7 @@ public:
 };
 
 void TActor::OnSessionStateSaved() {
-    AFL_VERIFY(ExportSession->IsFinished() || ErrorMessage);
+    AFL_VERIFY(ExportSession->IsFinished() || ExportSession->IsAborted());
     NYDBTest::TControllers::GetColumnShardController()->OnExportFinished();
     if (ExportSession->GetTxId()) {
         ExecuteTransaction(std::make_unique<TTxProposeFinish>(GetShardVerified<NColumnShard::TColumnShard>(), *ExportSession->GetTxId()));

--- a/ydb/core/tx/columnshard/export/actor/export_actor.cpp
+++ b/ydb/core/tx/columnshard/export/actor/export_actor.cpp
@@ -9,6 +9,15 @@ void TActor::SwitchStage(const EStage from, const EStage to) {
     Stage = to;
 }
 
+void TActor::AbortExport(const TString& errorMessage) {
+    ErrorMessage = errorMessage;
+    AFL_VERIFY(!ExportSession->GetCursor().IsFinished());
+    ExportSession->MutableCursor().InitNext({}, true);
+    Stage = EStage::WaitSaveCursor;
+    Become(&TActor::StateError);
+    SaveSessionProgress();
+}
+
 void TActor::HandleExecute(NKqp::TEvKqpCompute::TEvScanInitActor::TPtr& ev) {
     SwitchStage(EStage::Initialization, EStage::WaitData);
     AFL_VERIFY(!ScanActorId);
@@ -83,11 +92,7 @@ void TActor::HandleExecute(NKqp::TEvKqpCompute::TEvScanData::TPtr& ev) {
 }
 
 void TActor::HandleExecute(NColumnShard::TEvPrivate::TEvBackupExportError::TPtr& ev) {
-    ErrorMessage = ev->Get()->ErrorMessage;
-    TOwnedCellVec lastKey;
-    AFL_VERIFY(!ExportSession->GetCursor().IsFinished());
-    ExportSession->MutableCursor().InitNext(lastKey, true);
-    SaveSessionProgress();
+    AbortExport(ev->Get()->ErrorMessage);
 }
 
 std::unique_ptr<NKikimr::TEvDataShard::TEvKqpScan> TActor::BuildRequestInitiator(const TCursor& cursor) const {
@@ -140,7 +145,7 @@ public:
 };
 
 void TActor::OnSessionStateSaved() {
-    AFL_VERIFY(ExportSession->IsFinished());
+    AFL_VERIFY(ExportSession->IsFinished() || ErrorMessage);
     NYDBTest::TControllers::GetColumnShardController()->OnExportFinished();
     if (ExportSession->GetTxId()) {
         ExecuteTransaction(std::make_unique<TTxProposeFinish>(GetShardVerified<NColumnShard::TColumnShard>(), *ExportSession->GetTxId()));

--- a/ydb/core/tx/columnshard/export/actor/export_actor.h
+++ b/ydb/core/tx/columnshard/export/actor/export_actor.h
@@ -34,6 +34,8 @@ private:
     static inline const ui64 FreeSpace = ((ui64)8) << 20;
     void SwitchStage(const EStage from, const EStage to);
 
+    void AbortExport(const TString& errorMessage);
+
 protected:
     void HandleExecute(NKqp::TEvKqpCompute::TEvScanInitActor::TPtr& ev);
 
@@ -71,6 +73,18 @@ public:
             }
         } catch (...) {
             AFL_VERIFY(false);
+        }
+    }
+
+    STATEFN(StateError) {
+        const NActors::TLogContextGuard gLogging =
+            NActors::TLogContextBuilder::Build(NKikimrServices::TX_BACKGROUND)("SelfId", SelfId())("TabletId", TabletId);
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NBackground::TEvLocalTransactionCompleted, Handle);
+            hFunc(NBackground::TEvSessionControl, Handle);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
+            default:
+                break;
         }
     }
 };

--- a/ydb/core/tx/columnshard/export/session/session.cpp
+++ b/ydb/core/tx/columnshard/export/session/session.cpp
@@ -29,6 +29,10 @@ bool TSession::IsStarted() const {
     return Status == EStatus::Started;
 }
 
+bool TSession::IsAborted() const {
+    return Status == EStatus::Aborted;
+}
+
 void TSession::Abort(const TString &errorMessage) {
     AFL_VERIFY(Status != EStatus::Finished && Status != EStatus::Aborted);
     Status = EStatus::Aborted;

--- a/ydb/core/tx/columnshard/export/session/session.h
+++ b/ydb/core/tx/columnshard/export/session/session.h
@@ -76,6 +76,7 @@ public:
     void Abort(const TString &errorMessage);
 
     bool IsStarted() const;
+    bool IsAborted() const;
 
     const TExportTask &GetTask() const;
 

--- a/ydb/core/tx/schemeshard/ut_export/ut_export_fs.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export_fs.cpp
@@ -715,4 +715,42 @@ Y_UNIT_TEST_SUITE(TSchemeShardExportToFsTests) {
         UNIT_ASSERT(FileExists(MakeExportPath(basePath, "backup/Table", "scheme.pb")));
         UNIT_ASSERT(FileExists(MakeExportPath(basePath, "backup/Table/index/indexImplTable", "scheme.pb")));
     }
+
+    Y_UNIT_TEST(ShouldFailOnColumnTableExportToFs) {
+        TTempDir tempDir;
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+        runtime.GetAppData().FeatureFlags.SetEnableFsBackups(true);
+        runtime.GetAppData().FeatureFlags.SetEnableColumnTablesBackup(true);
+
+        TestCreateColumnTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "ColumnTable"
+            ColumnShardCount: 1
+            Schema {
+                Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: "timestamp"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TString basePath = tempDir.Path();
+        TString requestStr = Sprintf(R"(
+            ExportToFsSettings {
+              base_path: "%s"
+              items {
+                source_path: "/MyRoot/ColumnTable"
+                destination_path: "backup/ColumnTable"
+              }
+            }
+        )", basePath.c_str());
+
+        TestExport(runtime, ++txId, "/MyRoot", requestStr);
+        env.TestWaitNotification(runtime, txId);
+
+        auto desc = TestGetExport(runtime, txId, "/MyRoot", Ydb::StatusIds::CANCELLED);
+        const auto& entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Export::ExportProgress::PROGRESS_CANCELLED);
+    }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Как проявляется ошибка на примере вызова export в nfs:

1. `CreateIScanExportUploader()` вызывает ошибку:
```
case NKikimrSchemeOp::TBackupTask::kFSSettings:
            return TConclusionStatus::Fail("Exports to FS are not supported");
```

2. `TUploaderActor::Fail()`
3. KQP-скан шлёт `TEvScanInitActor` в `ExportActor`
4. ExportActor::HandleExecute(TEvBackupExportError)
5. SaveSessionProgress();
6. OnSessionProgressSaved()
7. SwitchStage(EStage::WaitSaveCursor, EStage::WaitData);
8. AFL_VERIFY(Stage == from)  // from=WaitSaveCursor, Stage=WaitData => FAIL
