### PR TITLE
Interactive transactions in YDB CLI interactive mode (ydb_int only)

### DIFF
--- a/ydb/apps/ydb_int/README.md
+++ b/ydb/apps/ydb_int/README.md
@@ -44,14 +44,45 @@ extra `experimental` command tree:
 ### Interactive transactions (draft)
 
 In interactive mode (run `ydb_int` with no subcommand), `ydb_int` supports
-multi-statement transactions over the Query service session:
+multi-statement transactions over a Query service session.
 
-- `BEGIN` / `START TRANSACTION` — optionally with isolation level
-  (`BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED`, `BEGIN read-committed-rw`, …)
-- `COMMIT` / `END` — commit the current transaction
-- `ROLLBACK` — rollback the current transaction
+Syntax (case-insensitive, trailing semicolon allowed):
 
-This feature is **not** available in the official `ydb` client.
+```sql
+-- Begin a transaction. Default mode: serializable-rw.
+BEGIN [TRANSACTION | WORK] [<mode>]
+START TRANSACTION              [<mode>]
+
+-- Commit / rollback:
+COMMIT [TRANSACTION | WORK]
+END    [TRANSACTION]
+ROLLBACK [TRANSACTION | WORK]
+```
+
+Supported `<mode>` values are the YDB-native mode names also accepted by
+`ydb table query --tx-mode`. Only modes that the Query service can open via
+`BeginTransaction` are listed here; `online-ro` and `stale-ro` are *not*
+supported as interactive transaction modes (the server rejects open
+transactions for them — they exist only as one-shot per-query tx modes).
+
+| Mode                | YDB SDK equivalent                    | Notes                                         |
+|---------------------|---------------------------------------|-----------------------------------------------|
+| `serializable-rw`   | `TTxSettings::SerializableRW()`       | Default if no mode is specified.              |
+| `snapshot-ro`       | `TTxSettings::SnapshotRO()`           |                                               |
+| `snapshot-rw`       | `TTxSettings::SnapshotRW()`           | Requires `EnableSnapshotIsolationRW` on server. |
+| `read-committed-rw` | `TTxSettings::ReadCommittedRW()`      | Requires server support (newer versions).     |
+
+The PostgreSQL-style `ISOLATION LEVEL ...` wording is intentionally not
+supported: we keep the YDB-native names from `--tx-mode` so that the user
+always knows which YDB transaction mode is actually used.
+
+While a transaction is open, the prompt is suffixed with `*` and the YDB
+driver is kept alive between input lines. Exiting (`exit` / `quit` / Ctrl-D)
+with an open transaction prints a warning and rolls it back implicitly.
+
+This feature is **not** available in the official `ydb` client; it is
+controlled by the `EnableInteractiveTransactions` client setting that is set
+only by `ydb_int`.
 
 ## Adding a new experimental command
 

