### PR TITLE
[Console] Fix per-database YAML config versioning

### DIFF
--- a/ydb/core/cms/console/console__replace_yaml_config.cpp
+++ b/ydb/core/cms/console/console__replace_yaml_config.cpp
@@ -307,7 +307,7 @@ public:
                 DoInternalAudit(txc, ctx);
 
                 db.Table<Schema::DatabaseYamlConfigs>().Key(TargetDatabase, Version + 1)
-                    .Update<Schema::DatabaseYamlConfigs::Config>(Config);
+                    .Update<Schema::DatabaseYamlConfigs::Config>(UpdatedDatabaseConfig);
 
                 /* Later we shift this boundary to support rollback and history */
                 db.Table<Schema::DatabaseYamlConfigs>().Key(TargetDatabase, Version)

--- a/ydb/core/cms/console/console_configs_manager.cpp
+++ b/ydb/core/cms/console/console_configs_manager.cpp
@@ -77,8 +77,9 @@ void TConfigsManager::ReplaceMainConfigMetadata(const TString &config, bool forc
 
 void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
     try {
+        // Re-applying an unchanged body with the same version is silently accepted
+        // (idempotent fast path)
         if (opCtx.UpdatedConfig != MainYamlConfig || YamlDropped) {
-            auto tree = NFyaml::TDocument::Parse(opCtx.UpdatedConfig);
             if (ClusterName != opCtx.Cluster) {
                 ythrow yexception() << "ClusterName mismatch"
                     << " expected " << ClusterName
@@ -91,6 +92,7 @@ void TConfigsManager::ValidateMainConfig(TUpdateConfigOpContext& opCtx) {
                     << " but got " << opCtx.Version;
             }
 
+            auto tree = NFyaml::TDocument::Parse(opCtx.UpdatedConfig);
             TSimpleSharedPtr<NYamlConfig::TBasicUnknownFieldsCollector> unknownFieldsCollector = new NYamlConfig::TBasicUnknownFieldsCollector;
 
             std::vector<TString> errors;
@@ -138,7 +140,12 @@ void TConfigsManager::ReplaceDatabaseConfigMetadata(const TString &config, bool 
         if (!force) {
             opCtx.Version = metadata.Version.value_or(0);
         } else {
-            opCtx.Version = YamlVersion;
+            ui32 currentVersion = 0;
+            if (auto it = DatabaseYamlConfigs.find(opCtx.TargetDatabase); it != DatabaseYamlConfigs.end())
+            {
+                currentVersion = it->second.Version;
+            }
+            opCtx.Version = currentVersion;
         }
 
         opCtx.UpdatedConfig = NYamlConfig::ReplaceMetadata(config, NYamlConfig::TDatabaseMetadata{
@@ -153,10 +160,22 @@ void TConfigsManager::ReplaceDatabaseConfigMetadata(const TString &config, bool 
 void TConfigsManager::ValidateDatabaseConfig(TUpdateDatabaseConfigOpContext& opCtx) {
     try {
         TString currentConfig;
+        ui32 currentVersion = 0;
+
         if (auto it = DatabaseYamlConfigs.find(opCtx.TargetDatabase); it != DatabaseYamlConfigs.end()) {
             currentConfig = it->second.Config;
+            currentVersion = it->second.Version;
         }
+
+        // Re-applying an unchanged body with the same version is silently accepted
+        // (idempotent fast path)
         if (opCtx.UpdatedConfig != currentConfig) {
+            if (opCtx.Version != currentVersion) {
+                ythrow yexception() << "Version mismatch"
+                    << " expected " << currentVersion
+                    << " but got " << opCtx.Version;
+            }
+
             auto databaseTree = NFyaml::TDocument::Parse(opCtx.UpdatedConfig);
             auto databaseConfig = NYamlConfig::ParseConfig(databaseTree);
 

--- a/ydb/core/cms/console/console_configs_provider.cpp
+++ b/ydb/core/cms/console/console_configs_provider.cpp
@@ -745,8 +745,7 @@ bool TConfigsProvider::CheckSubscription(TInMemorySubscription::TPtr subscriptio
     subscription->VolatileYamlConfigHashes = VolatileYamlConfigHashes;
 
     if (auto it = DatabaseYamlConfigs.find(subscription->Tenant); it != DatabaseYamlConfigs.end()) {
-        // FIXME: handle version change correctly, instead of always sending on first update
-        if (!subscription->DatabaseYamlConfigVersion || *subscription->DatabaseYamlConfigVersion != it->second.Version || !subscription->FirstUpdateSent) {
+        if (!subscription->DatabaseYamlConfigVersion || *subscription->DatabaseYamlConfigVersion != it->second.Version) {
             subscription->DatabaseYamlConfigVersion = it->second.Version;
             request->Record.SetDatabaseYamlConfig(it->second.Config);
         } else {

--- a/ydb/core/cms/console/console_ut_configs.cpp
+++ b/ydb/core/cms/console/console_ut_configs.cpp
@@ -874,6 +874,72 @@ config:
     some_removed_feature_flag_example: true
 )";
 
+const TString VERSIONED_MAIN_CONFIG_V0_STALE = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 0
+config:
+  log_config:
+    cluster_name: clusterA
+)";
+
+const TString VERSIONED_MAIN_CONFIG_V1 = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 1
+config:
+  log_config:
+    cluster_name: clusterA
+)";
+
+const TString VERSIONED_MAIN_CONFIG_V2 = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 2
+config:
+  log_config:
+    cluster_name: clusterB
+)";
+
+const TString VERSIONED_DATABASE_CONFIG_V0_STALE = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: 0
+config:
+  feature_flags:
+    some_removed_feature_flag_example: true
+)";
+
+const TString VERSIONED_DATABASE_CONFIG_V1 = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: 1
+config:
+  feature_flags:
+    some_removed_feature_flag_example: true
+)";
+
+const TString VERSIONED_DATABASE_CONFIG_V2 = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: 2
+config:
+  feature_flags:
+    some_removed_feature_flag_example: false
+)";
+
 
 void InitializeTestConfigItems()
 {
@@ -1116,6 +1182,42 @@ TVector<ui64> CheckConfigureLogAffected(TTenantTestRuntime &runtime,
     return {reply->Record.GetAddedItemIds().begin(), reply->Record.GetAddedItemIds().end()};
 }
 
+void DoReplaceYamlConfig(TTenantTestRuntime &runtime,
+                         const TString &yaml,
+                         Ydb::StatusIds::StatusCode expectedCode,
+                         const TString &errorSubstring = {},
+                         bool allowAbsentDatabase = false)
+{
+    auto *event = new TEvConsole::TEvReplaceYamlConfigRequest;
+    event->Record.MutableRequest()->set_config(yaml);
+    if (allowAbsentDatabase) {
+        event->Record.MutableRequest()->set_allow_absent_database(true);
+    }
+    runtime.SendToConsole(event);
+
+    TAutoPtr<IEventHandle> handle;
+    auto [success, error] = runtime.GrabEdgeEvents<
+        TEvConsole::TEvReplaceYamlConfigResponse,
+        TEvConsole::TEvGenericError>(handle);
+
+    if (expectedCode == Ydb::StatusIds::SUCCESS) {
+        UNIT_ASSERT_C(success != nullptr,
+            "expected success but got error: " <<
+            (error ? error->Record.ShortDebugString() : TString("no event")));
+    } else {
+        UNIT_ASSERT_C(error != nullptr,
+            "expected error " << static_cast<int>(expectedCode) << " but got success");
+        UNIT_ASSERT_VALUES_EQUAL(error->Record.GetYdbStatus(), expectedCode);
+        if (!errorSubstring.empty()) {
+            TString allMessages;
+            for (const auto& issue : error->Record.GetIssues()) {
+                allMessages += issue.message();
+                allMessages += ";";
+            }
+            UNIT_ASSERT_STRING_CONTAINS(allMessages, errorSubstring);
+        }
+    }
+}
 
 
 } // anonymous namespace
@@ -4519,6 +4621,108 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
         UNIT_ASSERT_VALUES_EQUAL(notification->Get()->Record.VolatileConfigsSize(), 2);
         UNIT_ASSERT(notification->Get()->Record.GetVolatileConfigs()[0].GetNotChanged());
         UNIT_ASSERT(notification->Get()->Record.GetVolatileConfigs()[1].GetNotChanged());
+    }
+
+    Y_UNIT_TEST(TestReplaceMainYamlConfigVersionCheck) {
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+
+        // Fresh runtime: YamlVersion = 0. Per documentation, the client must send
+        // the *current* stored version. A version ahead of stored is rejected.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V1,
+            Ydb::StatusIds::BAD_REQUEST, "Version mismatch");
+
+        // version: 0 matches stored YamlVersion = 0 — accepted; YamlVersion becomes 1.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
+            Ydb::StatusIds::SUCCESS);
+
+        // version: 2 with stored = 1 — rejected.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
+            Ydb::StatusIds::BAD_REQUEST, "Version mismatch");
+
+        // Re-applying the same body with the stale version: 0 is silently
+        // accepted (documented idempotent behaviour: wire == stored - 1 with
+        // identical content). YamlVersion stays at 1.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
+            Ydb::StatusIds::SUCCESS);
+
+        // version: 1 matches stored YamlVersion = 1 — accepted; YamlVersion becomes 2.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V1,
+            Ydb::StatusIds::SUCCESS);
+
+        // version: 2 with a differing body now matches stored — accepted; YamlVersion = 3.
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
+            Ydb::StatusIds::SUCCESS);
+
+        // Verify the stored version is one above the last accepted wire version.
+        // Confirms the Console invariant: stored version == sent version + 1.
+        runtime.SendToConsole(new TEvConsole::TEvGetAllConfigsRequest());
+        TAutoPtr<IEventHandle> handle;
+        auto configs = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(configs->Record.GetResponse().identity_size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(configs->Record.GetResponse().identity(0).version(), 3);
+    }
+
+    Y_UNIT_TEST(TestReplaceDatabaseYamlConfigVersionCheck) {
+        NKikimrConfig::TAppConfig appcfg;
+        appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
+        TTenantTestRuntime runtime(MultipleTenantsConsoleTestConfig(), appcfg);
+
+        // ValidateDatabaseConfig appends the database config into the main config
+        // and re-validates the result, which requires a non-empty MainYamlConfig.
+        // Seed a minimal main config first (fresh YamlVersion = 0, so wire = 0).
+        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
+            Ydb::StatusIds::SUCCESS);
+
+        // Fresh runtime: no per-database config stored, so currentVersion = 0.
+        // Per documentation, the wire version must equal the stored version.
+        // Sending version: 1 must be rejected.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V1,
+            Ydb::StatusIds::BAD_REQUEST, "Version mismatch",
+            /* allowAbsentDatabase = */ true);
+
+        // version: 0 matches stored currentVersion = 0 — accepted; stored version becomes 1.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
+            Ydb::StatusIds::SUCCESS, {},
+            /* allowAbsentDatabase = */ true);
+
+        // version: 2 with stored = 1 — rejected.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
+            Ydb::StatusIds::BAD_REQUEST, "Version mismatch",
+            /* allowAbsentDatabase = */ true);
+
+        // Re-applying the same body with the stale version: 0 is silently
+        // accepted (documented idempotent behaviour: wire == stored - 1 with
+        // identical content). Stored version stays at 1.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
+            Ydb::StatusIds::SUCCESS, {},
+            /* allowAbsentDatabase = */ true);
+
+        // version: 1 matches stored = 1 — accepted; stored version becomes 2.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V1,
+            Ydb::StatusIds::SUCCESS, {},
+            /* allowAbsentDatabase = */ true);
+
+        // version: 2 with a differing body now matches stored = 2 — accepted; version = 3.
+        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
+            Ydb::StatusIds::SUCCESS, {},
+            /* allowAbsentDatabase = */ true);
+
+        // Verify the stored database version is one above the last accepted wire version.
+        // Confirms the Console invariant: stored version == sent version + 1.
+        runtime.SendToConsole(new TEvConsole::TEvGetAllConfigsRequest());
+        TAutoPtr<IEventHandle> handle;
+        auto configs = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+        const auto& resp = configs->Record.GetResponse();
+        int dbIdx = -1;
+        for (int i = 0; i < resp.identity_size(); ++i) {
+            if (resp.identity(i).has_database() &&
+                resp.identity(i).database() == "/dc-1/users/tenant-1") {
+                dbIdx = i;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(dbIdx >= 0, "database identity for /dc-1/users/tenant-1 not found");
+        UNIT_ASSERT_VALUES_EQUAL(resp.identity(dbIdx).version(), 3);
     }
 }
 

