### PR TITLE
Improve error 'Path does not exist' from schemereq

### DIFF
--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -8038,10 +8038,10 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "External data sources are disabled for serverless domains. Please contact your system administrator to enable it", result.GetIssues().ToString());
         };
 
-        auto checkNotFound = [](const auto& result, const TString& error) {
+        auto checkNotFound = [](const auto& result, const TString& path, const TString& error) {
             const auto& issuesString = result.GetIssues().ToString();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, issuesString);
-            UNIT_ASSERT_STRING_CONTAINS_C(issuesString, "does not exist", issuesString);
+            UNIT_ASSERT_STRING_CONTAINS_C(issuesString, TStringBuilder() << "Path `" << path << "` does not exist", issuesString);
             UNIT_ASSERT_STRING_CONTAINS_C(issuesString, error, issuesString);
         };
 
@@ -8085,8 +8085,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         settings.Database(ydb->GetSettings().GetServerlessTenantName()).NodeIndex(ydb->GetServerlessTenantInfo().NodeIdx);
         checkDisabled(ydb->ExecuteQuery(createSourceSql, settings));
         checkDisabled(ydb->ExecuteQuery(createTableSql, settings));
-        checkNotFound(ydb->ExecuteQuery(dropTableSql, settings), "Executing ESchemeOpDropExternalTable");
-        checkNotFound(ydb->ExecuteQuery(dropSourceSql, settings), "Executing operation with object \"EXTERNAL_DATA_SOURCE\"");
+        checkNotFound(ydb->ExecuteQuery(dropTableSql, settings), ydb->GetSettings().GetServerlessTenantName() + "/MyExternalTable", "Executing ESchemeOpDropExternalTable");
+        checkNotFound(ydb->ExecuteQuery(dropSourceSql, settings), ydb->GetSettings().GetServerlessTenantName() + "/MyExternalDataSource", "Executing operation with object \"EXTERNAL_DATA_SOURCE\"");
     }
 
     Y_UNIT_TEST(CreateExternalDataSource) {
@@ -11865,9 +11865,10 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Resource pools are disabled for serverless domains. Please contact your system administrator to enable it", result.GetIssues().ToString());
         };
 
-        auto checkNotFound = [](const auto& result) {
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "does not exist", result.GetIssues().ToString());
+        auto checkNotFound = [](const auto& result, const TString& path) {
+            const auto& issuesString = result.GetIssues().ToString();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, issuesString);
+            UNIT_ASSERT_STRING_CONTAINS_C(issuesString, TStringBuilder() << "Path `" << path << "` does not exist", issuesString);
         };
 
         const auto& createSql = R"(
@@ -11901,8 +11902,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // Serverless, disabled
         settings.Database(ydb->GetSettings().GetServerlessTenantName()).NodeIndex(ydb->GetServerlessTenantInfo().NodeIdx);
         checkDisabled(ydb->ExecuteQuery(createSql, settings));
