### PR TITLE
backport: YDB_QA_CONFIG env + YDBWrapper scripts — minimal → stable-25-1-3

### DIFF
--- a/.github/actions/setup_ci_ydb_service_account_key_file_credentials/action.yml
+++ b/.github/actions/setup_ci_ydb_service_account_key_file_credentials/action.yml
@@ -4,6 +4,9 @@ inputs:
   ci_ydb_service_account_key_file_credentials:
     required: false
     description: "token for access"
+  ydb_qa_config:
+    required: false
+    description: "YDB QA JSON config (pass vars.YDB_QA_CONFIG); exported as YDB_QA_CONFIG for ydb_wrapper"
 runs:
   using: "composite"
   steps:
@@ -18,3 +21,18 @@ runs:
         EOF
 
         echo "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS=$CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" >> $GITHUB_ENV
+
+    - name: Setup YDB QA config
+      if: "${{ inputs.ydb_qa_config != '' }}"
+      shell: bash
+      env:
+        YDB_QA_CONFIG_INPUT: ${{ inputs.ydb_qa_config }}
+      run: |
+        set -eu
+        DELIM="YDB_QA_CONFIG_$(openssl rand -hex 8)"
+        {
+          echo "YDB_QA_CONFIG<<$DELIM"
+          printf '%s\n' "$YDB_QA_CONFIG_INPUT"
+          echo "$DELIM"
+        } >> "$GITHUB_ENV"
+

--- a/.github/config/variables.ini
+++ b/.github/config/variables.ini
@@ -1,0 +1,2 @@
+[YDBD]
+YDBD_PATH = ydb/apps/ydbd/ydbd

--- a/.github/config/ydb_qa_config.json
+++ b/.github/config/ydb_qa_config.json
@@ -1,0 +1,49 @@
+{
+  "databases": {
+      "main": {
+          "endpoint": "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135",
+          "path": "/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8",
+          "connection_timeout": 60,
+          "tables": {
+              "test_results": "test_results/test_runs_column",
+              "testowners": "test_results/analytics/testowners",
+              "tests_monitor": "test_results/analytics/tests_monitor",
+              "muted_tests_daily_by_team": "test_results/analytics/muted_tests_daily_by_team",
+              "muted_tests_with_issue_and_area": "test_results/analytics/muted_tests_with_issue_and_area",
+              "test_history_fast": "test_results/analytics/test_history_fast",
+              "github_issue_mapping": "test_results/analytics/github_issue_mapping",
+              "area_to_owner_mapping": "test_results/analytics/area_to_owner_mapping",
+              "github_issues_timeline": "test_results/analytics/github_issues_timeline",
+              "flaky_tests_window": "test_results/analytics/flaky_tests_window_1_days",
+              "all_tests_with_owner_and_mute": "test_results/all_tests_with_owner_and_mute",
+              "pr_blocked_by_failed_tests_rich": "test_results/analytics/pr_blocked_by_failed_tests_rich",
+              "pr_blocked_by_tests": "test_results/analytics/pr_blocked_by_tests",
+              "pr_check_failures_by_attempt": "test_results/analytics/pr_check_failures_by_attempt",
+              "binary_size": "binary_size",
+              "issues": "github_data/issues",
+              "pull_requests": "github_data/pull_requests",
+              "digest_queue": "test_results/analytics/digest_queue",
+              "fast_unmute_active": "test_mute/fast_unmute_active",
+              "fast_unmute_grace": "test_mute/fast_unmute_grace",
+              "mute_latency": "test_results/analytics/mute_latency",
+              "mute_latency_affected_prs": "test_results/analytics/mute_latency_affected_prs",
+              "mute_events": "test_results/analytics/mute_events"
+
+          }
+      },
+      "statistics": {
+          "endpoint": "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135",
+          "path": "/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8",
+          "connection_timeout": 60,
+          "tables": {
+              "query_statistics": "analytics/query_statistics"
+          }
+      }
+  },
+  "variables": {
+  },
+  "flags": {
+      "enable_statistics": true,
+      "enable_backup_write": false
+  }
+}

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -1,83 +1,52 @@
 #!/usr/bin/env python3
 
 import argparse
-import configparser
-import datetime
-import fnmatch
 import os
 import posixpath
-import shlex
-import subprocess
 import sys
-import time
 import xml.etree.ElementTree as ET
 import ydb
 
-
 from codeowners import CodeOwners
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import Decimal
 
-max_characters_for_status_description = int(7340032/4) #workaround for error "cannot split batch in according to limits: there is row with size more then limit (7340032)"
+# Add analytics directory to sys.path for ydb_wrapper import
+_analytics_dir = os.path.dirname(os.path.abspath(__file__))
+if _analytics_dir not in sys.path:
+    sys.path.insert(0, _analytics_dir)
+from ydb_wrapper import YDBWrapper
 
-def create_tables(pool,  table_path):
-    print(f"> create table if not exists:'{table_path}'")
+max_characters_for_status_description = int(7340032 / 4)
 
