### PR TITLE
[NBS-6779] Run ddisk copy on host state changes

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
@@ -23,22 +23,25 @@ message TOracleConfig
     // Interval between Oracle thinking in milliseconds.
     optional uint32 ThinkingInterval = 1;
 
+    // Maximum duration before host going temporary offline in milliseconds.
+    optional uint32 MaxDurationBeforeGoingTemporaryOffline = 2;
+
     // Maximum duration before host going offline in milliseconds.
-    optional uint32 MaxDurationBeforeGoingOffline = 2;
+    optional uint32 MaxDurationBeforeGoingOffline = 3;
 
     // The minimum number of erroneous requests after which the host is taken
     // offline. If the number of errors is less, the host will not go offline,
     // regardless of the time during which the errors occurred.
-    optional uint32 MinErrorsCountBeforeGoingOffline = 3;
+    optional uint32 MinErrorsCountBeforeGoingOffline = 4;
 
     // The number of failed requests after which the host is taken offline,
     // regardless of the time during which the errors occurred. Required to
     // protect PBuffer from overflow.
-    optional uint32 ErrorsCountForGoingOffline = 4;
+    optional uint32 ErrorsCountForGoingOffline = 5;
 
     // The total size of failed requests after which the host is taken offline.
     // Required to protect PBuffer from overflow.
-    optional uint64 ErrorsTotalSizeForGoingOffline = 5;
+    optional uint64 ErrorsTotalSizeForGoingOffline = 6;
 }
 
 message TStorageServiceConfig

--- a/ydb/core/nbs/cloud/blockstore/libs/service/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/service/partition_direct_service.h
@@ -10,11 +10,13 @@
 #include <util/datetime/base.h>
 #include <util/system/types.h>
 
-namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
-struct TVChunkConfig;
-}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect
-
 namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace NStorage::NPartitionDirect {
+class TVChunkConfig;
+}   // namespace NStorage::NPartitionDirect
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.cpp
@@ -97,7 +97,10 @@ TString ToString(const TLogTitle::TDirectBlockGroup& data)
 {
     TStringBuilder stream;
 
-    stream << "[dbg:" << data.DiskId;
+    stream << "[dbg:" << data.TabletId;
+    stream << " g:" << TOptional{data.Generation};
+    stream << " d:" << TOptional{data.DiskId};
+    stream << " indx:" << data.DirectBlockGroupIndex;
 
     return stream;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h
@@ -37,6 +37,9 @@ public:
     struct TDirectBlockGroup
     {
         TString DiskId;
+        ui64 TabletId = 0;
+        ui32 Generation = 0;
+        size_t DirectBlockGroupIndex = 0;
     };
 
     struct TVChunk

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -65,7 +65,7 @@ void TBaseFixture::Init()
          const NWilson::TTraceId& traceId)
     {
         Y_UNUSED(traceId);
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(THostIndex{0}, hostIndex);
 
         if (RangeData.empty()) {
@@ -96,7 +96,7 @@ void TBaseFixture::Init()
     {
         Y_UNUSED(lsn);
         Y_UNUSED(traceId);
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(THostIndex{0}, hostIndex);
 
         const ui64 offsetBlocks = range.Start - ExpectedRange.Start;
@@ -126,7 +126,7 @@ void TBaseFixture::Init()
         Y_UNUSED(hostIndex);
         Y_UNUSED(lsn);
 
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
         const ui64 offsetBlocks = range.Start - ExpectedRange.Start;
@@ -159,7 +159,7 @@ void TBaseFixture::Init()
     {
         Y_UNUSED(traceId);
 
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(FreshDDisk, hostIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
@@ -240,18 +240,23 @@ bool TBaseFixture::WaitScheduledTasks(size_t count, TDuration timeout)
     return Wait(ScheduledTasks, count, timeout);
 }
 
-void TBaseFixture::RunScheduledTasks()
+NThreading::TFuture<void> TBaseFixture::RunScheduledTasks()
 {
+    TPromise<void> promise = NewPromise<void>();
+    auto result = promise.GetFuture();
     auto guard = TGuard(PromisesGuard);
-    auto f = [scheduledTasks = std::move(ScheduledTasks)]   //
+    auto f = [scheduledTasks = std::move(ScheduledTasks),
+              promise = std::move(promise)]   //
         () mutable
     {
         for (auto& task: scheduledTasks) {
             task.Callback();
         }
+        promise.SetValue();
     };
 
     DirectBlockGroup->GetExecutor()->ExecuteSimple(f);
+    return result;
 }
 
 void TBaseFixture::SetReadResult(TDBGReadBlocksResponse response, bool async)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "direct_block_group_mock.h"
+#include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/context.h>
@@ -35,31 +36,27 @@ struct TScheduledTask
 struct TBaseFixture: public NUnitTest::TBaseFixture
 {
     static constexpr ui32 FixtureVChunkIndex = 100;
-    static constexpr size_t FixtureHostCount = 5;
-    static constexpr size_t FixturePrimaryCount = 3;
 
     const ui32 BlockSize = DefaultBlockSize;
+    const ui64 VChunkBlockCount = DefaultVChunkSize / BlockSize;
     const ui64 BlocksPerCopy = CopyRangeSize / BlockSize;
     const THostIndex FreshDDisk = 1;
-    TVChunkConfig VChunkConfig = TVChunkConfig::Make(
+    TVChunkConfig VChunkConfig = TVChunkConfig::MakeDefault(
         FixtureVChunkIndex,
-        FixtureHostCount,
-        FixturePrimaryCount);
+        DirectBlockGroupHostCount,
+        DefaultPrimaryCount);
     TLogTitle LogTitle{
         GetCycleCount(),
         TLogTitle::TVChunk{
             .DiskId = "disk-id",
-            .VChunkIndex = VChunkConfig.VChunkIndex}};
+            .VChunkIndex = VChunkConfig.GetVChunkIndex()}};
 
     std::unique_ptr<NActors::TTestActorRuntime> Runtime;
     TIntrusivePtr<::NMonitoring::TDynamicCounters> Counters{
         new ::NMonitoring::TDynamicCounters()};
     TPartitionDirectServiceMockPtr PartitionDirectService;
     TDirectBlockGroupMockPtr DirectBlockGroup;
-    TBlocksDirtyMap DirtyMap{
-        VChunkConfig,
-        BlockSize,
-        DefaultVChunkSize / BlockSize};
+    TBlocksDirtyMap DirtyMap{VChunkConfig, BlockSize, VChunkBlockCount};
 
     TBlockRange64 ExpectedRange;
     TString RangeData;
@@ -76,7 +73,7 @@ struct TBaseFixture: public NUnitTest::TBaseFixture
     TGuardedSgList MakeSgList() const;
 
     bool WaitScheduledTasks(size_t count, TDuration timeout);
-    void RunScheduledTasks();
+    NThreading::TFuture<void> RunScheduledTasks();
 
     void SetReadResult(TDBGReadBlocksResponse response, bool async);
     bool WaitReadRequests(size_t count, TDuration timeout);
@@ -89,6 +86,16 @@ struct TBaseFixture: public NUnitTest::TBaseFixture
 
     void SetEraseResult(TDBGEraseResponse response, bool async);
     bool WaitEraseRequests(size_t count, TDuration timeout);
+
+    static auto& AccessBlocksDirtyMap(TVChunk& vchunk)
+    {
+        return vchunk.BlocksDirtyMap;
+    }
+
+    static auto& AccessConfig(TVChunk& vchunk)
+    {
+        return vchunk.VChunkConfig;
+    }
 
 private:
     template <typename T>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.cpp
@@ -44,15 +44,15 @@ struct TDDiskDataCopier::TCopyRangeRequestState
 
 TDDiskDataCopier::TDDiskDataCopier(
     NActors::TActorSystem* actorSystem,
+    IPartitionDirectService* partitionDirectService,
     const TVChunkConfig& vChunkConfig,
-    IPartitionDirectServicePtr partitionDirectService,
     IDirectBlockGroupPtr directBlockGroup,
     TBlocksDirtyMap* dirtyMap,
     THostIndex destination)
     : ActorSystem(actorSystem)
+    , PartitionDirectService(partitionDirectService)
     , VChunkConfig(vChunkConfig)
     , VolumeConfig(partitionDirectService->GetVolumeConfig())
-    , PartitionDirectService(std::move(partitionDirectService))
     , DirectBlockGroup(std::move(directBlockGroup))
     , Destination(destination)
     , DirtyMap(dirtyMap)
@@ -62,7 +62,7 @@ TDDiskDataCopier::TDDiskDataCopier(
               .DiskId = VolumeConfig->DiskId,
               .Destination = static_cast<int>(Destination)}}
 {
-    Y_ASSERT(Destination < VChunkConfig.DDiskHosts.HostCount());
+    Y_ASSERT(Destination < VChunkConfig.GetHostCount());
 }
 
 TFuture<TDDiskDataCopier::EResult> TDDiskDataCopier::Start()
@@ -205,7 +205,7 @@ void TDDiskDataCopier::OnRangeRead(
     }
 
     auto writeFuture = DirectBlockGroup->WriteBlocksToDDisk(
-        VChunkConfig.VChunkIndex,
+        VChunkConfig.GetVChunkIndex(),
         Destination,
         copyRangeState->Range,
         copyRangeState->GetSgList(),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier.h
@@ -33,8 +33,8 @@ public:
 
     TDDiskDataCopier(
         NActors::TActorSystem* actorSystem,
+        IPartitionDirectService* partitionDirectService,
         const TVChunkConfig& vChunkConfig,
-        IPartitionDirectServicePtr partitionDirectService,
         IDirectBlockGroupPtr directBlockGroup,
         TBlocksDirtyMap* dirtyMap,
         THostIndex destination);
@@ -59,9 +59,9 @@ private:
         const TDBGWriteBlocksResponse& response);
 
     NActors::TActorSystem* const ActorSystem = nullptr;
+    IPartitionDirectService* const PartitionDirectService = nullptr;
     const TVChunkConfig VChunkConfig;
     const TVolumeConfigPtr VolumeConfig;
-    const IPartitionDirectServicePtr PartitionDirectService;
     const IDirectBlockGroupPtr DirectBlockGroup;
     const THostIndex Destination;
     TBlocksDirtyMap* const DirtyMap;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
@@ -30,15 +30,14 @@ struct TFixture: public TBaseFixture
     {
         TBaseFixture::Init();
 
-        DirtyMap.UpdateConfig(
-            VChunkConfig.PBufferHosts.GetPrimary(),
-            VChunkConfig.DDiskHosts.GetPrimary().Include(THostMask::MakeOne(3)),
-            /*disabled=*/THostMask::MakeEmpty());
+        VChunkConfig.PromoteHost(3);
+        VChunkConfig.SetWatermark(3, BlockSize * VChunkBlockCount);
+        DirtyMap.UpdateConfig(VChunkConfig);
 
         Copier = std::make_shared<TDDiskDataCopier>(
             Runtime->GetActorSystem(0),
+            PartitionDirectService.get(),
             VChunkConfig,
-            PartitionDirectService,
             DirectBlockGroup,
             &DirtyMap,
             FreshDDisk);
@@ -53,14 +52,22 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
     {
         Init();
 
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
+            DirtyMap.DebugPrintDDiskState());
+
         // Mark DDisk#1 completely fresh.
         DirtyMap.MarkFresh(FreshDDisk, 0);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,0,0};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,0,0};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
 
         // No ranges locked.
@@ -102,12 +109,12 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             if (i == 5) {
                 // Check state on 5th iteration
                 UNIT_ASSERT_VALUES_EQUAL(
-                    "H0{Operational,32768,32768};"
-                    "H1{Fresh,1536,1792};"   // Watermarks for reading
-                                             // and writing raised
-                    "H2{Operational,32768,32768};"
-                    "H3{Operational,32768,32768};"
-                    "H4{Operational,32768,32768};",
+                    "H0*{Operational,32768,32768};"
+                    "H1*{Fresh,1536,1792};"   // Watermarks for reading
+                                              // and writing raised
+                    "H2*{Operational,32768,32768};"
+                    "H3*{Operational,32768,32768};"
+                    "H4+{Disabled,0,0};",
                     DirtyMap.DebugPrintDDiskState());
             }
         }
@@ -120,11 +127,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
 
         // All DDisk fully operational
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Operational,32768,32768};"
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
     }
 
@@ -165,11 +172,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         UNIT_ASSERT_VALUES_EQUAL(0, *DirtyMap.GetFreshWatermark(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,0,256};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,0,256};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
     }
 
@@ -214,11 +221,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         UNIT_ASSERT_VALUES_EQUAL(0, *DirtyMap.GetFreshWatermark(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,0,256};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,0,256};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
     }
 
@@ -257,11 +264,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,256,256};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,256,256};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
 
         // Start data coping again
@@ -292,11 +299,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             complete.GetValue());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,512,512};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,512,512};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
     }
 
@@ -332,11 +339,11 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
             *DirtyMap.GetFreshWatermark(FreshDDisk));
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Operational,32768,32768};"
-            "H1{Fresh,512,512};"   // Watermarks
-            "H2{Operational,32768,32768};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Operational,32768,32768};"
+            "H1*{Fresh,512,512};"   // Watermarks
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
             DirtyMap.DebugPrintDDiskState());
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -87,6 +87,12 @@ TDirectBlockGroup::TDirectBlockGroup(
     , DirectBlockGroupIndex(directBlockGroupIndex)
     , StorageTransport(
           std::make_unique<NTransport::TICStorageTransport>(actorSystem))
+    , LogTitle(GetCycleCount(),
+          TLogTitle::TDirectBlockGroup{
+            .TabletId = TabletId,
+            .Generation = generation,
+              .DirectBlockGroupIndex = DirectBlockGroupIndex,
+            })
     , HostStatistics(DirectBlockGroupHostCount)
     , HostStates(DirectBlockGroupHostCount)
     , Oracle(StorageConfig, this, HostStatistics, HostStates)
@@ -165,6 +171,7 @@ std::shared_ptr<NWilson::TSpan> TDirectBlockGroup::CreateChildSpan(
 void TDirectBlockGroup::Run(IPartitionDirectService* service)
 {
     Service = service;
+    LogTitle.SetDiskId(Service->GetVolumeConfig()->DiskId);
 
     ScheduleOracleThinking();
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -29,18 +29,6 @@ constexpr auto DefaultOracleThinkInterval = TDuration::Seconds(1);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TString DoDump(
-    const TVector<THostStat>& statistics,
-    const TVector<THostState>& states)
-{
-    TStringBuilder sb;
-    for (size_t i = 0; i < states.size(); ++i) {
-        sb << " H" << i << ": " << states[i].DebugPrint() << " "
-           << statistics[i].DebugPrint() << "\n";
-    }
-    return sb;
-}
-
 TListPBufferResponse MakeListPBufferResponse(
     const NKikimrBlobStorage::NDDisk::TEvListPersistentBufferResult& response)
 {
@@ -87,15 +75,14 @@ TDirectBlockGroup::TDirectBlockGroup(
     , DirectBlockGroupIndex(directBlockGroupIndex)
     , StorageTransport(
           std::make_unique<NTransport::TICStorageTransport>(actorSystem))
-    , LogTitle(GetCycleCount(),
+    , LogTitle(
+          GetCycleCount(),
           TLogTitle::TDirectBlockGroup{
-            .TabletId = TabletId,
-            .Generation = generation,
+              .TabletId = TabletId,
+              .Generation = generation,
               .DirectBlockGroupIndex = DirectBlockGroupIndex,
-            })
-    , HostStatistics(DirectBlockGroupHostCount)
-    , HostStates(DirectBlockGroupHostCount)
-    , Oracle(StorageConfig, this, HostStatistics, HostStates)
+          })
+    , Oracle(StorageConfig, this)
 {
     Y_ASSERT(pbufferIds.size() == DirectBlockGroupHostCount);
     Y_ASSERT(ddisksIds.size() == DirectBlockGroupHostCount);
@@ -952,7 +939,10 @@ NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroup::Dump()
     return future;
 }
 
-void TDirectBlockGroup::SetHostState(THostIndex hostIndex, EHostState state)
+void TDirectBlockGroup::SetHostState(
+    THostIndex hostIndex,
+    EHostState oldState,
+    EHostState newState)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
@@ -961,13 +951,12 @@ void TDirectBlockGroup::SetHostState(THostIndex hostIndex, EHostState state)
         NKikimrServices::NBS_PARTITION,
         "Host[%ld] state changed: %s -> %s",
         static_cast<ui64>(hostIndex),
-        ToString(HostStates[hostIndex].State).c_str(),
-        ToString(state).c_str());
+        ToString(oldState).c_str(),
+        ToString(newState).c_str());
 
-    HostStates[hostIndex].State = state;
     for (const auto& weakVChunk: VChunks) {
         if (auto vChunk = weakVChunk.lock()) {
-            vChunk->SetHostState(hostIndex, state);
+            vChunk->SetHostState(hostIndex, newState);
         }
     }
 }
@@ -1118,7 +1107,7 @@ void TDirectBlockGroup::OnRequest(THostIndex hostIndex, EOperation operation)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
-    HostStatistics[hostIndex].OnRequest(operation);
+    Oracle.OnRequestStarted(hostIndex, operation, TInstant::Now());
 }
 
 void TDirectBlockGroup::OnResponse(
@@ -1130,12 +1119,13 @@ void TDirectBlockGroup::OnResponse(
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
     if (HasError(error)) {
-        HostStatistics[hostIndex].OnError(TInstant::Now(), operation);
+        Oracle.OnRequestFailed(hostIndex, operation, TInstant::Now());
     } else {
-        HostStatistics[hostIndex].OnSuccess(
+        Oracle.OnRequestSucceeded(
+            hostIndex,
+            operation,
             TInstant::Now(),
-            executionTime,
-            operation);
+            executionTime);
     }
 }
 
@@ -1157,26 +1147,22 @@ void TDirectBlockGroup::OnMultiFlushResponse(
             return HasError(error);
         });
 
+    const auto now = TInstant::Now();
     if (hasError) {
-        HostStatistics[ddiskHostIndex].OnError(TInstant::Now(), operation);
+        Oracle.OnRequestFailed(ddiskHostIndex, operation, now);
     } else {
-        HostStatistics[ddiskHostIndex].OnSuccess(
-            TInstant::Now(),
-            executionTime,
-            operation);
-        HostStatistics[pbufferHostIndex].OnSuccess(
-            TInstant::Now(),
-            executionTime,
-            operation);
+        Oracle
+            .OnRequestSucceeded(ddiskHostIndex, operation, now, executionTime);
+        Oracle.OnRequestSucceeded(
+            pbufferHostIndex,
+            operation,
+            now,
+            executionTime);
     }
 }
 
 void TDirectBlockGroup::Thinking()
 {
-    for (THostIndex hostIndex = 0; hostIndex < HostStates.size(); ++hostIndex) {
-        HostStates[hostIndex].PBufferUsedSize =
-            GetHostPBufferUsedSize(hostIndex);
-    }
     Oracle.Think(TInstant::Now());
 }
 
