### PR TITLE
ci: fix send_build_stats.py type mismatch (Datetime/Uint64) → stable-25-3-1-enterprise

### DIFF
--- a/.github/scripts/send_build_stats.py
+++ b/.github/scripts/send_build_stats.py
@@ -11,6 +11,7 @@ import uuid
 dir_path = os.path.dirname(__file__)
 sys.path.insert(0, f"{dir_path}/analytics")
 
+import ydb
 from ydb_wrapper import YDBWrapper
 
 FROM_ENV_COLUMNS = [
@@ -47,7 +48,7 @@ ALL_COLUMNS = STRING_COLUMNS + DATETIME_COLUMNS + UINT64_COLUMNS
 def sanitize_str(s):
     # YDB SDK expects bytes for 'String' columns
     if s is None:
-        s = "N\A"
+        s = "N/A"
     return s.encode("utf-8")
 
 
@@ -129,9 +130,17 @@ VALUES
                 "$id": sanitize_str(str(uuid.uuid4())),
                 "$build_preset": sanitize_str(build_preset),
                 "$binary_path": sanitize_str(ydbd_path),
-                "$size_stripped_bytes": int(binary_size_stripped_bytes.decode("utf-8")),
-                "$size_bytes": int(binary_size_bytes.decode("utf-8")),
-                "$git_commit_time": git_commit_time_unix,
+                "$size_stripped_bytes": ydb.TypedValue(
+                    int(binary_size_stripped_bytes.decode("utf-8")),
+                    ydb.PrimitiveType.Uint64,
+                ),
+                "$size_bytes": ydb.TypedValue(
+                    int(binary_size_bytes.decode("utf-8")),
+                    ydb.PrimitiveType.Uint64,
+                ),
+                "$git_commit_time": ydb.TypedValue(
+                    git_commit_time_unix, ydb.PrimitiveType.Datetime
+                ),
                 "$git_commit_message": sanitize_str(git_commit_message),
             }
 


### PR DESCRIPTION
## Summary

Fix type mismatch error in `send_build_stats.py` when using YDB Query Service API.

## Problem

After backporting `ydb_wrapper.py` from main (which switched `execute_dml` from Table Service to Query Service API), `send_build_stats.py` in this branch started passing parameters with incorrect types:
- `$git_commit_time`: bare Python `int` → Query Service sends as `Int64`, but table schema expects `Datetime`
- `$size_bytes`, `$size_stripped_bytes`: bare Python `int` → `Int64`, but DECLARE says `Uint64`

Error: `Parameter $git_commit_time type mismatch, expected: Datetime, actual: Int64`

Table Service (old) did implicit coercion of `ydb.TypedValue(int, Datetime)`; Query Service does not — it uses the Python native type for serialization.

## Fix

Updated `send_build_stats.py` to the main branch version which wraps all parameters in proper `ydb.TypedValue` calls.

Made with [Cursor](https://cursor.com)