### PR TITLE
test: validate s3/ut docker_compose after CI groups fix (#41887)

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -415,6 +415,15 @@ runs:
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
 
+          # systemd-run --uid/--gid does not inherit supplementary groups (e.g. docker).
+          YA_MAKE_SUPP_GROUPS=$(id -Gn | grep -vx "$(id -gn)" | tr '\n' ' ')
+          YA_MAKE_SUPP_GROUPS="${YA_MAKE_SUPP_GROUPS%" "}"
+          SYSTEMD_SUPP_GROUPS_ARG=()
+          if [ -n "$YA_MAKE_SUPP_GROUPS" ]; then
+            SYSTEMD_SUPP_GROUPS_ARG=(-p "SupplementaryGroups=${YA_MAKE_SUPP_GROUPS}")
+            echo "systemd-run SupplementaryGroups: ${YA_MAKE_SUPP_GROUPS}"
+          fi
+
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
             $RERUN_FAILED_OPT --log-file "$PUBLIC_DIR/ya_log.txt"
@@ -430,6 +439,7 @@ runs:
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
+             "${SYSTEMD_SUPP_GROUPS_ARG[@]}" \
              --uid=$(id -u) --gid=$(id -g) \
              -- \
              "${YA_MAKE_CMD[@]}"

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,7 +414,7 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-          echo "runuser groups: $(id -Gn)"
+          echo "runner groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
@@ -427,12 +427,13 @@ runs:
           DMESG_SINCE=$(date '+%Y-%m-%d %H:%M:%S')
 
           set +e
-          # runuser restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
+          # sudo -u restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
+          # runuser -m conflicts with systemd-run (--whitelist-environment).
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
-             -- runuser -u "$(id -un)" -m -w "$(pwd)" -- \
+             -- sudo -n -E -u "$(id -un)" -- \
              "${YA_MAKE_CMD[@]}"
            echo $? > exit_code) </dev/null >> $YA_MAKE_OUTPUT 2>&1
           set -e

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,7 +414,6 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-          echo "runner groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -427,7 +427,7 @@ runs:
 
           set +e
           # sudo -u restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
-          # runuser -m conflicts with systemd-run (--whitelist-environment).
+          # Inner sudo -E keeps job env (needs SETENV in sudoers; standard on self-hosted runners).
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -414,15 +414,7 @@ runs:
           YA_MAKE_SCOPE_NAME="ya-make-${GITHUB_RUN_ID:-local}-${RETRY}-$$.scope"
 
           echo "Launching ./ya make under systemd-run scope=${YA_MAKE_SCOPE_NAME} with MemoryMax=${YA_MAKE_MEM_MAX}"
-
-          # systemd-run --uid/--gid does not inherit supplementary groups (e.g. docker).
-          YA_MAKE_SUPP_GROUPS=$(id -Gn | grep -vx "$(id -gn)" | tr '\n' ' ')
-          YA_MAKE_SUPP_GROUPS="${YA_MAKE_SUPP_GROUPS%" "}"
-          SYSTEMD_SUPP_GROUPS_ARG=()
-          if [ -n "$YA_MAKE_SUPP_GROUPS" ]; then
-            SYSTEMD_SUPP_GROUPS_ARG=(-p "SupplementaryGroups=${YA_MAKE_SUPP_GROUPS}")
-            echo "systemd-run SupplementaryGroups: ${YA_MAKE_SUPP_GROUPS}"
-          fi
+          echo "runuser groups: $(id -Gn)"
 
           YA_MAKE_CMD=(
             ./ya make "${params[@]}" $YA_MAKE_TARGET $GRAPH_OPTS
@@ -435,13 +427,12 @@ runs:
           DMESG_SINCE=$(date '+%Y-%m-%d %H:%M:%S')
 
           set +e
+          # runuser restores supplementary groups (e.g. docker); --uid/--gid on systemd-run does not.
           (sudo -n -E systemd-run --scope \
              --unit="${YA_MAKE_SCOPE_NAME}" \
              -p MemoryMax="${YA_MAKE_MEM_MAX}" \
              -p MemorySwapMax=0 \
-             "${SYSTEMD_SUPP_GROUPS_ARG[@]}" \
-             --uid=$(id -u) --gid=$(id -g) \
-             -- \
+             -- runuser -u "$(id -un)" -m -w "$(pwd)" -- \
              "${YA_MAKE_CMD[@]}"
            echo $? > exit_code) </dev/null >> $YA_MAKE_OUTPUT 2>&1
           set -e

--- a/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
+++ b/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
@@ -21,6 +21,8 @@
 
 namespace NKikimr::NKqp {
 
+// Touch to run ydb/core/external_sources/s3/ut in pr-check (docker_compose recipe).
+
 using namespace NYdb;
 using namespace NYdb::NQuery;
 using namespace NKikimr::NKqp::NFederatedQueryTest;

--- a/ydb/core/external_sources/s3/ut/ya.make
+++ b/ydb/core/external_sources/s3/ut/ya.make
@@ -48,7 +48,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
-    TAG(ya:not_autocheck)
+    # TAG(ya:not_autocheck)  # temporarily enabled for pr-check (docker_compose recipe)
     REQUIREMENTS(cpu:4)
 ENDIF()
 

--- a/ydb/core/external_sources/s3/ut/ya.make
+++ b/ydb/core/external_sources/s3/ut/ya.make
@@ -33,15 +33,10 @@ ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
-    IF (SANITIZER_TYPE)
-        # Too huge for precommit check with sanitizers
-        SIZE(LARGE)
-    ELSE()
-        # Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 
-        # which makes it impossible to run them during precommit checks on Github CI. 
-        # Next several lines forces these tests to be MEDIUM. To see discussion, visit YDBOPS-8928.
-        SIZE(MEDIUM)
-    ENDIF()
+    # Temporarily force MEDIUM for pr-check validation (LARGE requires ya:fat in CI).
+    # Including of docker_compose/recipe.inc automatically converts these tests into LARGE;
+    # see YDBOPS-8928.
+    SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
 

--- a/ydb/core/external_sources/s3/ut/ya.make
+++ b/ydb/core/external_sources/s3/ut/ya.make
@@ -43,7 +43,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
-    # TAG(ya:not_autocheck)  # temporarily enabled for pr-check (docker_compose recipe)
+    # TAG(ya:not_autocheck)  # temporarily disabled for pr-check (docker_compose recipe)
     REQUIREMENTS(cpu:4)
 ENDIF()
 


### PR DESCRIPTION
## Summary

Stacked on #41887 — temporarily enables `ydb/core/external_sources/s3/ut` in PR-check to verify the `docker_compose` recipe works after the CI fix.

- Comment out `TAG(ya:not_autocheck)` so the suite runs in precommit (small/medium).
- Force `SIZE(MEDIUM)` under asan (avoids `LARGE` + `ya:fat` configure error).
- Trivial touch in `s3_aws_credentials_ut.cpp` for incremental graph selection.

**Not intended to merge to `main` as-is** — revert `not_autocheck` / SIZE overrides after validation, or close once #41887 is confirmed.

## Test plan

- [ ] PR-check runs `ydb/core/external_sources/s3/ut` and `docker_compose` recipe succeeds
- [ ] Merge #41887 first

Depends on #41887