### PR TITLE
fix querying datashard id in test_split_merge_by_load

### DIFF
--- a/ydb/tests/functional/split_merge/by_load/test_split_merge_by_load.py
+++ b/ydb/tests/functional/split_merge/by_load/test_split_merge_by_load.py
@@ -10,7 +10,6 @@ import attr
 import pytest
 import requests
 
-from ydb.tests.library.common.types import TabletTypes
 from ydb.tests.library.common.wait_for import wait_for
 from ydb.tests.library.fixtures import ydb_database_ctx
 from ydb.tests.library.fixtures.safe_parametrize import ParameterSet, safe_mark_parametrize
@@ -476,9 +475,6 @@ def _wait_for_tablet_resolver_cache(context: _YdbTestContext) -> None:
         urllib.parse.urlencode({
             "database": context.database,
             "path": "{}/{}".format(context.database, _TABLE_NAME),
-            "enums": "true",
-            "partition_stats": "true",
-            "subs": "0",
         }),
     )
     response = requests.get(describe_url)

--- a/ydb/tests/functional/split_merge/by_load/test_split_merge_by_load.py
+++ b/ydb/tests/functional/split_merge/by_load/test_split_merge_by_load.py
@@ -470,18 +470,21 @@ def _wait_for_tablet_resolver_cache(context: _YdbTestContext) -> None:
     """
     _logger.info("Waiting for the Tablet Resolver cache to become populated with followers")
 
-    # Find the tablet ID for the DataShard for the test table
-    #
-    # NOTE: Since there is only one table created for the test, there should be
-    #       only one DataShard present
-    tablet_state_response = context.cluster.client.tablet_state(TabletTypes.FLAT_DATASHARD)
-
-    leader_tablet_ids = [
-        info.TabletId
-        for info in tablet_state_response.TabletStateInfo
-        if info.Leader
-    ]
-
+    # Find the tablet ID for the single DataShard of the test table
+    describe_url = "{}/viewer/json/describe?{}".format(
+        context.db_http_endpoint,
+        urllib.parse.urlencode({
+            "database": context.database,
+            "path": "{}/{}".format(context.database, _TABLE_NAME),
+            "enums": "true",
+            "partition_stats": "true",
+            "subs": "0",
+        }),
+    )
+    response = requests.get(describe_url)
+    response.raise_for_status()
+    table_partitions = response.json()["PathDescription"]["TablePartitions"]
+    leader_tablet_ids = [int(p["DatashardId"]) for p in table_partitions]
     assert len(leader_tablet_ids) == 1, "There should be exactly one leader DataShard"
 
     follower_url = "{}/tablets/app?TabletID={}&FollowerID=1".format(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The test got confused by the datashard of the `.metadata/_statistics` table that appeared after EnableColumnStatistics flag got turned on in https://github.com/ydb-platform/ydb/pull/40570

Fixes https://github.com/ydb-platform/ydb/issues/41526