### PR TITLE
Add collaborator check and improve rebase label handling.

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -70,19 +70,6 @@ jobs:
               body: `@${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
             });
 
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
-
       - name: Decline rebase — label sender is not a contributor
         if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor != 'true'
         uses: actions/github-script@v7
@@ -98,19 +85,6 @@ jobs:
               body: `@${sender} Rebase declined, only contributor can rebase user branch` + footer
             });
 
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
-
       - name: Decline rebase — fork does not allow maintainer push
         if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
         uses: actions/github-script@v7
@@ -125,19 +99,6 @@ jobs:
               issue_number: context.issue.number,
               body: `@${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.` + footer
             });
-
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
 
       - name: Fail if preconditions are not met
         if: steps.preflight.outputs.pr_is_open != 'true' || steps.preflight.outputs.sender_is_contributor != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
@@ -239,24 +200,6 @@ jobs:
               body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated.' + forkHint + '\n\nPlease re-apply the `rebase-user-branch` label to retry.' + footer
             });
 
-      - name: Remove label after successful rebase
-        if: steps.push.outcome == 'success'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
-
       - name: Add success comment
         if: steps.push.outcome == 'success'
         uses: actions/github-script@v7
@@ -271,31 +214,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `✅ **Rebase complete!**\n\nPR has been automatically rebased onto \`${baseRef}\`.` + footer
-            });
-
-      - name: Replace label on failure
-        if: steps.rebase.outputs.rebase_status == 'failed'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['rebase-user-branch-failed']
             });
 
       - name: Add failure comment for conflicts
@@ -324,3 +242,37 @@ jobs:
       - name: Fail the job if conflicts
         if: steps.rebase.outputs.rebase_status == 'failed'
         run: exit 1
+
+      - name: Fail if push failed
+        if: steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
+        run: exit 1
+
+      - name: Remove trigger label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
+      - name: Mark rebase as failed
+        if: always() && steps.push.outcome != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['rebase-user-branch-failed']
+            });

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   rebase:
-    if: github.event.label.name == 'rebase-user-branch'
+    if: github.event.label.name == 'rebase-user-branch' && github.event.pull_request.state == 'open'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -167,23 +167,21 @@ jobs:
               body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated. Please re-apply the `rebase-user-branch` label to retry.'
             });
 
-      - name: Remove labels after successful rebase
+      - name: Remove label after successful rebase
         if: steps.check-permission.outputs.result == 'true' && steps.push.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |
-            for (const label of ['rebase-user-branch', 'rebase-user-branch-failed']) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  name: label
-                });
-              } catch (error) {
-                if (!error.status || error.status != 404) {
-                  throw error;
-                }
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
               }
             }
 
@@ -207,19 +205,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'rebase-user-branch-failed'
-              });
-            } catch (error) {
-              if (!error.status || error.status != 404) {
-                throw error;
-              }
-            }
-
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,7 +1,7 @@
 # SECURITY NOTE:
 # This workflow uses pull_request_target with checkout from forks.
 # Only git operations (rebase, push) are performed - no build/test scripts.
-# Preflight checks require a repository collaborator to add the label and,
+# Preflight checks require a repository collaborator to trigger rebase and,
 # for fork PRs, maintainer_can_modify (Allow edits from maintainers).
 # Do NOT add steps that execute untrusted code from the PR head.
 name: rebase
@@ -9,10 +9,20 @@ name: rebase
 on:
   pull_request_target:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: 'Pull Request number to rebase'
+        required: true
+        type: string
+
+concurrency:
+  group: rebase-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   rebase:
-    if: github.event.label.name == 'rebase-user-branch'
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'rebase-user-branch'
 
     runs-on: ubuntu-latest
     permissions:
@@ -22,9 +32,42 @@ jobs:
       WF_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            let pr;
+            if (context.eventName === 'workflow_dispatch') {
+              const pullNumber = Number.parseInt('${{ inputs.pull_number }}', 10);
+              if (!Number.isFinite(pullNumber) || pullNumber <= 0) {
+                core.setFailed('pull_number must be a positive integer');
+                return;
+              }
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              });
+              pr = data;
+            } else {
+              pr = context.payload.pull_request;
+            }
+
+            core.setOutput('number', String(pr.number));
+            core.setOutput('state', pr.state);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_repo_full_name', pr.head.repo.full_name);
+            core.setOutput('head_repo_fork', pr.head.repo.fork ? 'true' : 'false');
+            core.setOutput('maintainer_can_modify', pr.maintainer_can_modify ? 'true' : 'false');
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('base_repo_clone_url', pr.base.repo.clone_url);
+
       # Preconditions:
       # 1. Pull request must be open.
-      # 2. Label was added by a repository collaborator (not PR author check).
+      # 2. Triggered by a repository collaborator (label sender or workflow_dispatch actor).
       # 3. For fork PRs, "Allow edits from maintainers" must be enabled.
       - name: Verify rebase preconditions
         id: preflight
