### PR TITLE
Deflake RDMA XDC tests

### DIFF
--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -308,6 +308,110 @@ TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool*
     return ev;
 }
 
+static bool WaitForRdmaChecksumStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
+        TString& lastStatus)
+{
+    while (maxAttempt--) {
+        try {
+            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
+            if (lastStatus == expected) {
+                return true;
+            }
+        } catch (const TPatternNotFound&) {
+            lastStatus.clear();
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    return false;
+}
+
+static bool WaitForRdmaSessionDropOrStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
+        TString& lastStatus)
+{
+    ui32 missingAttempts = 0;
+    while (maxAttempt--) {
+        try {
+            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
+            missingAttempts = 0;
+            if (lastStatus == expected) {
+                return true;
+            }
+        } catch (const TPatternNotFound&) {
+            lastStatus.clear();
+            if (++missingAttempts >= 2) {
+                return true;
+            }
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    return false;
+}
+
+static TString FormatLastRdmaStatus(const TString& status) {
+    return status.empty() ? TString("<no session>") : status;
+}
+
+class TWaitForConnectionActor: public TActorBootstrapped<TWaitForConnectionActor> {
+public:
+    TWaitForConnectionActor(ui32 peerNodeId, NThreading::TPromise<bool> promise, ui32 attempts)
+        : PeerNodeId(peerNodeId)
+        , Promise(std::move(promise))
+        , AttemptsLeft(attempts)
+    {}
+
+    void Bootstrap() {
+        Become(&TWaitForConnectionActor::StateFunc);
+        SendConnect();
+    }
+
+private:
+    void SendConnect() {
+        if (!AttemptsLeft) {
+            return Finish(false);
+        }
+        --AttemptsLeft;
+        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvInterconnect::TEvConnectNode);
+    }
+
+    void Finish(bool connected) {
+        Promise.SetValue(connected);
+        PassAway();
+    }
+
+    void Handle(TEvInterconnect::TEvNodeConnected::TPtr&) {
+        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvents::TEvUnsubscribe);
+        Finish(true);
+    }
+
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr&) {
+        Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        SendConnect();
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvInterconnect::TEvNodeConnected, Handle);
+        hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
+        hFunc(TEvents::TEvWakeup, Handle);
+    )
+
+private:
+    const ui32 PeerNodeId;
+    NThreading::TPromise<bool> Promise;
+    ui32 AttemptsLeft;
+};
+
+static void WaitForInterconnectConnection(TTestICCluster& cluster, ui32 fromNode, ui32 toNode) {
+    auto promise = NThreading::NewPromise<bool>();
+    auto future = promise.GetFuture();
+    cluster.RegisterActor(new TWaitForConnectionActor(toNode, std::move(promise), 200), fromNode);
+
+    const bool connected = future.Wait(TDuration::Seconds(30)) && future.GetValueSync();
+    UNIT_ASSERT_C(connected, "failed to establish interconnect session from node " << fromNode << " to node " << toNode);
+}
+
 TEST_F(XdcRdmaTest, SerializeToRope) {
     auto common = MakeIntrusive<TInterconnectProxyCommon>();
     common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
@@ -1001,15 +1105,9 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     // Session is going to be recreated without RDMA,
     // but pending handshake timers are triggered (we can't check it directly in this UT).
     TString lastRdmaStatus;
-    for (size_t i = 0; i < 10; i++) {
-        lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
-        if (lastRdmaStatus == "Off") {
-            break;
-        }
-        Sleep(TDuration::Seconds(1));
-    }
-
-    UNIT_ASSERT_VALUES_EQUAL(lastRdmaStatus, "Off");
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "Off", 30, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    UNIT_ASSERT_STRINGS_EQUAL(lastRdmaStatus.c_str(), "Off");
     lastRdmaStatus.clear();
 
     // Send one more time (will be delivered through TCP)
@@ -1022,22 +1120,11 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(2, 20));
     // Free memory
     occupiedBuffers.clear();
-    // Wait for the pending handshake timer
-    Sleep(TDuration::MilliSeconds(5000));
 