--- a/ydb/apps/ydb_int/README.md
+++ b/ydb/apps/ydb_int/README.md
@@ -41,6 +41,18 @@ extra `experimental` command tree:
 ./ydb/apps/ydb_int/ydb_int experimental --help
 ```
 
+### Interactive transactions (draft)
+
+In interactive mode (run `ydb_int` with no subcommand), `ydb_int` supports
+multi-statement transactions over the Query service session:
+
+- `BEGIN` / `START TRANSACTION` — optionally with isolation level
+  (`BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED`, `BEGIN read-committed-rw`, …)
+- `COMMIT` / `END` — commit the current transaction
+- `ROLLBACK` — rollback the current transaction
+
+This feature is **not** available in the official `ydb` client.
+
 ## Adding a new experimental command
 
 The recipe below describes the minimum set of steps required to introduce a

--- a/ydb/apps/ydb_int/commands/ydb_root.cpp
+++ b/ydb/apps/ydb_int/commands/ydb_root.cpp
@@ -48,6 +48,7 @@ int NewInternalClient(int argc, char** argv) {
     };
 
     settings.EnableAiInteractive = true;
+    settings.EnableInteractiveTransactions = true;
 
     auto commandsRoot = MakeHolder<TClientCommandInternalRoot>(std::filesystem::path(argv[0]).stem().string(), settings);
     commandsRoot->Opts.SetTitle("YDB client with experimental features support");

--- a/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.cpp
@@ -97,9 +97,9 @@ public:
 
         YQLHighlighter = MakeYQLHighlighter(CurrentColorSchema);
 
-        std::vector<TString> completionCommands(settings.AdditionalCommands.begin(), settings.AdditionalCommands.end());
+        std::vector<TString> slashCommands(settings.AdditionalCommands.begin(), settings.AdditionalCommands.end());
         if (EnableSwitchMode) {
-            completionCommands.push_back("/switch");
+            slashCommands.push_back("/switch");
         }
 
         std::optional<TYQLCompleterConfig> yqlCompleterConfig;
@@ -107,7 +107,11 @@ public:
             Y_VALIDATE(settings.LazyDriver, "TLineReaderSettings::LazyDriver must be set when EnableYqlCompletion is true");
             yqlCompleterConfig = TYQLCompleterConfig{.Color = CurrentColorSchema, .LazyDriver = settings.LazyDriver, .Database = settings.Database, .IsVerbose = GetGlobalLogger().IsVerbose()};
         }
-        YQLCompleter = MakeYQLCompositeCompleter(completionCommands, yqlCompleterConfig);
+        YQLCompleter = MakeYQLCompositeCompleter({
+            .SlashCommands = std::move(slashCommands),
+            .TclCommands = settings.TclCommands,
+            .YqlCompleterConfig = std::move(yqlCompleterConfig),
+        });
 
         InitReplxx(settings.EnableYqlCompletion);
         Y_VALIDATE(Rx, "Replxx is not initialized");

--- a/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.h
@@ -45,7 +45,11 @@ struct TLineReaderSettings {
     TString Database;
     TString Prompt;
     std::optional<TString> HistoryFilePath;
+    // Slash-prefixed commands suggested when the input starts with '/'.
     std::vector<TString> AdditionalCommands;
+    // TCL command lines (e.g. BEGIN ..., COMMIT, ROLLBACK ...) suggested when
+    // the input looks like a transaction control statement.
+    std::vector<TString> TclCommands;
     TString Placeholder;
     bool EnableYqlCompletion = true;
     bool EnableSwitchMode = true;

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/ya.make
@@ -1,0 +1,11 @@
+UNITTEST_FOR(ydb/public/lib/ydb_cli/commands/interactive/complete)
+
+SRCS(
+    yql_completer_ut.cpp
+)
+
+PEERDIR(
+    ydb/public/lib/ydb_cli/common
+)
+
+END()

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -1,0 +1,225 @@
+#include <ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.h>
+#include <ydb/public/lib/ydb_cli/common/tx_mode_utils.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/string/cast.h>
+
+namespace NYdb::NConsoleClient {
+
+namespace {
+
+// Build a composite completer that has only the TCL completer enabled
+// (no slash commands, no YQL completer). This is enough to exercise the
+// context-aware TCL logic in isolation.
+IYQLCompleter::TPtr MakeTclOnlyCompleter() {
+    TCompositeCompleterConfig cfg;
+    auto fullForms = GetTransactionControlCompletions();
+    cfg.TclCommands.assign(fullForms.begin(), fullForms.end());
+    return MakeYQLCompositeCompleter(cfg);
+}
+
+THashSet<std::string> AsSet(const THints& hints) {
+    THashSet<std::string> set;
+    for (const auto& h : hints) {
+        set.insert(h);
+    }
+    return set;
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TclCompleter) {
+
+    Y_UNIT_TEST(SuggestsBeginOnPrefix) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEG";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+        UNIT_ASSERT(AsSet(hints).contains("BEGIN"));
+        // Must not propose tail words yet.
+        UNIT_ASSERT(!AsSet(hints).contains("TRANSACTION"));
+        UNIT_ASSERT(!AsSet(hints).contains("WORK"));
+    }
+
+    Y_UNIT_TEST(SuggestsBeginOnPrefixLowerCase) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "beg";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+        UNIT_ASSERT(AsSet(hints).contains("BEGIN"));
+    }
+
+    Y_UNIT_TEST(SuggestsStartOnPrefix) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "STA";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+        UNIT_ASSERT(AsSet(hints).contains("START"));
+    }
+
+    Y_UNIT_TEST(NextWordAfterBeginSpace) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN ";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("TRANSACTION"));
+        UNIT_ASSERT(set.contains("WORK"));
+        UNIT_ASSERT(set.contains("serializable-rw"));
+        UNIT_ASSERT(set.contains("read-committed-rw"));
+        UNIT_ASSERT(set.contains("snapshot-ro"));
+        UNIT_ASSERT(set.contains("snapshot-rw"));
+        // online-ro / stale-ro are NOT supported as interactive modes.
+        UNIT_ASSERT(!set.contains("online-ro"));
+        UNIT_ASSERT(!set.contains("stale-ro"));
+    }
+
+    Y_UNIT_TEST(NextWordAfterBeginPartialT) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN T";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 1);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("TRANSACTION"));
+        UNIT_ASSERT(!set.contains("WORK"));
+        UNIT_ASSERT(!set.contains("serializable-rw"));
+    }
+
+    Y_UNIT_TEST(NextWordAfterBeginTransactionSpace) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN TRANSACTION ";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("serializable-rw"));
+        UNIT_ASSERT(set.contains("read-committed-rw"));
+        UNIT_ASSERT(set.contains("snapshot-ro"));
+        UNIT_ASSERT(set.contains("snapshot-rw"));
+        UNIT_ASSERT(!set.contains("online-ro"));
+        UNIT_ASSERT(!set.contains("stale-ro"));
+        UNIT_ASSERT(!set.contains("TRANSACTION"));
+        UNIT_ASSERT(!set.contains("WORK"));
+    }
+
+    Y_UNIT_TEST(NextWordAfterStartTransactionSpace) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "START TRANSACTION ";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("serializable-rw"));
+        UNIT_ASSERT(set.contains("snapshot-ro"));
+        // Repeated phrase must NOT be proposed.
+        UNIT_ASSERT(!set.contains("START TRANSACTION serializable-rw"));
+        UNIT_ASSERT(!set.contains("TRANSACTION"));
+    }
+
+    Y_UNIT_TEST(NoOnlineRoSuggestion) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN o";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        // No mode starts with 'o' anymore (online-ro removed).
+        UNIT_ASSERT(hints.empty());
+    }
+
+    Y_UNIT_TEST(NoInconsistentReadsModifier) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        for (auto text : {TString("BEGIN snapshot-ro "), TString("BEGIN snapshot-rw ")}) {
+            auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+            const auto set = AsSet(hints);
+            UNIT_ASSERT(!set.contains("INCONSISTENT"));
+        }
+    }
+
+    Y_UNIT_TEST(CommitForms) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        {
+            const TString text = "COM";
+            auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+            UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+            UNIT_ASSERT(AsSet(hints).contains("COMMIT"));
+        }
+        {
+            const TString text = "COMMIT ";
+            auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+            UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
+            const auto set = AsSet(hints);
+            UNIT_ASSERT(set.contains("TRANSACTION"));
+            UNIT_ASSERT(set.contains("WORK"));
+        }
+    }
+
+    Y_UNIT_TEST(RollbackForms) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        {
+            const TString text = "ROL";
+            auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+            UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+            UNIT_ASSERT(AsSet(hints).contains("ROLLBACK"));
+        }
+        {
+            const TString text = "ROLLBACK ";
+            auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+            const auto set = AsSet(hints);
+            UNIT_ASSERT(set.contains("TRANSACTION"));
+            UNIT_ASSERT(set.contains("WORK"));
+        }
+    }
+
+    Y_UNIT_TEST(EndForms) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "END ";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("TRANSACTION"));
+        UNIT_ASSERT(!set.contains("WORK"));
+    }
+
+    Y_UNIT_TEST(NoTclSuggestionsForUnrelatedInput) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "SELECT * FROM";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT(hints.empty());
+    }
+
+    Y_UNIT_TEST(NoTclSuggestionsForEmptyInput) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT(hints.empty());
+    }
+
+    Y_UNIT_TEST(NoTclSuggestionsAfterUnknownMode) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN nosuchmode ";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT(hints.empty());
+    }
+
+    Y_UNIT_TEST(LeadingWhitespaceHandled) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "   BEG";
+        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
+        UNIT_ASSERT(AsSet(hints).contains("BEGIN"));
+    }
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -92,6 +92,20 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT(!set.contains("serializable-rw"));
     }
 
+    Y_UNIT_TEST(NextWordAfterBeginPartialS) {
+        auto completer = MakeTclOnlyCompleter();
+        int contextLen = -1;
+        const TString text = "BEGIN s";
+        // Replxx may pass only the current word as prefix; full line is in text.
+        auto hints = completer->ApplyLight(text, "s", contextLen);
+        UNIT_ASSERT_VALUES_EQUAL(contextLen, 1);
+        const auto set = AsSet(hints);
+        UNIT_ASSERT(set.contains("serializable-rw"));
+        UNIT_ASSERT(set.contains("snapshot-ro"));
+        UNIT_ASSERT(set.contains("snapshot-rw"));
+        UNIT_ASSERT(!set.contains("read-committed-rw"));
+    }
+
     Y_UNIT_TEST(NextWordAfterBeginTransactionSpace) {
         auto completer = MakeTclOnlyCompleter();
         int contextLen = -1;

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -3,6 +3,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/hash_set.h>
 #include <util/string/cast.h>
 
 namespace NYdb::NConsoleClient {

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
@@ -23,3 +23,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -16,6 +16,10 @@
 #include <yql/essentials/sql/v1/lexer/antlr4_pure_ansi/lexer.h>
 
 #include <util/charset/utf8.h>
+#include <util/generic/hash_set.h>
+
+#include <cctype>
+#include <vector>
 
 namespace NYdb::NConsoleClient {
 
@@ -123,58 +127,244 @@ namespace {
         TColorSchema Color;
     };
 
-    class TCompositeCommandCompleter final : public IYQLCompleter {
+    // TCL keywords that are allowed to appear as the very first token of an
+    // interactive transaction control line.
+    static const std::vector<TString>& TclKeywords() {
+        static const std::vector<TString> kKeywords = {
+            "BEGIN", "START", "COMMIT", "END", "ROLLBACK",
+        };
+        return kKeywords;
+    }
+
+    // Splits text into whitespace-separated tokens. The last "incomplete" token
+    // (without trailing whitespace) is returned as `partial`; everything before
+    // it as `complete`. The token offset (byte position) is preserved so the
+    // caller can compute contextLen as text.size() - partialOffset.
+    struct TTokenization {
+        std::vector<TStringBuf> Complete;
+        TStringBuf Partial;
+        size_t PartialOffset = 0;  // byte offset of the partial in the source
+    };
+
+    static TTokenization TokenizeForCompletion(TStringBuf text) {
+        TTokenization out;
+        out.PartialOffset = text.size();
+        size_t i = 0;
+        while (i < text.size()) {
+            while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) {
+                ++i;
+            }
+            if (i == text.size()) {
+                break;
+            }
+            const size_t s = i;
+            while (i < text.size() && !std::isspace(static_cast<unsigned char>(text[i]))) {
+                ++i;
+            }
+            TStringBuf token = text.SubStr(s, i - s);
+            if (i == text.size()) {
+                out.Partial = token;
+                out.PartialOffset = s;
+            } else {
+                out.Complete.push_back(token);
+            }
+        }
+        return out;
+    }
+
+    static bool IEquals(TStringBuf a, TStringBuf b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < a.size(); ++i) {
+            if (std::toupper(static_cast<unsigned char>(a[i]))
+                != std::toupper(static_cast<unsigned char>(b[i]))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool IStartsWith(TStringBuf s, TStringBuf prefix) {
+        if (s.size() < prefix.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < prefix.size(); ++i) {
+            if (std::toupper(static_cast<unsigned char>(s[i]))
+                != std::toupper(static_cast<unsigned char>(prefix[i]))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Context-aware completer for TCL command lines.
+    //
+    // Given the user's input split into completed tokens and a partial last
+    // token, the completer scans a precomputed list of "full TCL commands"
+    // (e.g. "BEGIN TRANSACTION online-ro INCONSISTENT READS") and for every
+    // match returns only the *next word* — never the whole tail. This produces
+    // the same UX as the YQL completer (e.g. typing `BEGIN T<TAB>` proposes
+    // `TRANSACTION`, not `TRANSACTION online-ro INCONSISTENT READS`).
+    class TTclCompleter {
     public:
-        TCompositeCommandCompleter(const std::vector<TString>& commands, const std::optional<TYQLCompleterConfig>& yqlCompleterConfig)
-            : Commands(commands)
-            , YQLCompleter(yqlCompleterConfig ? MakeYQLCompleter(*yqlCompleterConfig) : nullptr)
-        {}
-
-        TCompletions ApplyHeavy(TStringBuf text, const std::string& prefix, int& contextLen) final {
-            if (RunCommandCompletion(text)) {
-                auto completions = GetCommandCompletions(text, contextLen);
-
-                TCompletions result;
-                result.reserve(completions.size());
-                for (auto& completion : completions) {
-                    result.emplace_back(std::move(completion));
+        explicit TTclCompleter(const std::vector<TString>& commands) {
+            FullCommands.reserve(commands.size());
+            for (const auto& cmd : commands) {
+                std::vector<TString> tokens;
+                size_t i = 0;
+                while (i < cmd.size()) {
+                    while (i < cmd.size() && std::isspace(static_cast<unsigned char>(cmd[i]))) {
+                        ++i;
+                    }
+                    if (i == cmd.size()) {
+                        break;
+                    }
+                    const size_t s = i;
+                    while (i < cmd.size() && !std::isspace(static_cast<unsigned char>(cmd[i]))) {
+                        ++i;
+                    }
+                    tokens.emplace_back(cmd.substr(s, i - s));
                 }
-
-                return result;
-            }
-
-            return YQLCompleter ? YQLCompleter->ApplyHeavy(text, prefix, contextLen) : TCompletions{};
-        }
-
-        THints ApplyLight(TStringBuf text, const std::string& prefix, int& contextLen) final {
-            if (RunCommandCompletion(text)) {
-                return GetCommandCompletions(text, contextLen);
-            }
-
-            return YQLCompleter ? YQLCompleter->ApplyLight(text, prefix, contextLen) : THints{};
-        }
-
-    private:
-        bool RunCommandCompletion(TStringBuf text) const {
-            return text.StartsWith('/');
-        }
-
-        THints GetCommandCompletions(TStringBuf text, int& contextLen) const {
-            THints result;
-            result.reserve(Commands.size());
-
-            for (const auto& command : Commands) {
-                if (command.StartsWith(text)) {
-                    result.push_back(command);
+                if (!tokens.empty()) {
+                    FullCommands.push_back(std::move(tokens));
                 }
             }
+        }
 
-            contextLen = text.size();
+        // Returns true if the input may be a TCL command (so that the YQL
+        // completer should not be queried in addition). The check is permissive
+        // by design: any input whose first token is a prefix of a TCL keyword
+        // is treated as a TCL context.
+        bool IsContext(const TTokenization& t) const {
+            if (FullCommands.empty()) {
+                return false;
+            }
+            const TStringBuf firstToken = t.Complete.empty() ? t.Partial : t.Complete.front();
+            if (firstToken.empty()) {
+                return false;
+            }
+            for (const auto& kw : TclKeywords()) {
+                if (t.Complete.empty()) {
+                    if (IStartsWith(kw, firstToken)) {
+                        return true;
+                    }
+                } else if (IEquals(firstToken, kw)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Returns next-word candidates for the given tokenization. If no
+        // candidates apply, returns an empty list and leaves contextLen
+        // untouched. Otherwise contextLen is the length (in bytes) of the
+        // partial token that should be replaced.
+        std::vector<TString> Complete(const TTokenization& t, int& contextLen) const {
+            std::vector<TString> result;
+            THashSet<TString> seen;
+            for (const auto& full : FullCommands) {
+                if (full.size() <= t.Complete.size()) {
+                    continue;
+                }
+                bool matched = true;
+                for (size_t i = 0; i < t.Complete.size(); ++i) {
+                    if (!IEquals(t.Complete[i], full[i])) {
+                        matched = false;
+                        break;
+                    }
+                }
+                if (!matched) {
+                    continue;
+                }
+                const TString& nextWord = full[t.Complete.size()];
+                if (!IStartsWith(nextWord, t.Partial)) {
+                    continue;
+                }
+                if (seen.insert(nextWord).second) {
+                    result.push_back(nextWord);
+                }
+            }
+            if (!result.empty()) {
+                contextLen = t.Partial.size();
+            }
             return result;
         }
 
     private:
-        const std::vector<TString> Commands;
+        std::vector<std::vector<TString>> FullCommands;
+    };
+
+    class TCompositeCommandCompleter final : public IYQLCompleter {
+    public:
+        explicit TCompositeCommandCompleter(const TCompositeCompleterConfig& config)
+            : SlashCommands(config.SlashCommands)
+            , TclCompleter(config.TclCommands)
+            , HasTclCompleter(!config.TclCommands.empty())
+            , YQLCompleter(config.YqlCompleterConfig
+                ? MakeYQLCompleter(*config.YqlCompleterConfig)
+                : nullptr)
+        {}
+
+        TCompletions ApplyHeavy(TStringBuf text, const std::string& prefix, int& contextLen) final {
+            const TStringBuf prefixView(prefix.data(), prefix.size());
+            if (prefixView.StartsWith('/')) {
+                return ToCompletions(MatchSlashCommands(prefixView, contextLen));
+            }
+            if (HasTclCompleter) {
+                const auto tokenization = TokenizeForCompletion(prefixView);
+                if (TclCompleter.IsContext(tokenization)) {
+                    int tclCtx = 0;
+                    auto tclWords = TclCompleter.Complete(tokenization, tclCtx);
+                    contextLen = tclCtx;
+                    return ToCompletions(THints(tclWords.begin(), tclWords.end()));
+                }
+            }
+            return YQLCompleter ? YQLCompleter->ApplyHeavy(text, prefix, contextLen) : TCompletions{};
+        }
+
+        THints ApplyLight(TStringBuf text, const std::string& prefix, int& contextLen) final {
+            const TStringBuf prefixView(prefix.data(), prefix.size());
+            if (prefixView.StartsWith('/')) {
+                return MatchSlashCommands(prefixView, contextLen);
+            }
+            if (HasTclCompleter) {
+                const auto tokenization = TokenizeForCompletion(prefixView);
+                if (TclCompleter.IsContext(tokenization)) {
+                    int tclCtx = 0;
+                    auto tclWords = TclCompleter.Complete(tokenization, tclCtx);
+                    contextLen = tclCtx;
+                    return THints(tclWords.begin(), tclWords.end());
+                }
+            }
+            return YQLCompleter ? YQLCompleter->ApplyLight(text, prefix, contextLen) : THints{};
+        }
+
+    private:
+        THints MatchSlashCommands(TStringBuf prefix, int& contextLen) const {
+            THints result;
+            for (const auto& cmd : SlashCommands) {
+                if (cmd.StartsWith(prefix)) {
+                    result.push_back(cmd);
+                }
+            }
+            contextLen = prefix.size();
+            return result;
+        }
+
+        static TCompletions ToCompletions(THints hints) {
+            TCompletions out;
+            out.reserve(hints.size());
+            for (auto& h : hints) {
+                out.emplace_back(std::move(h));
+            }
+            return out;
+        }
+
+    private:
+        const std::vector<TString> SlashCommands;
+        const TTclCompleter TclCompleter;
+        const bool HasTclCompleter;
         const IYQLCompleter::TPtr YQLCompleter;
     };
 
@@ -244,8 +434,8 @@ namespace {
             std::move(settings.Color));
     }
 
-    IYQLCompleter::TPtr MakeYQLCompositeCompleter(const std::vector<TString>& commands, const std::optional<TYQLCompleterConfig>& yqlCompleterConfig) {
-        return MakeHolder<TCompositeCommandCompleter>(commands, yqlCompleterConfig);
+    IYQLCompleter::TPtr MakeYQLCompositeCompleter(const TCompositeCompleterConfig& config) {
+        return MakeHolder<TCompositeCommandCompleter>(config);
     }
 
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -312,7 +312,10 @@ namespace {
                 return ToCompletions(MatchSlashCommands(prefixView, contextLen));
             }
             if (HasTclCompleter) {
-                const auto tokenization = TokenizeForCompletion(prefixView);
+                // Replxx may pass only the current word as `prefix`; TCL completion
+                // needs the full input line (e.g. "BEGIN s", not just "s").
+                const TStringBuf lineView = !text.empty() ? text : prefixView;
+                const auto tokenization = TokenizeForCompletion(lineView);
                 if (TclCompleter.IsContext(tokenization)) {
                     int tclCtx = 0;
                     auto tclWords = TclCompleter.Complete(tokenization, tclCtx);
@@ -329,7 +332,8 @@ namespace {
                 return MatchSlashCommands(prefixView, contextLen);
             }
             if (HasTclCompleter) {
-                const auto tokenization = TokenizeForCompletion(prefixView);
+                const TStringBuf lineView = !text.empty() ? text : prefixView;
+                const auto tokenization = TokenizeForCompletion(lineView);
                 if (TclCompleter.IsContext(tokenization)) {
                     int tclCtx = 0;
                     auto tclWords = TclCompleter.Complete(tokenization, tclCtx);

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.h
@@ -31,6 +31,17 @@ namespace NYdb::NConsoleClient {
 
     IYQLCompleter::TPtr MakeYQLCompleter(const TYQLCompleterConfig& config);
 
-    IYQLCompleter::TPtr MakeYQLCompositeCompleter(const std::vector<TString>& commands, const std::optional<TYQLCompleterConfig>& yqlCompleterConfig);
+    struct TCompositeCompleterConfig {
+        // Commands matched on the leading '/' (case-sensitive prefix).
+        std::vector<TString> SlashCommands;
+        // TCL-style command lines (BEGIN, COMMIT, ROLLBACK, ...) used as
+        // case-insensitive completion candidates whenever the current input
+        // looks like a transaction control command.
+        std::vector<TString> TclCommands;
+        // YQL completer used for everything else; nullopt disables YQL completion.
+        std::optional<TYQLCompleterConfig> YqlCompleterConfig;
+    };
+
+    IYQLCompleter::TPtr MakeYQLCompositeCompleter(const TCompositeCompleterConfig& config);
 
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -94,6 +94,7 @@ std::vector<ISessionRunner::TPtr> SetupSessions(
         .CompleterLazyDriver = std::move(completerLazyDriver),
         .Database = config.Database,
         .EnableAiInteractive = config.EnableAiInteractive,
+        .EnableInteractiveTransactions = config.EnableInteractiveTransactions,
     }));
 
     if (config.EnableAiInteractive) {

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -7,6 +7,8 @@
 #include <ydb/public/lib/ydb_cli/common/format.h>
 #include <ydb/public/lib/ydb_cli/common/ftxui.h>
 #include <ydb/public/lib/ydb_cli/common/query_utils.h>
+#include <ydb/public/lib/ydb_cli/common/tx_mode_utils.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/query_stats/stats.h>
 
 #include <util/folder/path.h>
@@ -81,19 +83,37 @@ public:
         , QueryPlanPrinter(EDataFormat::Default)
         , SqlLazyDriver(settings.SqlLazyDriver)
         , EnableAiInteractive(settings.EnableAiInteractive)
+        , EnableInteractiveTransactions(settings.EnableInteractiveTransactions)
+        , BasePrompt(Settings.Prompt)
     {
         Y_VALIDATE(SqlLazyDriver, "TSqlSessionRunner requires a non-null SqlLazyDriver");
         Y_VALIDATE(settings.CompleterLazyDriver, "TSqlSessionRunner requires a non-null CompleterLazyDriver");
     }
 
+    ~TSqlSessionRunner() override {
+        if (!EnableInteractiveTransactions) {
+            return;
+        }
+        if (Transaction && Transaction->IsActive()) {
+            Cerr << Colors.Yellow() << "Warning: open transaction is rolled back on exit." << Colors.OldColor() << Endl;
+        }
+        RollbackOpenTransaction(/* silent */ true);
+    }
+
     void HandleLine(const TString& line) final {
         Y_DEFER { ResetInterrupted(); };
-        // Release the SQL driver as soon as control returns to the user;
-        // a fresh driver is created on the next turn.
-        Y_DEFER { SqlLazyDriver->Stop(true); };
+        // Keep the driver alive while an interactive transaction is open.
+        const bool inTransaction = EnableInteractiveTransactions
+            && Transaction && Transaction->IsActive();
+        if (!inTransaction) {
+            Y_DEFER { SqlLazyDriver->Stop(true); };
+        }
 
         if (to_lower(line) == "/help") {
-            PrintFtxuiMessage(CreateHelpMessage(EnableAiInteractive), "YDB CLI Interactive Mode – Hotkeys and Special Commands", ftxui::Color::White);
+            PrintFtxuiMessage(
+                CreateHelpMessage(EnableAiInteractive, EnableInteractiveTransactions),
+                "YDB CLI Interactive Mode – Hotkeys and Special Commands",
+                ftxui::Color::White);
             return;
         }
 
@@ -112,6 +132,33 @@ public:
 
         if (to_lower(TString(tokens[0].data)) == "set") {
             ParseSetCommand(tokens);
+            return;
+        }
+
+        if (IsBeginCommand(line) || IsCommitCommand(line) || IsRollbackCommand(line)) {
+            if (!EnableInteractiveTransactions) {
+                PrintInteractiveTransactionsNotAvailable();
+                return;
+            }
+        }
+
+        if (IsBeginCommand(line)) {
+            HandleBegin(line);
+            return;
+        }
+
+        if (IsCommitCommand(line)) {
+            HandleCommit();
+            return;
+        }
+
+        if (IsRollbackCommand(line)) {
+            HandleRollback();
+            return;
+        }
+
+        if (inTransaction) {
+            ExecuteInTransaction(line);
             return;
         }
 
@@ -155,8 +202,104 @@ public:
         }
     }
 
+    void HandleBegin(const TString& line) {
+        if (Transaction && Transaction->IsActive()) {
+            Cerr << Colors.Red() << "\nThere is already a transaction in progress." << Colors.OldColor() << Endl;
+            return;
+        }
+
+        auto txSettings = ParseBeginTransactionIsolation(line);
+        if (!txSettings) {
+            Cerr << Colors.Red() << "\nUnknown transaction isolation level." << Colors.OldColor() << Endl;
+            Cerr << "Supported modes: " << GetTxModeNamesForHelp() << Endl;
+            return;
+        }
+
+        try {
+            EnsureQuerySession();
+            auto beginResult = Session->BeginTransaction(*txSettings).GetValueSync();
+            NStatusHelpers::ThrowOnErrorOrPrintIssues(beginResult);
+            Transaction = beginResult.GetTransaction();
+            UpdateTransactionPrompt();
+            Cout << "BEGIN" << Endl;
+        } catch (NStatusHelpers::TYdbErrorException& error) {
+            Cerr << Colors.Red() << "\nFailed to begin transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+            ResetTransactionState();
+        } catch (std::exception& error) {
+            Cerr << Colors.Red() << "\nFailed to begin transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+            ResetTransactionState();
+        }
+    }
+
+    void HandleCommit() {
+        if (!Transaction || !Transaction->IsActive()) {
+            Cerr << Colors.Red() << "\nThere is no active transaction." << Colors.OldColor() << Endl;
+            return;
+        }
+
+        try {
+            auto commitResult = Transaction->Commit().GetValueSync();
+            NStatusHelpers::ThrowOnErrorOrPrintIssues(commitResult);
+            Cout << "COMMIT" << Endl;
+        } catch (NStatusHelpers::TYdbErrorException& error) {
+            Cerr << Colors.Red() << "\nFailed to commit transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+        } catch (std::exception& error) {
+            Cerr << Colors.Red() << "\nFailed to commit transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+        }
+        ResetTransactionState();
+        SqlLazyDriver->Stop(true);
+    }
+
+    void HandleRollback() {
+        if (!Transaction || !Transaction->IsActive()) {
+            Cerr << Colors.Red() << "\nThere is no active transaction." << Colors.OldColor() << Endl;
+            return;
+        }
+
+        try {
+            auto rollbackResult = Transaction->Rollback().GetValueSync();
+            NStatusHelpers::ThrowOnErrorOrPrintIssues(rollbackResult);
+            Cout << "ROLLBACK" << Endl;
+        } catch (NStatusHelpers::TYdbErrorException& error) {
+            Cerr << Colors.Red() << "\nFailed to rollback transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+        } catch (std::exception& error) {
+            Cerr << Colors.Red() << "\nFailed to rollback transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+        }
+        ResetTransactionState();
+        SqlLazyDriver->Stop(true);
+    }
+
+    void ExecuteInTransaction(const TString& line) {
+        NQuery::TExecuteQuerySettings settings;
+        settings.StatsMode(CollectStatsMode);
+        settings.ConcurrentResultSets(false);
+        if (!ResourcePool.empty()) {
+            settings.ResourcePool(ResourcePool);
+        }
+
+        try {
+            TExecuteGenericQuery executeRunner(SqlLazyDriver->Get());
+            executeRunner.Execute(line, {
+                .Settings = settings,
+                .AddIndent = true,
+                .Session = *Session,
+                .TxControl = NQuery::TTxControl::Tx(*Transaction),
+            });
+        } catch (NStatusHelpers::TYdbErrorException& error) {
+            Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+        } catch (std::exception& error) {
+            Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+        }
+    }
+
+    static void PrintInteractiveTransactionsNotAvailable() {
+        Cerr << Colors.Red()
+             << "\nInteractive transactions (BEGIN/COMMIT/ROLLBACK) are available only in ydb_int."
+             << Colors.OldColor() << Endl;
+    }
+
 private:
-    static ftxui::Element CreateHelpMessage(bool enableAiInteractive) {
+    static ftxui::Element CreateHelpMessage(bool enableAiInteractive, bool enableInteractiveTransactions) {
         using namespace ftxui;
 
         std::vector<ftxui::Element> elements = {
@@ -206,6 +349,23 @@ private:
             keyword("EXPLAIN"), text(" ["), keyword("AST"), text("] "), CreateEntityName("SQL_QUERY"),
             text(": execute query in explain mode and optionally print AST.")
         })));
+
+        if (enableInteractiveTransactions) {
+            elements.emplace_back(CreateListItem(hbox({
+                keyword("BEGIN"), text(" ["), keyword("TRANSACTION"), text("] ["),
+                keyword("ISOLATION LEVEL"), text(" "), CreateEntityName("MODE"),
+                text("]: start an interactive transaction (Query service session).")
+            })));
+            elements.emplace_back(CreateListItem(hbox({
+                text("  Modes: "), CreateEntityName(GetTxModeNamesForHelp())
+            })));
+            elements.emplace_back(CreateListItem(hbox({
+                keyword("COMMIT"), text(" | "), keyword("END"), text(": commit the current transaction.")
+            })));
+            elements.emplace_back(CreateListItem(hbox({
+                keyword("ROLLBACK"), text(": rollback the current transaction.")
+            })));
+        }
 
         elements.emplace_back(text(""));
         elements.emplace_back(CreateEntityName("Interactive Commands:"));
@@ -282,12 +442,62 @@ private:
         Cout << "Resource pool set to \"" << ResourcePool << "\"." << Endl;
     }
 
+    void EnsureQuerySession() {
+        if (Session) {
+            return;
+        }
+        QueryClient = NQuery::TQueryClient(SqlLazyDriver->Get());
+        auto sessionResult = QueryClient->GetSession().GetValueSync();
+        NStatusHelpers::ThrowOnErrorOrPrintIssues(sessionResult);
+        Session = sessionResult.GetSession();
+    }
+
+    void UpdateTransactionPrompt() {
+        if (LineReader) {
+            LineReader->SetPrompt(TStringBuilder() << BasePrompt << "* ");
+        }
+    }
+
+    void ResetTransactionPrompt() {
+        if (LineReader) {
+            LineReader->SetPrompt(BasePrompt);
+        }
+    }
+
+    void ResetTransactionState() {
+        Transaction.reset();
+        Session.reset();
+        QueryClient.reset();
+        ResetTransactionPrompt();
+    }
+
+    void RollbackOpenTransaction(bool silent) {
+        if (!Transaction || !Transaction->IsActive()) {
+            ResetTransactionState();
+            return;
+        }
+        auto rollbackResult = Transaction->Rollback().GetValueSync();
+        if (!rollbackResult.IsSuccess() && !silent) {
+            NStatusHelpers::ThrowOnErrorOrPrintIssues(rollbackResult);
+        }
+        if (!silent) {
+            Cout << "ROLLBACK" << Endl;
+        }
+        ResetTransactionState();
+    }
+
 private:
     TQueryPlanPrinter QueryPlanPrinter;
     TLazyDriver::TPtr SqlLazyDriver;
     NQuery::EStatsMode CollectStatsMode = NQuery::EStatsMode::None;
     std::string ResourcePool;
     bool EnableAiInteractive;
+    bool EnableInteractiveTransactions;
+    TString BasePrompt;
+
+    std::optional<NQuery::TQueryClient> QueryClient;
+    std::optional<NQuery::TSession> Session;
+    std::optional<NQuery::TTransaction> Transaction;
 };
 
 } // anonymous namespace

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -91,23 +91,23 @@ public:
     }
 
     ~TSqlSessionRunner() override {
-        if (!EnableInteractiveTransactions) {
+        if (!IsInteractiveTransactionActive()) {
             return;
         }
-        if (Transaction && Transaction->IsActive()) {
-            Cerr << Colors.Yellow() << "Warning: open transaction is rolled back on exit." << Colors.OldColor() << Endl;
-        }
+        Cerr << Colors.Yellow() << "Warning: open transaction is rolled back on exit." << Colors.OldColor() << Endl;
         RollbackOpenTransaction(/* silent */ true);
     }
 
     void HandleLine(const TString& line) final {
         Y_DEFER { ResetInterrupted(); };
-        // Keep the driver alive while an interactive transaction is open.
-        const bool inTransaction = EnableInteractiveTransactions
-            && Transaction && Transaction->IsActive();
-        if (!inTransaction) {
-            Y_DEFER { SqlLazyDriver->Stop(true); };
-        }
+        // Stop the driver at the end of the line iff no transaction is active.
+        // The flag is re-evaluated at scope exit (after BEGIN/COMMIT/ROLLBACK
+        // mutate the state) so the driver lives across queries inside a tx.
+        Y_DEFER {
+            if (!IsInteractiveTransactionActive()) {
+                SqlLazyDriver->Stop(true);
+            }
+        };
 
         if (to_lower(line) == "/help") {
             PrintFtxuiMessage(
@@ -135,29 +135,11 @@ public:
             return;
         }
 
-        if (IsBeginCommand(line) || IsCommitCommand(line) || IsRollbackCommand(line)) {
-            if (!EnableInteractiveTransactions) {
-                PrintInteractiveTransactionsNotAvailable();
-                return;
-            }
-        }
-
-        if (IsBeginCommand(line)) {
-            HandleBegin(line);
+        if (HandleTransactionControlCommand(line)) {
             return;
         }
 
-        if (IsCommitCommand(line)) {
-            HandleCommit();
-            return;
-        }
-
-        if (IsRollbackCommand(line)) {
-            HandleRollback();
-            return;
-        }
-
-        if (inTransaction) {
+        if (IsInteractiveTransactionActive()) {
             ExecuteInTransaction(line);
             return;
         }
@@ -202,16 +184,50 @@ public:
         }
     }
 
+    // Returns true if the line was a TCL command (regardless of success).
+    bool HandleTransactionControlCommand(const TString& line) {
+        const bool isBegin = IsBeginCommand(line);
+        const bool isCommit = !isBegin && IsCommitCommand(line);
+        const bool isRollback = !isBegin && !isCommit && IsRollbackCommand(line);
+        if (!isBegin && !isCommit && !isRollback) {
+            return false;
+        }
+        if (!EnableInteractiveTransactions) {
+            PrintInteractiveTransactionsNotAvailable();
+            return true;
+        }
+        if (isBegin) {
+            HandleBegin(line);
+        } else if (isCommit) {
+            HandleCommit();
+        } else {
+            HandleRollback();
+        }
+        return true;
+    }
+
     void HandleBegin(const TString& line) {
-        if (Transaction && Transaction->IsActive()) {
+        if (IsInteractiveTransactionActive()) {
             Cerr << Colors.Red() << "\nThere is already a transaction in progress." << Colors.OldColor() << Endl;
             return;
         }
 
         auto txSettings = ParseBeginTransactionIsolation(line);
         if (!txSettings) {
-            Cerr << Colors.Red() << "\nUnknown transaction isolation level." << Colors.OldColor() << Endl;
-            Cerr << "Supported modes: " << GetTxModeNamesForHelp() << Endl;
+            const auto modeToken = ExtractBeginModeToken(line);
+            if (modeToken && IsOneShotOnlyTxMode(*modeToken)) {
+                Cerr << Colors.Red()
+                     << "\nMode \"" << *modeToken
+                     << "\" cannot be used with BEGIN — the Query service does"
+                        " not support open transactions for this mode."
+                     << Colors.OldColor() << Endl;
+                Cerr << "Use it as a one-shot transaction mode for a single"
+                        " statement, e.g. \"ydb table query --tx-mode "
+                     << *modeToken << " ...\"." << Endl;
+            } else {
+                Cerr << Colors.Red() << "\nUnknown or malformed transaction mode." << Colors.OldColor() << Endl;
+                Cerr << "Supported modes: " << GetTxModeNamesForHelp() << "." << Endl;
+            }
             return;
         }
 
@@ -223,16 +239,16 @@ public:
             UpdateTransactionPrompt();
             Cout << "BEGIN" << Endl;
         } catch (NStatusHelpers::TYdbErrorException& error) {
-            Cerr << Colors.Red() << "\nFailed to begin transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+            PrintTcError("Failed to begin transaction", ToString(error));
             ResetTransactionState();
         } catch (std::exception& error) {
-            Cerr << Colors.Red() << "\nFailed to begin transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+            PrintTcError("Failed to begin transaction", error.what());
             ResetTransactionState();
         }
     }
 
     void HandleCommit() {
-        if (!Transaction || !Transaction->IsActive()) {
+        if (!IsInteractiveTransactionActive()) {
             Cerr << Colors.Red() << "\nThere is no active transaction." << Colors.OldColor() << Endl;
             return;
         }
@@ -241,17 +257,18 @@ public:
             auto commitResult = Transaction->Commit().GetValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(commitResult);
             Cout << "COMMIT" << Endl;
+            ResetTransactionState();
         } catch (NStatusHelpers::TYdbErrorException& error) {
-            Cerr << Colors.Red() << "\nFailed to commit transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+            PrintTcError("Failed to commit transaction", ToString(error));
+            // Keep the transaction state so the user can retry the COMMIT or
+            // explicitly ROLLBACK. The destructor rolls it back if needed.
         } catch (std::exception& error) {
-            Cerr << Colors.Red() << "\nFailed to commit transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+            PrintTcError("Failed to commit transaction", error.what());
         }
-        ResetTransactionState();
-        SqlLazyDriver->Stop(true);
     }
 
     void HandleRollback() {
-        if (!Transaction || !Transaction->IsActive()) {
+        if (!IsInteractiveTransactionActive()) {
             Cerr << Colors.Red() << "\nThere is no active transaction." << Colors.OldColor() << Endl;
             return;
         }
@@ -260,13 +277,12 @@ public:
             auto rollbackResult = Transaction->Rollback().GetValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(rollbackResult);
             Cout << "ROLLBACK" << Endl;
+            ResetTransactionState();
         } catch (NStatusHelpers::TYdbErrorException& error) {
-            Cerr << Colors.Red() << "\nFailed to rollback transaction:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+            PrintTcError("Failed to rollback transaction", ToString(error));
         } catch (std::exception& error) {
-            Cerr << Colors.Red() << "\nFailed to rollback transaction:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+            PrintTcError("Failed to rollback transaction", error.what());
         }
-        ResetTransactionState();
-        SqlLazyDriver->Stop(true);
     }
 
     void ExecuteInTransaction(const TString& line) {
@@ -352,18 +368,26 @@ private:
 
         if (enableInteractiveTransactions) {
             elements.emplace_back(CreateListItem(hbox({
-                keyword("BEGIN"), text(" ["), keyword("TRANSACTION"), text("] ["),
-                keyword("ISOLATION LEVEL"), text(" "), CreateEntityName("MODE"),
+                keyword("BEGIN"), text(" ["), keyword("TRANSACTION"), text(" | "),
+                keyword("WORK"), text("] ["), CreateEntityName("MODE"),
                 text("]: start an interactive transaction (Query service session).")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                text("  Modes: "), CreateEntityName(GetTxModeNamesForHelp())
+                keyword("START TRANSACTION"), text(" ["), CreateEntityName("MODE"),
+                text("]: alias of BEGIN TRANSACTION.")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("COMMIT"), text(" | "), keyword("END"), text(": commit the current transaction.")
+                text("  "), CreateEntityName("MODE"), text(": "), CreateEntityName(GetTxModeNamesForHelp()),
+                text(" (default: "), CreateEntityName(TString(kTxModeSerializableRw)), text(").")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("ROLLBACK"), text(": rollback the current transaction.")
+                keyword("COMMIT"), text(" | "), keyword("COMMIT TRANSACTION"), text(" | "),
+                keyword("COMMIT WORK"), text(" | "), keyword("END"), text(" | "),
+                keyword("END TRANSACTION"), text(": commit the current transaction.")
+            })));
+            elements.emplace_back(CreateListItem(hbox({
+                keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"), text(" | "),
+                keyword("ROLLBACK WORK"), text(": rollback the current transaction.")
             })));
         }
 
@@ -384,12 +408,20 @@ private:
         }
         placeholder << ", Ctrl+D to exit)";
 
+        std::vector<TString> tclCommands;
+        if (settings.EnableInteractiveTransactions) {
+            for (auto& candidate : GetTransactionControlCompletions()) {
+                tclCommands.push_back(std::move(candidate));
+            }
+        }
+
         return {
             .LazyDriver = settings.CompleterLazyDriver,
             .Database = settings.Database,
             .Prompt = TStringBuilder() << TInteractiveConfigurationManager::ModeToString(TInteractiveConfigurationManager::EMode::YQL) << "> ",
             .HistoryFilePath = TFsPath(HomeDir) / ".ydb_history",
             .AdditionalCommands = {"/help", "/config"},
+            .TclCommands = std::move(tclCommands),
             .Placeholder = placeholder,
             .EnableSwitchMode = settings.EnableAiInteractive,
         };
@@ -452,6 +484,15 @@ private:
         Session = sessionResult.GetSession();
     }
 
+    bool IsInteractiveTransactionActive() const {
+        return EnableInteractiveTransactions && Transaction && Transaction->IsActive();
+    }
+
+    void PrintTcError(TStringBuf prefix, TStringBuf details) {
+        Cerr << Colors.Red() << "\n" << prefix << ":" << Colors.OldColor() << Endl
+             << Strip(TString(details)) << Endl;
+    }
+
     void UpdateTransactionPrompt() {
         if (LineReader) {
             LineReader->SetPrompt(TStringBuilder() << BasePrompt << "* ");
@@ -471,17 +512,18 @@ private:
         ResetTransactionPrompt();
     }
 
+    // Rollback any transaction left open at shutdown. Errors are swallowed.
     void RollbackOpenTransaction(bool silent) {
         if (!Transaction || !Transaction->IsActive()) {
             ResetTransactionState();
             return;
         }
-        auto rollbackResult = Transaction->Rollback().GetValueSync();
-        if (!rollbackResult.IsSuccess() && !silent) {
-            NStatusHelpers::ThrowOnErrorOrPrintIssues(rollbackResult);
-        }
-        if (!silent) {
-            Cout << "ROLLBACK" << Endl;
+        try {
+            Transaction->Rollback().GetValueSync();
+        } catch (...) {
+            if (!silent) {
+                throw;
+            }
         }
         ResetTransactionState();
     }

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.h
@@ -17,6 +17,7 @@ struct TSqlSessionSettings {
 
     TString Database;
     bool EnableAiInteractive = false;
+    bool EnableInteractiveTransactions = false;
 };
 
 ISessionRunner::TPtr CreateSqlSessionRunner(const TSqlSessionSettings& settings);

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -314,6 +314,10 @@ void TClientCommandRootCommon::FillConfig(TConfig& config) {
         config.EnableAiInteractive = *Settings.EnableAiInteractive;
     }
 
+    if (Settings.EnableInteractiveTransactions) {
+        config.EnableInteractiveTransactions = *Settings.EnableInteractiveTransactions;
+    }
+
     config.BuildInfoProvider = Settings.BuildInfoProvider;
 
     SetCredentialsGetter(config);

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -47,6 +47,8 @@ struct TClientSettings {
     TString YdbDir;
     // AI Mode Settings
     std::optional<bool> EnableAiInteractive;
+    // Interactive transactions (BEGIN/COMMIT/ROLLBACK) in REPL
+    std::optional<bool> EnableInteractiveTransactions;
 
     // Called lazily on first driver creation to get distribution name and version.
     std::function<TYdbCliBuildInfo()> BuildInfoProvider;

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -181,6 +181,7 @@ public:
         bool AssumeYes = false;
         std::optional<std::string> StorageUrl = std::nullopt;
         bool EnableAiInteractive = false;
+        bool EnableInteractiveTransactions = false;
         TUsageInfoGetter UsageInfoGetter;
 
         // Filled by ValidateAndRun to point at the leaf command being executed

--- a/ydb/public/lib/ydb_cli/common/query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/query_utils.cpp
@@ -82,10 +82,29 @@ void TExecuteGenericQuery::OnResultPart(ui64 resultSetIndex, const TResultSet& r
 }
 
 NQuery::TAsyncExecuteQueryIterator TExecuteGenericQuery::StartQuery(const TString& query, const TSettings& execSettings) {
+    const auto& txControl = execSettings.TxControl;
+
+    if (execSettings.Session) {
+        NQuery::TSession session = *execSettings.Session;
+        if (execSettings.Parameters) {
+            return session.StreamExecuteQuery(
+                query,
+                txControl,
+                *execSettings.Parameters,
+                execSettings.Settings
+            );
+        }
+        return session.StreamExecuteQuery(
+            query,
+            txControl,
+            execSettings.Settings
+        );
+    }
+
     if (execSettings.Parameters) {
         return Client.StreamExecuteQuery(
             query,
-            NQuery::TTxControl::NoTx(),
+            txControl,
             *execSettings.Parameters,
             execSettings.Settings
         );
@@ -93,7 +112,7 @@ NQuery::TAsyncExecuteQueryIterator TExecuteGenericQuery::StartQuery(const TStrin
 
     return Client.StreamExecuteQuery(
         query,
-        NQuery::TTxControl::NoTx(),
+        txControl,
         execSettings.Settings
     );
 }

--- a/ydb/public/lib/ydb_cli/common/query_utils.h
+++ b/ydb/public/lib/ydb_cli/common/query_utils.h
@@ -6,6 +6,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 
 #include <util/generic/fwd.h>
+#include <optional>
 
 namespace NYdb::NConsoleClient {
 
@@ -37,6 +38,9 @@ public:
         NQuery::TExecuteQuerySettings Settings;
         std::optional<TParams> Parameters;
         bool AddIndent = false;
+        // When set, query is executed on this session (required for interactive transactions).
+        std::optional<NQuery::TSession> Session;
+        NQuery::TTxControl TxControl = NQuery::TTxControl::NoTx();
     };
 
     int Execute(const TString& query, const TSettings& execSettings);

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
@@ -1,0 +1,148 @@
+#include "tx_mode_utils.h"
+
+#include <util/string/builder.h>
+#include <util/string/strip.h>
+
+namespace NYdb::NConsoleClient {
+
+namespace {
+
+TString NormalizeModeToken(TStringBuf token) {
+    TString normalized = to_lower(TString(token));
+    for (auto& c : normalized) {
+        if (c == ' ') {
+            c = '-';
+        }
+    }
+    return normalized;
+}
+
+std::optional<NQuery::TTxSettings> ParseYdbTxModeName(TStringBuf mode) {
+    const TString normalized = NormalizeModeToken(mode);
+    if (normalized == kTxModeSerializableRw || normalized == "serializable") {
+        return NQuery::TTxSettings::SerializableRW();
+    }
+    if (normalized == kTxModeOnlineRo || normalized == "online") {
+        return NQuery::TTxSettings::OnlineRO();
+    }
+    if (normalized == kTxModeStaleRo || normalized == "stale") {
+        return NQuery::TTxSettings::StaleRO();
+    }
+    if (normalized == kTxModeSnapshotRo) {
+        return NQuery::TTxSettings::SnapshotRO();
+    }
+    if (normalized == kTxModeSnapshotRw) {
+        return NQuery::TTxSettings::SnapshotRW();
+    }
+    if (normalized == kTxModeReadCommittedRw || normalized == "read-committed") {
+        return NQuery::TTxSettings::ReadCommittedRW();
+    }
+    return {};
+}
+
+std::optional<NQuery::TTxSettings> ParsePsqlIsolationLevel(TStringBuf level) {
+    const auto normalized = to_upper(TString(level));
+    if (normalized == "READ UNCOMMITTED") {
+        return NQuery::TTxSettings::OnlineRO(
+            NQuery::TTxOnlineSettings().AllowInconsistentReads(true));
+    }
+    if (normalized == "READ COMMITTED") {
+        return NQuery::TTxSettings::ReadCommittedRW();
+    }
+    if (normalized == "REPEATABLE READ") {
+        return NQuery::TTxSettings::SnapshotRW();
+    }
+    if (normalized == "SERIALIZABLE") {
+        return NQuery::TTxSettings::SerializableRW();
+    }
+    return {};
+}
+
+TString StripTransactionKeywords(TStringBuf line) {
+    TString normalized = to_upper(TString(line));
+    StripInPlace(normalized);
+
+    if (normalized.StartsWith("START TRANSACTION")) {
+        normalized = normalized.substr(strlen("START TRANSACTION"));
+    } else if (normalized.StartsWith("BEGIN TRANSACTION")) {
+        normalized = normalized.substr(strlen("BEGIN TRANSACTION"));
+    } else if (normalized.StartsWith("BEGIN WORK")) {
+        normalized = normalized.substr(strlen("BEGIN WORK"));
+    } else if (normalized.StartsWith("BEGIN")) {
+        normalized = normalized.substr(strlen("BEGIN"));
+    } else {
+        return {};
+    }
+
+    StripInPlace(normalized);
+    return normalized;
+}
+
+} // anonymous namespace
+
+std::optional<NQuery::TTxSettings> ParseTxSettings(TStringBuf mode) {
+    if (mode.empty()) {
+        return NQuery::TTxSettings::SerializableRW();
+    }
+
+    if (auto settings = ParseYdbTxModeName(mode)) {
+        return settings;
+    }
+    return ParsePsqlIsolationLevel(mode);
+}
+
+TString GetTxModeNamesForHelp() {
+    return TStringBuilder()
+        << kTxModeSerializableRw << ", "
+        << kTxModeReadCommittedRw << ", "
+        << kTxModeOnlineRo << ", "
+        << kTxModeStaleRo << ", "
+        << kTxModeSnapshotRo << ", "
+        << kTxModeSnapshotRw
+        << " (or PostgreSQL-style ISOLATION LEVEL: READ COMMITTED, SERIALIZABLE, REPEATABLE READ, READ UNCOMMITTED)";
+}
+
+std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf line) {
+    const TString remainder = StripTransactionKeywords(line);
+    if (remainder.empty()) {
+        return NQuery::TTxSettings::SerializableRW();
+    }
+
+    TString spec = remainder;
+    const auto upperSpec = to_upper(spec);
+    const char* isolationPrefix = "ISOLATION LEVEL ";
+    if (upperSpec.StartsWith(isolationPrefix)) {
+        spec = spec.substr(strlen(isolationPrefix));
+        StripInPlace(spec);
+        return ParsePsqlIsolationLevel(spec);
+    }
+
+    return ParseTxSettings(spec);
+}
+
+bool IsCommitCommand(TStringBuf line) {
+    TString normalized = to_upper(TString(line));
+    StripInPlace(normalized);
+    return normalized == "COMMIT"
+        || normalized == "COMMIT WORK"
+        || normalized == "COMMIT TRANSACTION"
+        || normalized == "END"
+        || normalized == "END TRANSACTION";
+}
+
+bool IsRollbackCommand(TStringBuf line) {
+    TString normalized = to_upper(TString(line));
+    StripInPlace(normalized);
+    return normalized == "ROLLBACK"
+        || normalized == "ROLLBACK WORK"
+        || normalized == "ROLLBACK TRANSACTION";
+}
+
+bool IsBeginCommand(TStringBuf line) {
+    TString normalized = to_upper(TString(line));
+    StripInPlace(normalized);
+    return normalized.StartsWith("BEGIN")
+        || normalized.StartsWith("START TRANSACTION");
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
@@ -1,32 +1,108 @@
 #include "tx_mode_utils.h"
 
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
 #include <util/string/builder.h>
-#include <util/string/strip.h>
+#include <util/string/cast.h>
+
+#include <cctype>
 
 namespace NYdb::NConsoleClient {
 
 namespace {
 
-TString NormalizeModeToken(TStringBuf token) {
-    TString normalized = to_lower(TString(token));
-    for (auto& c : normalized) {
-        if (c == ' ') {
-            c = '-';
+// Tokenize a TCL command line into uppercased word tokens.
+// Trailing semicolons (any number, possibly separated by whitespace) are
+// dropped. Whitespace between tokens is collapsed, semicolons are treated as
+// separators, all other characters become part of the current token.
+//
+// Examples:
+//   "BEGIN"                              -> ["BEGIN"]
+//   "begin transaction"                  -> ["BEGIN", "TRANSACTION"]
+//   "BEGIN read-committed-rw;"           -> ["BEGIN", "READ-COMMITTED-RW"]
+//   "BEGIN snapshot-ro"                  -> ["BEGIN", "SNAPSHOT-RO"]
+TVector<TString> TokenizeUpper(TStringBuf line) {
+    TVector<TString> tokens;
+    TString current;
+    auto flush = [&]() {
+        if (!current.empty()) {
+            tokens.push_back(std::move(current));
+            current.clear();
+        }
+    };
+    for (char c : line) {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if (std::isspace(uc) || c == ';') {
+            flush();
+        } else {
+            current.push_back(static_cast<char>(std::toupper(uc)));
         }
     }
-    return normalized;
+    flush();
+    return tokens;
 }
 
-std::optional<NQuery::TTxSettings> ParseYdbTxModeName(TStringBuf mode) {
-    const TString normalized = NormalizeModeToken(mode);
-    if (normalized == kTxModeSerializableRw || normalized == "serializable") {
+// Returns true if tokens start with the given uppercase prefix.
+bool TokensStartWith(const TVector<TString>& tokens, std::initializer_list<TStringBuf> prefix) {
+    if (tokens.size() < prefix.size()) {
+        return false;
+    }
+    size_t i = 0;
+    for (auto p : prefix) {
+        if (tokens[i++] != p) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// How many leading tokens form the BEGIN/START preamble. Returns 0 if the
+// line does not start with a BEGIN-style preamble.
+size_t MatchBeginPrefix(const TVector<TString>& tokens) {
+    if (tokens.empty()) {
+        return 0;
+    }
+    if (TokensStartWith(tokens, {"START", "TRANSACTION"})) {
+        return 2;
+    }
+    if (TokensStartWith(tokens, {"BEGIN", "TRANSACTION"})) {
+        return 2;
+    }
+    if (TokensStartWith(tokens, {"BEGIN", "WORK"})) {
+        return 2;
+    }
+    if (tokens.front() == "BEGIN") {
+        return 1;
+    }
+    return 0;
+}
+
+bool MatchExactCommand(const TVector<TString>& tokens, std::initializer_list<TStringBuf> expected) {
+    if (tokens.size() != expected.size()) {
+        return false;
+    }
+    return TokensStartWith(tokens, expected);
+}
+
+} // anonymous namespace
+
+TVector<TStringBuf> GetSupportedTxModeNames() {
+    // Only modes that can be opened via Query.BeginTransaction. online-ro
+    // and stale-ro are intentionally excluded — server-side BeginTransaction
+    // rejects them with "open transactions not supported for transaction
+    // mode ..."; they are usable only as one-shot tx_control values.
+    return {
+        kTxModeSerializableRw,
+        kTxModeSnapshotRo,
+        kTxModeSnapshotRw,
+        kTxModeReadCommittedRw,
+    };
+}
+
+std::optional<NQuery::TTxSettings> ParseTxModeName(TStringBuf mode) {
+    const TString normalized = to_lower(TString(mode));
+    if (normalized == kTxModeSerializableRw) {
         return NQuery::TTxSettings::SerializableRW();
-    }
-    if (normalized == kTxModeOnlineRo || normalized == "online") {
-        return NQuery::TTxSettings::OnlineRO();
-    }
-    if (normalized == kTxModeStaleRo || normalized == "stale") {
-        return NQuery::TTxSettings::StaleRO();
     }
     if (normalized == kTxModeSnapshotRo) {
         return NQuery::TTxSettings::SnapshotRO();
@@ -34,115 +110,124 @@ std::optional<NQuery::TTxSettings> ParseYdbTxModeName(TStringBuf mode) {
     if (normalized == kTxModeSnapshotRw) {
         return NQuery::TTxSettings::SnapshotRW();
     }
-    if (normalized == kTxModeReadCommittedRw || normalized == "read-committed") {
+    if (normalized == kTxModeReadCommittedRw) {
         return NQuery::TTxSettings::ReadCommittedRW();
     }
     return {};
-}
-
-std::optional<NQuery::TTxSettings> ParsePsqlIsolationLevel(TStringBuf level) {
-    const auto normalized = to_upper(TString(level));
-    if (normalized == "READ UNCOMMITTED") {
-        return NQuery::TTxSettings::OnlineRO(
-            NQuery::TTxOnlineSettings().AllowInconsistentReads(true));
-    }
-    if (normalized == "READ COMMITTED") {
-        return NQuery::TTxSettings::ReadCommittedRW();
-    }
-    if (normalized == "REPEATABLE READ") {
-        return NQuery::TTxSettings::SnapshotRW();
-    }
-    if (normalized == "SERIALIZABLE") {
-        return NQuery::TTxSettings::SerializableRW();
-    }
-    return {};
-}
-
-TString StripTransactionKeywords(TStringBuf line) {
-    TString normalized = to_upper(TString(line));
-    StripInPlace(normalized);
-
-    if (normalized.StartsWith("START TRANSACTION")) {
-        normalized = normalized.substr(strlen("START TRANSACTION"));
-    } else if (normalized.StartsWith("BEGIN TRANSACTION")) {
-        normalized = normalized.substr(strlen("BEGIN TRANSACTION"));
-    } else if (normalized.StartsWith("BEGIN WORK")) {
-        normalized = normalized.substr(strlen("BEGIN WORK"));
-    } else if (normalized.StartsWith("BEGIN")) {
-        normalized = normalized.substr(strlen("BEGIN"));
-    } else {
-        return {};
-    }
-
-    StripInPlace(normalized);
-    return normalized;
-}
-
-} // anonymous namespace
-
-std::optional<NQuery::TTxSettings> ParseTxSettings(TStringBuf mode) {
-    if (mode.empty()) {
-        return NQuery::TTxSettings::SerializableRW();
-    }
-
-    if (auto settings = ParseYdbTxModeName(mode)) {
-        return settings;
-    }
-    return ParsePsqlIsolationLevel(mode);
 }
 
 TString GetTxModeNamesForHelp() {
-    return TStringBuilder()
-        << kTxModeSerializableRw << ", "
-        << kTxModeReadCommittedRw << ", "
-        << kTxModeOnlineRo << ", "
-        << kTxModeStaleRo << ", "
-        << kTxModeSnapshotRo << ", "
-        << kTxModeSnapshotRw
-        << " (or PostgreSQL-style ISOLATION LEVEL: READ COMMITTED, SERIALIZABLE, REPEATABLE READ, READ UNCOMMITTED)";
+    TStringBuilder builder;
+    bool first = true;
+    for (const auto name : GetSupportedTxModeNames()) {
+        if (!first) {
+            builder << ", ";
+        }
+        first = false;
+        builder << name;
+    }
+    return std::move(builder);
+}
+
+TVector<TString> GetTransactionControlCompletions() {
+    TVector<TString> result;
+
+    // Every BEGIN / START prefix can optionally be followed by a tx mode.
+    static constexpr TStringBuf kBeginPrefixes[] = {
+        "BEGIN",
+        "BEGIN TRANSACTION",
+        "BEGIN WORK",
+        "START TRANSACTION",
+    };
+    const auto modes = GetSupportedTxModeNames();
+    for (auto prefix : kBeginPrefixes) {
+        result.emplace_back(prefix);
+        for (auto mode : modes) {
+            result.emplace_back(TStringBuilder() << prefix << " " << mode);
+        }
+    }
+
+    static constexpr TStringBuf kCommitForms[] = {
+        "COMMIT",
+        "COMMIT TRANSACTION",
+        "COMMIT WORK",
+        "END",
+        "END TRANSACTION",
+    };
+    for (auto form : kCommitForms) {
+        result.emplace_back(form);
+    }
+
+    static constexpr TStringBuf kRollbackForms[] = {
+        "ROLLBACK",
+        "ROLLBACK TRANSACTION",
+        "ROLLBACK WORK",
+    };
+    for (auto form : kRollbackForms) {
+        result.emplace_back(form);
+    }
+
+    return result;
 }
 
 std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf line) {
-    const TString remainder = StripTransactionKeywords(line);
-    if (remainder.empty()) {
+    const auto tokens = TokenizeUpper(line);
+    const size_t skip = MatchBeginPrefix(tokens);
+    if (skip == 0) {
+        return {};
+    }
+
+    // Bare BEGIN/START TRANSACTION/etc. defaults to SerializableRW.
+    if (skip == tokens.size()) {
         return NQuery::TTxSettings::SerializableRW();
     }
 
-    TString spec = remainder;
-    const auto upperSpec = to_upper(spec);
-    const char* isolationPrefix = "ISOLATION LEVEL ";
-    if (upperSpec.StartsWith(isolationPrefix)) {
-        spec = spec.substr(strlen(isolationPrefix));
-        StripInPlace(spec);
-        return ParsePsqlIsolationLevel(spec);
+    const TString& modeToken = tokens[skip];
+    auto settings = ParseTxModeName(modeToken);
+    if (!settings) {
+        return {};
     }
 
-    return ParseTxSettings(spec);
+    // No trailing tokens are allowed after the mode.
+    if (skip + 1 != tokens.size()) {
+        return {};
+    }
+    return settings;
 }
 
-bool IsCommitCommand(TStringBuf line) {
-    TString normalized = to_upper(TString(line));
-    StripInPlace(normalized);
-    return normalized == "COMMIT"
-        || normalized == "COMMIT WORK"
-        || normalized == "COMMIT TRANSACTION"
-        || normalized == "END"
-        || normalized == "END TRANSACTION";
+std::optional<TString> ExtractBeginModeToken(TStringBuf line) {
+    const auto tokens = TokenizeUpper(line);
+    const size_t skip = MatchBeginPrefix(tokens);
+    if (skip == 0 || skip >= tokens.size()) {
+        return {};
+    }
+    return to_lower(tokens[skip]);
 }
 
-bool IsRollbackCommand(TStringBuf line) {
-    TString normalized = to_upper(TString(line));
-    StripInPlace(normalized);
-    return normalized == "ROLLBACK"
-        || normalized == "ROLLBACK WORK"
-        || normalized == "ROLLBACK TRANSACTION";
+bool IsOneShotOnlyTxMode(TStringBuf mode) {
+    const TString normalized = to_lower(TString(mode));
+    return normalized == "online-ro" || normalized == "stale-ro";
 }
 
 bool IsBeginCommand(TStringBuf line) {
-    TString normalized = to_upper(TString(line));
-    StripInPlace(normalized);
-    return normalized.StartsWith("BEGIN")
-        || normalized.StartsWith("START TRANSACTION");
+    const auto tokens = TokenizeUpper(line);
+    return MatchBeginPrefix(tokens) > 0;
+}
+
+bool IsCommitCommand(TStringBuf line) {
+    const auto tokens = TokenizeUpper(line);
+    return MatchExactCommand(tokens, {"COMMIT"})
+        || MatchExactCommand(tokens, {"COMMIT", "TRANSACTION"})
+        || MatchExactCommand(tokens, {"COMMIT", "WORK"})
+        || MatchExactCommand(tokens, {"END"})
+        || MatchExactCommand(tokens, {"END", "TRANSACTION"});
+}
+
+bool IsRollbackCommand(TStringBuf line) {
+    const auto tokens = TokenizeUpper(line);
+    return MatchExactCommand(tokens, {"ROLLBACK"})
+        || MatchExactCommand(tokens, {"ROLLBACK", "TRANSACTION"})
+        || MatchExactCommand(tokens, {"ROLLBACK", "WORK"});
 }
 
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
@@ -4,29 +4,73 @@
 
 #include <util/generic/fwd.h>
 #include <util/generic/strbuf.h>
+#include <util/generic/vector.h>
 
 #include <optional>
 
 namespace NYdb::NConsoleClient {
 
-// YDB transaction mode names accepted by CLI (e.g. ydb table query --tx-mode).
+// YDB transaction mode names supported by interactive BEGIN.
+//
+// Not the full set of CLI-recognized tx-mode strings (online-ro / stale-ro
+// remain valid for one-shot --tx-mode flags; they are simply not openable
+// via Query.BeginTransaction and therefore not listed here).
 constexpr TStringBuf kTxModeSerializableRw = "serializable-rw";
-constexpr TStringBuf kTxModeOnlineRo = "online-ro";
-constexpr TStringBuf kTxModeStaleRo = "stale-ro";
 constexpr TStringBuf kTxModeSnapshotRo = "snapshot-ro";
 constexpr TStringBuf kTxModeSnapshotRw = "snapshot-rw";
 constexpr TStringBuf kTxModeReadCommittedRw = "read-committed-rw";
 
-// Parse a transaction mode string into TTxSettings.
-// Accepts YDB mode names (serializable-rw, read-committed-rw, ...) and
-// PostgreSQL-style isolation level names (READ COMMITTED, SERIALIZABLE, ...).
-std::optional<NQuery::TTxSettings> ParseTxSettings(TStringBuf mode);
+// YDB transaction mode names accepted by interactive BEGIN.
+//
+// Note: only modes that the Query service accepts via BeginTransaction are
+// listed here. online-ro and stale-ro are intentionally excluded because the
+// server rejects open transactions for them ("open transactions not supported
+// for transaction mode ..."); they only make sense as one-shot tx_control
+// values for individual ExecuteQuery requests.
+TVector<TStringBuf> GetSupportedTxModeNames();
 
-// Human-readable list of supported mode names for help messages.
+// Parse a single transaction mode token (e.g. "read-committed-rw") into TTxSettings.
+// Returns std::nullopt if the token is not a recognized interactive mode
+// (online-ro / stale-ro are not interactive — see GetSupportedTxModeNames).
+std::optional<NQuery::TTxSettings> ParseTxModeName(TStringBuf mode);
+
+// Parse the isolation specification of a BEGIN / START TRANSACTION command line.
+//
+// Accepted forms (case-insensitive, trailing semicolon allowed):
+//   BEGIN
+//   BEGIN WORK
+//   BEGIN TRANSACTION
+//   START TRANSACTION
+//   BEGIN [TRANSACTION | WORK] <mode>
+//   START TRANSACTION <mode>
+//
+// Returns:
+//   - SerializableRW() for the bare command (no mode specified);
+//   - the parsed TTxSettings otherwise;
+//   - std::nullopt if the line is not a BEGIN command, the mode is unknown,
+//     or trailing tokens are unrecognized.
+std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf line);
+
+// Extracts the user-facing mode token from a BEGIN line, if any.
+//
+// Returns the lowercased mode token (e.g. "online-ro") for inputs like
+// "BEGIN online-ro" or "START TRANSACTION online-ro INCONSISTENT READS".
+// Returns std::nullopt if the line is not a BEGIN command or has no mode
+// token after the prefix. Used to produce targeted diagnostics for known but
+// unsupported modes.
+std::optional<TString> ExtractBeginModeToken(TStringBuf line);
+
+// True if `mode` is a YDB tx mode that is valid only as a one-shot per-query
+// tx_control (--tx-mode), not as an open interactive transaction. Today:
+// online-ro and stale-ro.
+bool IsOneShotOnlyTxMode(TStringBuf mode);
+
+// Human-readable list of supported mode names for help / error messages.
 TString GetTxModeNamesForHelp();
 
-// Parse isolation level from a BEGIN / START TRANSACTION command line.
-std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf line);
+// Returns the full set of TCL command-line forms accepted by the interactive
+// transaction engine, suitable for use as TAB completion candidates.
+TVector<TString> GetTransactionControlCompletions();
 
 bool IsBeginCommand(TStringBuf line);
 bool IsCommitCommand(TStringBuf line);

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/tx.h>
+
+#include <util/generic/fwd.h>
+#include <util/generic/strbuf.h>
+
+#include <optional>
+
+namespace NYdb::NConsoleClient {
+
+// YDB transaction mode names accepted by CLI (e.g. ydb table query --tx-mode).
+constexpr TStringBuf kTxModeSerializableRw = "serializable-rw";
+constexpr TStringBuf kTxModeOnlineRo = "online-ro";
+constexpr TStringBuf kTxModeStaleRo = "stale-ro";
+constexpr TStringBuf kTxModeSnapshotRo = "snapshot-ro";
+constexpr TStringBuf kTxModeSnapshotRw = "snapshot-rw";
+constexpr TStringBuf kTxModeReadCommittedRw = "read-committed-rw";
+
+// Parse a transaction mode string into TTxSettings.
+// Accepts YDB mode names (serializable-rw, read-committed-rw, ...) and
+// PostgreSQL-style isolation level names (READ COMMITTED, SERIALIZABLE, ...).
+std::optional<NQuery::TTxSettings> ParseTxSettings(TStringBuf mode);
+
+// Human-readable list of supported mode names for help messages.
+TString GetTxModeNamesForHelp();
+
+// Parse isolation level from a BEGIN / START TRANSACTION command line.
+std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf line);
+
+bool IsBeginCommand(TStringBuf line);
+bool IsCommitCommand(TStringBuf line);
+bool IsRollbackCommand(TStringBuf line);
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
@@ -1,0 +1,169 @@
+#include <ydb/public/lib/ydb_cli/common/tx_mode_utils.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::NConsoleClient {
+
+Y_UNIT_TEST_SUITE(TxModeUtils) {
+
+    // ------------------------------------------------------------------
+    // GetSupportedTxModeNames / GetTxModeNamesForHelp
+    // ------------------------------------------------------------------
+
+    Y_UNIT_TEST(SupportedNamesContainExpectedModes) {
+        const auto names = GetSupportedTxModeNames();
+        const THashSet<TStringBuf> set(names.begin(), names.end());
+        UNIT_ASSERT(set.contains("serializable-rw"));
+        UNIT_ASSERT(set.contains("snapshot-ro"));
+        UNIT_ASSERT(set.contains("snapshot-rw"));
+        UNIT_ASSERT(set.contains("read-committed-rw"));
+        // online-ro and stale-ro are not interactive-able.
+        UNIT_ASSERT(!set.contains("online-ro"));
+        UNIT_ASSERT(!set.contains("stale-ro"));
+    }
+
+    Y_UNIT_TEST(HelpStringMatchesSupportedNames) {
+        const TString help = GetTxModeNamesForHelp();
+        UNIT_ASSERT(help.Contains("serializable-rw"));
+        UNIT_ASSERT(help.Contains("read-committed-rw"));
+        UNIT_ASSERT(!help.Contains("online-ro"));
+        UNIT_ASSERT(!help.Contains("stale-ro"));
+    }
+
+    // ------------------------------------------------------------------
+    // ParseTxModeName
+    // ------------------------------------------------------------------
+
+    Y_UNIT_TEST(ParseModeAcceptsCanonicalNames) {
+        UNIT_ASSERT(ParseTxModeName("serializable-rw"));
+        UNIT_ASSERT(ParseTxModeName("snapshot-ro"));
+        UNIT_ASSERT(ParseTxModeName("snapshot-rw"));
+        UNIT_ASSERT(ParseTxModeName("read-committed-rw"));
+    }
+
+    Y_UNIT_TEST(ParseModeIsCaseInsensitive) {
+        UNIT_ASSERT(ParseTxModeName("Serializable-RW"));
+        UNIT_ASSERT(ParseTxModeName("SNAPSHOT-RO"));
+    }
+
+    Y_UNIT_TEST(ParseModeRejectsOneShotModes) {
+        UNIT_ASSERT(!ParseTxModeName("online-ro"));
+        UNIT_ASSERT(!ParseTxModeName("stale-ro"));
+    }
+
+    Y_UNIT_TEST(ParseModeRejectsUnknown) {
+        UNIT_ASSERT(!ParseTxModeName(""));
+        UNIT_ASSERT(!ParseTxModeName("garbage"));
+        UNIT_ASSERT(!ParseTxModeName("read-committed"));
+    }
+
+    // ------------------------------------------------------------------
+    // ParseBeginTransactionIsolation
+    // ------------------------------------------------------------------
+
+    Y_UNIT_TEST(BeginParsesAllPrefixes) {
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("begin"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN WORK"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("START TRANSACTION"));
+    }
+
+    Y_UNIT_TEST(BeginAllowsTrailingSemicolon) {
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN;"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION;"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN snapshot-ro;"));
+    }
+
+    Y_UNIT_TEST(BeginParsesMode) {
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN serializable-rw"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION snapshot-ro"));
+        UNIT_ASSERT(ParseBeginTransactionIsolation("START TRANSACTION read-committed-rw"));
+    }
+
+    Y_UNIT_TEST(BeginRejectsOneShotModes) {
+        // online-ro and stale-ro are not openable interactively even though
+        // they are valid YDB tx modes.
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN online-ro"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN stale-ro"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN online-ro INCONSISTENT READS"));
+    }
+
+    Y_UNIT_TEST(BeginRejectsUnknownMode) {
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN garbage-mode"));
+    }
+
+    Y_UNIT_TEST(BeginRejectsTrailingTokens) {
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN serializable-rw extra"));
+        // The PostgreSQL-style ISOLATION LEVEL form is intentionally rejected.
+        UNIT_ASSERT(!ParseBeginTransactionIsolation(
+            "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED"));
+    }
+
+    Y_UNIT_TEST(BeginRejectsNonBeginInput) {
+        UNIT_ASSERT(!ParseBeginTransactionIsolation(""));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("SELECT 1"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGINNING"));
+    }
+
+    // ------------------------------------------------------------------
+    // ExtractBeginModeToken / IsOneShotOnlyTxMode
+    // ------------------------------------------------------------------
+
+    Y_UNIT_TEST(ExtractBeginModeToken) {
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN online-ro"), "online-ro");
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("begin Stale-RO"), "stale-ro");
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN TRANSACTION snapshot-ro"), "snapshot-ro");
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("START TRANSACTION serializable-rw"), "serializable-rw");
+        UNIT_ASSERT(!ExtractBeginModeToken("BEGIN"));
+        UNIT_ASSERT(!ExtractBeginModeToken("BEGIN TRANSACTION"));
+        UNIT_ASSERT(!ExtractBeginModeToken("SELECT 1"));
+    }
+
+    Y_UNIT_TEST(IsOneShotOnlyTxMode) {
+        UNIT_ASSERT(IsOneShotOnlyTxMode("online-ro"));
+        UNIT_ASSERT(IsOneShotOnlyTxMode("ONLINE-RO"));
+        UNIT_ASSERT(IsOneShotOnlyTxMode("stale-ro"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode("serializable-rw"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode("snapshot-ro"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode("snapshot-rw"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode("read-committed-rw"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode("garbage"));
+        UNIT_ASSERT(!IsOneShotOnlyTxMode(""));
+    }
+
+    // ------------------------------------------------------------------
+    // IsBegin / IsCommit / IsRollback predicates
+    // ------------------------------------------------------------------
+
+    Y_UNIT_TEST(IsBeginCommand) {
+        UNIT_ASSERT(IsBeginCommand("BEGIN"));
+        UNIT_ASSERT(IsBeginCommand("begin transaction"));
+        UNIT_ASSERT(IsBeginCommand("Begin Work serializable-rw"));
+        UNIT_ASSERT(IsBeginCommand("START TRANSACTION"));
+        UNIT_ASSERT(IsBeginCommand("BEGIN;"));
+        UNIT_ASSERT(!IsBeginCommand(""));
+        UNIT_ASSERT(!IsBeginCommand("SELECT 1"));
+        UNIT_ASSERT(!IsBeginCommand("BEGINNING"));
+        UNIT_ASSERT(!IsBeginCommand("START "));  // START alone is not BEGIN
+    }
+
+    Y_UNIT_TEST(IsCommitCommand) {
+        UNIT_ASSERT(IsCommitCommand("COMMIT"));
+        UNIT_ASSERT(IsCommitCommand("commit transaction"));
+        UNIT_ASSERT(IsCommitCommand("COMMIT WORK;"));
+        UNIT_ASSERT(IsCommitCommand("END"));
+        UNIT_ASSERT(IsCommitCommand("END TRANSACTION"));
+        UNIT_ASSERT(!IsCommitCommand("COMMIT FOO"));
+        UNIT_ASSERT(!IsCommitCommand("END WORK"));  // END WORK is not a thing
+    }
+
+    Y_UNIT_TEST(IsRollbackCommand) {
+        UNIT_ASSERT(IsRollbackCommand("ROLLBACK"));
+        UNIT_ASSERT(IsRollbackCommand("rollback work"));
+        UNIT_ASSERT(IsRollbackCommand("ROLLBACK TRANSACTION;"));
+        UNIT_ASSERT(!IsRollbackCommand("ROLLBACK FOO"));
+    }
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/hash_set.h>
+
 namespace NYdb::NConsoleClient {
 
 Y_UNIT_TEST_SUITE(TxModeUtils) {

--- a/ydb/public/lib/ydb_cli/common/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ut/ya.make
@@ -11,6 +11,7 @@ SRCS(
     print_utils_ut.cpp
     recursive_remove_ut.cpp
     tabbed_table_ut.cpp
+    tx_mode_utils_ut.cpp
 )
 
 END()

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -37,6 +37,7 @@ SRCS(
     progress_indication.cpp
     query_stats.cpp
     query_utils.cpp
+    tx_mode_utils.cpp
     recursive_list.cpp
     recursive_remove.cpp
     retry_func.cpp

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1319,10 +1319,25 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         for _ in range(4):
             child.sendcontrol('c')
 
-    def _expect_keyword(self, child, keyword: str):
+    def _expect_keyword(self, child, keyword: str, *, anchor: str = ""):
         # Replxx may interleave color escape sequences inside the rendered
         # keyword/candidate text, so accept ANSI noise between letters.
         pattern = ".*".join(keyword)
+        if anchor:
+            pattern = ".*".join(anchor) + ".*" + pattern
+        child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
+
+    def _expect_s_prefixed_tx_modes(self, child, anchor: str):
+        """Expect all tx modes starting with 's' in one completion list."""
+        pattern = (
+            ".*".join(anchor)
+            + ".*"
+            + ".*".join("serializable-rw")
+            + ".*"
+            + ".*".join("snapshot-ro")
+            + ".*"
+            + ".*".join("snapshot-rw")
+        )
         child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
 
     def test_tab_completes_beg_to_begin(self):
@@ -1362,9 +1377,9 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             self._wait_for_prompt(child)
             child.send("BEGIN s")
             child.send("\t")
-            self._expect_keyword(child, "serializable-rw")
-            self._expect_keyword(child, "snapshot-ro")
-            self._expect_keyword(child, "snapshot-rw")
+            # Single expect: avoid false positives on "Server" in the welcome
+            # banner (s.*e.*r matches) and require the full candidate list.
+            self._expect_s_prefixed_tx_modes(child, "BEGIN s")
         finally:
             self._discard_and_exit(child)
             child.close()
@@ -1377,8 +1392,7 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             self._wait_for_prompt(child)
             child.send("START TRANSACTION s")
             child.send("\t")
-            self._expect_keyword(child, "serializable-rw")
-            self._expect_keyword(child, "snapshot-ro")
+            self._expect_s_prefixed_tx_modes(child, "START TRANSACTION s")
         finally:
             self._discard_and_exit(child)
             child.close()

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -975,8 +975,11 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "1" in result.stdout
 
     def test_begin_with_ydb_tx_mode(self):
+        # snapshot-ro is used here (and in similar tests below) instead of
+        # read-committed-rw because read-committed-rw is gated by server-side
+        # configuration and is not enabled in the default CI YDB setup.
         result = self.run_interactive_session(
-            ["BEGIN read-committed-rw", "SELECT 3;", "COMMIT", "exit"],
+            ["BEGIN snapshot-ro", "SELECT 3;", "COMMIT", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
@@ -1014,7 +1017,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
 
     def test_start_transaction_with_mode(self):
         result = self.run_interactive_session(
-            ["START TRANSACTION read-committed-rw", "SELECT 7;", "COMMIT", "exit"],
+            ["START TRANSACTION snapshot-ro", "SELECT 7;", "COMMIT", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
@@ -1088,7 +1091,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
 
     def test_trailing_semicolon_in_begin_with_mode(self):
         result = self.run_interactive_session(
-            ["BEGIN read-committed-rw;", "SELECT 22;", "COMMIT", "exit"],
+            ["BEGIN snapshot-ro;", "SELECT 22;", "COMMIT", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
@@ -1348,30 +1351,31 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             self._discard_and_exit(child)
             child.close()
 
-    def test_tab_after_begin_proposes_next_words(self):
-        """`BEGIN <TAB>` proposes TRANSACTION / WORK / modes (not full phrases)."""
+    def test_tab_after_begin_with_s_proposes_modes(self):
+        """`BEGIN s<TAB>` proposes the s-prefixed mode names only."""
+        # We exercise TAB on a non-empty partial because Replxx in pty mode
+        # only renders the candidate list when the current partial is
+        # non-empty; this matches the existing test_tab_shows_candidate_list_for_ambiguous_prefix.
         child = self.spawn_interactive()
         try:
             child.expect("Welcome to YDB CLI", timeout=15)
             self._wait_for_prompt(child)
-            child.send("BEGIN ")
+            child.send("BEGIN s")
             child.send("\t")
-            self._expect_keyword(child, "TRANSACTION")
-            self._expect_keyword(child, "WORK")
             self._expect_keyword(child, "serializable-rw")
             self._expect_keyword(child, "snapshot-ro")
-            self._expect_keyword(child, "read-committed-rw")
+            self._expect_keyword(child, "snapshot-rw")
         finally:
             self._discard_and_exit(child)
             child.close()
 
     def test_tab_after_start_transaction_proposes_modes(self):
-        """`START TRANSACTION <TAB>` proposes mode names, not the whole phrase."""
+        """`START TRANSACTION s<TAB>` proposes s-prefixed modes (no phrase repetition)."""
         child = self.spawn_interactive()
         try:
             child.expect("Welcome to YDB CLI", timeout=15)
             self._wait_for_prompt(child)
-            child.send("START TRANSACTION ")
+            child.send("START TRANSACTION s")
             child.send("\t")
             self._expect_keyword(child, "serializable-rw")
             self._expect_keyword(child, "snapshot-ro")

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -12,6 +12,7 @@ import yaml
 from pathlib import Path
 from typing import List, Optional
 from ydb.tests.functional.ydb_cli.ydb_cli_interactive_helpers import BaseInteractiveTest
+from ydb.tests.functional.ydb_cli.ydb_cli_helpers import ydb_bin
 
 logger = logging.getLogger(__name__)
 
@@ -918,3 +919,121 @@ class TestInteractiveHighlightAndCompletion(BaseSqlInteractiveTest):
         finally:
             self._discard_and_exit(child)
             child.close()
+
+
+# =============================================================================
+# Interactive transactions (BEGIN / COMMIT / ROLLBACK)
+# =============================================================================
+
+
+class TestInteractiveTransactions(BaseSqlInteractiveTest):
+    """Verify interactive transaction control via Query service session (ydb_int only)."""
+
+    CLI_BINARY_ENV = "YDB_CLI_INT_BINARY"
+
+    @classmethod
+    def run_interactive_session(cls, queries: List[str], tmp_path: Path, extra_args: List[str] = None, endpoint: Optional[str] = None) -> BaseInteractiveTest.ExecutionResult:
+        import yatest.common
+
+        extra_args = cls._with_profile_isolation(extra_args)
+
+        stdin_content = "\n".join(queries) + "\n"
+        stdin_path = str(tmp_path / f"interactive_stdin_{uuid.uuid4().hex}.txt")
+        with open(stdin_path, "w") as f:
+            f.write(stdin_content)
+
+        with open(stdin_path, "r") as stdin_file:
+            execution = yatest.common.execute(
+                [
+                    ydb_bin(cls.CLI_BINARY_ENV),
+                    "--endpoint", endpoint or cls.grpc_endpoint(),
+                    "--database", cls.root_dir,
+                ] + (extra_args or []),
+                stdin=stdin_file,
+                check_exit_code=False,
+            )
+
+        logger.debug("stdin:\n%s", stdin_content)
+        return cls.ExecutionResult(
+            stdout=execution.std_out.decode("utf-8") if execution.std_out else "",
+            stderr=execution.std_err.decode("utf-8") if execution.std_err else "",
+            exit_code=execution.exit_code,
+        )
+
+    def test_begin_commit_select(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+        assert "1" in result.stdout
+
+    def test_begin_read_committed_commit(self):
+        result = self.run_interactive_session(
+            [
+                "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                "SELECT 2;",
+                "COMMIT",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+        assert "2" in result.stdout
+
+    def test_begin_ydb_tx_mode_commit(self):
+        result = self.run_interactive_session(
+            ["BEGIN read-committed-rw", "SELECT 3;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" in result.stdout
+        assert "3" in result.stdout
+
+    def test_rollback(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 4;", "ROLLBACK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" in result.stdout
+        assert "4" in result.stdout
+
+    def test_commit_without_transaction_fails(self):
+        result = self.run_interactive_session(["COMMIT", "exit"], self.tmp_path)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "no active transaction" in combined.lower()
+
+    def test_nested_begin_fails(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "BEGIN", "ROLLBACK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "already a transaction" in combined.lower()
+
+    def test_exit_with_open_transaction_warns(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "open transaction" in combined.lower()
+
+
+class TestInteractiveTransactionsNotInPublicYdb(BaseSqlInteractiveTest):
+    """Public ydb CLI must not expose interactive transaction commands."""
+
+    def test_begin_not_available_in_public_ydb(self):
+        result = self.run_interactive_session(["BEGIN", "exit"], self.tmp_path)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "ydb_int" in combined.lower()
+        assert "BEGIN" not in result.stdout.split("\n")[-5:]

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -960,7 +960,11 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             exit_code=execution.exit_code,
         )
 
-    def test_begin_commit_select(self):
+    # ------------------------------------------------------------------
+    # Happy path: BEGIN / COMMIT / ROLLBACK forms
+    # ------------------------------------------------------------------
+
+    def test_bare_begin_commit_select(self):
         result = self.run_interactive_session(
             ["BEGIN", "SELECT 1;", "COMMIT", "exit"],
             self.tmp_path,
@@ -970,29 +974,69 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "COMMIT" in result.stdout
         assert "1" in result.stdout
 
-    def test_begin_read_committed_commit(self):
-        result = self.run_interactive_session(
-            [
-                "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED",
-                "SELECT 2;",
-                "COMMIT",
-                "exit",
-            ],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "BEGIN" in result.stdout
-        assert "COMMIT" in result.stdout
-        assert "2" in result.stdout
-
-    def test_begin_ydb_tx_mode_commit(self):
+    def test_begin_with_ydb_tx_mode(self):
         result = self.run_interactive_session(
             ["BEGIN read-committed-rw", "SELECT 3;", "COMMIT", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
         assert "COMMIT" in result.stdout
         assert "3" in result.stdout
+
+    def test_begin_transaction_with_ydb_tx_mode(self):
+        result = self.run_interactive_session(
+            ["BEGIN TRANSACTION serializable-rw", "SELECT 11;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_begin_work_commit(self):
+        result = self.run_interactive_session(
+            ["BEGIN WORK", "SELECT 5;", "COMMIT WORK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+        assert "5" in result.stdout
+
+    def test_start_transaction(self):
+        result = self.run_interactive_session(
+            ["START TRANSACTION", "SELECT 6;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_start_transaction_with_mode(self):
+        result = self.run_interactive_session(
+            ["START TRANSACTION read-committed-rw", "SELECT 7;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_end_aliases_commit(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 8;", "END", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_end_transaction_aliases_commit(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 9;", "END TRANSACTION", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" in result.stdout
 
     def test_rollback(self):
         result = self.run_interactive_session(
@@ -1003,8 +1047,167 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "ROLLBACK" in result.stdout
         assert "4" in result.stdout
 
+    def test_rollback_transaction(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 41;", "ROLLBACK TRANSACTION", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" in result.stdout
+
+    def test_rollback_work(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 42;", "ROLLBACK WORK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" in result.stdout
+
+    def test_lowercase_keywords(self):
+        """TCL keywords must be case-insensitive."""
+        result = self.run_interactive_session(
+            ["begin", "SELECT 12;", "commit", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    # ------------------------------------------------------------------
+    # Trailing semicolons
+    # ------------------------------------------------------------------
+
+    def test_trailing_semicolon_in_begin(self):
+        result = self.run_interactive_session(
+            ["BEGIN;", "SELECT 21;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_trailing_semicolon_in_begin_with_mode(self):
+        result = self.run_interactive_session(
+            ["BEGIN read-committed-rw;", "SELECT 22;", "COMMIT", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" in result.stdout
+        assert "COMMIT" in result.stdout
+
+    def test_trailing_semicolon_in_commit(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 23;", "COMMIT;", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" in result.stdout
+
+    def test_trailing_semicolon_in_rollback(self):
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 24;", "ROLLBACK;", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" in result.stdout
+
+    # ------------------------------------------------------------------
+    # Modes that the Query service rejects for interactive transactions
+    # ------------------------------------------------------------------
+
+    def test_online_ro_rejected_as_interactive_mode(self):
+        """online-ro is one-shot only; BEGIN must reject it client-side with a hint."""
+        result = self.run_interactive_session(
+            ["BEGIN online-ro", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        # Specific diagnostic must mention --tx-mode hint, not the generic
+        # "unknown mode" path (which would imply the user mistyped).
+        assert "online-ro" in combined
+        assert "--tx-mode" in combined
+        assert "COMMIT" not in result.stdout
+
+    def test_stale_ro_rejected_as_interactive_mode(self):
+        """stale-ro is one-shot only; BEGIN must reject it client-side with a hint."""
+        result = self.run_interactive_session(
+            ["BEGIN stale-ro", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "stale-ro" in combined
+        assert "--tx-mode" in combined
+        assert "COMMIT" not in result.stdout
+
+    def test_inconsistent_reads_modifier_rejected(self):
+        """The INCONSISTENT READS modifier is no longer supported in BEGIN."""
+        result = self.run_interactive_session(
+            ["BEGIN online-ro INCONSISTENT READS", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "unknown" in combined.lower() or "malformed" in combined.lower()
+
+    # ------------------------------------------------------------------
+    # Negative parsing: rejected forms
+    # ------------------------------------------------------------------
+
+    def test_invalid_mode_rejected(self):
+        result = self.run_interactive_session(
+            ["BEGIN garbage-mode", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "unknown" in combined.lower() or "malformed" in combined.lower()
+
+    def test_psql_isolation_level_syntax_rejected(self):
+        """The PostgreSQL-style "ISOLATION LEVEL READ COMMITTED" form is not supported.
+
+        Only YDB-native mode names are accepted; using the psql wording must
+        produce a parsing error and leave no transaction open.
+        """
+        result = self.run_interactive_session(
+            [
+                "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "unknown" in combined.lower() or "malformed" in combined.lower()
+        # Nothing actually got committed.
+        assert "COMMIT" not in result.stdout
+
+    def test_begin_word_boundary(self):
+        """An identifier starting with the letters BEGIN must not be parsed as BEGIN."""
+        result = self.run_interactive_session(
+            ['SELECT 1 AS BEGINNING;', "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        # Must not produce TCL-related diagnostics.
+        combined = result.stdout + result.stderr
+        assert "no active transaction" not in combined.lower()
+        assert "already a transaction" not in combined.lower()
+        assert "BEGINNING" in result.stdout
+
+    # ------------------------------------------------------------------
+    # State-machine errors
+    # ------------------------------------------------------------------
+
     def test_commit_without_transaction_fails(self):
         result = self.run_interactive_session(["COMMIT", "exit"], self.tmp_path)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "no active transaction" in combined.lower()
+
+    def test_rollback_without_transaction_fails(self):
+        result = self.run_interactive_session(["ROLLBACK", "exit"], self.tmp_path)
         assert result.exit_code == 0
         combined = result.stdout + result.stderr
         assert "no active transaction" in combined.lower()
@@ -1027,6 +1230,181 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         combined = result.stdout + result.stderr
         assert "open transaction" in combined.lower()
 
+    # ------------------------------------------------------------------
+    # Real DML rollback / commit semantics
+    # ------------------------------------------------------------------
+
+    def test_rollback_actually_reverts_dml(self):
+        """ROLLBACK after UPSERT must leave no row in the table."""
+        marker_id = 7777
+        marker_name = "rollback-marker"
+        result = self.run_interactive_session(
+            [
+                "BEGIN",
+                'UPSERT INTO `{}` (id, name) VALUES ({}u, "{}");'.format(
+                    self.table_path, marker_id, marker_name
+                ),
+                "ROLLBACK",
+                "SELECT name FROM `{}` WHERE id = {}u;".format(self.table_path, marker_id),
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" in result.stdout
+        assert marker_name not in result.stdout
+
+    def test_commit_actually_persists_dml(self):
+        """COMMIT after UPSERT must persist the row."""
+        marker_id = 7778
+        marker_name = "commit-marker"
+        result = self.run_interactive_session(
+            [
+                "BEGIN",
+                'UPSERT INTO `{}` (id, name) VALUES ({}u, "{}");'.format(
+                    self.table_path, marker_id, marker_name
+                ),
+                "COMMIT",
+                "SELECT name FROM `{}` WHERE id = {}u;".format(self.table_path, marker_id),
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" in result.stdout
+        assert marker_name in result.stdout
+
+    def test_sequential_transactions(self):
+        """Driver/session must be cleanly recreated between transactions."""
+        result = self.run_interactive_session(
+            [
+                "BEGIN", "SELECT 51;", "COMMIT",
+                "BEGIN", "SELECT 52;", "COMMIT",
+                "BEGIN", "SELECT 53;", "ROLLBACK",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        # All three TCL boundaries must have fired.
+        assert result.stdout.count("BEGIN") >= 3
+        assert result.stdout.count("COMMIT") >= 2
+        assert result.stdout.count("ROLLBACK") >= 1
+
+
+class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
+    """
+    Verify TAB-completion for transaction control commands.
+
+    These tests run ydb_int under a pty so we can drive the completer the way
+    a human user would: send a partial prefix, press TAB, observe the result.
+    """
+
+    CLI_BINARY_ENV = "YDB_CLI_INT_BINARY"
+    COMPLETION_TIMEOUT = 10
+
+    @classmethod
+    def spawn_interactive(cls, timeout=15, extra_args=None, env=None):
+        return super().spawn_interactive(
+            timeout=timeout,
+            extra_args=extra_args,
+            env_name=cls.CLI_BINARY_ENV,
+            env=env,
+        )
+
+    def _discard_and_exit(self, child):
+        for _ in range(4):
+            child.sendcontrol('c')
+
+    def _expect_keyword(self, child, keyword: str):
+        # Replxx may interleave color escape sequences inside the rendered
+        # keyword/candidate text, so accept ANSI noise between letters.
+        pattern = ".*".join(keyword)
+        child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
+
+    def test_tab_completes_beg_to_begin(self):
+        """`BEG<TAB>` should expand to BEGIN."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("BEG")
+            child.send("\t")
+            self._expect_keyword(child, "BEGIN")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
+    def test_tab_completes_partial_transaction(self):
+        """`BEGIN T<TAB>` should expand to TRANSACTION (single candidate)."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("BEGIN T")
+            child.send("\t")
+            self._expect_keyword(child, "TRANSACTION")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
+    def test_tab_after_begin_proposes_next_words(self):
+        """`BEGIN <TAB>` proposes TRANSACTION / WORK / modes (not full phrases)."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("BEGIN ")
+            child.send("\t")
+            self._expect_keyword(child, "TRANSACTION")
+            self._expect_keyword(child, "WORK")
+            self._expect_keyword(child, "serializable-rw")
+            self._expect_keyword(child, "snapshot-ro")
+            self._expect_keyword(child, "read-committed-rw")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
+    def test_tab_after_start_transaction_proposes_modes(self):
+        """`START TRANSACTION <TAB>` proposes mode names, not the whole phrase."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("START TRANSACTION ")
+            child.send("\t")
+            self._expect_keyword(child, "serializable-rw")
+            self._expect_keyword(child, "snapshot-ro")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
+    def test_tab_completes_com_to_commit(self):
+        """`COM<TAB>` should expand to COMMIT."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("COM")
+            child.send("\t")
+            self._expect_keyword(child, "COMMIT")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
+    def test_tab_completes_rol_to_rollback(self):
+        """`ROL<TAB>` should expand to ROLLBACK."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            child.send("ROL")
+            child.send("\t")
+            self._expect_keyword(child, "ROLLBACK")
+        finally:
+            self._discard_and_exit(child)
+            child.close()
+
 
 class TestInteractiveTransactionsNotInPublicYdb(BaseSqlInteractiveTest):
     """Public ydb CLI must not expose interactive transaction commands."""
@@ -1037,3 +1415,15 @@ class TestInteractiveTransactionsNotInPublicYdb(BaseSqlInteractiveTest):
         combined = result.stdout + result.stderr
         assert "ydb_int" in combined.lower()
         assert "BEGIN" not in result.stdout.split("\n")[-5:]
+
+    def test_commit_not_available_in_public_ydb(self):
+        result = self.run_interactive_session(["COMMIT", "exit"], self.tmp_path)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "ydb_int" in combined.lower()
+
+    def test_rollback_not_available_in_public_ydb(self):
+        result = self.run_interactive_session(["ROLLBACK", "exit"], self.tmp_path)
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "ydb_int" in combined.lower()

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -19,6 +19,7 @@ TEST_SRCS(
 
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
+ENV(YDB_CLI_INT_BINARY="ydb/apps/ydb_int/ydb_int")
 ENV(YDB_CLI_WITH_ENABLED_AI_BINARY="ydb/tests/functional/ydb_cli/ai_interactive/ydb")
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
 
@@ -31,6 +32,7 @@ ENDIF()
 
 DEPENDS(
     ydb/apps/ydb
+    ydb/apps/ydb_int
     ydb/tests/functional/ydb_cli/ai_interactive
 )
 


### PR DESCRIPTION
# Interactive transactions in YDB CLI interactive mode (`ydb_int` only)

## Summary

Adds explicit `BEGIN` / `COMMIT` / `ROLLBACK` to the YDB CLI REPL: multiple
YQL statements can now run inside a single Query service transaction bound
to a session.

The feature is exposed **only in `ydb_int`** (the experimental build). In the
public `ydb` client transaction control commands are inactive — typing
`BEGIN`, `COMMIT` or `ROLLBACK` prints a message that the feature is
available only in `ydb_int`.

## Syntax

Case-insensitive, trailing `;` allowed. Examples:

```sql
BEGIN
BEGIN TRANSACTION
BEGIN WORK
START TRANSACTION
BEGIN TRANSACTION snapshot-ro
START TRANSACTION read-committed-rw