@@ -1202,7 +1188,7 @@ TDBGDumpResponse TDirectBlockGroup::DoDebugPrintDirtyMap()
 
     TStringBuilder sb;
     sb << "DBG[" << DirectBlockGroupIndex << "]\n";
-    sb << DoDump(HostStatistics, HostStates);
+    sb << Oracle.Dump();
 
     TDBGDumpResponse result;
     result.DirectBlockGroupIndex = DirectBlockGroupIndex;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -121,7 +121,10 @@ public:
     NThreading::TFuture<TDBGDumpResponse> Dump() override;
 
     // IHostStateController implementation
-    void SetHostState(THostIndex hostIndex, EHostState state) override;
+    void SetHostState(
+        THostIndex hostIndex,
+        EHostState oldState,
+        EHostState newState) override;
     ui64 GetHostPBufferUsedSize(THostIndex hostIndex) const override;
 
 private:
@@ -201,8 +204,6 @@ private:
     IPartitionDirectService* Service = nullptr;
     TVector<TDDiskConnection> DDiskConnections;
     TVector<TDDiskConnection> PBufferConnections;
-    TVector<THostStat> HostStatistics;
-    TVector<THostState> HostStates;
     TDDiskIdToHostIndex PBufferIdToHostIndex;
     TVector<TVChunkWeakPtr> VChunks;
     TOracle Oracle;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -6,6 +6,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/common/thread_checker.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/storage.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h>
@@ -196,6 +197,7 @@ private:
     const size_t DirectBlockGroupIndex;
     const std::unique_ptr<NTransport::IStorageTransport> StorageTransport;
 
+    TLogTitle LogTitle;
     IPartitionDirectService* Service = nullptr;
     TVector<TDDiskConnection> DDiskConnections;
     TVector<TDDiskConnection> PBufferConnections;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -8,6 +8,31 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TOracleMock::OnRequestStarted(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now)
+{
+    Y_UNUSED(hostIndex, operation, now);
+}
+
+void TOracleMock::OnRequestSucceeded(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now,
+    TDuration executionTime)
+{
+    Y_UNUSED(hostIndex, operation, now, executionTime);
+}
+
+void TOracleMock::OnRequestFailed(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now)
+{
+    Y_UNUSED(hostIndex, operation, now);
+}
+
 THostIndex TOracleMock::SelectBestPBufferHost(
     std::span<const THostIndex> hostIndexes,
     EOperation operation) const
@@ -34,6 +59,11 @@ TDuration TOracleMock::GetPBufferReplyTimeout() const
 EWriteMode TOracleMock::GetWriteMode() const
 {
     return WriteMode;
+}
+
+TString TOracleMock::Dump() const
+{
+    return {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -15,6 +15,20 @@ struct TOracleMock: public IOracle
     TDuration PBufferReplyTimeout;
     EWriteMode WriteMode = EWriteMode::DirectPBuffersFilling;
 
+    void OnRequestStarted(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) override;
+    void OnRequestSucceeded(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now,
+        TDuration executionTime) override;
+    void OnRequestFailed(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) override;
+
     [[nodiscard]] THostIndex SelectBestPBufferHost(
         std::span<const THostIndex> hostIndexes,
         EOperation operation) const override;
@@ -23,6 +37,8 @@ struct TOracleMock: public IOracle
     [[nodiscard]] TDuration GetWriteRequestTimeout() const override;
     [[nodiscard]] TDuration GetPBufferReplyTimeout() const override;
     [[nodiscard]] EWriteMode GetWriteMode() const override;
+
+    [[nodiscard]] TString Dump() const override;
 };
 
 class TDirectBlockGroupMock: public IDirectBlockGroup

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -166,6 +166,13 @@ void TDDiskState::Init(ui64 totalBlockCount, ui64 operationalBlockCount)
     SetReadWatermark(operationalBlockCount);
 }
 
+void TDDiskState::SwitchOffline()
+{
+    State = EState::Disabled;
+    FlushableBlockCount = 0;
+    OperationalBlockCount = 0;
+}
+
 TDDiskState::EState TDDiskState::GetState() const
 {
     return State;
@@ -242,34 +249,31 @@ TBlocksDirtyMap::TBlocksDirtyMap(
     ui64 blockCount)
     : BlockSize(blockSize)
     , BlockCount(blockCount)
-    , DesiredPBuffers(vChunkConfig.PBufferHosts.GetPrimary())
-    , DesiredDDisks(vChunkConfig.DDiskHosts.GetPrimary())
+    , DDiskStates(vChunkConfig.GetHostCount())
+    , PBufferCounters(vChunkConfig.GetHostCount())
 {
-    const size_t pbufferHostCount = vChunkConfig.PBufferHosts.HostCount();
-    const size_t ddiskHostCount = vChunkConfig.DDiskHosts.HostCount();
-    Y_ABORT_UNLESS(pbufferHostCount > 0);
-    Y_ABORT_UNLESS(pbufferHostCount <= MaxHostCount);
-    Y_ABORT_UNLESS(ddiskHostCount > 0);
-    Y_ABORT_UNLESS(ddiskHostCount <= MaxHostCount);
-    PBufferCounters.resize(pbufferHostCount);
-
-    DDiskStates.resize(ddiskHostCount);
-    for (auto& state: DDiskStates) {
-        state.Init(BlockCount, BlockCount);
-    }
+    UpdateConfig(vChunkConfig);
 }
 
-void TBlocksDirtyMap::UpdateConfig(
-    THostMask desiredPBuffers,
-    THostMask desiredDDisks,
-    THostMask disabled)
+void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
 {
-    Y_ABORT_UNLESS(disabled.LogicalAnd(desiredPBuffers).Empty());
-    Y_ABORT_UNLESS(disabled.LogicalAnd(desiredDDisks).Empty());
+    const THostMask added = vChunkConfig.GetDDisks().Exclude(DesiredPBuffers);
+    const THostMask removed = DesiredPBuffers.Exclude(vChunkConfig.GetDDisks());
 
-    DesiredPBuffers = desiredPBuffers;
-    DesiredDDisks = desiredDDisks;
-    DisabledHosts = disabled;
+    DesiredPBuffers = vChunkConfig.GetDesiredPBuffers();
+    DesiredDDisks = vChunkConfig.GetDDisks();
+    DisabledHosts = vChunkConfig.GetDisabledHosts();
+
+    for (auto indx: added) {
+        const auto watermark = vChunkConfig.GetWatermark(indx);
+        DDiskStates[indx].Init(
+            BlockCount,
+            watermark ? *watermark / BlockSize : BlockCount);
+    }
+
+    for (auto indx: removed) {
+        DDiskStates[indx].SwitchOffline();
+    }
 }
 
 TBlocksDirtyMap::~TBlocksDirtyMap()
@@ -414,7 +418,8 @@ TFlushHints TBlocksDirtyMap::MakeFlushHint(size_t batchSize)
                 continue;
             }
 
-            const THostIndex source = val.RequestFlush(destination);
+            const THostIndex source =
+                val.RequestFlush(destination, DisabledHosts);
             if (source != InvalidHostIndex) {
                 result.AddHint(source, destination, item->Key, item->Range);
             }
@@ -816,7 +821,19 @@ TString TBlocksDirtyMap::DebugPrintDDiskState() const
 {
     TStringBuilder result;
     for (THostIndex h = 0; h < DDiskStates.size(); ++h) {
-        result << "H" << ui32(h) << DDiskStates[h].DebugPrint() << ";";
+        result << "H" << static_cast<ui32>(h);
+
+        const bool disabled = DisabledHosts.Get(h);
+        const bool desired = DesiredDDisks.Get(h);
+        if (disabled) {
+            result << "-";
+        } else if (desired) {
+            result << "*";
+        } else {
+            result << "+";
+        }
+
+        result << DDiskStates[h].DebugPrint() << ";";
     }
     return result;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -257,8 +257,8 @@ TBlocksDirtyMap::TBlocksDirtyMap(
 
 void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
 {
-    const THostMask added = vChunkConfig.GetDDisks().Exclude(DesiredPBuffers);
-    const THostMask removed = DesiredPBuffers.Exclude(vChunkConfig.GetDDisks());
+    const THostMask added = vChunkConfig.GetDDisks().Exclude(DesiredDDisks);
+    const THostMask removed = DesiredDDisks.Exclude(vChunkConfig.GetDDisks());
 
     DesiredPBuffers = vChunkConfig.GetDesiredPBuffers();
     DesiredDDisks = vChunkConfig.GetDDisks();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -821,7 +821,7 @@ TString TBlocksDirtyMap::DebugPrintDDiskState() const
 {
     TStringBuilder result;
     for (THostIndex h = 0; h < DDiskStates.size(); ++h) {
-        result << "H" << static_cast<ui32>(h);
+        result << PrintHostIndex(h);
 
         const bool disabled = DisabledHosts.Get(h);
         const bool desired = DesiredDDisks.Get(h);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -135,7 +135,11 @@ public:
                  // from the blocks below the OperationalBlockCount.
     };
 
+    // Enables the use of DDisk. If the operational blocks count less then total
+    // block count, then the DDisk is only partially filled (fresh).
     void Init(ui64 totalBlockCount, ui64 operationalBlockCount);
+
+    // Completely disables DDisk usage.
     void SwitchOffline();
 
     [[nodiscard]] EState GetState() const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -15,7 +15,7 @@
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
-struct TVChunkConfig;
+class TVChunkConfig;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -126,13 +126,17 @@ class TDDiskState
 public:
     enum class EState
     {
-        Operational,   // The ddisk is fully functional and can be read from
+        Disabled,   // There are no DDisks with data on the host and DDisk
+                    // cannot be used.
+
+        Operational,   // The DDisk is fully functional and can be read from
                        // anywhere.
         Fresh,   // The ddisk is only partially filled, and you can only read
                  // from the blocks below the OperationalBlockCount.
     };
 
     void Init(ui64 totalBlockCount, ui64 operationalBlockCount);
+    void SwitchOffline();
 
     [[nodiscard]] EState GetState() const;
     [[nodiscard]] bool CanReadFromDDisk(TBlockRange64 range) const;
@@ -147,7 +151,7 @@ public:
 private:
     void UpdateState();
 
-    EState State = EState::Operational;
+    EState State = EState::Disabled;
 
     ui64 TotalBlockCount = 0;
 
@@ -201,10 +205,8 @@ public:
         ui64 blockCount);
     ~TBlocksDirtyMap() override;
 
-    void UpdateConfig(
-        THostMask desiredPBuffers,
-        THostMask desiredDDisks,
-        THostMask disabled);
+    // Note. Fresh watermarks are not applying for exists DDisks.
+    void UpdateConfig(const TVChunkConfig& vChunkConfig);
 
     void RestorePBuffer(ui64 lsn, TBlockRange64 range, THostIndex host);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -143,9 +143,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
     Y_UNIT_TEST(ShouldSwitchOffline)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
-        TString error;
         // Offline H1
-        vchunkConfig.TurnOffline(1, &error);
+        vchunkConfig.TurnOffHost(1);
 
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
@@ -161,7 +160,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H0
-        vchunkConfig.TurnOffline(0, &error);
+        vchunkConfig.TurnOffHost(0);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -172,7 +171,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Can't switch H2 offline
-        vchunkConfig.TurnOffline(2, &error);
+        vchunkConfig.TurnOffHost(2);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -183,7 +182,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H3
-        vchunkConfig.TurnOffline(3, &error);
+        vchunkConfig.TurnOffHost(3);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -194,7 +193,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H4
-        vchunkConfig.TurnOffline(4, &error);
+        vchunkConfig.TurnOffHost(4);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -260,7 +259,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Can't switch H2 offline
-        vchunkConfig.TurnOffline(2, &error);
+        vchunkConfig.TurnOffHost(2);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0*{Fresh,0,0};"
@@ -621,7 +620,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Host 0 disabled, hosts 1,2,3 primary, host 4 hand-off.
         vchunkConfig.PromoteHost(3);
         TString error;
-        vchunkConfig.TurnOffline(0, &error);
+        vchunkConfig.TurnOffHost(0);
         UNIT_ASSERT_VALUES_EQUAL("", error);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
 
@@ -673,9 +672,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Hosts 0,1 disabled; hosts 2,3,4 are primary.
         TString error;
-        vchunkConfig.TurnOffline(0, &error);
+        vchunkConfig.TurnOffHost(0);
         UNIT_ASSERT_VALUES_EQUAL("", error);
-        vchunkConfig.TurnOffline(1, &error);
+        vchunkConfig.TurnOffHost(1);
         UNIT_ASSERT_VALUES_EQUAL("", error);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
         vchunkConfig.SetWatermark(4, DefaultBlockSize * 1024);
@@ -733,10 +732,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
         // Host 0 disabled; hosts 1,2,3 primary; host 4 hand-off.
-        TString error;
-        vchunkConfig.TurnOffline(0, &error);
+        vchunkConfig.TurnOffHost(0);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
-        UNIT_ASSERT_VALUES_EQUAL("", error);
 
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -144,7 +144,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
         // Offline H1
-        vchunkConfig.TurnOffHost(1);
+        vchunkConfig.EvacuateHost(1);
 
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
@@ -160,7 +160,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H0
-        vchunkConfig.TurnOffHost(0);
+        vchunkConfig.EvacuateHost(0);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -171,7 +171,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Can't switch H2 offline
-        vchunkConfig.TurnOffHost(2);
+        vchunkConfig.EvacuateHost(2);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -182,7 +182,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H3
-        vchunkConfig.TurnOffHost(3);
+        vchunkConfig.EvacuateHost(3);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -193,7 +193,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Offline H4
-        vchunkConfig.TurnOffHost(4);
+        vchunkConfig.EvacuateHost(4);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0-{Disabled,0,0};"
@@ -259,7 +259,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.DebugPrintDDiskState());
 
         // Can't switch H2 offline
-        vchunkConfig.TurnOffHost(2);
+        vchunkConfig.EvacuateHost(2);
         dirtyMap.UpdateConfig(vchunkConfig);
         UNIT_ASSERT_VALUES_EQUAL(
             "H0*{Fresh,0,0};"
@@ -620,7 +620,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Host 0 disabled, hosts 1,2,3 primary, host 4 hand-off.
         vchunkConfig.PromoteHost(3);
         TString error;
-        vchunkConfig.TurnOffHost(0);
+        vchunkConfig.EvacuateHost(0);
         UNIT_ASSERT_VALUES_EQUAL("", error);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
 
@@ -672,9 +672,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Hosts 0,1 disabled; hosts 2,3,4 are primary.
         TString error;
-        vchunkConfig.TurnOffHost(0);
+        vchunkConfig.EvacuateHost(0);
         UNIT_ASSERT_VALUES_EQUAL("", error);
-        vchunkConfig.TurnOffHost(1);
+        vchunkConfig.EvacuateHost(1);
         UNIT_ASSERT_VALUES_EQUAL("", error);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
         vchunkConfig.SetWatermark(4, DefaultBlockSize * 1024);
@@ -732,7 +732,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
     {
         auto vchunkConfig = MakeTestVChunkConfig();
         // Host 0 disabled; hosts 1,2,3 primary; host 4 hand-off.
-        vchunkConfig.TurnOffHost(0);
+        vchunkConfig.EvacuateHost(0);
         vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
 
         TBlocksDirtyMap dirtyMap(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -13,40 +13,13 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr ui64 DefaultVChunkSize = RegionSize / DirectBlockGroupsCount;
-constexpr size_t HostCount = 5;
-constexpr size_t PrimaryCount = 3;
 
 TVChunkConfig MakeTestVChunkConfig()
 {
-    return TVChunkConfig::Make(
+    return TVChunkConfig::MakeDefault(
         /*vChunkIndex=*/0,
-        HostCount,
-        PrimaryCount);
-}
-
-void ApplyStatuses(
-    TBlocksDirtyMap& map,
-    TVector<EHostRole> assignments,
-    TVector<EHostState> states)
-{
-    Y_ABORT_UNLESS(assignments.size() == HostCount);
-    Y_ABORT_UNLESS(states.size() == HostCount);
-
-    THostMask desired;
-    THostMask disabled;
-    for (THostIndex i = 0; i < assignments.size(); ++i) {
-        if (assignments[i] == EHostRole::Primary &&
-            states[i] == EHostState::Enabled)
-        {
-            desired.Set(i);
-        } else if (
-            assignments[i] == EHostRole::None ||
-            states[i] == EHostState::Disabled)
-        {
-            disabled.Set(i);
-        }
-    }
-    map.UpdateConfig(desired, desired, disabled);
+        DirectBlockGroupHostCount,
+        DefaultPrimaryCount);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,9 +32,6 @@ TVector<ui64> GetLsns(const TVector<TPBufferSegment>& segments)
     }
     return lsns;
 }
-
-using enum EHostRole;
-using enum EHostState;
 
 THostMask MakePrimaryHosts()
 {
@@ -97,11 +67,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 {
     Y_UNIT_TEST(ShouldReadWithoutWrites)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
 
         // We should be able to get read hints (default DesiredDDisks =
         // primary).
@@ -111,21 +89,191 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "0{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
-        // Disable host 0, demote host 4 to disabled, promote host 3 to
-        // primary.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, Primary, Primary, Primary, HandOff},
-            {Disabled, Enabled, Enabled, Enabled, Disabled});
+        // Disable host 0
+        vchunkConfig.DisableHost(0);
+        dirtyMap.UpdateConfig(vchunkConfig);
+
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "0{[H1,H2,H3][10..19][0..9]};",
+            "0{[H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
+    }
+
+    Y_UNIT_TEST(ShouldRespectWatermarksWhenConstruct)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+        vchunkConfig.SetWatermark(0, 30 * DefaultBlockSize);
+        vchunkConfig.SetWatermark(2, 40 * DefaultBlockSize);
+
+        TBlocksDirtyMap dirtyMap(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,30,30};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Fresh,40,40};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+    }
+
+    Y_UNIT_TEST(ShouldRespectWatermarksForAddedDDisks)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+        TBlocksDirtyMap dirtyMap(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(0, 30 * DefaultBlockSize);
+        vchunkConfig.SetWatermark(3, 40 * DefaultBlockSize);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,40,40};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+    }
+
+    Y_UNIT_TEST(ShouldSwitchOffline)
+    {
+        auto vchunkConfig = MakeTestVChunkConfig();
+        TString error;
+        // Offline H1
+        vchunkConfig.TurnOffline(1, &error);
+
+        TBlocksDirtyMap dirtyMap(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1-{Disabled,0,0};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,0,0};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Offline H0
+        vchunkConfig.TurnOffline(0, &error);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Can't switch H2 offline
+        vchunkConfig.TurnOffline(2, &error);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3*{Fresh,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Offline H3
+        vchunkConfig.TurnOffline(3, &error);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Offline H4
+        vchunkConfig.TurnOffline(4, &error);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4-{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Enable H4
+        vchunkConfig.EnableHost(4);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Enable H0
+        vchunkConfig.EnableHost(0);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Enable H1
+        vchunkConfig.EnableHost(1);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,0,0};"
+            "H1+{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Enable H2
+        vchunkConfig.EnableHost(2);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,0,0};"
+            "H1+{Disabled,0,0};"
+            "H2*{Operational,32768,32768};"
+            "H3-{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Enable H3
+        vchunkConfig.EnableHost(3);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,0,0};"
+            "H1+{Disabled,0,0};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
+
+        // Can't switch H2 offline
+        vchunkConfig.TurnOffline(2, &error);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Fresh,0,0};"
+            "H1+{Disabled,0,0};"
+            "H2-{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4*{Fresh,0,0};",
+            dirtyMap.DebugPrintDDiskState());
     }
 
     Y_UNIT_TEST(ShouldNotReadFromFresh)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
