### PR TITLE
Add `#pragma once` into `block_events.h`

### DIFF
--- a/ydb/core/testlib/actors/block_events.h
+++ b/ydb/core/testlib/actors/block_events.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "test_runtime.h"
 
 #include <deque>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stumbled upon double inclusion, so I added `#pragma once`