COMMIT
COMMIT TRANSACTION
COMMIT WORK
END
END TRANSACTION

ROLLBACK
ROLLBACK TRANSACTION
ROLLBACK WORK
```

PostgreSQL-style `ISOLATION LEVEL ...` is intentionally **not** supported —
we keep the YDB-native mode names from `ydb table query --tx-mode` so that
the user always knows which YDB transaction mode is actually used.

### Supported `<mode>` values

Only modes that the Query service can open via `BeginTransaction` are
listed; `online-ro` and `stale-ro` are intentionally excluded — the server
rejects open transactions for them ("open transactions not supported for
transaction mode ..."). Trying to use them with `BEGIN` produces a
client-side diagnostic that points the user at `--tx-mode`:

```
Mode "online-ro" cannot be used with BEGIN — the Query service does not
support open transactions for this mode.
Use it as a one-shot transaction mode for a single statement, e.g.
"ydb table query --tx-mode online-ro ...".
```

| Mode                | YDB SDK equivalent                | Notes                                           |
|---------------------|-----------------------------------|-------------------------------------------------|
| `serializable-rw`   | `TTxSettings::SerializableRW()`   | Default if no mode is specified.                |
| `snapshot-ro`       | `TTxSettings::SnapshotRO()`       |                                                 |
| `snapshot-rw`       | `TTxSettings::SnapshotRW()`       | Requires `EnableSnapshotIsolationRW` on server. |
| `read-committed-rw` | `TTxSettings::ReadCommittedRW()`  | Requires server support (newer versions).       |

## Autocomplete

`ydb_int`'s REPL completer is now aware of TCL commands. The behaviour
mirrors the YQL completer: TAB / inline hints suggest **only the next
relevant word**, never the whole tail of a phrase.

| Input              | Hint / TAB result                                                          |
|--------------------|----------------------------------------------------------------------------|
| `BEG`              | `BEGIN`                                                                    |
| `BEGIN ` (space)   | `TRANSACTION`, `WORK`, `serializable-rw`, `snapshot-ro`, `snapshot-rw`, `read-committed-rw` |
| `BEGIN T`          | `TRANSACTION` (single candidate, replaces the partial)                     |
| `BEGIN TRANSACTION ` | mode names only (no repetition of the prefix phrase)                     |
| `COM` / `ROL`      | `COMMIT` / `ROLLBACK`                                                      |
| `COMMIT ` / `ROLLBACK ` | `TRANSACTION`, `WORK`                                                 |

## Architecture

### Before

```
replxx → TSqlSessionRunner::HandleLine()
           → TExecuteGenericQuery
              → TQueryClient::StreamExecuteQuery(query, NoTx())
           → SqlLazyDriver->Stop(true)   // every line
