### PR TITLE
Replace std::move with std::forward in TRcBuf template constructor

### DIFF
--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -786,7 +786,7 @@ public:
         } else {
             beginOffset = data.data() - backend.GetData().data();
         }
-        Backend = std::move(backend);
+        Backend = std::forward<T>(backend);
         Begin = Backend.GetData().data() + beginOffset;
         End = Begin + data.size();
     }


### PR DESCRIPTION
[5844](https://github.com/ydb-platform/nbs/issues/5844)                                                                                                                                           


Replace std::move with std::forward in TRcBuf(T&& backend, TContiguousSpan)
std::move on a const lvalue reference conflicts with the deleted
move(const T&) overload in cloud/storage/core/libs/common/public.h.
std::forward preserves perfect forwarding semantics.