### PR TITLE
S3 GET throttling in BlobDepot

### DIFF
--- a/ydb/core/blob_depot/agent/agent.cpp
+++ b/ydb/core/blob_depot/agent/agent.cpp
@@ -89,6 +89,7 @@ namespace NKikimr::NBlobDepot {
         S3GetBytesOk = s3->GetCounter("GetBytesOk", true);
         S3GetsOk = s3->GetCounter("GetsOk", true);
         S3GetsError = s3->GetCounter("GetsError", true);
+        S3GetsSlowDown = s3->GetCounter("GetsSlowDown", true);
 
         S3PutBytesOk = s3->GetCounter("PutBytesOk", true);
         S3PutsOk = s3->GetCounter("PutsOk", true);

--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -4,6 +4,7 @@
 #include "resolved_value.h"
 
 #include <ydb/core/protos/blob_depot_config.pb.h>
+#include <ydb/core/util/backoff.h>
 
 namespace NKikimr::NBlobDepot {
 
@@ -223,6 +224,7 @@ namespace NKikimr::NBlobDepot {
         NMonitoring::TDynamicCounters::TCounterPtr S3GetBytesOk;
         NMonitoring::TDynamicCounters::TCounterPtr S3GetsOk;
         NMonitoring::TDynamicCounters::TCounterPtr S3GetsError;
+        NMonitoring::TDynamicCounters::TCounterPtr S3GetsSlowDown;
         NMonitoring::TDynamicCounters::TCounterPtr S3PutBytesOk;
         NMonitoring::TDynamicCounters::TCounterPtr S3PutsOk;
         NMonitoring::TDynamicCounters::TCounterPtr S3PutsError;
@@ -246,6 +248,7 @@ namespace NKikimr::NBlobDepot {
                 EvProcessPendingEvent,
                 EvPendingEventQueueWatchdog,
                 EvPushMetrics,
+                EvS3GetThrottleWakeup,
             };
         };
 
@@ -295,6 +298,8 @@ namespace NKikimr::NBlobDepot {
                 cFunc(TEvPrivate::EvQueryWatchdog, HandleQueryWatchdog);
 
                 cFunc(TEvPrivate::EvPushMetrics, HandlePushMetrics);
+
+                cFunc(TEvPrivate::EvS3GetThrottleWakeup, HandleS3GetThrottleWakeup);
             )
 
             DeletePendingQueries.Clear();
@@ -602,6 +607,42 @@ namespace NKikimr::NBlobDepot {
                 return EscapeC(key);
             }
         }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // S3 read throttling
+        //
+        // All agent-issued S3 GETs flow through this gate. On SlowDown/TooManyRequests we drop the concurrency cap
+        // to 1, arm an exponential backoff, and queue further reads until the cooldown elapses; successes gradually
+        // restore the cap. Throttling is per-agent because GETs are issued from the agent without any tablet
+        // round-trip, so there is no central place to gate them.
+
+        static constexpr ui32 MaxS3GetsInFlight = 32;
+        static constexpr ui32 SuccessesPerGetConcurrencyStepUp = 3;
+        static constexpr ui32 MaxS3GetSlowDownRetries = 100;
+
+        struct TPendingS3Read {
+            TString Key;
+            ui32 Offset;
+            ui32 Len;
+            TQuery::TFinishCallback Finish;
+            ui64 ReadId;
+            ui32 SlowDownRetries = 0;
+        };
+
+        TBackoff S3GetBackoff{TDuration::MilliSeconds(100), TDuration::Seconds(60)};
+        TMonotonic S3GetThrottleUntil;
+        bool S3GetWakeupScheduled = false;
+        ui32 CurrentMaxS3GetsInFlight = MaxS3GetsInFlight;
+        ui32 ConsecutiveSuccessfulGetBatches = 0;
+        ui32 S3GetsInFlight = 0;
+        std::deque<TPendingS3Read> PendingS3Reads;
+
+        void IssueOrEnqueueS3Read(TPendingS3Read&& read);
+        void DispatchS3Read(TPendingS3Read&& read);
+        void NotifyS3GetSlowDown();
+        void OnS3GetCompleted(bool success, ui64 bytes);
+        void RunPendingS3ReadsIfPossible();
+        void HandleS3GetThrottleWakeup();
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Metrics

--- a/ydb/core/blob_depot/agent/s3.cpp
+++ b/ydb/core/blob_depot/agent/s3.cpp
@@ -23,60 +23,105 @@ namespace NKikimr::NBlobDepot {
     }
 
     void TBlobDepotAgent::TQuery::IssueReadS3(const TString& key, ui32 offset, ui32 len, TFinishCallback finish, ui64 readId) {
+        Agent.IssueOrEnqueueS3Read(TPendingS3Read{
+            .Key = key,
+            .Offset = offset,
+            .Len = len,
+            .Finish = std::move(finish),
+            .ReadId = readId,
+        });
+    }
+
+    void TBlobDepotAgent::IssueOrEnqueueS3Read(TPendingS3Read&& read) {
+        const TMonotonic now = TActivationContext::Monotonic();
+        const bool timeThrottled = now < S3GetThrottleUntil;
+        const bool concurrencyThrottled = S3GetsInFlight >= CurrentMaxS3GetsInFlight;
+
+        if (timeThrottled || concurrencyThrottled) {
+            STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA65, "S3 read queued", (AgentId, LogId), (ReadId, read.ReadId),
+                (Key, read.Key), (TimeThrottled, timeThrottled), (ConcurrencyThrottled, concurrencyThrottled),
+                (S3GetsInFlight, S3GetsInFlight), (CurrentMaxS3GetsInFlight, CurrentMaxS3GetsInFlight),
+                (QueueSize, PendingS3Reads.size()));
+            PendingS3Reads.push_back(std::move(read));
+            if (timeThrottled && !S3GetWakeupScheduled) {
+                TActivationContext::Schedule(S3GetThrottleUntil, new IEventHandle(TEvPrivate::EvS3GetThrottleWakeup,
+                    0, SelfId(), {}, nullptr, 0));
+                S3GetWakeupScheduled = true;
+            }
+            return;
+        }
+
+        DispatchS3Read(std::move(read));
+    }
+
+    void TBlobDepotAgent::DispatchS3Read(TPendingS3Read&& read) {
         class TGetActor : public TActor<TGetActor> {
-            TFinishCallback Finish;
-
-            TString AgentLogId;
-            TString QueryId;
-            ui64 ReadId;
-
-            NMonitoring::TDynamicCounters::TCounterPtr GetBytesOk;
-            NMonitoring::TDynamicCounters::TCounterPtr GetsOk;
-            NMonitoring::TDynamicCounters::TCounterPtr GetsError;
+            TBlobDepotAgent& Agent;
+            TPendingS3Read Read;
 
         public:
-            TGetActor(TQuery *query, TFinishCallback finish, ui64 readId,
-                    NMonitoring::TDynamicCounters::TCounterPtr getBytesOk,
-                    NMonitoring::TDynamicCounters::TCounterPtr getsOk,
-                    NMonitoring::TDynamicCounters::TCounterPtr getsError)
+            TGetActor(TBlobDepotAgent& agent, TPendingS3Read&& read)
                 : TActor(&TThis::StateFunc)
-                , Finish(std::move(finish))
-                , AgentLogId(query->Agent.LogId)
-                , QueryId(query->GetQueryId())
-                , ReadId(readId)
-                , GetBytesOk(std::move(getBytesOk))
-                , GetsOk(std::move(getsOk))
-                , GetsError(std::move(getsError))
+                , Agent(agent)
+                , Read(std::move(read))
             {}
 
             void Handle(NWrappers::TEvExternalStorage::TEvGetObjectResponse::TPtr ev) {
                 auto& msg = *ev->Get();
 
                 STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA55, "received TEvGetObjectResponse",
-                    (AgentId, AgentLogId), (QueryId, QueryId), (ReadId, ReadId),
+                    (AgentId, Agent.LogId), (ReadId, Read.ReadId),
                     (Response, msg.Result), (BodyLen, std::size(msg.Body)));
 
                 if (msg.IsSuccess()) {
-                    ++*GetsOk;
-                    *GetBytesOk += msg.Body.size();
-                } else {
-                    ++*GetsError;
+                    ++*Agent.S3GetsOk;
+                    *Agent.S3GetBytesOk += msg.Body.size();
+                    const ui64 bytes = msg.Body.size();
+                    Read.Finish(std::move(msg.Body), "");
+                    Agent.OnS3GetCompleted(/*success=*/true, bytes);
+                    PassAway();
+                    return;
                 }
 
-                if (msg.IsSuccess()) {
-                    Finish(std::move(msg.Body), "");
-                } else if (const auto& error = msg.GetError(); error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY) {
-                    Finish(std::nullopt, "data has disappeared from S3");
-                } else {
-                    Finish(std::nullopt, msg.GetError().GetMessage().c_str());
+                ++*Agent.S3GetsError;
+                const auto& error = msg.GetError();
+
+                if (IsSlowDown(error)) {
+                    ++*Agent.S3GetsSlowDown;
+                    BDEV(BDEV43, "S3_get_slow_down", (VG, Agent.VirtualGroupId), (BDT, Agent.TabletId),
+                        (G, Agent.BlobDepotGeneration), (ReadId, Read.ReadId), (Key, Read.Key),
+                        (Retry, Read.SlowDownRetries));
+
+                    Agent.NotifyS3GetSlowDown();
+                    Agent.OnS3GetCompleted(/*success=*/false, 0);
+
+                    if (Read.SlowDownRetries >= MaxS3GetSlowDownRetries) {
+                        const TString reason = TStringBuilder()
+                            << "too many S3 SlowDown retries: " << error.GetMessage();
+                        Read.Finish(std::nullopt, reason.c_str());
+                    } else {
+                        ++Read.SlowDownRetries;
+                        Agent.IssueOrEnqueueS3Read(std::move(Read));
+                    }
+                    PassAway();
+                    return;
                 }
+
+                if (error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY) {
+                    Read.Finish(std::nullopt, "data has disappeared from S3");
+                } else {
+                    Read.Finish(std::nullopt, error.GetMessage().c_str());
+                }
+                Agent.OnS3GetCompleted(/*success=*/false, 0);
                 PassAway();
             }
 
             void HandleUndelivered() {
                 STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA56, "received TEvUndelivered",
-                    (AgentId, AgentLogId), (QueryId, QueryId), (ReadId, ReadId));
-                Finish(std::nullopt, "wrapper actor terminated");
+                    (AgentId, Agent.LogId), (ReadId, Read.ReadId));
+                ++*Agent.S3GetsError;
+                Read.Finish(std::nullopt, "wrapper actor terminated");
+                Agent.OnS3GetCompleted(/*success=*/false, 0);
                 PassAway();
             }
 
