### PR TITLE
[Console] Fix per-database YAML config replacing with main config existing selectors

### DIFF
--- a/ydb/library/yaml_config/public/yaml_config.cpp
+++ b/ydb/library/yaml_config/public/yaml_config.cpp
@@ -409,15 +409,15 @@ bool TIncompatibilityRule::TLabelPattern::Matches(
     if (Name != actualLabelName) {
         return false;
     }
-    
+
     bool baseMatch = false;
-    
+
     // If Values is monostate, match any value
     if (std::holds_alternative<std::monostate>(Values)) {
         baseMatch = true;
     } else {
         const auto& valueSet = std::get<THashSet<TString>>(Values);
-        
+
         if (label.Type == TLabel::EType::Empty) {
             // Empty label matches either empty string or $unset marker in pattern
             baseMatch = valueSet.contains("") || valueSet.contains(TIncompatibilityRules::UNSET_LABEL_MARKER);
@@ -426,19 +426,19 @@ bool TIncompatibilityRule::TLabelPattern::Matches(
             baseMatch = valueSet.contains(label.Value);
         }
     }
-    
+
     // Apply negation if needed
     return Negated ? !baseMatch : baseMatch;
 }
 
 TIncompatibilityRules TIncompatibilityRules::GetDefaultRules() {
     TIncompatibilityRules rules;
-    
+
     auto addRequiredLabelRule = [&](const TString& labelName) {
         TIncompatibilityRule rule;
         rule.RuleName = TString("builtin_") + labelName + "_must_have_value";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern;
         pattern.Name = labelName;
         THashSet<TString> valueSet;
@@ -446,23 +446,23 @@ TIncompatibilityRules TIncompatibilityRules::GetDefaultRules() {
         valueSet.insert("");
         pattern.Values = std::move(valueSet);
         pattern.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern));
         rules.AddRule(std::move(rule));
     };
-    
+
     auto addMustBeDefinedRule = [&](const TString& labelName) {
         TIncompatibilityRule rule;
         rule.RuleName = TString("builtin_") + labelName + "_must_be_defined";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern;
         pattern.Name = labelName;
         THashSet<TString> valueSet;
         valueSet.insert(UNSET_LABEL_MARKER);
         pattern.Values = std::move(valueSet);
         pattern.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern));
         rules.AddRule(std::move(rule));
     };