-    for (size_t i = 0; i < 5; i++) {
-        try {
-            lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
-        } catch (const TPatternNotFound&) {
-            // retry case if the session was not created yet
-            Sleep(TDuration::Seconds(1));
-            continue;
-        }
-        if (lastRdmaStatus == "On") {
-            break;
-        }
-        Sleep(TDuration::Seconds(1));
-    }
+    // Wait until the delayed RDMA retry closes the TCP-only session, or until RDMA
+    // is restored by an already pending reconnect.
+    UNIT_ASSERT_C(WaitForRdmaSessionDropOrStatus(cluster, 2, 1, "On | SoftwareChecksum", 45, lastRdmaStatus),
+        "last RDMA status before reconnect: " << FormatLastRdmaStatus(lastRdmaStatus));
 
     {
         auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
@@ -1046,8 +1133,9 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         cluster.RegisterActor(senderPtr, 2);
     }
     UNIT_ASSERT(receiverPtr->WaitForReceive(3, 20));
-    lastRdmaStatus = GetRdmaChecksumStatus(cluster, 2, 1);
-    UNIT_ASSERT_VALUES_EQUAL(lastRdmaStatus, "On | SoftwareChecksum");
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum", 30, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    UNIT_ASSERT_STRINGS_EQUAL(lastRdmaStatus.c_str(), "On | SoftwareChecksum");
 }
 
 TEST_P(XdcRdmaTestCqMode, SendMix) {
@@ -1182,8 +1270,6 @@ static void DoSendHugePayloadsNum(const ui32 numPayloads, const size_t payloadSz
     });
     const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
 
-    Sleep(TDuration::MilliSeconds(100));
-
     {
         auto senderPtr = new TSendActor(receiver, ev);
         cluster.RegisterActor(senderPtr, 2);
@@ -1200,6 +1286,7 @@ TEST_F(XdcRdmaTest, Send1Payload) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(1, 8192, cluster, pool);
 }
@@ -1212,18 +1299,20 @@ TEST_F(XdcRdmaTest, Send2Payloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(2, 8192, cluster, pool);
 }
 
 TEST_F(XdcRdmaTest, Send250Payloads) {
-        const NInterconnect::NRdma::TMemPoolSettings settings {
+    const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(250, 512, cluster, pool);
 }
@@ -1236,6 +1325,7 @@ TEST_F(XdcRdmaTest, Send500Payloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(500, 512, cluster, pool);
 }
@@ -1248,6 +1338,7 @@ TEST_F(XdcRdmaTest, Send4000Payloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(4000, 512, cluster, pool);
 }
@@ -1260,6 +1351,7 @@ TEST_F(XdcRdmaTest, Send16000Payloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(16000, 512, cluster, pool);
 }
@@ -1272,6 +1364,7 @@ TEST_F(XdcRdmaTest, Send32000Payloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(32000, 512, cluster, pool);
 }
@@ -1284,6 +1377,7 @@ TEST_F(XdcRdmaTest, SendXPayloads) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     for (size_t i = 640; i < 650; i++) {
         DoSendHugePayloadsNum(i, 512, cluster, pool);
@@ -1298,6 +1392,7 @@ TEST_F(XdcRdmaTest, SendXPayloadsWithRandSize) {
 
     TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
         TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    WaitForInterconnectConnection(cluster, 2, 1);
 
     for (size_t i = 640; i < 650; i++) {
         DoSendHugePayloadsNum(i, 512 + (RandomNumber<ui16>(4096) * 4), cluster, pool);


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

RestoreRdmaSession used fixed sleeps around delayed RDMA handshakes, which made the test race with the TCP-only session replacement. Poll the debug RDMA mode instead, wait for the TCP-only session to be dropped or promoted back to RDMA, and assert the final On | SoftwareChecksum state with string-aware assertions.

The large-payload tests could also send before the interconnect listener was ready, losing the first event after an early connection failure. Replace the startup sleep with a small readiness actor that drives TEvConnectNode until TEvNodeConnected is observed, then send the payload.


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
