### PR TITLE
[Console, ydb cli] Fix per-database YAML config fetching via ydb cli

### DIFF
--- a/ydb/core/cms/console/console__get_yaml_config.cpp
+++ b/ydb/core/cms/console/console__get_yaml_config.cpp
@@ -40,8 +40,9 @@ public:
         Response->Record.MutableResponse()->add_config(Self->MainYamlConfig);
 
         for (const auto& [database, config] : Self->DatabaseYamlConfigs) {
-            Response->Record.MutableResponse()->add_identity()->set_database(database);
-            Response->Record.MutableResponse()->add_identity()->set_version(config.Version);
+            auto& dbIdentity = *Response->Record.MutableResponse()->add_identity();
+            dbIdentity.set_database(database);
+            dbIdentity.set_version(config.Version);
             Response->Record.MutableResponse()->add_config(config.Config);
         }
 

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -55,13 +55,13 @@ bool ConvertGetConfigToFetchConfigResult(
     if (identityCount < configCount) {
         TStringBuilder descr;
         descr << (configCount - identityCount)
-              << " extra 'config' with no corresponding 'identity'";
+              << " extra 'config' field with no corresponding 'identity' field";
         error = descr;
         return false;
     }
     if (identityCount > configCount) {
         TStringBuilder descr;
-        descr << "no 'config' for 'identity'es [";
+        descr << "no 'config' fields for 'identity' fields [";
         for (int i = configCount; i < identityCount; i++) {
             if (i > configCount) {
                 descr << ", ";
@@ -78,7 +78,7 @@ bool ConvertGetConfigToFetchConfigResult(
         TStringBuilder descr;
         int unsetCount = 0;
 
-        descr << "'identity' with no type set at indices [";
+        descr << "'identity' fields with no type set at indices [";
         for (int i = 0; i < identityCount; i++) {
             if (from.identity(i).type_case()
                 == Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET)

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -13,6 +13,127 @@
 #include <ydb/core/base/auth.h>
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
+#include <ydb/library/services/services.pb.h>
+
+namespace {
+
+TString DescribeConfigIdentity(const Ydb::DynamicConfig::ConfigIdentity& id)
+{
+    TStringBuilder descr;
+
+    switch (id.type_case()) {
+        case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kCluster:
+            descr << "cluster=" << id.cluster();
+            break;
+        case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase:
+            descr << "database=" << id.database();
+            break;
+        case Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET:
+            descr << "<TYPE_NOT_SET>";
+            break;
+        default:
+            descr << "<unknown-type:" << static_cast<int>(id.type_case()) << ">";
+            break;
+    }
+
+    descr << ";version=" << id.version();
+
+    return descr;
+}
+
+bool ConvertGetConfigToFetchConfigResult(
+    const Ydb::DynamicConfig::GetConfigResult &from,
+    Ydb::Config::FetchConfigResult &to,
+    TString& error)
+{
+    const auto identityCount = from.identity_size();
+    const auto configCount = from.config_size();
+
+    error.clear();
+
+    // Reject Ydb::DynamicConfig::GetConfigResult invariant violation
+    if (identityCount < configCount) {
+        TStringBuilder descr;
+        descr << (configCount - identityCount)
+              << " extra 'config' with no corresponding 'identity'";
+        error = descr;
+        return false;
+    }
+    if (identityCount > configCount) {
+        TStringBuilder descr;
+        descr << "no 'config' for 'identity'es [";
+        for (int i = configCount; i < identityCount; i++) {
+            if (i > configCount) {
+                descr << ", ";
+            }
+            descr << "'" << DescribeConfigIdentity(from.identity(i)) << "'";
+        }
+        descr << "]";
+        error = descr;
+        return false;
+    }
+
+    // Reject TYPE_NOT_SET upfront so the error path leaves 'to' untouched
+    {
+        TStringBuilder descr;
+        int unsetCount = 0;
+
+        descr << "'identity' with no type set at indices [";
+        for (int i = 0; i < identityCount; i++) {
+            if (from.identity(i).type_case()
+                == Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET)
+            {
+                if (unsetCount > 0) {
+                    descr << ", ";
+                }
+                descr << "#" << i << " - " << "'" << DescribeConfigIdentity(from.identity(i)) << "'";
+                ++unsetCount;
+            }
+        }
+        descr << "]";
+
+        if (unsetCount > 0) {
+            error = descr;
+            return false;
+        }
+    }
+
+    for (int i = 0; i < identityCount; i++) {
+        const auto& srcIdentity = from.identity(i);
+        switch (srcIdentity.type_case()) {
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kCluster: {
+                auto dstEntry = to.add_config();
+                auto dstIdentity = dstEntry->mutable_identity();
+                dstIdentity->set_version(srcIdentity.version());
+                dstIdentity->set_cluster(srcIdentity.cluster());
+                dstIdentity->mutable_main();
+                dstEntry->set_config(from.config(i));
+                break;
+            }
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase: {
+                auto dstEntry = to.add_config();
+                auto dstIdentity = dstEntry->mutable_identity();
+                dstIdentity->set_version(srcIdentity.version());
+                dstIdentity->mutable_database()->set_database(srcIdentity.database());
+                dstEntry->set_config(from.config(i));
+                break;
+            }
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET:
+                // TYPE_NOT_SET is rejected with error by pre-validation above
+                break;
+            default:
+                // Any other value comes from a newer Console is skipped with a warning
+                // so we don't fail on forward-compatible additions
+                ALOG_NOTICE(NKikimrServices::GRPC_SERVER,
+                    "Convert Ydb::DynamicConfig::ConfigIdentity to Ydb::Config::FetchConfigResult: "
+                    << "skipped unknown config identity '" << DescribeConfigIdentity(srcIdentity) << "'" );
+                break;
+        }
+    }
+    return true;
+}
+
+} // namespace
 
 namespace NKikimr::NGRpcService {
 
@@ -88,32 +209,6 @@ bool CopyToConfigRequest(const Ydb::Config::FetchConfigRequest &/*from*/, NKikim
     to->AddCommand()->MutableReadHostConfig();
     to->AddCommand()->MutableReadBox();
     return true;
-}
-
-void ConvertGetConfigToFetchConfigResult(
-    const Ydb::DynamicConfig::GetConfigResult &from,
-    Ydb::Config::FetchConfigResult &to)
-{
-    const int pairs = std::min(from.identity_size(), from.config_size());
-    for (int i = 0; i < pairs; ++i) {
-        const auto& srcIdentity = from.identity(i);
-        auto entry = to.add_config();
-        auto dstIdentity = entry->mutable_identity();
-        dstIdentity->set_version(srcIdentity.version());
-        switch (srcIdentity.type_case()) {
-            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kCluster:
-                dstIdentity->set_cluster(srcIdentity.cluster());
-                dstIdentity->mutable_main();
-                break;
-            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase:
-                dstIdentity->mutable_database()->set_database(srcIdentity.database());
-                break;
-            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET:
-                dstIdentity->mutable_main();
-                break;
-        }
-        entry->set_config(from.config(i));
-    }
 }
 
 void CopyFromConfigResponse(const NKikimrBlobStorage::TConfigResponse &from, Ydb::Config::FetchConfigResult *to) {
@@ -573,8 +668,18 @@ private:
 
     void Handle(NConsole::TEvConsole::TEvGetAllConfigsResponse::TPtr& ev) {
         Ydb::Config::FetchConfigResult result;
-        ConvertGetConfigToFetchConfigResult(ev->Get()->Record.GetResponse(), result);
-        ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ActorContext());
+        TString error;
+
+        bool succeed = ConvertGetConfigToFetchConfigResult(ev->Get()->Record.GetResponse(), result, error);
+        if (succeed) {
+            ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ActorContext());
+        }
+        else {
+            // The malformed payload comes from the Console tablet (server-side),
+            // not from the gRPC client — so this is an internal-error condition.
+            Reply(Ydb::StatusIds::INTERNAL_ERROR, error,
+                NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
+        }
     }
 };
 

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -90,6 +90,32 @@ bool CopyToConfigRequest(const Ydb::Config::FetchConfigRequest &/*from*/, NKikim
     return true;
 }
 
+void ConvertGetConfigToFetchConfigResult(
+    const Ydb::DynamicConfig::GetConfigResult &from,
+    Ydb::Config::FetchConfigResult &to)
+{
+    const int pairs = std::min(from.identity_size(), from.config_size());
+    for (int i = 0; i < pairs; ++i) {
+        const auto& srcIdentity = from.identity(i);
+        auto entry = to.add_config();
+        auto dstIdentity = entry->mutable_identity();
+        dstIdentity->set_version(srcIdentity.version());
+        switch (srcIdentity.type_case()) {
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kCluster:
+                dstIdentity->set_cluster(srcIdentity.cluster());
+                dstIdentity->mutable_main();
+                break;
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase:
+                dstIdentity->mutable_database()->set_database(srcIdentity.database());
+                break;
+            case Ydb::DynamicConfig::ConfigIdentity::TypeCase::TYPE_NOT_SET:
+                dstIdentity->mutable_main();
+                break;
+        }
+        entry->set_config(from.config(i));
+    }
+}
+
 void CopyFromConfigResponse(const NKikimrBlobStorage::TConfigResponse &from, Ydb::Config::FetchConfigResult *to) {
     auto hostConfigStatus = from.GetStatus()[0];
     auto boxStatus = from.GetStatus()[1];
@@ -412,6 +438,8 @@ public:
         self->OnBootstrap();
 
         if (self->Request_->GetDatabaseName()) {
+            // Database YAML config (Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase)
+            // is requested directly from Console (like legacy API)
             SendRequestToConsole();
             return;
         }
@@ -544,7 +572,9 @@ private:
     }
 
     void Handle(NConsole::TEvConsole::TEvGetAllConfigsResponse::TPtr& ev) {
-        ReplyWithResult(Ydb::StatusIds::SUCCESS, ev->Get()->Record.GetResponse(), ActorContext());
+        Ydb::Config::FetchConfigResult result;
+        ConvertGetConfigToFetchConfigResult(ev->Get()->Record.GetResponse(), result);
+        ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ActorContext());
     }
 };
 

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -319,7 +319,7 @@ TString ReplaceMetadata(const TString& config, const TMainMetadata& metadata);
 /**
  * Takes valid MainConfig and increases version exactly by one
  */
-TString UpgradeMainConfigVersion(const TString &config);
+TString UpgradeMainConfigVersion(const TString& config);
 
 /**
  * Takes valid StorageConfig and increases version exactly by one

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -110,13 +110,13 @@ struct TIncompatibilityRule {
         TString Name;
         std::variant<std::monostate, THashSet<TString>> Values;
         bool Negated = false;
-        
+
         bool Matches(const TLabel& label, const TString& actualLabelName) const;
     };
-    
+
     TVector<TLabelPattern> Patterns;
     TString RuleName;
-    
+
     enum class ESource {
         BuiltIn,
         UserDefined
@@ -128,19 +128,19 @@ class TIncompatibilityRules {
 public:
     static constexpr const char* UNSET_LABEL_MARKER = "$unset";
     static constexpr const char* EMPTY_LABEL_MARKER = "$empty";
-    
+
     static TIncompatibilityRules GetDefaultRules();
-    
+
     void AddRule(TIncompatibilityRule rule);
     void RemoveRule(const TString& ruleName);
-    
+
     bool IsCompatible(const TVector<TLabel>& combination,
                      const TVector<std::pair<TString, TSet<TLabel>>>& labelNames) const;
-    
+
     bool IsCompatible(const TMap<TString, TString>& labels) const;
-    
+
     void MergeWith(const TIncompatibilityRules& userRules);
-    
+
     size_t GetRuleCount() const { return RulesByName.size(); }
     size_t GetDisabledCount() const { return DisabledRules.size(); }
 
@@ -149,7 +149,7 @@ public:
 private:
     TMap<TString, TIncompatibilityRule> RulesByName;
     THashSet<TString> DisabledRules;
-    
+
     friend TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root);
 };
 
@@ -319,10 +319,10 @@ TString ReplaceMetadata(const TString& config, const TMainMetadata& metadata);
 /**
  * Takes valid MainConfig and increases version exactly by one
  */
- TString UpgradeMainConfigVersion(const TString& config);
+TString UpgradeMainConfigVersion(const TString &config);
 
 /**
- * Takes valid MainConfig and increases version exactly by one
+ * Takes valid StorageConfig and increases version exactly by one
  */
 TString UpgradeStorageConfigVersion(const TString& config);
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -180,6 +180,7 @@ int TCommandConfigFetch::Run(TConfig& config) {
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
     TString clusterConfig;
     TString storageConfig;
+    TString databaseConfig;
 
     for (const auto& entry : result.GetConfigs()) {
         std::visit([&](auto&& arg) {
@@ -192,6 +193,8 @@ int TCommandConfigFetch::Run(TConfig& config) {
                 if (DedicatedStorageSection || !DedicatedClusterSection) {
                     storageConfig = entry.Config;
                 }
+            } else if constexpr (std::is_same_v<T, NYdb::NConfig::TDatabaseConfigIdentity>) {
+                databaseConfig = entry.Config;
             }
         }, entry.Identity);
     }
@@ -208,7 +211,9 @@ int TCommandConfigFetch::Run(TConfig& config) {
             // and will get attention that something went horribly wrong
             Cerr << "Unable to bump main config version, returning as-is" << Endl;
         }
-        if (!storageConfig.empty() || DedicatedStorageSection) {
+        if (!storageConfig.empty() || !databaseConfig.empty() ||
+            DedicatedStorageSection)
+        {
             Cerr << "cluster config: " << Endl;
         }
         Cout << clusterConfig << Endl;
@@ -224,13 +229,36 @@ int TCommandConfigFetch::Run(TConfig& config) {
             // and will get attention that something went horribly wrong
             Cerr << "Unable to bump storage config version, returning as-is" << Endl;
         }
-        if (!clusterConfig.empty() || DedicatedClusterSection) {
+        if (!clusterConfig.empty() || !databaseConfig.empty() ||
+            DedicatedClusterSection)
+        {
             Cerr << "storage config:" << Endl;
         }
         Cout << storageConfig << Endl;
     }
 
-    if (clusterConfig.empty() && storageConfig.empty()) {
+    if (!databaseConfig.empty()) {
+        // NOTE: there is no native new-API path for per-database YAML config fetch yet —
+        // the request is routed through Console via the legacy API (see
+        // TFetchStorageConfigRequest::Bootstrap() in rpc_config.cpp).
+        // Console's contract for per-database YAML config replace is
+        // wire metadata.version == stored version, so the CLI must return the fetched
+        // body as-is. Bumping metadata.version here would break the next
+        // fetch | edit | replace round-trip — the user would have to manually fix
+        // the version before re-submitting. Once a native new-API path lands,
+        // this branch can mirror the cluster/storage branches and call
+        // UpgradeDatabaseConfigVersion.
+
+        if (!clusterConfig.empty() || !storageConfig.empty() ||
+            DedicatedStorageSection || DedicatedClusterSection)
+        {
+            Cerr << "database config:" << Endl;
+        }
+        Cout << databaseConfig << Endl;
+    }
+
+    if (clusterConfig.empty() && storageConfig.empty() && databaseConfig.empty())
+    {
         Cerr << "No config returned." << Endl;
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
### Changelog entry 

### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers

## Summary

`ydb -d /Root/<db> admin database config fetch` returned `No config returned.` even when a per-database YAML config had been successfully stored in the Console tablet and was being broadcast to subscribers. The fetch path was broken end-to-end at three independent points across Console, the gRPC layer and the CLI:

1. **Console emitted malformed responses.** The loop in Console that builds the response to a "fetch all configs" request emitted *two* half-filled identities per database (one with only `database`, one with only `version`) instead of a single well-formed identity. The parallel `identity[] / config[]` arrays therefore went out of sync.

2. **The gRPC layer forwarded the wrong protobuf type.** The handler for the Console response forwarded an `Ydb::DynamicConfig::GetConfigResult` to the SDK while the gRPC class declared `Ydb::Config::FetchConfigResult`. `Any.type_url` carried the wrong contract and the SDK could not unpack the response.

3. **The CLI fetch path did not recognise per-database YAML config in the response.** Even with a correct response on the wire the CLI's visitor had no branch for `TDatabaseConfigIdentity`, so the database YAML was discarded before printing.

The CLI keeps using the new V2 API (`Ydb.Config.V1.ConfigService.FetchConfig`) for the `database` subcommand. The CLI does **not** bump `metadata.version` on the fetched per-database YAML config — Console's documented contract for replace is wire `metadata.version == stored`, so a fetched body must be re-submittable as-is (PR 3 enforces this contract on the Console side).

The combined effect is that `ydb -d /Root/<db> admin database config fetch` returns the YAML last applied via `admin database config replace`, with `metadata.version` matching the stored version (ready to be edited and re-submitted via `replace`).

## Detailed

### Bug 1 — Console emitted two half-identities per database

In [ydb/core/cms/console/console__get_yaml_config.cpp](ydb/core/cms/console/console__get_yaml_config.cpp) the loop that iterates `DatabaseYamlConfigs` calls `add_identity()` **twice** per entry — once with `database`, once with `version` — instead of populating both fields on the same identity. This produces two half-filled identities per database and breaks the parallel `identity[i] / config[i]` arrays.

Fix: build one identity per database with both `database` and `version` set on the same `add_identity()` call, alongside one `add_config()` per entry.

### Bug 2 — gRPC layer forwarded `GetConfigResult` as `FetchConfigResult`

`TFetchStorageConfigRequest::Handle(NConsole::TEvConsole::TEvGetAllConfigsResponse::TPtr&)` in [ydb/core/grpc_services/rpc_config.cpp](ydb/core/grpc_services/rpc_config.cpp) forwarded the Console response (`Ydb::DynamicConfig::GetConfigResult`) directly. But the gRPC class is `TBSConfigRequestGrpc<…, Ydb::Config::FetchConfigResult>`, so `Any.type_url` was wrong on the wire.

Fix: introduce `ConvertGetConfigToFetchConfigResult(const Ydb::DynamicConfig::GetConfigResult& from, Ydb::Config::FetchConfigResult& to)` placed next to the existing parallel helper `CopyFromConfigResponse` ([rpc_config.cpp around `CopyFromConfigResponse`](ydb/core/grpc_services/rpc_config.cpp)). It walks the parallel `identity[] / config[]` arrays of `from`, and for each pair adds a `ConfigEntry` to `to` whose `identity` is `kCluster → main(cluster)` or `kDatabase → database(database)`, and whose `config` is the YAML body. `volatile_configs` are ignored — they have no place in `FetchConfigResult`. `Handle(TEvGetAllConfigsResponse)` now constructs a local `FetchConfigResult`, fills it via the new helper, and passes that to `ReplyWithResult`.

### Bug 3 — CLI fetch visitor did not recognise per-database YAML config

In [ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp](ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp), `TCommandConfigFetch::Run` invokes a visitor that branches on `TMainConfigIdentity` / `TStorageConfigIdentity` only. A `TDatabaseConfigIdentity` entry in the response is silently dropped.

Fix: add a `TDatabaseConfigIdentity` overload to the visitor that pulls the YAML into a local `databaseConfig`, add an output block printing `database config:` as a section header (only emitted when more than one section is present, matching the existing `cluster config:` / `storage config:` blocks), and update the empty-result check to require *all three* (cluster, storage, database) to be empty before printing `No config returned.`. Unlike the cluster/storage branches, the database branch does **not** call any `Upgrade…ConfigVersion` helper — Console's contract for per-database YAML config replace is wire `metadata.version == stored`, so the CLI must return the fetched body as-is. This contract is enforced on the Console side; once a native new-API path for per-database YAML config lands on the Console side, this branch can mirror the cluster/storage ones and call a future `UpgradeDatabaseConfigVersion` helper.

## End user effect

`ydb -d /Root/<db> admin database config fetch` returns the YAML that was last applied via `admin database config replace`, with `metadata.version` matching the stored version, ready to be edited and re-submitted via `replace`.

## Test plan

- [`v`] `ya make ydb/apps/ydbd ydb/apps/ydb`.
- [`v`] On a local cluster with a tenant (e.g. `/Root/NBS`): apply a per-database YAML config via `ydb -d /Root/NBS admin database config replace -f nbs.yaml`, then run `ydb -d /Root/NBS admin database config fetch` — the same YAML must be returned with `metadata.version` matching the stored version.
- [`v`] Regression: `ydb admin config fetch` (legacy API through Console) still works.
- [`v`] Regression: `ydb admin cluster config fetch` (new V2 API, path through NodeWarden / BSC) still works.
- [`v`] `ya make -t ydb/services/config` (covers `bsconfig_ut.cpp`).

## Out of scope

- `test_config_with_metadata.py::TestKiKiMRStoreConfigDir::test_config_stored_in_config_store` (`use_config_store=True`) routes through BSC's `TEvControllerReplaceConfigRequest`, not Console — see [`mind/bscontroller/console_interaction.cpp:394`](ydb/core/mind/bscontroller/console_interaction.cpp#L394). Any failure there is pre-existing and unrelated to the Console-tablet contract.
- Adding a native per-database YAML config fetch event to Console (the proper architectural analogue of `TEvControllerFetchConfigResponse`) — left as a follow-up. With it, the cross-proto `ConvertGetConfigToFetchConfigResult` helper in `rpc_config.cpp` can be removed, the per-database branch in `TFetchStorageConfigRequest::Bootstrap` made symmetric with the cluster/storage path, and the per-database branch in `ydb_dynamic_config.cpp`'s fetch visitor can mirror the cluster/storage branches by calling a future `UpgradeDatabaseConfigVersion` helper.