@@ -472,101 +472,101 @@ TIncompatibilityRules TIncompatibilityRules::GetDefaultRules() {
     addRequiredLabelRule("node_host");
     addRequiredLabelRule("node_id");
     addRequiredLabelRule("rev");
-    
+
     addMustBeDefinedRule("node_type");
     addMustBeDefinedRule("tenant");
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_static_with_nonempty_tenant";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("false");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "tenant";
         THashSet<TString> valueSet2;
         valueSet2.insert("");
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = true;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_static_with_nonempty_node_type";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("false");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "node_type";
         THashSet<TString> valueSet2;
         valueSet2.insert("");
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = true;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     auto addStaticNodeCloudLabelRule = [&](const TString& labelName) {
         TIncompatibilityRule rule;
         rule.RuleName = TString("builtin_static_with_") + labelName;
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("false");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = labelName;
         THashSet<TString> valueSet2;
         valueSet2.insert(UNSET_LABEL_MARKER);
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = true;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     };
-    
+
     addStaticNodeCloudLabelRule("enable_auth");
     addStaticNodeCloudLabelRule("flavour");
     addStaticNodeCloudLabelRule("node_name");
     addStaticNodeCloudLabelRule("shared");
     addStaticNodeCloudLabelRule("ydb_postgres");
     addStaticNodeCloudLabelRule("ydbcp");
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_dynamic_without_valid_tenant";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("true");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "tenant";
         THashSet<TString> valueSet2;
@@ -574,146 +574,146 @@ TIncompatibilityRules TIncompatibilityRules::GetDefaultRules() {
         valueSet2.insert("");
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_dynamic_without_flavour";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("true");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "flavour";
         THashSet<TString> valueSet2;
         valueSet2.insert(UNSET_LABEL_MARKER);
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_dynamic_without_ydbcp";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("true");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "ydbcp";
         THashSet<TString> valueSet2;
         valueSet2.insert(UNSET_LABEL_MARKER);
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_cloud_node_without_enable_auth";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "dynamic";
         THashSet<TString> valueSet1;
         valueSet1.insert("true");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "node_type";
         THashSet<TString> valueSet2;
         valueSet2.insert("");
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern3;
         pattern3.Name = "enable_auth";
         THashSet<TString> valueSet3;
         valueSet3.insert(UNSET_LABEL_MARKER);
         pattern3.Values = std::move(valueSet3);
         pattern3.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rule.Patterns.push_back(std::move(pattern3));
         rules.AddRule(std::move(rule));
     }
-    
+
     {
         TIncompatibilityRule rule;
         rule.RuleName = "builtin_slot_type_static";
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "node_type";
         THashSet<TString> valueSet1;
         valueSet1.insert("slot");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = "dynamic";
         THashSet<TString> valueSet2;
         valueSet2.insert("false");
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = false;
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     }
-    
+
     auto addSlotNodeCloudLabelRule = [&](const TString& labelName) {
         TIncompatibilityRule rule;
         rule.RuleName = TString("builtin_slot_with_") + labelName;
         rule.Source = TIncompatibilityRule::ESource::BuiltIn;
-        
+
         TIncompatibilityRule::TLabelPattern pattern1;
         pattern1.Name = "node_type";
         THashSet<TString> valueSet1;
         valueSet1.insert("slot");
         pattern1.Values = std::move(valueSet1);
         pattern1.Negated = false;
-        
+
         TIncompatibilityRule::TLabelPattern pattern2;
         pattern2.Name = labelName;
         THashSet<TString> valueSet2;
         valueSet2.insert(UNSET_LABEL_MARKER);
         pattern2.Values = std::move(valueSet2);
         pattern2.Negated = true;  // IS set (NOT unset)
-        
+
         rule.Patterns.push_back(std::move(pattern1));
         rule.Patterns.push_back(std::move(pattern2));
         rules.AddRule(std::move(rule));
     };
-    
+
     addSlotNodeCloudLabelRule("enable_auth");
     addSlotNodeCloudLabelRule("node_name");
     addSlotNodeCloudLabelRule("shared");
     addSlotNodeCloudLabelRule("ydb_postgres");
 
-    
+
     return rules;
 }
 
@@ -733,29 +733,29 @@ bool TIncompatibilityRules::IsCompatible(
         if (DisabledRules.contains(ruleName)) {
             continue;
         }
-        
+
         bool allPatternsMatch = true;
         for (const auto& pattern : rule.Patterns) {
             bool found = false;
-            
+
             for (size_t i = 0; i < combination.size(); ++i) {
                 if (pattern.Matches(combination[i], labelNames[i].first)) {
                     found = true;
                     break;
                 }
             }
-            
+
             if (!found) {
                 allPatternsMatch = false;
                 break;
             }
         }
-        
+
         if (allPatternsMatch) {
             return false;
         }
     }
-    
+
     return true;
 }
 
@@ -764,19 +764,19 @@ bool TIncompatibilityRules::IsCompatible(const TMap<TString, TString>& labels) c
         if (DisabledRules.contains(ruleName)) {
             continue;
         }
-        
+
         bool allPatternsMatch = true;
         for (const auto& pattern : rule.Patterns) {
             auto it = labels.find(pattern.Name);
-            
+
             bool baseMatch = false;
-            
+
             // If Values is monostate, match any value
             if (std::holds_alternative<std::monostate>(pattern.Values)) {
             baseMatch = (it != labels.end());  // Only match if label exists
         } else {
             const auto& valueSet = std::get<THashSet<TString>>(pattern.Values);
-            
+
             if (it == labels.end()) {
                 // Label is completely missing - matches $unset marker only
                 baseMatch = valueSet.contains(TIncompatibilityRules::UNSET_LABEL_MARKER);
@@ -788,20 +788,20 @@ bool TIncompatibilityRules::IsCompatible(const TMap<TString, TString>& labels) c
                 baseMatch = valueSet.contains(it->second);
             }
         }
-        
+
         bool matches = pattern.Negated ? !baseMatch : baseMatch;
-        
+
         if (!matches) {
             allPatternsMatch = false;
             break;
         }
     }
-    
+
         if (allPatternsMatch) {
             return false;
         }
     }