@@ -135,11 +283,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         dirtyMap.MarkFresh(THostIndex{2}, 40 * DefaultBlockSize);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0{Fresh,30,30};"
-            "H1{Operational,32768,32768};"
-            "H2{Fresh,40,40};"
-            "H3{Operational,32768,32768};"
-            "H4{Operational,32768,32768};",
+            "H0*{Fresh,30,30};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Fresh,40,40};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
             dirtyMap.DebugPrintDDiskState());
 
         // Read below fresh watermark
@@ -170,7 +318,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldReadAfterWriteFinished)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
@@ -190,11 +338,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "123{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
-        // Disable host 0, promote host 3 to primary.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, Primary, Primary, Primary, HandOff},
-            {Disabled, Enabled, Enabled, Enabled, Enabled});
+        // Disable host 0.
+        vchunkConfig.DisableHost(0);
+        dirtyMap.UpdateConfig(vchunkConfig);
 
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         // WriteConfirmed mask is {0,1,2}; host 0 is disabled, so it is
@@ -220,7 +366,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldReadAfterWriteFinishedFromLastLsn)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
@@ -245,11 +391,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "124{[H0,H1,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
-        // Disable host 0, promote host 3 to primary.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, Primary, Primary, Primary, HandOff},
-            {Disabled, Enabled, Enabled, Enabled, Enabled});
+        // Disable host 0
+        vchunkConfig.DisableHost(0);
+        dirtyMap.UpdateConfig(vchunkConfig);
 
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
@@ -414,18 +558,23 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldWriteAndFlushAndEraseWhenAdditionalHandOffDesired)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        // Enable additional Hand-off: hosts 0,1,2,3 are primary, host 4 is
-        // hand-off.
-        ApplyStatuses(
-            dirtyMap,
-            {Primary, Primary, Primary, Primary, HandOff},
-            {Enabled, Enabled, Enabled, Enabled, Enabled});
+        // Promote hand-off H3 to primary.
+        vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
+        dirtyMap.UpdateConfig(vchunkConfig);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,1024,1024};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
 
         // Written to 2 primary and 1 hand-off
         const THostMask requested =
@@ -467,18 +616,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldWriteAndFlushAndEraseWithOneDisabled)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // Host 0 disabled, hosts 1,2,3 primary, host 4 hand-off.
+        vchunkConfig.PromoteHost(3);
+        TString error;
+        vchunkConfig.TurnOffline(0, &error);
+        UNIT_ASSERT_VALUES_EQUAL("", error);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
+
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
-
-        // Enable Hand-off-0 instead of DDisk0: host 0 disabled,
-        // hosts 1,2,3 primary, host 4 hand-off.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, Primary, Primary, Primary, HandOff},
-            {Disabled, Enabled, Enabled, Enabled, Enabled});
 
         // Written to two primary and one hand-off
         const THostMask requested =
@@ -519,17 +669,28 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldWriteAndFlushAndEraseWithTwoDisabled)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
+
+        // Hosts 0,1 disabled; hosts 2,3,4 are primary.
+        TString error;
+        vchunkConfig.TurnOffline(0, &error);
+        UNIT_ASSERT_VALUES_EQUAL("", error);
+        vchunkConfig.TurnOffline(1, &error);
+        UNIT_ASSERT_VALUES_EQUAL("", error);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
+        vchunkConfig.SetWatermark(4, DefaultBlockSize * 1024);
+
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
-
-        // Hosts 0,1 disabled; hosts 2,3,4 are primary.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, HandOff, Primary, Primary, Primary},
-            {Disabled, Disabled, Enabled, Enabled, Enabled});
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1-{Disabled,0,0};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,1024,1024};"
+            "H4*{Fresh,1024,1024};",
+            dirtyMap.DebugPrintDDiskState());
 
         // Written to one primary and two hand-off
         const THostMask requested =
@@ -570,20 +731,27 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldNotFlushAndEraseFromDisabled)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
+        // Host 0 disabled; hosts 1,2,3 primary; host 4 hand-off.
+        TString error;
+        vchunkConfig.TurnOffline(0, &error);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
+        UNIT_ASSERT_VALUES_EQUAL("", error);
+
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,1024,1024};"
+            "H4+{Disabled,0,0};",
+            dirtyMap.DebugPrintDDiskState());
 
-        // Host 0 disabled; hosts 1,2,3 primary; host 4 hand-off.
-        ApplyStatuses(
-            dirtyMap,
-            {HandOff, Primary, Primary, Primary, HandOff},
-            {Disabled, Enabled, Enabled, Enabled, Enabled});
-
-        // Written to all 3 primary PBuffers (hosts 0,1,2). Host 0 is
-        // disabled, but the data is still on its PBuffer.
+        // Written to all 3 primary PBuffers (hosts 0,1,2). Host 0 is disabled,
+        // but the data is still on its PBuffer.
         const THostMask requested =
             MakeHostMask(true, true, true, false, false);
         const THostMask confirmed = requested;
@@ -596,8 +764,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H3:123[10..19];"
             "H1->H1:123[10..19];"
+            "H1->H3:123[10..19];"
             "H2->H2:123[10..19];",
             flushHint.DebugPrint());
 
@@ -624,18 +792,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
     Y_UNIT_TEST(ShouldNotFlushOverWriteWatermark)
     {
-        const auto vchunkConfig = MakeTestVChunkConfig();
+        auto vchunkConfig = MakeTestVChunkConfig();
+        // Enable 4 DDisks (hosts 0,1,2,3 primary)
+        // Available DDisks is enough for a quorum.
+        vchunkConfig.PromoteHost(3);
+        vchunkConfig.SetWatermark(3, DefaultBlockSize * 1024);
         TBlocksDirtyMap dirtyMap(
             vchunkConfig,
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
-
-        // Enable 4 DDisks (hosts 0,1,2,3 primary). Available DDisks is
-        // enough for a quorum.
-        ApplyStatuses(
-            dirtyMap,
-            {Primary, Primary, Primary, Primary, HandOff},
-            {Enabled, Enabled, Enabled, Enabled, Enabled});
 
         dirtyMap.SetFlushWatermark(THostIndex{2}, 100 * DefaultBlockSize);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -148,7 +148,7 @@ THostIndex TInflightInfo::RequestFlush(
         return InvalidHostIndex;
     }
 
-    if (WriteConfirmed.Get(destination) && !disabledHosts.Get(destination)) {
+    if (WriteConfirmed.Get(destination)) {
         State = EState::PBufferFlushing;
         FlushRequested.Set(destination);
         return destination;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -135,7 +135,9 @@ TReadSource TInflightInfo::ReadMask() const
     }
 }
 
-THostIndex TInflightInfo::RequestFlush(THostIndex destination)
+THostIndex TInflightInfo::RequestFlush(
+    THostIndex destination,
+    THostMask disabledHosts)
 {
     Y_ABORT_UNLESS(
         State == EState::PBufferWritten || State == EState::PBufferFlushing);
@@ -146,12 +148,20 @@ THostIndex TInflightInfo::RequestFlush(THostIndex destination)
         return InvalidHostIndex;
     }
 
-    if (WriteConfirmed.Get(destination)) {
+    if (WriteConfirmed.Get(destination) && !disabledHosts.Get(destination)) {
         State = EState::PBufferFlushing;
         FlushRequested.Set(destination);
         return destination;
     }
 
+    // Prefer enabled hosts.
+    for (auto source: WriteConfirmed.Exclude(disabledHosts)) {
+        State = EState::PBufferFlushing;
+        FlushRequested.Set(destination);
+        return source;
+    }
+
+    // TODO. All hosts are disabled. Need to figure out what to do in this case.
     for (auto source: WriteConfirmed) {
         State = EState::PBufferFlushing;
         FlushRequested.Set(destination);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -137,7 +137,9 @@ public:
     // DDisk, specified in the parameter destination. If InvalidHostIndex is
     // returned, it means that the transfer of data to destination has already
     // been requested earlier.
-    [[nodiscard]] THostIndex RequestFlush(THostIndex destination);
+    [[nodiscard]] THostIndex RequestFlush(
+        THostIndex destination,
+        THostMask disabledHosts);
     void ConfirmFlush(THostRoute route);
     void FlushFailed(THostRoute route);
     [[nodiscard]] THostMask GetRequestedFlushes() const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -110,13 +110,13 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // Start flushes
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}));
+            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{1},
-            inflightInfo.RequestFlush(THostIndex{1}));
+            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{2},
-            inflightInfo.RequestFlush(THostIndex{2}));
+            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostRoute{
@@ -167,9 +167,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
 
         // Start flushes
-        auto l = inflightInfo.RequestFlush(THostIndex{0});
-        l = inflightInfo.RequestFlush(THostIndex{1});
-        l = inflightInfo.RequestFlush(THostIndex{2});
+        auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
+        l = inflightInfo.RequestFlush(THostIndex{1}, THostMask());
+        l = inflightInfo.RequestFlush(THostIndex{2}, THostMask());
         Y_UNUSED(l);
 
         // Confirm two flushes
@@ -229,13 +229,13 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // Flush started
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}));
+            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{1},
-            inflightInfo.RequestFlush(THostIndex{1}));
+            inflightInfo.RequestFlush(THostIndex{1}, THostMask()));
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{2},
-            inflightInfo.RequestFlush(THostIndex{2}));
+            inflightInfo.RequestFlush(THostIndex{2}, THostMask()));
 
         // When a flush fails, the lsn must be queued for a flush again.
         readyQueue.ReadyToFlush.clear();