@@ -32,7 +75,9 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const sender = context.payload.sender.login;
+            const sender = context.eventName === 'workflow_dispatch'
+              ? context.actor
+              : context.payload.sender.login;
             let senderIsCollaborator = false;
 
             try {
@@ -48,10 +93,11 @@ jobs:
               }
             }
 
-            const pr = context.payload.pull_request;
-            const forkPushAllowed = !pr.head.repo.fork || pr.maintainer_can_modify;
+            const forkPushAllowed = '${{ steps.pr.outputs.head_repo_fork }}' !== 'true'
+              || '${{ steps.pr.outputs.maintainer_can_modify }}' === 'true';
 
-            core.setOutput('pr_is_open', pr.state == 'open' ? 'true' : 'false');
+            core.setOutput('sender', sender);
+            core.setOutput('pr_is_open', '${{ steps.pr.outputs.state }}' === 'open' ? 'true' : 'false');
             core.setOutput('sender_is_collaborator', senderIsCollaborator ? 'true' : 'false');
             core.setOutput('fork_push_allowed', forkPushAllowed ? 'true' : 'false');
 
@@ -60,28 +106,30 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sender = context.payload.sender.login;
+            const sender = '${{ steps.preflight.outputs.sender }}';
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: `⚠️ @${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
             });
 
-      - name: Decline rebase — label sender is not a collaborator
+      - name: Decline rebase — trigger is not a collaborator
         if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_collaborator != 'true'
         uses: actions/github-script@v7
         with:
           script: |
-            const sender = context.payload.sender.login;
+            const sender = '${{ steps.preflight.outputs.sender }}';
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: `⚠️ @${sender} Rebase declined, only collaborator can rebase user branch` + footer
             });
 
@@ -90,13 +138,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sender = context.payload.sender.login;
+            const sender = '${{ steps.preflight.outputs.sender }}';
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: `⚠️ @${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.` + footer
             });
 
@@ -108,11 +157,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 name: 'rebase-user-branch-failed'
               });
             } catch (error) {
@@ -124,8 +174,8 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ steps.pr.outputs.head_sha }}
+          repository: ${{ steps.pr.outputs.head_repo_full_name }}
           token: ${{ secrets.YDBOT_TOKEN }}
           fetch-depth: 0
           filter: blob:none
@@ -137,8 +187,8 @@ jobs:
 
       - name: Fetch base branch
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          BASE_REPO: ${{ steps.pr.outputs.base_repo_clone_url }}
         run: |
           git remote set-url upstream "$BASE_REPO" 2>/dev/null || git remote add upstream "$BASE_REPO"
           git fetch upstream "$BASE_REF"
@@ -147,7 +197,7 @@ jobs:
         id: rebase
         continue-on-error: true
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
           if git rebase "upstream/$BASE_REF"; then
             echo "rebase_status=success" >> $GITHUB_OUTPUT
@@ -161,12 +211,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: '❌ **Rebase failed unexpectedly.**\n\nPlease check the workflow logs or try re-applying the `rebase-user-branch` label.' + footer
             });
 
@@ -179,7 +230,7 @@ jobs:
         if: steps.rebase.outputs.rebase_status == 'success'
         continue-on-error: true
         env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
           git push --force-with-lease origin HEAD:"$HEAD_REF"
 
@@ -188,7 +239,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const isFork = context.payload.pull_request.head.repo.fork;
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
+            const isFork = '${{ steps.pr.outputs.head_repo_fork }}' === 'true';
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
             const forkHint = isFork
               ? '\n\nIf this is a fork PR, verify that **Allow edits from maintainers** is still enabled.'
@@ -196,7 +248,7 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated.' + forkHint + '\n\nPlease re-apply the `rebase-user-branch` label to retry.' + footer
             });
 
@@ -204,15 +256,16 @@ jobs:
         if: steps.push.outcome == 'success'
         uses: actions/github-script@v7
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
         with:
           script: |
             const baseRef = process.env.BASE_REF;
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: `✅ **Rebase complete!**\n\nPR has been automatically rebased onto \`${baseRef}\`.` + footer
             });
 
@@ -220,11 +273,12 @@ jobs:
         if: steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
         with:
           script: |
             const baseRef = process.env.BASE_REF;
-            const isFork = context.payload.pull_request.head.repo.fork;
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
+            const isFork = '${{ steps.pr.outputs.head_repo_fork }}' === 'true';
             const upstreamUrl = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '.git';
             const instructions = isFork
               ? 'git remote set-url upstream ' + upstreamUrl + ' 2>/dev/null || git remote add upstream ' + upstreamUrl + '\n' +
@@ -236,7 +290,7 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               body: '❌ **Rebase failed due to conflicts.**\n\nPlease resolve them manually:\n```\n' + instructions + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.' + footer
             });
 
@@ -253,11 +307,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 name: 'rebase-user-branch'
               });
             } catch (error) {
@@ -271,9 +326,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const issueNumber = Number.parseInt('${{ steps.pr.outputs.number }}', 10);
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               labels: ['rebase-user-branch-failed']
             });

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -13,14 +13,86 @@ on:
 jobs:
   rebase:
     if: github.event.label.name == 'rebase-user-branch' && (!github.event.pull_request.head.repo.fork || github.event.pull_request.maintainer_can_modify)
