### PR TITLE
Fix BSController SelectGroups for empty groups

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -142,10 +142,16 @@ bool TBlobStorageController::TGroupInfo::FillInGroupParameters(
         return res;
     } else {
         bool res = true;
+        params->SetGroupSizeInUnits(GroupSizeInUnits);
+        if (VDisksInGroup.empty()
+            || !Topology
+            || !Topology->GetTotalVDisksNum()
+            || !Topology->GetTotalFailDomainsNum()) {
+            return false;
+        }
         res &= FillInResources(params->MutableAssuredResources(), true);
         res &= FillInResources(params->MutableCurrentResources(), false);
         res &= FillInVDiskResources(params);
-        params->SetGroupSizeInUnits(GroupSizeInUnits);
         return res;
     }
 }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -793,9 +793,10 @@ public:
 
         bool Listable() const {
             return VDisksInGroup
-                || !VirtualGroupState
-                || *VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::WORKING
-                || *VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::CREATE_FAILED;
+                || BridgeGroupInfo
+                || (VirtualGroupState
+                    && (*VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::WORKING
+                        || *VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::CREATE_FAILED));
         }
 
         void ClearVDisksInGroup() {

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/blobstorage/dsproxy/mock/dsproxy_mock.h>
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/core/mind/bscontroller/indir.h>
+#include <ydb/core/mind/bscontroller/impl.h>
 #include <ydb/core/mind/bscontroller/types.h>
 #include <ydb/core/mind/bscontroller/ut_helpers.h>
 #include <ydb/core/protos/blobstorage_config.pb.h>
@@ -1178,6 +1179,19 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
             }
             UNIT_ASSERT_VALUES_EQUAL(groupIds.size(), numGroups);
         }
+    }
+
+    Y_UNIT_TEST(EmptyPhysicalGroupIsNotListableAndDoesNotCrashResourceCalculation) {
+        TBlobStorageController::TGroupInfo group(TGroupId::FromValue(0x8200000f), 2, 0,
+            TBlobStorageGroupType::Erasure4Plus2Block, 0, NKikimrBlobStorage::TVDiskKind::Default,
+            0, 0, TString(), TString(), 0, 0, false, true, 0, TBridgePileId(), TBoxStoragePoolId(1, 1),
+            0, 0, 0, false);
+
+        UNIT_ASSERT(!group.Listable());
+
+        NKikimrBlobStorage::TEvControllerSelectGroupsResult::TGroupParameters params;
+        UNIT_ASSERT(!group.FillInGroupParameters(&params, nullptr));
+        UNIT_ASSERT_VALUES_EQUAL(params.GetGroupSizeInUnits(), 0);
     }
 
     Y_UNIT_TEST(AddDriveSerial) {


### PR DESCRIPTION
Fix BSController handling of dangling physical groups that have no VSlots/topology entries.

Summary:
- Do not list empty physical groups in SelectGroups candidates.
- Guard group parameter resource calculation from zero-topology groups before quorum/resource helpers run.
- Add a focused unit test for the empty physical group case.

Validation:
- `./ya make --build relwithdebinfo -tA -F '*EmptyPhysicalGroupIsNotListableAndDoesNotCrashResourceCalculation*' ydb/core/mind/bscontroller/ut_bscontroller`