@@ -86,15 +131,87 @@ namespace NKikimr::NBlobDepot {
                 cFunc(TEvents::TSystem::Poison, PassAway)
             )
         };
-        const TActorId actorId = Agent.RegisterWithSameMailbox(new TGetActor(this, std::move(finish), readId,
-            Agent.S3GetBytesOk, Agent.S3GetsOk, Agent.S3GetsError));
+
+        ++S3GetsInFlight;
+
+        STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA66, "starting S3 read", (AgentId, LogId), (ReadId, read.ReadId),
+            (Key, read.Key), (Offset, read.Offset), (Len, read.Len), (SlowDownRetries, read.SlowDownRetries),
+            (S3GetsInFlight, S3GetsInFlight), (CurrentMaxS3GetsInFlight, CurrentMaxS3GetsInFlight));
+
+        const TString key = read.Key;
+        const ui32 offset = read.Offset;
+        const ui32 len = read.Len;
+
+        const TActorId actorId = RegisterWithSameMailbox(new TGetActor(*this, std::move(read)));
+
         auto request = std::make_unique<NWrappers::TEvExternalStorage::TEvGetObjectRequest>(
             Aws::S3::Model::GetObjectRequest()
-                .WithBucket(Agent.S3BackendSettings->GetSettings().GetBucket())
+                .WithBucket(S3BackendSettings->GetSettings().GetBucket())
                 .WithKey(key)
                 .WithRange(TStringBuilder() << "bytes=" << offset << '-' << offset + len - 1)
         );
