### PR TITLE
EXT-2230 Support penalty for restarts of tablets in Hive independent of received status code

### DIFF
--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -3809,7 +3809,9 @@ Y_UNIT_TEST_SUITE(THiveTest) {
     void TestFollowerPromotion(bool killDuringPromotion) {
         constexpr int NODES = 3;
         TTestBasicRuntime runtime(NODES, false);
-        Setup(runtime, true);
+        Setup(runtime, true, 1, [](TAppPrepare& app) {
+            app.HiveConfig.SetTabletRestartsMaxCount(4);
+        });
 
         TVector<ui64> tabletIds;
         const ui64 hiveTablet = MakeDefaultHiveID();

--- a/ydb/core/mind/hive/tx__update_tablet_status.cpp
+++ b/ydb/core/mind/hive/tx__update_tablet_status.cpp
@@ -33,25 +33,6 @@ public:
 
     TTxType GetTxType() const override { return NHive::TXTYPE_UPDATE_TABLET_STATUS; }
 
-    bool IsGoodStatusForPenalties() const {
-        switch (Status) {
-            case TEvLocal::TEvTabletStatus::StatusBootFailed:
-                switch (Reason) {
-                    case TEvTablet::TEvTabletDead::EReason::ReasonBootSSError:
-                    case TEvTablet::TEvTabletDead::EReason::ReasonBootBSError:
-                    case TEvTablet::TEvTabletDead::EReason::ReasonBootSSTimeout:
-                        return true;
-                    default:
-                        break;
-                }
-                break;
-
-            default:
-                break;
-        }
-        return false;
-    }
-
     TString GetStatus() {
         TStringBuilder str;
         str << (ui32)Status;
@@ -149,11 +130,9 @@ public:
                         return true;
                     }
                     if (leader.GetRestartsPerPeriod(now - Self->GetTabletRestartsPeriodForPenalties()) >= Self->GetTabletRestartsMaxCount()) {
-                        if (IsGoodStatusForPenalties()) {
-                            leader.PostponeStart(now + Self->GetPostponeStartPeriod());
-                            BLOG_D("THive::TTxUpdateTabletStatus::Execute for tablet " << tablet->ToString()
-                                << " postponed start until " << leader.PostponedStart);
-                        }
+                        leader.PostponeStart(now + Self->GetPostponeStartPeriod());
+                        BLOG_D("THive::TTxUpdateTabletStatus::Execute for tablet " << tablet->ToString()
+                            << " postponed start until " << leader.PostponedStart);
                     }
                 }
                 if (Local) {
@@ -171,9 +150,7 @@ public:
                         }
                         tablet->InitiateStop(SideEffects);
                     }
-                    if (IsGoodStatusForPenalties()) {
-                        tablet->FailedNodeId = Local.NodeId();
-                    }
+                    tablet->FailedNodeId = Local.NodeId();
                 }
                 switch (tablet->GetLeader().State) {
                 case ETabletState::GroupAssignment:

--- a/ydb/core/mind/hive/tx__update_tablet_status.cpp
+++ b/ydb/core/mind/hive/tx__update_tablet_status.cpp
@@ -33,6 +33,15 @@ public:
 
     TTxType GetTxType() const override { return NHive::TXTYPE_UPDATE_TABLET_STATUS; }
 
+    bool IsFailStatusForPostponeRestart() const {
+        return Status != TEvLocal::TEvTabletStatus::StatusOk && Status != TEvLocal::TEvTabletStatus::StatusSupersededByLeader;
+    }
+
+    bool IsFailStatusForNodePenalty() const {
+        // Hive can send Poison to tablets, it must not make penalty for the node
+        return IsFailStatusForPostponeRestart() && Reason != TEvTablet::TEvTabletDead::EReason::ReasonPill;
+    }
+
     TString GetStatus() {
         TStringBuilder str;
         str << (ui32)Status;
@@ -129,10 +138,12 @@ public:
                     if (Generation < leader.KnownGeneration) {
                         return true;
                     }
-                    if (leader.GetRestartsPerPeriod(now - Self->GetTabletRestartsPeriodForPenalties()) >= Self->GetTabletRestartsMaxCount()) {
-                        leader.PostponeStart(now + Self->GetPostponeStartPeriod());
-                        BLOG_D("THive::TTxUpdateTabletStatus::Execute for tablet " << tablet->ToString()
-                            << " postponed start until " << leader.PostponedStart);
+                    if (IsFailStatusForPostponeRestart()) {
+                        if (leader.GetRestartsPerPeriod(now - Self->GetTabletRestartsPeriodForPenalties()) >= Self->GetTabletRestartsMaxCount()) {
+                            leader.PostponeStart(now + Self->GetPostponeStartPeriod());
+                            BLOG_D("THive::TTxUpdateTabletStatus::Execute for tablet " << tablet->ToString()
+                                << " postponed start until " << leader.PostponedStart);
+                        }
                     }
                 }
                 if (Local) {
@@ -150,7 +161,9 @@ public:
                         }
                         tablet->InitiateStop(SideEffects);
                     }
-                    tablet->FailedNodeId = Local.NodeId();
+                    if (IsFailStatusForNodePenalty()) {
+                        tablet->FailedNodeId = Local.NodeId();
+                    }
                 }
                 switch (tablet->GetLeader().State) {
                 case ETabletState::GroupAssignment:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I've made an experiment in which I sent poison event to datashard tablet after its init transaction. And hive restarted this tablet over 100 times per second. But the situation can be in prod too: for example one tablet can easily contain data that triggers some bug that restarts tablet.
Hive has the following algorithm of restart penalty: if it gets special tablet status (as marked for penalty), it postpones tablet restart (max 2 restarts per second by default, configurable). I suggest to postpone tablet restart for any case, not only for listed for penalty. Because it is the mechanism of prevention too often tablets restart. It must face with many different bugs in tablets/logic.