### PR TITLE
Removed deducing domain name from tenant while registering dynamic node

### DIFF
--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -888,17 +888,6 @@ TString DeduceNodeDomain(const NConfig::TCommonAppOptions& cf, const NKikimrConf
             return slot.GetDomainName();
         }
 
-        auto &tenantName = slot.GetTenantName();
-        if (IsStartWithSlash(tenantName)) {
-            return ToString(ExtractDomain(tenantName));
-        }
-    }
-
-    if (cf.TenantName) {
-        auto domain = ExtractDomain(cf.TenantName.GetRef());
-        if (!domain.empty()) {
-            return ToString(domain);
-        }
     }
 
     return "";

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -226,6 +226,11 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 "--key=%s" % self.__configurator.grpc_tls_key_path
             )
 
+        if self.__configurator.domain_name:
+            command.append(
+                "--node-domain=%s" % self.__configurator.domain_name
+            )
+
         if self.__role == 'slot' or (self.__configurator.node_kind == "yq" and self._tenant_affiliation is not None):
             command.append(
                 "--tenant=%s" % self._tenant_affiliation


### PR DESCRIPTION
We may have domain name containing `/` like `/cluster/root` so in this case deducing domain name from tenant is impossible. In this PR I deliberately removed deducing in node registration code and explicitly filled `domain-name` arg in python testing framework.