-    
+
     return true;
 }
 
@@ -809,7 +809,7 @@ void TIncompatibilityRules::MergeWith(const TIncompatibilityRules& userRules) {
     for (const auto& ruleName : userRules.DisabledRules) {
         DisabledRules.insert(ruleName);
     }
-    
+
     for (const auto& [name, rule] : userRules.RulesByName) {
         AddRule(rule);
     }
@@ -817,13 +817,13 @@ void TIncompatibilityRules::MergeWith(const TIncompatibilityRules& userRules) {
 
 TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root) {
     TIncompatibilityRules userRules;
-    
+
     if (!root.Map().Has("incompatibility_overrides")) {
         return userRules;
     }
-    
+
     auto overrides = root.Map().at("incompatibility_overrides");
-    
+
     if (overrides.Map().Has("disable_all_builtin_rules")) {
         auto value = overrides.Map().at("disable_all_builtin_rules").Scalar();
         if (value == "true") {
@@ -833,7 +833,7 @@ TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root) {
             }
         }
     }
-    
+
     if (overrides.Map().Has("disable_rules")) {
         auto disableRules = overrides.Map().at("disable_rules");
         if (disableRules.Type() == NFyaml::ENodeType::Sequence) {
@@ -842,32 +842,32 @@ TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root) {
             }
         }
     }
-    
+
     if (overrides.Map().Has("custom_rules")) {
         auto customRules = overrides.Map().at("custom_rules");
         if (customRules.Type() == NFyaml::ENodeType::Sequence) {
             for (auto ruleIt = customRules.Sequence().begin(); ruleIt != customRules.Sequence().end(); ++ruleIt) {
                 TIncompatibilityRule rule;
                 auto ruleMap = ruleIt->Map();
-                
+
                 rule.RuleName = ruleMap.at("name").Scalar();
                 rule.Source = TIncompatibilityRule::ESource::UserDefined;
-                
+
                 if (ruleMap.Has("patterns")) {
                     auto patterns = ruleMap.at("patterns");
                     if (patterns.Type() == NFyaml::ENodeType::Sequence) {
                         for (auto patternIt = patterns.Sequence().begin(); patternIt != patterns.Sequence().end(); ++patternIt) {
                             TIncompatibilityRule::TLabelPattern pattern;
                             auto patternMap = patternIt->Map();
-                            
+
                             pattern.Name = patternMap.at("label").Scalar();
-                            
+
                             // Check for negation
                             if (patternMap.Has("negated")) {
                                 TString negatedStr = patternMap.at("negated").Scalar();
                                 pattern.Negated = (negatedStr == "true");
                             }
-                            
+
                             // Helper to process value strings
                             // Keep $unset as-is, map $empty to empty string
                             auto processValue = [](const TString& valueStr) -> TString {
@@ -877,7 +877,7 @@ TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root) {
                                     return valueStr;  // Includes $unset as-is
                                 }
                             };
-                            
+
                             // Parse value or value_in
                             if (patternMap.Has("value_in")) {
                                 // Multiple values
@@ -897,17 +897,17 @@ TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root) {
                             }
                             // else: neither value nor value_in specified
                             // pattern.Values remains std::monostate (default-constructed)
-                            
+
                             rule.Patterns.push_back(std::move(pattern));
                         }
                     }
                 }
-                
+
                 userRules.AddRule(std::move(rule));
             }
         }
     }
-    
+
     return userRules;
 }
 
@@ -1211,7 +1211,7 @@ void ResolveUniqueDocs(
             auto resolvedDoc = states.back().Doc.Clone();
             RemoveTags(resolvedDoc);
             auto resolvedConfig = resolvedDoc.Root().Map().at("config");
-            
+
             size_t h = Hash(resolvedConfig);
             if (seenHashes.emplace(h).second) {
                 onDocument(TDocumentConfig{std::move(resolvedDoc), resolvedConfig});
@@ -1305,7 +1305,7 @@ description: Implicit DatabaseConfig node
 selector: {}
 )"));
     auto node = databaseConfigRoot.Map()["config"].Copy(config);
-    selectors.at(0).Map().Append(config.Buildf("config"), node);
+    selectors.at(selectors.size() - 1).Map().Append(config.Buildf("config"), node);
 }
 
 // Storage-only keys that should not be included in dynamic node configs

