### PR TITLE
row_dispatcher: format_handler: remove incorrect check

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
@@ -285,7 +285,7 @@ private:
             const auto numberRows = newNumberRows - NumberRows;
             const auto rowSize = newDataPackerSize - DataPackerSize;
 
-            if (!numberRows && !rowSize && !Watermark) {
+            if (!numberRows && !Watermark) {
                 return;
             }
 


### PR DESCRIPTION
DataPackerSize is only *estimate*, we should not ignore row if it did not changed.
Most likely, this affects only statistics (and, probably, may delay processing in case of slow or heavily-filtered stream).
And it definitely does not affect queries with watermarks.

"Regression" by #23482 (but largely theoretical; judging from what I've seen in tests, in practice row size strictly increases)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
