### PR TITLE
cli: Ignore CA file for non SSL connections

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed `ydb` CLI to ignore `ca-file` from profile when connecting without TLS (`grpc://`).
 * Added `--partition-max-inflight-bytes` option to `ydb topic workload`
 * Added `--partition-write-speed-mps` and `--partition-write-burst-messages` options to `ydb topic create` and `ydb topic alter` commands.
 * Added CPU Time statistics to benchmarks run commands.

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,3 @@
-* Fixed `ydb` CLI to ignore `ca-file` from profile when connecting without TLS (`grpc://`).
 * Added `--partition-max-inflight-bytes` option to `ydb topic workload`
 * Added `--partition-write-speed-mps` and `--partition-write-burst-messages` options to `ydb topic create` and `ydb topic alter` commands.
 * Added CPU Time statistics to benchmarks run commands.

--- a/ydb/apps/ydb/ut/mock_env.h
+++ b/ydb/apps/ydb/ut/mock_env.h
@@ -301,6 +301,16 @@ public:
         return TStringBuilder() << ConnectSchema << "://" << Address << ":" << Port;
     }
 
+    TString GetGrpcEndpoint() const {
+        UNIT_ASSERT_STRINGS_EQUAL(ConnectSchema, "grpc");
+        return GetEndpoint();
+    }
+
+    TString GetGrpcsEndpoint() const {
+        UNIT_ASSERT_STRINGS_EQUAL(ConnectSchema, "grpcs");
+        return GetEndpoint();
+    }
+
     TString GetAddress() const {
         return TStringBuilder() << Address << ":" << Port;
     }

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -895,7 +895,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectToken("token");
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcsEndpoint(),
             "-d", GetDatabase(),
             "--ca-file", GetRootCAFile(),
             "scheme", "ls",
@@ -908,7 +908,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectFail();
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcsEndpoint(),
             "-d", GetDatabase(),
             "--ca-file", GetWrongRootCAFile(),
             "scheme", "ls",
@@ -921,7 +921,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectFail();
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcsEndpoint(),
             "-d", GetDatabase(),
             "scheme", "ls",
         },
@@ -934,7 +934,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectToken("token");
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcsEndpoint(),
             "-d", GetDatabase(),
             "scheme", "ls",
         },
@@ -947,7 +947,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectFail();
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcsEndpoint(),
             "-d", GetDatabase(),
             "scheme", "ls",
         },
@@ -966,7 +966,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
                 ca-file: {ca_file}
         active_profile: active_test_profile
         )yaml",
-        "endpoint"_a = GetEndpoint(),
+        "endpoint"_a = GetGrpcsEndpoint(),
         "database"_a = GetDatabase(),
         "ca_file"_a = GetRootCAFile()
         );
@@ -1001,7 +1001,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         ExpectToken("token");
         RunCli({
             "-v",
-            "-e", GetEndpoint(),
+            "-e", GetGrpcEndpoint(),
             "-d", GetDatabase(),
             "--ca-file", GetRootCAFile(),
             "scheme", "ls",
@@ -1020,7 +1020,7 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
                 ca-file: {ca_file}
         active_profile: active_test_profile
         )yaml",
-        "endpoint"_a = GetEndpoint(),
+        "endpoint"_a = GetGrpcEndpoint(),
         "database"_a = GetDatabase(),
         "ca_file"_a = GetRootCAFile()
         );

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -997,6 +997,60 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         );
     }
 