--- a/ydb/core/cms/console/console_ut_configs.cpp
+++ b/ydb/core/cms/console/console_ut_configs.cpp
@@ -1182,6 +1182,47 @@ TVector<ui64> CheckConfigureLogAffected(TTenantTestRuntime &runtime,
     return {reply->Record.GetAddedItemIds().begin(), reply->Record.GetAddedItemIds().end()};
 }
 
+void DoFetchMainConfigFromConsole(TTenantTestRuntime &runtime, TString &yamlConfig)
+{
+    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
+    runtime.SendToConsole(event);
+
+    TAutoPtr<IEventHandle> handle;
+    auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+
+    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
+        "expected exactly one config in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
+        "expected exactly one identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kCluster,
+        "expected kCluster identity in response");
+
+    yamlConfig = response->Record.GetResponse().config(0);
+}
+
+void DoFetchDatabaseConfigFromConsole(TTenantTestRuntime &runtime, const TString &databasePath, TString &yamlConfig)
+{
+    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
+    event->Record.SetIngressDatabase(databasePath);
+    runtime.SendToConsole(event);
+
+    TAutoPtr<IEventHandle> handle;
+    auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+
+    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
+        "expected at least one config in response for database: " << databasePath);
+    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
+        "expected exactly one identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kDatabase,
+        "expected kDatabase identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).has_database(),
+        "kDatabase identity in response with no database set");
+    UNIT_ASSERT_EQUAL_C(response->Record.GetResponse().identity(0).database(), databasePath,
+        "database in response not match requested database");
+
+    yamlConfig = response->Record.GetResponse().config(0);
+}
+
 void DoReplaceYamlConfig(TTenantTestRuntime &runtime,
                          const TString &yaml,
                          Ydb::StatusIds::StatusCode expectedCode,
@@ -1219,6 +1260,23 @@ void DoReplaceYamlConfig(TTenantTestRuntime &runtime,
     }
 }
 
