### PR TITLE
Fix lock registration after datashard reboot

### DIFF
--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -247,6 +247,12 @@ TLockInfo::TPtr TDataShard::FindValidLockOwner(ui64 lockId) {
 
 void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr ev) {
     auto* msg = ev->Get();
+    LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+        "Handle TEvLockRows: at tablet# " << TabletID()
+        << ", sender: " << ev->Sender
+        << ", RequestId: " << msg->Record.GetRequestId()
+        << ", LockId: " << msg->Record.GetLockId()
+        << ", LockNode: " << msg->Record.GetLockNodeId());
 
     TLockRowsRequestId requestId(ev->Sender, msg->Record.GetRequestId());
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3306,6 +3306,7 @@ protected:
             HFuncTraced(TEvPrivate::TEvRemoveSchemaSnapshots, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsResult, Handle);
             HFunc(TEvPrivate::TEvBuildTableStatsError, Handle);
+            HFunc(TEvLongTxService::TEvLockStatus, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -1856,14 +1856,16 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         const ui64 RNG_SEED = 42;
         const size_t NODE_COUNT = 5;
         const size_t SHARD_COUNT = 10;
-        const size_t ROW_COUNT = 100;
-        const size_t MAX_LOCKED_ROWS_PER_SHARD = ROW_COUNT / SHARD_COUNT;
+        const size_t ROW_COUNT = 1000;
+        const size_t MAX_LOCKED_ROWS_PER_SHARD = ROW_COUNT / SHARD_COUNT / 10;
         const size_t IN_FLIGHT_TXS = 10;
         const size_t MIN_ROUNDS_PER_TX = 2;
         const size_t MAX_ROUNDS_PER_TX = 3;
         const ui64 MAX_IDLE_MS_BETWEEN_ROUNDS = 50;
-        const size_t REQUIRED_SUCCESSFUL_TXS = 100;
+        const size_t REQUIRED_SUCCESSFUL_TXS = 300;
         const size_t MAX_LOOP_ITERS = 5000;
+        const size_t MAX_TABLETS_REBOOTED_AT_ONCE = 3;
+        const size_t AVG_ROUNDS_BETWEEN_REBOOTS = 500;
 
         UNIT_ASSERT_VALUES_EQUAL(ROW_COUNT % SHARD_COUNT, 0);
 
@@ -1904,15 +1906,6 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         const auto shards = GetTableShards(server, sender, "/Root/table");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), SHARD_COUNT);
 
-        TVector<TVector<std::unique_ptr<TTestPipe>>> nodePipes;
-        for (size_t nodeIdx = 0; nodeIdx < NODE_COUNT; ++nodeIdx) {
-            TVector<std::unique_ptr<TTestPipe>> pipes;
-            for (size_t shardIdx = 0; shardIdx < shards.size(); ++shardIdx) {
-                pipes.push_back(std::make_unique<TTestPipe>(runtime, shards[shardIdx], nodeIdx));
-            }
-            nodePipes.push_back(std::move(pipes));
-        }
-
         ui64 nextLockId = 1;
         TFastRng64 rng(RNG_SEED);
 
@@ -1922,8 +1915,10 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             TActorId EdgeActor;
             TLockHandle Lock;
 
+            THashMap<ui64, TVector<int>> ShardToRows;
             ui64 NextRequestId = 1;
-            THashMap<ui64, size_t> ReqToShardIdx;
+            THashMap<ui64, ui64> ReqIdToShardId;
+            THashMap<ui64, TMonotonic> ShardToRetryAt;
 
             const size_t MaxRounds;
             size_t CompletedRounds = 0;
@@ -1938,6 +1933,12 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         auto observer = runtime.AddObserver<NEvents::TDataEvents::TEvLockRowsResult>(
             [&](auto& ev) {
                 arrivedResults.push_back(std::move(ev));
+            });
+
+        TVector<TEvPipeCache::TEvDeliveryProblem::TPtr> deliveryProblems;
+        auto deliveryProblemObserver = runtime.AddObserver<TEvPipeCache::TEvDeliveryProblem>(
+            [&](auto& ev) {
+                deliveryProblems.push_back(std::move(ev));
             });
 
         auto pickRows = [&]() -> THashMap<size_t, TVector<int>> {
@@ -1963,6 +1964,7 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
         THashMap<TActorId, TMockTx> actorToTxState;
         size_t successfulTxs = 0;
         size_t failedTxs = 0;
+        size_t rebootRounds = 0;
         TMap<NKikimrDataEvents::TEvLockRowsResult_EStatus, size_t> responseStatusStats;
 
         size_t loopIter = 0;
@@ -1984,41 +1986,71 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
                 break;
             }
 
