### PR TITLE
Fix deleted tablets in viewer state

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -7236,6 +7236,26 @@
             "TotalNodes": "3"
         }
     },
+    "test.TestViewer.test_viewer_nodes_deleted_tablets": {
+        "created_tablets": [
+            {
+                "Overall": "Green",
+                "State": "Active",
+                "Type": "DataShard"
+            }
+        ],
+        "deleted_tablets": [
+            {
+                "Overall": "Grey",
+                "State": "Deleted",
+                "Type": "DataShard"
+            }
+        ],
+        "nodes": {
+            "datashards_delta": 0,
+            "non_green_datashards": []
+        }
+    },
     "test.TestViewer.test_viewer_nodes_group": [
         {
             "FieldsAvailable": "1111010000000110100110111111100010111",

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1883,3 +1883,116 @@ class TestViewer(object):
             'filter_peer_role': 'database',
         })
         return result
+
+    @classmethod
+    def test_viewer_nodes_deleted_tablets(cls):
+        def tablet_summary(tablets):
+            return sorted(
+                [{
+                    'Overall': tablet.get('Overall'),
+                    'State': tablet.get('State'),
+                    'Type': tablet.get('Type'),
+                } for tablet in tablets],
+                key=lambda tablet: (tablet['Type'], tablet['State'], tablet['Overall']))
+
+        def node_tablets():
+            response = cls.get_viewer_normalized("/viewer/nodes", {
+                'database': cls.dedicated_db,
+                'tablets': 'true',
+            })
+            tablets = []
+            for node in response.get('Nodes', []):
+                for tablet in node.get('Tablets', []):
+                    tablets.append({
+                        'Count': tablet.get('Count', 1),
+                        'State': tablet.get('State'),
+                        'Type': tablet.get('Type'),
+                    })
+            return sorted(tablets, key=lambda tablet: (tablet['Type'], tablet['State'], tablet['Count']))
+
+        def count_tablets(tablets, tablet_type):
+            return sum(int(tablet.get('Count', 1)) for tablet in tablets if tablet.get('Type') == tablet_type)
+
+        def non_green_datashards(tablets):
+            return [
+                tablet for tablet in tablets
+                if tablet.get('Type') == 'DataShard' and tablet.get('State') != 'Green'
+            ]
+
+        table_name = 'table_deleted_tablet_state'
+        table_path = cls.dedicated_db + '/' + table_name
+
+        cls.call_viewer("/viewer/query", {
+            'database': cls.dedicated_db,
+            'query': 'drop table if exists ' + table_name,
+            'schema': 'multi'
+        })
+
+        baseline_node_tablets = node_tablets()
+        baseline_datashards = count_tablets(baseline_node_tablets, 'DataShard')
+
+        create_result = cls.call_viewer("/viewer/query", {
+            'database': cls.dedicated_db,
+            'query': 'create table ' + table_name + '(id int64, primary key(id))',
+            'schema': 'multi'
+        })
+        assert create_result.get('status') == 'SUCCESS', create_result
+
+        created_tablets = []
+        created_tablet_info = {}
+        for _ in range(30):
+            created_tablet_info = cls.call_viewer("/viewer/tabletinfo", {
+                'database': cls.dedicated_db,
+                'path': table_path,
+                'enums': 'true',
+            })
+            created_tablets = [
+                tablet for tablet in created_tablet_info.get('TabletStateInfo', [])
+                if tablet.get('Type') == 'DataShard'
+            ]
+            if created_tablets and all(
+                tablet.get('State') == 'Active' and tablet.get('Overall') == 'Green'
+                for tablet in created_tablets
+            ):
+                break
+            time.sleep(1)
+        assert created_tablets, created_tablet_info
+        created_tablet_ids = {tablet['TabletId'] for tablet in created_tablets}
+
+        drop_result = cls.call_viewer("/viewer/query", {
+            'database': cls.dedicated_db,
+            'query': 'drop table ' + table_name,
+            'schema': 'multi'
+        })
+        assert drop_result.get('status') == 'SUCCESS', drop_result
+
+        deleted_tablets = []
+        deleted_tablet_info = {}
+        after_drop_node_tablets = []
+        for _ in range(30):
+            deleted_tablet_info = cls.call_viewer("/viewer/tabletinfo", {
+                'database': cls.dedicated_db,
+                'enums': 'true',
+            })
+            deleted_tablets = [
+                tablet for tablet in deleted_tablet_info.get('TabletStateInfo', [])
+                if tablet.get('TabletId') in created_tablet_ids and tablet.get('State') == 'Deleted'
+            ]
+            after_drop_node_tablets = node_tablets()
+            if deleted_tablets and count_tablets(after_drop_node_tablets, 'DataShard') == baseline_datashards:
+                break
+            time.sleep(1)
+
+        assert deleted_tablets, deleted_tablet_info
+        assert all(tablet.get('Overall') == 'Grey' for tablet in deleted_tablets), deleted_tablets
+        assert count_tablets(after_drop_node_tablets, 'DataShard') == baseline_datashards, after_drop_node_tablets
+        assert not non_green_datashards(after_drop_node_tablets), after_drop_node_tablets
+
+        return {
+            'created_tablets': tablet_summary(created_tablets),
+            'deleted_tablets': tablet_summary(deleted_tablets),
+            'nodes': {
+                'datashards_delta': count_tablets(after_drop_node_tablets, 'DataShard') - baseline_datashards,
+                'non_green_datashards': non_green_datashards(after_drop_node_tablets),
+            },
+        }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -1020,6 +1020,7 @@ NKikimrViewer::EFlag GetFlagFromTabletState(NKikimrWhiteboard::TTabletStateInfo:
         flag = NKikimrViewer::EFlag::Yellow;
         break;
     case NKikimrWhiteboard::TTabletStateInfo::Deleted:
+        break;
     case NKikimrWhiteboard::TTabletStateInfo::Active:
         flag = NKikimrViewer::EFlag::Green;
         break;

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -2627,7 +2627,8 @@ public:
                     for (const auto& tabletState : tabletResponse.GetTabletStateInfo()) {
                         TNode* node = FindNode(tabletState.GetNodeId());
                         if (node) {
-                            if (tabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Dead) {
+                            if (tabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Dead
+                                && tabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Deleted) {
                                 NKikimrViewer::TTabletStateInfo& viewerTablet(node->Tablets.emplace_back());
                                 viewerTablet.SetType(NKikimrTabletBase::TTabletTypes::EType_Name(tabletState.GetType()));
                                 viewerTablet.SetState(GetFlagFromTabletState(tabletState.GetState()));
@@ -2643,7 +2644,8 @@ public:
                     TNode* node = FindNode(nodeId);
                     if (node) {
                         for (const auto& protoTabletState : tabletState.GetTabletStateInfo()) {
-                            if (protoTabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Dead) {
+                            if (protoTabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Dead
+                                && protoTabletState.GetState() != NKikimrWhiteboard::TTabletStateInfo::Deleted) {
                                 NKikimrViewer::TTabletStateInfo& viewerTablet(node->Tablets.emplace_back());
                                 viewerTablet.SetType(NKikimrTabletBase::TTabletTypes::EType_Name(protoTabletState.GetType()));
                                 viewerTablet.SetState(GetFlagFromTabletState(protoTabletState.GetState()));


### PR DESCRIPTION
Fixes #41285

Summary:
- Stop mapping deleted tablets to the green viewer flag.
- Exclude deleted tablets from `/viewer/json/nodes` tablet aggregates.
- Add a viewer canon test covering deleted tablet state and node aggregates.

Tests:
- `./ya make --build relwithdebinfo -tA ydb/core/viewer/tests -F *test_viewer_nodes_deleted_tablets*`