### PR TITLE
schemeshard: enable EnableDataShardSplit* flags by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -269,7 +269,7 @@ message TFeatureFlags {
     optional bool EnablePDiskSpaceColorOverride = 242 [default = false];
     optional bool EnableSkipConflictCheckForTopicsInTransaction = 243 [default = false];
     // Split protocol control.
-    // By default, the schemeshard handles sorting and split boundary selection.
+    // Originally, schemeshard handled histogram sorting and split boundary selection.
     // These flags move that work to the datashard side:
     //
     // EnableDataShardSplitHistogramSorting - sort KeyAccessSample on datashard
@@ -278,10 +278,10 @@ message TFeatureFlags {
     // EnableDataShardSplitHistogramOmission - stop sending KeyAccessSample
     //     and DataSizeHistogram in datashard stats
     //
-    // Enabling a flag also enables all flags above it (HistogramSorting ⊃ KeySelection ⊃ HistogramOmission).
-    optional bool EnableDataShardSplitHistogramSorting = 244 [default = false];
-    optional bool EnableDataShardSplitKeySelection = 245 [default = false];
-    optional bool EnableDataShardSplitHistogramOmission  = 246 [default = false];
+    // Enabling a flag effectively enables all flags above it (HistogramSorting <- KeySelection <- HistogramOmission).
+    optional bool EnableDataShardSplitHistogramSorting = 244 [default = true];
+    optional bool EnableDataShardSplitKeySelection = 245 [default = true];
+    optional bool EnableDataShardSplitHistogramOmission = 246 [default = true];
     optional bool EnableOnlineAddUniqueIndex = 247 [default = false];
     optional bool EnableSharedReadingInStreamingQueries = 248 [default = false];
     optional bool EnableCsDictionaryEncoding = 249 [default = true];


### PR DESCRIPTION
Related to:
- https://github.com/ydb-platform/ydb/pull/35513

Feature flags:
`EnableDataShardSplitHistogramSorting`
`EnableDataShardSplitKeySelection`
`EnableDataShardSplitHistogramOmission`

Enable them by default in `main` to broaden the use of covered functionality.