-     
+
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
 
     steps:
+      - name: Check if sender is a collaborator
+        id: check-permission
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const sender = context.payload.sender.login;
+
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: sender,
+              });
+              return true;
+            } catch (error) {
+              if (error.status && error.status == 404) {
+                return false;
+              }
+              throw error;
+            }
+
+      - name: Decline rebase for non-contributors
+        if: steps.check-permission.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sender = context.payload.sender.login;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `@${sender} Rebase declined, only contributor can rebase user branch`
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
+      - name: Fail if sender is not a collaborator
+        if: steps.check-permission.outputs.result != 'true'
+        run: exit 1
+
+      - name: Remove previous failure label
+        if: steps.check-permission.outputs.result == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch-failed'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
       - name: Checkout PR branch
+        if: steps.check-permission.outputs.result == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -28,13 +100,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           filter: blob:none
-        
+
       - name: Configure git
+        if: steps.check-permission.outputs.result == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Fetch base branch
+        if: steps.check-permission.outputs.result == 'true'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
@@ -44,6 +118,7 @@ jobs:
 
       - name: Attempt rebase
         id: rebase
+        if: steps.check-permission.outputs.result == 'true'
         continue-on-error: true
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -56,7 +131,7 @@ jobs:
           fi
 
       - name: Handle unexpected rebase failure
-        if: steps.rebase.outputs.rebase_status == ''
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -66,14 +141,14 @@ jobs:
               issue_number: context.issue.number,
               body: '❌ **Rebase failed unexpectedly.**\n\nPlease check the workflow logs or try re-applying the `rebase-user-branch` label.'
             });
-            
+
       - name: Fail on unexpected error
-        if: steps.rebase.outputs.rebase_status == ''
-        run: exit 1    
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
+        run: exit 1
 
       - name: Push rebased branch
         id: push
-        if: steps.rebase.outputs.rebase_status == 'success'
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success'
         continue-on-error: true
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -81,7 +156,7 @@ jobs:
           git push --force-with-lease origin "$HEAD_REF"
 
       - name: Add push failure comment
-        if: steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -91,21 +166,29 @@ jobs:
               issue_number: context.issue.number,
               body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated. Please re-apply the `rebase-user-branch` label to retry.'
             });
-      
-      - name: Remove label after rebase
-        if: steps.push.outcome == 'success'
+
+      - name: Remove labels after successful rebase
+        if: steps.check-permission.outputs.result == 'true' && steps.push.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'rebase-user-branch'
-            });
+            for (const label of ['rebase-user-branch', 'rebase-user-branch-failed']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                });
+              } catch (error) {
+                if (!error.status || error.status != 404) {
+                  throw error;
+                }
+              }
+            }
 
       - name: Add success comment
-        if: steps.push.outcome == 'success'
+        if: steps.check-permission.outputs.result == 'true' && steps.push.outcome == 'success'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -120,7 +203,7 @@ jobs:
             });
 
       - name: Replace label on failure
-        if: steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         with:
           script: |
@@ -129,19 +212,27 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                name: 'rebase-user-branch'
+                name: 'rebase-user-branch-failed'
               });
-            } catch(e) {}
-            
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                name: 'rebase-user-branch-failed'
+                name: 'rebase-user-branch'
               });
-            } catch(e) {}
-            
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -150,7 +241,7 @@ jobs:
             });
 
       - name: Add failure comment for conflicts
-        if: steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -161,10 +252,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ **Rebase failed!**\n\nConflicts detected. Please resolve them manually:\n```\ngit fetch origin\ngit rebase origin/' + baseRef + '\n```\nAfter resolving conflicts and pushing your branch, the CI will run automatically.'
+              body: '❌ **Rebase failed!**\n\nConflicts detected. Please resolve them manually:\n```\ngit fetch origin\ngit rebase origin/' + baseRef + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.'
             });
 
       - name: Fail the job if conflicts
-        if: steps.rebase.outputs.rebase_status == 'failed'
-        run: |
-          exit 1
+        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        run: exit 1

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -67,7 +67,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
+              body: `⚠️ @${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
             });
 
       - name: Decline rebase — label sender is not a collaborator
@@ -82,7 +82,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined, only collaborator can rebase user branch` + footer
+              body: `⚠️ @${sender} Rebase declined, only collaborator can rebase user branch` + footer
             });
 
       - name: Decline rebase — fork does not allow maintainer push
