### PR TITLE
Fix CREATE OR REPLACE for external data source, external table, resource pool

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -70,7 +70,6 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
     externalDataSourceDesc.SetSourceType(GetOrEmpty(settings, "source_type"));
     externalDataSourceDesc.SetLocation(GetOrEmpty(settings, "location"));
     externalDataSourceDesc.SetInstallation(GetOrEmpty(settings, "installation"));
-    externalDataSourceDesc.SetReplaceIfExists(settings.GetReplaceIfExists());
 
     const TString& authMethod = GetOrEmpty(settings, "auth_method");
     if (authMethod == "NONE") {
@@ -260,6 +259,7 @@ TYqlConclusionStatus TExternalDataSourceManager::PrepareCreateExternalDataSource
     schemeTx.SetWorkingDir(workingDir);
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalDataSource);
     schemeTx.SetFailedOnAlreadyExists(!settings.GetExistingOk());
+    schemeTx.SetReplaceIfExists(settings.GetReplaceIfExists());
 
     return FillCreateExternalDataSourceDesc(
         *schemeTx.MutableCreateExternalDataSource(), name, settings, context.GetExternalData().GetActorSystem());

--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -1193,9 +1193,10 @@ public:
             schemeTx.SetWorkingDir(pathPair.first);
             schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalTable);
             schemeTx.SetFailedOnAlreadyExists(!existingOk);
+            schemeTx.SetReplaceIfExists(replaceIfExists);
 
             NKikimrSchemeOp::TExternalTableDescription& externalTableDesc = *schemeTx.MutableCreateExternalTable();
