### PR TITLE
[NEW RBO] Always set output indexes in connections explicitly

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_stage_graph.h
+++ b/ydb/core/kqp/opt/rbo/kqp_stage_graph.h
@@ -44,7 +44,7 @@ struct TConnection: TSimpleRefCount<TConnection> {
 };
 
 struct TBroadcastConnection: public TConnection {
-    TBroadcastConnection(ui32 outputIndex = 0)
+    TBroadcastConnection(ui32 outputIndex)
         : TConnection("Broadcast", outputIndex) {
     }
     virtual NYql::TExprNode::TPtr BuildConnection(NYql::TExprNode::TPtr inputStage, NYql::TPositionHandle pos, NYql::TExprContext& ctx) override;
@@ -54,7 +54,7 @@ struct TBroadcastConnection: public TConnection {
 };
 
 struct TMapConnection: public TConnection {
-    TMapConnection(ui32 outputIndex = 0)
+    TMapConnection(ui32 outputIndex)
         : TConnection("Map", outputIndex) {
     }
     virtual NYql::TExprNode::TPtr BuildConnection(NYql::TExprNode::TPtr inputStage, NYql::TPositionHandle pos, NYql::TExprContext& ctx) override;
@@ -64,7 +64,7 @@ struct TMapConnection: public TConnection {
 };
 
 struct TUnionAllConnection: public TConnection {
-    TUnionAllConnection(ui32 outputIndex = 0, bool parallel = false)
+    TUnionAllConnection(ui32 outputIndex, bool parallel = false)
         : TConnection("UnionAll", outputIndex)
         , Parallel(parallel) {
     }
@@ -98,7 +98,7 @@ struct TShuffleConnection: public TConnection {
 };
 
 struct TMergeConnection: public TConnection {
-    TMergeConnection(const TVector<TSortElement>& order, ui32 outputIndex = 0)
+    TMergeConnection(const TVector<TSortElement>& order, ui32 outputIndex)
         : TConnection("Merge", outputIndex)
         , Order(order) {
     }


### PR DESCRIPTION
Basically the title. Stops output index from defaulting to 0.