@@ -97,7 +97,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.` + footer
+              body: `⚠️ @${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.` + footer
             });
 
       - name: Fail if preconditions are not met

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,8 +1,8 @@
 # SECURITY NOTE:
 # This workflow uses pull_request_target with checkout from forks.
 # Only git operations (rebase, push) are performed - no build/test scripts.
-# The maintainer_can_modify check ensures only PRs where the author
-# has granted edit permissions are processed.
+# Preflight checks require a repository collaborator to add the label and,
+# for fork PRs, maintainer_can_modify (Allow edits from maintainers).
 # Do NOT add steps that execute untrusted code from the PR head.
 name: rebase
 
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Preconditions:
       # 1. Pull request must be open.
-      # 2. Label was added by a repository contributor (not PR author check).
+      # 2. Label was added by a repository collaborator (not PR author check).
       # 3. For fork PRs, "Allow edits from maintainers" must be enabled.
       - name: Verify rebase preconditions
         id: preflight
@@ -33,7 +33,7 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const sender = context.payload.sender.login;
-            let senderIsContributor = false;
+            let senderIsCollaborator = false;
 
             try {
               await github.rest.repos.checkCollaborator({
@@ -41,7 +41,7 @@ jobs:
                 repo: context.repo.repo,
                 username: sender,
               });
-              senderIsContributor = true;
+              senderIsCollaborator = true;
             } catch (error) {
               if (!error.status || error.status != 404) {
                 throw error;
@@ -52,7 +52,7 @@ jobs:
             const forkPushAllowed = !pr.head.repo.fork || pr.maintainer_can_modify;
 
             core.setOutput('pr_is_open', pr.state == 'open' ? 'true' : 'false');
-            core.setOutput('sender_is_contributor', senderIsContributor ? 'true' : 'false');
+            core.setOutput('sender_is_collaborator', senderIsCollaborator ? 'true' : 'false');
             core.setOutput('fork_push_allowed', forkPushAllowed ? 'true' : 'false');
 
       - name: Decline rebase — pull request is not open
@@ -70,8 +70,8 @@ jobs:
               body: `@${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
             });
 
-      - name: Decline rebase — label sender is not a contributor
-        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor != 'true'
+      - name: Decline rebase — label sender is not a collaborator
+        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_collaborator != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -82,11 +82,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined, only contributor can rebase user branch` + footer
+              body: `@${sender} Rebase declined, only collaborator can rebase user branch` + footer
             });
 
       - name: Decline rebase — fork does not allow maintainer push
-        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
+        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_collaborator == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -101,7 +101,7 @@ jobs:
             });
 
       - name: Fail if preconditions are not met
-        if: steps.preflight.outputs.pr_is_open != 'true' || steps.preflight.outputs.sender_is_contributor != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
+        if: steps.preflight.outputs.pr_is_open != 'true' || steps.preflight.outputs.sender_is_collaborator != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
         run: exit 1
 
       - name: Remove previous failure label
@@ -140,7 +140,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
         run: |
-          git remote add upstream "$BASE_REPO"
+          git remote set-url upstream "$BASE_REPO" 2>/dev/null || git remote add upstream "$BASE_REPO"
           git fetch upstream "$BASE_REF"
 
       - name: Attempt rebase
@@ -181,7 +181,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git push --force-with-lease origin "$HEAD_REF"
+          git push --force-with-lease origin HEAD:"$HEAD_REF"
 
       - name: Add push failure comment
         if: steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
@@ -225,8 +225,9 @@ jobs:
           script: |
             const baseRef = process.env.BASE_REF;
             const isFork = context.payload.pull_request.head.repo.fork;
+            const upstreamUrl = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '.git';
             const instructions = isFork
-              ? 'git remote add upstream https://github.com/' + context.repo.owner + '/' + context.repo.repo + '.git\n' +
+              ? 'git remote set-url upstream ' + upstreamUrl + ' 2>/dev/null || git remote add upstream ' + upstreamUrl + '\n' +
                 'git fetch upstream\n' +
                 'git rebase upstream/' + baseRef
               : 'git fetch origin\n' +

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -40,7 +40,7 @@ jobs:
           script: |
             let pr;
             if (context.eventName === 'workflow_dispatch') {
-              const pullNumber = Number.parseInt('${{ inputs.pull_number }}', 10);
+              const pullNumber = Number.parseInt(context.payload.inputs.pull_number, 10);
               if (!Number.isFinite(pullNumber) || pullNumber <= 0) {
                 core.setFailed('pull_number must be a positive integer');
                 return;
@@ -191,7 +191,7 @@ jobs:
           BASE_REPO: ${{ steps.pr.outputs.base_repo_clone_url }}
         run: |
           git remote set-url upstream "$BASE_REPO" 2>/dev/null || git remote add upstream "$BASE_REPO"
-          git fetch upstream "$BASE_REF"
+          git fetch upstream "refs/heads/$BASE_REF:refs/remotes/upstream/$BASE_REF"
 
       - name: Attempt rebase
         id: rebase
@@ -303,7 +303,7 @@ jobs:
         run: exit 1
 
       - name: Remove trigger label
-        if: always()
+        if: always() && steps.pr.outputs.number != ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -322,7 +322,7 @@ jobs:
             }
 
       - name: Mark rebase as failed
-        if: always() && steps.push.outcome != 'success'
+        if: always() && steps.pr.outputs.number != '' && steps.push.outcome != 'success'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -20,7 +20,6 @@ jobs:
       pull-requests: write
     env:
       WF_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      WF_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rebase.yml
 
     steps:
       # Preconditions:
@@ -60,7 +59,7 @@ jobs:
         with:
           script: |
             const sender = context.payload.sender.login;
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -88,7 +87,7 @@ jobs:
         with:
           script: |
             const sender = context.payload.sender.login;
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -171,7 +170,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -199,7 +198,7 @@ jobs:
         with:
           script: |
             const isFork = context.payload.pull_request.head.repo.fork;
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
             const forkHint = isFork
               ? '\n\nIf this is a fork PR, verify that **Allow edits from maintainers** is still enabled.'
               : '';
@@ -236,7 +235,7 @@ jobs:
         with:
           script: |
             const baseRef = process.env.BASE_REF;
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -284,7 +283,7 @@ jobs:
                 'git rebase upstream/' + baseRef
               : 'git fetch origin\n' +
                 'git rebase origin/' + baseRef;
-            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   rebase:
-    if: github.event.label.name == 'rebase-user-branch' && github.event.pull_request.state == 'open'
+    if: github.event.label.name == 'rebase-user-branch'
 
     runs-on: ubuntu-latest
     permissions:
@@ -23,8 +23,9 @@ jobs:
 
     steps:
       # Preconditions:
-      # 1. Label was added by a repository contributor (not PR author check).
-      # 2. For fork PRs, "Allow edits from maintainers" must be enabled.
+      # 1. Pull request must be open.
+      # 2. Label was added by a repository contributor (not PR author check).
+      # 3. For fork PRs, "Allow edits from maintainers" must be enabled.
       - name: Verify rebase preconditions
         id: preflight
         uses: actions/github-script@v7
@@ -50,11 +51,40 @@ jobs:
             const pr = context.payload.pull_request;
             const forkPushAllowed = !pr.head.repo.fork || pr.maintainer_can_modify;
 
+            core.setOutput('pr_is_open', pr.state == 'open' ? 'true' : 'false');
             core.setOutput('sender_is_contributor', senderIsContributor ? 'true' : 'false');
             core.setOutput('fork_push_allowed', forkPushAllowed ? 'true' : 'false');
 
+      - name: Decline rebase — pull request is not open
+        if: steps.preflight.outputs.pr_is_open != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sender = context.payload.sender.login;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL})`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `@${sender} Rebase declined: rebase can only be run on open pull requests.` + footer
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
       - name: Decline rebase — label sender is not a contributor
