### PR TITLE
CI: default Run-tests to small+medium test sizes

### DIFF
--- a/.github/scripts/add_run_tests_table.py
+++ b/.github/scripts/add_run_tests_table.py
@@ -39,8 +39,7 @@ def generate_run_tests_table(pr_number: int, app_domain: str) -> str:
         "ref": "main",
         "pull_number": str(pr_number),
         "test_targets": "ydb/",
-        "test_type": "unittest,py3test,py2test,pytest",
-        "test_size": "small,medium,large",  # All test sizes
+        "test_size": "small,medium",
         "additional_ya_make_args": "",
         "build_preset": "relwithdebinfo",  # Default preset
         "collect_coredumps": "false",

--- a/.github/scripts/add_run_tests_table.py
+++ b/.github/scripts/add_run_tests_table.py
@@ -21,7 +21,7 @@ def normalize_app_domain(app_domain: str) -> str:
 
 
 def generate_run_tests_table(pr_number: int, app_domain: str) -> str:
-    """Generate run tests button with default parameters (relwithdebinfo, all test sizes)."""
+    """Generate run tests button with default parameters (relwithdebinfo, small and medium test sizes)."""
     domain = normalize_app_domain(app_domain)
     base_url = f"https://{domain}/workflow/trigger"
     repo_env = os.environ.get("GITHUB_REPOSITORY")
@@ -31,7 +31,7 @@ def generate_run_tests_table(pr_number: int, app_domain: str) -> str:
     workflow_id = "run_tests.yml"
     return_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
     
-    # Default parameters: relwithdebinfo preset, all test sizes
+    # Default parameters: relwithdebinfo preset, small and medium test sizes
     params = {
         "owner": owner,
         "repo": repo,
@@ -56,7 +56,7 @@ def generate_run_tests_table(pr_number: int, app_domain: str) -> str:
     comment = "<!-- run-tests-table -->\n"
     comment += "<h3>Run Extra Tests</h3>\n\n"
     comment += "Run additional tests for this PR. You can customize:\n"
-    comment += "- **Test Size**: small, medium, large (default: all)\n"
+    comment += "- **Test Size**: small, medium, large (default: small, medium)\n"
     comment += "- **Test Targets**: any directory path (default: `ydb/`)\n"
     comment += "- **Sanitizers**: ASAN, MSAN, TSAN\n"
     comment += "- **Coredumps**: enable for debugging (default: off)\n"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,13 +66,12 @@ on:
         description: 'Test size (small,medium,large)'
         required: false
         type: choice
-        default: small,medium,large
+        default: small,medium
         options:
           - small
           - medium
           - large
           - small,medium
-          - small,medium,large
       additional_ya_make_args:
         description: 'additional args for ya make'
         required: false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ on:
         description: 'Test size (small,medium,large)'
         required: false
         type: string
-        default: small,medium,large
+        default: small,medium
       additional_ya_make_args:
         description: 'additional args for ya make'
         required: false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: ''
       test_size:
-        description: 'Test size: small, medium, large or comma-separated combos (default: small,medium)'
+        description: 'Test size: small, medium, large (default: small,medium)'
         required: false
         type: string
         default: small,medium
@@ -63,7 +63,7 @@ on:
         required: false
         default: ''
       test_size:
-        description: 'Test size: small, medium, large or comma-separated combos (default: small,medium)'
+        description: 'Test size: small, medium, large (default: small,medium)'
         required: false
         type: choice
         default: small,medium

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: ''
       test_size:
-        description: 'Test size (small,medium,large)'
+        description: 'Test size: small, medium, large or comma-separated combos (default: small,medium)'
         required: false
         type: string
         default: small,medium
@@ -63,7 +63,7 @@ on:
         required: false
         default: ''
       test_size:
-        description: 'Test size (small,medium,large)'
+        description: 'Test size: small, medium, large or comma-separated combos (default: small,medium)'
         required: false
         type: choice
         default: small,medium

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,6 +72,7 @@ on:
           - medium
           - large
           - small,medium
+          - small,medium,large
       additional_ya_make_args:
         description: 'additional args for ya make'
         required: false


### PR DESCRIPTION

<img width="433" height="843" alt="image" src="https://github.com/user-attachments/assets/3b93b150-73a1-4b93-93c6-8d9bdbbcc07e" />


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Run-tests and the PR "Run Extra Tests" button previously defaulted to all test sizes (`small,medium,large`), which is expensive and rarely needed for ad-hoc runs.

**Changes:**
- Set default `test_size` to `small,medium` in `run_tests.yml` (`workflow_call` and `workflow_dispatch`).
- Remove the `small,medium,large` preset from `workflow_dispatch` choice options (`large` and other combinations remain available).
- Update the PR comment button to pass `test_size=small,medium` and stop passing an explicit `test_type` (workflow default: all types).
- Fix the "Run Extra Tests" comment text to show the correct default: `small, medium` instead of `all`.

Large tests can still be run manually by selecting `large` or combining sizes in the workflow UI.