+void DoEnsureMainConfigReplacedWith(TTenantTestRuntime &runtime, TString replaceConfig)
+{
+    TString consoleConfig;
+    TString expectedConfig = NYamlConfig::UpgradeMainConfigVersion(replaceConfig);
+
+    DoFetchMainConfigFromConsole(runtime, consoleConfig);
+    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
+}
+
+void DoEnsureDatabaseConfigReplacedWith(TTenantTestRuntime &runtime, const TString& database, TString replaceConfig)
+{
+    TString consoleConfig;
+    TString expectedConfig = NYamlConfig::UpgradeDatabaseConfigVersion(replaceConfig);
+
+    DoFetchDatabaseConfigFromConsole(runtime, database, consoleConfig);
+    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
+}
 
 } // anonymous namespace
 
@@ -4634,6 +4692,7 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
         // version: 0 matches stored YamlVersion = 0 — accepted; YamlVersion becomes 1.
         DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
             Ydb::StatusIds::SUCCESS);
+        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
 
         // version: 2 with stored = 1 — rejected.
         DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
@@ -4644,28 +4703,25 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
         // identical content). YamlVersion stays at 1.
         DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
             Ydb::StatusIds::SUCCESS);
+        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
 
         // version: 1 matches stored YamlVersion = 1 — accepted; YamlVersion becomes 2.
         DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V1,
             Ydb::StatusIds::SUCCESS);