-        if: steps.preflight.outputs.sender_is_contributor != 'true'
+        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -82,7 +112,7 @@ jobs:
             }
 
       - name: Decline rebase — fork does not allow maintainer push
-        if: steps.preflight.outputs.sender_is_contributor == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
+        if: steps.preflight.outputs.pr_is_open == 'true' && steps.preflight.outputs.sender_is_contributor == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -110,7 +140,7 @@ jobs:
             }
 
       - name: Fail if preconditions are not met
-        if: steps.preflight.outputs.sender_is_contributor != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
+        if: steps.preflight.outputs.pr_is_open != 'true' || steps.preflight.outputs.sender_is_contributor != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
         run: exit 1
 
       - name: Remove previous failure label

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      WF_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      WF_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rebase.yml
 
     steps:
       - name: Check if sender is a collaborator
@@ -48,12 +51,13 @@ jobs:
         with:
           script: |
             const sender = context.payload.sender.login;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined, only contributor can rebase user branch`
+              body: `@${sender} Rebase declined, only contributor can rebase user branch` + footer
             });
 
             try {
@@ -90,12 +94,13 @@ jobs:
         with:
           script: |
             const sender = context.payload.sender.login;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `@${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.`
+              body: `@${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.` + footer
             });
 
             try {
@@ -177,11 +182,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ **Rebase failed unexpectedly.**\n\nPlease check the workflow logs or try re-applying the `rebase-user-branch` label.'
+              body: '❌ **Rebase failed unexpectedly.**\n\nPlease check the workflow logs or try re-applying the `rebase-user-branch` label.' + footer
             });
 
       - name: Fail on unexpected error
@@ -203,6 +210,7 @@ jobs:
         with:
           script: |
             const isFork = context.payload.pull_request.head.repo.fork;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
             const forkHint = isFork
               ? '\n\nIf this is a fork PR, verify that **Allow edits from maintainers** is still enabled.'
               : '';
@@ -210,7 +218,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated.' + forkHint + '\n\nPlease re-apply the `rebase-user-branch` label to retry.'
+              body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated.' + forkHint + '\n\nPlease re-apply the `rebase-user-branch` label to retry.' + footer
             });
 
       - name: Remove label after successful rebase
@@ -239,11 +247,12 @@ jobs:
         with:
           script: |
             const baseRef = process.env.BASE_REF;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `✅ **Rebase complete!**\n\nPR has been automatically rebased onto \`${baseRef}\`.`
+              body: `✅ **Rebase complete!**\n\nPR has been automatically rebased onto \`${baseRef}\`.` + footer
             });
 
       - name: Replace label on failure
@@ -286,11 +295,12 @@ jobs:
                 'git rebase upstream/' + baseRef
               : 'git fetch origin\n' +
                 'git rebase origin/' + baseRef;
