### PR TITLE
ci: run ya make via sudo -u under systemd-run (restore docker group)

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -415,6 +415,15 @@ runs:
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
 
+          # systemd-run --uid/--gid does not inherit supplementary groups (e.g. docker).
+          YA_MAKE_SUPP_GROUPS=$(id -Gn | grep -vx "$(id -gn)" | tr '\n' ' ')
+          YA_MAKE_SUPP_GROUPS="${YA_MAKE_SUPP_GROUPS%" "}"
+          SYSTEMD_SUPP_GROUPS_ARG=()
+          if [ -n "$YA_MAKE_SUPP_GROUPS" ]; then
+            SYSTEMD_SUPP_GROUPS_ARG=(-p "SupplementaryGroups=${YA_MAKE_SUPP_GROUPS}")
+            echo "systemd-run SupplementaryGroups: ${YA_MAKE_SUPP_GROUPS}"
+          fi
+
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
             $RERUN_FAILED_OPT --log-file "$PUBLIC_DIR/ya_log.txt"
@@ -430,6 +439,7 @@ runs:
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
+             "${SYSTEMD_SUPP_GROUPS_ARG[@]}" \
              --uid=$(id -u) --gid=$(id -g) \
              -- \
              "${YA_MAKE_CMD[@]}"

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,7 +414,7 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-          echo "runuser groups: $(id -Gn)"
+          echo "runner groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
@@ -427,12 +427,13 @@ runs:
           DMESG_SINCE=$(date '+%Y-%m-%d %H:%M:%S')
 
           set +e
-          # runuser restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
+          # sudo -u restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
+          # runuser -m conflicts with systemd-run (--whitelist-environment).
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
-             -- runuser -u "$(id -un)" -m -w "$(pwd)" -- \
+             -- sudo -n -E -u "$(id -un)" -- \
              "${YA_MAKE_CMD[@]}"
            echo $? > exit_code) </dev/null >> $YA_MAKE_OUTPUT 2>&1
           set -e

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,7 +414,6 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-          echo "runner groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -427,7 +427,7 @@ runs:
 
           set +e
           # sudo -u restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
-          # runuser -m conflicts with systemd-run (--whitelist-environment).
+          # Inner sudo -E keeps job env (needs SETENV in sudoers; standard on self-hosted runners).
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,15 +414,7 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-
-          # systemd-run --uid/--gid does not inherit supplementary groups (e.g. docker).
-          YA_MAKE_SUPP_GROUPS=$(id -Gn | grep -vx "$(id -gn)" | tr '\n' ' ')
-          YA_MAKE_SUPP_GROUPS="${YA_MAKE_SUPP_GROUPS%" "}"
-          SYSTEMD_SUPP_GROUPS_ARG=()
-          if [ -n "$YA_MAKE_SUPP_GROUPS" ]; then
-            SYSTEMD_SUPP_GROUPS_ARG=(-p "SupplementaryGroups=${YA_MAKE_SUPP_GROUPS}")
-            echo "systemd-run SupplementaryGroups: ${YA_MAKE_SUPP_GROUPS}"
-          fi
+          echo "runuser groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
@@ -435,13 +427,12 @@ runs:
           DMESG_SINCE=$(date '+%Y-%m-%d %H:%M:%S')
 
           set +e
+          # runuser restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
-             "${SYSTEMD_SUPP_GROUPS_ARG[@]}" \
-             --uid=$(id -u) --gid=$(id -g) \
-             -- \
+             -- runuser -u "$(id -un)" -m -w "$(pwd)" -- \
              "${YA_MAKE_CMD[@]}"
            echo $? > exit_code) </dev/null >> $YA_MAKE_OUTPUT 2>&1
           set -e


### PR DESCRIPTION
## Summary

After #41300, `ya make` runs inside `systemd-run --scope` with memory limits. Using `systemd-run --uid/--gid` drops supplementary groups (e.g. `docker`), so `docker_compose` recipes fail with "Couldn't connect to Docker daemon".

Run `ya make` as the runner user via `sudo -u` inside the scope instead: cgroup limits stay on `systemd-run`, and all groups (including `docker`) are restored.

## Context

- Root cause: #41300 (`OOM-resistant ya make runs`)
- Failed approaches in this PR (reverted/superseded): `SupplementaryGroups` (not valid for scope units), `runuser -m` (conflicts with `systemd-run --whitelist-environment`)

## Test plan

- [x] PR-check on self-hosted runners (relwithdebinfo + release-asan)
- [ ] Validation PR: #41888 (`ydb/core/external_sources/s3/ut` + docker_compose recipe)