+        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V1);
 
         // version: 2 with a differing body now matches stored — accepted; YamlVersion = 3.
         DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
             Ydb::StatusIds::SUCCESS);
-
-        // Verify the stored version is one above the last accepted wire version.
-        // Confirms the Console invariant: stored version == sent version + 1.
-        runtime.SendToConsole(new TEvConsole::TEvGetAllConfigsRequest());
-        TAutoPtr<IEventHandle> handle;
-        auto configs = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
-        UNIT_ASSERT_VALUES_EQUAL(configs->Record.GetResponse().identity_size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(configs->Record.GetResponse().identity(0).version(), 3);
+        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V2);
     }
 
     Y_UNIT_TEST(TestReplaceDatabaseYamlConfigVersionCheck) {
         NKikimrConfig::TAppConfig appcfg;
         appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
         TTenantTestRuntime runtime(MultipleTenantsConsoleTestConfig(), appcfg);
+
+        const TString DATABASE = "/dc-1/users/tenant-1";
 
         // ValidateDatabaseConfig appends the database config into the main config
         // and re-validates the result, which requires a non-empty MainYamlConfig.
@@ -4684,6 +4740,7 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
         DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
             Ydb::StatusIds::SUCCESS, {},
             /* allowAbsentDatabase = */ true);