```

Stateless per line: each input went through a client-level execute with
`NoTx()` and the driver was torn down between inputs.

### After (transaction active)

```
replxx → TSqlSessionRunner::HandleLine()
           ├─ BEGIN     → TQueryClient::GetSession()
           │             → TSession::BeginTransaction(TTxSettings)
           │             → keep TSession + TTransaction in the runner
           ├─ <YQL>     → TExecuteGenericQuery(session, TTxControl::Tx(tx))
           ├─ COMMIT    → TTransaction::Commit()
           └─ ROLLBACK  → TTransaction::Rollback()
        (driver is NOT stopped while a transaction is active)
```

The runner re-evaluates *at scope exit* whether a transaction is active,
and only then decides whether to stop the lazy driver — this is what keeps
the driver alive across queries inside an open transaction.

### Feature flag

Mirrors the existing `EnableAiInteractive` plumbing:

```
TClientSettings::EnableInteractiveTransactions (set only by ydb_int)
  → TConfig::EnableInteractiveTransactions
  → TSqlSessionSettings → TSqlSessionRunner
```

The public `ydb` binary never sets the flag, so:

* `BEGIN` / `COMMIT` / `ROLLBACK` are recognized but routed to a "feature
  is available only in `ydb_int`" message;
* the help block about transactions is hidden in `/help`;
* TCL autocomplete candidates are not registered with the line reader.

## Files

| Area      | File                                                                 |
|-----------|----------------------------------------------------------------------|
| Parsing   | `ydb/public/lib/ydb_cli/common/tx_mode_utils.{h,cpp}`               |
| State machine | `ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp` |
| Completer | `ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.{h,cpp}` |
| Line reader | `ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.{h,cpp}` |
| Feature flag plumbing | `ydb/public/lib/ydb_cli/common/{command,ydb_root_common}.h`, `ydb/apps/ydb_int/commands/ydb_root.cpp` |
| Docs      | `ydb/apps/ydb_int/README.md`                                         |

## Testing

### Unit tests

* `ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp` — parsing of
  every BEGIN/COMMIT/ROLLBACK form, trailing `;`, case-insensitivity,
  unknown modes, word boundaries (`BEGINNING` ≠ `BEGIN`), one-shot mode
  detection (`online-ro`, `stale-ro`), rejection of trailing tokens after a
  mode and of the PostgreSQL `ISOLATION LEVEL` form.
* `ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp` —
  context-aware TCL completer: prefix completion (`BEG` → `BEGIN`), next
  words after `BEGIN ` / `BEGIN TRANSACTION ` / `START TRANSACTION ` /
  `COMMIT ` / `ROLLBACK `, no `online-ro` / `stale-ro` / `INCONSISTENT`
  hints, dedup, and that unrelated input does not trigger TCL hints.

### Functional tests (pty / `pexpect` via `ydb/tests/functional/ydb_cli`)

* `TestInteractiveTransactions` (against `ydb_int`):
  * happy paths: `BEGIN` / `BEGIN TRANSACTION` / `BEGIN WORK` / `START TRANSACTION`
    with each supported mode, plus `END`, `COMMIT`, `ROLLBACK` in all forms;
  * trailing `;` for every TCL command;
  * case-insensitive keywords;
  * word-boundary check (`SELECT 1 AS BEGINNING` is not parsed as `BEGIN`);
  * negative parsing: invalid mode, PostgreSQL `ISOLATION LEVEL` rejected,
    one-shot modes (`online-ro`, `stale-ro`) rejected client-side with the
    `--tx-mode` hint;
  * state machine: `COMMIT` / `ROLLBACK` without an active tx, nested `BEGIN`,
    warning + implicit rollback on exit with an open transaction;
  * DML semantics: `ROLLBACK` actually reverts data; `COMMIT` persists it;
  * sequential transactions across the same session.
* `TestInteractiveTransactionsAutocomplete` (pty against `ydb_int`):
  TAB completion for `BEG`, `BEGIN T`, `BEGIN ` (next words), `START TRANSACTION `,
  `COM`, `ROL`.
* `TestInteractiveTransactionsNotInPublicYdb` (against the public `ydb`):
  `BEGIN` / `COMMIT` / `ROLLBACK` all print the "available only in ydb_int"
  message and do not open a transaction.

Run on Linux:

```bash
./ya make --build relwithdebinfo -tA \
    ydb/public/lib/ydb_cli/common/ut \
    ydb/public/lib/ydb_cli/commands/interactive/complete/ut \
    ydb/tests/functional/ydb_cli -F 'TestInteractiveTransactions*'