@@ -247,7 +247,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // Restart flush to host 0
         UNIT_ASSERT_VALUES_EQUAL(
             THostIndex{0},
-            inflightInfo.RequestFlush(THostIndex{0}));
+            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostRoute{

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
@@ -39,7 +39,7 @@ TEraseRequestExecutor::~TEraseRequestExecutor()
 void TEraseRequestExecutor::Run()
 {
     auto future = DirectBlockGroup->EraseFromPBuffer(
-        VChunkConfig.VChunkIndex,
+        VChunkConfig.GetVChunkIndex(),
         Host,
         Hint.Segments,
         Span.GetTraceId());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -49,8 +49,10 @@ void DumpToFile(
     Sort(
         dumps,
         [](const TDBGDumpResponse::TVChunkDump& lhs,
-           const TDBGDumpResponse::TVChunkDump& rhs) {
-            return lhs.VChunkConfig.VChunkIndex < rhs.VChunkConfig.VChunkIndex;
+           const TDBGDumpResponse::TVChunkDump& rhs)
+        {
+            return lhs.VChunkConfig.GetVChunkIndex() <
+                   rhs.VChunkConfig.GetVChunkIndex();
         });
 
     auto dirPath = TString("/tmp/dirty_map/");
@@ -170,6 +172,12 @@ TFastPathService::~TFastPathService()
         NKikimrServices::NBS_PARTITION,
         "TFastPathService::Destroy %s",
         DiskId.Quote().c_str());
+
+    // TODO. Should stop and destroy regions before TFastPathService
+    // destruction.
+    for (const auto& region: Regions) {
+        region->Stop();
+    }
 }
 
 void TFastPathService::Run()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -30,7 +30,7 @@ private:
     const ISchedulerPtr Scheduler;
     const ITimerPtr Timer;
     const TVector<IDirectBlockGroupPtr> DirectBlockGroups;
-    const TVector<std::shared_ptr<TRegion>> Regions;   // 4 GiB each
+    const TVector<TRegionPtr> Regions;   // 4 GiB each
 
     std::atomic<ui64> SequenceGenerator;
     std::atomic<NActors::TMonotonic> LastTraceTs{NActors::TMonotonic::Zero()};

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
@@ -42,7 +42,7 @@ TFlushRequestExecutor::~TFlushRequestExecutor()
 void TFlushRequestExecutor::Run()
 {
     auto future = DirectBlockGroup->SyncWithPBuffer(
-        VChunkConfig.VChunkIndex,
+        VChunkConfig.GetVChunkIndex(),
         Route.SourceHostIndex,
         Route.DestinationHostIndex,
         Hint.Segments,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
@@ -19,16 +19,34 @@ constexpr size_t MaxHostCount = 32;
 // What the host is intended for: to be a primary or a handoff.
 enum class EHostRole: ui8
 {
+    // For PBuffer, Primary host should be preferred for writing a new data.
+    // For DDisk, data must be flushed to Primary host.
     Primary = 0,
+
+    // For PBuffer, HandOff should be used if data could not be written to the
+    // primary host. This role is not used for DDisk.
     HandOff = 1,
+
+    // The host should not be used.
     None = 2,
 };
 
 // Determines the current status of the host, whether it can be used or not.
 enum class EHostState
 {
-    Enabled,
-    Disabled,
+    // All OK.
+    Online,
+
+    // Errors have been noticed on the host, but they are not fatal and last for
+    // a short time. There is hope that everything will work fine, the host is
+    // not used for writing and reading, but some requests are still hedged
+    // against it to see when it will work.
+    TemporaryOffline,
+
+    // Fatal errors have been noticed on the host, or they have been going on
+    // for a long time. There is no hope that everything will work normally
+    // anymore. Reconfiguration is underway to avoid using this host.
+    Offline,
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.cpp
@@ -20,14 +20,15 @@ THostRoles::THostRoles(size_t hostCount)
 THostRoles THostRoles::MakeRotating(
     size_t hostCount,
     ui32 vChunkIndex,
-    size_t primaryCount)
+    size_t primaryCount,
+    EHostRole secondaryRole)
 {
     Y_ABORT_UNLESS(hostCount <= MaxHostCount);
     Y_ABORT_UNLESS(primaryCount <= hostCount);
 
     THostRoles result(hostCount);
     for (size_t i = 0; i < hostCount; ++i) {
-        result.Assignments[i] = EHostRole::HandOff;
+        result.Assignments[i] = secondaryRole;
     }
     for (size_t i = 0; i < primaryCount; ++i) {
         const size_t idx = (i + vChunkIndex) % hostCount;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "host.h"
 #include "host_mask.h"
 
 #include <array>
@@ -14,8 +15,11 @@ public:
     THostRoles() = default;
     explicit THostRoles(size_t hostCount);
 
-    static THostRoles
-    MakeRotating(size_t hostCount, ui32 vChunkIndex, size_t primaryCount);
+    static THostRoles MakeRotating(
+        size_t hostCount,
+        ui32 vChunkIndex,
+        size_t primaryCount,
+        EHostRole secondaryRole);
 
     [[nodiscard]] size_t HostCount() const;
     [[nodiscard]] EHostRole GetRole(THostIndex host) const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles_ut.cpp
@@ -8,7 +8,7 @@ Y_UNIT_TEST_SUITE(THostRolesTest)
 {
     Y_UNIT_TEST(ShouldMakeRotatingForVChunk0)
     {
-        const auto list = THostRoles::MakeRotating(5, 0, 3);
+        const auto list = THostRoles::MakeRotating(5, 0, 3, EHostRole::HandOff);
         UNIT_ASSERT_VALUES_EQUAL(5u, list.HostCount());
         UNIT_ASSERT(list.GetRole(0) == EHostRole::Primary);
         UNIT_ASSERT(list.GetRole(1) == EHostRole::Primary);
@@ -21,7 +21,7 @@ Y_UNIT_TEST_SUITE(THostRolesTest)
 
     Y_UNIT_TEST(ShouldMakeRotatingForVChunk1)
     {
-        const auto list = THostRoles::MakeRotating(5, 1, 3);
+        const auto list = THostRoles::MakeRotating(5, 1, 3, EHostRole::HandOff);
         UNIT_ASSERT(list.GetRole(0) == EHostRole::HandOff);
         UNIT_ASSERT(list.GetRole(1) == EHostRole::Primary);
         UNIT_ASSERT(list.GetRole(2) == EHostRole::Primary);
@@ -31,18 +31,18 @@ Y_UNIT_TEST_SUITE(THostRolesTest)
 
     Y_UNIT_TEST(ShouldMakeRotatingForVChunk4)
     {
-        const auto list = THostRoles::MakeRotating(5, 4, 3);
+        const auto list = THostRoles::MakeRotating(5, 4, 3, EHostRole::None);
         // Primary slots: (0+4)%5=4, (1+4)%5=0, (2+4)%5=1.
         UNIT_ASSERT(list.GetRole(0) == EHostRole::Primary);
         UNIT_ASSERT(list.GetRole(1) == EHostRole::Primary);
-        UNIT_ASSERT(list.GetRole(2) == EHostRole::HandOff);
-        UNIT_ASSERT(list.GetRole(3) == EHostRole::HandOff);
+        UNIT_ASSERT(list.GetRole(2) == EHostRole::None);
+        UNIT_ASSERT(list.GetRole(3) == EHostRole::None);
         UNIT_ASSERT(list.GetRole(4) == EHostRole::Primary);
     }
 
     Y_UNIT_TEST(ShouldReflectSetInMasks)
     {
-        auto list = THostRoles::MakeRotating(5, 0, 3);
+        auto list = THostRoles::MakeRotating(5, 0, 3, EHostRole::HandOff);
         list.SetRole(1, EHostRole::None);
 
         UNIT_ASSERT_VALUES_EQUAL(2u, list.GetPrimary().Count());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h
@@ -11,7 +11,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 struct THostState
 {
-    EHostState State = EHostState::Enabled;
+    EHostState State = EHostState::Online;
 
     ui64 PBufferUsedSize = 0;
 
@@ -25,7 +25,10 @@ class IHostStateController
 public:
     virtual ~IHostStateController() = default;
 
-    virtual void SetHostState(THostIndex hostIndex, EHostState state) = 0;
+    virtual void SetHostState(
+        THostIndex hostIndex,
+        EHostState oldState,
+        EHostState newState) = 0;
 
     [[nodiscard]] virtual ui64 GetHostPBufferUsedSize(
         THostIndex hostIndex) const = 0;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -1,9 +1,11 @@
 #include "oracle.h"
 
 #include <ydb/core/nbs/cloud/blockstore/config/config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 
 #include <util/generic/size_literals.h>
 #include <util/random/random.h>
+#include <util/string/builder.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
@@ -24,14 +26,16 @@ ui64 GetFromConfig(ui64 value, ui64 defaultValue)
     return value ? value : defaultValue;
 }
 
-EHostState StatusToState(EHostHealth status)
+EHostState HealthToState(EHostHealth health)
 {
-    switch (status) {
+    switch (health) {
         case EHostHealth::Online:
         case EHostHealth::Sufferer:
-            return EHostState::Enabled;
+            return EHostState::Online;
+        case EHostHealth::TemporaryOffline:
+            return EHostState::TemporaryOffline;
         case EHostHealth::Offline:
-            return EHostState::Disabled;
+            return EHostState::Offline;
     }
 }
 
@@ -41,6 +45,14 @@ public:
     explicit TOracleConfig(TStorageConfigPtr storageConfig)
         : StorageConfig(std::move(storageConfig))
     {}
+
+    [[nodiscard]] TDuration GetMaxDurationBeforeGoingTemporaryOffline() const
+    {
+        return GetFromConfig(
+            StorageConfig->GetOracleConfig()
+                .GetMaxDurationBeforeGoingTemporaryOffline(),
+            TDuration::Seconds(10));
+    }
 
     [[nodiscard]] TDuration GetMaxDurationBeforeGoingOffline() const
     {
@@ -82,25 +94,19 @@ private:
 
 TOracle::TOracle(
     TStorageConfigPtr storageConfig,
-    IHostStateController* hostStateController,
-    const TVector<THostStat>& stats,
-    const TVector<THostState>& states)
+    IHostStateController* hostStateController)
     : StorageConfig(std::move(storageConfig))
     , HostStateController(hostStateController)
-    , Stats(stats)
-    , States(states)
     , DefaultWriteHedgingDelay(StorageConfig->GetWriteHedgingDelay())
     , DefaultWriteRequestTimeout(StorageConfig->GetWriteRequestTimeout())
     , DefaultPBufferReplyTimeout(StorageConfig->GetPBufferReplyTimeout())
     , DefaultWriteMode(GetWriteModeFromProto(StorageConfig->GetWriteMode()))
+    , HostStatistics(DirectBlockGroupHostCount)
+    , HostStates(DirectBlockGroupHostCount)
 {
-    Y_ABORT_UNLESS(
-        Stats.size() == States.size(),
-        "Stats and States must have the same size");
-
-    Statuses.resize(Stats.size());
-    for (auto& status: Statuses) {
-        status = EHostHealth::Online;
+    HostsHealths.resize(HostStates.size());
+    for (auto& healths: HostsHealths) {
+        healths = EHostHealth::Online;
     }
 }
 
@@ -108,41 +114,80 @@ void TOracle::Think(TInstant now)
 {
     const TOracleConfig config(StorageConfig);
 
-    TVector<EHostHealth> newStatuses(Statuses);
+    for (THostIndex hostIndex = 0; hostIndex < HostStates.size(); ++hostIndex) {
+        HostStates[hostIndex].PBufferUsedSize =
+            HostStateController->GetHostPBufferUsedSize(hostIndex);
+    }
 
-    for (size_t i = 0; i < Stats.size(); ++i) {
-        auto errorsInfo = Stats[i].GetErrorsInfo(now);
+    TVector<EHostHealth> newHostsHealths(HostsHealths);
+
+    for (size_t i = 0; i < HostStatistics.size(); ++i) {
+        auto errorsInfo = HostStatistics[i].GetErrorsInfo(now);
 
         const bool hasSufferingSymptom = (errorsInfo.ErrorCount != 0);
-        const bool hasOfflineSymptom =
-            (hasSufferingSymptom) &&
+        const bool hasTemporaryOfflineSymptom =
+            hasSufferingSymptom &&
             ((errorsInfo.ErrorCount >=
                   config.GetMinErrorsCountBeforeGoingOffline() &&
               errorsInfo.FromFirstError >
-                  config.GetMaxDurationBeforeGoingOffline()) ||
+                  config.GetMaxDurationBeforeGoingTemporaryOffline()) ||
              (errorsInfo.ErrorCount >=
               config.GetErrorsCountForGoingOffline()) ||
              (HostStateController->GetHostPBufferUsedSize(i) >=
               config.GetErrorsTotalSizeForGoingOffline()));
-
-        newStatuses[i] = EHostHealth::Online;
+        const bool hasOfflineSymptom =
+            hasTemporaryOfflineSymptom &&
+            (errorsInfo.FromFirstError >
+             config.GetMaxDurationBeforeGoingOffline());
 
         if (hasOfflineSymptom) {
-            newStatuses[i] = EHostHealth::Offline;
+            newHostsHealths[i] = EHostHealth::Offline;
+        } else if (hasTemporaryOfflineSymptom) {
+            newHostsHealths[i] = EHostHealth::TemporaryOffline;
         } else if (hasSufferingSymptom) {
-            newStatuses[i] = EHostHealth::Sufferer;
+            newHostsHealths[i] = EHostHealth::Sufferer;
+        } else {
+            newHostsHealths[i] = EHostHealth::Online;
         }
     }
 
-    for (size_t i = 0; i < newStatuses.size(); ++i) {
-        if (newStatuses[i] != Statuses[i]) {
-            Statuses[i] = newStatuses[i];
-            const auto newState = StatusToState(newStatuses[i]);
-            if (newState != States[i].State) {
-                HostStateController->SetHostState(i, newState);
+    for (size_t i = 0; i < newHostsHealths.size(); ++i) {
+        if (newHostsHealths[i] != HostsHealths[i]) {
+            HostsHealths[i] = newHostsHealths[i];
+            const auto oldState = HostStates[i].State;
+            const auto newState = HealthToState(newHostsHealths[i]);
+            if (oldState != newState) {
+                HostStates[i].State = newState;
+                HostStateController->SetHostState(i, oldState, newState);
             }
         }
     }
+}
+
+void TOracle::OnRequestStarted(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now)
+{
+    Y_UNUSED(now);
+    HostStatistics[hostIndex].OnRequest(operation);
+}
+
+void TOracle::OnRequestSucceeded(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now,
+    TDuration executionTime)
+{
+    HostStatistics[hostIndex].OnSuccess(now, executionTime, operation);
+}
+
+void TOracle::OnRequestFailed(
+    THostIndex hostIndex,
+    EOperation operation,
+    TInstant now)
+{
+    HostStatistics[hostIndex].OnError(now, operation);
 }
 
 THostIndex TOracle::SelectBestPBufferHost(
@@ -153,7 +198,7 @@ THostIndex TOracle::SelectBestPBufferHost(
 
     auto getInflight = [this, operation](THostIndex hostIndex)
     {
-        return Stats[hostIndex].InflightCount(operation);
+        return HostStatistics[hostIndex].InflightCount(operation);
     };
 
     // Pick the host with the lowest number of currently inflight requests of
@@ -201,6 +246,16 @@ TDuration TOracle::GetPBufferReplyTimeout() const
 EWriteMode TOracle::GetWriteMode() const
 {
     return DefaultWriteMode;
+}
+
+TString TOracle::Dump() const
+{
+    TStringBuilder sb;
+    for (size_t i = 0; i < HostStates.size(); ++i) {
+        sb << " H" << i << ": " << HostStates[i].DebugPrint() << " "
+           << HostStatistics[i].DebugPrint() << "\n";
+    }
+    return sb;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
@@ -21,6 +21,7 @@ enum class EHostHealth
 {
     Online,
     Sufferer,
+    TemporaryOffline,
     Offline,
 };
 
@@ -29,6 +30,22 @@ class IOracle
 public:
     virtual ~IOracle() = default;
 
+    virtual void OnRequestStarted(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) = 0;
+    virtual void OnRequestSucceeded(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now,
+        TDuration executionTime) = 0;
+    virtual void OnRequestFailed(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) = 0;
+
+    // Picks the best host (by lowest inflight count) out of the provided set
+    // of hosts. Ties are broken uniformly at random.
     [[nodiscard]] virtual THostIndex SelectBestPBufferHost(
         std::span<const THostIndex> hostIndexes,
         EOperation operation) const = 0;
@@ -37,6 +54,8 @@ public:
     [[nodiscard]] virtual TDuration GetWriteRequestTimeout() const = 0;
     [[nodiscard]] virtual TDuration GetPBufferReplyTimeout() const = 0;
     [[nodiscard]] virtual EWriteMode GetWriteMode() const = 0;
+
+    [[nodiscard]] virtual TString Dump() const = 0;
 };
 
 class TOracle: public IOracle
@@ -44,14 +63,24 @@ class TOracle: public IOracle
 public:
     TOracle(
         TStorageConfigPtr storageConfig,
-        IHostStateController* hostStateController,
-        const TVector<THostStat>& stats,
-        const TVector<THostState>& states);
+        IHostStateController* hostStateController);
 
     void Think(TInstant now);
 
-    // Picks the best host (by lowest inflight count) out of the provided set
-    // of hosts. Ties are broken uniformly at random.
+    void OnRequestStarted(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) override;
+    void OnRequestSucceeded(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now,
+        TDuration executionTime) override;
+    void OnRequestFailed(
+        THostIndex hostIndex,
+        EOperation operation,
+        TInstant now) override;
+
     [[nodiscard]] THostIndex SelectBestPBufferHost(
         std::span<const THostIndex> hostIndexes,
         EOperation operation) const override;
@@ -61,18 +90,20 @@ public:
     [[nodiscard]] TDuration GetPBufferReplyTimeout() const override;
     [[nodiscard]] EWriteMode GetWriteMode() const override;
 
+    [[nodiscard]] TString Dump() const override;
+
 private:
     const TStorageConfigPtr StorageConfig;
 
     IHostStateController* const HostStateController;
-    const TVector<THostStat>& Stats;
-    const TVector<THostState>& States;
     const TDuration DefaultWriteHedgingDelay;
     const TDuration DefaultWriteRequestTimeout;
     const TDuration DefaultPBufferReplyTimeout;
     const EWriteMode DefaultWriteMode;
 
-    TVector<EHostHealth> Statuses;
+    TVector<THostStat> HostStatistics;
+    TVector<THostState> HostStates;
+    TVector<EHostHealth> HostsHealths;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -167,7 +167,7 @@ Y_UNIT_TEST_SUITE(TOracle)
             UNIT_ASSERT_C(
                 count + tolerance >= expected && count <= expected + tolerance,
                 TStringBuilder()
-                    << "host " << static_cast<ui32>(hostIndex) << " was picked "
+                    << "host " << PrintHostIndex(hostIndex) << " was picked "
                     << count << " times, expected ~" << expected);
         }
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -18,24 +18,26 @@ namespace {
 
 struct THostStateControllerMock: public IHostStateController
 {
-    TVector<THostState>* StatesPtr;
     TMap<THostIndex, EHostState> States;
+    ui64 HostPBufferUsedSize = 1_MB;
 
-    explicit THostStateControllerMock(TVector<THostState>* statesPtr)
-        : StatesPtr(statesPtr)
-    {}
+    THostStateControllerMock() = default;
 
-    void SetHostState(THostIndex hostIndex, EHostState state) override
+    void SetHostState(
+        THostIndex hostIndex,
+        EHostState oldState,
+        EHostState newState) override
     {
-        (*StatesPtr)[hostIndex].State = state;
-        States[hostIndex] = state;
+        Y_UNUSED(oldState);
+
+        States[hostIndex] = newState;
     }
 
     ui64 GetHostPBufferUsedSize(THostIndex hostIndex) const override
     {
         Y_UNUSED(hostIndex);
 
-        return 1_MB;
+        return HostPBufferUsedSize;
     }
 };
 
@@ -51,15 +53,16 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
 
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
+        TOracle oracle(storageConfig, nullptr);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
+        const auto now = TInstant::Now();
         for (THostIndex hostIndex: {0, 1, 3, 4}) {
-            stats[hostIndex].OnRequest(EOperation::WriteToManyPBuffers);
+            oracle.OnRequestStarted(
+                hostIndex,
+                EOperation::WriteToManyPBuffers,
+                now);
         }
-
-        TOracle oracle(storageConfig, nullptr, stats, states);
 
         // Run multiple times to ensure deterministic selection (no ties at
         // the minimum).
@@ -79,15 +82,16 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         const std::vector<THostIndex> hostIndexes = {3};
 
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
+        TOracle oracle(storageConfig, nullptr);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
+        const auto now = TInstant::Now();
         for (THostIndex hostIndex: {0, 1, 3, 4}) {
-            stats[hostIndex].OnRequest(EOperation::WriteToManyPBuffers);
+            oracle.OnRequestStarted(
+                hostIndex,
+                EOperation::WriteToManyPBuffers,
+                now);
         }
-
-        TOracle oracle(storageConfig, nullptr, stats, states);
 
         // Run multiple times to ensure deterministic selection (no ties at
         // the minimum).
@@ -109,14 +113,15 @@ Y_UNIT_TEST_SUITE(TOracle)
         // selection must be limited to the supplied hostIndexes.
         const std::vector<THostIndex> hostIndexes = {0, 3};
 
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
+        TOracle oracle(storageConfig, nullptr);
 
-        stats[0].OnRequest(EOperation::WriteToManyPBuffers);
-        stats[0].OnRequest(EOperation::WriteToManyPBuffers);
-        stats[3].OnRequest(EOperation::WriteToManyPBuffers);
-
-        TOracle oracle(storageConfig, nullptr, stats, states);
+        const auto now = TInstant::Now();
+        for (THostIndex hostIndex: {0, 0, 3}) {
+            oracle.OnRequestStarted(
+                hostIndex,
+                EOperation::WriteToManyPBuffers,
+                now);
+        }
 
         // Run multiple times to ensure deterministic selection (no ties at
         // the minimum).
@@ -140,10 +145,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         // and checking that every candidate appears at least once.
         const std::vector<THostIndex> hostIndexes = {1, 2, 4};
 
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
-
-        TOracle oracle(storageConfig, nullptr, stats, states);
+        TOracle oracle(storageConfig, nullptr);
 
         std::map<THostIndex, size_t> counts;
         const size_t iterations = 3000;
@@ -178,14 +180,13 @@ Y_UNIT_TEST_SUITE(TOracle)
         // Hosts with inflight equal to the (non-best) tie value must never be
         // picked - only ties at the global minimum are randomized.
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
 
-        TOracle oracle(storageConfig, nullptr, stats, states);
+        TOracle oracle(storageConfig, nullptr);
 
         // Host 2 has the lowest inflight count (zero), all others are higher.
+        const auto now = TInstant::Now();
         for (THostIndex hostIndex: {0, 1, 3, 4}) {
-            stats[hostIndex].OnRequest(EOperation::Flush);
+            oracle.OnRequestStarted(hostIndex, EOperation::Flush, now);
         }
 
         for (size_t iter = 0; iter < 200; ++iter) {
@@ -200,25 +201,24 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         NProto::TStorageServiceConfig rawConfig;
         auto& oracleConfig = *rawConfig.MutableOracleConfig();
-        oracleConfig.SetMaxDurationBeforeGoingOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingTemporaryOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingOffline(4000);
         oracleConfig.SetMinErrorsCountBeforeGoingOffline(1);
 
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
 
-        THostStateControllerMock hostStateController(&states);
-        TOracle oracle(config, &hostStateController, stats, states);
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController);
         auto now = TInstant::Now();
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
 
         // Generate error
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnError(now, EOperation::WriteToPBuffer);
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestFailed(0, EOperation::WriteToPBuffer, now);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
@@ -233,23 +233,35 @@ Y_UNIT_TEST_SUITE(TOracle)
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
 
-        // Three seconds later. Switching to the disabled state.
+        // Three seconds later. Switching to the temporaryOffline state.
         now += TDuration::Seconds(1);
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Disabled,
+            EHostState::TemporaryOffline,
+            hostStateController.States[0]);
+
+        // Six seconds later. Switching to the Offline state.
+        now += TDuration::Seconds(3);
+        oracle.Think(now);
+        UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
+        UNIT_ASSERT_VALUES_EQUAL(
+            EHostState::Offline,
             hostStateController.States[0]);
 
         // Generate success. Switching to the enabled state.
         now += TDuration::Seconds(1);
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnSuccess(now, TDuration(), EOperation::WriteToPBuffer);
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestSucceeded(
+            0,
+            EOperation::WriteToPBuffer,
+            now,
+            TDuration());
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Enabled,
+            EHostState::Online,
             hostStateController.States[0]);
     }
 
@@ -257,25 +269,24 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         NProto::TStorageServiceConfig rawConfig;
         auto& oracleConfig = *rawConfig.MutableOracleConfig();
-        oracleConfig.SetMaxDurationBeforeGoingOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingTemporaryOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingOffline(4000);
         oracleConfig.SetMinErrorsCountBeforeGoingOffline(5);
 
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
 
-        THostStateControllerMock hostStateController(&states);
-        TOracle oracle(config, &hostStateController, stats, states);
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController);
         auto now = TInstant::Now();
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
 
         // Generate error
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnError(now, EOperation::WriteToPBuffer);
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestFailed(0, EOperation::WriteToPBuffer, now);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
@@ -300,44 +311,47 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         NProto::TStorageServiceConfig rawConfig;
         auto& oracleConfig = *rawConfig.MutableOracleConfig();
-        oracleConfig.SetMaxDurationBeforeGoingOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingTemporaryOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingOffline(4000);
         oracleConfig.SetMinErrorsCountBeforeGoingOffline(5);
         oracleConfig.SetErrorsCountForGoingOffline(500);
 
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
 
-        THostStateControllerMock hostStateController(&states);
-        TOracle oracle(config, &hostStateController, stats, states);
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController);
         auto now = TInstant::Now();
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
 
-        // Generate a lot of errors. Switching to the disabled state.
+        // Generate a lot of errors. Switching to the temporaryOffline state.
         for (size_t i = 0; i < 500; ++i) {
-            stats[0].OnRequest(EOperation::WriteToPBuffer);
-            stats[0].OnError(now, EOperation::WriteToPBuffer);
+            oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+            oracle.OnRequestFailed(0, EOperation::WriteToPBuffer, now);
         }
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Disabled,
+            EHostState::TemporaryOffline,
             hostStateController.States[0]);
 
         // Generate success. Switching to the enabled state.
         now += TDuration::Seconds(1);
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnSuccess(now, TDuration(), EOperation::WriteToPBuffer);
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestSucceeded(
+            0,
+            EOperation::WriteToPBuffer,
+            now,
+            TDuration());
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Enabled,
+            EHostState::Online,
             hostStateController.States[0]);
     }
 
@@ -345,42 +359,45 @@ Y_UNIT_TEST_SUITE(TOracle)
     {
         NProto::TStorageServiceConfig rawConfig;
         auto& oracleConfig = *rawConfig.MutableOracleConfig();
-        oracleConfig.SetMaxDurationBeforeGoingOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingTemporaryOffline(2000);
+        oracleConfig.SetMaxDurationBeforeGoingOffline(4000);
         oracleConfig.SetErrorsTotalSizeForGoingOffline(1_MB);
 
         auto config = std::make_shared<TStorageConfig>(rawConfig);
 
         const std::vector<THostIndex> hostIndexes = {0, 1, 2, 3, 4};
-        TVector<THostStat> stats{{}, {}, {}, {}, {}};
-        TVector<THostState> states{{}, {}, {}, {}, {}};
 
-        THostStateControllerMock hostStateController(&states);
-        TOracle oracle(config, &hostStateController, stats, states);
+        THostStateControllerMock hostStateController;
+        TOracle oracle(config, &hostStateController);
         auto now = TInstant::Now();
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(0, hostStateController.States.size());
 
-        // Generate a error with large total size. Switching to the disabled
-        // state.
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnError(now, EOperation::WriteToPBuffer);
+        // Generate a error with large total size. Switching to the
+        // temporaryOffline state.
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestFailed(0, EOperation::WriteToPBuffer, now);
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Disabled,
+            EHostState::TemporaryOffline,
             hostStateController.States[0]);
 
         // Generate success. Switching to the enabled state.
         now += TDuration::Seconds(1);
-        stats[0].OnRequest(EOperation::WriteToPBuffer);
-        stats[0].OnSuccess(now, TDuration(), EOperation::WriteToPBuffer);
+        oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+        oracle.OnRequestSucceeded(
+            0,
+            EOperation::WriteToPBuffer,
+            now,
+            TDuration());
 
         oracle.Think(now);
         UNIT_ASSERT_VALUES_EQUAL(1, hostStateController.States.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            EHostState::Enabled,
+            EHostState::Online,
             hostStateController.States[0]);
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -1,5 +1,7 @@
 #include "vchunk_config.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+
 #include <util/string/builder.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -8,38 +10,95 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 namespace {
 
-THostMask GetDesired(const THostRoles& hosts, THostMask enabledHosts)
+THostMask
+Filter(const THostRoles& hosts, THostMask enabledHosts, EHostRole role)
 {
     THostMask result;
     for (THostIndex hostIndex = 0; hostIndex < hosts.HostCount(); ++hostIndex) {
-        if (hosts.GetRole(hostIndex) == EHostRole::Primary &&
-            enabledHosts.Get(hostIndex))
-        {
+        if (hosts.GetRole(hostIndex) == role && enabledHosts.Get(hostIndex)) {
             result.Set(hostIndex);
         }
     }
     return result;
 }
 
+THostIndex GetPrimaryCandidate(
+    const THostRoles& ddiskHosts,
+    const THostMask& enabledHosts)
+{
+    for (THostIndex indx: enabledHosts) {
+        if (ddiskHosts.GetRole(indx) != EHostRole::Primary) {
+            return indx;
+        }
+    }
+    return InvalidHostIndex;
+}
+
 }   // namespace
 
 // static
-TVChunkConfig
-TVChunkConfig::Make(ui32 vChunkIndex, size_t hostCount, size_t primaryCount)
+TVChunkConfig TVChunkConfig::MakeDefault(
+    ui32 vChunkIndex,
+    size_t hostCount,
+    size_t primaryCount)
 {
-    return TVChunkConfig{
-        .VChunkIndex = vChunkIndex,
-        .PBufferHosts =
-            THostRoles::MakeRotating(hostCount, vChunkIndex, primaryCount),
-        .DDiskHosts =
-            THostRoles::MakeRotating(hostCount, vChunkIndex, primaryCount),
-        .EnabledHosts = THostMask::MakeAll(hostCount),
-    };
+    TVChunkConfig result;
+    result.HostCount = hostCount;
+    result.VChunkIndex = vChunkIndex;
+    result.PBufferHosts = THostRoles::MakeRotating(
+        hostCount,
+        vChunkIndex,
+        primaryCount,
+        EHostRole::HandOff);
+    result.DDiskHosts = THostRoles::MakeRotating(
+        hostCount,
+        vChunkIndex,
+        primaryCount,
+        EHostRole::None);
+    result.EnabledHosts = THostMask::MakeAll(hostCount);
+    result.Watermarks = TVector<std::optional<ui64>>(hostCount);
+    return result;
+}
+
+// static
+TVChunkConfig TVChunkConfig::Make(
+    ui32 vChunkIndex,
+    THostRoles pbufferHosts,
+    THostRoles ddiskHosts,
+    THostMask enabledHosts,
+    TVector<std::optional<ui64>> watermarks)
+{
+    TVChunkConfig result;
+    result.HostCount = pbufferHosts.HostCount();
+    result.VChunkIndex = vChunkIndex;
+    result.PBufferHosts = pbufferHosts;
+    result.DDiskHosts = ddiskHosts;
+    result.EnabledHosts = enabledHosts;
+    watermarks.resize(result.HostCount);
+    result.Watermarks = std::move(watermarks);
+    return result;
+}
+
+size_t TVChunkConfig::GetHostCount() const
+{
+    return HostCount;
+}
+
+ui32 TVChunkConfig::GetVChunkIndex() const
+{
+    return VChunkIndex;
 }
 
 void TVChunkConfig::EnableHost(THostIndex hostIndex)
 {
     EnabledHosts.Set(hostIndex);
+    const auto ddisks = GetDDisks();
+    if (!ddisks.Get(hostIndex) &&
+        ddisks.Count() < QuorumDirectBlockGroupHostCount)
+    {
+        DDiskHosts.SetRole(hostIndex, EHostRole::Primary);
+        Watermarks[hostIndex] = 0;
+    }
 }
 
 void TVChunkConfig::DisableHost(THostIndex hostIndex)
@@ -47,19 +106,131 @@ void TVChunkConfig::DisableHost(THostIndex hostIndex)
     EnabledHosts.Reset(hostIndex);
 }
 
-THostMask TVChunkConfig::GetDesiredPBuffers() const
+THostIndex TVChunkConfig::TurnOffline(THostIndex from, TString* error)
 {
-    return GetDesired(PBufferHosts, EnabledHosts);
+    DisableHost(from);
+    if (DDiskHosts.GetRole(from) == EHostRole::None ||
+        DDiskHosts.GetRole(from) == EHostRole::HandOff)
+    {
+        DisableHost(from);
+        return InvalidHostIndex;
+    }
+
+    const auto fullDDisks = GetFullDDisks();
+    if (fullDDisks.Count() == 1 && fullDDisks.Get(from)) {
+        *error = TStringBuilder()
+                 << "Can't reset last healthy ddisk " << PrintHostIndex(from);
+        return InvalidHostIndex;
+    }
+
+    DDiskHosts.SetRole(from, EHostRole::None);
+    PBufferHosts.SetRole(from, EHostRole::HandOff);
+    Watermarks[from] = std::nullopt;
+
+    const THostIndex to = GetPrimaryCandidate(DDiskHosts, EnabledHosts);
+    if (to == InvalidHostIndex) {
+        *error = TStringBuilder() << "Can't find new primary candidate for "
+                                  << PrintHostIndex(from);
+        return InvalidHostIndex;
+    }
+
+    DDiskHosts.SetRole(to, EHostRole::Primary);
+    PBufferHosts.SetRole(to, EHostRole::Primary);
+    Watermarks[to] = 0;
+
+    Y_ABORT_UNLESS(EnabledHosts.Get(to) == true);
+
+    return to;
 }
 
-THostMask TVChunkConfig::GetDesiredDDisks() const
+void TVChunkConfig::PromoteHost(THostIndex hostIndex)
 {
-    return GetDesired(DDiskHosts, EnabledHosts);
+    PBufferHosts.SetRole(hostIndex, EHostRole::Primary);
+    if (DDiskHosts.GetRole(hostIndex) != EHostRole::Primary) {
+        DDiskHosts.SetRole(hostIndex, EHostRole::Primary);
+        Watermarks[hostIndex] = 0;
+    }
+}
+
+EHostRole TVChunkConfig::GetPBufferRole(THostIndex hostIndex) const
+{
+    return PBufferHosts.GetRole(hostIndex);
+}
+
+EHostRole TVChunkConfig::GetDDiskRole(THostIndex hostIndex) const
+{
+    return DDiskHosts.GetRole(hostIndex);
+}
+
+THostMask TVChunkConfig::GetDesiredPBuffers() const
+{
+    return Filter(PBufferHosts, EnabledHosts, EHostRole::Primary);
+}
+
+THostMask TVChunkConfig::GetSecondaryPBuffers() const
+{
+    return Filter(PBufferHosts, EnabledHosts, EHostRole::HandOff);
+}
+
+THostMask TVChunkConfig::GetTemporaryOfflinePBuffers() const
+{
+    THostMask result;
+    for (size_t i = 0; i < HostCount; ++i) {
+        if (!EnabledHosts.Get(i) && PBufferHosts.GetRole(i) != EHostRole::None)
+        {
+            result.Set(i);
+        }
+    }
+    return result;
+}
+
+THostMask TVChunkConfig::GetDDisks() const
+{
+    return Filter(
+        DDiskHosts,
+        THostMask::MakeAll(HostCount),
+        EHostRole::Primary);
+}
+
+THostMask TVChunkConfig::GetFullDDisks() const
+{
+    THostMask result;
+    for (THostIndex hostIndex: GetDDisks()) {
+        if (Watermarks[hostIndex] == std::nullopt) {
+            result.Set(hostIndex);
+        }
+    }
+    return result;
 }
 
 THostMask TVChunkConfig::GetDisabledHosts() const
 {
     return EnabledHosts.LogicalNot();
+}
+
+THostMask TVChunkConfig::GetHealthyDDisks() const
+{
+    THostMask result;
+    for (THostIndex hostIndex: EnabledHosts) {
+        if (DDiskHosts.GetRole(hostIndex) == EHostRole::Primary &&
+            Watermarks[hostIndex] == std::nullopt)
+        {
+            result.Set(hostIndex);
+        }
+    }
+    return result;
+}
+
+void TVChunkConfig::SetWatermark(
+    THostIndex hostIndex,
+    std::optional<ui64> watermark)
+{
+    Watermarks[hostIndex] = watermark;
+}
+
+std::optional<ui64> TVChunkConfig::GetWatermark(THostIndex hostIndex) const
+{
+    return Watermarks[hostIndex];
 }
 
 bool TVChunkConfig::IsValid() const
@@ -84,6 +255,9 @@ TString TVChunkConfig::DebugPrint() const
          ++hostIndex)
     {
         result << (EnabledHosts.Get(hostIndex) ? "+" : "-");
+        if (Watermarks[hostIndex] != std::nullopt) {
+            result << "[" << *Watermarks[hostIndex] << "]";
+        }
     }
     result << "}";
     return result;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -106,7 +106,7 @@ void TVChunkConfig::DisableHost(THostIndex hostIndex)
     EnabledHosts.Reset(hostIndex);
 }
 
-TString TVChunkConfig::TurnOffHost(THostIndex hostIndex)
+TString TVChunkConfig::EvacuateHost(THostIndex hostIndex)
 {
     DisableHost(hostIndex);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -106,41 +106,47 @@ void TVChunkConfig::DisableHost(THostIndex hostIndex)
     EnabledHosts.Reset(hostIndex);
 }
 
-THostIndex TVChunkConfig::TurnOffline(THostIndex from, TString* error)
+TString TVChunkConfig::TurnOffHost(THostIndex hostIndex)
 {
-    DisableHost(from);
-    if (DDiskHosts.GetRole(from) == EHostRole::None ||
-        DDiskHosts.GetRole(from) == EHostRole::HandOff)
+    DisableHost(hostIndex);
+
+    if (DDiskHosts.GetRole(hostIndex) == EHostRole::None ||
+        DDiskHosts.GetRole(hostIndex) == EHostRole::HandOff)
     {
-        DisableHost(from);
-        return InvalidHostIndex;
+        return {};
     }
 
-    const auto fullDDisks = GetFullDDisks();
-    if (fullDDisks.Count() == 1 && fullDDisks.Get(from)) {
-        *error = TStringBuilder()
-                 << "Can't reset last healthy ddisk " << PrintHostIndex(from);
-        return InvalidHostIndex;
+    TString error = DemoteHost(hostIndex);
+    if (!error.empty()) {
+        return error;
     }
-
-    DDiskHosts.SetRole(from, EHostRole::None);
-    PBufferHosts.SetRole(from, EHostRole::HandOff);
-    Watermarks[from] = std::nullopt;
 
     const THostIndex to = GetPrimaryCandidate(DDiskHosts, EnabledHosts);
     if (to == InvalidHostIndex) {
-        *error = TStringBuilder() << "Can't find new primary candidate for "
-                                  << PrintHostIndex(from);
-        return InvalidHostIndex;
+        return TStringBuilder() << "Can't find new primary candidate for "
+                                << PrintHostIndex(hostIndex);
     }
 
-    DDiskHosts.SetRole(to, EHostRole::Primary);
-    PBufferHosts.SetRole(to, EHostRole::Primary);
-    Watermarks[to] = 0;
-
+    PromoteHost(to);
     Y_ABORT_UNLESS(EnabledHosts.Get(to) == true);
 
-    return to;
+    return TStringBuilder()
+           << "Host " << PrintHostIndex(hostIndex) << " demoted, host "
+           << PrintHostIndex(to) << " promoted";
+}
+
+TString TVChunkConfig::DemoteHost(THostIndex hostIndex)
+{
+    const auto fullDDisks = GetFullDDisks();
+    if (fullDDisks.Count() == 1 && fullDDisks.Get(hostIndex)) {
+        return TStringBuilder() << "Can't demote last healthy ddisk "
+                                << PrintHostIndex(hostIndex);
+    }
+
+    DDiskHosts.SetRole(hostIndex, EHostRole::None);
+    PBufferHosts.SetRole(hostIndex, EHostRole::HandOff);
+    Watermarks[hostIndex] = std::nullopt;
+    return {};
 }
 
 void TVChunkConfig::PromoteHost(THostIndex hostIndex)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
@@ -25,9 +25,18 @@ public:
     [[nodiscard]] size_t GetHostCount() const;
     [[nodiscard]] ui32 GetVChunkIndex() const;
 
+    // Enables the host to work. Does not change the ddisk status for the host.
     void EnableHost(THostIndex hostIndex);
+    // Temporarily disables the host. Does not change the ddisk status for the
+    // host.
     void DisableHost(THostIndex hostIndex);
-    THostIndex TurnOffline(THostIndex from, TString* error);
+    // Disables the host and deletes ddisk on that host. If possible, adds ddisk
+    // on the new host. Returns the text of the error or message to be logged.
+    TString TurnOffHost(THostIndex hostIndex);
+    // Removes ddisk from the host. Returns error message or empty string when
+    // demote executed successfully.
+    TString DemoteHost(THostIndex hostIndex);
+    // Adds ddisk to the host.
     void PromoteHost(THostIndex hostIndex);
 
     [[nodiscard]] EHostRole GetPBufferRole(THostIndex hostIndex) const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
@@ -25,16 +25,19 @@ public:
     [[nodiscard]] size_t GetHostCount() const;
     [[nodiscard]] ui32 GetVChunkIndex() const;
 
-    // Enables the host to work. Does not change the ddisk status for the host.
+    // Enables the host to work. If the total count of ddisks is not enough to
+    // reach the quorum, then can make a promotion for ddisk.
     void EnableHost(THostIndex hostIndex);
     // Temporarily disables the host. Does not change the ddisk status for the
     // host.
     void DisableHost(THostIndex hostIndex);
-    // Disables the host and deletes ddisk on that host. If possible, adds ddisk
-    // on the new host. Returns the text of the error or message to be logged.
-    TString TurnOffHost(THostIndex hostIndex);
-    // Removes ddisk from the host. Returns error message or empty string when
-    // demote executed successfully.
+
+    // Disables the host. Demote ddisk and pbuffer. If possible, adds ddisk on
+    // the new host. Returns the text of the error or message to be logged.
+    TString EvacuateHost(THostIndex hostIndex);
+
+    // Removes ddisk from the host. Demote pbuffer to handoff. Returns error
+    // message or empty string when demote executed successfully.
     TString DemoteHost(THostIndex hostIndex);
     // Adds ddisk to the host.
     void PromoteHost(THostIndex hostIndex);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
@@ -2,8 +2,6 @@
 
 #include "host_roles.h"
 
-#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
-
 #include <util/generic/hash.h>
 #include <util/system/types.h>
 
@@ -11,28 +9,63 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TVChunkConfig
+class TVChunkConfig
 {
-    ui32 VChunkIndex = 0;
-    THostRoles PBufferHosts;
-    THostRoles DDiskHosts;
-    THostMask EnabledHosts;
+public:
+    static TVChunkConfig
+    MakeDefault(ui32 vChunkIndex, size_t hostCount, size_t primaryCount);
 
     static TVChunkConfig Make(
         ui32 vChunkIndex,
-        size_t hostCount = DirectBlockGroupHostCount,
-        size_t primaryCount = DefaultPrimaryCount);
+        THostRoles pbufferHosts,
+        THostRoles ddiskHosts,
+        THostMask enabledHosts,
+        TVector<std::optional<ui64>> watermarks);
+
+    [[nodiscard]] size_t GetHostCount() const;
+    [[nodiscard]] ui32 GetVChunkIndex() const;
 
     void EnableHost(THostIndex hostIndex);
     void DisableHost(THostIndex hostIndex);
+    THostIndex TurnOffline(THostIndex from, TString* error);
+    void PromoteHost(THostIndex hostIndex);
 
+    [[nodiscard]] EHostRole GetPBufferRole(THostIndex hostIndex) const;
+    [[nodiscard]] EHostRole GetDDiskRole(THostIndex hostIndex) const;
+
+    // Get a list of desired PBuffers. They are located next to DDisk and their
+    // use is most effective.
     [[nodiscard]] THostMask GetDesiredPBuffers() const;
-    [[nodiscard]] THostMask GetDesiredDDisks() const;
+    // Get a list of secondary PBuffers. They are not located near DDisk and
+    // their use is not effective.
+    [[nodiscard]] THostMask GetSecondaryPBuffers() const;
+    // Get a list of temporarily offline PBuffers. They may not work, but they
+    // need to be checked in order to be transferred online.
+    [[nodiscard]] THostMask GetTemporaryOfflinePBuffers() const;
+
+    // Get a list of all DDisks (enabled and disabled).
+    [[nodiscard]] THostMask GetDDisks() const;
+    // Get a list of all DDisks with full data (enabled or not).
+    [[nodiscard]] THostMask GetFullDDisks() const;
+    // Get a list of all healthy DDisks (enabled and full filed).
+    [[nodiscard]] THostMask GetHealthyDDisks() const;
+
+    void SetWatermark(THostIndex hostIndex, std::optional<ui64> watermark);
+    [[nodiscard]] std::optional<ui64> GetWatermark(THostIndex hostIndex) const;
+
     [[nodiscard]] THostMask GetDisabledHosts() const;
 
     [[nodiscard]] bool IsValid() const;
 
     [[nodiscard]] TString DebugPrint() const;
+
+private:
+    size_t HostCount = 0;
+    ui32 VChunkIndex = 0;
+    THostRoles PBufferHosts;
+    THostRoles DDiskHosts;
+    THostMask EnabledHosts;
+    TVector<std::optional<ui64>> Watermarks;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config_ut.cpp
@@ -8,47 +8,45 @@ Y_UNIT_TEST_SUITE(TVChunkConfigTest)
 {
     Y_UNIT_TEST(ShouldMakeDefaultLayout)
     {
-        const auto cfg = TVChunkConfig::Make(0, 5, 3);
-        UNIT_ASSERT_VALUES_EQUAL(0u, cfg.VChunkIndex);
-        UNIT_ASSERT(cfg.PBufferHosts == cfg.DDiskHosts);
-        UNIT_ASSERT_VALUES_EQUAL(3u, cfg.PBufferHosts.GetPrimary().Count());
-        UNIT_ASSERT_VALUES_EQUAL(2u, cfg.PBufferHosts.GetHandOff().Count());
+        const auto cfg = TVChunkConfig::MakeDefault(0, 5, 3);
+        UNIT_ASSERT_VALUES_EQUAL(0u, cfg.GetVChunkIndex());
+        UNIT_ASSERT(cfg.GetDesiredPBuffers() == cfg.GetDDisks());
+        UNIT_ASSERT_VALUES_EQUAL(3u, cfg.GetDesiredPBuffers().Count());
+        UNIT_ASSERT_VALUES_EQUAL(2u, cfg.GetSecondaryPBuffers().Count());
         UNIT_ASSERT(cfg.IsValid());
     }
 
     Y_UNIT_TEST(ShouldMakeForNonZeroVChunkIndex)
     {
-        const auto cfg = TVChunkConfig::Make(2, 5, 3);
+        const auto cfg = TVChunkConfig::MakeDefault(2, 5, 3);
         // Primary slots: (0+2)%5=2, (1+2)%5=3, (2+2)%5=4.
-        UNIT_ASSERT(cfg.PBufferHosts.GetRole(2) == EHostRole::Primary);
-        UNIT_ASSERT(cfg.PBufferHosts.GetRole(3) == EHostRole::Primary);
-        UNIT_ASSERT(cfg.PBufferHosts.GetRole(4) == EHostRole::Primary);
-        UNIT_ASSERT(cfg.PBufferHosts.GetRole(0) == EHostRole::HandOff);
-        UNIT_ASSERT(cfg.PBufferHosts.GetRole(1) == EHostRole::HandOff);
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[H2,H3,H4]",
+            cfg.GetDesiredPBuffers().Print());
     }
 
     Y_UNIT_TEST(ShouldBeInvalidWhenAllDisabledOnOneSide)
     {
-        auto cfg = TVChunkConfig::Make(0, 5, 3);
-        for (size_t i = 0; i < 5; ++i) {
-            cfg.PBufferHosts.SetRole(i, EHostRole::None);
-        }
+        auto cfg =
+            TVChunkConfig::Make(0, THostRoles(), THostRoles(), THostMask(), {});
         UNIT_ASSERT(!cfg.IsValid());
     }
 
     Y_UNIT_TEST(ShouldBeInvalidOnHostCountMismatch)
     {
-        TVChunkConfig cfg{
-            .VChunkIndex = 0,
-            .PBufferHosts = THostRoles::MakeRotating(5, 0, 3),
-            .DDiskHosts = THostRoles::MakeRotating(4, 0, 3),
-        };
+        auto cfg = TVChunkConfig::Make(
+            0,
+            THostRoles::MakeRotating(5, 0, 3, EHostRole::HandOff),
+            THostRoles::MakeRotating(4, 0, 3, EHostRole::None),
+            THostMask::MakeAll(5),
+            {});
         UNIT_ASSERT(!cfg.IsValid());
     }
 
     Y_UNIT_TEST(ShouldBeInvalidOnEmptyHostList)
     {
-        TVChunkConfig cfg{};
+        auto cfg =
+            TVChunkConfig::Make(0, THostRoles(), THostRoles(), THostMask(), {});
         UNIT_ASSERT(!cfg.IsValid());
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.cpp
@@ -8,49 +8,63 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-using TVChunkConfigProto = ::NYdb::NBS::PartitionDirect::NProto::TVChunkConfig;
+using TVChunkConfigProto = PartitionDirect::NProto::TVChunkConfig;
 
 TVChunkConfigProto ToProto(const TVChunkConfig& cfg)
 {
     TVChunkConfigProto proto;
-    proto.SetVChunkIndex(cfg.VChunkIndex);
-    for (THostIndex i = 0; i < cfg.PBufferHosts.HostCount(); ++i) {
-        proto.AddPBufferHostRoles(
-            static_cast<ui32>(cfg.PBufferHosts.GetRole(i)));
+    proto.SetVChunkIndex(cfg.GetVChunkIndex());
+    const auto disabled = cfg.GetDisabledHosts();
+    for (THostIndex i = 0; i < cfg.GetHostCount(); ++i) {
+        proto.AddPBufferHostRoles(static_cast<ui32>(cfg.GetPBufferRole(i)));
+        proto.AddDDiskHostRoles(static_cast<ui32>(cfg.GetDDiskRole(i)));
+        if (!disabled.Get(i)) {
+            proto.AddEnabledHosts(i);
+        }
+
+        if (const auto watermark = cfg.GetWatermark(i)) {
+            auto* w = proto.AddWatermarks();
+            w->SetHostIndex(i);
+            w->SetValue(watermark.value());
+        }
     }
-    for (THostIndex i = 0; i < cfg.DDiskHosts.HostCount(); ++i) {
-        proto.AddDDiskHostRoles(static_cast<ui32>(cfg.DDiskHosts.GetRole(i)));
-    }
-    for (const THostIndex host: cfg.EnabledHosts) {
-        proto.AddEnabledHosts(host);
-    }
+
     return proto;
 }
 
 TVChunkConfig FromProto(const TVChunkConfigProto& proto)
 {
-    TVChunkConfig cfg;
-    cfg.VChunkIndex = proto.GetVChunkIndex();
+    THostRoles pbufferHosts(proto.PBufferHostRolesSize());
+    THostRoles ddiskHosts(proto.DDiskHostRolesSize());
+    THostMask enabledHosts;
+    TVector<std::optional<ui64>> watermarks(proto.DDiskHostRolesSize());
 
-    cfg.PBufferHosts = THostRoles(proto.PBufferHostRolesSize());
     for (THostIndex i = 0; i < proto.PBufferHostRolesSize(); ++i) {
-        cfg.PBufferHosts.SetRole(
+        pbufferHosts.SetRole(
             i,
             static_cast<EHostRole>(proto.GetPBufferHostRoles(i)));
     }
 
-    cfg.DDiskHosts = THostRoles(proto.DDiskHostRolesSize());
     for (THostIndex i = 0; i < proto.DDiskHostRolesSize(); ++i) {
-        cfg.DDiskHosts.SetRole(
+        ddiskHosts.SetRole(
             i,
             static_cast<EHostRole>(proto.GetDDiskHostRoles(i)));
     }
 
     for (THostIndex i = 0; i < proto.EnabledHostsSize(); ++i) {
-        cfg.EnabledHosts.Set(static_cast<THostIndex>(proto.GetEnabledHosts(i)));
+        enabledHosts.Set(static_cast<THostIndex>(proto.GetEnabledHosts(i)));
     }
 
-    return cfg;
+    for (const auto& w: proto.GetWatermarks()) {
+        watermarks[w.GetHostIndex()] = w.GetValue();
+    }
+
+    return TVChunkConfig::Make(
+        proto.GetVChunkIndex(),
+        pbufferHosts,
+        ddiskHosts,
+        enabledHosts,
+        std::move(watermarks));
 }
 
 }   // namespace
@@ -159,7 +173,7 @@ void TPartitionDatabase::StoreVChunkConfig(const TVChunkConfig& cfg)
     using TTable = TPartitionSchema::VChunkConfigs;
 
     Table<TTable>()
-        .Key(cfg.VChunkIndex)
+        .Key(cfg.GetVChunkIndex())
         .Update(NKikimr::NIceDb::TUpdate<TTable::Config>(ToProto(cfg)));
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
@@ -226,8 +226,7 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
             5,
             DirectBlockGroupHostCount,
             DefaultPrimaryCount);
-        TString error;
-        updated.TurnOffline(0, &error);
+        updated.TurnOffHost(0);
 
         executor.WriteTx(
             [&](NKikimr::NTable::TDatabase& db)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
@@ -1,5 +1,6 @@
 #include "part_database.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/testlib/test_executor.h>
 
@@ -156,7 +157,10 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                 TPartitionDatabase partitionDb(db);
                 partitionDb.InitSchema();
                 for (ui32 i = 0; i < 3; ++i) {
-                    partitionDb.StoreVChunkConfig(TVChunkConfig::Make(i));
+                    partitionDb.StoreVChunkConfig(TVChunkConfig::MakeDefault(
+                        i,
+                        DirectBlockGroupHostCount,
+                        DefaultPrimaryCount));
                 }
             });
 
@@ -177,11 +181,28 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                     UNIT_ASSERT(cfg.IsValid());
                     UNIT_ASSERT_VALUES_EQUAL(
                         static_cast<ui32>(i),
-                        cfg.VChunkIndex);
-                    const auto expected = TVChunkConfig::Make(i);
-                    UNIT_ASSERT(expected.PBufferHosts == cfg.PBufferHosts);
-                    UNIT_ASSERT(expected.DDiskHosts == cfg.DDiskHosts);
-                    UNIT_ASSERT(expected.EnabledHosts == cfg.EnabledHosts);
+                        cfg.GetVChunkIndex());
+                    const auto expected = TVChunkConfig::MakeDefault(
+                        i,
+                        DirectBlockGroupHostCount,
+                        DefaultPrimaryCount);
+                    UNIT_ASSERT(
+                        expected.GetDesiredPBuffers() ==
+                        cfg.GetDesiredPBuffers());
+                    UNIT_ASSERT(
+                        expected.GetSecondaryPBuffers() ==
+                        cfg.GetSecondaryPBuffers());
+                    UNIT_ASSERT(
+                        expected.GetTemporaryOfflinePBuffers() ==
+                        cfg.GetTemporaryOfflinePBuffers());
+                    UNIT_ASSERT(expected.GetDDisks() == cfg.GetDDisks());
+                    UNIT_ASSERT(
+                        expected.GetHealthyDDisks() == cfg.GetHealthyDDisks());
+                    UNIT_ASSERT(
+                        expected.GetDisabledHosts() == cfg.GetDisabledHosts());
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        expected.DebugPrint(),
+                        cfg.DebugPrint());
                 }
             });
     }