-        TActivationContext::Send(new IEventHandle(Agent.S3WrapperId, actorId, request.release(), IEventHandle::FlagTrackDelivery));
+        TActivationContext::Send(new IEventHandle(S3WrapperId, actorId, request.release(), IEventHandle::FlagTrackDelivery));
+    }
+
+    void TBlobDepotAgent::NotifyS3GetSlowDown() {
+        CurrentMaxS3GetsInFlight = 1;
+        ConsecutiveSuccessfulGetBatches = 0;
+        const TDuration delay = S3GetBackoff.Next();
+        S3GetThrottleUntil = TActivationContext::Monotonic() + delay;
+
+        STLOG(PRI_WARN, BLOB_DEPOT_AGENT, BDA67, "S3 get throttled", (AgentId, LogId),
+            (Delay, delay), (CurrentMaxS3GetsInFlight, CurrentMaxS3GetsInFlight),
+            (S3GetsInFlight, S3GetsInFlight), (QueueSize, PendingS3Reads.size()));
+        BDEV(BDEV44, "S3_get_throttled", (VG, VirtualGroupId), (BDT, TabletId), (G, BlobDepotGeneration),
+            (DelayMs, delay.MilliSeconds()), (QueueSize, PendingS3Reads.size()));
+
+        if (!S3GetWakeupScheduled) {
+            TActivationContext::Schedule(S3GetThrottleUntil, new IEventHandle(TEvPrivate::EvS3GetThrottleWakeup,
+                0, SelfId(), {}, nullptr, 0));
+            S3GetWakeupScheduled = true;
+        }
+    }
+
+    void TBlobDepotAgent::OnS3GetCompleted(bool success, ui64 bytes) {
+        Y_UNUSED(bytes);
+        Y_ABORT_UNLESS(S3GetsInFlight);
+        --S3GetsInFlight;
+
+        if (success && CurrentMaxS3GetsInFlight < MaxS3GetsInFlight) {
+            if (++ConsecutiveSuccessfulGetBatches >= SuccessesPerGetConcurrencyStepUp) {
+                ConsecutiveSuccessfulGetBatches = 0;
+                ++CurrentMaxS3GetsInFlight;
+                if (CurrentMaxS3GetsInFlight >= MaxS3GetsInFlight) {
+                    CurrentMaxS3GetsInFlight = MaxS3GetsInFlight;
+                    S3GetBackoff.Reset();
+                }
+            }
+        }
+
+        RunPendingS3ReadsIfPossible();
+    }
+
+    void TBlobDepotAgent::RunPendingS3ReadsIfPossible() {
+        const TMonotonic now = TActivationContext::Monotonic();
+        if (now < S3GetThrottleUntil) {
+            if (!S3GetWakeupScheduled && !PendingS3Reads.empty()) {
+                TActivationContext::Schedule(S3GetThrottleUntil, new IEventHandle(TEvPrivate::EvS3GetThrottleWakeup,
+                    0, SelfId(), {}, nullptr, 0));
+                S3GetWakeupScheduled = true;
+            }
+            return;
+        }
+
+        while (!PendingS3Reads.empty() && S3GetsInFlight < CurrentMaxS3GetsInFlight) {
+            auto read = std::move(PendingS3Reads.front());
+            PendingS3Reads.pop_front();
+            DispatchS3Read(std::move(read));
+        }
+    }
+
+    void TBlobDepotAgent::HandleS3GetThrottleWakeup() {
+        S3GetWakeupScheduled = false;
+        RunPendingS3ReadsIfPossible();
     }
 
     TActorId TBlobDepotAgent::TQuery::IssueWriteS3(TString&& key, TRope&& buffer, TLogoBlobID id, TS3Locator locator) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

S3 GET throttling in BlobDepot

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch introduces S3 GET throttling in BlobDepot S3 mode.