--- a/ydb/library/yaml_config/yaml_config_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_ut.cpp
@@ -1519,6 +1519,147 @@ Y_UNIT_TEST_SUITE(YamlConfig) {
         stream << cfg;
     }
 
+    void AppendDatabaseConfigBase(
+        const TString mainConfig,
+        const TString databaseConfig)
+    {
+        auto treeOriginal = NFyaml::TDocument::Parse(mainConfig);
+        auto tree = NFyaml::TDocument::Parse(mainConfig);
+        auto dbTree = NFyaml::TDocument::Parse(databaseConfig);
+
+        const size_t selectorsCountBefore =
+            tree.Root().Map().Has("selector_config")
+                ? tree.Root().Map().at("selector_config").Sequence().size()
+                : 0;
+
+        // Add empty selector_config nodes to avoid processing missing YAML
+        // nodes
+        if (!tree.Root().Map().Has("selector_config")) {
+            tree.Root().Map().Append(
+                tree.Buildf("selector_config"),
+                tree.Buildf("[]"));
+        }
+        if (!treeOriginal.Root().Map().Has("selector_config")) {
+            treeOriginal.Root().Map().Append(
+                treeOriginal.Buildf("selector_config"),
+                treeOriginal.Buildf("[]"));
+        }
+
+        UNIT_ASSERT_NO_EXCEPTION(
+            NKikimr::NYamlConfig::AppendDatabaseConfig(tree, dbTree));
+
+        auto selectors = tree.Root().Map().at("selector_config").Sequence();
+        UNIT_ASSERT_VALUES_EQUAL(selectors.size(), selectorsCountBefore + 1);
+
+        auto lastSelector = selectors.at(selectors.size() - 1).Map();
+        UNIT_ASSERT(lastSelector.Has("config"));
+
+        // Check that main config selectors have not changed
+        auto selectorsOriginal =
+            treeOriginal.Root().Map().at("selector_config").Sequence();
+
+        for (size_t i = 0; i < selectorsCountBefore; i++) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                selectors.at(i).Map().size(),
+                selectorsOriginal.at(i).Map().size());
+
+            // Сheck all map elements (description, selector, config)
+            for (auto field = selectors.at(i).Map().begin(),
+                      fieldOrig = selectorsOriginal.at(i).Map().begin();
+                 field != selectors.at(i).Map().end();
+                 field++, fieldOrig++)
+            {
+                TStringStream fieldStr;
+                fieldStr << field->Key() << ": " << field->Value();
+
+                TStringStream fieldOriginalStr;
+                fieldOriginalStr << fieldOrig->Key() << ": "
+                                 << fieldOrig->Value();
+
+                UNIT_ASSERT_VALUES_EQUAL(
+                    fieldStr.Str(),
+                    fieldOriginalStr.Str());
+            }
+        }
+
+        // Check that the db config selector is appended to the end of the main
+        // config selectors
+        TStringStream actualLastConfig;
+        actualLastConfig << lastSelector.at("config");
+
+        TStringStream expectedConfig;
+        expectedConfig << dbTree.Root().Map().at("config");
+
+        UNIT_ASSERT_VALUES_EQUAL(actualLastConfig.Str(), expectedConfig.Str());
+    }
+
+    Y_UNIT_TEST(AppendDatabaseConfigAsTheOnlySelector)
+    {
+        const TString mainConfig = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 0
+config:
+  feature_flags:
+    some_param_1: true
+)";
+
+        const TString databaseConfig = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc/tenant"
+  version: 0
+config:
+  feature_flags: !inherit
+    some_param_1: false
+)";
+
+        AppendDatabaseConfigBase(mainConfig, databaseConfig);
+    }
+
+    Y_UNIT_TEST(AppendDatabaseConfigAfterExistingSelectors)
+    {
+        const TString mainConfig = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 0
+config:
+  feature_flags:
+    some_param_1: true
+selector_config:
+- description: pre-existing selector 1 with config
+  selector:
+    tenant: dynamic
+  config:
+    feature_flags: !inherit
+      some_param_2: true
+- description: pre-existing selector 2 with config
+  selector:
+    tenant: dynamic
+  config:
+    feature_flags: !inherit
+      some_param_3: true
+)";
+
+        const TString databaseConfig = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc/tenant"
+  version: 0
+config:
+  feature_flags: !inherit
+    some_param_1: false
+)";
+
+        AppendDatabaseConfigBase(mainConfig, databaseConfig);
+    }
+
     Y_UNIT_TEST(GetMetadata) {
         {
             TString str = R"(
@@ -2080,19 +2221,19 @@ Y_UNIT_TEST(AllTestConfigs) {
             uniqDocs.insert(toStr(cfg.second));
         }
 
-        UNIT_ASSERT_VALUES_EQUAL_C(uniqDocs.size(), resolvedUniq.size(), 
+        UNIT_ASSERT_VALUES_EQUAL_C(uniqDocs.size(), resolvedUniq.size(),
             TString("Config: ") + name + ", ResolveUniqueDocs has duplicates");
 
         for (const auto& s : uniqDocs) {
-            UNIT_ASSERT_C(allDocs.contains(s), 
+            UNIT_ASSERT_C(allDocs.contains(s),
                 TString("Config: ") + name + ", ResolveUniqueDocs has extra doc not in ResolveAll");
         }
 
-        UNIT_ASSERT_VALUES_EQUAL_C(allDocs.size(), uniqDocs.size(), 
+        UNIT_ASSERT_VALUES_EQUAL_C(allDocs.size(), uniqDocs.size(),
             TString("Config: ") + name + ", size mismatch");
 
         for (const auto& s : allDocs) {
-            UNIT_ASSERT_C(uniqDocs.contains(s), 
+            UNIT_ASSERT_C(uniqDocs.contains(s),
                 TString("Config: ") + name + ", ResolveUniqueDocs missing doc from ResolveAll");
         }
     };


### PR DESCRIPTION
### Changelog entry

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

## Summary

Before this fix, applying a per-database YAML config on top of a main cluster YAML config that already had **one or more selectors** was impossible: the `replace` request failed outright with an error. The helper that splices the per-database YAML config into the main config tree was about to corrupt the first existing selector (it glued an extra `config` key onto it), which lead to error and the entire `replace` was rejected, nothing was stored.

If the main config had **no** selectors at all the bug was hidden — the corruption-target selector index pointed at the (single) freshly appended selector, so the same code accidentally did the right thing. Pre-fix, you could therefore apply a per-database YAML config to a tenant *only* on a main config without selectors.

The root cause was a wrong index into the selector list inside the helper.

## Fix

Write the database `config` mapping onto the freshly appended selector instead of onto the first existing selector. The append step itself was already correct — only the subsequent write was indexing the wrong selector.

## Detailed

### Root cause

`NKikimr::NYamlConfig::AppendDatabaseConfig` in [ydb/library/yaml_config/public/yaml_config.cpp](ydb/library/yaml_config/public/yaml_config.cpp) appends a new selector to `selector_config`, but then writes the `config` mapping into `selectors.at(0)` instead of the freshly appended selector. When the main config already has selectors, this:

- leaves the new selector with only `description` and `selector` but no `config`;
- produces an exception on on trying to add duplicate `config` key into existing first selector and fails — Console rejects the whole `replace`, so the per-database YAML config can't be stored at all when any pre-existing selector is present.

When the main config has zero selectors, `selectors.at(0)` happens to coincide with the just-appended selector (it is the only one), the validator passes, and the helper accidentally produces the correct result.

### Fix

Use `selectors.at(selectors.size() - 1)` — the selector that was just added — instead of `selectors.at(0)`.

### Tests

Two new unit tests in [ydb/library/yaml_config/yaml_config_ut.cpp](ydb/library/yaml_config/yaml_config_ut.cpp):

- `AppendDatabaseConfigAsTheOnlySelector` — main config has no pre-existing selectors.
- `AppendDatabaseConfigAfterExistingSelectors` — main config already has two selectors; verifies they remain untouched and the database selector is appended after them with its `config` mapping intact.

## Test plan

- [`v`] `ya make -t ydb/library/yaml_config` — new unit tests pass.
- [`v`] Apply a per-database YAML config on top of a main config that already has selectors; verify `replace` succeeds (it used to be rejected), the database overrides take effect on the target tenant, and existing selectors are not corrupted.