@@ -195,11 +216,18 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
             {
                 TPartitionDatabase partitionDb(db);
                 partitionDb.InitSchema();
-                partitionDb.StoreVChunkConfig(TVChunkConfig::Make(5));
+                partitionDb.StoreVChunkConfig(TVChunkConfig::MakeDefault(
+                    5,
+                    DirectBlockGroupHostCount,
+                    DefaultPrimaryCount));
             });
 
-        auto updated = TVChunkConfig::Make(5);
-        updated.PBufferHosts.SetRole(0, EHostRole::None);
+        auto updated = TVChunkConfig::MakeDefault(
+            5,
+            DirectBlockGroupHostCount,
+            DefaultPrimaryCount);
+        TString error;
+        updated.TurnOffline(0, &error);
 
         executor.WriteTx(
             [&](NKikimr::NTable::TDatabase& db)
@@ -217,12 +245,23 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
                 UNIT_ASSERT_VALUES_EQUAL(1u, vChunkConfigs.size());
 
                 const auto& stored = vChunkConfigs[0];
+                UNIT_ASSERT(
+                    updated.GetDesiredPBuffers() ==
+                    stored.GetDesiredPBuffers());
+                UNIT_ASSERT(
+                    updated.GetSecondaryPBuffers() ==
+                    stored.GetSecondaryPBuffers());
+                UNIT_ASSERT(
+                    updated.GetTemporaryOfflinePBuffers() ==
+                    stored.GetTemporaryOfflinePBuffers());
+                UNIT_ASSERT(updated.GetDDisks() == stored.GetDDisks());
+                UNIT_ASSERT(
+                    updated.GetHealthyDDisks() == stored.GetHealthyDDisks());
+                UNIT_ASSERT(
+                    updated.GetDisabledHosts() == stored.GetDisabledHosts());
                 UNIT_ASSERT_VALUES_EQUAL(
-                    updated.VChunkIndex,
-                    stored.VChunkIndex);
-                UNIT_ASSERT(updated.PBufferHosts == stored.PBufferHosts);
-                UNIT_ASSERT(updated.DDiskHosts == stored.DDiskHosts);
-                UNIT_ASSERT(updated.EnabledHosts == stored.EnabledHosts);
+                    updated.DebugPrint(),
+                    stored.DebugPrint());
             });
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database_ut.cpp
@@ -226,7 +226,7 @@ Y_UNIT_TEST_SUITE(TPartitionDatabaseTest)
             5,
             DirectBlockGroupHostCount,
             DefaultPrimaryCount);