+            const footer = `\n\n---\n[Workflow run](${process.env.WF_RUN_URL}) · [rebase workflow](${process.env.WF_URL})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ **Rebase failed due to conflicts.**\n\nPlease resolve them manually:\n```\n' + instructions + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.'
+              body: '❌ **Rebase failed due to conflicts.**\n\nPlease resolve them manually:\n```\n' + instructions + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.' + footer
             });
 
       - name: Fail the job if conflicts

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -23,13 +23,17 @@ jobs:
       WF_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/rebase.yml
 
     steps:
-      - name: Check if sender is a collaborator
-        id: check-permission
+      # Preconditions:
+      # 1. Label was added by a repository contributor (not PR author check).
+      # 2. For fork PRs, "Allow edits from maintainers" must be enabled.
+      - name: Verify rebase preconditions
+        id: preflight
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const sender = context.payload.sender.login;
+            let senderIsContributor = false;
 
             try {
               await github.rest.repos.checkCollaborator({
@@ -37,16 +41,21 @@ jobs:
                 repo: context.repo.repo,
                 username: sender,
               });
-              return true;
+              senderIsContributor = true;
             } catch (error) {
-              if (error.status && error.status == 404) {
-                return false;
+              if (!error.status || error.status != 404) {
+                throw error;
               }
-              throw error;
             }
 
-      - name: Decline rebase for non-contributors
-        if: steps.check-permission.outputs.result != 'true'
+            const pr = context.payload.pull_request;
+            const forkPushAllowed = !pr.head.repo.fork || pr.maintainer_can_modify;
+
+            core.setOutput('sender_is_contributor', senderIsContributor ? 'true' : 'false');
+            core.setOutput('fork_push_allowed', forkPushAllowed ? 'true' : 'false');
+
+      - name: Decline rebase — label sender is not a contributor
+        if: steps.preflight.outputs.sender_is_contributor != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -73,24 +82,8 @@ jobs:
               }
             }
 
-      - name: Fail if sender is not a collaborator
-        if: steps.check-permission.outputs.result != 'true'
-        run: exit 1
-
-      - name: Check if fork allows maintainer push
-        id: check-fork-push
-        if: steps.check-permission.outputs.result == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            if (!pr.head.repo.fork) {
-              return true;
-            }
-            return pr.maintainer_can_modify;
-
-      - name: Decline rebase for fork without maintainer edits
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result != 'true'
+      - name: Decline rebase — fork does not allow maintainer push
+        if: steps.preflight.outputs.sender_is_contributor == 'true' && steps.preflight.outputs.fork_push_allowed != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -117,12 +110,11 @@ jobs:
               }
             }
 
-      - name: Fail if fork does not allow maintainer push
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result != 'true'
+      - name: Fail if preconditions are not met
+        if: steps.preflight.outputs.sender_is_contributor != 'true' || steps.preflight.outputs.fork_push_allowed != 'true'
         run: exit 1
 
       - name: Remove previous failure label
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -140,7 +132,6 @@ jobs:
             }
 
       - name: Checkout PR branch
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -150,13 +141,11 @@ jobs:
           filter: blob:none
 
       - name: Configure git
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Fetch base branch
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
@@ -166,7 +155,6 @@ jobs:
 
       - name: Attempt rebase
         id: rebase
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         continue-on-error: true
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -179,7 +167,7 @@ jobs:
           fi
 
       - name: Handle unexpected rebase failure
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
+        if: steps.rebase.outputs.rebase_status == ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -193,12 +181,12 @@ jobs:
             });
 
       - name: Fail on unexpected error
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
+        if: steps.rebase.outputs.rebase_status == ''
         run: exit 1
 
       - name: Push rebased branch
         id: push
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success'
+        if: steps.rebase.outputs.rebase_status == 'success'
         continue-on-error: true
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -206,7 +194,7 @@ jobs:
           git push --force-with-lease origin "$HEAD_REF"
 
       - name: Add push failure comment
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
+        if: steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -223,7 +211,7 @@ jobs:
             });
 
       - name: Remove label after successful rebase
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.push.outcome == 'success'
+        if: steps.push.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -241,7 +229,7 @@ jobs:
             }
 
       - name: Add success comment
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.push.outcome == 'success'
+        if: steps.push.outcome == 'success'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -257,7 +245,7 @@ jobs:
             });
 
       - name: Replace label on failure
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         with:
           script: |
@@ -282,7 +270,7 @@ jobs:
             });
 
       - name: Add failure comment for conflicts
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -305,5 +293,5 @@ jobs:
             });
 
       - name: Fail the job if conflicts
-        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.rebase.outputs.rebase_status == 'failed'
         run: exit 1

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -81,12 +81,13 @@ jobs:
         id: check-fork-push
         if: steps.check-permission.outputs.result == 'true'
         uses: actions/github-script@v7
-        script: |
-          const pr = context.payload.pull_request;
-          if (!pr.head.repo.fork) {
-            return true;
-          }
-          return pr.maintainer_can_modify;
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr.head.repo.fork) {
+              return true;
+            }
+            return pr.maintainer_can_modify;
 
       - name: Decline rebase for fork without maintainer edits
         if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result != 'true'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   rebase:
-    if: github.event.label.name == 'rebase-user-branch' && (!github.event.pull_request.head.repo.fork || github.event.pull_request.maintainer_can_modify)
+    if: github.event.label.name == 'rebase-user-branch'
 
     runs-on: ubuntu-latest
     permissions:
@@ -73,8 +73,50 @@ jobs:
         if: steps.check-permission.outputs.result != 'true'
         run: exit 1
 
-      - name: Remove previous failure label
+      - name: Check if fork allows maintainer push
+        id: check-fork-push
         if: steps.check-permission.outputs.result == 'true'
+        uses: actions/github-script@v7
+        script: |
+          const pr = context.payload.pull_request;
+          if (!pr.head.repo.fork) {
+            return true;
+          }
+          return pr.maintainer_can_modify;
+
+      - name: Decline rebase for fork without maintainer edits
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sender = context.payload.sender.login;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `@${sender} Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.\n\nThe PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.`
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'rebase-user-branch'
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) {
+                throw error;
+              }
+            }
+
+      - name: Fail if fork does not allow maintainer push
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result != 'true'
+        run: exit 1
+
+      - name: Remove previous failure label
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -92,23 +134,23 @@ jobs:
             }
 
       - name: Checkout PR branch
-        if: steps.check-permission.outputs.result == 'true'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.YDBOT_TOKEN }}
           fetch-depth: 0
           filter: blob:none
 
       - name: Configure git
-        if: steps.check-permission.outputs.result == 'true'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Fetch base branch
-        if: steps.check-permission.outputs.result == 'true'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
@@ -118,7 +160,7 @@ jobs:
 
       - name: Attempt rebase
         id: rebase
-        if: steps.check-permission.outputs.result == 'true'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true'
         continue-on-error: true
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -131,7 +173,7 @@ jobs:
           fi
 
       - name: Handle unexpected rebase failure
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -143,12 +185,12 @@ jobs:
             });
 
       - name: Fail on unexpected error
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == ''
         run: exit 1
 
       - name: Push rebased branch
         id: push
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success'
         continue-on-error: true
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -156,19 +198,23 @@ jobs:
           git push --force-with-lease origin "$HEAD_REF"
 
       - name: Add push failure comment
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'success' && steps.push.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
+            const isFork = context.payload.pull_request.head.repo.fork;
+            const forkHint = isFork
+              ? '\n\nIf this is a fork PR, verify that **Allow edits from maintainers** is still enabled.'
+              : '';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated. Please re-apply the `rebase-user-branch` label to retry.'
+              body: '⚠️ **Rebase succeeded but push failed.**\n\nThe remote branch may have been updated.' + forkHint + '\n\nPlease re-apply the `rebase-user-branch` label to retry.'
             });
 
       - name: Remove label after successful rebase
-        if: steps.check-permission.outputs.result == 'true' && steps.push.outcome == 'success'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.push.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -186,7 +232,7 @@ jobs:
             }
 
       - name: Add success comment
-        if: steps.check-permission.outputs.result == 'true' && steps.push.outcome == 'success'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.push.outcome == 'success'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -201,7 +247,7 @@ jobs:
             });
 
       - name: Replace label on failure
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         with:
           script: |
@@ -226,20 +272,27 @@ jobs:
             });
 
       - name: Add failure comment for conflicts
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
         uses: actions/github-script@v7
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         with:
           script: |
             const baseRef = process.env.BASE_REF;
