### PR TITLE
external_sources: require database_name or database_id for Ydb source

### DIFF
--- a/ydb/core/external_sources/external_data_source.cpp
+++ b/ydb/core/external_sources/external_data_source.cpp
@@ -69,7 +69,9 @@ struct TExternalDataSource : public IExternalSource {
         // opaque error far from the CREATE statement.
         if (proto.GetSourceType() == ToString(NYql::EDatabaseType::Ydb)) {
             const auto& props = proto.GetProperties().GetProperties();
-            if (!props.contains("database_name") && !props.contains("database_id")) {
+            const bool hasDatabaseName = props.contains("database_name") && !props.at("database_name").empty();
+            const bool hasDatabaseId = props.contains("database_id") && !props.at("database_id").empty();
+            if (!hasDatabaseName && !hasDatabaseId) {
                 throw TExternalSourceException()
                     << proto.GetSourceType() << " source must provide database_name or database_id";
             }

--- a/ydb/core/external_sources/external_data_source.cpp
+++ b/ydb/core/external_sources/external_data_source.cpp
@@ -63,6 +63,18 @@ struct TExternalDataSource : public IExternalSource {
             throw TExternalSourceException() << proto.GetSourceType() << " source must provide service_name";
         }
 
+        // Ydb source needs at least one of database_name or database_id;
+        // otherwise downstream consumers (e.g. PQ provider for streaming queries)
+        // silently default the database to empty and fail at query time with an
+        // opaque error far from the CREATE statement.
+        if (proto.GetSourceType() == ToString(NYql::EDatabaseType::Ydb)) {
+            const auto& props = proto.GetProperties().GetProperties();
+            if (!props.contains("database_name") && !props.contains("database_id")) {
+                throw TExternalSourceException()
+                    << proto.GetSourceType() << " source must provide database_name or database_id";
+            }
+        }
+
         if (proto.GetSourceType() == ToString(NYql::EDatabaseType::YdbTopics)) {
             throw TExternalSourceException() << "External source with type " << proto.GetSourceType() << " is not allowed, use " << ToString(NYql::EDatabaseType::Ydb)  << " source type to read from topics ";
         }

--- a/ydb/core/external_sources/external_data_source.cpp
+++ b/ydb/core/external_sources/external_data_source.cpp
@@ -63,17 +63,14 @@ struct TExternalDataSource : public IExternalSource {
             throw TExternalSourceException() << proto.GetSourceType() << " source must provide service_name";
         }
 
-        // Ydb source needs at least one of database_name or database_id;
-        // otherwise downstream consumers (e.g. PQ provider for streaming queries)
-        // silently default the database to empty and fail at query time with an
-        // opaque error far from the CREATE statement.
+        // Ydb source requires at least one non-empty database_name or database_id.
         if (proto.GetSourceType() == ToString(NYql::EDatabaseType::Ydb)) {
             const auto& props = proto.GetProperties().GetProperties();
             const bool hasDatabaseName = props.contains("database_name") && !props.at("database_name").empty();
             const bool hasDatabaseId = props.contains("database_id") && !props.at("database_id").empty();
             if (!hasDatabaseName && !hasDatabaseId) {
                 throw TExternalSourceException()
-                    << proto.GetSourceType() << " source must provide database_name or database_id";
+                    << proto.GetSourceType() << " source must provide a non-empty database_name or database_id";
             }
         }
 

--- a/ydb/core/external_sources/external_data_source_ut.cpp
+++ b/ydb/core/external_sources/external_data_source_ut.cpp
@@ -57,6 +57,32 @@ Y_UNIT_TEST_SUITE(ExternalDataSourceTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(source->ValidateExternalDataSource(proto.SerializeAsString()), NExternalSource::TExternalSourceException, "Unsupported property: another_property");
     }
 
+    Y_UNIT_TEST(ValidateYdbSourceRequiresDatabase) {
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        proto.SetSourceType("Ydb");
+
+        auto source = NExternalSource::CreateExternalDataSource(
+            "Ydb",
+            {"NONE", "BASIC", "SERVICE_ACCOUNT", "TOKEN", "IAM"},
+            {"database_name", "use_tls", "database_id", "shared_reading"},
+            {});
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()),
+            NExternalSource::TExternalSourceException,
+            "Ydb source must provide database_name or database_id");
+
+        proto.MutableProperties()->MutableProperties()->insert({"database_name", "/local"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"database_id", "etn0123456789"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        proto.MutableProperties()->MutableProperties()->insert({"database_name", "/local"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+    }
+
     Y_UNIT_TEST(ValidateLocation) {
         NKikimrSchemeOp::TExternalDataSourceDescription proto;
         auto source = CreateTestSource();

--- a/ydb/core/external_sources/external_data_source_ut.cpp
+++ b/ydb/core/external_sources/external_data_source_ut.cpp
@@ -70,8 +70,22 @@ Y_UNIT_TEST_SUITE(ExternalDataSourceTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             source->ValidateExternalDataSource(proto.SerializeAsString()),
             NExternalSource::TExternalSourceException,
-            "Ydb source must provide database_name or database_id");
+            "Ydb source must provide a non-empty database_name or database_id");
 
+        proto.MutableProperties()->MutableProperties()->insert({"database_name", ""});
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()),
+            NExternalSource::TExternalSourceException,
+            "Ydb source must provide a non-empty database_name or database_id");
+
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"database_id", ""});
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()),
+            NExternalSource::TExternalSourceException,
+            "Ydb source must provide a non-empty database_name or database_id");
+
+        proto.MutableProperties()->MutableProperties()->clear();
         proto.MutableProperties()->MutableProperties()->insert({"database_name", "/local"});
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

CREATE EXTERNAL DATA SOURCE ... SOURCE_TYPE='Ydb' previously accepted a source with neither DATABASE_NAME nor DATABASE_ID. The PQ provider (yql_pq_datasource.cpp:314) then silently defaulted the database to "", and streaming queries reading the source failed at run time with an opaque error far from the originating CREATE statement.

Validate at create time that at least one of database_name or database_id is set, mirroring the existing pattern for Oracle's service_name. database_id is preserved as an alternative so that managed clusters can keep relying on the DB resolver service to populate the endpoint/database from a database id alone.

Add a unit test covering the four cases (neither / database_name only / database_id only / both).