-        updated.TurnOffHost(0);
+        updated.EvacuateHost(0);
 
         executor.WriteTx(
             [&](NKikimr::NTable::TDatabase& db)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -259,7 +259,7 @@ void TPartitionActor::Start(
     TVChunkConfigByIndex vChunkConfigsByIndex;
     vChunkConfigsByIndex.reserve(vChunkConfigs.size());
     for (const auto& cfg: vChunkConfigs) {
-        vChunkConfigsByIndex[cfg.VChunkIndex] = cfg;
+        vChunkConfigsByIndex[cfg.GetVChunkIndex()] = cfg;
     }
 
     const ui64 blockCount = VolumeConfig.GetPartitions(0).GetBlockCount();
@@ -432,7 +432,8 @@ void TPartitionActor::HandleUpdateVChunkConfig(
         ctx,
         NKikimrServices::NBS_PARTITION,
         LogTitle.GetWithTime().c_str()
-            << " Handle UpdateVChunkConfig, vChunkIndex: " << cfg.VChunkIndex);
+            << " Handle UpdateVChunkConfig, vChunkIndex: "
+            << cfg.GetVChunkIndex());
 
     ExecuteTx(ctx, CreateTx<TUpdateVChunkConfig>(std::move(cfg)));
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/protos/partition_direct.proto
@@ -22,11 +22,19 @@ message TDirectBlockGroupsConnections {
 // One vchunk's host layout, persisted only when it deviates from the default
 // TVChunkConfig::Make() produces. PBufferHostRoles[i] / DDiskHostRoles[i] hold
 // the EHostRole value for host i; EnabledHosts lists the enabled host indices.
+
+// TODO. Make inner message THostConfig
 message TVChunkConfig {
+    message Watermark {
+        uint32 HostIndex = 1;
+        uint64 Value = 2;
+    }
+
     uint32 VChunkIndex = 1;
     repeated uint32 PBufferHostRoles = 2;
     repeated uint32 DDiskHostRoles = 3;
     repeated uint32 EnabledHosts = 4;
+    repeated Watermark Watermarks = 5;
 }
 
 message TTabletInfo {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/public.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/public.h
@@ -6,7 +6,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TVChunkConfig;
+class TVChunkConfig;
 
 class TVChunk;
 using TVChunkPtr = std::shared_ptr<TVChunk>;
@@ -22,6 +22,12 @@ struct TListPBufferResponse;
 struct TAggregatedListPBufferResponse;
 class IDirectBlockGroup;
 using IDirectBlockGroupPtr = std::shared_ptr<IDirectBlockGroup>;
+
+class TRegion;
+using TRegionPtr = std::shared_ptr<TRegion>;
+
+class TDDiskDataCopier;
+using TDDiskDataCopierPtr = std::shared_ptr<TDDiskDataCopier>;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
@@ -90,13 +90,13 @@ void TReadSingleLocationRequestExecutor::Run()
     };
 
     auto future = fromDDisk ? DirectBlockGroup->ReadBlocksFromDDisk(
-                                  VChunkConfig.VChunkIndex,
+                                  VChunkConfig.GetVChunkIndex(),
                                   *host,
                                   hint.VChunkRange,
                                   Request->Sglist,
                                   TraceId)
                             : DirectBlockGroup->ReadBlocksFromPBuffer(
-                                  VChunkConfig.VChunkIndex,
+                                  VChunkConfig.GetVChunkIndex(),
                                   *host,
                                   hint.Lsn,
                                   hint.VChunkRange,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
@@ -68,8 +68,8 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
         DirtyMap.WriteFinished(
             100,
             TBlockRange64::WithLength(20, 10),
-            VChunkConfig.PBufferHosts.GetPrimary(),
-            VChunkConfig.PBufferHosts.GetPrimary());
+            VChunkConfig.GetDesiredPBuffers(),
+            VChunkConfig.GetDesiredPBuffers());
         auto readHint = DirtyMap.MakeReadHint(range);
         auto readRequest = CreateReadRequestExecutor(
             Runtime->GetActorSystem(0),
@@ -134,14 +134,14 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
         DirtyMap.WriteFinished(
             100,
             TBlockRange64::WithLength(20, 10),
-            VChunkConfig.PBufferHosts.GetPrimary(),
-            VChunkConfig.PBufferHosts.GetPrimary());
+            VChunkConfig.GetDesiredPBuffers(),
+            VChunkConfig.GetDesiredPBuffers());
 
         DirtyMap.WriteFinished(
             200,
             TBlockRange64::WithLength(40, 10),
-            VChunkConfig.PBufferHosts.GetPrimary(),
-            VChunkConfig.PBufferHosts.GetPrimary());
+            VChunkConfig.GetDesiredPBuffers(),
+            VChunkConfig.GetDesiredPBuffers());
 
         const TBlockRange64 range = TBlockRange64::WithLength(10, 100);
         ExpectedRange = range;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
@@ -43,10 +43,13 @@ TRegion::TRegion(
             counters->GetSubgroup("vchunk", ToString(vChunkIndex));
 
         const auto* persisted = vChunkConfigs.FindPtr(vChunkIndex);
-        const auto vChunkConfig =
-            persisted ? *persisted : TVChunkConfig::Make(vChunkIndex);
+        const auto vChunkConfig = persisted ? *persisted
+                                            : TVChunkConfig::MakeDefault(
+                                                  vChunkIndex,
+                                                  DirectBlockGroupHostCount,
+                                                  DefaultPrimaryCount);
         Y_ABORT_UNLESS(vChunkConfig.IsValid());
-        Y_ABORT_UNLESS(vChunkConfig.VChunkIndex == vChunkIndex);
+        Y_ABORT_UNLESS(vChunkConfig.GetVChunkIndex() == vChunkIndex);
 
         auto vChunk = std::make_shared<TVChunk>(
             ActorSystem,
@@ -65,6 +68,14 @@ void TRegion::Run()
     for (const auto& vChunk: VChunks) {
         vChunk->Start();
     }
+}
+
+void TRegion::Stop()
+{
+    for (const auto& vChunk: VChunks) {
+        vChunk->Stop();
+    }
+    VChunks.clear();
 }
 
 NThreading::TFuture<TReadBlocksLocalResponse> TRegion::ReadBlocksLocal(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
@@ -30,6 +30,7 @@ public:
         NMonitoring::TDynamicCounterPtr counters);
 
     void Run();
+    void Stop();
 
     NThreading::TFuture<TReadBlocksLocalResponse> ReadBlocksLocal(
         TCallContextPtr callContext,
@@ -44,7 +45,7 @@ public:
 
 private:
     NActors::TActorSystem* const ActorSystem;
-    TVector<std::shared_ptr<TVChunk>> VChunks;
+    TVector<TVChunkPtr> VChunks;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -39,7 +39,7 @@ TVChunk::TVChunk(
     , BlockSize(DefaultBlockSize)
     , BlocksCount(vChunkSize / BlockSize)
     , SyncRequestsBatchSize(syncRequestsBatchSize)
-    , LogTitle{GetCycleCount(), TLogTitle::TVChunk{.VChunkIndex = vChunkConfig.VChunkIndex}}
+    , LogTitle{GetCycleCount(), TLogTitle::TVChunk{.VChunkIndex = vChunkConfig.GetVChunkIndex()}}
     , VChunkConfig(vChunkConfig)
     , BlocksDirtyMap(VChunkConfig, BlockSize, BlocksCount)
     , Counters(std::move(counters))
@@ -64,6 +64,17 @@ void TVChunk::Start()
         });
 }
 
+NThreading::TFuture<void> TVChunk::Stop()
+{
+    Executor->ExecuteSimple(
+        [self = shared_from_this()]() mutable
+        {
+            // Executor thread
+            self->DoStop();
+        });
+    return StopPromise.GetFuture();
+}
+
 TFuture<TReadBlocksLocalResponse> TVChunk::ReadBlocksLocal(
     TCallContextPtr callContext,
     std::shared_ptr<TReadBlocksLocalRequest> request,
@@ -77,7 +88,7 @@ TFuture<TReadBlocksLocalResponse> TVChunk::ReadBlocksLocal(
         "TVChunk.Read",
         NWilson::EFlags::AUTO_END,
         ActorSystem));
-    span->Attribute("VChunkIndex", VChunkConfig.VChunkIndex);
+    span->Attribute("VChunkIndex", VChunkConfig.GetVChunkIndex());
 
     const TBlockRange64 regionRange = TranslateToRegion(
         *request->Headers.VolumeConfig,
@@ -145,7 +156,7 @@ TFuture<TWriteBlocksLocalResponse> TVChunk::WriteBlocksLocal(
         "TVChunk.Write",
         NWilson::EFlags::AUTO_END,
         ActorSystem));
-    span->Attribute("VChunkIndex", VChunkConfig.VChunkIndex);
+    span->Attribute("VChunkIndex", VChunkConfig.GetVChunkIndex());
 
     const TBlockRange64 regionRange = TranslateToRegion(
         *request->Headers.VolumeConfig,
@@ -204,21 +215,22 @@ TFuture<TWriteBlocksLocalResponse> TVChunk::WriteBlocksLocal(
 void TVChunk::SetHostState(THostIndex hostIndex, EHostState state)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
-    switch (state) {
-        case EHostState::Enabled: {
-            VChunkConfig.EnableHost(hostIndex);
-            break;
-        }
-        case EHostState::Disabled: {
-            VChunkConfig.DisableHost(hostIndex);
-            break;
-        }
-    }
 
-    BlocksDirtyMap.UpdateConfig(
-        VChunkConfig.GetDesiredDDisks(),
-        VChunkConfig.GetDesiredPBuffers(),
-        VChunkConfig.GetDisabledHosts());
+    auto prepare = [weakSelf = weak_from_this(), hostIndex, state]()
+    {
+        if (auto self = weakSelf.lock()) {
+            return self->PrepareNewConfig(hostIndex, state);
+        }
+        return TVChunkConfig{};
+    };
+    auto apply = [weakSelf = weak_from_this()]()
+    {
+        if (auto self = weakSelf.lock()) {
+            self->ApplyConfig();
+        }
+    };
+
+    UpdateConfig(std::move(prepare), std::move(apply));
 }
 
 const TVChunkConfig& TVChunk::GetConfig() const
@@ -252,13 +264,6 @@ TString TVChunk::DebugPrintDirtyMap()
     return sb;
 }
 
-void TVChunk::UpdateConfig(const TVChunkConfig& newConfig)
-{
-    Y_ABORT_UNLESS(newConfig.VChunkIndex == VChunkConfig.VChunkIndex);
-    Y_ABORT_UNLESS(newConfig.IsValid());
-    PartitionDirectService->UpdateVChunkConfig(newConfig);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 void TVChunk::UpdateDirtyMap(const TDBGRestoreResponse& response)
@@ -288,7 +293,7 @@ void TVChunk::DoStart()
         LogTitle.GetWithTime().c_str());
 
     auto future =
-        DirectBlockGroup->RestoreDBGPBuffers(VChunkConfig.VChunkIndex);
+        DirectBlockGroup->RestoreDBGPBuffers(VChunkConfig.GetVChunkIndex());
     future.Subscribe(
         [weakSelf = weak_from_this()]   //
         (const TFuture<TDBGRestoreResponse>& f) mutable
@@ -297,6 +302,22 @@ void TVChunk::DoStart()
                 self->UpdateDirtyMap(f.GetValue());
             }
         });