+            const isFork = context.payload.pull_request.head.repo.fork;
+            const instructions = isFork
+              ? 'git remote add upstream https://github.com/' + context.repo.owner + '/' + context.repo.repo + '.git\n' +
+                'git fetch upstream\n' +
+                'git rebase upstream/' + baseRef
+              : 'git fetch origin\n' +
+                'git rebase origin/' + baseRef;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ **Rebase failed!**\n\nConflicts detected. Please resolve them manually:\n```\ngit fetch origin\ngit rebase origin/' + baseRef + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.'
+              body: '❌ **Rebase failed due to conflicts.**\n\nPlease resolve them manually:\n```\n' + instructions + '\n```\nAfter resolving conflicts and pushing your branch, PR checks will restart automatically.'
             });
 
       - name: Fail the job if conflicts
-        if: steps.check-permission.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
+        if: steps.check-permission.outputs.result == 'true' && steps.check-fork-push.outputs.result == 'true' && steps.rebase.outputs.rebase_status == 'failed'
         run: exit 1


### PR DESCRIPTION
## Changes vs `sintjuri-patch-4`

Улучшения поверх базового rebase-on-label workflow из [#41652](https://github.com/ydb-platform/ydb/pull/41652).

### Было → стало

| Ситуация | `sintjuri-patch-4` | этот PR |
|---|---|---|
| Fork без **Allow edits** | workflow молча не запускается — maintainer не понимает, почему ничего не произошло | workflow стартует, но сразу отказывает с комментарием: что не так и что сделать автору PR |
| Label на closed PR | rebase пытается запуститься на закрытом PR | decline-комментарий: rebase только для open PR |
| Label поставил не maintainer | любой, кто может повесить label, триггерит rebase | только **collaborator** репозитория `ydb-platform/ydb`; остальным — decline с объяснением |
| Параллельные rebase на одном PR | несколько run могут идти одновременно | **concurrency per PR** — новый run отменяет предыдущий на том же PR |
| Ручной запуск | только через label | + **workflow_dispatch** с `pull_number` (Actions → rebase → Run workflow) |
| Успех / ошибка | комментарии есть, но без ссылки на конкретный run | в каждом исходе — footer со ссылкой на workflow run для отладки |
| Push failed | job остаётся зелёным, trigger-label не снимается → «re-apply label» не работает | job красный, trigger снят, failed-label поставлен → retry через новую постановку label |
| Любая ошибка | `rebase-user-branch-failed` только при конфликтах | failed-label при **любой** ошибке — видно в sidebar PR, что попытка rebase не удалась |
| Конфликты на fork PR | инструкция `git rebase origin/<base>` — для fork часто неверная | отдельная инструкция через `upstream` + учёт уже существующего remote |
| Push в fork | `GITHUB_TOKEN` — push в чужой fork часто не проходит | `YDBOT_TOKEN` — bot с правами push при включённом Allow edits |

### Как запустить rebase

1. **Label** — collaborator ставит `rebase-user-branch` на open PR
2. **Manual** — collaborator запускает workflow **rebase** → Run workflow → указывает `pull_number`

В обоих случаях проверяется collaborator **`ydb-platform/ydb`** (label sender или actor dispatch).

### Когда rebase **не** запускается

Workflow отвечает комментарием и ставит `rebase-user-branch-failed`:

- **PR closed/merged** — rebase имеет смысл только пока PR open
- **Trigger не collaborator** — проверяем collaborator `ydb-platform/ydb` у того, кто повесил label или запустил dispatch
- **Fork PR без Allow edits from maintainers** — без этой галочки bot не может запушить rebased branch обратно в fork

### Concurrency

```yaml
concurrency:
  group: rebase-pr-<PR number>
  cancel-in-progress: true
```

Если на одном PR быстро поставили label дважды или параллельно label + dispatch — остаётся только последний run.

### Labels

- **`rebase-user-branch`** — trigger; снимается **всегда** при завершении (чтобы retry = явная новая постановка label)
- **`rebase-user-branch-failed`** — ставится при **любой** ошибке
- **Retry** — снова поставить `rebase-user-branch` или re-run dispatch; failed снимается автоматически в начале новой попытки

---

## Comment examples

### Closed PR

Maintainer по ошибке повесил label на merged/closed PR.

> ⚠️ @user Rebase declined: rebase can only be run on open pull requests.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`

### Not a collaborator

Label повесил или dispatch запустил внешний contributor (есть commits, но нет доступа к repo).

> ⚠️ @user Rebase declined, only collaborator can rebase user branch
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`

### Fork without Allow edits

PR из fork, автор не включил **Allow edits from maintainers**.

> ⚠️ @user Rebase declined: this PR is from a fork and **Allow edits from maintainers** is not enabled.
>
> The PR author must enable it in the PR sidebar so maintainers can push the rebased branch. Alternatively, rebase locally and push to the fork.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`

### Success

Rebase и push прошли успешно.

> ✅ **Rebase complete!**
>
> PR has been automatically rebased onto `main`.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят, failed не ставится

### Conflicts

Rebase дошёл до git, но есть конфликты с base branch. Для fork PR в комментарии — инструкция через `upstream`.

> ❌ **Rebase failed due to conflicts.**
>
> Please resolve them manually:
> ```
> git fetch origin
> git rebase origin/main
> ```
> After resolving conflicts and pushing your branch, PR checks will restart automatically.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`

### Push failed

Rebase локально прошёл, но push не удался (ветка обновилась, потерялись права на fork и т.п.).

> ⚠️ **Rebase succeeded but push failed.**
>
> The remote branch may have been updated.
>
> If this is a fork PR, verify that **Allow edits from maintainers** is still enabled.
>
> Please re-apply the `rebase-user-branch` label to retry.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`, job **failed**

### Unexpected error

Непредвиденный сбой workflow (checkout, git и т.д.) — не конфликты и не push.

> ❌ **Rebase failed unexpectedly.**
>
> Please check the workflow logs or try re-applying the `rebase-user-branch` label.
>
> ---
> [Workflow run](https://github.com/ydb-platform/ydb/actions/runs/123456789)

**Labels:** trigger снят → `rebase-user-branch-failed`

## Test plan

- [ ] Open PR + collaborator + label → rebase успешен, trigger снят, failed не ставится
- [ ] workflow_dispatch с `pull_number` → rebase успешен
- [ ] Два быстрых trigger на одном PR → второй run отменяет первый (concurrency)
- [ ] Closed PR → decline comment + failed label
- [ ] Non-collaborator → decline comment + failed label
- [ ] Fork без Allow edits → decline comment + failed label
- [ ] Конфликты → failed label + fork-aware инструкция
- [ ] Push failed → job red, failed label, retry через новый trigger
- [ ] Retry после failed → failed снимается, при успехе не возвращается