-        checkNotFound(ydb->ExecuteQuery(alterSql, settings));
-        checkNotFound(ydb->ExecuteQuery(dropSql, settings));
+        checkNotFound(ydb->ExecuteQuery(alterSql, settings), ydb->GetSettings().GetServerlessTenantName() + "/.metadata/workload_manager/pools/MyResourcePool");
+        checkNotFound(ydb->ExecuteQuery(dropSql, settings), ydb->GetSettings().GetServerlessTenantName() + "/.metadata/workload_manager/pools/MyResourcePool");
     }
 
     Y_UNIT_TEST(ResourcePoolsValidation) {
@@ -13673,7 +13674,7 @@ END DO)",
             } else if (result.GetStatus() == EStatus::NOT_FOUND) {
                 const auto& issues = result.GetIssues().ToString();
                 if (!issues.contains("Streaming query /Root/MyFolder/MyStreamingQuery not found or you don't have access permissions") &&
-                    !issues.contains("does not exist")) {
+                    !issues.contains("Path `/Root/MyFolder/MyStreamingQuery` does not exist")) {
                     UNIT_FAIL(TStringBuilder() << "Unexpected NOT_FOUND error: " << issues);
                 }
             } else if (result.GetStatus() == EStatus::ABORTED) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -11851,7 +11851,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // DROP RESOURCE POOL
         checkQuery("DROP RESOURCE POOL MyResourcePool;",
             EStatus::SCHEME_ERROR,
-            "Path `MyResourcePool` does not exist");
+            "Path `/Root/.metadata/workload_manager/pools/MyResourcePool` does not exist");
     }
 
     Y_UNIT_TEST(DisableResourcePoolsOnServerless) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -5986,7 +5986,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "/UnknownPath", result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Path `/UnknownPath` does not exist", result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Error for the path: /UnknownPath", result.GetIssues().ToString());
             CheckPermissions(session, {{.Path = "/Root", .Permissions = {{"user1", {"ydb.database.connect", "ydb.generic.list"}}}}});
         }
@@ -10153,7 +10153,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "/Root/table_not_exists");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "Path `/Root/table_not_exists` does not exist");
         }
 
         // positive
@@ -10471,7 +10471,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             const auto result = session.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "/Root/table_not_exists");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "Path `/Root/table_not_exists` does not exist");
         }
 
         // positive
@@ -11851,7 +11851,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // DROP RESOURCE POOL
         checkQuery("DROP RESOURCE POOL MyResourcePool;",
             EStatus::SCHEME_ERROR,
-            "MyResourcePool");
+            "Path `MyResourcePool` does not exist");
     }
 
     Y_UNIT_TEST(DisableResourcePoolsOnServerless) {
@@ -14598,7 +14598,7 @@ END DO)",
                 TRUNCATE TABLE `/Root/WrongTable`;
             )").ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Path '/Root/WrongTable' does not exist");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Path `/Root/WrongTable` does not exist");
         }
     }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -5986,7 +5986,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Path does not exist", result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "/UnknownPath", result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Error for the path: /UnknownPath", result.GetIssues().ToString());
             CheckPermissions(session, {{.Path = "/Root", .Permissions = {{"user1", {"ydb.database.connect", "ydb.generic.list"}}}}});
         }
@@ -8041,7 +8041,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         auto checkNotFound = [](const auto& result, const TString& error) {
             const auto& issuesString = result.GetIssues().ToString();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, issuesString);
-            UNIT_ASSERT_STRING_CONTAINS_C(issuesString, "Path does not exist", issuesString);
+            UNIT_ASSERT_STRING_CONTAINS_C(issuesString, "does not exist", issuesString);
             UNIT_ASSERT_STRING_CONTAINS_C(issuesString, error, issuesString);
         };
 
@@ -10153,7 +10153,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "Path does not exist");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "/Root/table_not_exists");
         }
 
         // positive
@@ -10471,7 +10471,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             const auto result = session.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "Path does not exist");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "/Root/table_not_exists");
         }
 
         // positive
@@ -11851,7 +11851,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // DROP RESOURCE POOL
         checkQuery("DROP RESOURCE POOL MyResourcePool;",
             EStatus::SCHEME_ERROR,
-            "Path does not exist");
+            "MyResourcePool");
     }
 
     Y_UNIT_TEST(DisableResourcePoolsOnServerless) {
@@ -11867,7 +11867,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         auto checkNotFound = [](const auto& result) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "Path does not exist", result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), "does not exist", result.GetIssues().ToString());
         };
 
         const auto& createSql = R"(
