### PR TITLE
pq rd: fix SystemMetadata('user_attributes') placeholder with shared reading

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -352,6 +352,7 @@ private:
     // Set on Children
     const THolderFactory& HolderFactory;
     const TTypeEnvironment& TypeEnv;
+    TStructType* StructType = nullptr;
     NYdb::TDriver Driver;
     std::shared_ptr<NYdb::ICredentialsProviderFactory> CredentialsProviderFactory;
     IFederatedTopicClient::TPtr FederatedTopicClient;
@@ -621,7 +622,7 @@ TDqPqRdReadActor::TDqPqRdReadActor(
     const auto outputItemType = NCommon::ParseTypeFromYson(outputTypeYson, *programBuilder, error);
     YQL_ENSURE(outputItemType, "Failed to parse output type: " << outputTypeYson << ", reason: " << error.Str());
     YQL_ENSURE(outputItemType->IsStruct(), "Output type " << outputTypeYson << " is not struct");
-    const auto structType = static_cast<TStructType*>(outputItemType);
+    StructType = static_cast<TStructType*>(outputItemType);
 
     const TStringBuf format = SourceParams.GetFormat();
     const TStringBuf normalizedFormat = format.empty() ? TStringBuf("raw") : format;
@@ -631,10 +632,10 @@ TDqPqRdReadActor::TDqPqRdReadActor(
     // Build input schema and unpacker (packed rows from row dispatcher; not raw csv/json strings)
     TVector<TType* const> inputTypeParts;
     inputTypeParts.reserve(SourceParams.ColumnsSize());
-    ColumnIndexes.resize(structType->GetMembersCount());
+    ColumnIndexes.resize(StructType->GetMembersCount());
     for (size_t i = 0; i < SourceParams.ColumnsSize(); ++i) {
-        const auto index = structType->GetMemberIndex(SourceParams.GetColumns().Get(i));
-        inputTypeParts.emplace_back(structType->GetMemberType(index));
+        const auto index = StructType->GetMemberIndex(SourceParams.GetColumns().Get(i));
+        inputTypeParts.emplace_back(StructType->GetMemberType(index));
         ColumnIndexes[index] = i;
     }
     InputDataType = programBuilder->NewMultiType(inputTypeParts);
@@ -1275,13 +1276,18 @@ void TDqPqRdReadActor::AddMessageBatch(TRope&& messageBatch, NKikimr::NMiniKQL::
 
         NUdf::TUnboxedValue* itemPtr;
         NUdf::TUnboxedValuePod item = HolderFactory.CreateDirectArrayHolder(ColumnIndexes.size(), itemPtr);
+        const auto itemHead = itemPtr;
         for (const auto index : ColumnIndexes) {
             if (index) {
                 YQL_ENSURE(*index < parsedData.Width(), "Unexpected data width " << parsedData.Width() << ", failed to extract column by index " << index);
                 *(itemPtr++) = parsedRow[*index];
             } else {
                 // TODO: support metadata fields here
-                *(itemPtr++) = NUdf::TUnboxedValuePod::Zero();
+                if (StructType->GetMemberType(itemPtr - itemHead)->IsData()) {
+                    *(itemPtr++) = NUdf::TUnboxedValuePod::Zero();
+                } else { // special handling for user_attributes
+                    *(itemPtr++) = HolderFactory.GetEmptyContainerLazy();
+                }
             }
         }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1284,7 +1284,7 @@ void TDqPqRdReadActor::AddMessageBatch(TRope&& messageBatch, NKikimr::NMiniKQL::
             } else {
                 // TODO: replace stub metadata implementation (and move inside row_dispatcher/format_handler)
                 const auto itemType = StructType->GetMemberType(itemPtr - itemHead);
-                // must be metaddata field, with exactly two cases:
+                // must be metadata field, with exactly two cases:
                 if (itemType->IsData()) {
                     // POD (cluster, create_time, etc)
                     *(itemPtr++) = NUdf::TUnboxedValuePod::Zero();

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1282,10 +1282,15 @@ void TDqPqRdReadActor::AddMessageBatch(TRope&& messageBatch, NKikimr::NMiniKQL::
                 YQL_ENSURE(*index < parsedData.Width(), "Unexpected data width " << parsedData.Width() << ", failed to extract column by index " << index);
                 *(itemPtr++) = parsedRow[*index];
             } else {
-                // TODO: support metadata fields here
-                if (StructType->GetMemberType(itemPtr - itemHead)->IsData()) {
+                // TODO: replace stub metadata implementation (and move inside row_dispatcher/format_handler)
+                const auto itemType = StructType->GetMemberType(itemPtr - itemHead);
+                // must be metaddata field, with exactly two cases:
+                if (itemType->IsData()) {
+                    // POD (cluster, create_time, etc)
                     *(itemPtr++) = NUdf::TUnboxedValuePod::Zero();
-                } else { // special handling for user_attributes
+                } else {
+                    // Dict (user_attributes)
+                    YQL_ENSURE(itemType->IsDict());
                     *(itemPtr++) = HolderFactory.GetEmptyContainerLazy();
                 }
             }

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
@@ -690,14 +690,20 @@ Y_UNIT_TEST_SUITE(TDqPqRdReadActorTests) {
 
     Y_UNIT_TEST_F(MetadataFields, TFixture) {
         TReadValueParser<TMessage> metadataUVParser = [](const NUdf::TUnboxedValue& item) -> std::vector<TMessage> {
-            UNIT_ASSERT_VALUES_EQUAL(item.GetListLength(), 3);
-            auto stringElement = item.GetElement(2);
-            return { {item.GetElement(1).Get<ui64>(), TString(stringElement.AsStringRef())} };
+            UNIT_ASSERT_VALUES_EQUAL(item.GetListLength(), 4);
+            // FIXME validate current status: SystemMetadata is unimplemented
+            UNIT_ASSERT(item.GetElement(0).IsEmbedded());
+            UNIT_ASSERT_EQUAL(item.GetElement(0).Get<ui64>(), 0);
+            UNIT_ASSERT(item.GetElement(1).IsBoxed());
+            UNIT_ASSERT_VALUES_EQUAL(item.GetElement(1).GetDictLength(), 0);
+            auto stringElement = item.GetElement(3);
+            return { {item.GetElement(2).Get<ui64>(), TString(stringElement.AsStringRef())} };
         };
 
         auto source = Settings;
         source.AddMetadataFields("_yql_sys_create_time");
-        source.SetRowType("[StructType; [[_yql_sys_create_time; [DataType; Uint32]]; [dt; [DataType; Uint64]]; [value; [DataType; String]]]]");
+        source.AddMetadataFields("_yql_sys_user_attributes");
+        source.SetRowType("[StructType; [[_yql_sys_create_time; [DataType; Uint32]]; [_yql_sys_user_attributes; [DictType; [DataType; String]; [DataType; String]]]; [dt; [DataType; Uint64]]; [value; [DataType; String]]]]");
         StartSession(source);
 
         auto messages = std::vector{Message1};


### PR DESCRIPTION
SystemMetadata('user_attributes') is typed Dict, but rd currently fills all (unimplemented) metadata fields with TUV::Zero(). This results in crashes on uses of Dict (e.g. DictLength(SystemMetadata('user_attributes')))

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

(non-working attempt to deny filed was replaced with properly-typed placeholder)

FTR, proper implementation of `SystemMetadata` for shared reading should be moved inside `row_dispatcher/format_parser`, so that metadata field are available for pushdown and watermark generation, and this placeholder inside `dq_pq_rd_read_actor` should be removed. There are problematic special case, though: `SystemMetadata('cluster') ` is not really part of message metadata provided by topic sdk and synthesized (and row dispatcher is not aware about federated clusters at all); it is not quite clear how this should be handled (probably, it does not even needs to be handled? Two main uses for `SystemMetadata('cluster')` are pushdown in table-mode reading (not useful for shared reading), and advanced parsing and watermark generation (again, not useful for shared reading)