### PR TITLE
fix u-a-f TryEnqueueOneShard

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -221,7 +221,7 @@ void TSchemeShard::TryEnqueueOneShard(
 {
     auto* shards = ForcedCompactionShardsByTable.FindPtr(tablePathId);
     if (shards && !shards->Empty() && compaction.MaxShardsInFlight > compaction.ShardsInFlight.size()) {
-        const auto& shardIdx = shards->Front();
+        const auto shardIdx = shards->Front();
         shards->PopFront();
         --ForcedCompactionTotalInQueues;
         compaction.ShardsInFlight.insert(shardIdx);


### PR DESCRIPTION
regression by 016b025bcec15e3d0433474a9ad758ee2764112b found in asan failures

```
==1695489==ERROR: AddressSanitizer: heap-use-after-free on address 0x7badb7ffa928 at pc 0x00002ee98386 bp 0x7ffc572837e0 sp 0x7ffc572837d8
READ of size 8 at 0x7badb7ffa928 thread T0
    #0 0x00002ee98385 in Hash /-S/ydb/core/tx/schemeshard/schemeshard_identificators.h:40:28
    #1 0x00002ee98385 in operator() /-S/ydb/core/tx/schemeshard/schemeshard_identificators.h:157:18
    #2 0x00002ee98385 in bkt_num_key<NKikimr::NSchemeShard::TShardIdx> /-S/util/generic/hash_table.h:935:46
    #3 0x00002ee98385 in bkt_num_key<NKikimr::NSchemeShard::TShardIdx> /-S/util/generic/hash_table.h:925:16
    #4 0x00002ee98385 in bkt_num<NKikimr::NSchemeShard::TShardIdx> /-S/util/generic/hash_table.h:930:16
    #5 0x00002ee98385 in std::__y1::pair<__yhashtable_iterator<NKikimr::NSchemeShard::TShardIdx>, bool> THashTable<NKikimr::NSchemeShard::TShardIdx, NKikimr::NSchemeShard::TShardIdx, THash<NKikimr::NSchemeShard::TShardIdx>, TIdentity, TEqualTo<NKikimr::NSchemeShard::TShardIdx>, std::__y1::allocator<NKikimr::NSchemeShard::TShardIdx>>::insert_unique_noresize<NKikimr::NSchemeShard::TShardIdx>(NKikimr::NSchemeShard::TShardIdx const&) /-S/util/generic/hash_table.h:1042:25
    #6 0x00003012cc08 in insert_unique<NKikimr::NSchemeShard::TShardIdx> /-S/util/generic/hash_table.h:674:16
    #7 0x00003012cc08 in insert /-S/util/generic/hash_set.h:162:51
    #8 0x00003012cc08 in NKikimr::NSchemeShard::TSchemeShard::TryEnqueueOneShard(NKikimr::TPathId const&, NKikimr::NSchemeShard::TForcedCompactionInfo&, THashSet<NKikimr::TPathId, THash<NKikimr::TPathId>, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>*) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:227:35
    #9 0x00003012bebb in NKikimr::NSchemeShard::TSchemeShard::ProcessForcedCompactionQueues() /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:201:9
    #10 0x0000301441ce in NKikimr::NSchemeShard::TSchemeShard::TForcedCompaction::TTxCreate::DoComplete(NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp:169:15
    #11 0x00001e3268d2 in NKikimr::NTabletFlatExecutor::TSeat::Complete(NActors::TActorContext const&, bool) /-S/ydb/core/tablet_flat/flat_exec_seat.cpp:18:15
    #12 0x00001e203a79 in NKikimr::NTabletFlatExecutor::TLogicRedo::Confirm(unsigned int, NActors::TActorContext const&, NActors::TActorId const&) /-S/ydb/core/tablet_flat/flat_executor_txloglogic.cpp:278:15
    #13 0x00001dfa099f in NKikimr::NTabletFlatExecutor::TExecutor::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::TEvTablet::TEvCommitResult>, TDelete>&, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/flat_executor.cpp:3259:59
    #14 0x00001df3e490 in NKikimr::NTabletFlatExecutor::TExecutor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tablet_flat/flat_executor.cpp:4375:9
    #15 0x0000194d0767 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:394:17
    #16 0x00003a1e9c57 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #17 0x00003a1e2272 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #18 0x00003a1ec873 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #19 0x00003eec23bc in NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse* NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse>(TAutoPtr<NActors::IEventHandle, TDelete>&, std::__y1::function<bool (NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse const&)>, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:476:13
    #20 0x00003ee46c7b in GrabEdgeEvent<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse> /-S/ydb/library/actors/testlib/test_runtime.h:540:20
    #21 0x00003ee46c7b in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2371:27
    #22 0x00003ee47fd8 in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2376:9
    #23 0x000017bad3b3 in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseCheckCancelOperationFailureRepeated::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2520:9
    #24 0x000017c41267 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #25 0x000017c41267 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #26 0x000017c41267 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #27 0x000017c41267 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #28 0x000017c41267 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #29 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #30 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #31 0x000018523069 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #32 0x0000184fbb47 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #33 0x000017c4054c in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #34 0x0000184fd2ff in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #35 0x00001851d17c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #36 0x7f6db8b2ed8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
    #37 0x7f6db8b2ee3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
    #38 0x000015808028 in _start (/home/runner/.ya/build/build_root/g5k3/0024b5/ydb/core/tx/schemeshard/ut_compaction/ydb-core-tx-schemeshard-ut_compaction+0x15808028) (BuildId: 73b13266cf2cdcfdd3af35335f7fd0740f3a46ff)
0x7badb7ffa928 is located 24 bytes inside of 40-byte region [0x7badb7ffa910,0x7badb7ffa938)
freed by thread T0 here:
    #0 0x000017d34612 in operator delete(void*, unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x00002ef2f2c0 in __libcpp_operator_delete<__yhashtable_node<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem> *, unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:46:3
    #2 0x00002ef2f2c0 in __libcpp_deallocate<__yhashtable_node<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem> > /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:86:12
    #3 0x00002ef2f2c0 in deallocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:120:7
    #4 0x00002ef2f2c0 in put_node /-S/util/generic/hash_table.h:502:28
    #5 0x00002ef2f2c0 in delete_node /-S/util/generic/hash_table.h:961:9
    #6 0x00002ef2f2c0 in THashTable<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem::THash, TIdentity, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem::TEqual, std::__y1::allocator<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem>>::erase(__yhashtable_iterator<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem> const&) /-S/util/generic/hash_table.h
    #7 0x00002ef2ef49 in erase /-S/util/generic/hash_table.h:1310:5
    #8 0x00002ef2ef49 in erase /-S/util/generic/hash_set.h:227:13
    #9 0x00002ef2ef49 in NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::Remove(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/util/circular_queue.h:86:15
    #10 0x00003012cba6 in PopFront /-S/ydb/core/util/circular_queue.h:123:9
    #11 0x00003012cba6 in NKikimr::NSchemeShard::TSchemeShard::TryEnqueueOneShard(NKikimr::TPathId const&, NKikimr::NSchemeShard::TForcedCompactionInfo&, THashSet<NKikimr::TPathId, THash<NKikimr::TPathId>, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>*) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:225:17
    #12 0x00003012bebb in NKikimr::NSchemeShard::TSchemeShard::ProcessForcedCompactionQueues() /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:201:9
    #13 0x0000301441ce in NKikimr::NSchemeShard::TSchemeShard::TForcedCompaction::TTxCreate::DoComplete(NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp:169:15
    #14 0x00001e3268d2 in NKikimr::NTabletFlatExecutor::TSeat::Complete(NActors::TActorContext const&, bool) /-S/ydb/core/tablet_flat/flat_exec_seat.cpp:18:15
    #15 0x00001e203a79 in NKikimr::NTabletFlatExecutor::TLogicRedo::Confirm(unsigned int, NActors::TActorContext const&, NActors::TActorId const&) /-S/ydb/core/tablet_flat/flat_executor_txloglogic.cpp:278:15
    #16 0x00001dfa099f in NKikimr::NTabletFlatExecutor::TExecutor::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::TEvTablet::TEvCommitResult>, TDelete>&, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/flat_executor.cpp:3259:59
    #17 0x00001df3e490 in NKikimr::NTabletFlatExecutor::TExecutor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tablet_flat/flat_executor.cpp:4375:9
    #18 0x0000194d0767 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:394:17
    #19 0x00003a1e9c57 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #20 0x00003a1e2272 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #21 0x00003a1ec873 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #22 0x00003eec23bc in NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse* NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse>(TAutoPtr<NActors::IEventHandle, TDelete>&, std::__y1::function<bool (NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse const&)>, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:476:13
    #23 0x00003ee46c7b in GrabEdgeEvent<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse> /-S/ydb/library/actors/testlib/test_runtime.h:540:20
    #24 0x00003ee46c7b in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2371:27
    #25 0x00003ee47fd8 in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2376:9
    #26 0x000017bad3b3 in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseCheckCancelOperationFailureRepeated::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2520:9
    #27 0x000017c41267 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #28 0x000017c41267 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #29 0x000017c41267 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #30 0x000017c41267 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #31 0x000017c41267 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #32 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #33 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #34 0x000018523069 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #35 0x0000184fbb47 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #36 0x000017c4054c in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #37 0x0000184fd2ff in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #38 0x00001851d17c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #39 0x7f6db8b2ed8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
previously allocated by thread T0 here:
    #0 0x000017d339ad in operator new(unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x00003013692f in __libcpp_operator_new<unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:37:10
    #2 0x00003013692f in __libcpp_allocate<__yhashtable_node<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem> > /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:64:28
    #3 0x00003013692f in allocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:105:14
    #4 0x00003013692f in get_node /-S/util/generic/hash_table.h:497:43
    #5 0x00003013692f in new_node<const NKikimr::NSchemeShard::TShardIdx &> /-S/util/generic/hash_table.h:947:19
    #6 0x00003013692f in __yhashtable_iterator<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem> THashTable<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem::THash, TIdentity, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem::TEqual, std::__y1::allocator<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem>>::emplace_direct<NKikimr::NSchemeShard::TShardIdx const&>(__yhashtable_node<NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::TItem>**, NKikimr::NSchemeShard::TShardIdx const&) /-S/util/generic/hash_table.h:697:21
    #7 0x000030136733 in emplace_direct<const NKikimr::NSchemeShard::TShardIdx &> /-S/util/generic/hash_set.h:192:20
    #8 0x000030136733 in bool NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>::PushBack<NKikimr::NSchemeShard::TShardIdx const&>(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/util/circular_queue.h:74:30
    #9 0x00003012812c in Enqueue<const NKikimr::NSchemeShard::TShardIdx &> /-S/ydb/core/util/circular_queue.h:62:16
    #10 0x00003012812c in NKikimr::NSchemeShard::TSchemeShard::AddForcedCompactionShard(NKikimr::NSchemeShard::TShardIdx const&, NKikimr::TPathId const&, TIntrusivePtr<NKikimr::NSchemeShard::TForcedCompactionInfo, TDefaultIntrusivePtrOps<NKikimr::NSchemeShard::TForcedCompactionInfo>> const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:29:52
    #11 0x000030141787 in NKikimr::NSchemeShard::TSchemeShard::TForcedCompaction::TTxCreate::DoExecute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp:158:19
    #12 0x00002ed72908 in NKikimr::NSchemeShard::TSchemeShard::TRwTxBase::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_impl.cpp:1881:9
    #13 0x00001df7bed0 in NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(NKikimr::NTabletFlatExecutor::TSeat*) /-S/ydb/core/tablet_flat/flat_executor.cpp:2043:35
    #14 0x00001df7622a in NKikimr::NTabletFlatExecutor::TExecutor::DoExecute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NKikimr::NTabletFlatExecutor::TExecutor::ETxMode) /-S/ydb/core/tablet_flat/flat_executor.cpp:1957:13
    #15 0x00001df7ebd5 in Execute /-S/ydb/core/tablet_flat/flat_executor.cpp:1971:5
    #16 0x00001df7ebd5 in non-virtual thunk to NKikimr::NTabletFlatExecutor::TExecutor::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/flat_executor.cpp
    #17 0x00001df0f6b1 in Execute /-S/ydb/core/tablet_flat/tablet_flat_executed.cpp:63:21
    #18 0x00001df0f6b1 in NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/tablet_flat_executed.cpp:58:5
    #19 0x00003012da97 in NKikimr::NSchemeShard::TSchemeShard::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateRequest>, TDelete>&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:247:5
    #20 0x00002ed40cfc in NKikimr::NSchemeShard::TSchemeShard::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tx/schemeshard/schemeshard_impl.cpp:5522:9
    #21 0x0000194d0767 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:394:17
    #22 0x00003a1e9c57 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #23 0x00003a1e2272 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #24 0x00003a1ec873 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #25 0x00003eec23bc in NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse* NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse>(TAutoPtr<NActors::IEventHandle, TDelete>&, std::__y1::function<bool (NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse const&)>, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:476:13
    #26 0x00003ee46c7b in GrabEdgeEvent<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse> /-S/ydb/library/actors/testlib/test_runtime.h:540:20
    #27 0x00003ee46c7b in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2371:27
    #28 0x00003ee47fd8 in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2376:9
    #29 0x000017bad3b3 in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseCheckCancelOperationFailureRepeated::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2520:9
    #30 0x000017c41267 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #31 0x000017c41267 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #32 0x000017c41267 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #33 0x000017c41267 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #34 0x000017c41267 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:199:12
    #35 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:299:12
    #36 0x000018523069 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:825:10
    #37 0x000018523069 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #38 0x0000184fbb47 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #39 0x000017c4054c in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #40 0x0000184fd2ff in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #41 0x00001851d17c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:899:44
    #42 0x7f6db8b2ed8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)
```
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

fire-and-forget mode, please merge or drop