+            auto sendRequest = [&](TMockTx& tx, ui64 shardId, const TVector<int>& rows) {
+                ui64 requestId = tx.NextRequestId++;
+
+                Cerr << "TX " << tx.Lock.GetLockId()
+                    << " sending request to shard: " << shardId
+                    << ", request id: " << requestId << Endl;
+
+                TVector<TCell> cells;
+                for (int row : rows) {
+                    cells.push_back(TCell::Make(row));
+                }
+                TSerializedCellMatrix matrix(cells, cells.size(), 1);
+
+                auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(requestId);
+                req->Record.SetLockId(tx.Lock.GetLockId());
+                req->Record.SetLockNodeId(runtime.GetNodeId(tx.NodeIdx));
+                req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
+                req->SetTableId(tableId);
+                req->Record.AddColumnIds(1);
+                req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+                req->SetCellMatrix(matrix.ReleaseBuffer());
+
+                runtime.Send(
+                    MakePipePerNodeCacheID(EPipePerNodeCache::Leader),
+                    tx.EdgeActor,
+                    new TEvPipeCache::TEvForward(req.release(), shardId, true),
+                    tx.NodeIdx);
+                tx.ReqIdToShardId[requestId] = shardId;
+            };
+
             // Start new rounds for idle transactions
             for (auto& [_, tx] : actorToTxState) {
-                if (!tx.ReqToShardIdx.empty() || runtime.GetCurrentMonotonicTime() < tx.StartNextRoundAt) {
+                if (!tx.ShardToRows.empty() || runtime.GetCurrentMonotonicTime() < tx.StartNextRoundAt) {
                     continue;
                 }
 
-                auto shardToRows = pickRows();
+                auto shardIdxToRows = pickRows();
                 size_t totalRows = 0;
-                for (const auto& [_, rows] : shardToRows) {
+                for (auto& [idx, rows] : shardIdxToRows) {
                     totalRows += rows.size();
+                    tx.ShardToRows[shards[idx]] = std::move(rows);
                 }
                 Cerr << "TX " << tx.Lock.GetLockId()
                     << " round: " << tx.CompletedRounds << " of " << tx.MaxRounds
-                    << " shards: " << shardToRows.size() << " rows: " << totalRows << Endl;
+                    << " shards: " << shardIdxToRows.size() << " rows: " << totalRows
+                    << " actor: " << tx.EdgeActor << Endl;
 
-                for (const auto& [shardIdx, shardRows] : shardToRows) {
-                    ui64 requestId = tx.NextRequestId++;
+                for (const auto& [shard, shardRows] : tx.ShardToRows) {
+                    sendRequest(tx, shard, shardRows);
+                }
+            }
 
-                    TVector<TCell> cells;
-                    for (int row : shardRows) {
-                        cells.push_back(TCell::Make(row));
+            // Retry requests to unavailable shards
+            for (auto& [_, tx] : actorToTxState) {
+                for (auto it = tx.ShardToRetryAt.begin(); it != tx.ShardToRetryAt.end(); ) {
+                    if (it->second > runtime.GetCurrentMonotonicTime())  {
+                        ++it;
+                        continue;
                     }
-                    TSerializedCellMatrix matrix(cells, cells.size(), 1);
-
-                    auto req = std::make_unique<NEvents::TDataEvents::TEvLockRows>(requestId);
-                    req->Record.SetLockId(tx.Lock.GetLockId());
-                    req->Record.SetLockNodeId(runtime.GetNodeId(tx.NodeIdx));
-                    req->Record.SetLockMode(NKikimrDataEvents::PESSIMISTIC_EXCLUSIVE);
-                    req->SetTableId(tableId);
-                    req->Record.AddColumnIds(1);
-                    req->Record.SetPayloadFormat(NKikimrDataEvents::FORMAT_CELLVEC);
-                    req->SetCellMatrix(matrix.ReleaseBuffer());
-
-                    nodePipes.at(tx.NodeIdx).at(shardIdx)->Send(tx.EdgeActor, req.release(), requestId);
-                    tx.ReqToShardIdx[requestId] = shardIdx;
+                    ui64 shard = it->first;
+                    auto reqIt = tx.ShardToRows.find(shard);
+                    if (reqIt != tx.ShardToRows.end()) {
+                        sendRequest(tx, shard, reqIt->second);
+                    }
+                    tx.ShardToRetryAt.erase(it++);
                 }
             }
 
@@ -2035,17 +2067,24 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
                 auto& tx = txIt->second;
 
                 auto requestId = ev->Get()->Record.GetRequestId();
-                auto shardIt = tx.ReqToShardIdx.find(requestId);
-                if (shardIt == tx.ReqToShardIdx.end()) {
+                Cerr << "TX " << tx.Lock.GetLockId()
+                    << " got response, request id: " << requestId << Endl;
+
+                auto shardIt = tx.ReqIdToShardId.find(requestId);
+                if (shardIt == tx.ReqIdToShardId.end()) {
                     continue;
                 }
-                tx.ReqToShardIdx.erase(shardIt);
+                ui64 shard = shardIt->second;
+
+                tx.ReqIdToShardId.erase(shardIt);
+                tx.ShardToRows.erase(shard);
+                tx.ShardToRetryAt.erase(shard);
 
                 auto status = ev->Get()->Record.GetStatus();
                 ++responseStatusStats[status];
 
                 if (status == NKikimrDataEvents::TEvLockRowsResult::STATUS_SUCCESS) {
-                    if (tx.ReqToShardIdx.empty()) {
+                    if (tx.ShardToRows.empty()) {
                         ++tx.CompletedRounds;
                         if (tx.CompletedRounds >= tx.MaxRounds) {
                             Cerr << "TX " << tx.Lock.GetLockId() << " succeeded" << Endl;
@@ -2055,20 +2094,58 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
                     }
                 } else {
                     Cerr << "TX " << tx.Lock.GetLockId() << " failed" << Endl;
-                    for (const auto& [pendingReqId, shardIdx] : tx.ReqToShardIdx) {
+                    for (const auto& [pendingReqId, shardId] : tx.ReqIdToShardId) {
                         auto cancelEv = std::make_unique<NEvents::TDataEvents::TEvLockRowsCancel>(
                             pendingReqId);
-                        nodePipes.at(tx.NodeIdx).at(shardIdx)->Send(tx.EdgeActor, cancelEv.release());
+                        runtime.Send(
+                            MakePipePerNodeCacheID(EPipePerNodeCache::Leader),
+                            tx.EdgeActor,
+                            new TEvPipeCache::TEvForward(cancelEv.release(), shardId, true),
+                            tx.NodeIdx);
                     }
                     actorToTxState.erase(txIt);
                     ++failedTxs;
+                }
+            }
+
+            auto deliveryProblemsThisCycle = std::exchange(deliveryProblems, {});
+            for (auto& ev : deliveryProblemsThisCycle) {
+                auto txIt = actorToTxState.find(ev->Recipient);
+                if (txIt == actorToTxState.end()) {
+                    continue;
+                }
+                auto& tx = txIt->second;
+
+                ui64 tabletId = ev->Get()->TabletId;
+                if (!tx.ShardToRows.contains(tabletId)) {
+                    continue;
+                }
+
+                const bool emplaced = tx.ShardToRetryAt.emplace(
+                    tabletId,
+                    runtime.GetCurrentMonotonicTime()
+                        + TDuration::MilliSeconds(rng.Uniform(MAX_IDLE_MS_BETWEEN_ROUNDS + 1))).second;
+                if (emplaced) {
+                    Cerr << "TX " << tx.Lock.GetLockId() << " delivery problem to shard " << tabletId << Endl;
+                }
+            }
+
+            if (rng.Uniform(AVG_ROUNDS_BETWEEN_REBOOTS) == 0) {
+                ++rebootRounds;
+                // Reboot numTablets random tablets
+                const size_t numTablets = rng.Uniform(1, MAX_TABLETS_REBOOTED_AT_ONCE + 1);
+                for (size_t i = 0; i < numTablets; ++i) {
+                    ui64 tabletId = shards[rng.Uniform(shards.size())];
+                    Cerr << "Rebooting tablet " << tabletId << Endl;
+                    ForwardToTablet(runtime, tabletId, sender, new TEvents::TEvPoison);
                 }
             }
         }
 
         Cerr << "Loop iterations: " << loopIter << Endl
             << "Successful transactions: " << successfulTxs << Endl
-            << "Failed transactions: " << failedTxs << Endl;
+            << "Failed transactions: " << failedTxs << Endl
+            << "Reboot rounds: " << rebootRounds << Endl;
         Cerr << "Response status counts:" << Endl;
         for (const auto& [status, count] : responseStatusStats) {
             Cerr << status << ": " << count << Endl;

--- a/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_committed.cpp
@@ -259,6 +259,79 @@ Y_UNIT_TEST(BlockedWritesAndConflicts) {
         "ERROR: STATUS_LOCKS_BROKEN");
 }
 
+Y_UNIT_TEST(CommitAfterDeadlockResolution) {
+    // Test that when two transactions enter a deadlock, one of them is able to commit
+    // after deadlock resolution.
+
+    TTestEnv env;
+    auto [server, runtime, sender, tableId, shards] = env.GetAll();
+
+    ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table` (key, value) VALUES (1, 100), (2, 200);
+    )");
+
+    TTransactionState tx1(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+    TTransactionState tx2(runtime, NKikimrDataEvents::PESSIMISTIC_NONE);
+
+    // tx1 locks key 1 and updates it.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.LockRows(tableId, shards.at(0), {1}),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx1.Locks.size(), 1);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.Write(tableId, shards.at(0), TWriteOperation::Upsert(1, 101)),
+        "OK");
+
+    // tx2 locks key 2 and updates it.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.LockRows(tableId, shards.at(0), {2}),
+        "OK");
+    UNIT_ASSERT_VALUES_EQUAL(tx2.Locks.size(), 1);
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 202)),
+        "OK");
+
+    // tx1 tries locking key 2 and blocks.
+    auto tx1LockPromise = tx1.SendLockRows(tableId, shards.at(0), {2});
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1LockPromise.NextString(TDuration::Seconds(1)),
+        "<timeout>");
+
+    // tx2 tries locking key 1 and fails.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.LockRows(tableId, shards.at(0), {1}),
+        "ERROR: STATUS_DEADLOCK");
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx2.Rollback(shards.at(0)),
+        "OK"
+    );
+
+    // tx1 unblocks
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1LockPromise.NextString(),
+        "OK");
+
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.Write(tableId, shards.at(0), TWriteOperation::Upsert(2, 201)),
+        "OK");
+
+    // tx1 should be able to commit now.
+    UNIT_ASSERT_VALUES_EQUAL(
+        tx1.WriteCommit(tableId, shards.at(0)),
+        "OK");
+
+    // We should now observe the commit by tx1.
+    UNIT_ASSERT_VALUES_EQUAL(
+        KqpSimpleExec(runtime, R"(
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )"),
+        "{ items { int32_value: 1 } items { int32_value: 101 } }, "
+        "{ items { int32_value: 2 } items { int32_value: 201 } }");
+}
+
 } // Y_UNIT_TEST_SUITE(DataShardReadCommitted)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -301,4 +301,23 @@ void TTransactionState::SendPlan() {
         });
 }
 
+TString TTransactionState::Rollback(ui64 shardId) {
+        auto sender = Runtime.AllocateEdgeActor();
+        ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+
+        const auto* pLock = FindLastLock(shardId);
+        if (!pLock) {
+            return "<noop>";
+        }
+
+        auto req = MakeHolder<NEvents::TDataEvents::TEvWrite>(
+            0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
+        req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Rollback);
+        *req->Record.MutableLocks()->AddLocks() = *pLock;
+
+        Runtime.SendToPipe(shardId, sender, req.Release(), nodeIndex);
+        return TWritePromise{*this, sender}.NextString();
+}
+
+
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.cpp
@@ -302,22 +302,21 @@ void TTransactionState::SendPlan() {
 }
 
 TString TTransactionState::Rollback(ui64 shardId) {
-        auto sender = Runtime.AllocateEdgeActor();
-        ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
+    auto sender = Runtime.AllocateEdgeActor();
+    ui32 nodeIndex = sender.NodeId() - Runtime.GetNodeId(0);
 
-        const auto* pLock = FindLastLock(shardId);
-        if (!pLock) {
-            return "<noop>";
-        }
+    const auto* pLock = FindLastLock(shardId);
+    if (!pLock) {
+        return "<noop>";
+    }
 
-        auto req = MakeHolder<NEvents::TDataEvents::TEvWrite>(
-            0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
-        req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Rollback);
-        *req->Record.MutableLocks()->AddLocks() = *pLock;
+    auto req = MakeHolder<NEvents::TDataEvents::TEvWrite>(
+        0, NKikimrDataEvents::TEvWrite::MODE_IMMEDIATE);
+    req->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Rollback);
+    *req->Record.MutableLocks()->AddLocks() = *pLock;
 
-        Runtime.SendToPipe(shardId, sender, req.Release(), nodeIndex);
-        return TWritePromise{*this, sender}.NextString();
+    Runtime.SendToPipe(shardId, sender, req.Release(), nodeIndex);
+    return TWritePromise{*this, sender}.NextString();
 }
-
 
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common_tx.h
@@ -214,6 +214,8 @@ public:
 
     void SendPlan();
 
+    TString Rollback(ui64 shardId);
+
 public:
     TTestActorRuntime& Runtime;
     NKikimrDataEvents::ELockMode LockMode;

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -35,6 +35,12 @@ void TLongTxServiceActor::Bootstrap() {
 
     Send(SelfId(), new TEvPrivate::TEvSnapshotMaintenance());
 
+    if (NActors::TMon* mon = AppData()->Mon) {
+        NMonitoring::TIndexMonPage *actorsMonPage = mon->RegisterIndexPage("actors", "Actors");
+        mon->RegisterActorPage(actorsMonPage, "long_tx_service", "Long Tx Service",
+            false, TActivationContext::ActorSystem(), SelfId());
+    }
+
     TXLOG_NOTICE("Started, SelfId: " << SelfId());
     Become(&TThis::StateWork);
 }
@@ -1788,6 +1794,79 @@ void TLongTxServiceActor::UpdateImmutableSnapshotsRegistry() {
     TXLOG_DEBUG("Updated immutable snapshots registry. "
         << "Local snapshots count: " << localSnapshotsCount
         << ", Remote snapshots count: " << remoteSnapshotsCount);
+}
+
+void TLongTxServiceActor::Handle(NMon::TEvHttpInfo::TPtr& ev) {
+    auto now = AppData()->TimeProvider->Now();
+    TStringStream str;
+    HTML(str) {
+        PRE() {
+            str << "Local locks: " << Locks.size() << Endl;
+            for (const auto& [id, lock] : Locks) {
+                str << "    Id: " << id
+                    << " Local subscribers: " << lock.LocalSubscribers.size()
+                    << " Remote subscribers: " << lock.RemoteSubscribers.size()
+                    << " Timestamp: " << lock.Timestamp
+                    << " (Age: " << (now - lock.Timestamp).MilliSeconds() << "ms)"
+                    << Endl;
+            }
+        }
+        PRE() {
+            str << "Proxy nodes: " << ProxyNodes.size() << Endl;
+            for (const auto& [nodeId, node] : ProxyNodes) {
+                str << "    NodeId: " << nodeId
+                    << " State: " << static_cast<int>(node.State)
+                    << " Locks: " << node.Locks.size()
+                    << Endl;
+                for (const auto& [lockId, lock] : node.Locks) {
+                    str << "        LockId: " << lockId
+                        << " State: " << static_cast<int>(lock.State)
+                        << " Timestamp: ";
+                    if (lock.TimestampReady) {
+                        str << lock.Timestamp
+                            << " (Age: " << (now - lock.Timestamp).MilliSeconds() << "ms)";
+                    } else {
+                        str << "(not ready)";
+                    }
+                    str << Endl;
+                }
+            }
+        }
+        PRE() {
+            str << "Wait edges: " << WaitEdges.size() << Endl;
+            str << "Lock islands: " << LockIslands.size() << Endl;
+            TVector<const TWaitEdge*> islandEdges;
+            for (const auto& [id, island] : LockIslands) {
+                str << "Island " << id << ": " << island.LocksCount << " locks" << Endl;
+                islandEdges.clear();
+                for (const auto& lock : island.Locks) {
+                    for (const auto& blocker : lock.Blockers) {
+                        islandEdges.push_back(&blocker);
+                    }
+                }
+                auto sortingTuple = [&](const TWaitEdge* edge) {
+                    return std::tuple(
+                        edge->Awaiter.LockNodeId(SelfId()), edge->Awaiter.LockId(),
+                        edge->Blocker.LockNodeId(SelfId()), edge->Blocker.LockId());
+                };
+                std::sort(
+                    islandEdges.begin(), islandEdges.end(),
+                    [&](const TWaitEdge* left, const TWaitEdge* right) {
+                        return sortingTuple(left) < sortingTuple(right);
+                    });
+                for (const auto* edge : islandEdges) {
+                    str << "    (" << edge->Awaiter.LockNodeId(SelfId())
+                        << ", " << edge->Awaiter.LockId() <<  ") -> ("
+                        << edge->Blocker.LockNodeId(SelfId())
+                        << ", " << edge->Blocker.LockId() << ") "
+                        << (edge->Broken ? "(broken) " : "")
+                        << "Id: " << edge->Id
+                        << Endl;
+                }
+            }
+        }
+    }
+    Send(ev->Sender, new NMon::TEvHttpInfoRes(str.Str()));
 }
 
 } // namespace NLongTxService

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/domain.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/mon/mon.h>
 #include <ydb/core/protos/long_tx_service_config.pb.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_handle.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_registry.h>
@@ -1830,7 +1831,7 @@ TString TLongTxServiceActor::RenderLocksMonPage() {
             }
         }
         PRE() {
-            str << "Proxy nodes: " << ProxyNodes.size() << Endl;
+            str << "Remote locks proxy nodes: " << ProxyNodes.size() << Endl;
             for (const auto& [nodeId, node] : ProxyNodes) {
                 str << "    NodeId: " << nodeId
                     << " State: " << static_cast<int>(node.State)

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -5,6 +5,7 @@
 #include <util/string/builder.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/domain.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/protos/long_tx_service_config.pb.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_handle.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_registry.h>
@@ -36,8 +37,10 @@ void TLongTxServiceActor::Bootstrap() {
     Send(SelfId(), new TEvPrivate::TEvSnapshotMaintenance());
 
     if (NActors::TMon* mon = AppData()->Mon) {
-        NMonitoring::TIndexMonPage *actorsMonPage = mon->RegisterIndexPage("actors", "Actors");
-        mon->RegisterActorPage(actorsMonPage, "long_tx_service", "Long Tx Service",
+        NMonitoring::TIndexMonPage* actorsMonPage = mon->RegisterIndexPage("actors", "Actors");
+        NMonitoring::TIndexMonPage* longTxMonPage = actorsMonPage->RegisterIndexPage(
+            "long_tx_service", "Long Tx Service");
+        mon->RegisterActorPage(longTxMonPage, "locks", "Locks",
             false, TActivationContext::ActorSystem(), SelfId());
     }
 
@@ -1797,6 +1800,23 @@ void TLongTxServiceActor::UpdateImmutableSnapshotsRegistry() {
 }
 
 void TLongTxServiceActor::Handle(NMon::TEvHttpInfo::TPtr& ev) {
+    TString path(ev->Get()->Request.GetPath());
+    auto pathParts = SplitPath(path);
+    if (pathParts.empty()) {
+        Send(ev->Sender, new NMon::TEvHttpInfoRes("Bad path: " + path));
+        return;
+    }
+    const auto& page = pathParts[pathParts.size() - 1];
+    TString res;
+    if (page == "locks") {
+        res = RenderLocksMonPage();
+    } else {
+        res = "Unknown page: " + page;
+    }
+    Send(ev->Sender, new NMon::TEvHttpInfoRes(std::move(res)));
+}
+
+TString TLongTxServiceActor::RenderLocksMonPage() {
     auto now = AppData()->TimeProvider->Now();
     TStringStream str;
     HTML(str) {
@@ -1804,8 +1824,6 @@ void TLongTxServiceActor::Handle(NMon::TEvHttpInfo::TPtr& ev) {
             str << "Local locks: " << Locks.size() << Endl;
             for (const auto& [id, lock] : Locks) {
                 str << "    Id: " << id
-                    << " Local subscribers: " << lock.LocalSubscribers.size()
-                    << " Remote subscribers: " << lock.RemoteSubscribers.size()
                     << " Timestamp: " << lock.Timestamp
                     << " (Age: " << (now - lock.Timestamp).MilliSeconds() << "ms)"
                     << Endl;
@@ -1866,7 +1884,7 @@ void TLongTxServiceActor::Handle(NMon::TEvHttpInfo::TPtr& ev) {
             }
         }
     }
-    Send(ev->Sender, new NMon::TEvHttpInfoRes(str.Str()));
+    return str.Str();
 }
 
 } // namespace NLongTxService

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.h
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.h
@@ -4,7 +4,7 @@
 
 #include <ydb/core/tx/long_tx_service/public/events.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_registry.h>
-#include <ydb/core/mon/mon.h>
+#include <ydb/library/actors/core/mon.h>
 #include <ydb/core/util/intrusive_heap.h>
 #include <ydb/core/util/ulid.h>
 #include <ydb/library/services/services.pb.h>

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.h
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.h
@@ -501,7 +501,6 @@ namespace NLongTxService {
         void Handle(TEvLongTxService::TEvUpdateLockWaitEdges::TPtr& ev);
         void Handle(TEvLongTxService::TEvGetLockWaitGraph::TPtr& ev);
         void Handle(TEvPrivate::TEvRunDeadlockDetection::TPtr& ev);
-        void Handle(NMon::TEvHttpInfo::TPtr& ev);
 
     private:
         void SendViaSession(const TActorId& sessionId, const TActorId& recipient,
@@ -556,6 +555,10 @@ namespace NLongTxService {
         void UnlinkWaitNode(TWaitNode&);
 
         void ScheduleDeadlockDetection(TLockIsland&, TDuration delay);
+
+    private:
+        void Handle(NMon::TEvHttpInfo::TPtr& ev);
+        TString RenderLocksMonPage();
 
     private:
         const TLongTxServiceSettings Settings;

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.h
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.h
@@ -4,6 +4,7 @@
 
 #include <ydb/core/tx/long_tx_service/public/events.h>
 #include <ydb/core/tx/long_tx_service/public/snapshot_registry.h>
+#include <ydb/core/mon/mon.h>
 #include <ydb/core/util/intrusive_heap.h>
 #include <ydb/core/util/ulid.h>
 #include <ydb/library/services/services.pb.h>
@@ -473,6 +474,7 @@ namespace NLongTxService {
                 hFunc(TEvPrivate::TEvReconnect, Handle);
                 hFunc(TEvPrivate::TEvSnapshotMaintenance, Handle);
                 hFunc(TEvents::TEvUndelivered, Handle);
+                hFunc(NMon::TEvHttpInfo, Handle);
             }
         }
 
@@ -499,6 +501,7 @@ namespace NLongTxService {
         void Handle(TEvLongTxService::TEvUpdateLockWaitEdges::TPtr& ev);
         void Handle(TEvLongTxService::TEvGetLockWaitGraph::TPtr& ev);
         void Handle(TEvPrivate::TEvRunDeadlockDetection::TPtr& ev);
+        void Handle(NMon::TEvHttpInfo::TPtr& ev);
 
     private:
         void SendViaSession(const TActorId& sessionId, const TActorId& recipient,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Fix handling lock status msgs from LongTxActor in datashard StateInactive - missing these messages could result in missed lock deletions.
* Add LongTxActor monitoring page with various locks info.
* Add shard reboots to RandomizedDeadlockDetection test (this is a regression test for the bug)
* Add a simple commit-after-deadlock scenario to datashard read committed tests.