-    def callee(session):
-        session.execute_scheme(f"""
-            CREATE table IF NOT EXISTS `{table_path}` (
-                build_type Utf8 NOT NULL,
-                job_name Utf8,
-                job_id Uint64,
-                commit Utf8,
-                branch Utf8 NOT NULL,
-                pull Utf8,
-                run_timestamp Timestamp NOT NULL,
-                test_id Utf8 NOT NULL,
-                suite_folder Utf8 NOT NULL,
-                test_name Utf8 NOT NULL,
-                duration Double,
-                status Utf8 NOT NULL,
-                status_description Utf8,
-                owners Utf8,
-                log Utf8,
-                logsdir Utf8,
-                stderr Utf8,
-                stdout Utf8,
-                PRIMARY KEY (`test_name`, `suite_folder`,build_type, branch, status, run_timestamp)
-            )
-              PARTITION BY HASH(`suite_folder`,test_name, build_type, branch )
-                WITH (STORE = COLUMN)
-            """)
-
-    return pool.retry_operation_sync(callee)
+TABLE_NAME = "test_results/test_runs_column"
 
 
-def bulk_upsert(table_client, table_path, rows):
-    print(f"> bulk upsert: {table_path}")
-    column_types = (
-        ydb.BulkUpsertColumns()
-        .add_column("branch", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("build_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("commit", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("duration", ydb.OptionalType(ydb.PrimitiveType.Double))
-        .add_column("job_id", ydb.OptionalType(ydb.PrimitiveType.Uint64))
-        .add_column("job_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("log", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("logsdir", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("owners", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("pull", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("run_timestamp", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
-        .add_column("status", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("status_description", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("stderr", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("stdout", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("suite_folder", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("test_id", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-        .add_column("test_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
-
-    )
-    table_client.bulk_upsert(table_path, rows, column_types)
+def get_table_schema(table_path):
+    return f"""
+        CREATE TABLE IF NOT EXISTS `{table_path}` (
+            build_type Utf8 NOT NULL,
+            job_name Utf8,
+            job_id Uint64,
+            commit Utf8,
+            branch Utf8 NOT NULL,
+            pull Utf8,
+            run_timestamp Timestamp NOT NULL,
+            test_id Utf8 NOT NULL,
+            suite_folder Utf8 NOT NULL,
+            test_name Utf8 NOT NULL,
+            duration Double,
+            status Utf8 NOT NULL,
+            status_description Utf8,
+            owners Utf8,
+            log Utf8,
+            logsdir Utf8,
+            stderr Utf8,
+            stdout Utf8,
+            PRIMARY KEY (`test_name`, `suite_folder`, build_type, branch, status, run_timestamp)
+        )
+        PARTITION BY HASH(`suite_folder`, test_name, build_type, branch)
+        WITH (STORE = COLUMN)
+    """
 
 
 def parse_junit_xml(test_results_file, build_type, job_name, job_id, commit, branch, pull, run_timestamp):
@@ -115,19 +84,18 @@ def parse_junit_xml(test_results_file, build_type, job_name, job_id, commit, bra
                     "commit": commit,
                     "branch": branch,
                     "pull": pull,
-                    "run_timestamp": int(run_timestamp)*1000000,
+                    "run_timestamp": int(run_timestamp) * 1000000,
                     "job_name": job_name,
                     "job_id": int(job_id),
                     "suite_folder": suite_folder,
                     "test_name": name,
-                    "duration": Decimal(duration),
+                    "duration": Decimal(duration) if duration else Decimal(0),
                     "status": status,
-                    "status_description": status_description.replace("\r\n", ";;").replace("\n", ";;").replace("\"", "'")[:max_characters_for_status_description],
+                    "status_description": (status_description or "").replace("\r\n", ";;").replace("\n", ";;").replace("\"", "'")[:max_characters_for_status_description],
                     "log": "" if testcase.find("properties/property/[@name='url:log']") is None else testcase.find("properties/property/[@name='url:log']").get('value'),
                     "logsdir": "" if testcase.find("properties/property/[@name='url:logsdir']") is None else testcase.find("properties/property/[@name='url:logsdir']").get('value'),
                     "stderr": "" if testcase.find("properties/property/[@name='url:stderr']") is None else testcase.find("properties/property/[@name='url:stderr']").get('value'),
                     "stdout": "" if testcase.find("properties/property/[@name='url:stdout']") is None else testcase.find("properties/property/[@name='url:stdout']").get('value'),
-
                 }
             )
     return results
@@ -135,139 +103,116 @@ def parse_junit_xml(test_results_file, build_type, job_name, job_id, commit, bra
 
 def sort_codeowners_lines(codeowners_lines):
     def path_specificity(line):
-        # removing comments
         trimmed_line = line.strip()
         if not trimmed_line or trimmed_line.startswith('#'):
             return -1, -1
         path = trimmed_line.split()[0]
         return len(path.split('/')), len(path)
 
-    sorted_lines = sorted(codeowners_lines, key=path_specificity)
-    return sorted_lines
+    return sorted(codeowners_lines, key=path_specificity)
+
 
 def get_codeowners_for_tests(codeowners_file_path, tests_data):
     with open(codeowners_file_path, 'r') as file:
         data = file.readlines()
-        owners_odj = CodeOwners(''.join(sort_codeowners_lines(data)))
-        tests_data_with_owners = []
+        owners_obj = CodeOwners(''.join(sort_codeowners_lines(data)))
         for test in tests_data:
-            target_path = f'{test["suite_folder"]}'
-            owners = owners_odj.of(target_path)
-            test["owners"] = ";;".join(
-                [(":".join(x)) for x in owners])
-            tests_data_with_owners.append(test)
-        return tests_data_with_owners
+            owners = owners_obj.of(test["suite_folder"])
+            test["owners"] = ";;".join([":".join(x) for x in owners])
+    return tests_data
 
 
 def main():
-
     parser = argparse.ArgumentParser()
-    parser.add_argument('--test-results-file', action='store',
-                        required=True, help='XML with results of tests')
-    parser.add_argument('--build-type', action='store',
-                        required=True, help='build type')
-    parser.add_argument('--commit', default='store',
-                        dest="commit", required=True, help='commit sha')
-    parser.add_argument('--branch', default='store',
-                        dest="branch", required=True, help='branch name ')
-    parser.add_argument('--pull', action='store', dest="pull",
-                        required=True, help='pull number')
-    parser.add_argument('--run-timestamp', action='store',
-                        dest="run_timestamp", required=True, help='time of test run start')
-    parser.add_argument('--job-name', action='store', dest="job_name",
-                        required=True, help='job name where launched')
-    parser.add_argument('--job-id', action='store', dest="job_id",
-                        required=True, help='job id of workflow')
-
+    parser.add_argument('--test-results-file', required=True,
+                        help='JUnit XML with results of tests')
+    parser.add_argument('--build-type', required=True)
+    parser.add_argument('--commit', required=True)
+    parser.add_argument('--branch', required=True)
+    parser.add_argument('--pull', required=True)
+    parser.add_argument('--run-timestamp', dest="run_timestamp", required=True)
+    parser.add_argument('--job-name', dest="job_name", required=True)
+    parser.add_argument('--job-id', dest="job_id", required=True)
     args = parser.parse_args()
 
-    test_results_file = args.test_results_file
-    build_type = args.build_type
-    commit = args.commit
-    branch = args.branch
-    pull = args.pull
-    run_timestamp = args.run_timestamp
-    job_name = args.job_name
-    job_id = args.job_id
-
-    path_in_database = "test_results"
-    dir = os.path.dirname(__file__)
-    git_root = f"{dir}/../../.."
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    git_root = os.path.normpath(f"{dir_path}/../../..")
     codeowners = f"{git_root}/.github/TESTOWNERS"
-    config = configparser.ConfigParser()
-    config_file_path = f"{git_root}/.github/config/ydb_qa_db.ini"
-    config.read(config_file_path)
 
-    DATABASE_ENDPOINT = config["QA_DB"]["DATABASE_ENDPOINT"]
-    DATABASE_PATH = config["QA_DB"]["DATABASE_PATH"]
+    column_types = (
+        ydb.BulkUpsertColumns()
+        .add_column("branch", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("build_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("commit", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("duration", ydb.OptionalType(ydb.PrimitiveType.Double))
+        .add_column("job_id", ydb.OptionalType(ydb.PrimitiveType.Uint64))
+        .add_column("job_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("log", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("logsdir", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("owners", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("pull", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("run_timestamp", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+        .add_column("status", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("status_description", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("stderr", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("stdout", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("suite_folder", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("test_id", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("test_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+    )
 
-    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        print(
-            "Error: Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping"
-        )
-        return 1
-    else:
-        # Do not set up 'real' variable from gh workflows because it interfere with ydb tests
-        # So, set up it locally
-        os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ[
-            "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
-        ]
-    test_table_name = f"{path_in_database}/test_runs_column"
-    full_path = posixpath.join(DATABASE_PATH, test_table_name)
+    try:
+        with YDBWrapper() as wrapper:
+            if not wrapper.check_credentials():
+                print("Warning: YDB credentials not found, skipping upload")
+                return 0
 
-    with ydb.Driver(
-        endpoint=DATABASE_ENDPOINT,
-        database=DATABASE_PATH,
-        credentials=ydb.credentials_from_env_variables(),
-    ) as driver:
-        driver.wait(timeout=10, fail_fast=True)
-        session = ydb.retry_operation_sync(
-            lambda: driver.table_client.session().create()
-        )
+            full_table_path = posixpath.join(wrapper.database_path, TABLE_NAME)
+            wrapper.create_table(full_table_path, get_table_schema(full_table_path))
 
-        # Parse and upload
-        results = parse_junit_xml(
-            test_results_file, build_type, job_name, job_id, commit, branch, pull, run_timestamp
-        )
-        result_with_owners = get_codeowners_for_tests(codeowners, results)
-        prepared_for_upload_rows = []
-        for index, row in enumerate(result_with_owners):
-            prepared_for_upload_rows.append({
-                'branch': row['branch'],
-                'build_type': row['build_type'],
-                'commit': row['commit'],
-                'duration': row['duration'],
-                'job_id': row['job_id'],
-                'job_name': row['job_name'],
-                'log': row['log'],
-                'logsdir': row['logsdir'],
-                'owners': row['owners'],
-                'pull': row['pull'],
-                'run_timestamp': row['run_timestamp'],
-                'status_description': row['status_description'],
-                'status': row['status'],
-                'stderr': row['stderr'],
-                'stdout': row['stdout'],
-                'suite_folder': row['suite_folder'],
-                'test_id': f"{row['pull']}_{row['run_timestamp']}_{index}",
-                'test_name': row['test_name'],
-            })
-        print(f'upserting runs: {len(prepared_for_upload_rows)} rows')
-        if prepared_for_upload_rows:
-            batch_rows_for_upload_size = 1000
-            with ydb.SessionPool(driver) as pool:
-                create_tables(pool, test_table_name)
-                for start in range(0, len(prepared_for_upload_rows), batch_rows_for_upload_size):
-                    batch_rows_for_upload = prepared_for_upload_rows[start:start + batch_rows_for_upload_size]     
-                    bulk_upsert(driver.table_client, full_path,
-                            batch_rows_for_upload)
-                
-            print('tests uploaded')
-        else:
-            print('nothing to upload')
+            results = parse_junit_xml(
+                args.test_results_file, args.build_type, args.job_name, args.job_id,
+                args.commit, args.branch, args.pull, args.run_timestamp
+            )
+            results_with_owners = get_codeowners_for_tests(codeowners, results)
 
-       
+            rows = []
+            for index, row in enumerate(results_with_owners):
+                rows.append({
+                    'branch': row['branch'],
+                    'build_type': row['build_type'],
+                    'commit': row['commit'],
+                    'duration': row['duration'],
+                    'job_id': row['job_id'],
+                    'job_name': row['job_name'],
+                    'log': row['log'],
+                    'logsdir': row['logsdir'],
+                    'owners': row['owners'],
+                    'pull': row['pull'],
+                    'run_timestamp': row['run_timestamp'],
+                    'status_description': row['status_description'],
+                    'status': row['status'],
+                    'stderr': row['stderr'],
+                    'stdout': row['stdout'],
+                    'suite_folder': row['suite_folder'],
+                    'test_id': f"{row['pull']}_{row['run_timestamp']}_{index}",
+                    'test_name': row['test_name'],
+                })
+
+            if rows:
+                print(f'Uploading {len(rows)} test results to {full_table_path}')
+                wrapper.bulk_upsert_batches(full_table_path, rows, column_types)
+                print('tests uploaded')
+            else:
+                print('nothing to upload')
+
+    except Exception as e:
+        print(f"Warning: Failed to upload test results to YDB: {e}")
+        print("This is not a critical error, continuing with CI process...")
+        return 0
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.github/scripts/analytics/ydb_wrapper.py
+++ b/.github/scripts/analytics/ydb_wrapper.py
@@ -1,0 +1,938 @@
+#!/usr/bin/env python3
+
+import datetime
+import inspect
+import json
+import os
+import sys
+import time
+import uuid
+import ydb
+from typing import List, Dict, Any, Optional, Callable, Tuple
+from contextlib import contextmanager
+
+class YDBWrapper:
+    """Wrapper for YDB with statistics logging.
+
+    Use as::
+
+        with YDBWrapper() as w:
+            w.execute_scan_query_with_metadata(...)
+            w.create_table(...)
+            w.bulk_upsert_batches(...)
+
+    All data operations (scan, create_table, bulk_upsert, execute_dml) use a single
+    cached main driver (no reconnection between calls). Statistics are written via
+    a separate cached stats driver. Both drivers are created lazily and closed
+    when exiting the ``with`` block.
+    """
+
+    def __init__(self, config_path: str = None, enable_statistics: bool = None, script_name: str = None, silent: bool = False, use_local_config: bool = None):
+        # use_local_config=None (default): YDB_QA_CONFIG env if set, else local config file
+        # use_local_config=True: only local config file (ignore YDB_QA_CONFIG env)
+        # use_local_config=False: YDB_QA_CONFIG env > config file (JSON)
+        # By default logs go to stdout (as before)
+        # If silent=True, logs go to stderr (for scripts called from other scripts)
+        self._log_stream = sys.stderr if silent else sys.stdout
+
+        _explicit_local = use_local_config  # remember if caller forced the choice
+        if use_local_config is None:
+            use_local_config = not os.environ.get("YDB_QA_CONFIG")
+
+        if use_local_config:
+            resolved_path = self._default_config_path(config_path)
+            enable_statistics = self._load_config_from_file(resolved_path, enable_statistics)
+            if _explicit_local is True:
+                self._config_source = f"file:{resolved_path} (forced, vars.YDB_QA_CONFIG ignored)"
+            else:
+                self._config_source = f"file:{resolved_path} (vars.YDB_QA_CONFIG not set)"
+        else:
+            ydb_qa_config_env = os.environ.get("YDB_QA_CONFIG")
+            if ydb_qa_config_env:
+                try:
+                    config_dict = json.loads(ydb_qa_config_env)
+                    enable_statistics = self._load_config_from_dict(config_dict, enable_statistics)
+                    self._config_source = "env:YDB_QA_CONFIG"
+                except (json.JSONDecodeError, KeyError) as e:
+                    raise RuntimeError(f"Invalid YDB_QA_CONFIG format: {e}")
+            else:
+                resolved_path = self._default_config_path(config_path)
+                enable_statistics = self._load_config_from_file(resolved_path, enable_statistics)
+                if _explicit_local is False:
+                    self._config_source = f"file:{resolved_path} (fallback: vars.YDB_QA_CONFIG not set)"
+                else:
+                    self._config_source = f"file:{resolved_path} (vars.YDB_QA_CONFIG not set)"
+
+        self._log("info", f"YDB config source: {self._config_source}")
+        
+        # Statistics settings
+        self._enable_statistics = enable_statistics
+        self._cluster_version = None
+        self._session_id = str(uuid.uuid4())
+        # One driver per endpoint for the whole wrapper lifetime
+        self._driver = None
+        self._stats_driver = None
+        
+        # Automatically determine script_name if not provided
+        if script_name is None:
+            script_name = self._get_caller_script_name()
+        self._script_name = script_name
+        
+        # GitHub Action info - get once
+        self._github_info = self._get_github_action_info()
+        
+        # Get cluster version once during initialization (uses cached main driver)
+        try:
+            self._get_cluster_version(self._get_driver())
+        except Exception as e:
+            self._log("warning", f"Failed to get cluster version: {e}")
+            self._cluster_version = "unknown"
+
+        # Statistics: if stats and main use the same endpoint/path, reuse main driver (no extra connection)
+        self._stats_available = None
+        if self._enable_statistics:
+            stats_same_as_main = (
+                self.stats_endpoint == self.database_endpoint and self.stats_path == self.database_path
+            )
+            if stats_same_as_main:
+                self._stats_available = True
+                self._log("info", f"Statistics logging enabled (same DB as main) - session_id: {self._session_id}")
+            else:
+                self._stats_available = self._check_stats_availability()
+                if self._stats_available:
+                    self._log("info", f"Statistics logging enabled - session_id: {self._session_id}")
+                else:
+                    self._log("warning", "Statistics database is not available, statistics will not be logged")
+        else:
+            self._log("info", "Statistics logging disabled")
+
+    @property
+    def config_source(self) -> str:
+        """Human-readable description of where YDB QA config was loaded from."""
+        return self._config_source
+
+    @staticmethod
+    def _default_config_path(config_path: Optional[str]) -> str:
+        """Resolve default config path relative to this file if not provided."""
+        if config_path is not None:
+            return config_path
+        dir_path = os.path.dirname(__file__)
+        return os.path.normpath(os.path.join(dir_path, "..", "..", "config", "ydb_qa_config.json"))
+
+    def _load_config_from_file(self, config_path: str, enable_statistics: Optional[bool]) -> Optional[bool]:
+        """Load config dict from JSON file and apply it."""
+        try:
+            with open(config_path, 'r') as f:
+                config_dict = json.load(f)
+            return self._load_config_from_dict(config_dict, enable_statistics)
+        except FileNotFoundError:
+            raise RuntimeError(f"Config file not found: {config_path}")
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Invalid JSON config file: {e}")
+
+    def _load_config_from_dict(self, config_dict: dict, enable_statistics: bool = None):
+        """Load configuration from dictionary"""
+        dbs = config_dict["databases"]
+        main = dbs["main"]
+        stats = dbs.get("statistics", {})
+        variables = config_dict.get("variables", {})
+        flags = config_dict.get("flags", {})
+        
+        # Store flags as attribute for access from other scripts
+        self._flags = flags
+        
+        # Automatic field mapping
+        config_mapping = {
+            'database_endpoint': main["endpoint"],
+            'database_path': main["path"],
+            '_connection_timeout': main.get("connection_timeout", 60),
+            '_main_db_tables': main.get("tables", {}),
+            'stats_endpoint': stats.get("endpoint", main["endpoint"]),
+            'stats_path': stats.get("path", main["path"]),
+            '_stats_connection_timeout': stats.get("connection_timeout",60),
+            'stats_table': stats.get("tables", {}).get("query_statistics", "analytics/query_statistics"),
+            '_stats_db_tables': stats.get("tables", {})
+        }
+        
+        for key, value in config_mapping.items():
+            setattr(self, key, value)
+        
+        # Enable statistics from flags (default True)
+        if enable_statistics is None:
+            enable_statistics = flags.get("enable_statistics", True)
+        
+        return enable_statistics
+    
+    def _get_caller_script_name(self) -> str:
+        """Automatically determine the name of the script that called YDBWrapper"""
+        try:
+            # Get call stack
+            stack = inspect.stack()
+            
+            # Find first frame that is outside ydb_wrapper.py
+            for frame_info in stack:
+                frame_filename = frame_info.filename
+                
+                # Skip current file (ydb_wrapper.py)
+                if 'ydb_wrapper.py' not in frame_filename:
+                    # Get filename without path but with extension
+                    script_name = os.path.basename(frame_filename)
+                    return script_name
+            
+            # If not found, use default value
+            return "unknown_script"
+            
+        except Exception:
+            # On error return default value
+            return "unknown_script"
+    
+    def _make_full_path(self, table_path: str) -> str:
+        """Convert relative path to full path (with database_path)
+        
+        Args:
+            table_path: Relative path to table
+            
+        Returns:
+            Full path to table
+        """
+        # If path is already full (starts with database_path), return as is
+        if table_path.startswith(self.database_path):
+            return table_path
+        
+        # Remove leading slash if present
+        table_path = table_path.lstrip('/')
+        
+        # Add database_path
+        return f"{self.database_path}/{table_path}"
+    
+    def __enter__(self):
+        """Context manager - entry"""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager - exit: close cached drivers"""
+        if self._driver is not None:
+            try:
+                self._driver.stop()
+            except Exception:
+                pass
+            self._driver = None
+        if self._stats_driver is not None:
+            try:
+                self._stats_driver.stop()
+            except Exception:
+                pass
+            self._stats_driver = None
+    
+    def _log(self, level: str, message: str, details: str = ""):
+        """Universal logging"""
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+        icons = {"start": "🚀", "progress": "⏳", "success": "✅", "error": "❌", "info": "ℹ️", "warning": "⚠️", "stats": "📊"}
+        if details:
+            print(f"🕐 [{timestamp}] {icons.get(level, '📝')} {message} | {details}", file=self._log_stream)
+        else:
+            print(f"🕐 [{timestamp}] {icons.get(level, '📝')} {message}", file=self._log_stream)
+    
+    def _setup_credentials(self):
+        """Setup YDB credentials"""
+        if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
+            raise RuntimeError("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing")
+        
+        os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ[
+            "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
+        ]
+    
+    def check_credentials(self):
+        """Check for YDB credentials"""
+        if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
+            print("Error: Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping", file=self._log_stream)
+            return False
+        
+        # Do not set up 'real' variable from gh workflows because it interfere with ydb tests
+        # So, set up it locally
+        os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ[
+            "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
+        ]
+        return True
+    
+    def _get_cluster_version(self, driver) -> str:
+        """Get YDB cluster version"""
+        if self._cluster_version is not None:
+            return self._cluster_version
+            
+        try:
+            tc_settings = ydb.TableClientSettings().with_native_date_in_result_sets(enabled=True)
+            table_client = ydb.TableClient(driver, tc_settings)
+            scan_query = ydb.ScanQuery("SELECT Version() as version", {})
+            it = table_client.scan_query(scan_query)
+            result = next(it)
+            
+            if result.result_set.rows:
+                self._cluster_version = result.result_set.rows[0]['version']
+                return self._cluster_version
+            else:
+                raise RuntimeError("No version data returned from cluster")
+                
+        except Exception as e:
+            raise RuntimeError(f"Failed to get cluster version: {e}")
+    
+    def _get_driver(self):
+        """Return the single cached main driver; create and connect once if needed."""
+        self._setup_credentials()
+        if self._driver is None:
+            self._driver = ydb.Driver(
+                endpoint=self.database_endpoint,
+                database=self.database_path,
+                credentials=ydb.credentials_from_env_variables(),
+            )
+            try:
+                self._driver.wait(timeout=self._connection_timeout, fail_fast=True)
+            except TimeoutError as e:
+                self._log("error", f"Failed to connect to YDB: {e}")
+                self._log("error", f"Endpoint: {self.database_endpoint}")
+                self._log("error", f"Database: {self.database_path}")
+                self._log("error", f"Timeout: {self._connection_timeout} seconds")
+                self._log("error", "Possible causes: network issues, YDB service unavailable, or invalid credentials")
+                self._log("error", f"Try increasing timeout with: export YDB_CONNECTION_TIMEOUT=30")
+                try:
+                    self._driver.stop()
+                except Exception:
+                    pass
+                self._driver = None
+                raise RuntimeError(f"YDB connection timeout after {self._connection_timeout}s: {e}") from e
+            except Exception as e:
+                self._log("error", f"Failed to connect to YDB: {e}")
+                self._log("error", f"Endpoint: {self.database_endpoint}")
+                self._log("error", f"Database: {self.database_path}")
+                self._log("error", f"Timeout: {self._connection_timeout} seconds")
+                self._log("error", "Check your YDB credentials and network connectivity")
+                try:
+                    self._driver.stop()
+                except Exception:
+                    pass
+                self._driver = None
+                raise RuntimeError(f"YDB connection failed: {e}") from e
+        if self._cluster_version is None:
+            try:
+                self._get_cluster_version(self._driver)
+            except Exception as e:
+                self._log("warning", f"Failed to get cluster version during operation: {e}")
+                self._cluster_version = "unknown"
+        return self._driver
+
+    @contextmanager
+    def get_driver(self):
+        """Context manager that yields the cached main driver (for compatibility)."""
+        yield self._get_driver()
+    
+    def _check_stats_availability(self) -> bool:
+        """Check statistics database availability and cache stats driver on success (called once in __init__)."""
+        driver = None
+        try:
+            self._setup_credentials()
+            driver = ydb.Driver(
+                endpoint=self.stats_endpoint,
+                database=self.stats_path,
+                credentials=ydb.credentials_from_env_variables()
+            )
+            driver.wait(timeout=self._stats_connection_timeout, fail_fast=True)
+            tc_settings = ydb.TableClientSettings().with_native_date_in_result_sets(enabled=True)
+            table_client = ydb.TableClient(driver, tc_settings)
+            scan_query = ydb.ScanQuery("SELECT 1 as test", {})
+            it = table_client.scan_query(scan_query)
+            next(it)
+            self._stats_driver = driver
+            return True
+        except Exception:
+            if driver is not None:
+                try:
+                    driver.stop()
+                except Exception:
+                    pass
+            return False
+    
+    def _log_statistics(self, operation_type: str, query: str, duration: float, 
+                       status: str, error: str = None, rows_affected: int = None,
+                       cluster_version: str = None, table_path: str = None, query_name: str = None):
+        """Log operation statistics (synchronously)
+        
+        Args:
+            query_name: Optional name for the query (e.g., monitoring query filename)
+        """
+        # Check if we need to log statistics
+        if not self._enable_statistics or not self._stats_available:
+            return
+        
+        # Prepare data for writing
+        # Use timestamp in microseconds (as YDB Timestamp)
+        timestamp_us = int(time.time() * 1000000)
+        
+        stats_data = {
+            'timestamp': timestamp_us,
+            'session_id': self._session_id,
+            'operation_type': operation_type,
+            'query': query,
+            'duration_ms': int(duration * 1000),
+            'status': status,
+            'error': error,
+            'rows_affected': rows_affected,
+            'script_name': self._script_name,
+            'query_name': query_name,
+            'cluster_version': cluster_version,
+            'database_endpoint': self.database_endpoint,
+            'database_path': self.database_path,
+            'table_path': self._normalize_table_path(table_path),
+            'github_workflow_name': self._github_info['workflow_name'],
+            'github_run_id': self._github_info['run_id'],
+            'github_run_url': self._github_info['run_url']
+        }
+        
+        # Log details of statistics being sent
+        self._log("stats", "Sending statistics", 
+                  f"operation={operation_type}, status={status}, duration={duration:.2f}s, rows={rows_affected or 0}, cluster={cluster_version or 'unknown'}")
+        
+        # Write statistics synchronously
+        send_start = time.time()
+        success = self._write_stats_sync(stats_data)
+        send_duration = time.time() - send_start
+        
+        # Log send result
+        if success:
+            self._log("success", f"Statistics sent successfully in {send_duration:.2f}s")
+    
+    def _write_stats_sync(self, stats_data):
+        """Synchronous statistics writing (uses stats driver or main driver if same DB)."""
+        if not self._stats_available:
+            return False
+        try:
+            self._setup_credentials()
+            driver = self._stats_driver if self._stats_driver is not None else self._get_driver()
+            # Ensure statistics table exists
+            self._ensure_stats_table_exists(driver)
+            stats_data_list = [stats_data]
+            table_client = ydb.TableClient(driver)
+            column_types = (
+                ydb.BulkUpsertColumns()
+                .add_column("timestamp", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+                .add_column("session_id", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("operation_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("query", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("duration_ms", ydb.OptionalType(ydb.PrimitiveType.Uint64))
+                .add_column("status", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("error", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("rows_affected", ydb.OptionalType(ydb.PrimitiveType.Uint64))
+                .add_column("script_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("query_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("cluster_version", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("database_endpoint", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("database_path", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("table_path", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("github_workflow_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("github_run_id", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("github_run_url", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+            )
+            full_path = f"{self.stats_path}/{self.stats_table}"
+            table_client.bulk_upsert(full_path, stats_data_list, column_types)
+            return True
+        except TimeoutError as e:
+            self._log("warning", f"Failed to send statistics: connection timeout (timeout={self._stats_connection_timeout}s)")
+            self._stats_available = False
+            return False
+        except Exception as e:
+            error_type = type(e).__name__
+            error_msg = str(e)
+            self._log("warning", f"Failed to send statistics ({error_type}): {error_msg}")
+            return False
+    
+    def _ensure_stats_table_exists(self, driver):
+        """Create statistics table if it doesn't exist"""
+        def create_stats_table(session):
+            create_sql = f"""
+                CREATE TABLE IF NOT EXISTS `{self.stats_table}` (
+                    `timestamp` Timestamp NOT NULL,
+                    `session_id` Utf8 NOT NULL,
+                    `operation_type` Utf8 NOT NULL,
+                    `query` Utf8,
+                    `duration_ms` Uint64 NOT NULL,
+                    `status` Utf8 NOT NULL,
+                    `error` Utf8,
+                    `rows_affected` Uint64,
+                    `script_name` Utf8 NOT NULL,
+                    `query_name` Utf8,
+                    `cluster_version` Utf8,
+                    `database_endpoint` Utf8,
+                    `database_path` Utf8,
+                    `table_path` Utf8,
+                    `github_workflow_name` Utf8,
+                    `github_run_id` Utf8,
+                    `github_run_url` Utf8,
+                    PRIMARY KEY (`timestamp`, `session_id`, `operation_type`, `script_name`)
+                )
+                PARTITION BY HASH(`session_id`)
+                WITH (STORE = COLUMN)
+            """
+            session.execute_scheme(create_sql)
+        
+        with ydb.SessionPool(driver) as pool:
+            pool.retry_operation_sync(create_stats_table)
+    
+    def _execute_with_logging(self, operation_type: str, operation_func: Callable, 
+                             query: str = None, table_path: str = None, query_name: str = None) -> Any:
+        """Universal method for executing operations with logging"""
+        start_time = None
+        
+        # Log operation start
+        self._log("start", f"Executing {operation_type}")
+        
+        if query:
+            # For bulk_upsert don't show details for each batch
+            if operation_type != "bulk_upsert":
+                self._log("info", f"Query details:\n{query}")
+        
+        status = "success"
+        error = None
+        rows_affected = 0
+        
+        # Use _cluster_version or 'unknown' if it's None
+        cluster_version = self._cluster_version or "unknown"
+        
+        try:
+            driver = self._get_driver()
+            start_time = time.time()
+
+            if operation_type == "scan_query":
+                tc_settings = ydb.TableClientSettings().with_native_date_in_result_sets(enabled=False)
+                table_client = ydb.TableClient(driver, tc_settings)
+                scan_query = ydb.ScanQuery(query, {})
+                it = table_client.scan_query(scan_query)
+
+                results = []
+                batch_count = 0
+                scan_start = time.time()
+
+                while True:
+                    try:
+                        result = next(it)
+                        batch_count += 1
+                        batch_size = len(result.result_set.rows) if result.result_set.rows else 0
+                        results = results + result.result_set.rows
+                        rows_affected += batch_size
+
+                        if (batch_count % 50 == 0 or (rows_affected > 0 and rows_affected % 10000 == 0)) and rows_affected > 0:
+                            elapsed = time.time() - scan_start
+                            self._log("progress", f"Batch {batch_count}: {batch_size} rows (total: {rows_affected})", f"{elapsed:.2f}s")
+
+                    except StopIteration:
+                        break
+
+                duration = time.time() - scan_start
+
+                if rows_affected == 0:
+                    self._log("success", f"Scan query completed", f"No results found, Duration: {duration:.2f}s")
+                else:
+                    self._log("success", f"Scan query completed", f"Total results: {rows_affected} rows, Duration: {duration:.2f}s")
+
+                self._log_statistics(
+                    operation_type=operation_type,
+                    query=query,
+                    duration=duration,
+                    status=status,
+                    rows_affected=rows_affected,
+                    cluster_version=cluster_version,
+                    table_path=table_path,
+                    query_name=query_name
+                )
+
+                return results
+
+            elif operation_type == "scan_query_with_metadata":
+                result = operation_func(driver)
+                data, metadata = result
+                rows_affected = len(data) if isinstance(data, list) else 0
+                duration = getattr(self, "_last_scan_duration", None)
+                if duration is None:
+                    duration = time.time() - start_time
+                else:
+                    del self._last_scan_duration
+
+                if rows_affected == 0:
+                    self._log("success", f"Scan query with metadata completed", f"No results found, Duration: {duration:.2f}s")
+                else:
+                    self._log("success", f"Scan query with metadata completed", f"Total results: {rows_affected} rows, Duration: {duration:.2f}s")
+
+                self._log_statistics(
+                    operation_type="scan_query",
+                    query=query,
+                    duration=duration,
+                    status=status,
+                    rows_affected=rows_affected,
+                    cluster_version=cluster_version,
+                    table_path=table_path,
+                    query_name=query_name
+                )
+
+                return result
+
+            else:
+                result = operation_func(driver)
+
+                if isinstance(result, (int, float)) and operation_type in ["bulk_upsert", "create_table"]:
+                    rows_affected = int(result)
+                elif isinstance(result, tuple) and len(result) == 2 and operation_type == "scan_query":
+                    data, metadata = result
+                    rows_affected = len(data) if isinstance(data, list) else 0
+                elif isinstance(result, list) and operation_type == "scan_query":
+                    rows_affected = len(result)
+
+                end_time = time.time()
+                duration = end_time - start_time
+
+                self._log("success", f"{operation_type} completed", f"Duration: {duration:.2f}s")
+
+                self._log_statistics(
+                    operation_type=operation_type,
+                    query=query or f"{operation_type} operation",
+                    duration=duration,
+                    status=status,
+                    rows_affected=rows_affected,
+                    cluster_version=cluster_version,
+                    table_path=table_path,
+                    query_name=query_name
+                )
+
+                return result
+
+        except Exception as e:
+            end_time = time.time()
+            duration = end_time - start_time if start_time is not None else 0
+            status = "error"
+            error = str(e)
+            
+            self._log("error", f"{operation_type} failed", f"Error: {error}, Duration: {duration:.2f}s")
+            
+            # Normalize operation_type for statistics (use "scan_query" for both scan operations)
+            stats_operation_type = "scan_query" if operation_type == "scan_query_with_metadata" else operation_type
+            
+            # Log error statistics
+            self._log_statistics(
+                operation_type=stats_operation_type,
+                query=query or f"{operation_type} operation",
+                duration=duration,
+                status=status,
+                error=error,
+                cluster_version=cluster_version,
+                table_path=table_path if operation_type == "bulk_upsert" else None,
+                query_name=query_name
+            )
+            
+            raise
+    
+    
+    def execute_scan_query(self, query: str, query_name: str = None) -> List[Dict[str, Any]]:
+        """Execute scan query with logging"""
+        return self._execute_with_logging("scan_query", None, query, None, query_name)
+    
+    def execute_scan_query_with_metadata(self, query: str, query_name: str = None) -> Tuple[List[Dict[str, Any]], List[Tuple[str, Any]]]:
+        """Execute scan query with return of data and column metadata"""
+        def operation(driver):
+            tc_settings = ydb.TableClientSettings().with_native_date_in_result_sets(enabled=True)
+            table_client = ydb.TableClient(driver, tc_settings)
+            scan_query = ydb.ScanQuery(query, {})
+            it = table_client.scan_query(scan_query)
+            
+            results = []
+            column_types = None
+            scan_start = time.time()
+            
+            while True:
+                try:
+                    result = next(it)
+                    if column_types is None:
+                        column_types = [(col.name, col.type) for col in result.result_set.columns]
+                    
+                    results.extend(result.result_set.rows)
+                
+                except StopIteration:
+                    break
+            
+            self._last_scan_duration = time.time() - scan_start
+            # If no results, column_types may be None
+            if column_types is None:
+                column_types = []
+            
+            return results, column_types
+        
+        return self._execute_with_logging("scan_query_with_metadata", operation, query, None, query_name)
+    
+    def create_table(self, table_path: str, create_sql: str):
+        """Create table with logging
+        
+        Args:
+            table_path: Relative path to table (e.g., 'test_results/test_runs')
+            create_sql: SQL for table creation
+        """
+        # Convert to full path for YDB (if not already full)
+        full_path = self._make_full_path(table_path)
+        
+        def operation(driver):
+            def callee(session):
+                session.execute_scheme(create_sql)
+            
+            with ydb.SessionPool(driver) as pool:
+                pool.retry_operation_sync(callee)
+            return 1  # Return 1 to indicate table creation
+        
+        return self._execute_with_logging("create_table", operation, create_sql, table_path)
+    
+    def bulk_upsert(self, table_path: str, rows: List[Dict[str, Any]], 
+                   column_types: ydb.BulkUpsertColumns):
+        """Execute bulk upsert with logging
+        
+        Args:
+            table_path: Relative path to table (e.g., 'test_results/test_runs')
+        """
+        # Convert to full path for YDB
+        full_path = self._make_full_path(table_path)
+        rows_count = len(rows) if rows else 0
+        
+        def operation(driver):
+            table_client = ydb.TableClient(driver)
+            table_client.bulk_upsert(full_path, rows, column_types)
+            return rows_count  # Return row count for statistics
+        
+        return self._execute_with_logging("bulk_upsert", operation, f"BULK_UPSERT to {table_path}", table_path)
+    
+    def bulk_upsert_batches(self, table_path: str, all_rows: List[Dict[str, Any]], 
+                           column_types: ydb.BulkUpsertColumns, batch_size: int = 1000, query_name: str = None):
+        """Execute bulk upsert with batching and aggregated statistics
+        
+        Args:
+            table_path: Relative path to table (e.g., 'test_results/test_runs')
+            all_rows: All data to insert
+            column_types: Column types
+            batch_size: Batch size (default 1000)
+            query_name: Optional name for the query (e.g., table name)
+        """
+        # Convert to full path for YDB
+        full_path = self._make_full_path(table_path)
+        
+        start_time = None
+        total_rows = len(all_rows)
+        
+        if total_rows == 0:
+            self._log("info", "bulk_upsert_batches: no rows to insert")
+            return
+        
+        num_batches = (total_rows - 1) // batch_size + 1
+        self._log("start", f"Executing bulk_upsert_batches", 
+                  f"{total_rows} rows in {num_batches} batches of {batch_size}")
+        
+        status = "success"
+        error = None
+        
+        # Use _cluster_version or 'unknown' if it's None
+        cluster_version = self._cluster_version or "unknown"
+        
+        try:
+            driver = self._get_driver()
+            start_time = time.time()
+
+            table_client = ydb.TableClient(driver)
+
+            for batch_num, start_idx in enumerate(range(0, total_rows, batch_size), 1):
+                batch_rows = all_rows[start_idx:start_idx + batch_size]
+                table_client.bulk_upsert(full_path, batch_rows, column_types)
+
+                if batch_num % 10 == 0 or start_idx + batch_size >= total_rows:
+                    elapsed = time.time() - start_time
+                    processed = min(start_idx + batch_size, total_rows)
+                    self._log("progress", f"Batch {batch_num}/{num_batches}",
+                              f"{processed}/{total_rows} rows, {elapsed:.2f}s")
+
+            duration = time.time() - start_time
+            self._log("success", f"bulk_upsert_batches completed", 
+                      f"Total: {total_rows} rows in {num_batches} batches, Duration: {duration:.2f}s")
+            
+            # Log ONE statistics record for the entire operation
+            self._log_statistics(
+                operation_type="bulk_upsert",
+                query=f"BULK_UPSERT to {table_path} ({total_rows} rows in {num_batches} batches)",
+                duration=duration,
+                status=status,
+                rows_affected=total_rows,
+                cluster_version=cluster_version,
+                table_path=table_path,
+                query_name=query_name
+            )
+            
+        except Exception as e:
+            duration = time.time() - start_time if start_time is not None else 0
+            status = "error"
+            error = str(e)
+            
+            self._log("error", f"bulk_upsert_batches failed", f"Error: {error}, Duration: {duration:.2f}s")
+            
+            self._log_statistics(
+                operation_type="bulk_upsert",
+                query=f"BULK_UPSERT to {table_path}",
+                duration=duration,
+                status=status,
+                error=error,
+                cluster_version=cluster_version,
+                table_path=table_path,
+                query_name=query_name
+            )
+            raise
+    
+    def execute_dml(self, query: str, parameters: Dict[str, Any] = None, query_name: str = None):
+        """Execute DML query (INSERT/UPDATE/DELETE) with parameters
+        
+        Args:
+            query: SQL query with DECLARE parameters
+            parameters: Parameters dictionary {$param_name: value}
+            query_name: Query name for logging
+        """
+        def operation(driver):
+            # Use Query Service API because Table Service DML does not support
+            # modifications for column shard tables.
+            with ydb.QuerySessionPool(driver) as pool:
+                pool.execute_with_retries(query=query, parameters=parameters or {})
+                return 1  # Successful execution
+        
+        return self._execute_with_logging("dml_query", operation, query, None, query_name)
+    
+    
+    def _get_github_action_info(self) -> dict:
+        """Get GitHub Action information if script is run in GitHub Actions"""
+        github_info = {
+            "workflow_name": None,
+            "run_id": None,
+            "run_url": None
+        }
+        
+        try:
+            # GitHub Actions sets these environment variables
+            workflow_name = os.environ.get("GITHUB_WORKFLOW")
+            run_id = os.environ.get("GITHUB_RUN_ID")
+            repository = os.environ.get("GITHUB_REPOSITORY")
+            
+            if workflow_name:
+                github_info["workflow_name"] = workflow_name
+            
+            if run_id and repository:
+                github_info["run_id"] = run_id
+                github_info["run_url"] = f"https://github.com/{repository}/actions/runs/{run_id}"
+                
+        except Exception:
+            # Ignore errors getting GitHub information
+            pass
+            
+        return github_info
+    
+    def _normalize_table_path(self, table_path: str) -> str:
+        """Normalize table path - exclude database_path for brevity"""
+        if not table_path:
+            return None
+            
+        # If path starts with database_path, remove it
+        if self.database_path and table_path.startswith(self.database_path):
+            normalized = table_path[len(self.database_path):]
+            # Remove leading slash if present
+            if normalized.startswith('/'):
+                normalized = normalized[1:]
+            return normalized
+            
+        return table_path
+    
+    def get_table_path(self, table_name: str, database: str = "main") -> str:
+        """Get table path from configuration
+        
+        Args:
+            table_name: Table name (e.g., 'test_results')
+            database: Database ('main' or 'statistics')
+        
+        Returns:
+            Table path relative to database
+        
+        Raises:
+            KeyError: If table not found in configuration
+        """
+        if database == "main":
+            if table_name not in self._main_db_tables:
+                raise KeyError(f"Table '{table_name}' not found in databases.main.tables config")
+            return self._main_db_tables[table_name]
+        elif database == "statistics":
+            if table_name not in self._stats_db_tables:
+                raise KeyError(f"Table '{table_name}' not found in databases.statistics.tables config")
+            return self._stats_db_tables[table_name]
+        else:
+            raise ValueError(f"Unknown database: {database}. Use 'main' or 'statistics'")
+    
+    def get_flag(self, flag_name: str, default: Any = None) -> Any:
+        """Get flag value from configuration
+        
+        Args:
+            flag_name: Flag name (e.g., 'enable_backup_write')
+            default: Default value if flag is not found
+        
+        Returns:
+            Flag value or default if not found
+        """
+        flags = getattr(self, '_flags', {})
+        return flags.get(flag_name, default)
+    
+    def get_available_tables(self, database: str = "main") -> dict:
+        """Get dictionary of all available tables
+        
+        Args:
+            database: Database ('main' or 'statistics')
+        
+        Returns:
+            Dictionary {table_name: table_path}
+        """
+        if database == "main":
+            return self._main_db_tables.copy()
+        elif database == "statistics":
+            return self._stats_db_tables.copy()
+        else:
+            raise ValueError(f"Unknown database: {database}")
+    
+    def get_cluster_info(self) -> Dict[str, Any]:
+        """Get cluster and statistics information (without creating new connection)"""
+        try:
+            # Use already obtained version, don't create new connection
+            version = self._cluster_version
+            
+            # Check statistics status
+            stats_status = "disabled"
+            if self._enable_statistics:
+                stats_status = "enabled_and_available" if self._stats_available else "enabled_but_unavailable"
+            
+            return {
+                'session_id': self._session_id,
+                'version': version,
+                'endpoint': self.database_endpoint,
+                'database': self.database_path,
+                'statistics_enabled': self._enable_statistics,
+                'statistics_status': stats_status,
+                'statistics_endpoint': self.stats_endpoint,
+                'statistics_database': self.stats_path,
+                'statistics_table': self.stats_table,
+                'github_workflow': self._github_info['workflow_name'],
+                'github_run_id': self._github_info['run_id'],
+                'github_run_url': self._github_info['run_url']
+            }
+                
+        except Exception as e:
+            return {
+                'session_id': self._session_id,
+                'version': None,
+                'endpoint': self.database_endpoint,
+                'database': self.database_path,
+                'error': str(e),
+                'statistics_enabled': self._enable_statistics,
+                'statistics_status': "disabled",
+                'statistics_endpoint': self.stats_endpoint,
+                'statistics_database': self.stats_path,
+                'statistics_table': self.stats_table
+            }

--- a/.github/scripts/get_build_diff.py
+++ b/.github/scripts/get_build_diff.py
@@ -7,6 +7,7 @@ import get_main_build_size
 import humanize
 import os
 import subprocess
+import sys
 
 
 # Форматирование числа
@@ -39,7 +40,7 @@ def main():
         )
         git_commit_time_unix = int(git_commit_time.timestamp())
     else:
-        print(f"Error: Cant get commit {current_pr_commit_sha} timestamp")
+        print(f"Error: Cant get commit {current_pr_commit_sha} timestamp", file=sys.stderr)
         return 1
 
     current_sizes_result = get_current_build_size.get_build_size()
@@ -101,7 +102,8 @@ def main():
         print(f"{color};;;{comment}")
     else:
         print(
-            f"Error: Cant get build data: {branch}_sizes_result = {main_sizes_result}, current_sizes_result = {current_sizes_result}"
+            f"Error: Cant get build data: {branch}_sizes_result = {main_sizes_result}, current_sizes_result = {current_sizes_result}",
+            file=sys.stderr
         )
 
 

--- a/.github/scripts/get_current_build_size.py
+++ b/.github/scripts/get_current_build_size.py
@@ -3,28 +3,33 @@
 import configparser
 import os
 import subprocess
+import sys
 
 
-dir = os.path.dirname(__file__)
-config = configparser.ConfigParser()
-config_file_path = f"{dir}/../config/ydb_qa_db.ini"
-config.read(config_file_path)
-
-YDBD_PATH = config["YDBD"]["YDBD_PATH"]
+def get_ydbd_path():
+    dir_path = os.path.dirname(__file__)
+    config_path = f"{dir_path}/../config/variables.ini"
+    
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    
+    # Читаем из секции [YDBD] параметр YDBD_PATH
+    return config.get("YDBD", "YDBD_PATH")
 
 
 def get_build_size():
-
-    if not os.path.exists(YDBD_PATH):
+    ydbd_path = get_ydbd_path()
+    
+    if not os.path.exists(ydbd_path):
         # can be possible due to incremental builds and ydbd itself is not affected by changes
-        print("Error: {} not exists, skipping".format(YDBD_PATH))
+        print("Error: {} not exists, skipping".format(ydbd_path), file=sys.stderr)
         return 0
 
     binary_size_bytes = subprocess.check_output(
-        ["bash", "-c", "cat {} | wc -c".format(YDBD_PATH)]
+        ["bash", "-c", "cat {} | wc -c".format(ydbd_path)]
     )
     binary_size_stripped_bytes = subprocess.check_output(
-        ["bash", "-c", "./ya tool strip {} -o - | wc -c".format(YDBD_PATH)]
+        ["bash", "-c", "./ya tool strip {} -o - | wc -c".format(ydbd_path)]
     )
 
     size_stripped_bytes = int(binary_size_stripped_bytes.decode("utf-8"))
@@ -32,7 +37,7 @@ def get_build_size():
     if binary_size_bytes and binary_size_stripped_bytes:
         return {"size_bytes": size_bytes, "size_stripped_bytes": size_stripped_bytes}
     else:
-        print(f"Error: Cant get build size")
+        print(f"Error: Cant get build size", file=sys.stderr)
         return 1
 
 

--- a/.github/scripts/get_main_build_size.py
+++ b/.github/scripts/get_main_build_size.py
@@ -1,79 +1,66 @@
 #!/usr/bin/env python3
 
-import configparser
 import os
-import ydb
+import sys
 
+# Add path to analytics scripts
+dir_path = os.path.dirname(__file__)
+sys.path.insert(0, f"{dir_path}/analytics")
 
-dir = os.path.dirname(__file__)
-config = configparser.ConfigParser()
-config_file_path = f"{dir}/../config/ydb_qa_db.ini"
-config.read(config_file_path)
+from ydb_wrapper import YDBWrapper
 
 build_preset = os.environ.get("build_preset")
 branch = os.environ.get("branch_to_compare")
 
-DATABASE_ENDPOINT = config["QA_DB"]["DATABASE_ENDPOINT"]
-DATABASE_PATH = config["QA_DB"]["DATABASE_PATH"]
-
 
 def get_build_size(time_of_current_commit):
-    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        print(
-            "Error: Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping"
-        )
-        return 0
-    else:
-        # Do not set up 'real' variable from gh workflows because it interfere with ydb tests
-        # So, set up it locally
-        os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ[
-            "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
-        ]
-
-    sql = f"""
-    --!syntax_v1
-    select git_commit_time,github_sha,size_bytes,size_stripped_bytes,build_preset from binary_size 
-    where 
-    github_workflow like "Postcommit%" and 
-    github_ref_name="{branch}" and 
-    build_preset="{build_preset}" and
-    git_commit_time <= DateTime::FromSeconds({time_of_current_commit})
-    order by git_commit_time desc
-    limit 1;    
-    """
-
-    with ydb.Driver(
-        endpoint=DATABASE_ENDPOINT,
-        database=DATABASE_PATH,
-        credentials=ydb.credentials_from_env_variables(),
-    ) as driver:
-        driver.wait(timeout=10, fail_fast=True)
-        session = ydb.retry_operation_sync(
-            lambda: driver.table_client.session().create()
-        )
-        with session.transaction() as transaction:
-            result = transaction.execute(sql, commit_tx=True)
-            if result[0].rows:
-                for row in result[0].rows:
-                    main_data = {}
-                    for field in row:
-                        main_data[field] = (
-                            row[field]
-                            if type(row[field]) != bytes
-                            else row[field].decode("utf-8")
-                        )
-            else:
-                print(
-                    f"Error: Cant get binary size in db with params: github_workflow like 'Postcommit%', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'"
-                )
+    try:
+        # Используем silent режим, чтобы логи не попадали в stdout и не загрязняли результат
+        with YDBWrapper(silent=True) as wrapper:
+            if not wrapper.check_credentials():
+                print("Error: Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping", file=sys.stderr)
                 return 0
 
-        return {
-            "github_sha": main_data["github_sha"],
-            "git_commit_time": str(main_data["git_commit_time"]),
-            "size_bytes": str(main_data["size_bytes"]),
-            "size_stripped_bytes": str(main_data["size_stripped_bytes"]),
-        }
+            sql = f"""
+            --!syntax_v1
+            select git_commit_time,github_sha,size_bytes,size_stripped_bytes,build_preset
+            from binary_size 
+            where 
+            github_workflow like "Postcommit%" and 
+            github_ref_name="{branch}" and 
+            build_preset="{build_preset}" and
+            git_commit_time <= DateTime::FromSeconds({time_of_current_commit})
+            order by git_commit_time desc
+            limit 1;    
+            """
+
+            results = wrapper.execute_scan_query(sql)
+            
+            if results:
+                row = results[0]
+                main_data = {}
+                for field in row:
+                    main_data[field] = (
+                        row[field]
+                        if type(row[field]) != bytes
+                        else row[field].decode("utf-8")
+                    )
+                
+                return {
+                    "github_sha": main_data["github_sha"],
+                    "git_commit_time": str(main_data["git_commit_time"]),
+                    "size_bytes": str(main_data["size_bytes"]),
+                    "size_stripped_bytes": str(main_data["size_stripped_bytes"]),
+                }
+            else:
+                print(
+                    f"Error: Cant get binary size in db with params: github_workflow like 'Postcommit%', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
+                    file=sys.stderr
+                )
+                return 0
+    except Exception as e:
+        print(f"Error: Failed to get main build size from YDB: {e}", file=sys.stderr)
+        return 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/send_build_stats.py
+++ b/.github/scripts/send_build_stats.py
@@ -3,18 +3,16 @@
 import configparser
 import datetime
 import os
-import ydb
-import uuid
 import subprocess
+import sys
+import uuid
 
-dir = os.path.dirname(__file__)
-config = configparser.ConfigParser()
-config_file_path = f"{dir}/../config/ydb_qa_db.ini"
-config.read(config_file_path)
+# Add path to analytics scripts
+dir_path = os.path.dirname(__file__)
+sys.path.insert(0, f"{dir_path}/analytics")
 
-YDBD_PATH = config["YDBD"]["YDBD_PATH"]
-DATABASE_ENDPOINT = config["QA_DB"]["DATABASE_ENDPOINT"]
-DATABASE_PATH = config["QA_DB"]["DATABASE_PATH"]
+import ydb
+from ydb_wrapper import YDBWrapper
 
 FROM_ENV_COLUMNS = [
     "github_head_ref",
@@ -50,34 +48,27 @@ ALL_COLUMNS = STRING_COLUMNS + DATETIME_COLUMNS + UINT64_COLUMNS
 def sanitize_str(s):
     # YDB SDK expects bytes for 'String' columns
     if s is None:
-        s = "N\A"
+        s = "N/A"
     return s.encode("utf-8")
 
 
 def main():
-    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        print("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping")
-        return 1
-    
-    # Do not set up 'real' variable from gh workflows because it interfere with ydb tests 
-    # So, set up it locally
-    os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ["CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"]
+    try:
+        with YDBWrapper() as wrapper:
+            if not wrapper.check_credentials():
+                print("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping")
+                return 1
+            
+            config_path = f"{dir_path}/../config/variables.ini"
+            config = configparser.ConfigParser()
+            config.read(config_path)
+            ydbd_path = config.get("YDBD", "YDBD_PATH")
+            
+            if not os.path.exists(ydbd_path):
+                # can be possible due to incremental builds and ydbd itself is not affected by changes
+                print("{} not exists, skipping".format(ydbd_path))
+                return 0
 
-    if not os.path.exists(YDBD_PATH):
-        # can be possible due to incremental builds and ydbd itself is not affected by changes
-        print("{} not exists, skipping".format(YDBD_PATH))
-        return 0
-
-    with ydb.Driver(
-        endpoint=DATABASE_ENDPOINT,
-        database=DATABASE_PATH,
-        credentials=ydb.credentials_from_env_variables()
-    ) as driver:
-        driver.wait(timeout=10, fail_fast=True)
-        session = ydb.retry_operation_sync(
-            lambda: driver.table_client.session().create()
-        )
-        with session.transaction() as tx:
             text_query_builder = []
             for type_ in STRING_COLUMNS:
                 text_query_builder.append("DECLARE ${} as String;".format(type_))
@@ -86,8 +77,11 @@ def main():
             for type_ in DATETIME_COLUMNS:
                 text_query_builder.append("DECLARE ${} as Datetime;".format(type_))
 
+            # Get table path from config
+            binary_size_table = wrapper.get_table_path("binary_size")
+            
             text_query_builder.append(
-                """INSERT INTO binary_size
+                """INSERT INTO `{}`
 (
     {}
 )
@@ -96,6 +90,7 @@ VALUES
     {}                   
 );                         
 """.format(
+                    binary_size_table,
                     ", \n    ".join(ALL_COLUMNS),
                     ", \n    ".join(["$" + column for column in ALL_COLUMNS]),
                 )
@@ -103,13 +98,12 @@ VALUES
 
             text_query = "\n".join(text_query_builder)
 
-            prepared_query = session.prepare(text_query)
-
+            # Get binary sizes
             binary_size_bytes = subprocess.check_output(
-                ["bash", "-c", "cat {} | wc -c".format(YDBD_PATH)]
+                ["bash", "-c", "cat {} | wc -c".format(ydbd_path)]
             )
             binary_size_stripped_bytes = subprocess.check_output(
-                ["bash", "-c", "./ya tool strip {} -o - | wc -c".format(YDBD_PATH)]
+                ["bash", "-c", "./ya tool strip {} -o - | wc -c".format(ydbd_path)]
             )
 
             build_preset = os.environ.get("build_preset", None)
@@ -135,10 +129,18 @@ VALUES
             parameters = {
                 "$id": sanitize_str(str(uuid.uuid4())),
                 "$build_preset": sanitize_str(build_preset),
-                "$binary_path": sanitize_str(YDBD_PATH),
-                "$size_stripped_bytes": int(binary_size_stripped_bytes.decode("utf-8")),
-                "$size_bytes": int(binary_size_bytes.decode("utf-8")),
-                "$git_commit_time": git_commit_time_unix,
+                "$binary_path": sanitize_str(ydbd_path),
+                "$size_stripped_bytes": ydb.TypedValue(
+                    int(binary_size_stripped_bytes.decode("utf-8")),
+                    ydb.PrimitiveType.Uint64,
+                ),
+                "$size_bytes": ydb.TypedValue(
+                    int(binary_size_bytes.decode("utf-8")),
+                    ydb.PrimitiveType.Uint64,
+                ),
+                "$git_commit_time": ydb.TypedValue(
+                    git_commit_time_unix, ydb.PrimitiveType.Datetime
+                ),
                 "$git_commit_message": sanitize_str(git_commit_message),
             }
 
@@ -146,7 +148,7 @@ VALUES
                 value = os.environ.get(column.upper(), None)
                 parameters["$" + column] = sanitize_str(value)
             
-            #workaround for https://github.com/ydb-platform/ydb/issues/5294
+            # workaround for https://github.com/ydb-platform/ydb/issues/5294
             parameters["$github_sha"] = sanitize_str(github_sha)
             
             print("Executing query:\n{}".format(text_query))
@@ -154,7 +156,14 @@ VALUES
             for k, v in parameters.items():
                 print("{}: {}".format(k, v))
 
-            tx.execute(prepared_query, parameters, commit_tx=True)
+            wrapper.execute_dml(text_query, parameters)
+            print("Successfully sent build stats to YDB")
+            
+    except Exception as e:
+        print(f"Warning: Failed to send build stats to YDB: {e}")
+        return 0  # Не фейлим CI, если не удалось отправить статистику
+    
+    return 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/get_test_history.py
+++ b/.github/scripts/tests/get_test_history.py
@@ -1,141 +1,126 @@
 #!/usr/bin/env python3
 
-import configparser
 import datetime
 import os
+import sys
 import time
 import ydb
 
-
-dir = os.path.dirname(__file__)
-config = configparser.ConfigParser()
-config_file_path = f"{dir}/../../config/ydb_qa_db.ini"
-config.read(config_file_path)
-
-DATABASE_ENDPOINT = config["QA_DB"]["DATABASE_ENDPOINT"]
-DATABASE_PATH = config["QA_DB"]["DATABASE_PATH"]
+# Add analytics directory to path for ydb_wrapper import
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'analytics'))
+from ydb_wrapper import YDBWrapper
 
 
-def get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, branch):
-    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        print(
-            "Error: Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping"
-        )
-        return {}
-    else:
-        # Do not set up 'real' variable from gh workflows because it interfere with ydb tests
-        # So, set up it locally
-        os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ[
-            "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
-        ]
+def get_test_history(test_names_array, days_back, build_type, branch):
+    """
+    Get test history for the specified number of days back.
+    
+    Args:
+        test_names_array: List of test full names (suite_folder/test_name)
+        days_back: Number of days to look back (instead of last N runs)
+        build_type: Build type filter (can be empty string for all)
+        branch: Branch filter (can be empty string for all)
+    
+    Returns:
+        Dictionary with test history: {test_name: {timestamp: {status, datetime, ...}}}
+    """
+    # Cap days_back to prevent performance issues
+    MAX_DAYS_BACK = 180
+    if days_back > MAX_DAYS_BACK:
+        print(f"Warning: days_back ({days_back}) exceeds maximum ({MAX_DAYS_BACK}), capping to {MAX_DAYS_BACK}")
+        days_back = MAX_DAYS_BACK
+    
+    with YDBWrapper() as ydb_wrapper:
+        # Check credentials
+        if not ydb_wrapper.check_credentials():
+            print(f"Warning: YDB credentials not found, returning empty history")
+            return {}
 
-    results = {}
-    with ydb.Driver(
-        endpoint=DATABASE_ENDPOINT,
-        database=DATABASE_PATH,
-        credentials=ydb.credentials_from_env_variables(),
-    ) as driver:
-        driver.wait(timeout=10, fail_fast=True)
-        session = ydb.retry_operation_sync(
-            lambda: driver.table_client.session().create()
-        )
+        # Get table paths from config
+        test_runs_table = ydb_wrapper.get_table_path("test_results")
+        
+        print(f"Querying history for {len(test_names_array)} tests:")
+        print(f"  build_type: {build_type}")
+        print(f"  branch: {branch}")
+        print(f"  days_back: {days_back}")
+        
+        results = {}
         batch_size = 500
-        start_time = time.time()
+        
         for start in range(0, len(test_names_array), batch_size):
             test_names_batch = test_names_array[start:start + batch_size]
             history_query = f"""
-        PRAGMA AnsiInForEmptyOrNullableItemsCollections;
-        DECLARE $test_names AS List<Utf8>;
-        DECLARE $rn_max AS Int32;
-        DECLARE $build_type AS Utf8;
-        DECLARE $branch AS Utf8;
+    PRAGMA AnsiInForEmptyOrNullableItemsCollections;
+    DECLARE $test_names AS List<Utf8>;
+    DECLARE $days_back AS Int32;
+    DECLARE $build_type AS Utf8;
+    DECLARE $branch AS Utf8;
 
-        $test_names = [{','.join("'{0}'".format(x) for x in test_names_batch)}];
-        $rn_max = {last_n_runs_of_test_amount};
-        $build_type = '{build_type}';
-        $branch = '{branch}';
+    $test_names = [{','.join("'{0}'".format(x) for x in test_names_batch)}];
+    $days_back = {days_back};
+    $build_type = '{build_type}';
+    $branch = '{branch}';
 
-        -- Оптимизированный запрос с учетом особенностей YDB
-        $filtered_tests = (
-            SELECT 
-                suite_folder || '/' || test_name AS full_name,
-                test_name,
-                build_type, 
-                commit, 
-                branch, 
-                run_timestamp, 
-                status, 
-                status_description,
-                job_id,
-                job_name,
-                ROW_NUMBER() OVER (PARTITION BY test_name ORDER BY run_timestamp DESC) AS rn
-            FROM 
-                `test_results/test_runs_column` AS t
-            WHERE 
-                t.build_type = $build_type
-                AND t.branch = $branch
-                AND t.job_name IN (
-                    'Nightly-run',
-                    'Regression-run',
-                    'Regression-whitelist-run',
-                    'Postcommit_relwithdebinfo', 
-                    'Postcommit_asan'
-                )
-                AND t.status != 'skipped'
-                AND suite_folder || '/' || test_name IN $test_names
-        );
+    -- Query to get test history for the specified number of days
+    -- Results are ordered by test_name, then by run_timestamp DESC (newest first)
+    -- This order is expected by the UI which displays results from newest to oldest
+    SELECT 
+        suite_folder || '/' || test_name AS full_name,
+        test_name,
+        build_type, 
+        commit, 
+        branch, 
+        run_timestamp, 
+        status, 
+        status_description,
+        job_id,
+        job_name
+    FROM 
+        `{test_runs_table}` AS t
+    WHERE 
+        t.status != 'skipped'
+        AND suite_folder || '/' || test_name IN $test_names
+        AND t.run_timestamp > CurrentUtcDate() - $days_back * Interval("P1D")
+        AND ($build_type = '' OR t.build_type = $build_type)
+        AND ($branch = '' OR t.branch = $branch)
+        AND t.job_name != 'Run-tests'
+        AND (t.pull IS NULL OR NOT String::Contains(t.pull, 'manual'))
+    ORDER BY 
+        test_name, 
+        run_timestamp DESC;
 
-        -- Финальный запрос с ограничением по количеству запусков
-        SELECT 
-            full_name,
-            test_name,
-            build_type, 
-            commit, 
-            branch, 
-            run_timestamp, 
-            status, 
-            status_description,
-            job_id,
-            job_name,
-            rn
-        FROM 
-            $filtered_tests
-        WHERE 
-            rn <= $rn_max
-        ORDER BY 
-            test_name, 
-            run_timestamp;
-
-    """
-            query = ydb.ScanQuery(history_query, {})
-            it = driver.table_client.scan_query(query)
-            query_result = []
-
-            while True:
-                try:
-                    result = next(it)
-                    query_result = query_result + result.result_set.rows
-                except StopIteration:
-                    break
-
+"""
+            query_result = ydb_wrapper.execute_scan_query(history_query)
+            
+            rows_found = 0
             for row in query_result:
-                if not row["full_name"].decode("utf-8") in results:
-                    results[row["full_name"].decode("utf-8")] = {}
+                rows_found += 1
+                full_name = row["full_name"].decode("utf-8") if isinstance(row["full_name"], bytes) else row["full_name"]
+                if full_name not in results:
+                    results[full_name] = {}
 
-                results[row["full_name"].decode("utf-8")][row["run_timestamp"]] = {
-                    "branch": row["branch"],
-                    "status": row["status"],
-                    "commit": row["commit"],
-                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%H:%m %B %d %Y"),
-                    "status_description": row["status_description"].replace(';;','\n'),
-                    "job_id": row["job_id"],
-                    "job_name": row["job_name"]
+                results[full_name][row["run_timestamp"]] = {
+                    "branch": row["branch"].decode("utf-8") if isinstance(row["branch"], bytes) else row["branch"],
+                    "status": row["status"].decode("utf-8") if isinstance(row["status"], bytes) else row["status"],
+                    "commit": row["commit"].decode("utf-8") if isinstance(row["commit"], bytes) else row["commit"],
+                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%Y-%m-%d %H:%M:%S"),
+                    "status_description": (row["status_description"].decode("utf-8") if isinstance(row["status_description"], bytes) else row["status_description"]).replace(';;','\n'),
+                    "job_id": row["job_id"].decode("utf-8") if isinstance(row["job_id"], bytes) else row["job_id"],
+                    "job_name": row["job_name"].decode("utf-8") if isinstance(row["job_name"], bytes) else row["job_name"]
                 }
-        end_time = time.time()
-        print(
-            f'durations of getting history for {len(test_names_array)} tests :{end_time-start_time} sec')
+            
+            if rows_found == 0:
+                print(f"  Warning: No rows found in YDB for batch {start // batch_size + 1}")
+                print(f"  This could mean:")
+                print(f"    - No data with build_type='{build_type}' and branch='{branch}' in last {days_back} days")
+                print(f"    - Test names don't match (check format: suite_folder/test_name)")
+        
+        print(f'Retrieved history: {len(results)} tests with data out of {len(test_names_array)} requested')
+        if results:
+            sample_test = list(results.keys())[0]
+            print(f"  Sample: {sample_test} has {len(results[sample_test])} runs")
         return results
 
 
 if __name__ == "__main__":
-    get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, branch)
+    get_test_history(test_names_array, days_back, build_type, branch)

--- a/.github/scripts/tests/get_test_history.py
+++ b/.github/scripts/tests/get_test_history.py
@@ -4,97 +4,92 @@ import datetime
 import os
 import sys
 import time
-import ydb
 
 # Add analytics directory to path for ydb_wrapper import
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'analytics'))
 from ydb_wrapper import YDBWrapper
 
 
-def get_test_history(test_names_array, days_back, build_type, branch):
-    """
-    Get test history for the specified number of days back.
-    
-    Args:
-        test_names_array: List of test full names (suite_folder/test_name)
-        days_back: Number of days to look back (instead of last N runs)
-        build_type: Build type filter (can be empty string for all)
-        branch: Branch filter (can be empty string for all)
-    
-    Returns:
-        Dictionary with test history: {test_name: {timestamp: {status, datetime, ...}}}
-    """
-    # Cap days_back to prevent performance issues
-    MAX_DAYS_BACK = 180
-    if days_back > MAX_DAYS_BACK:
-        print(f"Warning: days_back ({days_back}) exceeds maximum ({MAX_DAYS_BACK}), capping to {MAX_DAYS_BACK}")
-        days_back = MAX_DAYS_BACK
-    
+def get_test_history(test_names_array, last_n_runs_of_test_amount, build_type, branch=None):
     with YDBWrapper() as ydb_wrapper:
-        # Check credentials
         if not ydb_wrapper.check_credentials():
-            print(f"Warning: YDB credentials not found, returning empty history")
+            print("Warning: YDB credentials not found, skipping history")
             return {}
 
-        # Get table paths from config
         test_runs_table = ydb_wrapper.get_table_path("test_results")
-        
-        print(f"Querying history for {len(test_names_array)} tests:")
-        print(f"  build_type: {build_type}")
-        print(f"  branch: {branch}")
-        print(f"  days_back: {days_back}")
-        
+
         results = {}
         batch_size = 500
-        
+        start_time = time.time()
+
         for start in range(0, len(test_names_array), batch_size):
             test_names_batch = test_names_array[start:start + batch_size]
+
+            branch_filter = f"AND t.branch = '{branch}'" if branch else ""
+
             history_query = f"""
-    PRAGMA AnsiInForEmptyOrNullableItemsCollections;
-    DECLARE $test_names AS List<Utf8>;
-    DECLARE $days_back AS Int32;
-    DECLARE $build_type AS Utf8;
-    DECLARE $branch AS Utf8;
+        PRAGMA AnsiInForEmptyOrNullableItemsCollections;
+        DECLARE $test_names AS List<Utf8>;
+        DECLARE $rn_max AS Int32;
+        DECLARE $build_type AS Utf8;
 
-    $test_names = [{','.join("'{0}'".format(x) for x in test_names_batch)}];
-    $days_back = {days_back};
-    $build_type = '{build_type}';
-    $branch = '{branch}';
+        $test_names = [{','.join("'{0}'".format(x) for x in test_names_batch)}];
+        $rn_max = {last_n_runs_of_test_amount};
+        $build_type = '{build_type}';
 
-    -- Query to get test history for the specified number of days
-    -- Results are ordered by test_name, then by run_timestamp DESC (newest first)
-    -- This order is expected by the UI which displays results from newest to oldest
-    SELECT 
-        suite_folder || '/' || test_name AS full_name,
-        test_name,
-        build_type, 
-        commit, 
-        branch, 
-        run_timestamp, 
-        status, 
-        status_description,
-        job_id,
-        job_name
-    FROM 
-        `{test_runs_table}` AS t
-    WHERE 
-        t.status != 'skipped'
-        AND suite_folder || '/' || test_name IN $test_names
-        AND t.run_timestamp > CurrentUtcDate() - $days_back * Interval("P1D")
-        AND ($build_type = '' OR t.build_type = $build_type)
-        AND ($branch = '' OR t.branch = $branch)
-        AND t.job_name != 'Run-tests'
-        AND (t.pull IS NULL OR NOT String::Contains(t.pull, 'manual'))
-    ORDER BY 
-        test_name, 
-        run_timestamp DESC;
+        $filtered_tests = (
+            SELECT
+                suite_folder || '/' || test_name AS full_name,
+                test_name,
+                build_type,
+                commit,
+                branch,
+                run_timestamp,
+                status,
+                status_description,
+                job_id,
+                job_name,
+                ROW_NUMBER() OVER (PARTITION BY test_name ORDER BY run_timestamp DESC) AS rn
+            FROM
+                `{test_runs_table}` AS t
+            WHERE
+                t.build_type = $build_type
+                {branch_filter}
+                AND t.job_name IN (
+                    'Nightly-run',
+                    'Regression-run',
+                    'Regression-whitelist-run',
+                    'Postcommit_relwithdebinfo',
+                    'Postcommit_asan'
+                )
+                AND t.status != 'skipped'
+                AND suite_folder || '/' || test_name IN $test_names
+        );
+
+        SELECT
+            full_name,
+            test_name,
+            build_type,
+            commit,
+            branch,
+            run_timestamp,
+            status,
+            status_description,
+            job_id,
+            job_name,
+            rn
+        FROM
+            $filtered_tests
+        WHERE
+            rn <= $rn_max
+        ORDER BY
+            test_name,
+            run_timestamp;
 
 """
             query_result = ydb_wrapper.execute_scan_query(history_query)
-            
-            rows_found = 0
+
             for row in query_result:
-                rows_found += 1
                 full_name = row["full_name"].decode("utf-8") if isinstance(row["full_name"], bytes) else row["full_name"]
                 if full_name not in results:
                     results[full_name] = {}
@@ -103,24 +98,16 @@ def get_test_history(test_names_array, days_back, build_type, branch):
                     "branch": row["branch"].decode("utf-8") if isinstance(row["branch"], bytes) else row["branch"],
                     "status": row["status"].decode("utf-8") if isinstance(row["status"], bytes) else row["status"],
                     "commit": row["commit"].decode("utf-8") if isinstance(row["commit"], bytes) else row["commit"],
-                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%Y-%m-%d %H:%M:%S"),
-                    "status_description": (row["status_description"].decode("utf-8") if isinstance(row["status_description"], bytes) else row["status_description"]).replace(';;','\n'),
+                    "datetime": datetime.datetime.fromtimestamp(int(row["run_timestamp"] / 1000000)).strftime("%H:%m %B %d %Y"),
+                    "status_description": (row["status_description"].decode("utf-8") if isinstance(row["status_description"], bytes) else row["status_description"]).replace(';;', '\n'),
                     "job_id": row["job_id"].decode("utf-8") if isinstance(row["job_id"], bytes) else row["job_id"],
-                    "job_name": row["job_name"].decode("utf-8") if isinstance(row["job_name"], bytes) else row["job_name"]
+                    "job_name": row["job_name"].decode("utf-8") if isinstance(row["job_name"], bytes) else row["job_name"],
                 }
-            
-            if rows_found == 0:
-                print(f"  Warning: No rows found in YDB for batch {start // batch_size + 1}")
-                print(f"  This could mean:")
-                print(f"    - No data with build_type='{build_type}' and branch='{branch}' in last {days_back} days")
-                print(f"    - Test names don't match (check format: suite_folder/test_name)")
-        
-        print(f'Retrieved history: {len(results)} tests with data out of {len(test_names_array)} requested')
-        if results:
-            sample_test = list(results.keys())[0]
-            print(f"  Sample: {sample_test} has {len(results[sample_test])} runs")
+
+        end_time = time.time()
+        print(f'durations of getting history for {len(test_names_array)} tests: {end_time - start_time} sec')
         return results
 
 
 if __name__ == "__main__":
-    get_test_history(test_names_array, days_back, build_type, branch)
+    get_test_history([], 5, "relwithdebinfo", "main")

--- a/.github/workflows/acceptance_run.yml
+++ b/.github/workflows/acceptance_run.yml
@@ -42,6 +42,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
 
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya

--- a/.github/workflows/build_analytics.yml
+++ b/.github/workflows/build_analytics.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
 
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya

--- a/.github/workflows/build_and_test_ya.yml
+++ b/.github/workflows/build_and_test_ya.yml
@@ -73,6 +73,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
 
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya

--- a/.github/workflows/collect_analytics.yml
+++ b/.github/workflows/collect_analytics.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Install dependencies
       run: |
         python3 -m pip install ydb ydb[yc] codeowners pandas
@@ -46,6 +47,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Install dependencies
       run: |
         python3 -m pip install ydb ydb[yc] codeowners pandas

--- a/.github/workflows/collect_analytics_fast.yml
+++ b/.github/workflows/collect_analytics_fast.yml
@@ -24,6 +24,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Install dependencies
       run: |
         python3 -m pip install ydb ydb[yc] codeowners pandas

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya
       with:

--- a/.github/workflows/postcommit_asan.yml
+++ b/.github/workflows/postcommit_asan.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya
       with:

--- a/.github/workflows/postcommit_relwithdebinfo.yml
+++ b/.github/workflows/postcommit_relwithdebinfo.yml
@@ -21,6 +21,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya
       with:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -231,6 +231,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Build and test
       if: |
           (matrix.build_preset == 'release-asan') || 

--- a/.github/workflows/prewarm-debug.yaml
+++ b/.github/workflows/prewarm-debug.yaml
@@ -21,6 +21,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya
       with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -143,6 +143,7 @@ jobs:
         uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
         with:
           ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+          ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
 
       - name: Run YDB Tests
         timeout-minutes: ${{ fromJson(env.timeout) }}

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -58,6 +58,7 @@ jobs:
         uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
         with:
           ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+          ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     
       - name: Collect test history data
         run: python3 .github/scripts/analytics/flaky_tests_history.py --days-window=1 --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }}

--- a/.github/workflows/weekly_analytic.yml
+++ b/.github/workflows/weekly_analytic.yml
@@ -20,6 +20,7 @@ jobs:
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+        ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
     - name: Install dependencies
       run: |
         python3 -m pip install ydb ydb[yc] pandas  # Add any other required packages


### PR DESCRIPTION
## Backport: YDB_QA_CONFIG — minimal (< stable-25-3)

Backport of #40807 (YDB QA config from GH VARS).

**Scope**: minimal — branches older than stable-25-3 using **JUnit XML** test reports.
`generate-summary.py` and related files are **not changed** (preserved at base branch version).

### Changes (6 scripts + workflows)
| File | Mode | Change |
|------|------|--------|
| `setup_ci_ydb_service_account_key_file_credentials/action.yml` | — | Added `ydb_qa_config` input → exports `YDB_QA_CONFIG` env var |
| All `workflows/*.yml` | — | Added `ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}` to action calls |
| `analytics/upload_tests_results.py` | 100755 | Hybrid: JUnit XML parse + YDBWrapper upload |
| `analytics/ydb_wrapper.py` | 100755 | Updated: `use_local_config=None` (reads `YDB_QA_CONFIG`) |
| `send_build_stats.py` | 100755 | Updated to use YDBWrapper |
| `get_build_diff.py` | 100755 | Updated to use YDBWrapper |
| `get_main_build_size.py` | 100755 | Updated to use YDBWrapper |
| `get_current_build_size.py` | 100755 | Updated to use YDBWrapper |
| `tests/get_test_history.py` | 100644 | Updated to use YDBWrapper |
| `config/ydb_qa_config.json` | — | Updated to main version (23 tables) |

### Not included
- `generate-summary.py`, `error_type_utils.py`, `testowners_utils.py`, `templates/summary.html` — preserved at base branch version
- `mute/` directory, `test_ya/action.yml` MAIN_SCRIPTS removal

### Changelog entry
Not for Changelog (CI/internal tooling only)