+        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
 
         // version: 2 with stored = 1 — rejected.
         DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
@@ -4696,33 +4753,19 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
         DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
             Ydb::StatusIds::SUCCESS, {},
             /* allowAbsentDatabase = */ true);
+        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
 
         // version: 1 matches stored = 1 — accepted; stored version becomes 2.
         DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V1,
             Ydb::StatusIds::SUCCESS, {},
             /* allowAbsentDatabase = */ true);
+        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V1);
 
         // version: 2 with a differing body now matches stored = 2 — accepted; version = 3.
         DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
             Ydb::StatusIds::SUCCESS, {},
             /* allowAbsentDatabase = */ true);
-
-        // Verify the stored database version is one above the last accepted wire version.
-        // Confirms the Console invariant: stored version == sent version + 1.
-        runtime.SendToConsole(new TEvConsole::TEvGetAllConfigsRequest());
-        TAutoPtr<IEventHandle> handle;
-        auto configs = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
-        const auto& resp = configs->Record.GetResponse();
-        int dbIdx = -1;
-        for (int i = 0; i < resp.identity_size(); ++i) {
-            if (resp.identity(i).has_database() &&
-                resp.identity(i).database() == "/dc-1/users/tenant-1") {
-                dbIdx = i;
-                break;
-            }
-        }
-        UNIT_ASSERT_C(dbIdx >= 0, "database identity for /dc-1/users/tenant-1 not found");
-        UNIT_ASSERT_VALUES_EQUAL(resp.identity(dbIdx).version(), 3);
+        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V2);
     }
 }
 

--- a/ydb/library/yaml_config/public/yaml_config.cpp
+++ b/ydb/library/yaml_config/public/yaml_config.cpp
@@ -1630,6 +1630,13 @@ TString UpgradeStorageConfigVersion(const TString& config) {
     return ReplaceMetadata(config, metadata);
 }
 
+TString UpgradeDatabaseConfigVersion(const TString& config) {
+    auto metadata = GetDatabaseMetadata(config);
+    Y_ENSURE(metadata.Version);
+    *metadata.Version = *metadata.Version + 1;
+    return ReplaceMetadata(config, metadata);
+}
+
 } // namespace NKikimr::NYamlConfig
 
 template <>

--- a/ydb/library/yaml_config/public/yaml_config.h
+++ b/ydb/library/yaml_config/public/yaml_config.h
@@ -327,6 +327,11 @@ TString UpgradeMainConfigVersion(const TString& config);
 TString UpgradeStorageConfigVersion(const TString& config);
 
 /**
+ * Takes valid DatabaseConfig and increases version exactly by one
+ */
+TString UpgradeDatabaseConfigVersion(const TString& config);
+
+/**
  * Replaces metadata in database config
  */
 TString ReplaceMetadata(const TString& config, const TDatabaseMetadata& metadata);


### PR DESCRIPTION
### Changelog entry

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

## Summary

End-to-end fix for the per-database YAML config `fetch | edit | replace` round-trip on the Console tablet. The wire-version contract (same as documented for main-config) — **CLI sends `metadata.version == stored_version`, Console stores `stored_version + 1`** — is enforced. The fix combines a missing version check on the per-database YAML config replace path with two pre-existing per-database YAML config bugs around the same path. See the [`ydb/docs/en/core/devops/configuration-management/configuration-v1/dynamic-config.md`](ydb/docs/en/core/devops/configuration-management/configuration-v1/dynamic-config.md) documentation for the contract this code now matches.

The four logical issues addressed:

1. **No version check on per-database YAML config replace.** The validator for per-database YAML config body checked proto conversion, ran a validator pass, and verified that the result still appends into the main config tree — but never compared the wire `metadata.version` to the stored version. Stale or arbitrary versions were accepted as long as the body parsed.

