### PR TITLE
Deflake kernel liveness reconnect test

### DIFF
--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -513,13 +513,22 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
 
     auto reconnectFromNode2 = [&](TStringBuf description) {
         const TString handshakeBefore = GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone");
+        auto sessionStaysAliveOnEof = [&](ui32 fromNode, ui32 toNode) {
+            const ui64 numEventsInQueue = GetSessionCounter(cluster, fromNode, toNode, "NumEventsInQueue");
+            const ui64 outputCounter = GetSessionCounter(cluster, fromNode, toNode, "OutputCounter");
+            const ui64 lastConfirmed = GetSessionCounter(cluster, fromNode, toNode, "LastConfirmed");
+            return numEventsInQueue > 0 || outputCounter != lastConfirmed;
+        };
+
+        // Keep both session instances alive after the socket is closed. This matches the session lifetime predicate
+        // used on EOF; otherwise the peer may destroy its idle session before accepting the continuation request.
         WaitForCondition(TDuration::Seconds(10), [&] {
             try {
-                return GetSessionCounter(cluster, 2, 1, "NumEventsInQueue") > 0;
+                return sessionStaysAliveOnEof(2, 1) && sessionStaysAliveOnEof(1, 2);
             } catch (const TPatternNotFound&) {
                 return false;
             }
-        }, "session has pending output before forced reconnect");
+        }, "both sessions stay alive on EOF before forced reconnect");
         cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvClosePeerSocket);
         WaitForCondition(TDuration::Seconds(20), [&] {
             try {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

KernelLivenessReconnectLocalFallbackNotApplied expects to exercise same-session continuation, but the peer-side session may be idle and get destroyed before it accepts the continuation request. In that case the reconnect becomes a new-session handshake and the test fails before checking the kernel-liveness fallback behavior.

Before forcing the socket close, wait until both directions satisfy the same non-idle predicate used by TInterconnectSessionTCP on EOF: NumEventsInQueue > 0 or OutputCounter != LastConfirmed. This keeps both session instances alive long enough for the continuation handshake without relying on the transient pre-serialization queue state alone.



...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
