### PR TITLE
SchemeShard: add drop table test for forced compaction and fix ProcessForcedCompactionQueues

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -2,6 +2,8 @@
 
 #include "schemeshard_impl.h"
 
+#include <util/generic/scope.h>
+
 namespace NKikimr::NSchemeShard {
 
 void TSchemeShard::AddForcedCompaction(
@@ -175,6 +177,13 @@ void TSchemeShard::RetryForcedCompactionForShard(const TShardIdx& shardIdx, cons
 }
 
 void TSchemeShard::ProcessForcedCompactionQueues() {
+    // Skip the nested call: the outer loop will continue with consistent state.
+    if (InProcessForcedCompactionQueues) {
+        return;
+    }
+    InProcessForcedCompactionQueues = true;
+    Y_DEFER { InProcessForcedCompactionQueues = false; };
+
     // try enqueue shards from multiple tables fairly
     auto initialQueueSize = ForcedCompactionTablesQueue.Size();
     THashSet<TPathId> tablesWithoutCandidates;
@@ -184,10 +193,10 @@ void TSchemeShard::ProcessForcedCompactionQueues() {
         auto* shards = ForcedCompactionShardsByTable.FindPtr(tablePathId);
         if (shards && !shards->Empty() && compaction->MaxShardsInFlight > compaction->ShardsInFlight.size()) {
             const auto& shardIdx = shards->Front();
-            EnqueueForcedCompaction(shardIdx);
-            compaction->ShardsInFlight.insert(shardIdx);
             shards->PopFront();
             --ForcedCompactionTotalInQueues;
+            compaction->ShardsInFlight.insert(shardIdx);
+            EnqueueForcedCompaction(shardIdx);
         }
         if (!shards || shards->Empty()) {
             tablesWithoutCandidates.insert(tablePathId);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1865,6 +1865,7 @@ public:
     TFifoQueue<TPathId> ForcedCompactionTablesQueue;
     THashMap<TPathId, TFifoQueue<TShardIdx>> ForcedCompactionShardsByTable;
     ui64 ForcedCompactionTotalInQueues = 0;
+    bool InProcessForcedCompactionQueues = false;
 
     TVector<std::pair<TShardIdx, TForcedCompactionInfo::TPtr>> ForcedCompactionsDoneShardsToPersist; // info may be null
     ui32 ForcedCompactionPersistBatchSize = 100;

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -2821,7 +2821,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
             WriteData(runtime, "Simple1", 0, 100, TTestTxConfig::FakeHiveTablets);
             WriteData(runtime, "Simple1", 0, 100, TTestTxConfig::FakeHiveTablets + 1);
 
-            // block compact request, so compaction results will never delivered
+            // block compact requests, so compaction results will never be delivered
             TBlockEvents<TEvDataShard::TEvCompactTable> block(runtime);
 
             TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple1");
@@ -2838,7 +2838,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
             // release blocked EvCompactTable, but shards should be deleted and no EvCompactTable will be delivered
             block.Stop().Unblock();
-            env.SimulateSleep(runtime, TDuration::Seconds(35)); // greter than two default timouts (15 sec)
+            env.SimulateSleep(runtime, TDuration::Seconds(35)); // greater than two default timeouts (15 sec)
 
             UNIT_ASSERT_VALUES_EQUAL(
                 TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2870,7 +2870,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
             // release blocked results so schemeshard can finalize the compaction
             block.Stop().Unblock();
-            env.SimulateSleep(runtime, TDuration::Seconds(16)); // greter than default timout (15 sec)
+            env.SimulateSleep(runtime, TDuration::Seconds(16)); // greater than default timeout (15 sec)
 
             UNIT_ASSERT_VALUES_EQUAL(
                 TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -2806,6 +2806,78 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
             Ydb::Table::CompactState::STATE_DONE
         );
     }
+
+    Y_UNIT_TEST(SchemeshardShouldHandleTableDropDuringCompaction) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        Setup(runtime, env);
+
+        ui64 txId = 1000;
+
+        {
+            // first case: compaction should progress after timeout
+
+            CreateTable(runtime, env, "/MyRoot", "Simple1", 2, ++txId);
+            WriteData(runtime, "Simple1", 0, 100, TTestTxConfig::FakeHiveTablets);
+            WriteData(runtime, "Simple1", 0, 100, TTestTxConfig::FakeHiveTablets + 1);
+
+            // block compact request, so compaction results will never delivered
+            TBlockEvents<TEvDataShard::TEvCompactTable> block(runtime);
+
+            TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple1");
+            ui64 compactionId = txId;
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
+                Ydb::Table::CompactState::STATE_IN_PROGRESS
+            );
+
+            // drop the table mid-compaction
+            TestDropTable(runtime, ++txId, "/MyRoot", "Simple1");
+            env.TestWaitNotification(runtime, txId);
+
+            // release blocked EvCompactTable, but shards should be deleted and no EvCompactTable will be delivered
+            block.Stop().Unblock();
+            env.SimulateSleep(runtime, TDuration::Seconds(35)); // greter than two default timouts (15 sec)
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
+                Ydb::Table::CompactState::STATE_DONE
+            );
+        }
+
+        {
+            // second case: compaction should progress after stale or failed EvCompactTableResult
+            
+            CreateTable(runtime, env, "/MyRoot", "Simple2", 2, ++txId);
+            WriteData(runtime, "Simple2", 0, 100, TTestTxConfig::FakeHiveTablets + 2);
+            WriteData(runtime, "Simple2", 0, 100, TTestTxConfig::FakeHiveTablets + 3);
+
+            // block result, so compaction will be stuck in progress
+            TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
+
+            TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple2");
+            ui64 compactionId = txId;
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
+                Ydb::Table::CompactState::STATE_IN_PROGRESS
+            );
+
+            // drop the table mid-compaction
+            TestDropTable(runtime, ++txId, "/MyRoot", "Simple2");
+            env.TestWaitNotification(runtime, txId);
+
+            // release blocked results so schemeshard can finalize the compaction
+            block.Stop().Unblock();
+            env.SimulateSleep(runtime, TDuration::Seconds(16)); // greter than default timout (15 sec)
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
+                Ydb::Table::CompactState::STATE_DONE
+            );
+        }
+    }
 }
 
 } // NKikimr::NSchemeShard


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- add test when the compacted table is dropped
- fix the possible re-entry of ProcessForcedCompactionQueues inside EnqueueForcedCompaction
