### PR TITLE
Allow creation of new groups on INACTIVE PDisks

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/group_creation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/group_creation.cpp
@@ -1,0 +1,173 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/base/blobstorage_common.h>
+
+Y_UNIT_TEST_SUITE(GroupCreationInactive) {
+
+    struct TTestCtx {
+        std::unique_ptr<TEnvironmentSetup> Env;
+        ui32 NumDCs = 3;
+        ui32 NumNodesInDC = 3;
+        ui32 DisksPerNode = 2;
+        ui32 NumNodes = NumDCs * NumNodesInDC + 1; // last node hosts BSC
+
+        TTestCtxs() {
+            Env = std::make_unique<TEnvironmentSetup>(TEnvironmentSetup::TSettings{
+                .NodeCount = NumNodes,
+                .Erasure = TBlobStorageGroupType::ErasureMirror3dc,
+                .ControllerNodeId = NumNodes,
+                .LocationGenerator = [this](ui32 nodeId) {
+                    NActorsInterconnect::TNodeLocation proto;
+                    if (nodeId == NumNodes) {
+                        proto.SetDataCenter("bsc");
+                        proto.SetRack("bsc");
+                        proto.SetUnit("1");
+                    } else {
+                        const ui32 dc = (nodeId - 1) / NumNodesInDC;
+                        const ui32 rack = (nodeId - 1) % NumNodesInDC;
+                        proto.SetDataCenter(ToString(dc));
+                        proto.SetRack(ToString(rack));
+                        proto.SetUnit("1");
+                    }
+                    return TNodeLocation(proto);
+                },
+            });
+            Env->CreateBoxAndPool(DisksPerNode, /*numGroups=*/1, /*numStorageNodes=*/NumNodes - 1);
+            Env->Sim(TDuration::Seconds(30));
+        }
+
+        ui32 NodeDC(ui32 nodeId) const {
+            return (nodeId - 1) / NumNodesInDC;
+        }
+
+        void MarkDCInactive(ui32 dc) {
+            auto config = Env->FetchBaseConfig();
+            for (const auto& pdisk : config.GetPDisk()) {
+                if (pdisk.GetNodeId() == NumNodes) {
+                    continue;
+                }
+                if (NodeDC(pdisk.GetNodeId()) == dc) {
+                    Env->UpdateDriveStatus(pdisk.GetNodeId(), pdisk.GetPDiskId(),
+                        NKikimrBlobStorage::EDriveStatus::INACTIVE,
+                        NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE);
+                }
+            }
+            Env->Sim(TDuration::Seconds(5));
+        }
+
+        NKikimrBlobStorage::TConfigResponse SetNumGroups(ui32 numGroups, ui32 itemConfigGeneration) {
+            NKikimrBlobStorage::TConfigRequest readReq;
+            auto* read = readReq.AddCommand()->MutableReadStoragePool();
+            read->SetBoxId(1);
+            auto readResp = Env->Invoke(readReq);
+            UNIT_ASSERT_C(readResp.GetSuccess(), readResp.GetErrorDescription());
+            UNIT_ASSERT_VALUES_EQUAL(readResp.GetStatus(0).StoragePoolSize(), 1);
+            auto pool = readResp.GetStatus(0).GetStoragePool(0);
+
+            NKikimrBlobStorage::TConfigRequest req;
+            auto* cmd = req.AddCommand()->MutableDefineStoragePool();
+            cmd->CopyFrom(pool);
+            cmd->SetNumGroups(numGroups);
+            cmd->SetItemConfigGeneration(itemConfigGeneration);
+            return Env->Invoke(req);
+        }
+    };
+
+    Y_UNIT_TEST(CreateGroupWithOneDcInactive) {
+        TTestCtx ctx;
+
+        auto initialGroups = ctx.Env->GetGroups();
+        UNIT_ASSERT_VALUES_EQUAL(initialGroups.size(), 1);
+
+        ctx.MarkDCInactive(0);
+
+        auto response = ctx.SetNumGroups(/*numGroups=*/2, /*itemConfigGeneration=*/1);
+        UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+        ctx.Env->Sim(TDuration::Seconds(30));
+
+        auto groups = ctx.Env->GetGroups();
+        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 2);
+
+        ui32 newGroupId = (groups[0] == initialGroups[0]) ? groups[1] : groups[0];
+        auto baseConfig = ctx.Env->FetchBaseConfig();
+        std::set<ui32> dcsCovered;
+        for (const auto& vslot : baseConfig.GetVSlot()) {
+            if (vslot.GetGroupId() == newGroupId) {
+                dcsCovered.insert(ctx.NodeDC(vslot.GetVSlotId().GetNodeId()));
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(dcsCovered.size(), 3);
+        UNIT_ASSERT(dcsCovered.count(0));
+        UNIT_ASSERT(dcsCovered.count(1));
+        UNIT_ASSERT(dcsCovered.count(2));
+    }
+
+    Y_UNIT_TEST(NoSlotReassignmentToInactivePdisk) {
+        TTestCtx ctx;
+        auto groups = ctx.Env->GetGroups();
+        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
+        const ui32 groupId = groups[0];
+
+        auto baseConfig = ctx.Env->FetchBaseConfig();
+
+        std::optional<NKikimrBlobStorage::TBaseConfig::TVSlot> sourceSlot;
+        std::set<std::pair<ui32, ui32>> usedPDisks;
+        for (const auto& vslot : baseConfig.GetVSlot()) {
+            if (vslot.GetGroupId() == groupId) {
+                usedPDisks.emplace(vslot.GetVSlotId().GetNodeId(), vslot.GetVSlotId().GetPDiskId());
+                if (!sourceSlot) {
+                    sourceSlot = vslot;
+                }
+            }
+        }
+        UNIT_ASSERT(sourceSlot.has_value());
+        const ui32 sourceDC = ctx.NodeDC(sourceSlot->GetVSlotId().GetNodeId());
+
+        std::optional<NKikimrBlobStorage::TBaseConfig::TPDisk> targetPDisk;
+        for (const auto& pdisk : baseConfig.GetPDisk()) {
+            if (pdisk.GetNodeId() == ctx.NumNodes) {
+                continue;
+            }
+            if (ctx.NodeDC(pdisk.GetNodeId()) != sourceDC) {
+                continue;
+            }
+            if (usedPDisks.count({pdisk.GetNodeId(), pdisk.GetPDiskId()})) {
+                continue;
+            }
+            targetPDisk = pdisk;
+            break;
+        }
+        UNIT_ASSERT(targetPDisk);
+
+        ctx.Env->UpdateDriveStatus(targetPDisk->GetNodeId(), targetPDisk->GetPDiskId(),
+            NKikimrBlobStorage::EDriveStatus::INACTIVE,
+            NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE);
+        ctx.Env->Sim(TDuration::Seconds(5));
+
+        NKikimrBlobStorage::TConfigRequest req;
+        auto* reassign = req.AddCommand()->MutableReassignGroupDisk();
+        reassign->SetGroupId(sourceSlot->GetGroupId());
+        reassign->SetGroupGeneration(sourceSlot->GetGroupGeneration());
+        reassign->SetFailRealmIdx(sourceSlot->GetFailRealmIdx());
+        reassign->SetFailDomainIdx(sourceSlot->GetFailDomainIdx());
+        reassign->SetVDiskIdx(sourceSlot->GetVDiskIdx());
+        auto* target = reassign->MutableTargetPDiskId();
+        target->SetNodeId(targetPDisk->GetNodeId());
+        target->SetPDiskId(targetPDisk->GetPDiskId());
+
+        auto response = ctx.Env->Invoke(req);
+        UNIT_ASSERT_C(!response.GetSuccess(),
+            "Reassignment to INACTIVE PDisk unexpectedly succeeded: "
+                << response.DebugString());
+    }
+
+    Y_UNIT_TEST(CreateGroupStrictWhenActiveSufficient) {
+        TTestCtx ctx;
+        UNIT_ASSERT_VALUES_EQUAL(ctx.Env->GetGroups().size(), 1);
+
+        auto response = ctx.SetNumGroups(/*numGroups=*/2, /*itemConfigGeneration=*/1);
+        UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+        ctx.Env->Sim(TDuration::Seconds(30));
+        UNIT_ASSERT_VALUES_EQUAL(ctx.Env->GetGroups().size(), 2);
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/group_creation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/group_creation.cpp
@@ -10,7 +10,7 @@ Y_UNIT_TEST_SUITE(GroupCreationInactive) {
         ui32 DisksPerNode = 2;
         ui32 NumNodes = NumDCs * NumNodesInDC + 1; // last node hosts BSC
 
-        TTestCtxs() {
+        TTestCtx() {
             Env = std::make_unique<TEnvironmentSetup>(TEnvironmentSetup::TSettings{
                 .NodeCount = NumNodes,
                 .Erasure = TBlobStorageGroupType::ErasureMirror3dc,

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -32,6 +32,7 @@ SRCS(
     gc_quorum_3dc.cpp
     get.cpp
     get_block.cpp
+    group_creation_inactive.cpp
     group_reconfiguration.cpp
     incorrect_queries.cpp
     index_restore_get.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -32,7 +32,7 @@ SRCS(
     gc_quorum_3dc.cpp
     get.cpp
     get_block.cpp
-    group_creation_inactive.cpp
+    group_creation.cpp
     group_reconfiguration.cpp
     incorrect_queries.cpp
     index_restore_get.cpp

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -167,7 +167,7 @@ namespace NKikimr {
 
                     struct TResetGuard {
                         ~TResetGuard() {
-                            Self->ResetMapper(false);
+                            Self->RecreateMapper(false);
                         }
 
                         TGroupFitter* Self;
@@ -176,7 +176,7 @@ namespace NKikimr {
                     STLOG(PRI_WARN, BS_CONTROLLER, BSCFG02,
                         "Falling back to allocation allowing INACTIVE PDisks",
                         (GroupId, groupId), (StoragePoolId, StoragePoolId));
-                    ResetMapper(true);
+                    RecreateMapper(true);
                     try {
                         AllocateOrSanitizeGroup(groupId, group, {}, {}, groupSizeInUnits, requiredSpace, false, bridgePileId,
                             &TGroupGeometryInfo::AllocateGroup);
@@ -602,8 +602,7 @@ namespace NKikimr {
                     TBridgePileId bridgePileId,
                     T&& func) {
                 if (!Mapper) {
-                    Mapper.emplace(Geometry, StoragePool.RandomizeGroupMapping, State.Fit.PreferLessOccupiedRack, State.Fit.WithAttentionToReplication);
-                    PopulateGroupMapper();
+                    RecreateMapper(false);
                 }
                 TPDiskSlotTracker& pdiskSlotTracker= Mapper->GetPDiskSlotTracker();
                 TStackVec<TPDiskId, 32> removeQ;
@@ -689,9 +688,10 @@ namespace NKikimr {
                 Mapper->SetPDiskSlotTracker(std::move(pdiskSlotTracker));
             }
 
-            void ResetMapper(bool allowSlotCreationOnInactive) {
+            void RecreateMapper(bool allowSlotCreationOnInactive) {
                 AllowSlotCreationOnInactive = allowSlotCreationOnInactive;
-                Mapper.reset();
+                Mapper.emplace(Geometry, StoragePool.RandomizeGroupMapping, State.Fit.PreferLessOccupiedRack, State.Fit.WithAttentionToReplication);
+                PopulateGroupMapper();
             }
 
             bool HasInactivePDiskInPool() const {

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -24,6 +24,7 @@ namespace NKikimr {
             const TBoxStoragePoolId StoragePoolId;
             const TStoragePoolInfo& StoragePool;
             std::optional<TGroupMapper> Mapper;
+            bool AllowSlotCreationOnInactive = false;
             NKikimrBlobStorage::TConfigResponse::TStatus& Status;
             TVSlotReadyTimestampQ& VSlotReadyTimestampQ;
 
@@ -156,8 +157,33 @@ namespace NKikimr {
                     ExpectedSlotSize.pop_front();
                 }
                 ui32 groupSizeInUnits = StoragePool.DefaultGroupSizeInUnits;
-                AllocateOrSanitizeGroup(groupId, group, {}, {}, groupSizeInUnits, requiredSpace, false, bridgePileId,
-                    &TGroupGeometryInfo::AllocateGroup);
+                try {
+                    AllocateOrSanitizeGroup(groupId, group, {}, {}, groupSizeInUnits, requiredSpace, false, bridgePileId,
+                        &TGroupGeometryInfo::AllocateGroup);
+                } catch (const TExFitGroupError&) {
+                    if (AllowSlotCreationOnInactive || !HasInactivePDiskInPool()) {
+                        throw;
+                    }
+
+                    struct TResetGuard {
+                        ~TResetGuard() {
+                            Self->ResetMapper(false);
+                        }
+
+                        TGroupFitter* Self;
+                    } resetGuard{this};
+
+                    STLOG(PRI_WARN, BS_CONTROLLER, BSCFG02,
+                        "Falling back to allocation allowing INACTIVE PDisks",
+                        (GroupId, groupId), (StoragePoolId, StoragePoolId));
+                    ResetMapper(true);
+                    try {
+                        AllocateOrSanitizeGroup(groupId, group, {}, {}, groupSizeInUnits, requiredSpace, false, bridgePileId,
+                            &TGroupGeometryInfo::AllocateGroup);
+                    } catch (...) {
+                        throw;
+                    }
+                }
 
                 // scan all comprising PDisks for PDiskCategory
                 TMaybe<TPDiskCategory> desiredPDiskCategory;
@@ -663,6 +689,37 @@ namespace NKikimr {
                 Mapper->SetPDiskSlotTracker(std::move(pdiskSlotTracker));
             }
 
+            void ResetMapper(bool allowSlotCreationOnInactive) {
+                AllowSlotCreationOnInactive = allowSlotCreationOnInactive;
+                Mapper.reset();
+            }
+
+            bool HasInactivePDiskInPool() const {
+                const TBoxId boxId = std::get<0>(StoragePoolId);
+                bool found = false;
+                State.PDisks.ForEach([&](const TPDiskId& id, const TPDiskInfo& info) {
+                    if (found) {
+                        return;
+                    }
+                    if (info.BoxId != boxId) {
+                        return;
+                    }
+                    if (State.PDisksToRemove.count(id)) {
+                        return;
+                    }
+                    if (info.Status != NKikimrBlobStorage::EDriveStatus::INACTIVE) {
+                        return;
+                    }
+                    for (const auto& filter : StoragePool.PDiskFilters) {
+                        if (filter.MatchPDisk(info)) {
+                            found = true;
+                            return;
+                        }
+                    }
+                });
+                return found;
+            }
+
             bool RegisterPDisk(TPDiskId id, const TPDiskInfo& info, bool usable, TPDiskSlotTracker& pdiskSlotTracker, TString whyUnusable = {}) {
                 // calculate number of used slots on this PDisk, also counting the static ones
                 ui32 numSlots = info.NumActiveSlots + info.StaticSlotUsage;
@@ -703,7 +760,7 @@ namespace NKikimr {
                     }
                 }
 
-                if (!info.AcceptsNewSlots()) {
+                if (!info.AcceptsNewSlots(AllowSlotCreationOnInactive)) {
                     usable = false;
                     whyUnusable.append('S');
                 }

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -57,8 +57,7 @@ namespace NKikimr {
                 for (ui64 reserve = 0; reserve < min || (reserve - min) * 1000000 / Max<ui64>(1, total) < part; ++reserve, ++total) {
                     TGroupMapper::TGroupDefinition group;
                     try {
-                        AllocateOrSanitizeGroup(TGroupId::Zero(), group, {}, {}, 1u, 0, false, {},
-                            &TGroupGeometryInfo::AllocateGroup);
+                        AllocateGroupWithFallbackToInactive(TGroupId::Zero(), group, 1u, 0, {});
                     } catch (const TExFitGroupError&) {
                         throw TExError() << "group reserve constraint hit";
                     }
@@ -141,22 +140,8 @@ namespace NKikimr {
                 }
             }
 
-            TGroupId CreateGroup(TBridgePileId bridgePileId, std::optional<TGroupId> bridgeProxyGroupId) {
-                ////////////////////////////////////////////////////////////////////////////////////////////
-                // ALLOCATE GROUP ID FOR THE NEW GROUP
-                ////////////////////////////////////////////////////////////////////////////////////////////
-                TGroupId groupId = AllocateGroupId();
-
-                ////////////////////////////////////////////////////////////////////////////////////////////////
-                // CREATE MORE GROUPS
-                ////////////////////////////////////////////////////////////////////////////////////////////////
-                TGroupMapper::TGroupDefinition group;
-                i64 requiredSpace = Min<i64>();
-                if (!ExpectedSlotSize.empty()) {
-                    requiredSpace = ExpectedSlotSize.front();
-                    ExpectedSlotSize.pop_front();
-                }
-                ui32 groupSizeInUnits = StoragePool.DefaultGroupSizeInUnits;
+            void AllocateGroupWithFallbackToInactive(TGroupId groupId, TGroupMapper::TGroupDefinition& group,
+                    ui32 groupSizeInUnits, i64 requiredSpace, TBridgePileId bridgePileId) {
                 try {
                     AllocateOrSanitizeGroup(groupId, group, {}, {}, groupSizeInUnits, requiredSpace, false, bridgePileId,
                         &TGroupGeometryInfo::AllocateGroup);
@@ -184,6 +169,25 @@ namespace NKikimr {
                         throw;
                     }
                 }
+            }
+
+            TGroupId CreateGroup(TBridgePileId bridgePileId, std::optional<TGroupId> bridgeProxyGroupId) {
+                ////////////////////////////////////////////////////////////////////////////////////////////
+                // ALLOCATE GROUP ID FOR THE NEW GROUP
+                ////////////////////////////////////////////////////////////////////////////////////////////
+                TGroupId groupId = AllocateGroupId();
+
+                ////////////////////////////////////////////////////////////////////////////////////////////////
+                // CREATE MORE GROUPS
+                ////////////////////////////////////////////////////////////////////////////////////////////////
+                TGroupMapper::TGroupDefinition group;
+                i64 requiredSpace = Min<i64>();
+                if (!ExpectedSlotSize.empty()) {
+                    requiredSpace = ExpectedSlotSize.front();
+                    ExpectedSlotSize.pop_front();
+                }
+                ui32 groupSizeInUnits = StoragePool.DefaultGroupSizeInUnits;
+                AllocateGroupWithFallbackToInactive(groupId, group, groupSizeInUnits, requiredSpace, bridgePileId);
 
                 // scan all comprising PDisks for PDiskCategory
                 TMaybe<TPDiskCategory> desiredPDiskCategory;
@@ -259,8 +263,8 @@ namespace NKikimr {
 
                     // TODO(alexvru): calculate required space
                     Geometry.ResizeGroup(group);
-                    AllocateOrSanitizeGroup(groupId, group, {}, {}, groupInfo->GroupSizeInUnits, Min<i64>(), false,
-                        groupInfo->BridgePileId, &TGroupGeometryInfo::AllocateGroup);
+                    AllocateGroupWithFallbackToInactive(groupId, group, groupInfo->GroupSizeInUnits, Min<i64>(),
+                            groupInfo->BridgePileId);
 
                     CreateVSlotsForGroup(groupInfo, group, {});
                     return;

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -534,8 +534,10 @@ public:
             return std::make_tuple(ShouldBeSettledBySelfHeal(), BadInTermsOfSelfHeal(), Decommitted(), IsSelfHealReasonDecommit());
         }
 
-        bool AcceptsNewSlots() const {
-            return Status == NKikimrBlobStorage::EDriveStatus::ACTIVE
+        bool AcceptsNewSlots(bool allowInactive = false) const {
+            const bool allowByStatus = (Status == NKikimrBlobStorage::EDriveStatus::ACTIVE) ||
+                    (allowInactive && Status == NKikimrBlobStorage::EDriveStatus::INACTIVE);
+            return allowByStatus
                 && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED
                 && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::NO_NEW_VDISKS;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow creation of new groups on INACTIVE PDisks to make possible the addition of new groups when one DC is offline.

### Changelog category <!-- remove all except one -->

* Improvement