```

## Out of scope

* Public `ydb` client and CHANGELOG — the feature is not released in the
  stable CLI.
* AI interactive mode — AI tool queries still go through `NoTx()` and do
  not participate in the user's transaction.
* Server-side limitations — `read-committed-rw` and `snapshot-rw` require
  matching server support / configuration; the CLI does not duplicate those
  checks.
* Nested savepoints — `BEGIN` inside an open transaction returns an error.

## Manual test plan

* [x] `BEG`, `STA`, `COM`, `ROL` + TAB / inline hint expand to single
      keywords.
* [x] `BEGIN ` + TAB lists `TRANSACTION`, `WORK`, and all supported modes;
      no `online-ro` / `stale-ro` / `INCONSISTENT`.
* [x] `BEGIN T` + TAB → `TRANSACTION` (replaces partial).
* [x] `BEGIN TRANSACTION ` + TAB → mode names only, no phrase repetition.
* [x] `BEGIN snapshot-ro` opens a transaction; queries inside and `COMMIT`
      succeed.
* [x] `BEGIN online-ro` is rejected client-side with the `--tx-mode` hint
      (no server round trip).
* [x] `BEGIN online-ro INCONSISTENT READS` is rejected client-side.
* [x] `BEGIN garbage-mode` falls back to the generic "Unknown mode" diagnostic.
* [x] Public `ydb`: `BEGIN` / `COMMIT` / `ROLLBACK` print the "ydb_int only"
      message, no transaction is opened.
* [x] `/help` shows the transactions block in `ydb_int`, not in `ydb`.
* [ ] CI: `TestInteractiveTransactions*` and `TestInteractiveTransactionsAutocomplete*`
      green on Linux.

---

<details>
<summary><b>Original PR description (kept for history)</b></summary>

# Interactive transactions in YDB CLI interactive mode (`ydb_int` only)

## Summary

Добавлена поддержка **интерактивных транзакций** в REPL YDB CLI: явные `BEGIN` / `COMMIT` / `ROLLBACK` и выполнение нескольких YQL-запросов в одной транзакции поверх **Query service** с привязкой к **сессии**.

Фича включена **только в `ydb_int`** (experimental build). В публичном `ydb` команды транзакций не активны — при попытке использования выводится сообщение, что функционал доступен только в `ydb_int`.

Основной сценарий — режим изоляции **Read Committed** (`read-committed-rw`) с пессимистичными блокировками, который сервер YDB начал поддерживать для generic-запросов. При этом на `BEGIN` можно задать **любой** режим изоляции YDB Query API.

---

## Motivation

До этого интерактивный режим CLI был **stateless по строкам**: каждый ввод отправлялся через `TQueryClient::StreamExecuteQuery(..., NoTx())`, драйвер останавливался после каждой строки. Нельзя было:

- открыть транзакцию, выполнить несколько запросов и зафиксировать/откатить;
- выбрать режим изоляции в момент `BEGIN` (как в psql).

Для отладки и экспериментов с **Read Committed** и многошаговыми сценариями нужен REPL с TCL-подобным управлением транзакцией — без выхода в batch-команды вроде `ydb table query execute --tx-mode`.

---

## User-facing behavior

### Где доступно

| Бинарь | Интерактивные транзакции |
|--------|--------------------------|
| `ydb_int` | Да |
| `ydb` (public) | Нет (сообщение об ошибке) |

Включение: `settings.EnableInteractiveTransactions = true` в `ydb/apps/ydb_int/commands/ydb_root.cpp`.

### Команды (стиль psql)

| Команда | Действие |
|---------|----------|
| `BEGIN` / `START TRANSACTION` | Открыть транзакцию |
| `BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED` | Открыть с уровнем изоляции (psql-синтаксис) |
| `BEGIN read-committed-rw` | Открыть с YDB-именем режима |
| `COMMIT` / `END` | Зафиксировать |
| `ROLLBACK` | Откатить |
| Любой другой ввод | YQL внутри открытой транзакции |

**Промпт:** во время транзакции `YQL> * ` (звёздочка как индикатор активной транзакции).

**Выход:** при `exit`/`quit` с незакрытой транзакцией — предупреждение и неявный `ROLLBACK` в деструкторе `TSqlSessionRunner`.

**Повторный `BEGIN`:** ошибка «already a transaction in progress».

**Справка:** блок про транзакции в `/help` только при включённом флаге.

### Режимы изоляции

**YDB-имена** (как в `ydb table query --tx-mode`):

- `serializable-rw` (по умолчанию при голом `BEGIN`)
- `read-committed-rw`
- `online-ro`, `stale-ro`, `snapshot-ro`, `snapshot-rw`

**PostgreSQL-style** (`ISOLATION LEVEL ...`):

| psql | YDB mapping |
|------|-------------|
| `READ COMMITTED` | `ReadCommittedRW()` |
| `SERIALIZABLE` | `SerializableRW()` |
| `REPEATABLE READ` | `SnapshotRW()` |
| `READ UNCOMMITTED` | `OnlineRO` + `AllowInconsistentReads(true)` |

</details>