2. **Redundant per-database YAML config re-delivery on first subscription update.** The provider that broadcasts config changes to subscribers had a special-case "first delivery" disjunct in the per-database YAML config update guard. A fresh subscriber therefore got an unconditional re-delivery on bootstrap, bypassing the version-equality short-circuit and producing a redundant notification every time a subscriber attached. The main-config update guard already behaved correctly — this PR aligns the per-database YAML config guard with it.

3. **Force-branch in `ReplaceDatabaseConfigMetadata` used the main config's version.** The force branch (taken from the `--force` CLI flag and from the legacy `TEvSetYamlConfigRequest` event) initialised the new per-database YAML config's `metadata.version` from the **main** config's stored version. The resulting `metadata.version` on disk became `main_version + 1` instead of `database_version + 1`, attaching an unrelated number to the per-database YAML config.

4. **`TTxReplaceDatabaseYamlConfig::Execute` wrote the unmodified user input to disk.** Every consumer downstream (audit, in-memory cache, broadcast to subscribers) used the post-metadata-replace body — the version-bumped one — but the row in `Schema::DatabaseYamlConfigs` was written with the raw user-supplied body. So the on-disk YAML's `metadata.version` lagged the row key by one, breaking the next `fetch | edit | replace` round-trip. The main-config transaction already handled this correctly.

### Behaviour after the fix

Together these changes implement and enforce the documented Console contract:

- **Wire `version == stored`** is accepted and the stored version advances by 1.
- **Wire `version == stored + 1`** (the BSC-style "send N+1" convention) is rejected with `Version mismatch — expected X but got Y`.
- **Wire `version != stored` with a changed body** is rejected with the same `Version mismatch` error.
- **Wire `version != stored` with an unchanged body** is silently accepted (idempotent fast-path through the body-diff gate — no version check is performed when the new body byte-for-byte matches the stored one).
- Forced per-database YAML config replace (`--force`) bumps the per-database YAML config's *own* version, not the main config's.
- A fresh subscriber bootstrap no longer triggers redundant per-database YAML config re-delivery.

## Detailed

### Bug 1 — `ValidateDatabaseConfig` did not check the version

`TConfigsManager::ValidateDatabaseConfig` in [ydb/core/cms/console/console_configs_manager.cpp](ydb/core/cms/console/console_configs_manager.cpp) validated the per-database YAML config body (proto conversion, validator pass, append-into-main check) but **never validated `metadata.version`**. A `replace` request with a stale or arbitrary version was accepted as long as the body parsed.

Fix: read the per-database YAML config's current stored version alongside the current config (from `DatabaseYamlConfigs[opCtx.TargetDatabase]`, default 0 if absent), gate on the body diff (idempotent fast path on unchanged body), and require `opCtx.Version == currentVersion`. Throw `Version mismatch — expected X but got Y` otherwise.

### Bug 2 — Redundant first-delivery in `CheckSubscription`

In `TConfigsProvider::CheckSubscription` ([ydb/core/cms/console/console_configs_provider.cpp](ydb/core/cms/console/console_configs_provider.cpp)), the per-database YAML config update guard had an extra `|| !subscription->FirstUpdateSent` disjunct, so the per-database YAML config update was unconditionally re-sent on the very first subscription update, bypassing the version-equality short-circuit and producing a redundant notification on every subscriber bootstrap.

Fix: drop the `|| !subscription->FirstUpdateSent` disjunct from the per-database YAML config update guard so that re-delivery on first-update is gated by the version-equality check, matching the main-config behaviour.

### Bug 3 — `ReplaceDatabaseConfigMetadata` force branch used the main-config version

`ReplaceDatabaseConfigMetadata` (the per-database YAML config analogue of `ReplaceMainConfigMetadata`) initialised its `opCtx.Version` from `YamlVersion` — i.e. the **main** config's stored version — when forcing a per-database YAML config replace:

```cpp
} else {
    opCtx.Version = YamlVersion;  // wrong: this is the main config version
}
```

This attaches an unrelated version to the new per-database YAML config; the `metadata.version` written into the database body becomes `main_version + 1` instead of `database_version + 1`. The "force" branch is taken from the CLI's `--force` flag and from the legacy `TEvSetYamlConfigRequest` event.

