### PR TITLE
Parquet export public API

### DIFF
--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -156,16 +156,16 @@ message ExportToS3Settings {
     // - Object is excluded from export operation if it matches any of the specified exclude regexps.
     repeated string exclude_regexps = 17;
 
-    message CsvSettings {
+    message YdbDumpFormat {
     }
 
-    message ParquetSettings {
+    message ParquetFormat {
         uint32 row_group_size = 1;
     }
 
     oneof format {
-        CsvSettings csv_format = 18;
-        ParquetSettings parquet_format = 19;
+        YdbDumpFormat ydb_dump = 18;
+        ParquetFormat parquet = 19;
     }
 }
 

--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -155,7 +155,7 @@ message ExportToS3Settings {
     // - Patterns are matched against the object path relative to the export's source_path.
     // - Object is excluded from export operation if it matches any of the specified exclude regexps.
     repeated string exclude_regexps = 17;
-    
+
     message CsvSettings {
     }
 

--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -155,6 +155,18 @@ message ExportToS3Settings {
     // - Patterns are matched against the object path relative to the export's source_path.
     // - Object is excluded from export operation if it matches any of the specified exclude regexps.
     repeated string exclude_regexps = 17;
+    
+    message CsvSettings {
+    }
+
+    message ParquetSettings {
+        uint32 row_group_size = 1;
+    }
+
+    oneof format {
+        CsvSettings csv_format = 18;
+        ParquetSettings parquet_format = 19;
+    }
 }
 
 message ExportToS3Result {

--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -71,6 +71,13 @@ message ExportToYtResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
+message YdbDumpFormat {
+}
+
+message ParquetFormat {
+    uint32 row_group_size = 1;
+}
+
 /// S3
 message ExportToS3Settings {
     enum Scheme {
@@ -155,13 +162,6 @@ message ExportToS3Settings {
     // - Patterns are matched against the object path relative to the export's source_path.
     // - Object is excluded from export operation if it matches any of the specified exclude regexps.
     repeated string exclude_regexps = 17;
-
-    message YdbDumpFormat {
-    }
-
-    message ParquetFormat {
-        uint32 row_group_size = 1;
-    }
 
     oneof format {
         YdbDumpFormat ydb_dump = 18;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Предложение расширить grpc public API для export s3. Описание export https://ydb.tech/docs/en/reference/ydb-cli/export-import/export-s3?version=v25.3 В расширение добавляется формат данных для export: csv или parquet. Формат задается как oneof c message чтобы оставить возможность расширения параметров форматов (например для parquet строить индексы или нет). Если не указаны параметры в oneof, то по умолчанию используется csv как и раньше.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
