### PR TITLE
ci: test stable-25-1 backport (CI trigger v2)

### DIFF
--- a/ydb/core/base/appdata.h
+++ b/ydb/core/base/appdata.h
@@ -61,3 +61,4 @@ namespace NKikimr {
 #endif
 
 #undef __PROTOS_WERE_INCLUDED
+// ci trigger v2


### PR DESCRIPTION
CI trigger PR for stable-25-1 backport verification (updated with get_test_history fix).

Backport PR: #41332

Adds a trivial change to `ydb/core/base/appdata.h` to trigger full CI on the backported branch.

## Changelog

Not for Changelog

Made with [Cursor](https://cursor.com)