@@ -13673,7 +13673,7 @@ END DO)",
             } else if (result.GetStatus() == EStatus::NOT_FOUND) {
                 const auto& issues = result.GetIssues().ToString();
                 if (!issues.contains("Streaming query /Root/MyFolder/MyStreamingQuery not found or you don't have access permissions") &&
-                    !issues.contains("Path does not exist")) {
+                    !issues.contains("does not exist")) {
                     UNIT_FAIL(TStringBuilder() << "Unexpected NOT_FOUND error: " << issues);
                 }
             } else if (result.GetStatus() == EStatus::ABORTED) {
@@ -14468,7 +14468,6 @@ END DO)",
 
         {
             auto result = session.ExecuteSchemeQuery(R"(
-                --!syntax_v1
                 CREATE TABLE `/Root/SerialTable` (
                     Key   Serial,
                     Value String,
@@ -14480,7 +14479,6 @@ END DO)",
 
         {
             auto result = session.ExecuteDataQuery(R"(
-                --!syntax_v1
                 INSERT INTO `/Root/SerialTable` (Value) VALUES ("a"), ("b"), ("c");
             )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -14489,7 +14487,6 @@ END DO)",
         // Verify rows exist with keys 1, 2, 3
         {
             auto result = session.ExecuteDataQuery(R"(
-                --!syntax_v1
                 SELECT Key, Value FROM `/Root/SerialTable` ORDER BY Key;
             )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -14508,7 +14505,6 @@ END DO)",
 
         {
             auto result = session.ExecuteDataQuery(R"(
-                --!syntax_v1
                 INSERT INTO `/Root/SerialTable` (Value) VALUES ("d"), ("e");
             )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -14516,7 +14512,6 @@ END DO)",
 
         {
             auto result = session.ExecuteDataQuery(R"(
-                --!syntax_v1
                 SELECT Key, Value FROM `/Root/SerialTable` ORDER BY Key;
             )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -14537,7 +14532,6 @@ END DO)",
 
         {
             auto result = session.ExecuteSchemeQuery(R"(
-                --!syntax_v1
                 CREATE TABLE `/Root/TtlTable` (
                     Key   Uint32,
                     Ts    Timestamp,
@@ -14552,7 +14546,6 @@ END DO)",
 
         {
             auto result = session.ExecuteDataQuery(R"(
-                --!syntax_v1
                 UPSERT INTO `/Root/TtlTable` (Key, Ts, Value) VALUES
                     (1, Timestamp("2020-01-01T00:00:00.000000Z"), "a"),
                     (2, Timestamp("2020-01-02T00:00:00.000000Z"), "b"),
@@ -14579,6 +14572,33 @@ END DO)",
             TResultSetParser parser(resultSet);
             UNIT_ASSERT(parser.TryNextRow());
             UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser(0).GetUint64(), 0u);
+        }
+    }
+
+    Y_UNIT_TEST(TruncateNonExistentTable) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableTruncateTable(true);
+        TKikimrRunner kikimr(featureFlags);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/Root/TestTable` (
+                    k Uint32,
+                    v String,
+                    PRIMARY KEY(k)
+                );
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto result = session.ExecuteSchemeQuery(R"(
+                TRUNCATE TABLE `/Root/WrongTable`;
+            )").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Path '/Root/WrongTable' does not exist");
         }
     }
 

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -418,7 +418,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         ).ExtractValueSync();
 
         UNIT_ASSERT(!dropResult.IsSuccess());
-        UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "/Root/NonexistingView");
+        UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "Error: Path `/Root/NonexistingView` does not exist");
     }
 
     Y_UNIT_TEST(CallDropViewOnTable) {
@@ -467,7 +467,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         {
             const auto dropResult = session.ExecuteSchemeQuery(dropQuery).GetValueSync();
             UNIT_ASSERT(!dropResult.IsSuccess());
-            UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "/Root/TheView");
+            UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "Error: Path `/Root/TheView` does not exist");
         }
     }
 

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -418,7 +418,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         ).ExtractValueSync();
 
         UNIT_ASSERT(!dropResult.IsSuccess());
-        UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "Error: Path does not exist");
+        UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "/Root/NonexistingView");
     }
 
     Y_UNIT_TEST(CallDropViewOnTable) {
@@ -467,7 +467,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         {
             const auto dropResult = session.ExecuteSchemeQuery(dropQuery).GetValueSync();
             UNIT_ASSERT(!dropResult.IsSuccess());
-            UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "Error: Path does not exist");
+            UNIT_ASSERT_STRING_CONTAINS(dropResult.GetIssues().ToString(), "/Root/TheView");
         }
     }
 

--- a/ydb/core/transfer/ut/functional/transfer_ut.cpp
+++ b/ydb/core/transfer/ut/functional/transfer_ut.cpp
@@ -60,7 +60,7 @@ Y_UNIT_TEST_SUITE(Transfer)
                         |>
                     ];
                 };
-        )", MainTestCase::CreateTransferSettings::WithExpectedError(TStringBuilder() << "Path does not exist"));
+        )", MainTestCase::CreateTransferSettings::WithExpectedError(TStringBuilder() << "does not exist"));
 
         testCase.DropTopic();
     }
@@ -1167,7 +1167,7 @@ Y_UNIT_TEST_SUITE(Transfer)
                         |>
                     ];
                 };
-            )", MainTestCase::CreateTransferSettings::WithExpectedError("Path does not exist"));
+            )", MainTestCase::CreateTransferSettings::WithExpectedError("does not exist"));
 
         testCase.DropTopic();
     }

--- a/ydb/core/transfer/ut/functional/transfer_ut.cpp
+++ b/ydb/core/transfer/ut/functional/transfer_ut.cpp
@@ -60,7 +60,7 @@ Y_UNIT_TEST_SUITE(Transfer)
                         |>
                     ];
                 };
-        )", MainTestCase::CreateTransferSettings::WithExpectedError(TStringBuilder() << "does not exist"));
+        )", MainTestCase::CreateTransferSettings::WithExpectedError(TStringBuilder() << "Path `/local/" << testCase.TableName << "` does not exist"));
 
         testCase.DropTopic();
     }
@@ -1167,7 +1167,7 @@ Y_UNIT_TEST_SUITE(Transfer)
                         |>
                     ];
                 };
-            )", MainTestCase::CreateTransferSettings::WithExpectedError("does not exist"));
+            )", MainTestCase::CreateTransferSettings::WithExpectedError(TStringBuilder() << "Path `/local/" << testCase.TableName << "` does not exist"));
 
         testCase.DropTopic();
     }

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -579,7 +579,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         const NKikimrScheme::TEvModifySchemeTransactionResult* shardResult,
         const NYql::TIssue* issue,
         const TActorContext& ctx,
-        TString path = {})
+        const TString& path = {})
     {
         auto *result = new TEvTxUserProxy::TEvProposeTransactionStatus(status);
         if (issue) {

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -623,7 +623,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     // (xenoxeno) for compatibility with KQP and maybe others...
                     result->Record.SetSchemeShardStatus(NKikimrScheme::EStatus::StatusPathDoesNotExist);
                     if (path) {
-                        result->Record.SetSchemeShardReason(TStringBuilder() << "Path '" << path << "' does not exist");
+                        result->Record.SetSchemeShardReason(TStringBuilder() << "Path `" << path << "` does not exist");
                     } else {
                         result->Record.SetSchemeShardReason("Path does not exist");
                     }

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -578,7 +578,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     void ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status,
         const NKikimrScheme::TEvModifySchemeTransactionResult* shardResult,
         const NYql::TIssue* issue,
-        const TActorContext& ctx)
+        const TActorContext& ctx,
+        TString path = {})
     {
         auto *result = new TEvTxUserProxy::TEvProposeTransactionStatus(status);
         if (issue) {
@@ -621,7 +622,11 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                 case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError:
                     // (xenoxeno) for compatibility with KQP and maybe others...
                     result->Record.SetSchemeShardStatus(NKikimrScheme::EStatus::StatusPathDoesNotExist);
-                    result->Record.SetSchemeShardReason("Path does not exist");
+                    if (path) {
+                        result->Record.SetSchemeShardReason(TStringBuilder() << "Path '" << path << "' does not exist");
+                    } else {
+                        result->Record.SetSchemeShardReason("Path does not exist");
+                    }
                     break;
                 case TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ProxyShardNotAvailable:
                     result->Record.SetSchemeShardStatus(NKikimrScheme::EStatus::StatusNotAvailable);
@@ -1282,12 +1287,12 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
             case NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown:
                 TxProxyMon->ResolveKeySetWrongRequest->Inc();
-                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, ctx);
+                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, nullptr, nullptr, ctx, CanonizePath(entry.Path));
                 break;
             case NSchemeCache::TSchemeCacheNavigate::EStatus::PathNotPath:
             case NSchemeCache::TSchemeCacheNavigate::EStatus::RootUnknown:
                 TxProxyMon->ResolveKeySetWrongRequest->Inc();
-                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, ctx);
+                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, nullptr, nullptr, ctx, CanonizePath(entry.Path));
                 break;
             case NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError:
             case NSchemeCache::TSchemeCacheNavigate::EStatus::RedirectLookupError:
@@ -1298,7 +1303,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             case NSchemeCache::TSchemeCacheNavigate::EStatus::TableCreationNotComplete:
             case NSchemeCache::TSchemeCacheNavigate::EStatus::Unknown:
                 TxProxyMon->ResolveKeySetFail->Inc();
-                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, ctx);
+                ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, nullptr, nullptr, ctx, CanonizePath(entry.Path));
                 break;
             }
 

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -1012,7 +1012,7 @@ Y_UNIT_TEST_SUITE(TGRpcYdbTest) {
             NYql::TIssues issues;
             NYql::IssuesFromMessage(deferred.issues(), issues);
             TString tmp = issues.ToString();
-            TString expected = "<main>: Error: Path '/Root/TheNotExistedDirectory' does not exist, code: 200200\n";
+            TString expected = "<main>: Error: Path `/Root/TheNotExistedDirectory` does not exist, code: 200200\n";
             UNIT_ASSERT_NO_DIFF(tmp, expected);
         }
     }

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -1012,7 +1012,7 @@ Y_UNIT_TEST_SUITE(TGRpcYdbTest) {
             NYql::TIssues issues;
             NYql::IssuesFromMessage(deferred.issues(), issues);
             TString tmp = issues.ToString();
-            TString expected = "<main>: Error: Path does not exist, code: 200200\n";
+            TString expected = "<main>: Error: Path '/Root/TheNotExistedDirectory' does not exist, code: 200200\n";
             UNIT_ASSERT_NO_DIFF(tmp, expected);
         }
     }

--- a/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
+++ b/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
@@ -37,7 +37,7 @@ class TestSchemeShardSimpleOps(object):
             callee,
             raises(
                 ydb.SchemeError,
-                "does not exist"
+                "Path `/Root/test_delete_table_that_doesnt_exist_failure` does not exist"
             )
         )
 
@@ -312,6 +312,6 @@ class TestSchemeShardSimpleOps(object):
             callee,
             raises(
                 ydb.SchemeError,
-                "does not exist"
+                "Path `/Root/test_ydb_remove_directory_that_does_not_exist_failure` does not exist"
             )
         )

--- a/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
+++ b/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
@@ -37,7 +37,7 @@ class TestSchemeShardSimpleOps(object):
             callee,
             raises(
                 ydb.SchemeError,
-                "Path does not exist"
+                "does not exist"
             )
         )
 
@@ -312,6 +312,6 @@ class TestSchemeShardSimpleOps(object):
             callee,
             raises(
                 ydb.SchemeError,
-                "Path does not exist"
+                "does not exist"
             )
         )

--- a/ydb/tests/functional/security/test_paths_lookup.py
+++ b/ydb/tests/functional/security/test_paths_lookup.py
@@ -66,7 +66,7 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(TENANT_NAME_1 + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'does not exist' in exc_info.value.message
+        assert "Path `/Root/Tenant1/.sys` does not exist" in exc_info.value.message
 
     # Check allowed lookups from Tenant database
     tenant_driver_config = ydb.DriverConfig(
@@ -81,14 +81,14 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(DOMAIN_NAME, permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'does not exist' in exc_info.value.message
+        assert "Path `/Root` does not exist" in exc_info.value.message
 
         # Modify permissions on Domain regular path
         with pytest.raises(ydb.issues.Error) as exc_info:
             driver.scheme_client.modify_permissions(DOMAIN_NAME + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'does not exist' in exc_info.value.message
+        assert "Path `/Root/.sys` does not exist" in exc_info.value.message
 
         # Modify permissions on current Tenant root path
         driver.scheme_client.modify_permissions(TENANT_NAME_1, permissions_settings)
@@ -101,14 +101,14 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(TENANT_NAME_2, permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'does not exist' in exc_info.value.message
+        assert "Path `/Root/Tenant2` does not exist" in exc_info.value.message
 
         # Modify permissions on other Tenant regular path
         with pytest.raises(ydb.issues.Error) as exc_info:
             driver.scheme_client.modify_permissions(TENANT_NAME_2 + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'does not exist' in exc_info.value.message
+        assert "Path `/Root/Tenant2/.sys` does not exist" in exc_info.value.message
 
     ydb_cluster.remove_database(TENANT_NAME_1)
     ydb_cluster.unregister_and_stop_slots(tenant_nodes_1)

--- a/ydb/tests/functional/security/test_paths_lookup.py
+++ b/ydb/tests/functional/security/test_paths_lookup.py
@@ -66,7 +66,7 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(TENANT_NAME_1 + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'Path does not exist' in exc_info.value.message
+        assert 'does not exist' in exc_info.value.message
 
     # Check allowed lookups from Tenant database
     tenant_driver_config = ydb.DriverConfig(
@@ -81,14 +81,14 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(DOMAIN_NAME, permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'Path does not exist' in exc_info.value.message
+        assert 'does not exist' in exc_info.value.message
 
         # Modify permissions on Domain regular path
         with pytest.raises(ydb.issues.Error) as exc_info:
             driver.scheme_client.modify_permissions(DOMAIN_NAME + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'Path does not exist' in exc_info.value.message
+        assert 'does not exist' in exc_info.value.message
 
         # Modify permissions on current Tenant root path
         driver.scheme_client.modify_permissions(TENANT_NAME_1, permissions_settings)
@@ -101,14 +101,14 @@ def test_allowed_paths_lookup(ydb_cluster):
             driver.scheme_client.modify_permissions(TENANT_NAME_2, permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'Path does not exist' in exc_info.value.message
+        assert 'does not exist' in exc_info.value.message
 
         # Modify permissions on other Tenant regular path
         with pytest.raises(ydb.issues.Error) as exc_info:
             driver.scheme_client.modify_permissions(TENANT_NAME_2 + '/.sys', permissions_settings)
 
         assert exc_info.type is ydb.issues.SchemeError
-        assert 'Path does not exist' in exc_info.value.message
+        assert 'does not exist' in exc_info.value.message
 
     ydb_cluster.remove_database(TENANT_NAME_1)
     ydb_cluster.unregister_and_stop_slots(tenant_nodes_1)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improves the error message for missing paths by including the actual path that was not found.

Changed from:

```text
Path does not exist
```

to:

```text
Path `/path/to/object` does not exist
```

This makes the error more informative and easier to debug SQL-queries.

For example, there is note about `TRUNCATE TABLE` on non-existent table:

<img width="1006" height="950" alt="image" src="https://github.com/user-attachments/assets/0b2301fd-0af4-4902-abdc-187900231be2" />


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