+}
+
+void TVChunk::DoStop()
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    if (StopPromise.HasValue()) {
+        return;
+    }
+
+    for (const auto& [_, copier]: Copiers) {
+        copier->Stop();
+    }
+    Copiers.clear();
+
+    StopPromise.SetValue();
 }
 
 void TVChunk::DoReadBlocksLocal(
@@ -772,6 +793,190 @@ void TVChunk::UpdatePendingCounters()
     Counters.UpdateMinLsn(
         EVChunkOperation::Erase,
         BlocksDirtyMap.GetMinErasePendingLsn());
+}
+
+void TVChunk::UpdateConfig(
+    TPrepareConfigFunc prepareConfig,
+    TApplyPersistedConfigFunc applyPersisted)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    PendingVChunkConfigs.push_back(TPendingVChunkConfig{
+        .PrepareConfig = std::move(prepareConfig),
+        .ApplyPersisted = std::move(applyPersisted)});
+    PersistNextPendingConfig();
+}
+
+void TVChunk::PersistNextPendingConfig()
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    if (PendingVChunkConfigs.size() != 1) {
+        return;
+    }
+
+    auto& pending = *PendingVChunkConfigs.begin();
+
+    pending.Config = std::move(pending.PrepareConfig)();
+    Y_ABORT_UNLESS(
+        pending.Config.GetVChunkIndex() == VChunkConfig.GetVChunkIndex());
+    Y_ABORT_UNLESS(pending.Config.IsValid());
+
+    PartitionDirectService->UpdateVChunkConfig(pending.Config);
+
+    DirectBlockGroup->Schedule(
+        TDuration::Seconds(1),
+        [weakSelf = weak_from_this()]()
+        {
+            if (auto self = weakSelf.lock()) {
+                self->OnConfigPersisted();
+            }
+        });
+}
+
+void TVChunk::OnConfigPersisted()
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+    Y_ABORT_UNLESS(!PendingVChunkConfigs.empty());
+
+    auto& pending = *PendingVChunkConfigs.begin();
+    VChunkConfig = pending.Config;
+    auto apply = std::move(pending.ApplyPersisted);
+    PendingVChunkConfigs.pop_front();
+    PersistNextPendingConfig();
+    apply();
+}
+
+TVChunkConfig TVChunk::PrepareNewConfig(
+    THostIndex hostIndex,
+    EHostState state) const
+{
+    auto newConfig = VChunkConfig;
+
+    switch (state) {
+        case EHostState::Online: {
+            newConfig.EnableHost(hostIndex);
+            break;
+        }
+        case EHostState::TemporaryOffline: {
+            newConfig.DisableHost(hostIndex);
+            break;
+        }
+        case EHostState::Offline: {
+            TString error;
+            THostIndex to = newConfig.TurnOffline(hostIndex, &error);
+            if (to == InvalidHostIndex) {
+                if (error.empty()) {
+                    LOG_INFO(
+                        *ActorSystem,
+                        NKikimrServices::NBS_PARTITION,
+                        "%s Switch host to offline %s",
+                        LogTitle.GetWithTime().c_str(),
+                        PrintHostIndex(hostIndex).c_str());
+                } else {
+                    LOG_ERROR(
+                        *ActorSystem,
+                        NKikimrServices::NBS_PARTITION,
+                        "%s TransferDDisk error. %s",
+                        LogTitle.GetWithTime().c_str(),
+                        error.c_str());
+                }
+            } else {
+                LOG_INFO(
+                    *ActorSystem,
+                    NKikimrServices::NBS_PARTITION,
+                    "%s TransferDDisk from %d to %d",
+                    LogTitle.GetWithTime().c_str(),
+                    PrintHostIndex(hostIndex).c_str(),
+                    PrintHostIndex(to).c_str());
+            }
+
+            break;
+        }
+    }
+    return newConfig;
+}
+
+void TVChunk::ApplyConfig()
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    BlocksDirtyMap.UpdateConfig(VChunkConfig);
+
+    // Remove unnecessary copiers
+    for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
+         ++hostIndex)
+    {
+        if (VChunkConfig.GetWatermark(hostIndex) != std::nullopt) {
+            continue;
+        }
+        if (auto* copier = Copiers.FindPtr(hostIndex)) {
+            (*copier)->Stop();
+            Copiers.erase(hostIndex);
+        }
+    }
+
+    // Add new copiers
+    for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
+         ++hostIndex)
+    {
+        auto watermark = VChunkConfig.GetWatermark(hostIndex);
+        if (watermark == std::nullopt || Copiers.contains(hostIndex)) {
+            continue;
+        }
+
+        BlocksDirtyMap.SetReadWatermark(hostIndex, *watermark);
+        auto newCopier = Copiers[hostIndex] =
+            std::make_shared<TDDiskDataCopier>(
+                ActorSystem,
+                PartitionDirectService,
+                VChunkConfig,
+                DirectBlockGroup,
+                &BlocksDirtyMap,
+                hostIndex);
+
+        newCopier->Start().Subscribe(
+            [weakSelf = weak_from_this(), hostIndex]   //
+            (const TFuture<TDDiskDataCopier::EResult>& f)
+            {
+                if (auto self = weakSelf.lock()) {
+                    self->OnCopyComplete(hostIndex, f.GetValue());
+                }
+            });
+    }
+}
+
+void TVChunk::OnCopyComplete(
+    THostIndex hostIndex,
+    TDDiskDataCopier::EResult result)
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    LOG_INFO(
+        *ActorSystem,
+        NKikimrServices::NBS_PARTITION,
+        "%s CopyDDisk %d finished: %s",
+        LogTitle.GetWithTime().c_str(),
+        static_cast<int>(hostIndex),
+        ToString(result).c_str());
+
+    auto prepare = [weakSelf = weak_from_this(), hostIndex]()
+    {
+        if (auto self = weakSelf.lock()) {
+            auto newConfig = self->VChunkConfig;
+            newConfig.SetWatermark(hostIndex, std::nullopt);
+            return newConfig;
+        }
+        return TVChunkConfig{};
+    };
+    auto apply = [weakSelf = weak_from_this()]()
+    {
+        if (auto self = weakSelf.lock()) {
+            self->ApplyConfig();
+        }
+    };
+
+    UpdateConfig(std::move(prepare), std::move(apply));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -863,7 +863,7 @@ TVChunkConfig TVChunk::PrepareNewConfig(
             break;
         }
         case EHostState::Offline: {
-            const TString message = newConfig.TurnOffHost(hostIndex);
+            const TString message = newConfig.EvacuateHost(hostIndex);
             if (!message.empty()) {
                 LOG_WARN(
                     *ActorSystem,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -863,32 +863,14 @@ TVChunkConfig TVChunk::PrepareNewConfig(
             break;
         }
         case EHostState::Offline: {
-            TString error;
-            THostIndex to = newConfig.TurnOffline(hostIndex, &error);
-            if (to == InvalidHostIndex) {
-                if (error.empty()) {
-                    LOG_INFO(
-                        *ActorSystem,
-                        NKikimrServices::NBS_PARTITION,
-                        "%s Switch host to offline %s",
-                        LogTitle.GetWithTime().c_str(),
-                        PrintHostIndex(hostIndex).c_str());
-                } else {
-                    LOG_ERROR(
-                        *ActorSystem,
-                        NKikimrServices::NBS_PARTITION,
-                        "%s TransferDDisk error. %s",
-                        LogTitle.GetWithTime().c_str(),
-                        error.c_str());
-                }
-            } else {
-                LOG_INFO(
+            const TString message = newConfig.TurnOffHost(hostIndex);
+            if (!message.empty()) {
+                LOG_WARN(
                     *ActorSystem,
                     NKikimrServices::NBS_PARTITION,
-                    "%s TransferDDisk from %d to %d",
+                    "%s %s",
                     LogTitle.GetWithTime().c_str(),
-                    PrintHostIndex(hostIndex).c_str(),
-                    PrintHostIndex(to).c_str());
+                    message.c_str());
             }
 
             break;
@@ -907,21 +889,26 @@ void TVChunk::ApplyConfig()
     for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
          ++hostIndex)
     {
-        if (VChunkConfig.GetWatermark(hostIndex) != std::nullopt) {
+        const auto watermark = VChunkConfig.GetWatermark(hostIndex);
+        const bool needCopier = watermark != std::nullopt;
+        const auto* copier = Copiers.FindPtr(hostIndex);
+        if (needCopier || !copier) {
             continue;
         }
-        if (auto* copier = Copiers.FindPtr(hostIndex)) {
-            (*copier)->Stop();
-            Copiers.erase(hostIndex);
-        }
+
+        (*copier)->Stop();
+        Copiers.erase(hostIndex);
     }
 
     // Add new copiers
     for (THostIndex hostIndex = 0; hostIndex < VChunkConfig.GetHostCount();
          ++hostIndex)
     {
-        auto watermark = VChunkConfig.GetWatermark(hostIndex);
-        if (watermark == std::nullopt || Copiers.contains(hostIndex)) {
+        const auto watermark = VChunkConfig.GetWatermark(hostIndex);
+        const bool needCopier = watermark != std::nullopt;
+        const auto* copier = Copiers.FindPtr(hostIndex);
+
+        if (!needCopier || copier) {
             continue;
         }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -944,7 +944,7 @@ void TVChunk::OnCopyComplete(
         NKikimrServices::NBS_PARTITION,
         "%s CopyDDisk %d finished: %s",
         LogTitle.GetWithTime().c_str(),
-        static_cast<int>(hostIndex),
+        PrintHostIndex(hostIndex).c_str(),
         ToString(result).c_str());
 
     auto prepare = [weakSelf = weak_from_this(), hostIndex]()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include "ddisk_data_copier.h"
 #include "erase_request.h"
 #include "flush_request.h"
 #include "write_request.h"
@@ -42,6 +43,7 @@ public:
     ~TVChunk();
 
     void Start();
+    NThreading::TFuture<void> Stop();
 
     NThreading::TFuture<TReadBlocksLocalResponse> ReadBlocksLocal(
         TCallContextPtr callContext,
@@ -60,14 +62,24 @@ public:
     [[nodiscard]] ui64 GetPBufferUsedSize(THostIndex hostIndex) const;
     [[nodiscard]] TString DebugPrintDirtyMap();
 
-    // Persists newConfig to the partition's local DB. The in-memory config is
-    // unchanged; the new value applies after the next partition restart.
-    void UpdateConfig(const TVChunkConfig& newConfig);
-
 private:
+    friend struct TBaseFixture;
+
+    using TPrepareConfigFunc = std::function<TVChunkConfig()>;
+    using TApplyPersistedConfigFunc = std::function<void()>;
+
+    struct TPendingVChunkConfig
+    {
+        TPrepareConfigFunc PrepareConfig;
+        TApplyPersistedConfigFunc ApplyPersisted;
+
+        TVChunkConfig Config;
+    };
+
     void UpdateDirtyMap(const TDBGRestoreResponse& response);
 
     void DoStart();
+    void DoStop();
 
     void DoReadBlocksLocal(
         TTracedPromise<TReadBlocksLocalResponse> promise,
@@ -106,6 +118,21 @@ private:
 
     void UpdatePendingCounters();
 
+    // Persists newConfig to the partition's local DB. The in-memory config is
+    // unchanged; the new value applies after config persisted.
+    void UpdateConfig(
+        TPrepareConfigFunc prepareConfig,
+        TApplyPersistedConfigFunc applyPersisted);
+    void PersistNextPendingConfig();
+    void OnConfigPersisted();
+
+    TVChunkConfig PrepareNewConfig(
+        THostIndex hostIndex,
+        EHostState state) const;
+    void ApplyConfig();
+
+    void OnCopyComplete(THostIndex hostIndex, TDDiskDataCopier::EResult result);
+
     NActors::TActorSystem* const ActorSystem = nullptr;
     IPartitionDirectService* const PartitionDirectService = nullptr;
     const TExecutorPtr Executor;
@@ -117,14 +144,18 @@ private:
 
     TLogTitle LogTitle;
     TVChunkConfig VChunkConfig;
+    TList<TPendingVChunkConfig> PendingVChunkConfigs;
     TBlocksDirtyMap BlocksDirtyMap;
     bool DirtyMapRestored = false;
+    TMap<THostIndex, TDDiskDataCopierPtr> Copiers;
 
     size_t InflightWritesCount = 0;
     size_t InflightFlushesCount = 0;
     bool CleaningUpScheduled = false;
 
     TVChunkCounters Counters;
+
+    NThreading::TPromise<void> StopPromise = NThreading::NewPromise();
 };
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -101,6 +101,313 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         UNIT_ASSERT_VALUES_EQUAL(
             false,
             WaitScheduledTasks(1, TDuration::MilliSeconds(100)));
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
+    }
+
+    Y_UNIT_TEST_F(ShouldSwitchHostToTemporaryOfflineAndBack, TBaseFixture)
+    {
+        Init();
+
+        auto vchunk = std::make_shared<TVChunk>(
+            Runtime->GetActorSystem(0),
+            PartitionDirectService.get(),
+            VChunkConfig,
+            DirectBlockGroup,
+            3,   // syncRequestsBatchSize
+            DefaultVChunkSize,
+            Counters);
+        vchunk->Start();
+
+        // Call SetHostState(TemporaryOffline)
+        {
+            TPromise<void> ready = NewPromise();
+            auto wait = ready.GetFuture();
+            DirectBlockGroup->GetExecutor()->ExecuteSimple(
+                [&]()
+                {
+                    vchunk->SetHostState(0, EHostState::TemporaryOffline);
+                    ready.SetValue();
+                });
+            wait.GetValue(TDuration::Seconds(10));
+        }
+
+        // Config should stay the same since new config is not persisted yet.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
+            "DDisk{Primary;Primary;Primary;None;None} "
+            "Enabled{+++++}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should stay the same too.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        // Scheduled DBResponse.
+        // TODO replace with real DB response.
+        {
+            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
+            auto task = RunScheduledTasks();
+            task.Wait(TDuration::Seconds(10));
+        }
+
+        // Config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
+            "DDisk{Primary;Primary;Primary;None;None} "
+            "Enabled{-++++}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        // Call SetHostState(Online)
+        {
+            TPromise<void> ready = NewPromise();
+            auto wait = ready.GetFuture();
+            DirectBlockGroup->GetExecutor()->ExecuteSimple(
+                [&]()
+                {
+                    vchunk->SetHostState(0, EHostState::Online);
+                    ready.SetValue();
+                });
+            wait.GetValue(TDuration::Seconds(10));
+        }
+
+        // Scheduled DBResponse.
+        // TODO replace with real DB response.
+        {
+            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
+            auto task = RunScheduledTasks();
+            task.Wait(TDuration::Seconds(10));
+        }
+
+        // Config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
+            "DDisk{Primary;Primary;Primary;None;None} "
+            "Enabled{+++++}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
+    }
+
+    Y_UNIT_TEST_F(ShouldSwitchHostToOfflineAndBack, TBaseFixture)
+    {
+        Init();
+
+        DirectBlockGroup->ReadBlocksFromDDiskHandler = [&]   //
+            (ui32 vChunkIndex,
+             THostIndex hostIndex,
+             TBlockRange64 range,
+             const TGuardedSgList& guardedSglist,
+             const NWilson::TTraceId& traceId)
+        {
+            Y_UNUSED(vChunkIndex);
+
+            Y_UNUSED(range);
+            Y_UNUSED(guardedSglist);
+            Y_UNUSED(traceId);
+
+            // Should not read from offline host.
+            UNIT_ASSERT_VALUES_UNEQUAL(0, hostIndex);
+
+            auto promise = NewPromise<TDBGReadBlocksResponse>();
+            auto future = promise.GetFuture();
+            auto guard = TGuard(PromisesGuard);
+            ReadPromises.push_back(std::move(promise));
+            return future;
+        };
+
+        DirectBlockGroup->WriteBlocksToDDiskHandler = [&]   //
+            (ui32 vChunkIndex,
+             THostIndex hostIndex,
+             TBlockRange64 range,
+             const TGuardedSgList& guardedSglist,
+             const NWilson::TTraceId& traceId)
+        {
+            Y_UNUSED(vChunkIndex);
+
+            Y_UNUSED(range);
+            Y_UNUSED(guardedSglist);
+            Y_UNUSED(traceId);
+
+            // Should write to fresh host.
+            UNIT_ASSERT_VALUES_EQUAL(3, hostIndex);
+
+            auto promise = NewPromise<TDBGWriteBlocksResponse>();
+            auto future = promise.GetFuture();
+            auto guard = TGuard(PromisesGuard);
+            WritePromises.push_back(std::move(promise));
+            return future;
+        };
+
+        auto vchunk = std::make_shared<TVChunk>(
+            Runtime->GetActorSystem(0),
+            PartitionDirectService.get(),
+            VChunkConfig,
+            DirectBlockGroup,
+            3,   // syncRequestsBatchSize
+            DefaultVChunkSize,
+            Counters);
+        vchunk->Start();
+
+        // Call SetHostState(Offline)
+        {
+            TPromise<void> ready = NewPromise();
+            auto wait = ready.GetFuture();
+            DirectBlockGroup->GetExecutor()->ExecuteSimple(
+                [&]()
+                {
+                    vchunk->SetHostState(0, EHostState::Offline);
+                    ready.SetValue();
+                });
+            wait.GetValue(TDuration::Seconds(10));
+        }
+
+        // Config should stay the same since new config is not persisted yet.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
+            "DDisk{Primary;Primary;Primary;None;None} "
+            "Enabled{+++++}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should stay the same too.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0*{Operational,32768,32768};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3+{Disabled,0,0};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        // Scheduled DBResponse.
+        // TODO replace with real DB response.
+        {
+            WaitScheduledTasks(1, TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
+            auto task = RunScheduledTasks();
+            task.Wait(TDuration::Seconds(10));
+        }
+
+        // Config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
+            "DDisk{None;Primary;Primary;Primary;None} "
+            "Enabled{-+++[0]+}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0-{Disabled,0,0};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,0,256};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        // Call SetHostState(Online)
+        {
+            TPromise<void> ready = NewPromise();
+            auto wait = ready.GetFuture();
+            DirectBlockGroup->GetExecutor()->ExecuteSimple(
+                [&]()
+                {
+                    vchunk->SetHostState(0, EHostState::Online);
+                    ready.SetValue();
+                });
+            wait.GetValue(TDuration::Seconds(10));
+        }
+
+        // Scheduled DBResponse.
+        // TODO replace with real DB response.
+        {
+            WaitScheduledTasks(1, TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
+            auto task = RunScheduledTasks();
+            task.Wait(TDuration::Seconds(10));
+        }
+
+        // Config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
+            "DDisk{None;Primary;Primary;Primary;None} "
+            "Enabled{++++[0]+}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0+{Disabled,0,0};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Fresh,0,256};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        // Execute copier reads and writes.
+        for (size_t i = 0; i < VChunkBlockCount / BlocksPerCopy; ++i) {
+            WaitReadRequests(1, TDuration::Seconds(10));
+            SetReadResult({.Error = MakeError(S_OK)}, true);
+
+            WaitWriteRequests(1, TDuration::Seconds(10));
+            SetWriteResult({.Error = MakeError(S_OK)}, true);
+        }
+
+        // Waiting for the coping to be completed.
+        {
+            WaitScheduledTasks(1, TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
+            auto task = RunScheduledTasks();
+            task.Wait(TDuration::Seconds(10));
+        }
+
+        // Config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "[100] "
+            "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
+            "DDisk{None;Primary;Primary;Primary;None} "
+            "Enabled{+++++}",
+            AccessConfig(*vchunk).DebugPrint());
+
+        // DirtyMap config should be updated.
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0+{Disabled,0,0};"
+            "H1*{Operational,32768,32768};"
+            "H2*{Operational,32768,32768};"
+            "H3*{Operational,32768,32768};"
+            "H4+{Disabled,0,0};",
+            AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
+
+        auto onStop = vchunk->Stop();
+        onStop.GetValue(TDuration::Seconds(10));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -149,7 +149,7 @@ void TBaseWriteRequestExecutor::SendWriteRequest(THostIndex host)
         NKikimrServices::NBS_PARTITION,
         "%s SendWriteRequest. HostIndex: %u",
         LogTitle.GetWithTime().c_str(),
-        static_cast<ui32>(host));
+        PrintHostIndex(host).c_str());
 
     auto span =
         DirectBlockGroup->CreateChildSpan(TraceId, "TBaseWriteRequestExecutor");
@@ -184,7 +184,7 @@ void TBaseWriteRequestExecutor::OnWriteResponse(
         NKikimrServices::NBS_PARTITION,
         "%s OnWriteResponse. HostIndex: %u, Error: %s",
         LogTitle.GetWithTime().c_str(),
-        static_cast<ui32>(host),
+        PrintHostIndex(host).c_str(),
         FormatError(response.Error).c_str());
 
     if (!HasError(response.Error)) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -160,7 +160,7 @@ void TBaseWriteRequestExecutor::SendWriteRequest(THostIndex host)
     RequestedWrites.Set(host);
 
     auto future = DirectBlockGroup->WriteBlocksToPBuffer(
-        VChunkConfig.VChunkIndex,
+        VChunkConfig.GetVChunkIndex(),
         host,
         Lsn,
         VChunkRange,
@@ -196,7 +196,7 @@ void TBaseWriteRequestExecutor::OnWriteResponse(
     }
 
     const auto candidates =
-        VChunkConfig.PBufferHosts.GetHandOff().Exclude(RequestedWrites);
+        VChunkConfig.GetSecondaryPBuffers().Exclude(RequestedWrites);
     if (auto next = candidates.First()) {
         LOG_WARN(
             *ActorSystem,
@@ -260,9 +260,7 @@ bool TBaseWriteRequestExecutor::ShouldReplyOk() const
 
 TVector<THostIndex> TBaseWriteRequestExecutor::GetAvailableHandOffHosts() const
 {
-    return VChunkConfig.PBufferHosts.GetHandOff()
-        .Exclude(RequestedWrites)
-        .Hosts();
+    return VChunkConfig.GetSecondaryPBuffers().Exclude(RequestedWrites).Hosts();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
@@ -85,7 +85,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(guardedSglist);
 
             UNIT_ASSERT_C(userLsn, lsn);
-            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(
+                VChunkConfig.GetVChunkIndex(),
+                vChunkIndex);
             UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
             writePBufferPromises.emplace(
@@ -166,7 +168,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(guardedSglist);
 
             UNIT_ASSERT_C(userLsn, lsn);
-            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(
+                VChunkConfig.GetVChunkIndex(),
+                vChunkIndex);
             UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
             writePBufferPromises.emplace(
@@ -252,7 +256,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(guardedSglist);
 
             UNIT_ASSERT_C(userLsn, lsn);
-            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(
+                VChunkConfig.GetVChunkIndex(),
+                vChunkIndex);
             UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
             writePBufferPromises.emplace(
@@ -350,7 +356,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(guardedSglist);
 
             UNIT_ASSERT_C(userLsn, lsn);
-            UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+            UNIT_ASSERT_VALUES_EQUAL(
+                VChunkConfig.GetVChunkIndex(),
+                vChunkIndex);
             UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
             writePBufferPromises.emplace(
@@ -438,10 +446,10 @@ Y_UNIT_TEST_SUITE(TWriteRequestWithPbReplicationTest)
 
         UNIT_ASSERT_VALUES_EQUAL(S_OK, response.Error.GetCode());
         UNIT_ASSERT_EQUAL(
-            VChunkConfig.PBufferHosts.GetPrimary(),
+            VChunkConfig.GetDesiredPBuffers(),
             response.RequestedWrites);
         UNIT_ASSERT_EQUAL(
-            VChunkConfig.PBufferHosts.GetPrimary(),
+            VChunkConfig.GetDesiredPBuffers(),
             response.CompletedWrites);
     }
 
@@ -521,7 +529,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestWithPbReplicationTest)
         UNIT_ASSERT_EQUAL(MakeAllHostsMask(), response.RequestedWrites);
 
         UNIT_ASSERT_EQUAL(
-            VChunkConfig.PBufferHosts.GetPrimary(),
+            VChunkConfig.GetDesiredPBuffers(),
             response.CompletedWrites);
     }
 
@@ -573,9 +581,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestWithPbReplicationTest)
         UNIT_ASSERT_EQUAL(true, response.CompletedWrites.Get(THostIndex{0}));
         bool atLeastOneHandoffResponded =
             response.CompletedWrites.Get(
-                *VChunkConfig.PBufferHosts.GetHandOff().Nth(0)) ||
+                *VChunkConfig.GetSecondaryPBuffers().Nth(0)) ||
             response.CompletedWrites.Get(
-                *VChunkConfig.PBufferHosts.GetHandOff().Nth(1));
+                *VChunkConfig.GetSecondaryPBuffers().Nth(1));
         UNIT_ASSERT_EQUAL(true, atLeastOneHandoffResponded);
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
@@ -40,7 +40,7 @@ void TWriteWithDirectReplicationRequestExecutor::Run()
 {
     ScheduleRequestTimeoutCallback();
     ScheduleHedging();
-    for (auto host: VChunkConfig.PBufferHosts.GetPrimary()) {
+    for (auto host: VChunkConfig.GetDesiredPBuffers()) {
         SendWriteRequest(host);
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_direct_replication_request.cpp
@@ -82,7 +82,7 @@ void TWriteWithDirectReplicationRequestExecutor::
             "TWriteWithDirectReplicationRequestExecutor. Send write request to "
             "handoff host %u since we "
             "have %lu completed writes",
-            static_cast<ui32>(host),
+            PrintHostIndex(host).c_str(),
             CompletedWrites.Count());
 
         SendWriteRequest(host);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_replication_request.cpp
@@ -75,9 +75,8 @@ TWriteWithPbReplicationRequestExecutor::TWriteWithPbReplicationRequestExecutor(
     , PbufferReplyTimeout(
           directBlockGroup->GetOracle()->GetPBufferReplyTimeout())
 {
-    const auto& pbufferHosts = VChunkConfig.PBufferHosts;
-    AvailableHostsForDirectSending =
-        pbufferHosts.GetPrimary().Include(pbufferHosts.GetHandOff());
+    AvailableHostsForDirectSending = VChunkConfig.GetDesiredPBuffers().Include(
+        VChunkConfig.GetSecondaryPBuffers());
 }
 
 void TWriteWithPbReplicationRequestExecutor::Run()
@@ -85,8 +84,7 @@ void TWriteWithPbReplicationRequestExecutor::Run()
     ScheduleRequestTimeoutCallback();
     ScheduleHedging();
 
-    SendWriteRequestToManyPBuffers(
-        VChunkConfig.PBufferHosts.GetPrimary().Hosts());
+    SendWriteRequestToManyPBuffers(VChunkConfig.GetDesiredPBuffers().Hosts());
 }
 
 void TWriteWithPbReplicationRequestExecutor::SendWriteRequestToManyPBuffers(
@@ -114,7 +112,7 @@ void TWriteWithPbReplicationRequestExecutor::SendWriteRequestToManyPBuffers(
     }
 
     DirectBlockGroup->WriteBlocksToManyPBuffers(
-        VChunkConfig.VChunkIndex,
+        VChunkConfig.GetVChunkIndex(),
         coordinatorHostIndex,
         std::move(hosts),
         Lsn,
@@ -225,8 +223,8 @@ void TWriteWithPbReplicationRequestExecutor::TryToSendDirectWrites(bool isHedge)
     }
 
     TVector<std::optional<THostIndex>> mainCandidates = {
-        VChunkConfig.PBufferHosts.GetHandOff().Nth(0),
-        VChunkConfig.PBufferHosts.GetHandOff().Nth(1)};
+        VChunkConfig.GetSecondaryPBuffers().Nth(0),
+        VChunkConfig.GetSecondaryPBuffers().Nth(1)};
     for (auto host: TakeNHosts(
              std::move(mainCandidates),
              AvailableHostsForDirectSending,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_with_pb_test_fixture.cpp
@@ -52,20 +52,20 @@ TWriteWithPbTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
         Y_UNUSED(coordinatorHostIndex, replyTimeout, guardedSglist, traceId);
 
         UNIT_ASSERT_VALUES_EQUAL(UserLsn, lsn);
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
         UNIT_ASSERT_VALUES_EQUAL(3u, hostIndexes.size());
 
         UNIT_ASSERT_EQUAL(
             true,
-            VChunkConfig.PBufferHosts.GetPrimary().Get(hostIndexes[0]));
+            VChunkConfig.GetDesiredPBuffers().Get(hostIndexes[0]));
         UNIT_ASSERT_EQUAL(
             true,
-            VChunkConfig.PBufferHosts.GetPrimary().Get(hostIndexes[1]));
+            VChunkConfig.GetDesiredPBuffers().Get(hostIndexes[1]));
         UNIT_ASSERT_EQUAL(
             true,
-            VChunkConfig.PBufferHosts.GetPrimary().Get(hostIndexes[2]));
+            VChunkConfig.GetDesiredPBuffers().Get(hostIndexes[2]));
 
         callback(CreateOkResponse());
     };
@@ -119,7 +119,7 @@ TWriteWithPbTestFixture::GetDirectWriteHandlerHanging()
     {
         Y_UNUSED(hostIndex, lsn, traceId, guardedSglist);
 
-        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.VChunkIndex, vChunkIndex);
+        UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
         TPromise<TDBGWriteBlocksResponse> response(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. More logging
2. to oracle config added MaxDurationBeforeGoingTemporaryOffline
3. TVChunkConfig converted to class. Added methods: TurnOffline(), PromoteHost(), watermarks-related methods.
4. TDirtyMap state updated by TVChunkConfig
5. TDDiskDataCopier created when need to fill new ddisk

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
