### PR TITLE
[EXT-2250] Store return_to in OIDC state

### DIFF
--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -43,12 +43,13 @@ TString TContext::GetRequestedAddress() const {
 }
 
 TString TContext::CreateYdbOidcCookie(const TString& secret) const {
+    const TString cookieValue = GenerateCookie(secret);
     if (cookieValue.size() > TOpenIdConnectSettings::MAX_AUTH_FLOW_COOKIE_VALUE_SIZE) {
         return {};
     }
 
     return TStringBuilder()
-        << TOpenIdConnectSettings::YDB_OIDC_COOKIE << "=" << GenerateCookie(secret) << "; "
+        << TOpenIdConnectSettings::YDB_OIDC_COOKIE << "=" << cookieValue << "; "
         << "Path=" << GetAuthCallbackUrl() << "; "
         << "Max-Age=" << TOpenIdConnectSettings::DEFAULT_AUTH_STATE_LIFETIME.Seconds() << "; "
         << "Secure; "

--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -24,13 +24,13 @@ TContext::TContext(const NHttp::THttpIncomingRequestPtr& request)
     , RequestedAddress(GetRequestedUrl(request, NavigationRequest))
 {}
 
-TString TContext::GetState(const TString& key) const {
+TString TContext::GetState(const TString& key, bool includeRequestedAddress) const {
     TState payload;
     payload.AntiForgeryToken = State;
-    payload.ExpirationTime = TInstant::Now() + TOpenIdConnectSettings::DEFAULT_AUTH_STATE_LIFETIME;
-    if (!NavigationRequest) {
-        payload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
+    if (includeRequestedAddress) {
+        payload.RequestedAddress = RequestedAddress;
     }
+    payload.ExpirationTime = TInstant::Now() + TOpenIdConnectSettings::DEFAULT_AUTH_STATE_LIFETIME;
     return EncodeState(payload, key);
 }
 
@@ -43,11 +43,17 @@ TString TContext::GetRequestedAddress() const {
 }
 
 TString TContext::CreateYdbOidcCookie(const TString& secret) const {
-    return TStringBuilder() << CreateNameYdbOidcCookie(NavigationRequest ? TStringBuf() : TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX) << "="
-                            << GenerateCookie(secret) << ";"
-                            " Path=" << GetAuthCallbackUrl() << ";"
-                            " Max-Age=" << TOpenIdConnectSettings::DEFAULT_AUTH_STATE_LIFETIME.Seconds() << ";"
-                            " SameSite=None; Secure";
+    if (cookieValue.size() > TOpenIdConnectSettings::MAX_AUTH_FLOW_COOKIE_VALUE_SIZE) {
+        return {};
+    }
+
+    return TStringBuilder()
+        << TOpenIdConnectSettings::YDB_OIDC_COOKIE << "=" << GenerateCookie(secret) << "; "
+        << "Path=" << GetAuthCallbackUrl() << "; "
+        << "Max-Age=" << TOpenIdConnectSettings::DEFAULT_AUTH_STATE_LIFETIME.Seconds() << "; "
+        << "Secure; "
+        << "HttpOnly; "
+        << "SameSite=None";
 }
 
 TString TContext::GenerateCookie(const TString& key) const {

--- a/ydb/mvp/oidc_proxy/context.h
+++ b/ydb/mvp/oidc_proxy/context.h
@@ -30,7 +30,7 @@ public:
     TContext(const TInitializer& initializer);
     TContext(const NHttp::THttpIncomingRequestPtr& request);
 
-    TString GetState(const TString& key) const;
+    TString GetState(const TString& key, bool includeRequestedAddress = true) const;
     bool IsNavigationRequest() const;
     TString GetRequestedAddress() const;
 

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -585,9 +585,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         UNIT_ASSERT(headers.Has("X-Request-Id"));
         UNIT_ASSERT(headers.Has("Set-Cookie"));
         TStringBuf setCookie = headers.Get("Set-Cookie");
-        UNIT_ASSERT_STRING_CONTAINS(
-            setCookie,
-            CreateNameYdbOidcCookie(redirectStrategy.IsNavigationRequest() ? TStringBuf() : TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX));
+        UNIT_ASSERT_STRING_CONTAINS(setCookie, "ydb_oidc_cookie=");
         redirectStrategy.CheckSpecificHeaders(headers);
 
         const NActors::TActorId sessionCreator = runtime.Register(new TSessionCreateHandler(edge, settings));
@@ -696,14 +694,9 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TAutoPtr<IEventHandle> handle;
         NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
         const NHttp::THeaders protectedPageHeaders(outgoingResponseEv->Response->Headers);
-        if (redirectStrategy.IsNavigationRequest()) {
-            UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
-            UNIT_ASSERT(protectedPageHeaders.Has("Location"));
-            UNIT_ASSERT_STRINGS_EQUAL(protectedPageHeaders.Get("Location"), "/requested/page");
-        } else {
-            UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "400");
-            UNIT_ASSERT(!protectedPageHeaders.Has("Location"));
-        }
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+        UNIT_ASSERT(protectedPageHeaders.Has("Location"));
+        UNIT_ASSERT_STRINGS_EQUAL(protectedPageHeaders.Get("Location"), "/requested/page");
     }
 
     Y_UNIT_TEST(OpenIdConnectWrongStateAuthorizationFlow) {
@@ -716,19 +709,16 @@ Y_UNIT_TEST_SUITE(Mvp) {
         OidcWrongStateAuthorizationFlow(redirectStrategy);
     }
 
-    Y_UNIT_TEST(OpenIdConnectExpiredBackgroundStateKeepsCookieSuffix) {
+    Y_UNIT_TEST(OpenIdConnectExpiredStateCheckFails) {
         TPortManager tp;
         auto settings = BuildBaseSettings(tp);
         TState sourcePayload;
         sourcePayload.AntiForgeryToken = "state";
         sourcePayload.ExpirationTime = TInstant::Seconds(0);
-        sourcePayload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
 
         TCheckStateResult result = CheckState(EncodeState(sourcePayload, settings.ClientSecret), settings.ClientSecret);
-        const TString expectedCookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
 
         UNIT_ASSERT(!result.Ok);
-        UNIT_ASSERT_STRINGS_EQUAL(result.CookieSuffix, expectedCookieSuffix);
         UNIT_ASSERT_STRING_CONTAINS(result.ErrorMessage, "State life time expired");
     }
 
@@ -1015,8 +1005,8 @@ Y_UNIT_TEST_SUITE(Mvp) {
 
         TAutoPtr<IEventHandle> handle;
         NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
-        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "400");
-        UNIT_ASSERT_STRING_CONTAINS(outgoingResponseEv->Response->Body, "Unknown error has occurred. Please open the page again");
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "302");
+        UNIT_ASSERT_STRING_CONTAINS(outgoingResponseEv->Response->Headers, "Location: /requested/page");
     }
 
     Y_UNIT_TEST(OpenIdConnectSessionServiceCreateGetWrongStateAndWrongCookie) {
@@ -1638,14 +1628,12 @@ Y_UNIT_TEST_SUITE(Utils) {
         TState sourcePayload;
         sourcePayload.AntiForgeryToken = "state";
         sourcePayload.ExpirationTime = TInstant::Seconds(TInstant::Now().Seconds() + TDuration::Minutes(10).Seconds());
-        sourcePayload.CookieSuffix = TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE_BACKGROUND_SUFFIX);
 
         const TString state = EncodeState(sourcePayload, settings.ClientSecret);
         const TCheckStateResult result = CheckState(state, settings.ClientSecret);
         const TDecodeStateResult decodedResult = DecodeState(state);
 
         UNIT_ASSERT(result.Ok);
-        UNIT_ASSERT_STRINGS_EQUAL(result.CookieSuffix, sourcePayload.CookieSuffix);
         UNIT_ASSERT(result.ErrorMessage.empty());
         UNIT_ASSERT(decodedResult.HasSignedStateJson);
         UNIT_ASSERT(decodedResult.HasStateContainerJson);

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -7,6 +7,7 @@
 #include <ydb/library/actors/http/http.h>
 
 #include <library/cpp/json/json_reader.h>
+#include <library/cpp/string_utils/base64/base64.h>
 
 namespace NMVP::NOIDC {
 
@@ -21,6 +22,98 @@ THandlerSessionCreate::THandlerSessionCreate(const NActors::TActorId& sender,
     , Settings(settings)
 {}
 
+TRestoreOidcContextResult THandlerSessionCreate::RestoreOidcContext(const NHttp::TCookies& cookies, const TCheckStateResult& checkStateResult) {
+    TString requestedAddress = checkStateResult.RequestedAddress;
+    if (!cookies.Has(TOpenIdConnectSettings::YDB_OIDC_COOKIE)) {
+        if (requestedAddress.empty()) {
+            return TRestoreOidcContextResult(
+                {.IsSuccess = false,
+                 .IsErrorRetryable = false,
+                 .ErrorMessage = "Restore oidc context failed: requested address is missing in state and auth flow cookie"}
+            );
+        }
+
+        return TRestoreOidcContextResult(
+            {.IsSuccess = false,
+             .IsErrorRetryable = true,
+             .ErrorMessage = "Restore oidc context failed: auth flow cookie is missing"},
+            TContext({.RequestedAddress = requestedAddress})
+        );
+    }
+
+    TStringBuf authFlowCookieValue = cookies.Get(TOpenIdConnectSettings::YDB_OIDC_COOKIE);
+    TString requestedAddressFromCookie;
+    TString signedRequestedAddress;
+    try {
+        signedRequestedAddress = Base64StrictDecode(authFlowCookieValue);
+    } catch (std::exception& e) {
+        BLOG_D("Base64Decode auth flow cookie: " << e.what());
+    }
+
+    TString requestedAddressContext;
+    TString expectedDigest;
+    NJson::TJsonValue jsonValue;
+    NJson::TJsonReaderConfig jsonConfig;
+    if (NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
+        const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
+        if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
+            try {
+                requestedAddressContext = Base64StrictDecode(jsonRequestedAddressContext->GetString());
+            } catch (std::exception& e) {
+                BLOG_D("Base64Decode requested_address_context from auth flow cookie: " << e.what());
+            }
+        }
+        const NJson::TJsonValue* jsonDigest = nullptr;
+        if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
+            try {
+                expectedDigest = Base64StrictDecode(jsonDigest->GetString());
+            } catch (std::exception& e) {
+                BLOG_D("Base64Decode digest from auth flow cookie: " << e.what());
+            }
+        }
+    }
+
+    if (!requestedAddressContext.empty() &&
+        !expectedDigest.empty() &&
+        expectedDigest == HmacSHA256(Settings.ClientSecret, requestedAddressContext)) {
+        NJson::TJsonValue requestedAddressJsonValue;
+        if (NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &requestedAddressJsonValue)) {
+            const NJson::TJsonValue* jsonRequestedAddress = nullptr;
+            if (requestedAddressJsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
+                requestedAddressFromCookie = jsonRequestedAddress->GetString();
+            }
+        }
+    }
+
+    if (requestedAddress.empty()) {
+        requestedAddress = requestedAddressFromCookie;
+    }
+
+    if (requestedAddress.empty()) {
+        return TRestoreOidcContextResult(
+            {.IsSuccess = false,
+             .IsErrorRetryable = false,
+             .ErrorMessage = "Restore oidc context failed: requested address is missing in state and auth flow cookie"}
+        );
+    }
+
+    if (requestedAddressFromCookie.empty()) {
+        return TRestoreOidcContextResult(
+            {.IsSuccess = false,
+             .IsErrorRetryable = true,
+             .ErrorMessage = "Restore oidc context failed: auth flow cookie is invalid"},
+            TContext({.RequestedAddress = requestedAddress})
+        );
+    }
+
+    return TRestoreOidcContextResult(
+        {.IsSuccess = true,
+         .IsErrorRetryable = true,
+         .ErrorMessage = ""},
+        TContext({.RequestedAddress = requestedAddress})
+    );
+}
+
 void THandlerSessionCreate::Bootstrap() {
     BLOG_D("Restore oidc session");
     NHttp::TUrlParameters urlParameters(Request->URL);
@@ -31,7 +124,7 @@ void THandlerSessionCreate::Bootstrap() {
 
     NHttp::THeaders headers(Request->Headers);
     NHttp::TCookies cookies(headers.Get("cookie"));
-    TRestoreOidcContextResult restoreContextResult = RestoreOidcContext(cookies, Settings.ClientSecret, checkStateResult.CookieSuffix);
+    TRestoreOidcContextResult restoreContextResult = RestoreOidcContext(cookies, checkStateResult);
     Context = restoreContextResult.Context;
 
     if (checkStateResult.Ok) {

--- a/ydb/mvp/oidc_proxy/oidc_session_create.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.h
@@ -13,6 +13,9 @@
 
 namespace NMVP::NOIDC {
 
+struct TCheckStateResult;
+struct TRestoreOidcContextResult;
+
 class THandlerSessionCreate
     : public NActors::TActorBootstrapped<THandlerSessionCreate>
     , protected TMvpLogContextProvider {
@@ -46,6 +49,7 @@ protected:
     void ReplyBadRequestAndPassAway(TString errorMessage);
 
 private:
+    TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TCheckStateResult& checkStateResult);
     void SendUnknownErrorResponseAndDie();
 };
 

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -10,7 +10,6 @@ namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings {
     static const inline TString YDB_OIDC_COOKIE = "ydb_oidc_cookie";
-    static const inline TStringBuf YDB_OIDC_COOKIE_BACKGROUND_SUFFIX = "_background";
     static const inline TString SESSION_COOKIE = "session_cookie";
     static const inline TString IMPERSONATED_COOKIE = "impersonated_cookie";
 
@@ -20,6 +19,9 @@ struct TOpenIdConnectSettings {
     static const inline TString DEFAULT_EXCHANGE_URL_PATH = "/oauth2/session/exchange";
     static const inline TString DEFAULT_IMPERSONATE_URL_PATH = "/oauth2/impersonation/impersonate";
 
+    // Keep the auth-flow cookie value well below common 4 KiB limits to leave
+    // room for the cookie name, attributes, and other cookies in the header.
+    static constexpr inline ui32 MAX_AUTH_FLOW_COOKIE_VALUE_SIZE = 3700;
     static constexpr inline TDuration DEFAULT_REQUEST_TIMEOUT = TDuration::Seconds(120);
     static constexpr inline TDuration DEFAULT_AUTH_STATE_LIFETIME = TDuration::Minutes(10);
 

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -28,18 +28,32 @@ bool TRestoreOidcContextResult::IsSuccess() const {
     return Status.IsSuccess;
 }
 
-TCheckStateResult::TCheckStateResult(bool ok, const TString& cookieSuffix, const TString& errorMessage)
+TCheckStateResult::TCheckStateResult(bool ok, const TString& errorMessage, const TString& requestedAddress)
     : Ok(ok)
     , ErrorMessage(errorMessage)
-    , CookieSuffix(cookieSuffix)
+    , RequestedAddress(requestedAddress)
 {}
 
-TCheckStateResult TCheckStateResult::Error(const TString& errorMessage, const TString& cookieSuffix) {
-    return TCheckStateResult(false, cookieSuffix, errorMessage);
+TCheckStateResult TCheckStateResult::Error(const TString& errorMessage, const TString& requestedAddress) {
+    return TCheckStateResult(false, errorMessage, requestedAddress);
 }
 
-TCheckStateResult TCheckStateResult::Success(const TString& cookieSuffix) {
-    return TCheckStateResult(true, cookieSuffix, "");
+TCheckStateResult TCheckStateResult::Success(const TString& requestedAddress) {
+    return TCheckStateResult(true, "", requestedAddress);
+}
+
+TString CreateAuthorizationServerRedirectUrl(const TOpenIdConnectSettings& settings, TStringBuf redirectUri, TStringBuf state) {
+    TCgiParameters authParams;
+    authParams.InsertUnescaped("response_type", "code");
+    authParams.InsertUnescaped("scope", "openid");
+    authParams.InsertUnescaped("state", state);
+    authParams.InsertUnescaped("client_id", settings.ClientId);
+    authParams.InsertUnescaped("redirect_uri", redirectUri);
+
+    return TStringBuilder()
+        << settings.GetAuthEndpointURL()
+        << "?"
+        << authParams.Print();
 }
 
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers) {
@@ -90,18 +104,28 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
         << request->Host
         << GetAuthCallbackUrl();
 
-    TCgiParameters authParams;
-    authParams.InsertUnescaped("response_type", "code");
-    authParams.InsertUnescaped("scope", "openid");
-    authParams.InsertUnescaped("state", context.GetState(settings.ClientSecret));
-    authParams.InsertUnescaped("client_id", settings.ClientId);
-    authParams.InsertUnescaped("redirect_uri", redirectUri);
+    TString state = context.GetState(settings.ClientSecret);
+    TString redirectUrl = CreateAuthorizationServerRedirectUrl(settings, redirectUri, state);
+    static constexpr size_t AUTH_CALLBACK_CODE_RESERVE_BYTES = 200;
+    if (redirectUrl.size() + AUTH_CALLBACK_CODE_RESERVE_BYTES > NHttp::THttpRequestParser::MaxURLSize) {
+        // Keep return_to in the temp cookie when the authorization request URL is too large
+        // to leave room for the code returned by IAM in the callback.
+        state = context.GetState(settings.ClientSecret, false);
+        redirectUrl = CreateAuthorizationServerRedirectUrl(settings, redirectUri, state);
+    }
+    const TString authFlowCookie = context.CreateYdbOidcCookie(settings.ClientSecret);
+    if (authFlowCookie.empty()) {
+        return CreateResponseForNotExistingResponseFromProtectedResource(
+            request,
+            "requested address is too large to preserve during authentication",
+            requestId
+        );
+    }
 
-    const TString redirectUrl = settings.GetAuthEndpointURL() + "?" + authParams.Print();
     NHttp::THeadersBuilder responseHeaders;
     SetCORS(request, &responseHeaders);
     SetRequestIdHeader(responseHeaders, requestId);
-    responseHeaders.Set("Set-Cookie", context.CreateYdbOidcCookie(settings.ClientSecret));
+    responseHeaders.Set("Set-Cookie", authFlowCookie);
     if (context.IsNavigationRequest()) {
         responseHeaders.Set(LOCATION_HEADER, redirectUrl);
         return request->CreateResponse("302", "Authorization required", responseHeaders);
@@ -112,10 +136,6 @@ NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpInc
     json["authUrl"] = redirectUrl;
     const TString body = NJson::WriteJson(json, false);
     return request->CreateResponse("401", "Unauthorized", responseHeaders, body);
-}
-
-TString CreateNameYdbOidcCookie(TStringBuf suffix) {
-    return TString(TOpenIdConnectSettings::YDB_OIDC_COOKIE) + TString(suffix);
 }
 
 TString CreateNameSessionCookie(TStringBuf key) {
@@ -145,67 +165,6 @@ TString ClearSecureCookie(const TString& name) {
     return cookieBuilder;
 }
 
-TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix) {
-    TStringBuilder errorMessage;
-    errorMessage << "Restore oidc context failed: ";
-    TString cookieName = CreateNameYdbOidcCookie(cookieSuffix);
-    if (!cookies.Has(cookieName)) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Cannot find cookie " << cookieName});
-    }
-    TString signedRequestedAddress = Base64Decode(cookies.Get(cookieName));
-    TString requestedAddressContext;
-    TString expectedDigest;
-    NJson::TJsonValue jsonValue;
-    NJson::TJsonReaderConfig jsonConfig;
-    if (NJson::ReadJsonTree(signedRequestedAddress, &jsonConfig, &jsonValue)) {
-        const NJson::TJsonValue* jsonRequestedAddressContext = nullptr;
-        if (jsonValue.GetValuePointer("requested_address_context", &jsonRequestedAddressContext) && jsonRequestedAddressContext->IsString()) {
-            requestedAddressContext = jsonRequestedAddressContext->GetString();
-            requestedAddressContext = Base64Decode(requestedAddressContext);
-        }
-        if (requestedAddressContext.empty()) {
-            return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Struct with state is empty"});
-        }
-        const NJson::TJsonValue* jsonDigest = nullptr;
-        if (jsonValue.GetValuePointer("digest", &jsonDigest) && jsonDigest->IsString()) {
-            expectedDigest = jsonDigest->GetString();
-            expectedDigest = Base64Decode(expectedDigest);
-        }
-        if (expectedDigest.empty()) {
-            return TRestoreOidcContextResult({.IsSuccess = false,
-                                            .IsErrorRetryable = false,
-                                            .ErrorMessage = errorMessage << "Expected digest is empty"});
-        }
-    }
-    TString digest = HmacSHA256(key, requestedAddressContext);
-    if (expectedDigest != digest) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Calculated digest is not equal expected digest"});
-    }
-    TString requestedAddress;
-    if (!NJson::ReadJsonTree(requestedAddressContext, &jsonConfig, &jsonValue)) {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Requested address context is not valid json"});
-    }
-    const NJson::TJsonValue* jsonRequestedAddress = nullptr;
-    if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
-        requestedAddress = jsonRequestedAddress->GetString();
-    } else {
-        return TRestoreOidcContextResult({.IsSuccess = false,
-                                         .IsErrorRetryable = false,
-                                         .ErrorMessage = errorMessage << "Requested address was not found in the cookie"});
-    }
-    return TRestoreOidcContextResult({.IsSuccess = true,
-                                     .IsErrorRetryable = true,
-                                     .ErrorMessage = ""}, TContext({.RequestedAddress = requestedAddress}));
-}
-
 TCheckStateResult TDecodeStateResult::Check(const TString& key) const {
     static constexpr TStringBuf ErrorPrefix = "Check state failed: ";
     if (!HasSignedStateJson) {
@@ -226,22 +185,22 @@ TCheckStateResult TDecodeStateResult::Check(const TString& key) const {
         return TCheckStateResult::Error(TString(ErrorPrefix) + "State container is not valid json");
     }
     if (!Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time not found in json", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "Expiration time not found in json", Payload.RequestedAddress);
     }
     if (TInstant::Now() > *Payload.ExpirationTime) {
-        return TCheckStateResult::Error(TString(ErrorPrefix) + "State life time expired", Payload.CookieSuffix);
+        return TCheckStateResult::Error(TString(ErrorPrefix) + "State life time expired", Payload.RequestedAddress);
     }
-    return TCheckStateResult::Success(Payload.CookieSuffix);
+    return TCheckStateResult::Success(Payload.RequestedAddress);
 }
 
 TString EncodeState(const TState& payload, TStringBuf signingKey) {
     NJson::TJsonValue json(NJson::JSON_MAP);
     json["state"] = payload.AntiForgeryToken;
+    if (!payload.RequestedAddress.empty()) {
+        json["requested_address"] = payload.RequestedAddress;
+    }
     if (payload.ExpirationTime) {
         json["expiration_time"] = ToString(payload.ExpirationTime->TimeT());
-    }
-    if (!payload.CookieSuffix.empty()) {
-        json["cookie_suffix"] = payload.CookieSuffix;
     }
     const TString stateContainer = NJson::WriteJson(json, false);
 
@@ -279,9 +238,9 @@ TDecodeStateResult DecodeState(TStringBuf encodedState) {
             if (jsonValue.GetValuePointer("state", &jsonState) && jsonState->IsString()) {
                 result.Payload.AntiForgeryToken = jsonState->GetString();
             }
-            const NJson::TJsonValue* jsonCookieSuffix = nullptr;
-            if (jsonValue.GetValuePointer("cookie_suffix", &jsonCookieSuffix) && jsonCookieSuffix->IsString()) {
-                result.Payload.CookieSuffix = jsonCookieSuffix->GetString();
+            const NJson::TJsonValue* jsonRequestedAddress = nullptr;
+            if (jsonValue.GetValuePointer("requested_address", &jsonRequestedAddress) && jsonRequestedAddress->IsString()) {
+                result.Payload.RequestedAddress = jsonRequestedAddress->GetString();
             }
             const NJson::TJsonValue* jsonExpirationTime = nullptr;
             if (jsonValue.GetValuePointer("expiration_time", &jsonExpirationTime)) {

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -51,12 +51,12 @@ struct TCheckStateResult;
 
 struct TState {
     TString AntiForgeryToken;
-    TString CookieSuffix;
+    TString RequestedAddress;
     TMaybe<TInstant> ExpirationTime;
 
     bool operator==(const TState& other) const {
         return AntiForgeryToken == other.AntiForgeryToken
-            && CookieSuffix == other.CookieSuffix
+            && RequestedAddress == other.RequestedAddress
             && ExpirationTime == other.ExpirationTime;
     }
 };
@@ -75,27 +75,25 @@ struct TDecodeStateResult {
 struct TCheckStateResult {
     bool Ok = true;
     TString ErrorMessage;
-    TString CookieSuffix;
+    TString RequestedAddress;
 
-    static TCheckStateResult Error(const TString& errorMessage, const TString& cookieSuffix = "");
-    static TCheckStateResult Success(const TString& cookieSuffix = "");
+    static TCheckStateResult Error(const TString& errorMessage, const TString& requestedAddress = "");
+    static TCheckStateResult Success(const TString& requestedAddress = "");
 
 private:
-    TCheckStateResult(bool ok, const TString& cookieSuffix, const TString& errorMessage);
+    TCheckStateResult(bool ok, const TString& errorMessage, const TString& requestedAddress);
 };
 
 TString HmacSHA256(TStringBuf key, TStringBuf data);
 TString HmacSHA1(TStringBuf key, TStringBuf data);
 void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& value);
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings, TStringBuf requestId);
-TString CreateNameYdbOidcCookie(TStringBuf suffix = "");
 TString CreateNameSessionCookie(TStringBuf key);
 TString CreateNameImpersonatedCookie(TStringBuf key);
 const TString& GetAuthCallbackUrl();
 TString CreateSecureCookie(const TString& name, const TString& value, const ui32 expiredSeconds);
 TString ClearSecureCookie(const TString& name);
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers);
-TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key, TStringBuf cookieSuffix = "");
 TString EncodeState(const TState& payload, TStringBuf signingKey);
 TDecodeStateResult DecodeState(TStringBuf encodedState);
 TCheckStateResult CheckState(const TString& state, const TString& key);

--- a/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/oidc_proxy_testlib.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import re
 from base64 import b64encode
@@ -93,10 +94,12 @@ def assert_nc_auth_not_started(auth_service):
 
 def assert_cookie_is_set(response, expected_status, cookie_marker):
     assert response.status_code == expected_status, response.text
-    assert "Set-Cookie" in response.headers, response.headers
-    set_cookie = response.headers["Set-Cookie"]
-    assert cookie_marker in set_cookie, set_cookie
-    return set_cookie
+    set_cookie_headers = response_set_cookie_headers(response)
+    assert set_cookie_headers, response.headers
+    for set_cookie in set_cookie_headers:
+        if cookie_marker in set_cookie:
+            return set_cookie
+    raise AssertionError(f"cookie marker {cookie_marker!r} is missing in {set_cookie_headers!r}")
 
 
 def assert_cookie_is_cleared(response, expected_status, cookie_marker):
@@ -175,6 +178,37 @@ def get_multipart_stream_with_session(env, path, session_cookie, timeout=10):
     )
 
 
+def response_set_cookie_headers(response):
+    raw_headers = getattr(response.raw, "headers", None)
+    if raw_headers is not None and hasattr(raw_headers, "getlist"):
+        return list(raw_headers.getlist("Set-Cookie"))
+    set_cookie = response.headers.get("Set-Cookie")
+    if not set_cookie:
+        return []
+    return [set_cookie]
+
+
+def response_cookie_by_name(response, cookie_name):
+    for set_cookie in response_set_cookie_headers(response):
+        cookie_pair = set_cookie.split(";", 1)[0]
+        if cookie_pair.startswith(f"{cookie_name}="):
+            return cookie_pair
+    raise AssertionError(f"cookie {cookie_name!r} is missing in {response_set_cookie_headers(response)!r}")
+
+
+def auth_url_from_response(response):
+    if response.status_code == 302:
+        return response.headers["Location"]
+    response_json = response.json()
+    return response_json["authUrl"]
+
+
+def decode_oidc_state(state):
+    padded_state = state + "=" * (-len(state) % 4)
+    signed_state = json.loads(base64.urlsafe_b64decode(padded_state))
+    return json.loads(base64.b64decode(signed_state["container"]))
+
+
 def authenticate_session(oidc_proxy_full_flow_env, start_path):
     start_response = oidc_proxy_full_flow_env.get(
         start_path,
@@ -183,12 +217,11 @@ def authenticate_session(oidc_proxy_full_flow_env, start_path):
     )
 
     assert start_response.status_code == 302
-    assert "Set-Cookie" in start_response.headers
-    redirect_url = start_response.headers["Location"]
-    parsed_redirect = urlparse(redirect_url)
-    assert redirect_url.startswith(oidc_proxy_full_flow_env.auth_service.endpoint + "/oauth/authorize"), redirect_url
-    state = parse_qs(parsed_redirect.query)["state"][0]
-    oidc_cookie = start_response.headers["Set-Cookie"].split(";", 1)[0]
+    auth_flow_cookie = assert_cookie_is_set(start_response, 302, "ydb_oidc_cookie=")
+    assert "Path=/auth/callback;" in auth_flow_cookie, auth_flow_cookie
+    auth_url = auth_url_from_response(start_response)
+    state = parse_qs(urlparse(auth_url).query)["state"][0]
+    oidc_cookie = response_cookie_by_name(start_response, "ydb_oidc_cookie")
 
     callback_response = oidc_proxy_full_flow_env.get(
         f"/auth/callback?code=code_template%23&state={state}",
@@ -201,9 +234,9 @@ def authenticate_session(oidc_proxy_full_flow_env, start_path):
 
     assert callback_response.status_code == 302, callback_response.text
     assert callback_response.headers["Location"] == start_path, callback_response.headers
-    assert "__Host-session_cookie_" in callback_response.headers["Set-Cookie"], callback_response.headers["Set-Cookie"]
+    assert_cookie_is_set(callback_response, 302, "__Host-session_cookie_")
 
-    return callback_response.headers["Set-Cookie"].split(";", 1)[0]
+    return response_cookie_by_name(callback_response, session_cookie_name())
 
 
 def read_stream_body(response):

--- a/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
+++ b/ydb/tests/functional/mvp/oidc_proxy/test_auth_failures.py
@@ -4,19 +4,45 @@ from urllib.parse import parse_qs, urlparse
 from oidc_proxy_testlib import (
     CALLBACK_PATH,
     assert_nc_auth_not_started,
+    auth_url_from_response,
+    decode_oidc_state,
     get_auth_callback,
     protected_host,
+    response_cookie_by_name,
     session_cookie_header,
 )
 
-AUTH_AUTHORIZE_PATH = "/oauth/authorize"
 LANDING_DATA_PATH = "/tablets/app?TabletID=72057594037968897&page=LandingData"
+AUTH_AUTHORIZE_PATH = "/oauth/authorize"
+BROKEN_SESSION_TOKEN = "broken-session"
+BACKGROUND_FETCH_HEADERS = {
+    "Accept": "*/*",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "X-Requested-With": "XMLHttpRequest",
+}
+NAVIGATION_FETCH_HEADERS = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-User": "?1",
+}
 
 
 def assert_bad_auth_callback_response(response):
     assert response.status_code == 400
     assert "Set-Cookie" not in response.headers, response.headers
     assert "Location" not in response.headers, response.headers
+
+
+def tamper_cookie_value(cookie_pair):
+    cookie_name, cookie_value = cookie_pair.split("=", 1)
+    tampered_first_char = "b" if cookie_value[0] == "a" else "a"
+    return f"{cookie_name}={tampered_first_char}{cookie_value[1:]}"
+
+
+def oidc_authorize_url_prefix(env):
+    return env.auth_service.endpoint + AUTH_AUTHORIZE_PATH
 
 
 def test_auth_callback_without_request_id_is_bad_request(oidc_proxy_env):
@@ -47,36 +73,23 @@ def test_auth_callback_on_keep_alive_session_handles_two_requests(oidc_proxy_env
     assert_nc_auth_not_started(oidc_proxy_env.auth_service)
 
 
-def build_base_expired_session_request_headers(host):
+def build_expired_session_request_headers(host, extra_headers, referer=None):
     headers = {
         "Host": "oidcproxy.net",
-        "Cookie": session_cookie_header(token="broken-session"),
-        "Referer": f"https://oidcproxy.net/{host}/tablets/app?TabletID=72057594037968897",
+        "Cookie": session_cookie_header(token=BROKEN_SESSION_TOKEN),
+        "Referer": referer or f"https://oidcproxy.net/{host}/tablets/app?TabletID=72057594037968897",
         "Sec-Fetch-Site": "same-origin",
     }
+    headers.update(extra_headers)
     return headers
 
 
 def build_background_expired_session_request_headers(host):
-    headers = build_base_expired_session_request_headers(host)
-    headers.update({
-        "Accept": "*/*",
-        "Sec-Fetch-Dest": "empty",
-        "Sec-Fetch-Mode": "cors",
-        "X-Requested-With": "XMLHttpRequest",
-    })
-    return headers
+    return build_expired_session_request_headers(host, BACKGROUND_FETCH_HEADERS)
 
 
 def build_navigation_expired_session_request_headers(host):
-    headers = build_base_expired_session_request_headers(host)
-    headers.update({
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Sec-Fetch-Dest": "document",
-        "Sec-Fetch-Mode": "navigate",
-        "Sec-Fetch-User": "?1",
-    })
-    return headers
+    return build_expired_session_request_headers(host, NAVIGATION_FETCH_HEADERS)
 
 
 def start_auth_challenge_request(env, headers):
@@ -109,11 +122,11 @@ def start_navigation_auth_challenge_request(env):
     )
 
 
-def assert_background_auth_challenge(response):
+def assert_background_auth_challenge(env, response):
     assert response.status_code == 401, response.text
     response_json = response.json()
     assert response_json["error"] == "Authorization Required", response_json
-    assert urlparse(response_json["authUrl"]).path == AUTH_AUTHORIZE_PATH, response_json
+    assert response_json["authUrl"].startswith(oidc_authorize_url_prefix(env)), response_json
     assert "Location" not in response.headers, response.headers
     assert "Set-Cookie" in response.headers, response.headers
 
@@ -121,8 +134,20 @@ def assert_background_auth_challenge(response):
 def assert_navigation_auth_redirect(env, response):
     assert response.status_code == 302, response.text
     redirect_url = response.headers["Location"]
-    assert redirect_url.startswith(env.auth_service.endpoint + AUTH_AUTHORIZE_PATH), redirect_url
+    assert redirect_url.startswith(oidc_authorize_url_prefix(env)), redirect_url
     assert "Set-Cookie" in response.headers, response.headers
+
+
+def extract_auth_flow(response):
+    auth_url = auth_url_from_response(response)
+    state = parse_qs(urlparse(auth_url).query)["state"][0]
+    oidc_cookie = response_cookie_by_name(response, "ydb_oidc_cookie")
+    return state, oidc_cookie
+
+
+def assert_callback_restarts_to(response, target):
+    assert response.status_code == 302, response.text
+    assert response.headers["Location"] == target, response.headers
 
 
 def start_navigation_auth_flow(env, start_path):
@@ -132,12 +157,19 @@ def start_navigation_auth_flow(env, start_path):
         headers={"Host": "oidcproxy.net"},
     )
     assert_navigation_auth_redirect(env, response)
-    state = parse_qs(urlparse(response.headers["Location"]).query)["state"][0]
-    oidc_cookie = response.headers["Set-Cookie"].split(";", 1)[0]
-    return state, oidc_cookie
+    return extract_auth_flow(response)
 
 
-def finish_auth_callback(env, state, oidc_cookies):
+def start_background_auth_flow(env):
+    response = start_background_auth_challenge_request(env)
+    assert_background_auth_challenge(env, response)
+    return extract_auth_flow(response)
+
+
+def finish_auth_callback(env, state, oidc_cookies=()):
+    headers = {"Host": "oidcproxy.net"}
+    if oidc_cookies:
+        headers["Cookie"] = "; ".join(oidc_cookies)
     return env.get(
         "/auth/callback",
         params={
@@ -145,16 +177,13 @@ def finish_auth_callback(env, state, oidc_cookies):
             "state": state,
         },
         allow_redirects=False,
-        headers={
-            "Host": "oidcproxy.net",
-            "Cookie": "; ".join(oidc_cookies),
-        },
+        headers=headers,
     )
 
 
 def test_background_request_returns_json_401_with_auth_url(oidc_proxy_full_flow_env):
     response = start_background_auth_challenge_request(oidc_proxy_full_flow_env)
-    assert_background_auth_challenge(response)
+    assert_background_auth_challenge(oidc_proxy_full_flow_env, response)
 
 
 def test_navigation_request_returns_oidc_redirect(oidc_proxy_full_flow_env):
@@ -162,17 +191,92 @@ def test_navigation_request_returns_oidc_redirect(oidc_proxy_full_flow_env):
     assert_navigation_auth_redirect(oidc_proxy_full_flow_env, response)
 
 
-def test_navigation_callback_uses_cookie_from_state_when_background_cookie_exists(oidc_proxy_full_flow_env):
+def test_parallel_auth_attempts_keep_navigation_callback_context(oidc_proxy_full_flow_env):
     env = oidc_proxy_full_flow_env
     host = protected_host(env)
     navigation_target = f"/{host}{LANDING_DATA_PATH}&from=navigation"
 
     navigation_state, navigation_oidc_cookie = start_navigation_auth_flow(env, navigation_target)
-    background_response = start_background_auth_challenge_request(env)
-    assert_background_auth_challenge(background_response)
-    background_oidc_cookie = background_response.headers["Set-Cookie"].split(";", 1)[0]
+    background_state, background_oidc_cookie = start_background_auth_flow(env)
+    assert navigation_state != background_state
 
-    callback_response = finish_auth_callback(env, navigation_state, [navigation_oidc_cookie, background_oidc_cookie])
+    callback_response = finish_auth_callback(env, navigation_state, [background_oidc_cookie])
 
-    assert callback_response.status_code == 302, callback_response.text
-    assert callback_response.headers["Location"] == navigation_target, callback_response.headers
+    assert_callback_restarts_to(callback_response, navigation_target)
+
+
+def test_callback_without_matching_auth_flow_cookie_restarts_without_contacting_auth_server(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    navigation_target = f"/{host}{LANDING_DATA_PATH}&from=navigation"
+
+    navigation_state, _ = start_navigation_auth_flow(env, navigation_target)
+
+    callback_response = finish_auth_callback(env, navigation_state)
+
+    assert_callback_restarts_to(callback_response, navigation_target)
+    assert_nc_auth_not_started(env.auth_service)
+
+
+def test_callback_with_invalid_auth_flow_cookie_restarts_without_contacting_auth_server(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    navigation_target = f"/{host}{LANDING_DATA_PATH}&from=navigation"
+
+    navigation_state, navigation_oidc_cookie = start_navigation_auth_flow(env, navigation_target)
+
+    callback_response = finish_auth_callback(env, navigation_state, [tamper_cookie_value(navigation_oidc_cookie)])
+
+    assert_callback_restarts_to(callback_response, navigation_target)
+    assert_nc_auth_not_started(env.auth_service)
+
+
+def test_long_navigation_url_falls_back_to_auth_flow_cookie(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    navigation_target = f"/{host}{LANDING_DATA_PATH}&pad={'a' * 1000}"
+
+    navigation_state, navigation_oidc_cookie = start_navigation_auth_flow(env, navigation_target)
+    decoded_state = decode_oidc_state(navigation_state)
+    assert "requested_address" not in decoded_state, decoded_state
+
+    callback_response = finish_auth_callback(env, navigation_state, [navigation_oidc_cookie])
+
+    assert_callback_restarts_to(callback_response, navigation_target)
+
+
+def test_parallel_long_navigation_urls_latest_auth_flow_cookie_fallback_wins(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    first_navigation_target = f"/{host}{LANDING_DATA_PATH}&pad={'a' * 1000}&attempt=first"
+    second_navigation_target = f"/{host}{LANDING_DATA_PATH}&pad={'b' * 1000}&attempt=second"
+
+    first_state, first_oidc_cookie = start_navigation_auth_flow(env, first_navigation_target)
+    second_state, second_oidc_cookie = start_navigation_auth_flow(env, second_navigation_target)
+
+    assert first_state != second_state
+    assert "requested_address" not in decode_oidc_state(first_state)
+    assert "requested_address" not in decode_oidc_state(second_state)
+
+    callback_response = finish_auth_callback(env, first_state, [second_oidc_cookie])
+
+    assert_callback_restarts_to(callback_response, second_navigation_target)
+
+
+def test_background_request_with_requested_address_too_large_for_state_and_cookie_is_bad_request(oidc_proxy_full_flow_env):
+    env = oidc_proxy_full_flow_env
+    host = protected_host(env)
+    oversized_requested_address = f"https://oidcproxy.net/{host}{LANDING_DATA_PATH}&pad={'a' * 5000}"
+    headers = build_expired_session_request_headers(
+        host,
+        BACKGROUND_FETCH_HEADERS,
+        referer=oversized_requested_address,
+    )
+
+    response = start_auth_challenge_request(env, headers)
+
+    assert response.status_code == 400, response.text
+    assert "Location" not in response.headers, response.headers
+    assert "Set-Cookie" not in response.headers, response.headers
+    assert "requested address is too large to preserve during authentication" in response.text, response.text
+    assert env.auth_service.token_requests == []


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move return_to storage to signed OIDC state and keep legacy auth-flow cookie as fallback for oversized URLs.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Reworks auth-flow cookie storage to support multiple parallel nonces.
- Updates callback handling and tests for parallel auth attempts and missing/mismatched auth cookies.
