### PR TITLE
[CBO] Reapply ReverseBlockJoin support to KQP CBO fork

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_dphyp_solver.h
@@ -749,11 +749,20 @@ template <typename TNodeSet> TBestJoin TDPHypSolverShuffleElimination<TNodeSet>:
     }
 
     if (shuffleLeftSide || shuffleRightSide) { // we don't have rules to put shuffles into not grace join yet.
+        auto joinAlgo = EJoinAlgoType::GraceJoin;
         auto stats = this->Pctx_.ComputeJoinStatsV2(left->Stats, right->Stats, edge.LeftJoinKeys, edge.RightJoinKeys, EJoinAlgoType::GraceJoin, edge.JoinKind, maybeCardHint, shuffleLeftSide, shuffleRightSide, maybeBytesHint);
+        if (this->Pctx_.IsJoinApplicable(left, right, edge.LeftJoinKeys, edge.RightJoinKeys, EJoinAlgoType::ReverseBlockJoin, edge.JoinKind)) {
+            auto revStats = this->Pctx_.ComputeJoinStatsV2(left->Stats, right->Stats, edge.LeftJoinKeys, edge.RightJoinKeys, EJoinAlgoType::ReverseBlockJoin, edge.JoinKind, maybeCardHint, shuffleLeftSide, shuffleRightSide, maybeBytesHint);
+            if (revStats.Cost < stats.Cost) {
+                stats = revStats;
+                joinAlgo = EJoinAlgoType::ReverseBlockJoin;
+            }
+        }
+
         if (!edge.IsCommutative) {
             return TBestJoin {
                 .Stats = std::move(stats),
-                .Algo = EJoinAlgoType::GraceJoin,
+                .Algo = joinAlgo,
                 .IsReversed = false
             };
         }

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_cost_based.cpp
@@ -468,7 +468,9 @@ private:
 
         joinNode->Stats.LogicalOrderings = fsm.CreateState();
         switch (joinNode->JoinAlgo) {
-            case EJoinAlgoType::GraceJoin: {
+            case EJoinAlgoType::GraceJoin:
+            case EJoinAlgoType::ReverseBlockJoin:
+            {
                 /* look at dphyp shuffle elimination EmitCsgCmp function. it has the same logic. */
 
                 bool lhsShuffled =

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_join_tree_node.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<TJoinOptimizerNode> ConvertFromInternal(
             return {}; // SE — do not shuffle.
         }
 
-        if (join->JoinAlgo != EJoinAlgoType::GraceJoin) {
+        if (join->JoinAlgo != EJoinAlgoType::GraceJoin && join->JoinAlgo != EJoinAlgoType::ReverseBlockJoin) {
             return {};
         }
 

--- a/ydb/core/kqp/opt/cbo/solver/ut/kqp_cbo_ut.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/ut/kqp_cbo_ut.cpp
@@ -271,6 +271,47 @@ Y_UNIT_TEST(JoinSearchYT24403) {
     }
 }
 
+Y_UNIT_TEST(ReverseBlockJoinHint) {
+    TBaseProviderContext pctx;
+    NYql::TExprContext dummyCtx;
+    auto orderings = MakeSimpleShared<TOrderingsStateMachine>();
+    std::unique_ptr<IOptimizerNew> optimizer = std::unique_ptr<IOptimizerNew>(
+        MakeNativeOptimizerNew(pctx, TCBOSettings{}, dummyCtx, true, orderings)
+    );
+
+    auto left = std::make_shared<TRelOptimizerNode>(
+        "left",
+        TOptimizerStatistics(BaseTable, 1000, 1, 0, 1000)
+    );
+    auto right = std::make_shared<TRelOptimizerNode>(
+        "right",
+        TOptimizerStatistics(BaseTable, 10, 1, 0, 10)
+    );
+    auto input = std::make_shared<TJoinOptimizerNode>(
+        std::static_pointer_cast<IBaseOptimizerNode>(left),
+        std::static_pointer_cast<IBaseOptimizerNode>(right),
+        TVector<TJoinColumn>{TJoinColumn("left", "key")},
+        TVector<TJoinColumn>{TJoinColumn("right", "key")},
+        EJoinKind::LeftJoin,
+        EJoinAlgoType::Undefined,
+        false,
+        false
+    );
+
+    TOptimizerHints hints;
+    hints.JoinAlgoHints->PushBack({"left", "right"}, EJoinAlgoType::ReverseBlockJoin, "ReverseBlockJoin(left right)");
+
+    auto join = optimizer->JoinSearch(input, hints);
+
+    UNIT_ASSERT_VALUES_EQUAL(join->JoinAlgo, EJoinAlgoType::ReverseBlockJoin);
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleLeftSideBy.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleRightSideBy.size(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleLeftSideBy[0].RelName, "left");
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleLeftSideBy[0].AttributeName, "key");
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleRightSideBy[0].RelName, "right");
+    UNIT_ASSERT_VALUES_EQUAL(join->ShuffleRightSideBy[0].AttributeName, "key");
+}
+
 Y_UNIT_TEST(DqPhyMapJoinStatsUsesMapJoinAlgo) {
     TMockProviderContextYT24403 pctx;
     NYql::TExprContext ctx;


### PR DESCRIPTION
The KQP CBO fork (done in #35783) missed the ReverseBlockJoin changes from #36739. Reapply missing changes so that left block joins can choose left side as build side again.