-            NSchemeHelpers::FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, replaceIfExists, settings);
+            NSchemeHelpers::FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, settings);
             return SendSchemeRequest(ev.Release(), true);
         }
         catch (yexception& e) {

--- a/ydb/core/kqp/gateway/utils/scheme_helpers.cpp
+++ b/ydb/core/kqp/gateway/utils/scheme_helpers.cpp
@@ -83,14 +83,12 @@ TString SelectDatabaseForAlterLoginOperations(const TAppData* appData, const TSt
 
 void FillCreateExternalTableColumnDesc(NKikimrSchemeOp::TExternalTableDescription& externalTableDesc,
                                        const TString& name,
-                                       bool replaceIfExists,
                                        const TCreateExternalTableSettings& settings)
 {
     externalTableDesc.SetName(name);
     externalTableDesc.SetDataSourcePath(settings.DataSourcePath);
     externalTableDesc.SetLocation(settings.Location);
     externalTableDesc.SetSourceType("General");
-    externalTableDesc.SetReplaceIfExists(replaceIfExists);
 
     Y_ENSURE(settings.ColumnOrder.size() == settings.Columns.size());
     for (const auto& name : settings.ColumnOrder) {

--- a/ydb/core/kqp/gateway/utils/scheme_helpers.h
+++ b/ydb/core/kqp/gateway/utils/scheme_helpers.h
@@ -31,7 +31,6 @@ TString SelectDatabaseForAlterLoginOperations(const TAppData* appData, const TSt
 
 void FillCreateExternalTableColumnDesc(NKikimrSchemeOp::TExternalTableDescription& externalTableDesc,
                                        const TString& name,
-                                       bool replaceIfExists,
                                        const NYql::TCreateExternalTableSettings& settings);
 
 bool Validate(const NYql::TAlterDatabaseSettings& settings, NYql::TIssue& error);

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -2836,9 +2836,10 @@ public:
             schemeTx.SetWorkingDir(pathPair.first);
             schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalTable);
             schemeTx.SetFailedOnAlreadyExists(!existingOk);
+            schemeTx.SetReplaceIfExists(replaceIfExists);
 
             NKikimrSchemeOp::TExternalTableDescription& externalTableDesc = *schemeTx.MutableCreateExternalTable();
-            NSchemeHelpers::FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, replaceIfExists, settings);
+            NSchemeHelpers::FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, settings);
             TGenericResult result;
             result.SetSuccess();
             phyTxRemover.Forget();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
@@ -146,14 +146,6 @@ class TAlterExternalDataSource : public TSubOperation {
         return externalDataSource;
     }
 
-    void CreateTransaction(const TOperationContext& context,
-                           const TPathId& externalDataSourcePathId) const {
-        TTxState& txState = context.SS->CreateTx(OperationId,
-                                                 TTxState::TxAlterExternalDataSource,
-                                                 externalDataSourcePathId);
-        txState.Shards.clear();
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {
@@ -162,29 +154,6 @@ class TAlterExternalDataSource : public TSubOperation {
                                          : parentPath.Base()->LastTxId;
             context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
         }
-    }
-
-    void AdvanceTransactionStateToPropose(const TOperationContext& context,
-                                          NIceDb::TNiceDb& db) const {
-        context.SS->ChangeTxState(db, OperationId, TTxState::Propose);
-        context.OnComplete.ActivateTx(OperationId);
-    }
-
-    void PersistExternalDataSource(
-        const TOperationContext& context,
-        NIceDb::TNiceDb& db,
-        const TPathElement::TPtr& externalDataSourcePath,
-        const TExternalDataSourceInfo::TPtr& externalDataSourceInfo) const {
-        const auto& externalDataSourcePathId = externalDataSourcePath->PathId;
-
-        context.SS->ExternalDataSources[externalDataSourcePathId] = externalDataSourceInfo;
-
-        context.SS->PersistPath(db, externalDataSourcePathId);
-
-        context.SS->PersistExternalDataSource(db,
-                                              externalDataSourcePathId,
-                                              externalDataSourceInfo);
-        context.SS->PersistTxState(db, OperationId);
     }
 
 public:
@@ -255,15 +224,27 @@ public:
 
         AddPathInSchemeShard(result, dstPath);
         const TPathElement::TPtr externalDataSource = ReplaceExternalDataSourcePathElement(dstPath);
-        CreateTransaction(context, externalDataSource->PathId);
 
-        NIceDb::TNiceDb db(context.GetDB());
+        auto guard = context.DbGuard();
+
+        context.MemChanges.GrabPath(context.SS, externalDataSource->PathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabExternalDataSource(context.SS, externalDataSource->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(externalDataSource->PathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistExternalDataSource(externalDataSource->PathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        context.SS->ExternalDataSources[externalDataSource->PathId] = externalDataSourceInfo;
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxAlterExternalDataSource, externalDataSource->PathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
 
         RegisterParentPathDependencies(context, parentPath);
-
-        AdvanceTransactionStateToPropose(context, db);
-
-        PersistExternalDataSource(context, db, externalDataSource, externalDataSourceInfo);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,
@@ -277,7 +258,6 @@ public:
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TAlterExternalDataSource AbortPropose"
               << ": opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TAlterExternalDataSource");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
@@ -146,16 +146,6 @@ class TAlterExternalDataSource : public TSubOperation {
         return externalDataSource;
     }
 
-    void RegisterParentPathDependencies(const TOperationContext& context,
-                                        const TPath& parentPath) const {
-        if (parentPath.Base()->HasActiveChanges()) {
-            const TTxId parentTxId = parentPath.Base()->PlannedToCreate()
-                                         ? parentPath.Base()->CreateTxId
-                                         : parentPath.Base()->LastTxId;
-            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
-        }
-    }
-
 public:
     using TSubOperation::TSubOperation;
 
@@ -244,7 +234,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        RegisterParentPathDependencies(context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
@@ -212,16 +212,6 @@ private:
         return externalTable;
     }
 
-    void CreateTransaction(const TOperationContext& context,
-                           const TPathId& externalTablePathId,
-                           const TPathId& externalDataSourcePathId) const {
-        TTxState& txState = context.SS->CreateTx(OperationId,
-                                                 TTxState::TxAlterExternalTable,
-                                                 externalTablePathId,
-                                                 externalDataSourcePathId);
-        txState.Shards.clear();
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {
@@ -230,12 +220,6 @@ private:
                                    : parentPath.Base()->LastTxId;
             context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
         }
-    }
-
-    void AdvanceTransactionStateToPropose(const TOperationContext& context,
-                                          NIceDb::TNiceDb& db) const {
-        context.SS->ChangeTxState(db, OperationId, TTxState::Propose);
-        context.OnComplete.ActivateTx(OperationId);
     }
 
     static void LinkExternalDataSourceWithExternalTable(
@@ -258,36 +242,6 @@ private:
         }
     }
 
-    void PersistExternalTable(
-        const TOperationContext& context,
-        NIceDb::TNiceDb& db,
-        const TPathElement::TPtr& externalTable,
-        const TExternalTableInfo::TPtr& externalTableInfo,
-        const TExternalTableInfo::TPtr& oldExternalTableInfo,
-        const TPathId& externalDataSourcePathId,
-        const TExternalDataSourceInfo::TPtr& externalDataSource,
-        const TPathId& oldExternalDataSourcePathId,
-        const TExternalDataSourceInfo::TPtr& oldExternalDataSource,
-        bool isSameDataSource) const {
-        context.SS->ExternalTables[externalTable->PathId] = externalTableInfo;
-
-        context.SS->PersistPath(db, externalTable->PathId);
-
-        if (!isSameDataSource) {
-            context.SS->PersistExternalDataSource(db, externalDataSourcePathId, externalDataSource);
-            context.SS->PersistExternalDataSource(db, oldExternalDataSourcePathId, oldExternalDataSource);
-        }
-
-        for (const auto& [oldColId, _] : oldExternalTableInfo->Columns) {
-            if (!externalTableInfo->Columns.contains(oldColId)) {
-                db.Table<Schema::MigratedColumns>().Key(externalTable->PathId.OwnerId, externalTable->PathId.LocalPathId, oldColId).Delete();
-            }
-        }
-
-        context.SS->PersistExternalTable(db, externalTable->PathId, externalTableInfo);
-        context.SS->PersistTxState(db, OperationId);
-    }
-
 public:
     using TSubOperation::TSubOperation;
 
@@ -301,7 +255,7 @@ public:
 
         LOG_N("TAlterExternalTable Propose"
             << ": opId# " << OperationId
-            << ", path# " << parentPathStr << "/" << name << ", ReplaceIfExists: " << externalTableDescription.GetReplaceIfExists());
+            << ", path# " << parentPathStr << "/" << name << ", ReplaceIfExists: " << Transaction.GetReplaceIfExists());
 
         auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted,
                                                    static_cast<ui64>(OperationId.GetTxId()),
@@ -368,12 +322,27 @@ public:
         AddPathInSchemeShard(result, dstPath);
 
         const auto externalTable = ReplaceExternalTablePathElement(dstPath);
-        CreateTransaction(context, externalTable->PathId, dataSourcePath->PathId);
 
-        NIceDb::TNiceDb db(context.GetDB());
+        auto guard = context.DbGuard();
 
-        RegisterParentPathDependencies(context, parentPath);
-        AdvanceTransactionStateToPropose(context, db);
+        context.MemChanges.GrabPath(context.SS, externalTable->PathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabExternalTable(context.SS, externalTable->PathId);
+        context.MemChanges.GrabExternalDataSource(context.SS, dataSourcePath.Base()->PathId);
+        if (!IsSameDataSource) {
+            context.MemChanges.GrabPath(context.SS, dataSourcePath.Base()->PathId);
+            context.MemChanges.GrabExternalDataSource(context.SS, OldDataSourcePathId);
+        }
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(externalTable->PathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistExternalTable(externalTable->PathId);
+        if (!IsSameDataSource) {
+            context.DbChanges.PersistExternalDataSource(dataSourcePath.Base()->PathId);
+            context.DbChanges.PersistExternalDataSource(OldDataSourcePathId);
+        }
+        context.DbChanges.PersistTxState(OperationId);
 
         LinkExternalDataSourceWithExternalTable(externalDataSource,
                                                 externalTable,
@@ -381,10 +350,24 @@ public:
                                                 oldDataSource,
                                                 IsSameDataSource);
 
-        PersistExternalTable(context, db, externalTable, externalTableInfo, oldExternalTableInfo,
-                             dataSourcePath->PathId, externalDataSource,
-                             OldDataSourcePathId, oldDataSource,
-                             IsSameDataSource);
+        // Carry over removed columns with DeleteVersion set (soft-delete, like regular tables)
+        for (const auto& [oldColId, oldCol] : oldExternalTableInfo->Columns) {
+            if (!externalTableInfo->Columns.contains(oldColId)) {
+                auto deletedCol = oldCol;
+                deletedCol.DeleteVersion = externalTableInfo->AlterVersion;
+                externalTableInfo->Columns[oldColId] = deletedCol;
+            }
+        }
+
+        context.SS->ExternalTables[externalTable->PathId] = externalTableInfo;
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxAlterExternalTable,
+                                                  externalTable->PathId, dataSourcePath.Base()->PathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        RegisterParentPathDependencies(context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,
@@ -398,7 +381,6 @@ public:
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TAlterExternalTable AbortPropose"
             << ": opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TAlterExternalTable");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
@@ -212,16 +212,6 @@ private:
         return externalTable;
     }
 
-    void RegisterParentPathDependencies(const TOperationContext& context,
-                                        const TPath& parentPath) const {
-        if (parentPath.Base()->HasActiveChanges()) {
-            const auto parentTxId = parentPath.Base()->PlannedToCreate()
-                                   ? parentPath.Base()->CreateTxId
-                                   : parentPath.Base()->LastTxId;
-            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
-        }
-    }
-
     static void LinkExternalDataSourceWithExternalTable(
         const TExternalDataSourceInfo::TPtr& externalDataSource,
         const TPathElement::TPtr& externalTable,
@@ -367,7 +357,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        RegisterParentPathDependencies(context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
@@ -149,12 +149,27 @@ public:
 
         result->SetPathId(dstPath.Base()->PathId.LocalPathId);
         const TPathElement::TPtr resourcePool = ReplaceResourcePoolPathElement(dstPath);
-        NResourcePool::CreateTransaction(OperationId, context, resourcePool->PathId, TTxState::TxAlterResourcePool);
-        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
 
-        NIceDb::TNiceDb db(context.GetDB());
-        NResourcePool::AdvanceTransactionStateToPropose(OperationId, context, db);
-        NResourcePool::PersistResourcePool(OperationId, context, db, resourcePool, resourcePoolInfo, /* acl */ TString());
+        auto guard = context.DbGuard();
+
+        context.MemChanges.GrabPath(context.SS, resourcePool->PathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabResourcePool(context.SS, resourcePool->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(resourcePool->PathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistResourcePool(resourcePool->PathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        context.SS->ResourcePools[resourcePool->PathId] = resourcePoolInfo;
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxAlterResourcePool, resourcePool->PathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId, dstPath, context.SS, context.OnComplete);
 
@@ -164,7 +179,6 @@ public:
 
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TAlterResourcePool AbortPropose: opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TAlterResourcePool");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
@@ -169,7 +169,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId, dstPath, context.SS, context.OnComplete);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -1243,6 +1243,15 @@ void ValidateNoTransactionOnPaths(TOperationId operationId, const THashSet<TPath
 
 }  // namespace NForceDrop
 
+void RegisterParentPathDependencies(const TOperationId& operationId, const TOperationContext& context, const TPath& parentPath) {
+    if (parentPath.Base()->HasActiveChanges()) {
+        const TTxId parentTxId = parentPath.Base()->PlannedToCreate()
+                                    ? parentPath.Base()->CreateTxId
+                                    : parentPath.Base()->LastTxId;
+        context.OnComplete.Dependence(parentTxId, operationId.GetTxId());
+    }
+}
+
 void IncParentDirAlterVersionWithRepublishSafeWithUndo(const TOperationId& opId, const TPath& path, TSchemeShard* ss, TSideEffects& onComplete) {
     auto parent = path.Parent();
     if (parent.Base()->IsDirectory() || parent.Base()->IsDomainRoot()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.h
@@ -55,6 +55,8 @@ TSet<ui32> AllIncomingEvents();
 void IncParentDirAlterVersionWithRepublishSafeWithUndo(const TOperationId& opId, const TPath& path, TSchemeShard* ss, TSideEffects& onComplete);
 void IncParentDirAlterVersionWithRepublish(const TOperationId& opId, const TPath& path, TOperationContext& context);
 
+void RegisterParentPathDependencies(const TOperationId& operationId, const TOperationContext& context, const TPath& parentPath);
+
 void IncAliveChildrenSafeWithUndo(const TOperationId& opId, const TPath& parentPath, TOperationContext& context, bool isBackup = false);
 void IncAliveChildrenDirect(const TOperationId& opId, const TPath& parentPath, TOperationContext& context, bool isBackup = false);
 void DecAliveChildrenDirect(const TOperationId& opId, TPathElement::TPtr parentPath, TOperationContext& context, bool isBackup = false);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
@@ -118,26 +118,4 @@ void RegisterParentPathDependencies(const TOperationId& operationId, const TOper
     }
 }
 
-void AdvanceTransactionStateToPropose(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db) {
-    context.SS->ChangeTxState(db, operationId, TTxState::Propose);
-    context.OnComplete.ActivateTx(operationId);
-}
-
-void PersistResourcePool(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db, const TPathElement::TPtr& resourcePoolPath, const TResourcePoolInfo::TPtr& resourcePoolInfo, const TString& acl) {
-    const auto& resourcePoolPathId = resourcePoolPath->PathId;
-
-    if (!context.SS->ResourcePools.contains(resourcePoolPathId)) {
-        context.SS->IncrementPathDbRefCount(resourcePoolPathId);
-    }
-    context.SS->ResourcePools[resourcePoolPathId] = resourcePoolInfo;
-
-    if (!acl.empty()) {
-        resourcePoolPath->ApplyACL(acl);
-    }
-
-    context.SS->PersistPath(db, resourcePoolPathId);
-    context.SS->PersistResourcePool(db, resourcePoolPathId, resourcePoolInfo);
-    context.SS->PersistTxState(db, operationId);
-}
-
 }  // namespace NKikimr::NSchemeShard::NResourcePool

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
@@ -109,13 +109,5 @@ TTxState& CreateTransaction(const TOperationId& operationId, const TOperationCon
     return txState;
 }
 
-void RegisterParentPathDependencies(const TOperationId& operationId, const TOperationContext& context, const TPath& parentPath) {
-    if (parentPath.Base()->HasActiveChanges()) {
-        const TTxId parentTxId = parentPath.Base()->PlannedToCreate()
-                                    ? parentPath.Base()->CreateTxId
-                                    : parentPath.Base()->LastTxId;
-        context.OnComplete.Dependence(parentTxId, operationId.GetTxId());
-    }
-}
 
 }  // namespace NKikimr::NSchemeShard::NResourcePool

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
@@ -30,8 +30,4 @@ TTxState& CreateTransaction(const TOperationId& operationId, const TOperationCon
 
 void RegisterParentPathDependencies(const TOperationId& operationId, const TOperationContext& context, const TPath& parentPath);
 
-void AdvanceTransactionStateToPropose(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db);
-
-void PersistResourcePool(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db, const TPathElement::TPtr& resourcePoolPath, const TResourcePoolInfo::TPtr& resourcePoolInfo, const TString& acl);
-
 }  // namespace NKikimr::NSchemeShard::NResourcePool

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
@@ -28,6 +28,4 @@ bool IsResourcePoolInfoValid(const THolder<TProposeResponse>& result, const TRes
 
 TTxState& CreateTransaction(const TOperationId& operationId, const TOperationContext& context, const TPathId& resourcePoolPathId, TTxState::ETxType txType);
 
-void RegisterParentPathDependencies(const TOperationId& operationId, const TOperationContext& context, const TPath& parentPath);
-
 }  // namespace NKikimr::NSchemeShard::NResourcePool

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
@@ -171,14 +171,6 @@ class TCreateExternalDataSource : public TSubOperation {
         return externalDataSource;
     }
 
-    void CreateTransaction(const TOperationContext &context,
-                           const TPathId &externalDataSourcePathId) const {
-        TTxState& txState = context.SS->CreateTx(OperationId,
-                                                 TTxState::TxCreateExternalDataSource,
-                                                 externalDataSourcePathId);
-        txState.Shards.clear();
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {
@@ -187,34 +179,6 @@ class TCreateExternalDataSource : public TSubOperation {
                                          : parentPath.Base()->LastTxId;
             context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
         }
-    }
-
-    void AdvanceTransactionStateToPropose(const TOperationContext& context,
-                                          NIceDb::TNiceDb& db) const {
-        context.SS->ChangeTxState(db, OperationId, TTxState::Propose);
-        context.OnComplete.ActivateTx(OperationId);
-    }
-
-    void PersistExternalDataSource(
-        const TOperationContext& context,
-        NIceDb::TNiceDb& db,
-        const TPathElement::TPtr& externalDataSourcePath,
-        const TExternalDataSourceInfo::TPtr& externalDataSourceInfo,
-        const TString& acl) const {
-        const auto& externalDataSourcePathId = externalDataSourcePath->PathId;
-
-        context.SS->ExternalDataSources[externalDataSourcePathId] = externalDataSourceInfo;
-        context.SS->IncrementPathDbRefCount(externalDataSourcePathId);
-
-        if (!acl.empty()) {
-            externalDataSourcePath->ApplyACL(acl);
-        }
-        context.SS->PersistPath(db, externalDataSourcePathId);
-
-        context.SS->PersistExternalDataSource(db,
-                                              externalDataSourcePathId,
-                                              externalDataSourceInfo);
-        context.SS->PersistTxState(db, OperationId);
     }
 
 public:
@@ -260,19 +224,41 @@ public:
             NExternalDataSource::CreateExternalDataSource(externalDataSourceDescription, 1);
         Y_ABORT_UNLESS(externalDataSourceInfo);
 
-        AddPathInSchemeShard(result, dstPath, owner);
-        const TPathElement::TPtr externalDataSource =
-            CreateExternalDataSourcePathElement(dstPath);
-        CreateTransaction(context, externalDataSource->PathId);
+        const auto newPathId = context.SS->AllocatePathId();
 
-        NIceDb::TNiceDb db(context.GetDB());
+        auto guard = context.DbGuard();
+
+        context.MemChanges.GrabNewPath(context.SS, newPathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabNewExternalDataSource(context.SS, newPathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(newPathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistExternalDataSource(newPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        dstPath.MaterializeLeaf(owner, newPathId);
+        result->SetPathId(newPathId.LocalPathId);
+
+        TPathElement::TPtr externalDataSource = dstPath.Base();
+        externalDataSource->CreateTxId = OperationId.GetTxId();
+        externalDataSource->PathType = TPathElement::EPathType::EPathTypeExternalDataSource;
+        externalDataSource->PathState = TPathElement::EPathState::EPathStateCreate;
+        externalDataSource->LastTxId  = OperationId.GetTxId();
+
+        context.SS->ExternalDataSources[newPathId] = externalDataSourceInfo;
+        context.SS->IncrementPathDbRefCount(newPathId);
+        if (!acl.empty()) {
+            externalDataSource->ApplyACL(acl);
+        }
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxCreateExternalDataSource, newPathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
 
         RegisterParentPathDependencies(context, parentPath);
-
-        AdvanceTransactionStateToPropose(context, db);
-
-        PersistExternalDataSource(context, db, externalDataSource,
-                                  externalDataSourceInfo, acl);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,
@@ -280,7 +266,7 @@ public:
                                                           context.OnComplete);
 
         dstPath.DomainInfo()->IncPathsInside(context.SS);
-        IncAliveChildrenDirect(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
 
         SetState(NextState());
         return result;
@@ -289,7 +275,6 @@ public:
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TCreateExternalDataSource AbortPropose"
               << ": opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TCreateExternalDataSource");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
@@ -341,7 +326,7 @@ TVector<ISubOperation::TPtr> CreateNewExternalDataSource(TOperationId id,
     };
 
     const auto &operation = tx.GetCreateExternalDataSource();
-    const auto replaceIfExists = operation.GetReplaceIfExists();
+    const auto replaceIfExists = tx.GetReplaceIfExists();
     const TString &name = operation.GetName();
 
     if (replaceIfExists && !context.SS->EnableReplaceIfExistsForExternalEntities) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
@@ -154,16 +154,6 @@ class TCreateExternalDataSource : public TSubOperation {
         return true;
     }
 
-    void RegisterParentPathDependencies(const TOperationContext& context,
-                                        const TPath& parentPath) const {
-        if (parentPath.Base()->HasActiveChanges()) {
-            const TTxId parentTxId = parentPath.Base()->PlannedToCreate()
-                                         ? parentPath.Base()->CreateTxId
-                                         : parentPath.Base()->LastTxId;
-            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
-        }
-    }
-
 public:
     using TSubOperation::TSubOperation;
 
@@ -241,7 +231,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        RegisterParentPathDependencies(context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
@@ -154,23 +154,6 @@ class TCreateExternalDataSource : public TSubOperation {
         return true;
     }
 
-    static void AddPathInSchemeShard(
-        const THolder<TProposeResponse>& result, TPath& dstPath, const TString& owner) {
-        dstPath.MaterializeLeaf(owner);
-        result->SetPathId(dstPath.Base()->PathId.LocalPathId);
-    }
-
-    TPathElement::TPtr CreateExternalDataSourcePathElement(const TPath& dstPath) const {
-        TPathElement::TPtr externalDataSource = dstPath.Base();
-
-        externalDataSource->CreateTxId = OperationId.GetTxId();
-        externalDataSource->PathType = TPathElement::EPathType::EPathTypeExternalDataSource;
-        externalDataSource->PathState = TPathElement::EPathState::EPathStateCreate;
-        externalDataSource->LastTxId  = OperationId.GetTxId();
-
-        return externalDataSource;
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
@@ -230,15 +230,6 @@ private:
         return externalTable;
     }
 
-    void CreateTransaction(const TOperationContext &context,
-                           const TPathId &externalTablePathId,
-                           const TPathId &externalDataSourcePathId) const {
-      TTxState &txState =
-          context.SS->CreateTx(OperationId, TTxState::TxCreateExternalTable,
-                               externalTablePathId, externalDataSourcePathId);
-      txState.Shards.clear();
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {
@@ -249,12 +240,6 @@ private:
         }
     }
 
-    void AdvanceTransactionStateToPropose(const TOperationContext& context,
-                                          NIceDb::TNiceDb& db) const {
-        context.SS->ChangeTxState(db, OperationId, TTxState::Propose);
-        context.OnComplete.ActivateTx(OperationId);
-    }
-
     static void LinkExternalDataSourceWithExternalTable(
         const TExternalDataSourceInfo::TPtr& externalDataSource,
         const TPathElement::TPtr& externalTable,
@@ -262,28 +247,6 @@ private:
         auto& reference = *externalDataSource->ExternalTableReferences.AddReferences();
         reference.SetPath(dstPath.PathString());
         externalTable->PathId.ToProto(reference.MutablePathId());
-    }
-
-    void PersistExternalTable(
-        const TOperationContext& context,
-        NIceDb::TNiceDb& db,
-        const TPathElement::TPtr& externalTable,
-        const TExternalTableInfo::TPtr& externalTableInfo,
-        const TPathId& externalDataSourcePathId,
-        const TExternalDataSourceInfo::TPtr& externalDataSource,
-        const TString& acl) const {
-        context.SS->ExternalTables[externalTable->PathId] = externalTableInfo;
-        context.SS->IncrementPathDbRefCount(externalTable->PathId);
-
-
-        if (!acl.empty()) {
-            externalTable->ApplyACL(acl);
-        }
-        context.SS->PersistPath(db, externalTable->PathId);
-
-        context.SS->PersistExternalDataSource(db, externalDataSourcePathId, externalDataSource);
-        context.SS->PersistExternalTable(db, externalTable->PathId, externalTableInfo);
-        context.SS->PersistTxState(db, OperationId);
     }
 
 public:
@@ -344,27 +307,49 @@ public:
         }
         Y_ABORT_UNLESS(externalTableInfo);
 
-        AddPathInSchemeShard(result, dstPath, owner);
+        const auto newPathId = context.SS->AllocatePathId();
 
-        const auto externalTable = CreateExternalTablePathElement(dstPath);
-        CreateTransaction(context, externalTable->PathId, dataSourcePath->PathId);
+        auto guard = context.DbGuard();
 
-        NIceDb::TNiceDb db(context.GetDB());
+        context.MemChanges.GrabNewPath(context.SS, newPathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabPath(context.SS, dataSourcePath.Base()->PathId);
+        context.MemChanges.GrabNewExternalTable(context.SS, newPathId);
+        context.MemChanges.GrabExternalDataSource(context.SS, dataSourcePath.Base()->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
 
-        RegisterParentPathDependencies(context, parentPath);
-        AdvanceTransactionStateToPropose(context, db);
+        context.DbChanges.PersistPath(newPathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistExternalDataSource(dataSourcePath.Base()->PathId);
+        context.DbChanges.PersistExternalTable(newPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        dstPath.MaterializeLeaf(owner, newPathId);
+        result->SetPathId(newPathId.LocalPathId);
+
+        TPathElement::TPtr externalTable = dstPath.Base();
+        externalTable->CreateTxId = OperationId.GetTxId();
+        externalTable->PathType  = TPathElement::EPathType::EPathTypeExternalTable;
+        externalTable->PathState = TPathElement::EPathState::EPathStateCreate;
+        externalTable->LastTxId  = OperationId.GetTxId();
 
         LinkExternalDataSourceWithExternalTable(externalDataSource,
                                                 externalTable,
                                                 dstPath);
 
-        PersistExternalTable(context,
-                             db,
-                             externalTable,
-                             externalTableInfo,
-                             dataSourcePath->PathId,
-                             externalDataSource,
-                             acl);
+        context.SS->ExternalTables[newPathId] = externalTableInfo;
+        context.SS->IncrementPathDbRefCount(newPathId);
+        if (!acl.empty()) {
+            externalTable->ApplyACL(acl);
+        }
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxCreateExternalTable,
+                                                  newPathId, dataSourcePath.Base()->PathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        RegisterParentPathDependencies(context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,
@@ -372,7 +357,7 @@ public:
                                                           context.OnComplete);
 
         dstPath.DomainInfo()->IncPathsInside(context.SS);
-        IncAliveChildrenDirect(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
 
         SetState(NextState());
         return result;
@@ -381,7 +366,6 @@ public:
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TCreateExternalTable AbortPropose"
             << ": opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TCreateExternalTable");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
@@ -432,7 +416,7 @@ TVector<ISubOperation::TPtr> CreateNewExternalTable(TOperationId id, const TTxTr
     };
 
     const auto &operation = tx.GetCreateExternalTable();
-    const auto replaceIfExists = operation.GetReplaceIfExists();
+    const auto replaceIfExists = tx.GetReplaceIfExists();
     const TString &name = operation.GetName();
 
     if (replaceIfExists && !context.SS->EnableReplaceIfExistsForExternalEntities) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
@@ -214,16 +214,6 @@ private:
         return true;
     }
 
-    void RegisterParentPathDependencies(const TOperationContext& context,
-                                        const TPath& parentPath) const {
-        if (parentPath.Base()->HasActiveChanges()) {
-            const auto parentTxId = parentPath.Base()->PlannedToCreate()
-                                   ? parentPath.Base()->CreateTxId
-                                   : parentPath.Base()->LastTxId;
-            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
-        }
-    }
-
     static void LinkExternalDataSourceWithExternalTable(
         const TExternalDataSourceInfo::TPtr& externalDataSource,
         const TPathElement::TPtr& externalTable,
@@ -333,7 +323,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        RegisterParentPathDependencies(context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
@@ -214,22 +214,6 @@ private:
         return true;
     }
 
-    static void AddPathInSchemeShard(const THolder<TProposeResponse> &result,
-                                     TPath &dstPath, const TString &owner) {
-        dstPath.MaterializeLeaf(owner);
-        result->SetPathId(dstPath.Base()->PathId.LocalPathId);
-    }
-
-    TPathElement::TPtr CreateExternalTablePathElement(const TPath& dstPath) const {
-        TPathElement::TPtr externalTable = dstPath.Base();
-        externalTable->CreateTxId        = OperationId.GetTxId();
-        externalTable->PathType  = TPathElement::EPathType::EPathTypeExternalTable;
-        externalTable->PathState = TPathElement::EPathState::EPathStateCreate;
-        externalTable->LastTxId  = OperationId.GetTxId();
-
-        return externalTable;
-    }
-
     void RegisterParentPathDependencies(const TOperationContext& context,
                                         const TPath& parentPath) const {
         if (parentPath.Base()->HasActiveChanges()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
@@ -171,19 +171,46 @@ public:
         Y_ABORT_UNLESS(resourcePoolInfo);
         RETURN_RESULT_UNLESS(NResourcePool::IsResourcePoolInfoValid(result, resourcePoolInfo));
 
-        AddPathInSchemeShard(result, dstPath, owner);
-        const TPathElement::TPtr resourcePool = CreateResourcePoolPathElement(dstPath);
-        NResourcePool::CreateTransaction(OperationId, context, resourcePool->PathId, TTxState::TxCreateResourcePool);
-        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
+        const auto newPathId = context.SS->AllocatePathId();
 
-        NIceDb::TNiceDb db(context.GetDB());
-        NResourcePool::AdvanceTransactionStateToPropose(OperationId, context, db);
-        NResourcePool::PersistResourcePool(OperationId, context, db, resourcePool, resourcePoolInfo, acl);
+        auto guard = context.DbGuard();
+
+        context.MemChanges.GrabNewPath(context.SS, newPathId);
+        context.MemChanges.GrabPath(context.SS, parentPath.Base()->PathId);
+        context.MemChanges.GrabNewResourcePool(context.SS, newPathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(newPathId);
+        context.DbChanges.PersistPath(parentPath.Base()->PathId);
+        context.DbChanges.PersistResourcePool(newPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        dstPath.MaterializeLeaf(owner, newPathId);
+        result->SetPathId(newPathId.LocalPathId);
+
+        TPathElement::TPtr resourcePool = dstPath.Base();
+        resourcePool->CreateTxId = OperationId.GetTxId();
+        resourcePool->PathType = TPathElement::EPathType::EPathTypeResourcePool;
+        resourcePool->PathState = TPathElement::EPathState::EPathStateCreate;
+        resourcePool->LastTxId  = OperationId.GetTxId();
+
+        context.SS->ResourcePools[newPathId] = resourcePoolInfo;
+        context.SS->IncrementPathDbRefCount(newPathId);
+        if (!acl.empty()) {
+            resourcePool->ApplyACL(acl);
+        }
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxCreateResourcePool, newPathId);
+        txState.Shards.clear();
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId, dstPath, context.SS, context.OnComplete);
 
         dstPath.DomainInfo()->IncPathsInside(context.SS);
-        IncAliveChildrenDirect(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
 
         SetState(NextState());
         return result;
@@ -191,7 +218,6 @@ public:
 
     void AbortPropose(TOperationContext& context) override {
         LOG_N("TCreateResourcePool AbortPropose: opId# " << OperationId);
-        Y_ABORT("no AbortPropose for TCreateResourcePool");
     }
 
     void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
@@ -189,7 +189,7 @@ public:
         txState.State = TTxState::Propose;
         context.OnComplete.ActivateTx(OperationId);
 
-        NResourcePool::RegisterParentPathDependencies(OperationId, context, parentPath);
+        RegisterParentPathDependencies(OperationId, context, parentPath);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId, dstPath, context.SS, context.OnComplete);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
@@ -122,22 +122,6 @@ class TCreateResourcePool : public TSubOperation {
         return static_cast<bool>(checks);
     }
 
-    static void AddPathInSchemeShard(const THolder<TProposeResponse>& result, TPath& dstPath, const TString& owner) {
-        dstPath.MaterializeLeaf(owner);
-        result->SetPathId(dstPath.Base()->PathId.LocalPathId);
-    }
-
-    TPathElement::TPtr CreateResourcePoolPathElement(const TPath& dstPath) const {
-        TPathElement::TPtr resourcePool = dstPath.Base();
-
-        resourcePool->CreateTxId = OperationId.GetTxId();
-        resourcePool->PathType = TPathElement::EPathType::EPathTypeResourcePool;
-        resourcePool->PathState = TPathElement::EPathState::EPathStateCreate;
-        resourcePool->LastTxId  = OperationId.GetTxId();
-
-        return resourcePool;
-    }
-
 public:
     using TSubOperation::TSubOperation;
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
@@ -132,6 +132,18 @@ void TStorageChanges::Apply(TSchemeShard* ss, NTabletFlatExecutor::TTransactionC
     for (const auto& pId : StreamingQueries) {
         ss->PersistStreamingQuery(db, pId);
     }
+
+    for (const auto& pId : ExternalDataSources) {
+        ss->PersistExternalDataSource(db, pId);
+    }
+
+    for (const auto& pId : ExternalTables) {
+        ss->PersistExternalTable(db, pId);
+    }
+
+    for (const auto& pId : ResourcePools) {
+        ss->PersistResourcePool(db, pId);
+    }
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
@@ -54,6 +54,10 @@ class TStorageChanges: public TSimpleRefCount<TStorageChanges> {
 
     TDeque<TPathId> StreamingQueries;
 
+    TDeque<TPathId> ExternalDataSources;
+    TDeque<TPathId> ExternalTables;
+    TDeque<TPathId> ResourcePools;
+
     //PQ part
     TDeque<std::tuple<TPathId, TShardIdx, TTopicTabletInfo::TTopicPartitionInfo>> PersQueue;
     TDeque<std::pair<TPathId, TTopicInfo::TPtr>> PersQueueGroup;
@@ -168,6 +172,18 @@ public:
 
     void PersistStreamingQuery(const TPathId& pathId) {
         StreamingQueries.emplace_back(pathId);
+    }
+
+    void PersistExternalDataSource(const TPathId& pathId) {
+        ExternalDataSources.emplace_back(pathId);
+    }
+
+    void PersistExternalTable(const TPathId& pathId) {
+        ExternalTables.emplace_back(pathId);
+    }
+
+    void PersistResourcePool(const TPathId& pathId) {
+        ResourcePools.emplace_back(pathId);
     }
 
     void Apply(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_external_table.cpp
@@ -61,7 +61,7 @@ public:
         EraseIf(*externalDataSourceInfo->ExternalTableReferences.MutableReferences(), [pathId](const NKikimrSchemeOp::TExternalTableReferences::TReference& reference) { return TPathId::FromProto(reference.GetPathId()) == pathId; });
 
         context.SS->TabletCounters->Simple()[COUNTER_EXTERNAL_TABLE_COUNT].Sub(1);
-        context.SS->PersistExternalDataSource(db, dataSourcePathId, externalDataSourceInfo);
+        context.SS->PersistExternalDataSource(db, dataSourcePathId);
         context.SS->PersistRemoveExternalTable(db, pathId);
 
         ++parentDir->DirAlterVersion;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
@@ -97,8 +97,16 @@ void TMemoryChanges::GrabLongLock(TSchemeShard* ss, const TPathId& pathId, TTxId
     LockedPaths.emplace(pathId, lockTxId); // will be restored on UnDo()
 }
 
+void TMemoryChanges::GrabNewExternalTable(TSchemeShard* ss, const TPathId& pathId) {
+    GrabNew(pathId, ss->ExternalTables, ExternalTables);
+}
+
 void TMemoryChanges::GrabExternalTable(TSchemeShard* ss, const TPathId& pathId) {
     Grab<TExternalTableInfo>(pathId, ss->ExternalTables, ExternalTables);
+}
+
+void TMemoryChanges::GrabNewExternalDataSource(TSchemeShard* ss, const TPathId& pathId) {
+    GrabNew(pathId, ss->ExternalDataSources, ExternalDataSources);
 }
 
 void TMemoryChanges::GrabExternalDataSource(TSchemeShard* ss, const TPathId& pathId) {
@@ -111,6 +119,10 @@ void TMemoryChanges::GrabNewView(TSchemeShard* ss, const TPathId& pathId) {
 
 void TMemoryChanges::GrabView(TSchemeShard* ss, const TPathId& pathId) {
     Grab<TViewInfo>(pathId, ss->Views, Views);
+}
+
+void TMemoryChanges::GrabNewResourcePool(TSchemeShard* ss, const TPathId& pathId) {
+    GrabNew(pathId, ss->ResourcePools, ResourcePools);
 }
 
 void TMemoryChanges::GrabResourcePool(TSchemeShard* ss, const TPathId& pathId) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
@@ -108,13 +108,16 @@ public:
     void GrabNewLongLock(TSchemeShard* ss, const TPathId& pathId);
     void GrabLongLock(TSchemeShard* ss, const TPathId& pathId, TTxId lockTxId);
 
+    void GrabNewExternalTable(TSchemeShard* ss, const TPathId& pathId);
     void GrabExternalTable(TSchemeShard* ss, const TPathId& pathId);
 
+    void GrabNewExternalDataSource(TSchemeShard* ss, const TPathId& pathId);
     void GrabExternalDataSource(TSchemeShard* ss, const TPathId& pathId);
 
     void GrabNewView(TSchemeShard* ss, const TPathId& pathId);
     void GrabView(TSchemeShard* ss, const TPathId& pathId);
 
+    void GrabNewResourcePool(TSchemeShard* ss, const TPathId& pathId);
     void GrabResourcePool(TSchemeShard* ss, const TPathId& pathId);
 
     void GrabNewBackupCollection(TSchemeShard* ss, const TPathId& pathId);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3268,6 +3268,15 @@ void TSchemeShard::PersistRtmrVolume(NIceDb::TNiceDb &db, TPathId pathId, const 
     }
 }
 
+void TSchemeShard::PersistExternalTable(NIceDb::TNiceDb &db, TPathId pathId) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+    const auto it = ExternalTables.find(pathId);
+    Y_ABORT_UNLESS(it != ExternalTables.end());
+    const auto info = it->second;
+    Y_ABORT_UNLESS(info);
+    PersistExternalTable(db, pathId, info);
+}
+
 void TSchemeShard::PersistExternalTable(NIceDb::TNiceDb &db, TPathId pathId, const TExternalTableInfo::TPtr externalTableInfo) {
     Y_ABORT_UNLESS(IsLocalId(pathId));
 
@@ -3317,6 +3326,15 @@ void TSchemeShard::PersistRemoveExternalTable(NIceDb::TNiceDb& db, TPathId pathI
     }
 
     db.Table<Schema::ExternalTable>().Key(pathId.OwnerId, pathId.LocalPathId).Delete();
+}
+
+void TSchemeShard::PersistExternalDataSource(NIceDb::TNiceDb &db, TPathId pathId) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+    const auto it = ExternalDataSources.find(pathId);
+    Y_ABORT_UNLESS(it != ExternalDataSources.end());
+    const auto info = it->second;
+    Y_ABORT_UNLESS(info);
+    PersistExternalDataSource(db, pathId, info);
 }
 
 void TSchemeShard::PersistExternalDataSource(NIceDb::TNiceDb &db, TPathId pathId, const TExternalDataSourceInfo::TPtr externalDataSourceInfo) {
@@ -3421,6 +3439,15 @@ void TSchemeShard::PersistRemoveSysView(NIceDb::TNiceDb& db, TPathId pathId) {
     }
 
     db.Table<Schema::SysView>().Key(pathId.LocalPathId).Delete();
+}
+
+void TSchemeShard::PersistResourcePool(NIceDb::TNiceDb& db, TPathId pathId) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+    const auto it = ResourcePools.find(pathId);
+    Y_ABORT_UNLESS(it != ResourcePools.end());
+    const auto info = it->second;
+    Y_ABORT_UNLESS(info);
+    PersistResourcePool(db, pathId, info);
 }
 
 void TSchemeShard::PersistResourcePool(NIceDb::TNiceDb& db, TPathId pathId, const TResourcePoolInfo::TPtr resourcePool) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -962,10 +962,12 @@ public:
     void PersistStorageBillingTime(NIceDb::TNiceDb& db);
 
     // ExternalTable
+    void PersistExternalTable(NIceDb::TNiceDb &db, TPathId pathId);
     void PersistExternalTable(NIceDb::TNiceDb &db, TPathId pathId, const TExternalTableInfo::TPtr externalTable);
     void PersistRemoveExternalTable(NIceDb::TNiceDb& db, TPathId pathId);
 
     // ExternalDataSource
+    void PersistExternalDataSource(NIceDb::TNiceDb &db, TPathId pathId);
     void PersistExternalDataSource(NIceDb::TNiceDb &db, TPathId pathId, const TExternalDataSourceInfo::TPtr externalDataSource);
     void PersistRemoveExternalDataSource(NIceDb::TNiceDb& db, TPathId pathId);
     void PersistExternalDataSourceReference(NIceDb::TNiceDb &db, TPathId pathId, const TPath& referrer);
@@ -975,6 +977,7 @@ public:
     void PersistRemoveView(NIceDb::TNiceDb& db, TPathId pathId);
 
     // ResourcePool
+    void PersistResourcePool(NIceDb::TNiceDb& db, TPathId pathId);
     void PersistResourcePool(NIceDb::TNiceDb& db, TPathId pathId, const TResourcePoolInfo::TPtr resourcePool);
     void PersistRemoveResourcePool(NIceDb::TNiceDb& db, TPathId pathId);
 

--- a/ydb/core/tx/schemeshard/ut_external_data_source/ut_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/ut_external_data_source/ut_external_data_source.cpp
@@ -413,7 +413,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
         TTestEnv env(runtime, TTestEnvOptions().EnableReplaceIfExistsForExternalEntities(true).RunFakeConfigDispatcher(true));
         ui64 txId = 100;
 
-        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+        TestCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                 Name: "MyExternalDataSource"
                 SourceType: "ObjectStorage"
                 Location: "https://s3.cloud.net/my_bucket"
@@ -421,7 +421,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                     None {
                     }
                 }
-                ReplaceIfExists: true
             )",{NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
@@ -438,7 +437,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
             UNIT_ASSERT_EQUAL(externalDataSourceDescription.GetAuth().identity_case(), NKikimrSchemeOp::TAuth::kNone);
         }
 
-        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+        TestCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                 Name: "MyExternalDataSource"
                 SourceType: "ObjectStorage"
                 Location: "https://s3.cloud.net/my_new_bucket"
@@ -446,7 +445,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                     None {
                     }
                 }
-                ReplaceIfExists: true
             )",{NKikimrScheme::StatusAccepted});
         env.TestWaitNotification(runtime, txId);
 
@@ -468,7 +466,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
         TTestEnv env(runtime, TTestEnvOptions().EnableReplaceIfExistsForExternalEntities(true).RunFakeConfigDispatcher(true));
         ui64 txId = 100;
 
-        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+        TestCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                 Name: "MyExternalDataSource"
                 SourceType: "ObjectStorage"
                 Location: "https://s3.cloud.net/my_bucket"
@@ -476,7 +474,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                     None {
                     }
                 }
-                ReplaceIfExists: true
             )", {NKikimrScheme::StatusAccepted}
         );
 
@@ -485,7 +482,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
         constexpr ui32 TEST_RUNS = 30;
         TSet<ui64> txIds;
         for (ui32 i = 0; i < TEST_RUNS; ++i) {
-            AsyncCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+            AsyncCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                     Name: "MyExternalDataSource"
                     SourceType: "ObjectStorage"
                     Location: "https://s3.cloud.net/other_bucket"
@@ -493,7 +490,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                         None {
                         }
                     }
-                    ReplaceIfExists: true
                 )"
             );
 
@@ -589,7 +585,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
 
         TestLs(runtime, "/MyRoot/UniqueName", false, NLs::PathExist);
 
-        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+        TestCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                 Name: "UniqueName"
                 SourceType: "ObjectStorage"
                 Location: "https://s3.cloud.net/my_bucket"
@@ -597,7 +593,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                     None {
                     }
                 }
-                ReplaceIfExists: true
             )",{{NKikimrScheme::StatusNameConflict, "error: unexpected path type"}});
 
         env.TestWaitNotification(runtime, txId);
@@ -608,7 +603,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
         TTestEnv env(runtime, TTestEnvOptions().EnableReplaceIfExistsForExternalEntities(false).RunFakeConfigDispatcher(true));
         ui64 txId = 100;
 
-        TestCreateExternalDataSource(runtime, ++txId, "/MyRoot",R"(
+        TestCreateExternalDataSourceOrReplace(runtime, ++txId, "/MyRoot",R"(
                 Name: "MyExternalDataSource"
                 SourceType: "ObjectStorage"
                 Location: "https://s3.cloud.net/my_bucket"
@@ -616,7 +611,6 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
                     None {
                     }
                 }
-                ReplaceIfExists: true
             )",{{NKikimrScheme::StatusPreconditionFailed, "Unsupported: feature flag EnableReplaceIfExistsForExternalEntities is off"}});
 
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_external_table/ut_external_table.cpp
+++ b/ydb/core/tx/schemeshard/ut_external_table/ut_external_table.cpp
@@ -334,13 +334,12 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
         ui64 txId = 100;
 
         CreateExternalDataSource(runtime, env, ++txId);
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/"
                 Columns { Name: "key" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
@@ -353,14 +352,13 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
             UNIT_ASSERT_VALUES_EQUAL(columns[0].GetNotNull(), false);
         }
 
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/new_location"
                 Columns { Name: "key" Type: "Uint64" }
                 Columns { Name: "value" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {NKikimrScheme::StatusAccepted});
         env.TestWaitNotification(runtime, txId);
 
@@ -375,13 +373,12 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
             UNIT_ASSERT_VALUES_EQUAL(columns[1].GetNotNull(), false);
         }
 
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/other_location"
                 Columns { Name: "value" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {NKikimrScheme::StatusAccepted});
         env.TestWaitNotification(runtime, txId);
 
@@ -400,13 +397,12 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
         ui64 txId = 100;
 
         CreateExternalDataSource(runtime, env, ++txId);
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/"
                 Columns { Name: "key" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {NKikimrScheme::StatusAccepted}
         );
 
@@ -415,14 +411,13 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
         constexpr ui32 TEST_RUNS = 30;
         TSet<ui64> txIds;
         for (ui32 i = 0; i < TEST_RUNS; ++i) {
-            AsyncCreateExternalTable(runtime, ++txId, "/MyRoot",R"(
+            AsyncCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot",R"(
                     Name: "ExternalTable"
                     SourceType: "General"
                     DataSourcePath: "/MyRoot/ExternalDataSource"
                     Location: "/new_location"
                     Columns { Name: "key" Type: "Uint64" }
                     Columns { Name: "value" Type: "Uint64" }
-                    ReplaceIfExists: true
                 )"
             );
 
@@ -526,13 +521,12 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
         TestLs(runtime, "/MyRoot/UniqueName", false, NLs::PathExist);
 
         CreateExternalDataSource(runtime, env, ++txId);
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "UniqueName"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/"
                 Columns { Name: "key" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {{NKikimrScheme::StatusNameConflict, "error: unexpected path type"}});
 
         env.TestWaitNotification(runtime, txId);
@@ -544,13 +538,12 @@ Y_UNIT_TEST_SUITE(TExternalTableTest) {
         ui64 txId = 100;
 
         CreateExternalDataSource(runtime, env, ++txId);
-        TestCreateExternalTable(runtime, ++txId, "/MyRoot", R"(
+        TestCreateExternalTableOrReplace(runtime, ++txId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/"
                 Columns { Name: "key" Type: "Uint64" }
-                ReplaceIfExists: true
             )", {{NKikimrScheme::StatusPreconditionFailed, "Unsupported: feature flag EnableReplaceIfExistsForExternalEntities is off"}});
 
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_external_table_reboots/ut_external_table_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_external_table_reboots/ut_external_table_reboots.cpp
@@ -294,14 +294,13 @@ Y_UNIT_TEST_SUITE(TExternalTableTestReboots) {
             )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-            TestCreateExternalTable(runtime, ++t.TxId, "/MyRoot", R"(
+            TestCreateExternalTableOrReplace(runtime, ++t.TxId, "/MyRoot", R"(
                 Name: "ExternalTable"
                 SourceType: "General"
                 DataSourcePath: "/MyRoot/ExternalDataSource"
                 Location: "/"
                 Columns { Name: "RowId" Type: "Uint64"}
-                ReplaceIfExists: true
-            )");
+            )", {NKikimrScheme::StatusAccepted});
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             TestDropExternalTable(runtime, ++t.TxId, "/MyRoot", "ExternalTable");

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1129,6 +1129,35 @@ namespace NSchemeShardUT_Private {
     #undef GENERIC_WITH_ATTRS_HELPERS
     #undef GENERIC_HELPERS
 
+    // external table
+    void AsyncCreateExternalTableOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme) {
+        auto* ev = CreateExternalTableRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
+        ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+    }
+
+    void TestCreateExternalTableOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults) {
+        auto* ev = CreateExternalTableRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
+        ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
+    // external data source
+    void AsyncCreateExternalDataSourceOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme) {
+        auto* ev = CreateExternalDataSourceRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
+        ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+    }
+
+    void TestCreateExternalDataSourceOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults) {
+        auto* ev = CreateExternalDataSourceRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
+        ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
+    // streaming query
     void TestCreateStreamingQueryOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults) {
         auto* ev = CreateStreamingQueryRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
         ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -212,11 +212,15 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(CreateExternalTable);
     GENERIC_HELPERS(DropExternalTable);
     DROP_BY_PATH_ID_HELPERS(DropExternalTable);
+    void AsyncCreateExternalTableOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme);
+    void TestCreateExternalTableOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults);
 
     // external data source
     GENERIC_HELPERS(CreateExternalDataSource);
     GENERIC_HELPERS(DropExternalDataSource);
     DROP_BY_PATH_ID_HELPERS(DropExternalDataSource);
+    void AsyncCreateExternalDataSourceOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme);
+    void TestCreateExternalDataSourceOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults);
 
     // backup & restore
     GENERIC_HELPERS(Backup);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed CREATE OR REPLACE for external data sources, external tables, and resource pools

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes `SchemeShard` operations for external data source, external table, and resource pool to follow the correct patterns established by streaming query operations.

1. Migrate to` MemChanges/DbChanges` pattern

Replaced direct NIceDb persistence in Propose methods with the `DbGuard `+ `MemChanges/DbChanges` pattern, enabling proper undo on AbortPropose.

3. Use common `ReplaceIfExists` flag

Changed `CREATE OR REPLACE` to use `TModifyScheme.ReplaceIfExists` instead of per-entity `ReplaceIfExists` in: `SchemeShard`, `KQP gateway`.

5. Fix ProtectDB violation in alter_external_table

Replaced direct `NIceDb` column deletion (which violated `ProtectDB` guard) with soft-delete pattern: old columns are carried over with DeleteVersion set, matching how regular tables handle column.

fixes: YQ-4610