Fix: look up the per-database YAML config's own current version from `DatabaseYamlConfigs[opCtx.TargetDatabase]` (default 0 if absent), and use that.

### Bug 4 — `TTxReplaceDatabaseYamlConfig::Execute` wrote the unmodified user input

In [ydb/core/cms/console/console__replace_yaml_config.cpp](ydb/core/cms/console/console__replace_yaml_config.cpp), the transaction wrote the raw `Config` field (the wire body, with the user-supplied `metadata.version`) into `Schema::DatabaseYamlConfigs`, while everything else in the system (audit, in-memory `DatabaseYamlConfigs[]`, ConfigsProvider broadcast) used the `UpdatedDatabaseConfig` field — the post-`ReplaceMetadata` body with the bumped version. The on-disk YAML's `metadata.version` therefore lagged one step behind the row key, breaking the next `fetch | edit | replace` round-trip.

Fix: write `UpdatedDatabaseConfig` instead of `Config`. (The main-config transaction already did this correctly.)

### Unit tests

Two new Console-tablet unit tests cover the documented contract end-to-end:

- `TestReplaceMainYamlConfigVersionCheck`
- `TestReplaceDatabaseYamlConfigVersionCheck`

Each test exercises:

1. Wire `version = stored + 1` is rejected (BSC-style version sent to Console).
2. Wire `version = stored` is accepted, stored version advances by 1.
3. Wire `version = stored - 1` with an unchanged body is silently accepted (idempotent fast path).
4. The final `identity.version` returned by `Self->YamlVersion` matches the documented post-state.

## Fix

In [console_configs_manager.cpp](ydb/core/cms/console/console_configs_manager.cpp):
- `ReplaceDatabaseConfigMetadata`, force branch: look up `currentVersion` from `DatabaseYamlConfigs[opCtx.TargetDatabase]` (default 0 if absent) and set `opCtx.Version = currentVersion`.
- `ValidateMainConfig`: move `NFyaml::TDocument::Parse(...)` inside the body-diff gate.
- `ValidateDatabaseConfig`: read the per-database YAML config's current stored version and require `opCtx.Version == currentVersion`.

In [console_configs_provider.cpp](ydb/core/cms/console/console_configs_provider.cpp):
- `CheckSubscription`: drop the `|| !subscription->FirstUpdateSent` disjunct from the per-database YAML config update guard.

In [console__replace_yaml_config.cpp](ydb/core/cms/console/console__replace_yaml_config.cpp):
- `TTxReplaceDatabaseYamlConfig::Execute`: write `UpdatedDatabaseConfig` (the post-metadata-replace body) into `Schema::DatabaseYamlConfigs`, not `Config`.

In [console_ut_configs.cpp](ydb/core/cms/console/console_ut_configs.cpp):
- `TestReplaceMainYamlConfigVersionCheck` and `TestReplaceDatabaseYamlConfigVersionCheck` added as described above.

## Backward compatibility

No schema or wire-format change. Pre-upgrade rows in `Schema::YamlConfig` / `Schema::DatabaseYamlConfigs` are loaded as-is; the version-bump direction and key layout are unchanged. After upgrade, the first `replace` for a per-database YAML config that previously hit the `force` path will store the correct `database_version + 1` instead of `main_version + 1` — the bug stops producing wrong metadata; existing rows are not rewritten.

## Test plan

- [`v`] Unit tests `TestReplaceMainYamlConfigVersionCheck` / `TestReplaceDatabaseYamlConfigVersionCheck` pass against the documented contract.
- [`v`] All Console-path functional tests in `ydb/tests/functional/config/` pass (`test_config_migration.py`, `test_config_with_metadata.py` minus the BSC-path test below).
- [`v`] Full round-trip for per-database YAML config: `ydb -d /Root/<db> admin database config fetch | edit | replace -f -` — Console must accept it and the stored `metadata.version` must match what the CLI sent.
- [`v`] Forced per-database YAML config replace (`--force`) sets the new version based on the per-database YAML config's own current version, not the main config's.
- [`v`] Re-applying a **changed** body with a stale version is rejected with a `Version mismatch` error. Re-applying an unchanged body with the same version is silently accepted (idempotent fast path through the body-diff gate).