### PR TITLE
Fixed unexpected exception from TSplitRequestsStorageWrapper

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/service/split_requests_wrapper.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/split_requests_wrapper.cpp
@@ -106,6 +106,11 @@ public:
                 .Error = MakeError(E_CANCELLED, "failed to acquire sglist")});
         }
 
+        // Acquire the future before subscribing to sub-request callbacks.
+        // A sub-request can be completed synchronously and swapped with another
+        // Promise inside the OnSubResponse() function.
+        auto future = Promise.GetFuture();
+
         for (const auto& subRequest: SubRequests) {
             auto subFuture =
                 TStorageAdapter::Execute(storage, callContext, subRequest);
@@ -117,7 +122,7 @@ public:
                 });
         }
 
-        return Promise.GetFuture();
+        return future;
     }
 
 private:

--- a/ydb/core/nbs/cloud/blockstore/libs/service/split_requests_wrapper_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/split_requests_wrapper_ut.cpp
@@ -45,6 +45,8 @@ struct TTestEnvironment
         TBlockRangeComparator>
         ZeroPromises;
 
+    std::optional<NProto::TError> SyncZeroBlocksError;
+
     TTestEnvironment()
     {
         Storage = std::make_shared<TTestStorage>();
@@ -80,6 +82,12 @@ struct TTestEnvironment
             -> TFuture<TZeroBlocksLocalResponse>
         {
             Y_UNUSED(callContext);
+
+            if (SyncZeroBlocksError) {
+                TZeroBlocksLocalResponse response;
+                response.Error = *SyncZeroBlocksError;
+                return MakeFuture(std::move(response));
+            }
 
             auto& info =
                 ZeroPromises[request->Headers.Range] = {.Request = request};
@@ -483,6 +491,47 @@ Y_UNIT_TEST_SUITE(TSplitRequestsStorageWrapperTest)
         UNIT_ASSERT_VALUES_EQUAL_C(
             E_REJECTED,
             result.Error.code(),
+            FormatError(result.Error));
+    }
+
+    Y_UNIT_TEST(ShouldNotFailWhenSubRequestCompletesSynchronously)
+    {
+        constexpr ui32 BlockSize = 2;
+        constexpr ui32 BlockCount = 10;
+        constexpr ui32 TotalBlockCount = 1000;
+        constexpr ui32 StripeSize = 6;
+
+        TString diskId("disk-1");
+
+        auto volumeConfig(std::make_shared<TVolumeConfig>(
+            diskId,
+            BlockSize,
+            TotalBlockCount,
+            StripeSize));
+
+        TTestEnvironment env;
+
+        env.SyncZeroBlocksError = MakeError(E_REJECTED, "sync fail");
+
+        auto range = TBlockRange64::WithLength(1, BlockCount);
+
+        // Run request
+        auto request = std::make_shared<TZeroBlocksLocalRequest>(
+            TRequestHeaders{.VolumeConfig = volumeConfig, .Range = range});
+
+        TFuture<TZeroBlocksLocalResponse> future;
+        UNIT_ASSERT_NO_EXCEPTION(
+            future = env.Wrapper->ZeroBlocksLocal(
+                MakeIntrusive<TCallContext>(),
+                std::move(request)));
+
+        // Future must be valid and already carry the propagated error.
+        UNIT_ASSERT(future.Initialized());
+        UNIT_ASSERT(future.HasValue());
+        const auto& result = future.GetValue();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            E_REJECTED,
+            result.Error.GetCode(),
             FormatError(result.Error));
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When the TSplitRequestService gets a synchronous or very fast response from another thread after splitting the request, this leads to an error that we send to the user.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
