### PR TITLE
Fix flaky test_workload_manager_version_upgrade compatibility (#40903)

### DIFF
--- a/ydb/tests/compatibility/test_workload_manager.py
+++ b/ydb/tests/compatibility/test_workload_manager.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from ydb.tests.library.common.wait_for import wait_for
@@ -7,6 +8,8 @@ from ydb.tests.library.compatibility.fixtures import (
     RollingUpgradeAndDowngradeFixture,
 )
 from ydb.tests.oss.ydb_sdk_import import ydb
+
+logger = logging.getLogger(__name__)
 
 
 class WorkloadManagerWorkload:
@@ -148,8 +151,19 @@ class TestWorkloadManagerRestartToAnotherVersion(RestartToAnotherVersionFixture)
         workload.create_resource_pool_classifier()
         workload.validate_resource_pool_classifier()
         self.change_cluster_version()
-        workload.validate_resource_pool()
-        workload.validate_resource_pool_classifier()
+
+        def validate_after_upgrade():
+            try:
+                workload.validate_resource_pool()
+                workload.validate_resource_pool_classifier()
+                return True
+            except Exception as e:
+                logger.warning("System views validation failed, retrying: %s", e)
+                return False
+
+        assert wait_for(validate_after_upgrade, timeout_seconds=240, step_seconds=5), \
+            "System views not available after version upgrade"
+
         workload.alter_resource_pool()
         workload.validate_altered_resource_pool()
         workload.alter_resource_pool_classifier()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Fix flaky test_workload_manager_version_upgrade compatibility (#40903)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add retry logic for system view validations after cluster version upgrade. The metadata service needs time to initialize after a full restart, which can cause "System view: timeout" errors when the 60s scan timeout expires before the first snapshot refresh completes.

Wrap post-upgrade validations in wait_for() with 240s timeout and add warning logging for failed retry attempts.

fixes: #40903