+    Y_UNIT_TEST_F(ParseCAFileWithGrpcEndpointFromCommandLine, TCliTestFixture) {
+        ExpectToken("token");
+        RunCli({
+            "-v",
+            "-e", GetEndpoint(),
+            "-d", GetDatabase(),
+            "--ca-file", GetRootCAFile(),
+            "scheme", "ls",
+        },
+        {
+            {"YDB_TOKEN", "token"},
+        });
+    }
+
+    Y_UNIT_TEST_F(ParseCAFileWithGrpcEndpointFromProfile, TCliTestFixture) {
+        TString profile = fmt::format(R"yaml(
+        profiles:
+            active_test_profile:
+                endpoint: {endpoint}
+                database: {database}
+                ca-file: {ca_file}
+        active_profile: active_test_profile
+        )yaml",
+        "endpoint"_a = GetEndpoint(),
+        "database"_a = GetDatabase(),
+        "ca_file"_a = GetRootCAFile()
+        );
+
+        ExpectToken("token");
+        RunCli(
+            {
+                "-v",
+                "scheme", "ls",
+            },
+            {
+                {"YDB_TOKEN", "token"},
+            },
+            profile
+        );
+
+        ExpectToken("token");
+        RunCli(
+            {
+                "-v",
+                "-p", "active_test_profile",
+                "scheme", "ls",
+            },
+            {
+                {"YDB_TOKEN", "token"},
+            },
+            profile
+        );
+    }
+
     Y_UNIT_TEST_F(ParseClientCertFile, TCliTestFixtureWithSsl) {
         ExpectToken("token");
         ExpectClientCert();

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -739,10 +739,7 @@ void TClientCommandRootCommon::ExtractParams(TConfig& config) {
 }
 
 void TClientCommandRootCommon::ParseCaCerts(TConfig& config) {
-    if (!config.EnableSsl && config.CaCerts) {
-        config.CaCerts.clear();
-        config.CaCertsFile.clear();
-    }
+    TClientCommandRootBase::ParseCaCerts(config);
 }
 
 void TClientCommandRootCommon::ParseClientCert(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -740,7 +740,8 @@ void TClientCommandRootCommon::ExtractParams(TConfig& config) {
 
 void TClientCommandRootCommon::ParseCaCerts(TConfig& config) {
     if (!config.EnableSsl && config.CaCerts) {
-        MisuseErrors.push_back("\"ca-file\" option is provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.");
+        config.CaCerts.clear();
+        config.CaCertsFile.clear();
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -738,10 +738,6 @@ void TClientCommandRootCommon::ExtractParams(TConfig& config) {
     config.ChosenAuthMethod = ParseResult->GetChosenAuthMethod();
 }
 
-void TClientCommandRootCommon::ParseCaCerts(TConfig& config) {
-    TClientCommandRootBase::ParseCaCerts(config);
-}
-
 void TClientCommandRootCommon::ParseClientCert(TConfig& config) {
     if (!config.EnableSsl && config.ClientCert) {
         MisuseErrors.push_back("\"client-cert-file\"/\"client-cert-key-file\"/\"client-cert-key-password-file\" options are provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.");

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -76,7 +76,6 @@ private:
     void ParseProfile();
     void ParseAddress(TConfig&) override {}
     void ParseIamEndpoint(TConfig& config);
-    void ParseCaCerts(TConfig& config) override;
     void ParseClientCert(TConfig& config) override;
     void ParseStaticCredentials(TConfig& config);
     static TString GetAddressFromString(const TString& address, bool* enableSsl = nullptr, std::vector<TString>* errors = nullptr);

--- a/ydb/public/lib/ydb_cli/common/root.cpp
+++ b/ydb/public/lib/ydb_cli/common/root.cpp
@@ -25,10 +25,10 @@ void TClientCommandRootBase::Config(TConfig& config) {
     opts.AddLongOption("ca-file",
         "File containing PEM encoded root certificates for SSL/TLS connections.\n"
         "If this parameter is empty, the default roots will be used")
-        .FileName("CA certificates").ProfileParam("ca-file", true)
+        .ProfileParam("ca-file", false)
         .LogToConnectionParams("ca-file")
-        .Env("YDB_CA_FILE", true, "CA certificates")
-        .RequiredArgument("PATH").StoreFilePath(&config.CaCertsFile).StoreResult(&config.CaCerts);
+        .Env("YDB_CA_FILE", false, "CA certificates")
+        .RequiredArgument("PATH").StoreResult(&config.CaCertsFile);
     opts.AddLongOption("client-cert-file",
         "File containing client certificate for SSL/TLS connections (PKCS#12 or PEM-encoded)")
         .FileName("Client certificate")
@@ -109,9 +109,13 @@ bool TClientCommandRootBase::ParseProtocol(TConfig& config, TString& message) {
 }
 
 void TClientCommandRootBase::ParseCaCerts(TConfig& config) {
-    if (!config.EnableSsl && config.CaCerts) {
+    if (!config.EnableSsl) {
         config.CaCerts.clear();
         config.CaCertsFile.clear();
+        return;
+    }
+    if (config.CaCertsFile) {
+        config.CaCerts = ReadFromFile(config.CaCertsFile, "CA certificates");
     }
 }
 

--- a/ydb/public/lib/ydb_cli/common/root.cpp
+++ b/ydb/public/lib/ydb_cli/common/root.cpp
@@ -110,8 +110,8 @@ bool TClientCommandRootBase::ParseProtocol(TConfig& config, TString& message) {
 
 void TClientCommandRootBase::ParseCaCerts(TConfig& config) {
     if (!config.EnableSsl && config.CaCerts) {
-        throw TMisuseException()
-            << "\"ca-file\" option provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
+        config.CaCerts.clear();
+        config.CaCertsFile.clear();
     }
 }
 

--- a/ydb/public/lib/ydb_cli/common/root.cpp
+++ b/ydb/public/lib/ydb_cli/common/root.cpp
@@ -25,10 +25,10 @@ void TClientCommandRootBase::Config(TConfig& config) {
     opts.AddLongOption("ca-file",
         "File containing PEM encoded root certificates for SSL/TLS connections.\n"
         "If this parameter is empty, the default roots will be used")
-        .ProfileParam("ca-file", false)
+        .FileName("CA certificates").ProfileParam("ca-file", true)
         .LogToConnectionParams("ca-file")
-        .Env("YDB_CA_FILE", false, "CA certificates")
-        .RequiredArgument("PATH").StoreResult(&config.CaCertsFile);
+        .Env("YDB_CA_FILE", true, "CA certificates")
+        .RequiredArgument("PATH").StoreFilePath(&config.CaCertsFile).StoreResult(&config.CaCerts);
     opts.AddLongOption("client-cert-file",
         "File containing client certificate for SSL/TLS connections (PKCS#12 or PEM-encoded)")
         .FileName("Client certificate")
@@ -109,14 +109,7 @@ bool TClientCommandRootBase::ParseProtocol(TConfig& config, TString& message) {
 }
 
 void TClientCommandRootBase::ParseCaCerts(TConfig& config) {
-    if (!config.EnableSsl) {
-        config.CaCerts.clear();
-        config.CaCertsFile.clear();
-        return;
-    }
-    if (config.CaCertsFile) {
-        config.CaCerts = ReadFromFile(config.CaCertsFile, "CA certificates");
-    }
+    Y_UNUSED(config);
 }
 
 void TClientCommandRootBase::ParseClientCert(TConfig& config) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed YDB CLI to ignore `ca-file` from profile when connecting without TLS (`grpc://`).

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes #41472
