### PR TITLE
Refactor result accumulation in YDBWrapper to use extend method for better performance

### DIFF
--- a/.github/scripts/analytics/ydb_wrapper.py
+++ b/.github/scripts/analytics/ydb_wrapper.py
@@ -515,7 +515,7 @@ class YDBWrapper:
                         result = next(it)
                         batch_count += 1
                         batch_size = len(result.result_set.rows) if result.result_set.rows else 0
-                        results = results + result.result_set.rows
+                        results.extend(result.result_set.rows)
                         rows_affected += batch_size
 
                         if (batch_count % 50 == 0 or (rows_affected > 0 and rows_affected % 10000 == 0)) and rows_affected > 0:


### PR DESCRIPTION
Конкатенация каждый раз создаёт новый список и копирует всё накопленное — O(n²).  =>
extend добавляет элементы in-place за O(k) на батч (k — размер батча), итого O(n) 

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
