### PR TITLE
Skip deleted index impl tables when copying/exporting indexed tables

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -305,6 +305,11 @@ bool CreateConsistentCopyTables(
 
             for (const auto& [srcImplTableName, srcImplTablePathId] : srcIndexPath.Base()->GetChildren()) {
                 TPath srcImplTable = srcIndexPath.Child(srcImplTableName);
+                if (srcImplTable.IsDeleted()) {
+                    LOG_TRACE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                        "CreateConsistentCopyTables: Skipping deleted index impl child: " << srcImplTableName);
+                    continue;
+                }
                 Y_ABORT_UNLESS(srcImplTable.Base()->PathId == srcImplTablePathId);
                 TPath dstImplTable = dstIndexPath.Child(srcImplTableName);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -1080,6 +1080,9 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
 
         for (const auto& [implTableName, implTablePathId] : childPath.Base()->GetChildren()) {
             TPath implTable = childPath.Child(implTableName);
+            if (implTable.IsDeleted()) {
+                continue;
+            }
             Y_ABORT_UNLESS(implTable.Base()->PathId == implTablePathId);
 
             NKikimrSchemeOp::TModifyScheme schema;

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -339,6 +339,10 @@ private:
                         continue;
                     }
                     for (const auto& [implTableName, implTablePathId] : childPath.Base()->GetChildren()) {
+                        auto implTablePath = childPath.Child(implTableName);
+                        if (implTablePath.IsDeleted()) {
+                            continue;
+                        }
                         const auto implTableRelPath = JoinPath(ChildPath(childParts, implTableName));
                         indexItems.emplace_back(implTableRelPath, implTablePathId, childPath->PathType, itemIdx);
                     }

--- a/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
@@ -392,4 +392,49 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
             i++;
         }
     }
+
+    // After a real vector index build, the transient 'indexImplPostingTable<N>build' intermediates are dropped
+    // but their entries linger in the parent index's Children map.
+    // CreateConsistentCopyTables should not fail on these stale references.
+    Y_UNIT_TEST(ConsistentCopyTableAfterVectorIndexBuild) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"       Type: "Uint32" }
+            Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++txId, "/MyRoot/Table", 0, 0, 200);
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard,
+            "/MyRoot", "/MyRoot/Table", "index1", {"embedding"});
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        TestConsistentCopyTables(runtime, ++txId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/Table"
+                DstPath: "/MyRoot/TableCopy"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/TableCopy"),
+            {NLs::PathExist, NLs::IsTable, NLs::IndexesCount(1)});
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/TableCopy/index1", true, true), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree),
+            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady),
+        });
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -9,6 +9,10 @@
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/metering/metering.h>
 
+#include <ydb/core/wrappers/ut_helpers/s3_mock.h>
+#include <ydb/core/util/aws.h>
+#include <ydb/public/api/protos/ydb_import.pb.h>
+
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 using namespace NKikimr;
@@ -2156,6 +2160,103 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, buildIndexTx, tenantSchemeShard);
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
             {NLs::PathExist, NLs::IndexesCount(1)});
+    }
+
+    Y_UNIT_TEST_FLAG(ImportExport, Materialized) {
+        NKikimr::InitAwsAPI();
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        NWrappers::NTestHelpers::TS3Mock s3Mock({}, NWrappers::NTestHelpers::TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableIndexMaterialization(Materialized));
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"       Type: "Uint32" }
+            Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++txId, "/MyRoot/Table", 0, 0, 200);
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "index1", {"embedding"});
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        {
+            auto buildIndexOperation = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                buildIndexOperation.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                buildIndexOperation.DebugString()
+            );
+        }
+
+        auto checkIndex = [&](const TString& tablePath) {
+            const auto d = DescribePath(runtime, tablePath, true, true);
+            bool found = false;
+            for (const auto& idx : d.GetPathDescription().GetTable().GetTableIndexes()) {
+                if (idx.GetName() == "index1") {
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree);
+                    found = true;
+                }
+            }
+            UNIT_ASSERT_C(found, "missing index1 on " << tablePath);
+        };
+
+        checkIndex("/MyRoot/Table");
+
+        const ui64 exportTxId = ++txId;
+        TestExport(runtime, exportTxId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_path: "/MyRoot/Table"
+                    destination_prefix: "test"
+                }
+                %s
+            }
+        )", port, Materialized ? "include_index_data: true" : ""));
+        env.TestWaitNotification(runtime, exportTxId);
+        TestGetExport(runtime, exportTxId, "/MyRoot", Ydb::StatusIds::SUCCESS);
+
+        const ui64 importId = ++txId;
+        const TString popMode = Materialized
+            ? "index_population_mode: " + Ydb::Import::ImportFromS3Settings::IndexPopulationMode_Name(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT)
+            : "";
+        TestImport(runtime, importId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_prefix: "test"
+                    destination_path: "/MyRoot/TableImported"
+                }
+                %s
+            }
+        )", port, popMode.c_str()));
+        env.TestWaitNotification(runtime, importId);
+        TestGetImport(runtime, importId, "/MyRoot", Ydb::StatusIds::SUCCESS);
+
+        checkIndex("/MyRoot/TableImported");
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/TableImported/index1", true, true), {
+            NLs::PathExist,
+            NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady),
+        });
+
+        NKikimr::ShutdownAwsAPI();
     }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

During a vector index build, schemeshard creates transient impl tables (`indexImplPostingTable0build`, `indexImplPostingTable1build`) under the index path, and drops them once the build finishes. Per the standard schemeshard pattern, the dropped path is marked `EPathStateNotExist` but its entry remains in the parent index's Children map so historical pathIds stay resolvable until garbage collection.

Three code paths iterated those children without checking `IsDeleted()` on each impl table. The deletion check existed for the index level but was missing one level deeper. As a result, any flow that walked index → impl-table children after a successful vector build tried to copy/export the dropped intermediates and failed

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
