### PR TITLE
generic provider: fix iam cloud auth

### DIFF
--- a/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
@@ -99,7 +99,6 @@ void TGenericDescribeTableTransformer::FillCredentials(NConnector::NApi::TDescri
     }
 
     // 2. Client provided service account creds that must be converted into IAM-token
-    Y_ENSURE(State_->CredentialsFactory, "CredentialsFactory is not initialized");
     auto structuredTokenJSON = TStructuredTokenBuilder()
                                    .SetServiceAccountIdAuth(clusterConfig.GetServiceAccountId(),
                                                             clusterConfig.GetServiceAccountIdSignature())

--- a/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
@@ -98,11 +98,9 @@ void TGenericDescribeTableTransformer::FillCredentials(NConnector::NApi::TDescri
         return;
     }
 
-    // 2. Client provided service account creds that must be converted into IAM-token
-    auto structuredTokenJSON = TStructuredTokenBuilder()
-                                   .SetServiceAccountIdAuth(clusterConfig.GetServiceAccountId(),
-                                                            clusterConfig.GetServiceAccountIdSignature())
-                                   .ToJson();
+    // 2. Client provided other creds (service account, iam delegated cloud auth,...) that must be converted into IAM-token
+    auto structuredTokenJSON = State_->Configuration->Tokens[clusterConfig.name()];
+
     Y_ENSURE(structuredTokenJSON, "empty structured token");
 
     // Create provider or get existing one.

--- a/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_describe_table.cpp
@@ -99,9 +99,14 @@ void TGenericDescribeTableTransformer::FillCredentials(NConnector::NApi::TDescri
     }
 
     // 2. Client provided other creds (service account, iam delegated cloud auth,...) that must be converted into IAM-token
-    auto structuredTokenJSON = State_->Configuration->Tokens[clusterConfig.name()];
-
-    Y_ENSURE(structuredTokenJSON, "empty structured token");
+    const auto tokenIt = State_->Configuration->Tokens.find(clusterConfig.name());
+    Y_ENSURE(
+            tokenIt != State_->Configuration->Tokens.end(),
+            TStringBuilder() << "missing structured token for cluster `" << clusterConfig.name() << "`");
+    const auto& structuredTokenJSON = tokenIt->second;
+    Y_ENSURE(
+            !structuredTokenJSON.empty(),
+            TStringBuilder() << "empty structured token for cluster `" << clusterConfig.name() << "`");
 
     // Create provider or get existing one.
     // It's crucial to reuse providers because their construction implies synchronous IO.

--- a/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
@@ -418,7 +418,6 @@ namespace NYql {
             }
 
             // 2. Client provided service account creds that must be converted into IAM-token
-            Y_ENSURE(State_->CredentialsFactory, "CredentialsFactory is not initialized");
 
             auto structuredTokenJSON = TStructuredTokenBuilder()
                                            .SetServiceAccountIdAuth(clusterConfig.GetServiceAccountId(),

--- a/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
@@ -417,12 +417,9 @@ namespace NYql {
                 return;
             }
 
-            // 2. Client provided service account creds that must be converted into IAM-token
+            // 2. Client provided other creds (service account, iam delegated cloud auth,...) that must be converted into IAM-token
 
-            auto structuredTokenJSON = TStructuredTokenBuilder()
-                                           .SetServiceAccountIdAuth(clusterConfig.GetServiceAccountId(),
-                                                                    clusterConfig.GetServiceAccountIdSignature())
-                                           .ToJson();
+            auto structuredTokenJSON = State_->Configuration->Tokens[clusterConfig.name()];
 
             Y_ENSURE(structuredTokenJSON, "empty structured token");
 

--- a/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
@@ -419,9 +419,14 @@ namespace NYql {
 
             // 2. Client provided other creds (service account, iam delegated cloud auth,...) that must be converted into IAM-token
 
-            auto structuredTokenJSON = State_->Configuration->Tokens[clusterConfig.name()];
-
-            Y_ENSURE(structuredTokenJSON, "empty structured token");
+            const auto tokenIt = State_->Configuration->Tokens.find(clusterConfig.name());
+            Y_ENSURE(
+                    tokenIt != State_->Configuration->Tokens.end(),
+                    TStringBuilder() << "missing structured token for cluster `" << clusterConfig.name() << "`");
+            const auto& structuredTokenJSON = tokenIt->second;
+            Y_ENSURE(
+                    !structuredTokenJSON.empty(),
+                    TStringBuilder() << "empty structured token for cluster `" << clusterConfig.name() << "`");
 
             // Create provider or get existing one.
             // It's crucial to reuse providers because their construction implies synchronous IO.


### PR DESCRIPTION
* Remove unnecessary CredentialsFactory check (only set in yqv1): it must be only present for service account auth, and it is already ensured in this case.
* Use already added StructuedToken instead of hardcoded SeviceAccount auth token

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
