### PR TITLE
Add `vector_ivf_pq` support into vector workload

### DIFF
--- a/ydb/core/base/ivf_pq.cpp
+++ b/ydb/core/base/ivf_pq.cpp
@@ -1,0 +1,238 @@
+#include "ivf_pq.h"
+#include "kmeans_clusters.h"
+
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
+#include <optional>
+
+namespace NKikimr::NIvfPq {
+
+namespace {
+
+    constexpr ui64 MinVectorDimension = 1;
+    constexpr ui64 MaxVectorDimension = 16384;
+    constexpr ui64 MinLevels = 1;
+    constexpr ui64 MaxLevels = 16;
+    constexpr ui64 MinClusters = 2;
+    constexpr ui64 MaxClusters = 2048;
+    constexpr ui64 MaxClustersPowLevels = ui64(1) << 30;
+    constexpr ui64 MaxVectorDimensionMultiplyClusters = ui64(4) << 20;
+    constexpr ui64 MinSubspaces = 1;
+    constexpr ui64 MaxSubspaces = 1024;
+    constexpr ui64 MinSubspaceBits = 1;
+    constexpr ui64 MaxSubspaceBits = 12;
+    constexpr ui64 MaxCodebookEntries = ui64(1) << 20;
+    
+    bool ValidateSettingInRange(const TString& name, std::optional<ui64> value, ui64 minValue, ui64 maxValue, TString& error) {
+        if (!value.has_value()) {
+            error = TStringBuilder() << name << " should be set";
+            return false;
+        }
+
+        if (minValue <= *value && *value <= maxValue) {
+            return true;
+        }
+
+        error = TStringBuilder() << "Invalid " << name << ": " << *value << " should be between " << minValue << " and " << maxValue;
+        return false;
+    };
+
+    Ydb::Table::VectorIndexSettings_Metric ParseDistance(const TString& distance_, TString& error) {
+        const TString distance = to_lower(distance_);
+        if (distance == "cosine")
+            return Ydb::Table::VectorIndexSettings::DISTANCE_COSINE;
+        else if (distance == "manhattan")
+            return Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN;
+        else if (distance == "euclidean")
+            return Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN;
+        else {
+            error = TStringBuilder() << "Invalid distance: " << distance_;
+            return Ydb::Table::VectorIndexSettings::METRIC_UNSPECIFIED;
+        }
+    };
+
+    Ydb::Table::VectorIndexSettings_Metric ParseSimilarity(const TString& similarity_, TString& error) {
+        const TString similarity = to_lower(similarity_);
+        if (similarity == "cosine")
+            return Ydb::Table::VectorIndexSettings::SIMILARITY_COSINE;
+        else if (similarity == "inner_product")
+            return Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT;
+        else {
+            error = TStringBuilder() << "Invalid similarity: " << similarity_;
+            return Ydb::Table::VectorIndexSettings::METRIC_UNSPECIFIED;
+        }
+    };
+
+    Ydb::Table::VectorIndexSettings_VectorType ParseVectorType(const TString& vectorType_, TString& error) {
+        const TString vectorType = to_lower(vectorType_);
+        if (vectorType == "float")
+            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT;
+        else if (vectorType == "uint8")
+            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
+        else if (vectorType == "int8")
+            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_INT8;
+        else if (vectorType == "bit")
+            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_BIT;
+        else {
+            error = TStringBuilder() << "Invalid vector_type: " << vectorType_;
+            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED;
+        }
+    }
+
+    ui32 ParseUInt32(const TString& name, const TString& value, ui64 minValue, ui64 maxValue, TString& error) {
+        ui32 result = 0;
+        if (!TryFromString(value, result)) {
+            error = TStringBuilder() << "Invalid " << name << ": " << value;
+            return result;
+        }
+        ValidateSettingInRange(name, result, minValue, maxValue, error);
+        return result;
+    }
+
+    double ParseDouble(const TString& name, const TString& value, TString& error) {
+        double result = 0;
+        if (!TryFromString(value, result)) {
+            error = TStringBuilder() << "Invalid " << name << ": " << value;
+        }
+        return result;
+    }
+
+} // namespace
+
+bool FillSetting(Ydb::Table::IvfPqSettings& settings, const TString& name, const TString& value, TString& error) {
+    error = "";
+
+    const TString nameLower = to_lower(name);
+    if (nameLower == "distance") {
+        if (settings.mutable_settings()->has_metric()) {
+            error = "only one of distance or similarity should be set, not both";
+            return false;
+        }
+        settings.mutable_settings()->set_metric(ParseDistance(value, error));
+    } else if (nameLower == "similarity") {
+        if (settings.mutable_settings()->has_metric()) {
+            error = "only one of distance or similarity should be set, not both";
+            return false;
+        }
+        settings.mutable_settings()->set_metric(ParseSimilarity(value, error));
+    } else if (nameLower == "vector_type") {
+        settings.mutable_settings()->set_vector_type(ParseVectorType(value, error));
+    } else if (nameLower == "vector_dimension") {
+        settings.mutable_settings()->set_vector_dimension(ParseUInt32(name, value, MinVectorDimension, MaxVectorDimension, error));
+    } else if (nameLower == "kmeans_tree_clusters") {
+        settings.mutable_kmeans_tree_settings()->set_clusters(ParseUInt32(name, value, MinClusters, MaxClusters, error));
+    } else if (nameLower =="kmeans_tree_levels") {
+        settings.mutable_kmeans_tree_settings()->set_levels(ParseUInt32(name, value, MinLevels, MaxLevels, error));
+    } else if (nameLower == "kmeans_tree_overlap_clusters") {
+        settings.mutable_kmeans_tree_settings()->set_overlap_clusters(ParseUInt32(name, value, MinClusters, MaxClusters, error));
+    } else if (nameLower == "kmeans_tree_overlap_ratio") {
+        settings.mutable_kmeans_tree_settings()->set_overlap_ratio(ParseDouble(name, value, error));
+    } else if (nameLower == "subspaces") {
+        settings.set_subspaces(ParseUInt32(name, value, MinSubspaces, MaxSubspaces, error));
+    } else if (nameLower == "subspace_bits") {
+        settings.set_subspace_bits(ParseUInt32(name, value, MinSubspaceBits, MaxSubspaceBits, error));
+    } else{
+        error = TStringBuilder() << "Unknown index setting: " << name;
+        return false;
+    }
+    
+    return !error;
+}
+
+bool ValidateSettings(const Ydb::Table::IvfPqSettings& settings, TString& error) {
+    error = "";
+
+    if (auto unknownCount = settings.GetReflection()->GetUnknownFields(settings).field_count(); unknownCount > 0) {
+        error = TStringBuilder() << "ivf_pq index settings contain " << unknownCount << " unsupported parameter(s)";
+        return false;
+    }
+
+    if (!settings.has_settings()) {
+        error = "vector index settings should be set";
+        return false;
+    }
+    if (!NKMeans::ValidateSettings(settings.settings(), error)) {
+        return false;
+    }
+
+    if (settings.settings().vector_type() != Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT) {
+        error = "ivf_pq index supports only vector_type=float";
+        return false;
+    }
+
+    if (!ValidateSettingInRange("subspaces",
+        settings.has_subspaces() ? std::optional<ui64>(settings.subspaces()) : std::nullopt,
+        MinSubspaces, MaxSubspaces, error))
+    {
+        return false;
+    }
+
+    if (!ValidateSettingInRange("subspace_bits",
+        settings.has_subspace_bits() ? std::optional<ui64>(settings.subspace_bits()) : std::nullopt,
+        MinSubspaceBits, MaxSubspaceBits, error))
+    {
+        return false;
+    }
+
+    if (settings.settings().vector_dimension() % settings.subspaces() != 0) {
+        error = TStringBuilder() << "vector_dimension (" << settings.settings().vector_dimension()
+            << ") must be a multiple of subspaces (" << settings.subspaces() << ")";
+        return false;
+    }
+
+    const ui64 codebookEntries = ui64(settings.subspaces()) << settings.subspace_bits();
+    if (codebookEntries > MaxCodebookEntries) {
+        error = TStringBuilder() << "subspaces * 2^subspace_bits (" << settings.subspaces()
+            << " * 2^" << settings.subspace_bits() << " = " << codebookEntries
+            << ") should be less than or equal to " << MaxCodebookEntries;
+        return false;
+    }
+
+    if (settings.ivf_type_case() != Ydb::Table::IvfPqSettings::kKmeansTreeSettings) {
+        error = "ivf_pq requires kmeans_tree_settings to be set";
+        return false;
+    }
+    const auto& kmeans = settings.kmeans_tree_settings();
+    if (!ValidateSettingInRange("kmeans_tree_levels",
+        kmeans.has_levels() ? std::optional<ui64>(kmeans.levels()) : std::nullopt,
+        MinLevels, MaxLevels, error))
+    {
+        return false;
+    }
+    if (!ValidateSettingInRange("kmeans_tree_clusters",
+        kmeans.has_clusters() ? std::optional<ui64>(kmeans.clusters()) : std::nullopt,
+        MinClusters, MaxClusters, error))
+    {
+        return false;
+    }
+    if (kmeans.has_overlap_clusters() && kmeans.overlap_clusters() > kmeans.clusters()) {
+        error = "kmeans_tree_overlap_clusters should be less than or equal to kmeans_tree_clusters";
+        return false;
+    }
+    if (kmeans.has_overlap_ratio() && kmeans.overlap_ratio() < 0) {
+        error = "kmeans_tree_overlap_ratio should be >= 0";
+        return false;
+    }
+
+    ui64 clustersPowLevels = 1;
+    for (ui64 i = 0; i < kmeans.levels(); ++i) {
+        clustersPowLevels *= kmeans.clusters();
+        if (clustersPowLevels > MaxClustersPowLevels) {
+            error = TStringBuilder() << "Invalid kmeans_tree_clusters^kmeans_tree_levels: "
+                << kmeans.clusters() << "^" << kmeans.levels()
+                << " should be less than " << MaxClustersPowLevels;
+            return false;
+        }
+    }
+    if (ui64(settings.settings().vector_dimension()) * kmeans.clusters() > MaxVectorDimensionMultiplyClusters) {
+        error = TStringBuilder() << "Invalid vector_dimension*kmeans_tree_clusters: "
+            << settings.settings().vector_dimension() << "*" << kmeans.clusters()
+            << " should be less than " << MaxVectorDimensionMultiplyClusters;
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/ydb/core/base/ivf_pq.h
+++ b/ydb/core/base/ivf_pq.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ydb/public/api/protos/ydb_table.pb.h>
+
+#include <util/generic/string.h>
+
+namespace NKikimr::NIvfPq {
+
+bool FillSetting(Ydb::Table::IvfPqSettings& settings, const TString& name, const TString& value, TString& error);
+
+bool ValidateSettings(const Ydb::Table::IvfPqSettings& settings, TString& error);
+
+} // NKikimr::NIvfPq

--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -47,6 +47,10 @@ const TString ImplTables[] = {
     NKMeans::PrefixTable,
     TString{NKMeans::PostingTable} + NKMeans::BuildSuffix0,
     TString{NKMeans::PostingTable} + NKMeans::BuildSuffix1,
+    NIvfPq::CodebookTable,
+    NIvfPq::LevelTable,
+    NIvfPq::PostingTable,
+    NIvfPq::PrefixTable,
     NFulltext::DocsTable,
     NFulltext::DictTable,
     NFulltext::StatsTable,
@@ -66,6 +70,16 @@ constexpr std::string_view PrefixedGlobalKMeansTreeImplTables[] = {
     NKMeans::LevelTable, NKMeans::PostingTable, NKMeans::PrefixTable,
 };
 static_assert(std::is_sorted(std::begin(PrefixedGlobalKMeansTreeImplTables), std::end(PrefixedGlobalKMeansTreeImplTables)));
+
+constexpr std::string_view GlobalIvfPqImplTables[] = {
+    NIvfPq::CodebookTable, NIvfPq::LevelTable, NIvfPq::PostingTable
+};
+static_assert(std::is_sorted(std::begin(GlobalIvfPqImplTables), std::end(GlobalIvfPqImplTables)));
+
+constexpr std::string_view PrefixedGlobalIvfPqImplTables[] = {
+    NIvfPq::CodebookTable, NIvfPq::LevelTable, NIvfPq::PostingTable, NIvfPq::PrefixTable
+};
+static_assert(std::is_sorted(std::begin(PrefixedGlobalIvfPqImplTables), std::end(PrefixedGlobalIvfPqImplTables)));
 
 constexpr std::string_view GlobalFulltextPlainImplTables[] = {
     ImplTable,
@@ -87,6 +101,7 @@ bool IsSecondaryIndex(NKikimrSchemeOp::EIndexType indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             return true;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
@@ -106,6 +121,7 @@ TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType indexType, co
     auto takeKeyColumns = index.KeyColumns.size();
     if (!isSecondaryIndex) { // vector and fulltext indexes have special embedding and text key columns
         Y_ASSERT(indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson);
@@ -153,6 +169,8 @@ std::optional<NKikimrSchemeOp::EIndexType> TryConvertIndexType(Ydb::Table::Table
             return NKikimrSchemeOp::EIndexTypeGlobalUnique;
         case Ydb::Table::TableIndex::TypeCase::kGlobalVectorKmeansTreeIndex:
             return NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree;
+        case Ydb::Table::TableIndex::TypeCase::kGlobalVectorIvfPqIndex:
+            return NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq;
         case Ydb::Table::TableIndex::TypeCase::kGlobalFulltextPlainIndex:
             return NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain;
         case Ydb::Table::TableIndex::TypeCase::kGlobalFulltextRelevanceIndex:
@@ -176,6 +194,7 @@ bool IsLocalTableIndex(Ydb::Table::TableIndex::TypeCase type) {
         case Ydb::Table::TableIndex::kGlobalAsyncIndex:
         case Ydb::Table::TableIndex::kGlobalUniqueIndex:
         case Ydb::Table::TableIndex::kGlobalVectorKmeansTreeIndex:
+        case Ydb::Table::TableIndex::kGlobalVectorIvfPqIndex:
         case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex:
         case Ydb::Table::TableIndex::kGlobalFulltextRelevanceIndex:
         case Ydb::Table::TableIndex::kGlobalJsonIndex:
@@ -262,6 +281,7 @@ bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType indexType, const TTableColumn
     } else {
         // Vector and fulltext indexes allow to add all columns both to index & data
         Y_ASSERT(indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson);
@@ -281,6 +301,7 @@ bool DoesIndexSupportTTL(NKikimrSchemeOp::EIndexType indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             return true;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
@@ -305,6 +326,13 @@ std::span<const std::string_view> GetImplTables(
                 return GlobalKMeansTreeImplTables;
             } else {
                 return PrefixedGlobalKMeansTreeImplTables;
+            }
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+            if (indexKeys.size() == 1) {
+                return GlobalIvfPqImplTables;
+            } else {
+                Y_ENSURE(false, "Not implemented");
+                return PrefixedGlobalIvfPqImplTables;
             }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             return GlobalFulltextPlainImplTables;

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -105,6 +105,44 @@ TClusterId SetPostingParentFlag(TClusterId parent);
 
 }
 
+namespace NIvfPq {
+
+using TClusterId = NKMeans::TClusterId;
+inline constexpr auto ClusterIdType = NKMeans::ClusterIdType;
+inline constexpr const char* ClusterIdTypeName = NKMeans::ClusterIdTypeName;
+
+using TSubspaceIdx = ui16;
+inline constexpr auto SubspaceIdxType = Ydb::Type::UINT16;
+inline constexpr const char* SubspaceIdxTypeName = "Uint16";
+
+using TCell = ui16;
+inline constexpr auto CellType = Ydb::Type::UINT16;
+inline constexpr const char* CellTypeName = "Uint16";
+
+using TCode = TString;
+inline constexpr auto CodeType = Ydb::Type::STRING;
+inline constexpr const char* CodeTypeName = "String";
+
+inline constexpr const char* CodebookTable = "indexImplCodebookTable";
+inline constexpr const char* LevelTable = NKMeans::LevelTable;
+inline constexpr const char* PostingTable = "indexImplPostingTable";
+inline constexpr const char* PrefixTable = NKMeans::PrefixTable;
+
+// Impl table positions in partitioning setting list
+inline constexpr const int CodebookTablePosition = 0;
+inline constexpr const int LevelTablePosition = 1;
+inline constexpr const int PostingTablePosition = 2;
+inline constexpr const int PrefixTablePosition = 3;
+
+inline constexpr const char* ParentColumn = NKMeans::ParentColumn;
+inline constexpr const char* IdColumn = NKMeans::IdColumn;
+inline constexpr const char* SubspaceColumn = "__ydb_subspace";
+inline constexpr const char* CellColumn = "__ydb_cell";
+inline constexpr const char* CodeColumn = "__ydb_code";
+inline constexpr const char* CentroidColumn = NKMeans::CentroidColumn;
+
+}
+
 namespace NFulltext {
     // Type for token frequency within a document - uint32 is OK
     using TTokenCount = ui32;

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -37,6 +37,7 @@ SRCS(
     group_stat.h
     hive.h
     interconnect_channels.h
+    ivf_pq.cpp
     kmeans_clusters.cpp
     local_user_token.cpp
     local_user_token.h

--- a/ydb/core/kqp/common/kqp_batch_operations.cpp
+++ b/ydb/core/kqp/common/kqp_batch_operations.cpp
@@ -10,6 +10,7 @@ bool IsIndexSupported(NYql::TIndexDescription::EType type, bool enabledIndexStre
         case NYql::TIndexDescription::EType::GlobalSyncUnique:
             return enabledIndexStreamWrite;
         case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+        case NYql::TIndexDescription::EType::GlobalSyncVectorIvfPq:
         case NYql::TIndexDescription::EType::GlobalFulltextPlain:
         case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
         case NYql::TIndexDescription::EType::GlobalJson:

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1098,6 +1098,9 @@ public:
                             case TIndexDescription::EType::GlobalSyncVectorKMeansTree:
                                 *indexDesc->MutableVectorIndexKmeansTreeDescription()->MutableSettings() = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(index.SpecializedIndexDescription).GetSettings();
                                 break;
+                            case TIndexDescription::EType::GlobalSyncVectorIvfPq:
+                                *indexDesc->MutableVectorIndexIvfPqDescription()->MutableSettings() = std::get<NKikimrKqp::TVectorIndexIvfPqDescription>(index.SpecializedIndexDescription).GetSettings();
+                                break;
                             case TIndexDescription::EType::GlobalFulltextPlain:
                             case TIndexDescription::EType::GlobalFulltextRelevance:
                                 *indexDesc->MutableFulltextIndexDescription()->MutableSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(index.SpecializedIndexDescription).GetSettings();

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -152,6 +152,8 @@ TString IndexTypeToName(NYql::TIndexDescription::EType type) {
             return "global sync unique secondary";
         case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
             return "global sync vector_kmeans_tree";
+        case NYql::TIndexDescription::EType::GlobalSyncVectorIvfPq:
+            return "global sync vector_ivf_pq";
         case NYql::TIndexDescription::EType::GlobalFulltextPlain:
             return "global sync fulltext_plain";
         case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
@@ -842,6 +844,7 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
                 return false;
             case TIndexDescription::EType::GlobalSyncUnique:
             case TIndexDescription::EType::GlobalSyncVectorKMeansTree:
+            case TIndexDescription::EType::GlobalSyncVectorIvfPq:
             case TIndexDescription::EType::GlobalFulltextPlain:
             case TIndexDescription::EType::GlobalFulltextRelevance:
             case TIndexDescription::EType::GlobalJson:

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1,6 +1,7 @@
 #include "yql_kikimr_provider_impl.h"
 
 #include <ydb/core/base/fulltext.h>
+#include <ydb/core/base/ivf_pq.h>
 #include <ydb/core/base/kmeans_clusters.h>
 #include <ydb/core/docapi/traits.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
@@ -2353,6 +2354,8 @@ public:
                                 add_index->mutable_global_async_index();
                             } else if (type == "globalVectorKmeansTree") {
                                 add_index->mutable_global_vector_kmeans_tree_index();
+                            } else if (type == "globalVectorIvfPq") {
+                                add_index->mutable_global_vector_ivf_pq_index();
                             } else if (type == "globalFulltextPlain") {
                                 if (!SessionCtx->Config().FeatureFlags.GetEnableFulltextIndex()) {
                                     ctx.AddError(TIssue(ctx.GetPosition(columnTuple.Item(1).Cast<TCoAtom>().Pos()),
@@ -2473,6 +2476,12 @@ public:
                                                 name, value.StringValue(), error);
                                             break;
                                         }
+                                        case Ydb::Table::TableIndex::kGlobalVectorIvfPqIndex: {
+                                            NKikimr::NIvfPq::FillSetting(
+                                                *add_index->mutable_global_vector_ivf_pq_index()->mutable_vector_settings(),
+                                                name, value.StringValue(), error);
+                                            break;
+                                        }
                                         case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex: {
                                             NKikimr::NFulltext::FillSetting(
                                                 *add_index->mutable_global_fulltext_plain_index()->mutable_fulltext_settings(),
@@ -2550,6 +2559,14 @@ public:
                         case Ydb::Table::TableIndex::kGlobalVectorKmeansTreeIndex: {
                             TString error;
                             if (!NKikimr::NKMeans::ValidateSettingsPartial(add_index->global_vector_kmeans_tree_index().vector_settings(), error)) {
+                                ctx.AddError(TIssue(ctx.GetPosition(action.Pos()), error));
+                                return SyncError();
+                            }
+                            break;
+                        }
+                        case Ydb::Table::TableIndex::kGlobalVectorIvfPqIndex: {
+                            TString error;
+                            if (!NKikimr::NIvfPq::ValidateSettings(add_index->global_vector_ivf_pq_index().vector_settings(), error)) {
                                 ctx.AddError(TIssue(ctx.GetPosition(action.Pos()), error));
                                 return SyncError();
                             }

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -90,6 +90,7 @@ struct TIndexDescription {
         LocalBloomNgramFilter = 7,
         GlobalJson = 8,
         LocalMinMax = 9,
+        GlobalSyncVectorIvfPq = 10,
     };
 
     // Index states here must be in sync with NKikimrSchemeOp::EIndexState protobuf
@@ -114,7 +115,8 @@ struct TIndexDescription {
         NKikimrKqp::TVectorIndexKmeansTreeDescription,
         NKikimrSchemeOp::TFulltextIndexDescription,
         TLocalBloomFilterDescription,
-        TLocalBloomNgramFilterDescription>;
+        TLocalBloomNgramFilterDescription,
+        NKikimrKqp::TVectorIndexIvfPqDescription>;
     TSpecializedIndexDescription SpecializedIndexDescription;
 
     TIndexDescription(const TString& name, const TVector<TString>& keyColumns, const TVector<TString>& dataColumns,
@@ -156,6 +158,12 @@ struct TIndexDescription {
                 SpecializedIndexDescription = std::move(vectorIndexDescription);
                 break;
             }
+            case EType::GlobalSyncVectorIvfPq: {
+                NKikimrKqp::TVectorIndexIvfPqDescription vectorIndexDescription;
+                *vectorIndexDescription.MutableSettings() = index.GetVectorIndexIvfPqDescription().GetSettings();
+                SpecializedIndexDescription = std::move(vectorIndexDescription);
+                break;
+            }
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance: {
                 NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
@@ -194,6 +202,9 @@ struct TIndexDescription {
             case EType::GlobalSyncVectorKMeansTree:
                 SpecializedIndexDescription = message->GetVectorIndexKmeansTreeDescription();
                 break;
+            case EType::GlobalSyncVectorIvfPq:
+                SpecializedIndexDescription = message->GetVectorIndexIvfPqDescription();
+                break;
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
                 SpecializedIndexDescription = message->GetFulltextIndexDescription();
@@ -219,6 +230,8 @@ struct TIndexDescription {
                 return TIndexDescription::EType::GlobalSyncUnique;
             case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree:
                 return TIndexDescription::EType::GlobalSyncVectorKMeansTree;
+            case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorIvfPq:
+                return TIndexDescription::EType::GlobalSyncVectorIvfPq;
             case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextPlain:
                 return TIndexDescription::EType::GlobalFulltextPlain;
             case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance:
@@ -240,6 +253,8 @@ struct TIndexDescription {
                 return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique;
             case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
                 return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree;
+            case NYql::TIndexDescription::EType::GlobalSyncVectorIvfPq:
+                return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorIvfPq;
             case NYql::TIndexDescription::EType::GlobalFulltextPlain:
                 return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextPlain;
             case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
@@ -287,6 +302,9 @@ struct TIndexDescription {
             case EType::GlobalSyncVectorKMeansTree:
                 *message->MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(SpecializedIndexDescription);
                 break;
+            case EType::GlobalSyncVectorIvfPq:
+                *message->MutableVectorIndexIvfPqDescription() = std::get<NKikimrKqp::TVectorIndexIvfPqDescription>(SpecializedIndexDescription);
+                break;
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
                 *message->MutableFulltextIndexDescription() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(SpecializedIndexDescription);
@@ -316,6 +334,7 @@ struct TIndexDescription {
             case EType::GlobalAsync:
                 return false;
             case EType::GlobalSyncVectorKMeansTree:
+            case EType::GlobalSyncVectorIvfPq:
                 if (State != EIndexState::Ready) {
                     // Do not try to update vector indexes until their build is finished
                     return false;
@@ -338,6 +357,7 @@ struct TIndexDescription {
             case EType::GlobalSyncUnique:
             case EType::GlobalAsync:
             case EType::GlobalSyncVectorKMeansTree:
+            case EType::GlobalSyncVectorIvfPq:
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
             case EType::GlobalJson:

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -209,6 +209,10 @@ struct TKiExploreTxResults {
                 YQL_ENSURE(indexTables.size() >= 2, "K-means tree index should have at least 2 tables");
                 dataTable = indexTable = indexTables[1];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::NKMeans::PostingTable));
+            } else if (index.Type == TIndexDescription::EType::GlobalSyncVectorIvfPq) {
+                YQL_ENSURE(indexTables.size() >= 3, "IVF-PQ index should have at least 3 tables");
+                dataTable = indexTable = indexTables[2];
+                YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::NIvfPq::PostingTable));
             } else if (index.Type == TIndexDescription::EType::GlobalFulltextPlain) {
                 YQL_ENSURE(indexTables.size() == 1, "Global fulltext plain index should have 1 table");
                 dataTable = indexTable = indexTables[0];

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -3,6 +3,7 @@
 #include "yql_kikimr_type_ann_pg.h"
 
 #include <ydb/core/base/fulltext.h>
+#include <ydb/core/base/ivf_pq.h>
 #include <ydb/core/base/kmeans_clusters.h>
 #include <ydb/core/docapi/traits.h>
 #include <ydb/core/tx/columnshard/engines/storage/indexes/min_max/misc/misc.h>
@@ -1229,6 +1230,8 @@ private:
                 indexType = TIndexDescription::EType::GlobalSyncUnique;
             } else if (type == "globalVectorKmeansTree") {
                 indexType = TIndexDescription::EType::GlobalSyncVectorKMeansTree;
+            } else if (type == "globalVectorIvfPq") {
+                indexType = TIndexDescription::EType::GlobalSyncVectorIvfPq;
             } else if (type == "globalFulltextPlain") {
                 if (!SessionCtx->Config().FeatureFlags.GetEnableFulltextIndex()) {
                     ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), "Fulltext index support is disabled"));
@@ -1314,6 +1317,7 @@ private:
             }
 
             NKikimrKqp::TVectorIndexKmeansTreeDescription vectorIndexKmeansTreeDescription;
+            NKikimrKqp::TVectorIndexIvfPqDescription vectorIndexIvfPqDescription;
             NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
             TIndexDescription::TLocalBloomFilterDescription localBloomFilterDescription;
             TIndexDescription::TLocalBloomNgramFilterDescription localBloomNgramFilterDescription;
@@ -1333,6 +1337,11 @@ private:
                             nameLower, value.StringValue(), error);
                         break;
                     }
+                    case TIndexDescription::EType::GlobalSyncVectorIvfPq:
+                        NKikimr::NIvfPq::FillSetting(
+                            *vectorIndexIvfPqDescription.MutableSettings(),
+                            nameLower, value.StringValue(), error);
+                        break;
                     case TIndexDescription::EType::GlobalFulltextPlain:
                     case TIndexDescription::EType::GlobalFulltextRelevance: {
                         NKikimr::NFulltext::FillSetting(
@@ -1382,6 +1391,15 @@ private:
                         return IGraphTransformer::TStatus::Error;
                     }
                     specializedIndexDescription = std::move(vectorIndexKmeansTreeDescription);
+                    break;
+                }
+                case TIndexDescription::EType::GlobalSyncVectorIvfPq: {
+                    TString error;
+                    if (!NKikimr::NIvfPq::ValidateSettings(vectorIndexIvfPqDescription.GetSettings(), error)) {
+                        ctx.AddError(TIssue(ctx.GetPosition(index.IndexSettings().Pos()), error));
+                        return IGraphTransformer::TStatus::Error;
+                    }
+                    specializedIndexDescription = std::move(vectorIndexIvfPqDescription);
                     break;
                 }
                 case TIndexDescription::EType::GlobalFulltextPlain: {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -306,4 +306,5 @@ message TFeatureFlags {
     optional bool EnableJsonIndexAutoSelect = 267 [default = false];
     optional bool ForbidRequestsToStaticNodesWithoutDatabase = 268 [default = true];
     optional bool EnableTabletDevUiSecurePath = 269 [default = false];
+    optional bool EnableIvfPqIndex = 270 [default = false];
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1323,6 +1323,7 @@ enum EIndexType {
     EIndexTypeGlobalFulltextPlain = 5;
     EIndexTypeGlobalFulltextRelevance = 6;
     EIndexTypeGlobalJson = 7;
+    EIndexTypeGlobalVectorIvfPq = 8;
 }
 
 enum EIndexState {
@@ -1334,6 +1335,10 @@ enum EIndexState {
 
 message TVectorIndexKmeansTreeDescription {
     optional Ydb.Table.KMeansTreeSettings Settings = 1;
+}
+
+message TVectorIndexIvfPqDescription {
+    optional Ydb.Table.IvfPqSettings Settings = 1;
 }
 
 message TFulltextIndexDescription {
@@ -1362,6 +1367,7 @@ message TIndexDescription {
     oneof SpecializedIndexDescription {
         TVectorIndexKmeansTreeDescription VectorIndexKmeansTreeDescription = 11;
         TFulltextIndexDescription FulltextIndexDescription = 12;
+        TVectorIndexIvfPqDescription VectorIndexIvfPqDescription = 13;
     }
 }
 
@@ -1375,6 +1381,7 @@ message TIndexCreationConfig {
     oneof SpecializedIndexDescription {
         TVectorIndexKmeansTreeDescription VectorIndexKmeansTreeDescription = 7;
         TFulltextIndexDescription FulltextIndexDescription = 8;
+        TVectorIndexIvfPqDescription VectorIndexIvfPqDescription = 9;
     }
 }
 
@@ -2165,6 +2172,7 @@ enum EPathSubType {
     EPathSubTypeVectorKmeansTreeIndexImplTable = 4;
     EPathSubTypeFulltextIndexImplTable = 5;
     EPathSubTypeJsonIndexImplTable = 6;
+    EPathSubTypeVectorIvfPqIndexImplTable = 7;
 }
 
 enum EPathState {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -180,6 +180,10 @@ message TVectorIndexKmeansTreeDescription {
     optional Ydb.Table.KMeansTreeSettings Settings = 1;
 }
 
+message TVectorIndexIvfPqDescription {
+    optional Ydb.Table.IvfPqSettings Settings = 1;
+}
+
 
 message TIndexDescriptionProto {
     optional string Name = 1;
@@ -193,6 +197,7 @@ message TIndexDescriptionProto {
     oneof SpecializedIndexDescription {
         TVectorIndexKmeansTreeDescription VectorIndexKmeansTreeDescription = 9;
         NKikimrSchemeOp.TFulltextIndexDescription FulltextIndexDescription = 10;
+        TVectorIndexIvfPqDescription VectorIndexIvfPqDescription = 11;
     }
 };
 

--- a/ydb/core/sys_view/show_create/create_table_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_table_formatter.cpp
@@ -519,6 +519,7 @@ void TCreateTableFormatter::Format(const TableIndex& index) {
     Stream << "\tINDEX ";
     EscapeName(index.name(), Stream);
     std::optional<KMeansTreeSettings> kMeansTreeSettings;
+    std::optional<IvfPqSettings> ivfPqSettings;
     std::optional<FulltextIndexSettings> fulltextIndexSettings;
     bool isLocalBloomFilter = false;
     bool isLocalBloomNgramFilter = false;
@@ -538,6 +539,11 @@ void TCreateTableFormatter::Format(const TableIndex& index) {
         case TableIndex::kGlobalVectorKmeansTreeIndex: {
             Stream << " GLOBAL USING vector_kmeans_tree ON ";
             kMeansTreeSettings = index.global_vector_kmeans_tree_index().vector_settings();
+            break;
+        }
+        case TableIndex::kGlobalVectorIvfPqIndex: {
+            Stream << " GLOBAL USING vector_ivf_pq ON ";
+            ivfPqSettings = index.global_vector_ivf_pq_index().vector_settings();
             break;
         }
         case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex: {
@@ -662,6 +668,103 @@ void TCreateTableFormatter::Format(const TableIndex& index) {
 
         if (kMeansTreeSettings->overlap_ratio() != 0) {
             Stream << del << "overlap_ratio=\"" << kMeansTreeSettings->overlap_ratio() << "\"";
+            del = ", ";
+        }
+
+        Stream << ")";
+    }
+
+    if (ivfPqSettings) {
+        Stream << " WITH (";
+
+        switch (ivfPqSettings->settings().metric()) {
+            case Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT:
+                Stream << "similarity=product";
+                break;
+            case Ydb::Table::VectorIndexSettings::SIMILARITY_COSINE:
+                Stream << "similarity=cosine";
+                break;
+            case Ydb::Table::VectorIndexSettings::DISTANCE_COSINE:
+                Stream << "distance=cosine";
+                break;
+            case Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN:
+                Stream << "distance=manhattan";
+                break;
+            case Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN:
+                Stream << "distance=euclidean";
+                break;
+            default:
+                ythrow TFormatFail(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected Ydb::Table::VectorIndexSettings");
+        }
+
+        TString del = "";
+        if (ivfPqSettings->settings().metric() != Ydb::Table::VectorIndexSettings::METRIC_UNSPECIFIED) {
+            del = ", ";
+        }
+
+        switch (ivfPqSettings->settings().vector_type()) {
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_BIT:
+                Stream << del << "vector_type=\"bit\"";
+                break;
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_INT8:
+                Stream << del << "vector_type=\"int8\"";
+                break;
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8:
+                Stream << del << "vector_type=\"uint8\"";
+                break;
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT:
+                Stream << del << "vector_type=\"float\"";
+                break;
+            default:
+                ythrow TFormatFail(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected Ydb::Table::VectorIndexSettings");
+        }
+
+        if (ivfPqSettings->settings().vector_type() != Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED) {
+            del = ", ";
+        }
+
+        if (ivfPqSettings->settings().vector_dimension() != 0) {
+            Stream << del << "vector_dimension=" << ivfPqSettings->settings().vector_dimension();
+            del = ", ";
+        }
+
+        switch (ivfPqSettings->ivf_type_case()) {
+            case Ydb::Table::IvfPqSettings::IvfTypeCase::kKmeansTreeSettings: {
+                const auto& kMeansTreeSettings = ivfPqSettings->kmeans_tree_settings();
+
+                if (kMeansTreeSettings.clusters() != 0) {
+                    Stream << del << "kmeans_tree_clusters=" << kMeansTreeSettings.clusters();
+                    del = ", ";
+                }
+
+                if (kMeansTreeSettings.levels() != 0) {
+                    Stream << del << "kmeans_tree_levels=" << kMeansTreeSettings.levels();
+                    del = ", ";
+                }
+
+                if (kMeansTreeSettings.overlap_clusters() != 0) {
+                    Stream << del << "kmeans_tree_overlap_clusters=" << kMeansTreeSettings.overlap_clusters();
+                    del = ", ";
+                }
+
+                if (kMeansTreeSettings.overlap_ratio() != 0) {
+                    Stream << del << "kmeans_tree_overlap_ratio=\"" << kMeansTreeSettings.overlap_ratio() << "\"";
+                    del = ", ";
+                }
+
+                break;
+            }
+            case Ydb::Table::IvfPqSettings::IvfTypeCase::IVF_TYPE_NOT_SET:
+                Y_ENSURE(false);
+        }
+
+        if (ivfPqSettings->subspaces() != 0) {
+            Stream << del << "subspaces=" << ivfPqSettings->subspaces();
+            del = ", ";
+        }
+
+        if (ivfPqSettings->subspace_bits() != 0) {
+            Stream << del << "subspace_bits=" << ivfPqSettings->subspace_bits();
             del = ", ";
         }
 

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -917,6 +917,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
             case NKikimrSchemeOp::EPathSubTypeAsyncIndexImplTable:
                 return NSchemeCache::ETableKind::KindAsyncIndexTable;
             case NKikimrSchemeOp::EPathSubTypeVectorKmeansTreeIndexImplTable:
+            case NKikimrSchemeOp::EPathSubTypeVectorIvfPqIndexImplTable:
                 return NSchemeCache::ETableKind::KindVectorIndexTable;
             case NKikimrSchemeOp::EPathSubTypeFulltextIndexImplTable:
                 return NSchemeCache::ETableKind::KindFulltextIndexTable;
@@ -934,6 +935,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 case NKikimrSchemeOp::EPathSubTypeSyncIndexImplTable:
                 case NKikimrSchemeOp::EPathSubTypeAsyncIndexImplTable:
                 case NKikimrSchemeOp::EPathSubTypeVectorKmeansTreeIndexImplTable:
+                case NKikimrSchemeOp::EPathSubTypeVectorIvfPqIndexImplTable:
                 case NKikimrSchemeOp::EPathSubTypeFulltextIndexImplTable:
                 case NKikimrSchemeOp::EPathSubTypeJsonIndexImplTable:
                     return !AppData()->FeatureFlags.GetEnableAccessToIndexImplTables();

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -121,6 +121,10 @@ void TSchemeShard::PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuil
                 *serializableRepresentation.MutableVectorIndexKmeansTreeDescription() =
                     std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(info.SpecializedIndexDescription);
                 break;
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+                *serializableRepresentation.MutableVectorIndexIvfPqDescription() =
+                    std::get<NKikimrSchemeOp::TVectorIndexIvfPqDescription>(info.SpecializedIndexDescription);
+                break;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
                 *serializableRepresentation.MutableFulltextIndexDescription() =

--- a/ydb/core/tx/schemeshard/index/build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__create.cpp
@@ -321,6 +321,16 @@ private:
             }
             break;
         }
+        case Ydb::Table::TableIndex::TypeCase::kGlobalVectorIvfPqIndex: {
+            if (!Self->EnableIvfPqIndex) {
+                explain = "IVF-PQ index support is disabled";
+                return false;
+            }
+
+            // TODO(raydzast)
+            Y_ENSURE(false, "Not implemented");
+            break;
+        }
         case Ydb::Table::TableIndex::TypeCase::kGlobalFulltextPlainIndex: {
             if (!Self->EnableFulltextIndex) {
                 explain = "Fulltext index support is disabled";

--- a/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
@@ -303,6 +303,9 @@ void TSchemeShard::TIndexBuilder::TTxBase::Fill(NKikimrIndexBuilder::TIndexBuild
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree:
             *index.mutable_global_vector_kmeans_tree_index() = Ydb::Table::GlobalVectorKMeansTreeIndex();
             break;
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorIvfPq:
+            *index.mutable_global_vector_ivf_pq_index() = Ydb::Table::GlobalVectorIvfPqIndex();
+            break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextPlain:
             *index.mutable_global_fulltext_plain_index() = Ydb::Table::GlobalFulltextPlainIndex();
             break;

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -45,6 +45,9 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             *index.MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(SpecializedIndexDescription);
             break;
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+            *index.MutableVectorIndexIvfPqDescription() = std::get<NKikimrSchemeOp::TVectorIndexIvfPqDescription>(SpecializedIndexDescription);
+            break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
             *index.MutableFulltextIndexDescription() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(SpecializedIndexDescription);

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -163,7 +163,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
     std::variant<std::monostate,
         NKikimrSchemeOp::TVectorIndexKmeansTreeDescription,
-        NKikimrSchemeOp::TFulltextIndexDescription> SpecializedIndexDescription;
+        NKikimrSchemeOp::TFulltextIndexDescription,
+        NKikimrSchemeOp::TVectorIndexIvfPqDescription> SpecializedIndexDescription;
 
     struct TKMeans {
         // TODO(mbkkt) move to TVectorIndexKmeansTreeDescription
@@ -612,6 +613,11 @@ public:
                         : NTableIndex::NKMeans::DefaultOverlapRatio;
                     indexInfo->Clusters = NKikimr::NKMeans::CreateClusters(desc.settings().settings(), indexInfo->KMeans.Rounds, createError);
                     indexInfo->SpecializedIndexDescription = std::move(desc);
+                    break;
+                }
+                case NKikimrSchemeOp::TIndexCreationConfig::kVectorIndexIvfPqDescription: {
+                    // TODO(raydzast)
+                    Y_ENSURE(false, "Not implemented");
                     break;
                 }
                 case NKikimrSchemeOp::TIndexCreationConfig::kFulltextIndexDescription: {

--- a/ydb/core/tx/schemeshard/index/index_utils.cpp
+++ b/ydb/core/tx/schemeshard/index/index_utils.cpp
@@ -24,6 +24,12 @@ TIndexObjectCounts GetIndexObjectCounts(const NKikimrSchemeOp::TIndexCreationCon
             res.SequenceCount = (prefixVectorIndex ? 1 : 0);
             break;
         }
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+            const bool prefixVectorIndex = indexDesc.GetKeyColumnNames().size() > 1;
+            res.IndexTableCount = (prefixVectorIndex ? 4 : 3);
+            res.SequenceCount = (prefixVectorIndex ? 1 : 0);
+            break;
+        }
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain: {
             res.IndexTableCount = 1;
@@ -419,6 +425,51 @@ auto CalcVectorKmeansTreeBuildOverlapTableDescImpl(
     return implTableDesc;
 }
 
+auto CalcVectorIvfPqPostingImplTableDescImpl(
+    const auto& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const THashSet<TString>& indexDataColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    auto tableColumns = ExtractInfo(baseTable);
+    THashSet<TString> indexColumns = indexDataColumns;
+    for (const auto& keyColumn: tableColumns.Keys) {
+        indexColumns.insert(keyColumn);
+    }
+
+    NKikimrSchemeOp::TTableDescription implTableDesc;
+    implTableDesc.SetName(NIvfPq::PostingTable);
+    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
+    {
+        auto parentColumn = implTableDesc.AddColumns();
+        parentColumn->SetName(NIvfPq::ParentColumn);
+        parentColumn->SetType(NIvfPq::ClusterIdTypeName);
+        parentColumn->SetTypeId(NIvfPq::ClusterIdType);
+        parentColumn->SetNotNull(true);
+    }
+    {
+        auto codeColumn = implTableDesc.AddColumns();
+        codeColumn->SetName(NIvfPq::CodeColumn);
+        codeColumn->SetType(NIvfPq::CodeTypeName);
+        codeColumn->SetTypeId(NIvfPq::CodeType);
+        codeColumn->SetNotNull(false);
+    }
+    // TODO(raydzast): add support for foreign
+    // if (withForeign) {
+    //     auto col = implTableDesc.AddColumns();
+    //     col->SetName(NKMeans::IsForeignColumn);
+    //     col->SetType(NTableIndex::NKMeans::IsForeignTypeName);
+    //     col->SetTypeId(NTableIndex::NKMeans::IsForeignType);
+    //     col->SetNotNull(true);
+    // }
+    implTableDesc.AddKeyColumnNames(NIvfPq::ParentColumn);
+    FillIndexImplTableColumns(GetColumns(baseTable), tableColumns.Keys, indexColumns, implTableDesc);
+
+    implTableDesc.SetSystemColumnNamesAllowed(true);
+
+    return implTableDesc;
+}
+
 auto CalcFulltextImplTableDescImpl(
     const auto& baseTable,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
@@ -695,6 +746,89 @@ NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeBuildOverlapTableDesc(
     std::string_view suffix)
 {
     return CalcVectorKmeansTreeBuildOverlapTableDescImpl(baseTableInfo, baseTablePartitionConfig, indexDataColumns, indexTableDesc, suffix);
+}
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqCodebookImplTableDesc(
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    NKikimrSchemeOp::TTableDescription implTableDesc;
+
+    implTableDesc.SetName(NIvfPq::CodebookTable);
+
+    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
+
+    {
+        auto parentColumn = implTableDesc.AddColumns();
+        parentColumn->SetName(NIvfPq::ParentColumn);
+        parentColumn->SetType(NIvfPq::ClusterIdTypeName);
+        parentColumn->SetTypeId(NIvfPq::ClusterIdType);
+        parentColumn->SetNotNull(true);
+    }
+    {
+        auto subspaceColumn = implTableDesc.AddColumns();
+        subspaceColumn->SetName(NIvfPq::SubspaceColumn);
+        subspaceColumn->SetType(NIvfPq::SubspaceIdxTypeName);
+        subspaceColumn->SetTypeId(NIvfPq::SubspaceIdxType);
+        subspaceColumn->SetNotNull(true);
+    }
+    {
+        auto cellColumn = implTableDesc.AddColumns();
+        cellColumn->SetName(NIvfPq::CellColumn);
+        cellColumn->SetType(NIvfPq::CellTypeName);
+        cellColumn->SetTypeId(NIvfPq::CellType);
+        cellColumn->SetNotNull(true);
+    }
+    {
+        auto centroidColumn = implTableDesc.AddColumns();
+        centroidColumn->SetName(NIvfPq::CentroidColumn);
+        centroidColumn->SetType("String");
+        centroidColumn->SetTypeId(NScheme::NTypeIds::String);
+        centroidColumn->SetNotNull(true);
+    }
+
+    implTableDesc.AddKeyColumnNames(NIvfPq::ParentColumn);
+    implTableDesc.AddKeyColumnNames(NIvfPq::SubspaceColumn);
+    implTableDesc.AddKeyColumnNames(NIvfPq::CellColumn);
+
+    implTableDesc.SetSystemColumnNamesAllowed(true);
+
+    return implTableDesc;
+}
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqLevelImplTableDesc(
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    return CalcVectorKmeansTreeLevelImplTableDesc(baseTablePartitionConfig, indexTableDesc);
+}
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPostingImplTableDesc(
+    const NKikimrSchemeOp::TTableDescription& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const THashSet<TString>& indexDataColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    return CalcVectorIvfPqPostingImplTableDescImpl(baseTable, baseTablePartitionConfig, indexDataColumns, indexTableDesc);
+}
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPostingImplTableDesc(
+    const NSchemeShard::TTableInfo::TPtr& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const THashSet<TString>& indexDataColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    return CalcVectorIvfPqPostingImplTableDescImpl(baseTable, baseTablePartitionConfig, indexDataColumns, indexTableDesc);
+}
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPrefixImplTableDesc(
+    const THashSet<TString>& indexKeyColumns,
+    const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const TTableColumns& implTableColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+{
+    return CalcVectorKmeansTreePrefixImplTableDesc(indexKeyColumns, baseTableInfo, baseTablePartitionConfig, implTableColumns, indexTableDesc);
 }
 
 NKikimrSchemeOp::TTableDescription CalcFulltextImplTableDesc(

--- a/ydb/core/tx/schemeshard/index/index_utils.h
+++ b/ydb/core/tx/schemeshard/index/index_utils.h
@@ -77,6 +77,33 @@ NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeBuildOverlapTableDesc(
     const NKikimrSchemeOp::TTableDescription& indexTableDesc,
     std::string_view suffix = {});
 
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqCodebookImplTableDesc(
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqLevelImplTableDesc(
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPostingImplTableDesc(
+    const NSchemeShard::TTableInfo::TPtr& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const THashSet<TString>& indexDataColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPostingImplTableDesc(
+    const NKikimrSchemeOp::TTableDescription& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const THashSet<TString>& indexDataColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+
+NKikimrSchemeOp::TTableDescription CalcVectorIvfPqPrefixImplTableDesc(
+    const THashSet<TString>& indexKeyColumns,
+    const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const TTableColumns& implTableColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+
 NKikimrSchemeOp::TTableDescription CalcFulltextImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
@@ -190,7 +217,8 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
                 return false;
             }
             break;
-        case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
             // We have already checked this in IsCompatibleIndex
             Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
 

--- a/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
@@ -68,7 +68,8 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Adding a unique index to an existing table is disabled")};
             }
             break;
-        case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
             break;
         }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
@@ -224,6 +225,27 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 outTx.MutableSequence()->SetName(NTableIndex::NKMeans::IdColumnSequence);
                 outTx.SetInternal(tx.GetInternal());
                 result.push_back(CreateNewSequence(NextPartId(opId, result), outTx));
+            }
+            break;
+        }
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+            const bool prefixVectorIndex = indexDesc.GetKeyColumnNames().size() > 1;
+            NKikimrSchemeOp::TTableDescription indexCodebookTableDesc, indexLevelTableDesc, indexPostingTableDesc, indexPrefixTableDesc;
+            // TODO After IndexImplTableDescriptions are persisted, this should be replaced with Y_ABORT_UNLESS
+            if (indexDesc.IndexImplTableDescriptionsSize() == 3 + prefixVectorIndex) {
+                indexCodebookTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::CodebookTablePosition);
+                indexLevelTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::LevelTablePosition);
+                indexPostingTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PostingTablePosition);
+                if (prefixVectorIndex) {
+                    indexPrefixTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PrefixTablePosition);
+                }
+            }
+            const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
+            result.push_back(createImplTable(CalcVectorIvfPqCodebookImplTableDesc(tableInfo->PartitionConfig(), indexCodebookTableDesc)));
+            result.push_back(createImplTable(CalcVectorIvfPqLevelImplTableDesc(tableInfo->PartitionConfig(), indexLevelTableDesc)));
+            result.push_back(createImplTable(CalcVectorIvfPqPostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns, indexPostingTableDesc)));
+            if (prefixVectorIndex) {
+                Y_ENSURE(false, "Not implemented");
             }
             break;
         }

--- a/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard__operation_part.h>
 #include <ydb/core/tx/schemeshard/index/index_utils.h>
 
+#include <ydb/core/base/ivf_pq.h>
 #include <ydb/core/base/kmeans_clusters.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
@@ -152,6 +153,13 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 if (NKikimr::NKMeans::NeedsVectorSettingsAutoSelect(indexDescription.GetVectorIndexKmeansTreeDescription().GetSettings().settings())) {
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed,
                         "Cannot build vector index: table is empty and vector_type/vector_dimension were not specified")};
+                }
+                break;
+            }
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+                TString msg;
+                if (!NKikimr::NIvfPq::ValidateSettings(indexDescription.GetVectorIndexIvfPqDescription().GetSettings(), msg)) {
+                    return {CreateReject(nextId, NKikimrScheme::EStatus::StatusInvalidParameter, msg)};
                 }
                 break;
             }
@@ -365,6 +373,29 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     outTx.SetAllowCreateInTempDir(tx.GetAllowCreateInTempDir());
                     outTx.SetInternal(tx.GetInternal());
                     result.push_back(CreateNewSequence(NextPartId(nextId, result), outTx));
+                }
+                break;
+            }
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+                const bool prefixVectorIndex = indexDescription.GetKeyColumnNames().size() > 1;
+                NKikimrSchemeOp::TTableDescription userCodebookDesc, userLevelDesc, userPostingDesc, userPrefixDesc;
+                if (indexDescription.IndexImplTableDescriptionsSize() == 3 + prefixVectorIndex) {
+                    // This description provided by user to override partition policy
+                    userCodebookDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::CodebookTablePosition);
+                    userLevelDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::LevelTablePosition);
+                    userPostingDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PostingTablePosition);
+                    if (prefixVectorIndex) {
+                        userPrefixDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PrefixTablePosition);
+                    }
+                }
+
+                const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
+                result.push_back(createIndexImplTable(CalcVectorIvfPqCodebookImplTableDesc(baseTableDescription.GetPartitionConfig(), userCodebookDesc)));
+                result.push_back(createIndexImplTable(CalcVectorIvfPqLevelImplTableDesc(baseTableDescription.GetPartitionConfig(), userLevelDesc)));
+                result.push_back(createIndexImplTable(CalcVectorIvfPqPostingImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), indexDataColumns, userPostingDesc)));
+                if (prefixVectorIndex) {
+                    // TODO(raydzast)
+                    Y_ENSURE(false, "Not implemented");
                 }
                 break;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -84,6 +84,10 @@ static std::optional<NKikimrSchemeOp::TModifyScheme> CreateIndexTask(NKikimr::NS
             *operation->MutableVectorIndexKmeansTreeDescription() =
                 std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(indexInfo->SpecializedIndexDescription);
             break;
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+            *operation->MutableVectorIndexIvfPqDescription() =
+                std::get<NKikimrSchemeOp::TVectorIndexIvfPqDescription>(indexInfo->SpecializedIndexDescription);
+            break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
             *operation->MutableFulltextIndexDescription() =

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -1061,6 +1061,10 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
                     *operation->MutableVectorIndexKmeansTreeDescription() =
                         std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(indexInfo->SpecializedIndexDescription);
                     break;
+                case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+                    *operation->MutableVectorIndexIvfPqDescription() =
+                        std::get<NKikimrSchemeOp::TVectorIndexIvfPqDescription>(indexInfo->SpecializedIndexDescription);
+                    break;
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
                     *operation->MutableFulltextIndexDescription() =

--- a/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
@@ -432,6 +432,11 @@ bool DfsOnTableChildrenTree(
 
                                 break;
                             }
+                            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+                                // TODO(raydzast)
+                                Y_ENSURE(false, "Not implemented");
+                                break;
+                            }
                             case NKikimrSchemeOp::EIndexTypeGlobalJson:
                             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
                             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5213,6 +5213,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     EnableOnlineAddUniqueIndex = appData->FeatureFlags.GetEnableOnlineAddUniqueIndex();
     EnableFulltextIndex = appData->FeatureFlags.GetEnableFulltextIndex();
     EnableJsonIndex = appData->FeatureFlags.GetEnableJsonIndex();
+    EnableIvfPqIndex = appData->FeatureFlags.GetEnableIvfPqIndex();
     EnableResourcePoolsOnServerless = appData->FeatureFlags.GetEnableResourcePoolsOnServerless();
     EnableExternalDataSourcesOnServerless = appData->FeatureFlags.GetEnableExternalDataSourcesOnServerless();
     EnableShred = appData->FeatureFlags.GetEnableDataErasure();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -416,6 +416,7 @@ public:
     bool EnableOnlineAddUniqueIndex = false;
     bool EnableFulltextIndex = false;
     bool EnableJsonIndex = false;
+    bool EnableIvfPqIndex = false;
     bool EnableExternalDataSourcesOnServerless = false;
     bool EnableShred = false;
     bool EnableExternalSourceSchemaInference = false;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3015,6 +3015,13 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
                 Y_ENSURE(success, description);
                 break;
             }
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq: {
+                auto success = SpecializedIndexDescription
+                    .emplace<NKikimrSchemeOp::TVectorIndexIvfPqDescription>()
+                    .ParseFromString(description);
+                Y_ENSURE(success, description);
+                break;
+            }
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
                 auto success = SpecializedIndexDescription
@@ -3084,6 +3091,9 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
                 alterData->SpecializedIndexDescription = config.GetVectorIndexKmeansTreeDescription();
                 break;
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+                alterData->SpecializedIndexDescription = config.GetVectorIndexIvfPqDescription();
+                break;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
                 alterData->SpecializedIndexDescription = config.GetFulltextIndexDescription();
@@ -3107,7 +3117,8 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
 
     std::variant<std::monostate,
         NKikimrSchemeOp::TVectorIndexKmeansTreeDescription,
-        NKikimrSchemeOp::TFulltextIndexDescription> SpecializedIndexDescription;
+        NKikimrSchemeOp::TFulltextIndexDescription,
+        NKikimrSchemeOp::TVectorIndexIvfPqDescription> SpecializedIndexDescription;
 };
 
 struct TCdcStreamSettings {

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -217,6 +217,8 @@ TPathElement::EPathSubType TPathDescriber::CalcPathSubType(const TPath& path) {
                 return TPathElement::EPathSubType::EPathSubTypeSyncIndexImplTable;
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
                 return TPathElement::EPathSubType::EPathSubTypeVectorKmeansTreeIndexImplTable;
+            case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+                return TPathElement::EPathSubType::EPathSubTypeVectorIvfPqIndexImplTable;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
                 return TPathElement::EPathSubType::EPathSubTypeFulltextIndexImplTable;
@@ -1502,6 +1504,9 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             *entry.MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(indexInfo->SpecializedIndexDescription);
+            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalVectorIvfPq:
+            *entry.MutableVectorIndexIvfPqDescription() = std::get<NKikimrSchemeOp::TVectorIndexIvfPqDescription>(indexInfo->SpecializedIndexDescription);
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -1750,6 +1750,31 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
 
             break;
         }
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorIvfPq: {
+            FillGlobalIndexSettings(
+                *index->mutable_global_vector_ivf_pq_index()->mutable_codebook_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::CodebookTablePosition)
+            );
+            FillGlobalIndexSettings(
+                *index->mutable_global_vector_ivf_pq_index()->mutable_level_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::LevelTablePosition)
+            );
+            FillGlobalIndexSettings(
+                *index->mutable_global_vector_ivf_pq_index()->mutable_posting_table_settings(),
+                tableIndex.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PostingTablePosition)
+            );
+            const bool prefixVectorIndex = tableIndex.GetKeyColumnNames().size() > 1;
+            if (prefixVectorIndex) {
+                FillGlobalIndexSettings(
+                    *index->mutable_global_vector_ivf_pq_index()->mutable_prefix_table_settings(),
+                    tableIndex.GetIndexImplTableDescriptions(NTableIndex::NIvfPq::PrefixTablePosition)
+                );
+            }
+
+            *index->mutable_global_vector_ivf_pq_index()->mutable_vector_settings() = tableIndex.GetVectorIndexIvfPqDescription().GetSettings();
+
+            break;
+        }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             FillGlobalIndexSettings(
                 *index->mutable_global_fulltext_plain_index()->mutable_settings(),
@@ -1890,6 +1915,11 @@ bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
         case Ydb::Table::TableIndex::kGlobalVectorKmeansTreeIndex:
             indexDesc->SetType(NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree);
             *indexDesc->MutableVectorIndexKmeansTreeDescription()->MutableSettings() = index.global_vector_kmeans_tree_index().vector_settings();
+            break;
+        
+        case Ydb::Table::TableIndex::kGlobalVectorIvfPqIndex:
+            indexDesc->SetType(NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorIvfPq);
+            *indexDesc->MutableVectorIndexIvfPqDescription()->MutableSettings() = index.global_vector_ivf_pq_index().vector_settings();
             break;
 
         case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex:

--- a/ydb/core/ydb_convert/table_settings.cpp
+++ b/ydb/core/ydb_convert/table_settings.cpp
@@ -532,6 +532,25 @@ bool FillIndexTablePartitioning(
         }
         break;
     }
+    case Ydb::Table::TableIndex::kGlobalVectorIvfPqIndex: {
+        const bool prefixVectorIndex = index.index_columns().size() > 1;
+        indexImplTableDescriptions.resize(prefixVectorIndex ? 4 : 3);
+        if (!fillIndexPartitioning(index.global_vector_ivf_pq_index().codebook_table_settings(), indexImplTableDescriptions[NTableIndex::NIvfPq::CodebookTablePosition])) {
+            return false;
+        }
+        if (!fillIndexPartitioning(index.global_vector_ivf_pq_index().level_table_settings(), indexImplTableDescriptions[NTableIndex::NIvfPq::LevelTablePosition])) {
+            return false;
+        }
+        if (!fillIndexPartitioning(index.global_vector_ivf_pq_index().posting_table_settings(), indexImplTableDescriptions[NTableIndex::NIvfPq::PostingTablePosition])) {
+            return false;
+        }
+        if (prefixVectorIndex) {
+            if (!fillIndexPartitioning(index.global_vector_ivf_pq_index().prefix_table_settings(), indexImplTableDescriptions[NTableIndex::NIvfPq::PrefixTablePosition])) {
+                return false;
+            }
+        }
+        break;
+    }
     case Ydb::Table::TableIndex::kGlobalFulltextPlainIndex:
         indexImplTableDescriptions.resize(1);
         if (!fillIndexPartitioning(index.global_fulltext_plain_index().settings(), indexImplTableDescriptions[0])) {

--- a/ydb/library/workload/vector/vector_workload_params.cpp
+++ b/ydb/library/workload/vector/vector_workload_params.cpp
@@ -140,9 +140,16 @@ void TVectorWorkloadParams::Init() {
             EmbeddingColumn = keyColumns.back();
 
             // Extract the distance metric from index settings
-            const auto& indexSettings = std::get<NYdb::NTable::TKMeansTreeSettings>(index.GetIndexSettings());
-            Metric = indexSettings.Settings.Metric;
-            VectorOpts.VectorDimension = indexSettings.Settings.VectorDimension;
+            const auto& settingsVariant = index.GetIndexSettings();
+            const NYdb::NTable::TVectorIndexSettings* vectorSettings = nullptr;
+            if (const auto* kmeansTreeSettings = std::get_if<NYdb::NTable::TKMeansTreeSettings>(&settingsVariant)) {
+                vectorSettings = &kmeansTreeSettings->Settings;
+            } else if (const auto* ivfPqSettings = std::get_if<NYdb::NTable::TIvfPqSettings>(&settingsVariant)) {
+                vectorSettings = &ivfPqSettings->Settings;
+            }
+            Y_ABORT_UNLESS(vectorSettings, "Unsupported index settings type for index %s", IndexName.c_str());
+            Metric = vectorSettings->Metric;
+            VectorOpts.VectorDimension = vectorSettings->VectorDimension;
 
             break;
         }

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -104,6 +104,18 @@ message KMeansTreeSettings {
     optional double overlap_ratio = 5;
 }
 
+message IvfPqSettings {
+    VectorIndexSettings settings = 1;
+
+    optional uint32 subspaces = 2;
+
+    optional uint32 subspace_bits = 3;
+
+    oneof ivf_type {
+        KMeansTreeSettings kmeans_tree_settings = 4;
+    }
+}
+
 message GlobalIndex {
     GlobalIndexSettings settings = 1;
 }
@@ -121,6 +133,14 @@ message GlobalVectorKMeansTreeIndex {
     GlobalIndexSettings posting_table_settings = 2;
     GlobalIndexSettings prefix_table_settings = 4;
     KMeansTreeSettings vector_settings = 3;
+}
+
+message GlobalVectorIvfPqIndex {
+    GlobalIndexSettings level_table_settings = 1;
+    GlobalIndexSettings codebook_table_settings = 2;
+    GlobalIndexSettings posting_table_settings = 3;
+    GlobalIndexSettings prefix_table_settings = 4;
+    IvfPqSettings vector_settings = 5;
 }
 
 message FulltextIndexSettings {
@@ -359,6 +379,7 @@ message TableIndex {
        LocalBloomNgramFilterIndex local_bloom_ngram_filter_index = 11;
        GlobalJsonIndex global_json_index = 12;
        LocalMinMaxIndex local_min_max_index = 14;
+       GlobalVectorIvfPqIndex global_vector_ivf_pq_index = 15;
     }
     // list of columns content to be copied in to index table
     repeated string data_columns = 5;
@@ -391,6 +412,7 @@ message TableIndexDescription {
        LocalBloomNgramFilterIndex local_bloom_ngram_filter_index = 13;
        GlobalJsonIndex global_json_index = 14;
        LocalMinMaxIndex local_min_max_index = 15;
+       GlobalVectorIvfPqIndex global_vector_ivf_pq_index = 16;
     }
     Status status = 4;
     // list of columns content to be copied in to index table

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/fwd.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/fwd.h
@@ -23,6 +23,7 @@ struct TRenameIndex;
 struct TGlobalIndexSettings;
 struct TVectorIndexSettings;
 struct TKMeansTreeSettings;
+struct TIvfPqSettings;
 struct TCreateSessionSettings;
 struct TSessionPoolSettings;
 struct TClientSettings;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -31,6 +31,7 @@ class ExplicitPartitions;
 class GlobalIndexSettings;
 class VectorIndexSettings;
 class KMeansTreeSettings;
+class IvfPqSettings;
 class FulltextIndexSettings;
 class PartitioningSettings;
 class ReadReplicasSettings;
@@ -299,6 +300,10 @@ struct TGlobalIndexSettings {
     static constexpr const int VectorKMeansTreeLevelTablePosition = 0;
     static constexpr const int VectorKMeansTreePostingTablePosition = 1;
     static constexpr const int VectorKMeansTreePrefixTablePosition = 2;
+    static constexpr const int VectorIvfPqCodebookTablePosition = 0;
+    static constexpr const int VectorIvfPqLevelTablePosition = 1;
+    static constexpr const int VectorIvfPqPostingTablePosition = 2;
+    static constexpr const int VectorIvfPqPrefixTablePosition = 3;
     static constexpr const int FulltextRelevanceDictTablePosition = 0;
     static constexpr const int FulltextRelevanceDocsTablePosition = 1;
     static constexpr const int FulltextRelevanceStatsTablePosition = 2;
@@ -375,7 +380,21 @@ public:
 
     void SerializeTo(Ydb::Table::KMeansTreeSettings& settings) const;
 
-    void Out(IOutputStream &o) const;
+    void Out(IOutputStream& o) const;
+};
+
+struct TIvfPqSettings {
+public:
+    TVectorIndexSettings Settings;
+    std::variant<std::monostate, TKMeansTreeSettings> IvfSettings;
+    uint32_t Subspaces = 0;
+    uint32_t SubspaceBits = 0;
+
+    static TIvfPqSettings FromProto(const Ydb::Table::IvfPqSettings& proto);
+
+    void SerializeTo(Ydb::Table::IvfPqSettings& settings) const;
+
+    void Out(IOutputStream& o) const;
 };
 
 struct TFulltextIndexSettings {
@@ -426,7 +445,7 @@ public:
         const std::vector<std::string>& indexColumns,
         const std::vector<std::string>& dataColumns = {},
         const std::vector<TGlobalIndexSettings>& globalIndexSettings = {},
-        const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings>& specializedIndexSettings = {}
+        const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings>& specializedIndexSettings = {}
     );
 
     TIndexDescription(
@@ -440,7 +459,7 @@ public:
     EIndexType GetIndexType() const;
     const std::vector<std::string>& GetIndexColumns() const;
     const std::vector<std::string>& GetDataColumns() const;
-    const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings>& GetIndexSettings() const;
+    const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings>& GetIndexSettings() const;
     uint64_t GetSizeBytes() const;
     void SetParallel(uint32_t parallel);
 
@@ -520,7 +539,7 @@ private:
     std::vector<std::string> IndexColumns_;
     std::vector<std::string> DataColumns_;
     std::vector<TGlobalIndexSettings> GlobalIndexSettings_;
-    std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings> SpecializedIndexSettings_;
+    std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings> SpecializedIndexSettings_;
     uint64_t SizeBytes_ = 0;
     uint32_t Parallel_ = 0;
 };

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
@@ -35,6 +35,7 @@ enum class EIndexType {
     GlobalAsync,
     GlobalUnique,
     GlobalVectorKMeansTree,
+    GlobalVectorIvfPq,
     GlobalFulltextPlain,
     GlobalFulltextRelevance,
     GlobalJson,

--- a/ydb/public/sdk/cpp/src/client/table/out.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/out.cpp
@@ -86,6 +86,20 @@ Y_DECLARE_OUT_SPEC(, NYdb::NTable::TKMeansTreeSettings, stream, value) {
         " }";
 }
 
+Y_DECLARE_OUT_SPEC(, NYdb::NTable::TIvfPqSettings, stream, value) {
+    stream <<
+        "{ settings: " << value.Settings <<
+        ", subspace_bits: " << value.SubspaceBits <<
+        ", subspaces: " << value.Subspaces;
+
+    if (const auto* settings = std::get_if<NYdb::NTable::TKMeansTreeSettings>(&value.IvfSettings)) {
+        stream <<
+            ", kmeans_tree_settings: " << *settings;
+    }
+
+    stream << " }";
+}
+
 Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings::ETokenizer, stream, value) {
     switch (value) {
         case NYdb::NTable::TFulltextIndexSettings::ETokenizer::Whitespace:

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -2460,7 +2460,7 @@ TIndexDescription::TIndexDescription(
     const std::vector<std::string>& indexColumns,
     const std::vector<std::string>& dataColumns,
     const std::vector<TGlobalIndexSettings>& globalIndexSettings,
-    const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings>& specializedIndexSettings
+    const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings>& specializedIndexSettings
 )   : IndexName_(name)
     , IndexType_(type)
     , IndexColumns_(indexColumns)
@@ -2501,7 +2501,7 @@ const std::vector<std::string>& TIndexDescription::GetDataColumns() const {
     return DataColumns_;
 }
 
-const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings>& TIndexDescription::GetIndexSettings() const {
+const std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings>& TIndexDescription::GetIndexSettings() const {
     return SpecializedIndexSettings_;
 }
 
@@ -2832,6 +2832,38 @@ void TKMeansTreeSettings::Out(IOutputStream& o) const {
     o << *this;
 }
 
+TIvfPqSettings TIvfPqSettings::FromProto(const Ydb::Table::IvfPqSettings& proto) {
+    TIvfPqSettings result = {
+        .Settings = TVectorIndexSettings::FromProto(proto.settings()),
+        .Subspaces = proto.subspaces(),
+        .SubspaceBits = proto.subspace_bits(),
+    };
+
+    switch (proto.ivf_type_case()) {
+        case Ydb::Table::IvfPqSettings::kKmeansTreeSettings:
+            result.IvfSettings = TKMeansTreeSettings::FromProto(proto.kmeans_tree_settings());
+            break;
+        case Ydb::Table::IvfPqSettings::IVF_TYPE_NOT_SET:
+            break;
+    }
+
+    return result;
+}
+
+void TIvfPqSettings::SerializeTo(Ydb::Table::IvfPqSettings& proto) const {
+    Settings.SerializeTo(*proto.mutable_settings());
+    proto.set_subspaces(Subspaces);
+    proto.set_subspace_bits(SubspaceBits);
+
+    if (const auto* kmeansTreeSettings = std::get_if<TKMeansTreeSettings>(&IvfSettings)) {
+        kmeansTreeSettings->SerializeTo(*proto.mutable_kmeans_tree_settings());
+    }
+}
+
+void TIvfPqSettings::Out(IOutputStream& o) const {
+    o << *this;
+}
+
 TFulltextIndexSettings::TAnalyzers FromProto(const Ydb::Table::FulltextIndexSettings::Analyzers& proto) {
     using ETokenizer = TFulltextIndexSettings::ETokenizer;
     using TAnalyzers = TFulltextIndexSettings::TAnalyzers;
@@ -2987,7 +3019,7 @@ TIndexDescription TIndexDescription::FromProto(const TProto& proto) {
     std::vector<std::string> indexColumns;
     std::vector<std::string> dataColumns;
     std::vector<TGlobalIndexSettings> globalIndexSettings;
-    std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings> specializedIndexSettings = std::monostate{};
+    std::variant<std::monostate, TKMeansTreeSettings, TFulltextIndexSettings, TIvfPqSettings> specializedIndexSettings = std::monostate{};
 
     indexColumns.assign(proto.index_columns().begin(), proto.index_columns().end());
     dataColumns.assign(proto.data_columns().begin(), proto.data_columns().end());
@@ -3019,6 +3051,24 @@ TIndexDescription TIndexDescription::FromProto(const TProto& proto) {
                 TGlobalIndexSettings::FromProto(vectorProto.prefix_table_settings());
         }
         specializedIndexSettings = TKMeansTreeSettings::FromProto(vectorProto.vector_settings());
+        break;
+    }
+    case TProto::kGlobalVectorIvfPqIndex: {
+        type = EIndexType::GlobalVectorIvfPq;
+        const auto& vectorProto = proto.global_vector_ivf_pq_index();
+        const bool prefixVectorIndex = indexColumns.size() > 1;
+        globalIndexSettings.resize(prefixVectorIndex ? 4 : 3);
+        globalIndexSettings[TGlobalIndexSettings::VectorIvfPqCodebookTablePosition] =
+            TGlobalIndexSettings::FromProto(vectorProto.codebook_table_settings());
+        globalIndexSettings[TGlobalIndexSettings::VectorIvfPqLevelTablePosition] =
+            TGlobalIndexSettings::FromProto(vectorProto.level_table_settings());
+        globalIndexSettings[TGlobalIndexSettings::VectorIvfPqPostingTablePosition] =
+            TGlobalIndexSettings::FromProto(vectorProto.posting_table_settings());
+        if (prefixVectorIndex) {
+            globalIndexSettings[TGlobalIndexSettings::VectorIvfPqPrefixTablePosition] =
+                TGlobalIndexSettings::FromProto(vectorProto.prefix_table_settings());
+        }
+        specializedIndexSettings = TIvfPqSettings::FromProto(vectorProto.vector_settings());
         break;
     }
     case TProto::kGlobalFulltextPlainIndex: {
@@ -3112,6 +3162,27 @@ void TIndexDescription::SerializeTo(Ydb::Table::TableIndex& proto) const {
         }
         break;
     }
+    case EIndexType::GlobalVectorIvfPq: {
+        auto* global_vector_ivf_pq_index = proto.mutable_global_vector_ivf_pq_index();
+        auto& codebook_settings = *global_vector_ivf_pq_index->mutable_codebook_table_settings();
+        auto& level_settings = *global_vector_ivf_pq_index->mutable_level_table_settings();
+        auto& posting_settings = *global_vector_ivf_pq_index->mutable_posting_table_settings();
+        auto& vector_settings = *global_vector_ivf_pq_index->mutable_vector_settings();
+        const bool is_prefixed = IndexColumns_.size() > 1;
+        if (GlobalIndexSettings_.size() == (is_prefixed ? 4 : 3)) {
+            GlobalIndexSettings_.at(TGlobalIndexSettings::VectorIvfPqCodebookTablePosition).SerializeTo(codebook_settings);
+            GlobalIndexSettings_.at(TGlobalIndexSettings::VectorIvfPqLevelTablePosition).SerializeTo(level_settings);
+            GlobalIndexSettings_.at(TGlobalIndexSettings::VectorIvfPqPostingTablePosition).SerializeTo(posting_settings);
+            if (is_prefixed) {
+                auto& prefix_settings = *global_vector_ivf_pq_index->mutable_prefix_table_settings();
+                GlobalIndexSettings_.at(TGlobalIndexSettings::VectorIvfPqPrefixTablePosition).SerializeTo(prefix_settings);
+            }
+        }
+        if (const auto* settings = std::get_if<TIvfPqSettings>(&SpecializedIndexSettings_)) {
+            settings->SerializeTo(vector_settings);
+        }
+        break;
+    }
     case EIndexType::GlobalFulltextPlain: {
         auto* global_fulltext_index = proto.mutable_global_fulltext_plain_index();
         auto& settings = *global_fulltext_index->mutable_settings();
@@ -3179,6 +3250,11 @@ void TIndexDescription::Out(IOutputStream& o) const {
         break;
     case EIndexType::GlobalVectorKMeansTree:
         if (auto settings = std::get_if<TKMeansTreeSettings>(&SpecializedIndexSettings_)) {
+            o << ", vector_settings: " << *settings;
+        }
+        break;
+    case EIndexType::GlobalVectorIvfPq:
+        if (auto settings = std::get_if<TIvfPqSettings>(&SpecializedIndexSettings_)) {
             o << ", vector_settings: " << *settings;
         }
         break;

--- a/yql/essentials/sql/v1/node.h
+++ b/yql/essentials/sql/v1/node.h
@@ -1298,7 +1298,8 @@ struct TIndexDescription {
         LocalBloomFilter,
         LocalBloomNgramFilter,
         GlobalJson,
-        LocalMinMax
+        LocalMinMax,
+        GlobalVectorIvfPq,
     };
 
     struct TIndexSetting {

--- a/yql/essentials/sql/v1/query.cpp
+++ b/yql/essentials/sql/v1/query.cpp
@@ -155,6 +155,8 @@ INode::TPtr CreateIndexType(TIndexDescription::EType type, const INode& node) {
             return node.Q("syncGlobalUnique");
         case TIndexDescription::EType::GlobalVectorKmeansTree:
             return node.Q("globalVectorKmeansTree");
+        case TIndexDescription::EType::GlobalVectorIvfPq:
+            return node.Q("globalVectorIvfPq");
         case TIndexDescription::EType::GlobalFulltextPlain:
             return node.Q("globalFulltextPlain");
         case TIndexDescription::EType::GlobalFulltextRelevance:

--- a/yql/essentials/sql/v1/sql_translation.cpp
+++ b/yql/essentials/sql/v1/sql_translation.cpp
@@ -712,8 +712,8 @@ bool TSqlTranslation::CreateTableIndex(const TRule_table_index& node, TVector<TI
 
     if (node.GetRule_table_index_type3().HasBlock2()) {
         const TString subType = to_upper(IdEx(node.GetRule_table_index_type3().GetBlock2().GetRule_index_subtype2().GetRule_an_id1(), *this).Name);
-        if (subType == "VECTOR_KMEANS_TREE" || subType == "FULLTEXT_PLAIN" ||
-            subType == "FULLTEXT_RELEVANCE" || subType == "JSON") {
+        if (subType == "VECTOR_KMEANS_TREE" || subType == "VECTOR_IVF_PQ" || 
+            subType == "FULLTEXT_PLAIN" || subType == "FULLTEXT_RELEVANCE" || subType == "JSON") {
             if (isLocalIndex || indexes.back().Type != TIndexDescription::EType::GlobalSync) {
                 Ctx_.Error() << subType << " index can only be GLOBAL [SYNC]";
                 return false;
@@ -721,6 +721,8 @@ bool TSqlTranslation::CreateTableIndex(const TRule_table_index& node, TVector<TI
 
             if (subType == "VECTOR_KMEANS_TREE") {
                 indexes.back().Type = TIndexDescription::EType::GlobalVectorKmeansTree;
+            } else if (subType == "VECTOR_IVF_PQ") {
+                indexes.back().Type = TIndexDescription::EType::GlobalVectorIvfPq;
             } else if (subType == "FULLTEXT_PLAIN") {
                 indexes.back().Type = TIndexDescription::EType::GlobalFulltextPlain;
             } else if (subType == "FULLTEXT_RELEVANCE") {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`ydb workload vector` now can run queries using `vector_ivf_pq` index type

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added extraction of common vector settings from specialized variants (vector_kmeans_tree, vector_ivf_pq)

Requires #41304
