### PR TITLE
ci: validate OOM error_type pipeline (#41894)

### DIFF
--- a/.github/scripts/analytics/test_history_fast.py
+++ b/.github/scripts/analytics/test_history_fast.py
@@ -135,6 +135,7 @@ def get_missed_data_for_upload(
     print(f"[classify] {total} failure rows...", flush=True)
     verify_count = 0
     sanitizer_count = 0
+    possible_oom_count = 0
     t_classify = time.time()
     progress_step = max(200, total // 10) if total > 200 else 0
 
@@ -152,11 +153,13 @@ def get_missed_data_for_upload(
             verify_count += 1
         if source_has_tag(row["error_type"], "SANITIZER"):
             sanitizer_count += 1
+        if source_has_tag(row["error_type"], "POSSIBLE_OOM"):
+            possible_oom_count += 1
         if progress_step and i % progress_step == 0 and i < total:
             print(f"[classify] {i}/{total} ({time.time() - t_classify:.1f}s)", flush=True)
     print(
         f"[classify] done {total} rows in {time.time() - t_classify:.1f}s, "
-        f"verify={verify_count}, sanitizer={sanitizer_count}",
+        f"verify={verify_count}, sanitizer={sanitizer_count}, possible_oom={possible_oom_count}",
         flush=True,
     )
     return results

--- a/.github/scripts/tests/error_type_utils.py
+++ b/.github/scripts/tests/error_type_utils.py
@@ -200,6 +200,69 @@ def failure_row_from_test_result(test: Any, status_str: str) -> FailureRow:
     )
 
 
+def _link_url_from_report(links, *keys):
+    for key in keys:
+        vals = links.get(key)
+        if isinstance(vals, list) and vals:
+            return vals[0]
+    return None
+
+
+def failure_row_from_report_result(result: Dict[str, Any], status_str: str) -> FailureRow:
+    links = result.get("links") or {}
+    return FailureRow(
+        status=status_str,
+        status_description=result.get("rich-snippet"),
+        source_error_type=result.get("error_type"),
+        stderr_url=_link_url_from_report(links, "stderr"),
+        log_url=_link_url_from_report(links, "log", "Log"),
+    )
+
+
+def _failure_status_str_for_report(result: Dict[str, Any]) -> Optional[str]:
+    status = _normalize_text(result.get("status")).upper()
+    if status in ("FAILED", "ERROR"):
+        return "failure"
+    if status == "MUTE":
+        return "mute"
+    return None
+
+
+def enrich_error_types_in_results(
+    results: Sequence[Dict[str, Any]],
+    public_dir: Optional[str] = None,
+    public_dir_url: Optional[str] = None,
+) -> None:
+    """Classify failure-like test rows and write merged tags into ``error_type``."""
+    failure_rows = []
+    targets = []
+    for result in results:
+        status_str = _failure_status_str_for_report(result)
+        if not status_str:
+            continue
+        failure_rows.append(failure_row_from_report_result(result, status_str))
+        targets.append(result)
+
+    if not failure_rows:
+        return
+
+    cache = prefetch_text_cache_for_failure_rows(
+        failure_rows,
+        local_dir=public_dir,
+        local_url_prefix=public_dir_url,
+    )
+    for result, fr in zip(targets, failure_rows):
+        stderr_text, log_text = get_debug_texts_from_cache(fr, cache)
+        result["error_type"] = build_error_type_csv_for_storage(
+            fr.status,
+            fr.status_description,
+            fr.source_error_type,
+            stderr_text,
+            log_text,
+            status_name_for_not_launched=result.get("status"),
+        )
+
+
 def get_debug_texts_from_cache(fr: FailureRow, fetch_cache: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
     """Return (stderr_text, log_text) from cache. None if URL missing, not fetched, or fetch failed."""
     if not is_failure_like_status(fr.status):

--- a/.github/scripts/tests/error_type_utils.py
+++ b/.github/scripts/tests/error_type_utils.py
@@ -23,8 +23,18 @@ DEFAULT_PREFETCH_RETRY_DELAY_SEC = 5.0
 _FETCH_FAILED = object()
 
 _ERROR_TYPE_BLACKLIST = frozenset({"REGULAR"})
-_STORAGE_TAG_ORDER = ("TIMEOUT", "XFAILED", "NOT_LAUNCHED", "VERIFY", "SANITIZER")
+_STORAGE_TAG_ORDER = (
+    "TIMEOUT",
+    "XFAILED",
+    "NOT_LAUNCHED",
+    "VERIFY",
+    "SANITIZER",
+    "POSSIBLE_OOM",
+)
 _KNOWN_STORAGE_TAGS = frozenset(_STORAGE_TAG_ORDER)
+
+# Test runner reports `Process exit_code = -9` when killed by SIGKILL (typical OOM-killer).
+_POSSIBLE_OOM_RE = re.compile(r"\bProcess exit_code\s*=\s*-9\b")
 
 
 def _normalize_text(value):
@@ -70,6 +80,10 @@ def is_not_launched_issue(source_error_type, status_name=None):
     return _normalize_text(status_name).upper() in ("SKIP", "SKIPPED", "MUTE")
 
 
+def is_possible_oom_issue(source_error_type):
+    return source_has_tag(source_error_type, "POSSIBLE_OOM")
+
+
 def _is_verify_issue(text):
     text = _normalize_text(text)
     return bool(text and re.search(r'\bVERIFY\s+failed\b', text, re.IGNORECASE))
@@ -109,6 +123,14 @@ def is_sanitizer_classification(status_description=None, stderr_text=None, log_t
     )
 
 
+def is_possible_oom_classification(status_description=None, stderr_text=None, log_text=None):
+    """True if snippet or logs show SIGKILL exit (likely kernel OOM-killer)."""
+    for text in (status_description, stderr_text, log_text):
+        if text is not None and _POSSIBLE_OOM_RE.search(_normalize_text(text)):
+            return True
+    return False
+
+
 def build_error_type_csv_for_storage(
     status,
     status_description,
@@ -120,7 +142,7 @@ def build_error_type_csv_for_storage(
     """Return stable comma-separated error_type tags for DB storage.
 
     Seeds from upstream ``source_error_type``, then adds text-derived tags
-    (VERIFY, SANITIZER) for failure-like statuses. Blacklisted tags stripped.
+    (VERIFY, SANITIZER, POSSIBLE_OOM) for failure-like statuses. Blacklisted tags stripped.
     """
     tags = set()
     for part in re.split(r"\s*,\s*", _normalize_text(source_error_type).strip()):
@@ -133,6 +155,8 @@ def build_error_type_csv_for_storage(
             tags.add("VERIFY")
         if is_sanitizer_classification(status_description, stderr_text, log_text):
             tags.add("SANITIZER")
+        if is_possible_oom_classification(status_description, stderr_text, log_text):
+            tags.add("POSSIBLE_OOM")
         if status_name_for_not_launched is not None and is_not_launched_issue(
             source_error_type, status_name_for_not_launched
         ):

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -13,14 +13,10 @@ from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from get_test_history import get_test_history
 from error_type_utils import (
-    build_error_type_csv_for_storage,
-    failure_row_from_test_result,
-    get_debug_texts_from_cache,
     is_not_launched_issue,
     is_possible_oom_issue,
     is_timeout_issue,
     is_xfailed_issue,
-    prefetch_text_cache_for_failure_rows,
     source_has_tag,
 )
 
@@ -193,7 +189,7 @@ class TestResult:
             stderr_url=log_urls.get('stderr', ''),
             log_url=log_url,
             error_type=error_type or '',
-            # is_sanitizer_issue, is_verify_issue and is_possible_oom are set after stderr/log prefetch in gen_summary.
+            # is_sanitizer_issue, is_verify_issue and is_possible_oom are set in gen_summary from error_type.
             is_sanitizer_issue=False,
             is_timeout_issue=is_timeout_issue(error_type),
             is_xfailed_issue=is_xfailed_issue(error_type),
@@ -589,29 +585,6 @@ def iter_build_results_files(path):
             continue
 
 
-def _status_string_for_error_utils(st: TestStatus) -> str:
-    """Map TestStatus to the failure|error|mute tokens used by is_failure_like_status."""
-    return {
-        TestStatus.FAIL: "failure",
-        TestStatus.ERROR: "error",
-        TestStatus.MUTE: "mute",
-    }.get(st, "")
-
-
-def _failure_row_pairs_for_summary_tests(tests):
-    """Return ``[(TestResult, FailureRow)]`` for tests with failure-like statuses."""
-    pairs = []
-    for test in tests:
-        st = getattr(test, "status", None)
-        if st is None or not getattr(st, "is_error", False):
-            continue
-        status_str = _status_string_for_error_utils(st)
-        if not status_str:
-            continue
-        pairs.append((test, failure_row_from_test_result(test, status_str)))
-    return pairs
-
-
 # Did dmesg show ANY OOM-killer event during this try?
 _OOM_DMESG_EVIDENCE_RE = re.compile(
     r'\b(?:Out of memory:\s+Killed process|invoked oom-killer|Memory cgroup out of memory)\b',
@@ -632,32 +605,8 @@ def _dmesg_has_oom(oom_dmesg_log):
         return False
 
 
-def _apply_classified_error_types_to_reports(files_data, test_source_result, pairs, stderr_fetch_cache):
-    """Write merged error_type tags back into report JSON for upload_tests_results."""
-    for test, fr in pairs:
-        stderr_text, log_text = get_debug_texts_from_cache(fr, stderr_fetch_cache)
-        status_str = _status_string_for_error_utils(test.status)
-        new_error_type = build_error_type_csv_for_storage(
-            status_str,
-            test.status_description,
-            test.error_type,
-            stderr_text,
-            log_text,
-            status_name_for_not_launched=test.status.name,
-        )
-        test.error_type = new_error_type
-        _fn, result = test_source_result.get(id(test), (None, None))
-        if result is not None:
-            result["error_type"] = new_error_type
-
-    for fn, report in files_data.items():
-        with open(fn, "w", encoding="utf-8") as f:
-            json.dump(report, f, ensure_ascii=False)
-
-
 def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset, branch, pr_number=None, workflow_run_id=None, oom_dmesg_log=None):
     summary = TestSummary(is_retry=is_retry)
-    stderr_fetch_cache = {}
     summary.dmesg_has_oom = _dmesg_has_oom(oom_dmesg_log)
     if summary.dmesg_has_oom and oom_dmesg_log:
         try:
@@ -671,35 +620,14 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset,
 
     for title, html_fn, path in paths:
         summary_line = TestSummaryLine(title)
-        files_data = {}
-        test_source_result = {}
 
-        for fn in _list_build_results_report_files(path):
-            with open(fn, encoding="utf-8") as f:
-                files_data[fn] = json.load(f)
+        for _fn, result in iter_build_results_files(path):
+            test_result = TestResult.from_build_results_report(result)
+            summary_line.add(test_result)
 
-        for fn, report in files_data.items():
-            for result in report.get("results") or []:
-                if not result.get("status"):
-                    continue
-                test_result = TestResult.from_build_results_report(result)
-                summary_line.add(test_result)
-                if _status_string_for_error_utils(test_result.status):
-                    test_source_result[id(test_result)] = (fn, result)
-
-        pairs = _failure_row_pairs_for_summary_tests(summary_line.tests)
-        stderr_fetch_cache = prefetch_text_cache_for_failure_rows(
-            [fr for _, fr in pairs],
-            existing_cache=stderr_fetch_cache,
-            local_dir=public_dir,
-            local_url_prefix=public_dir_url,
-        )
-        if pairs:
-            _apply_classified_error_types_to_reports(
-                files_data, test_source_result, pairs, stderr_fetch_cache
-            )
-        # Badge flags from merged error_type (same tags as YDB / report.json).
-        for test, _fr in pairs:
+        for test in summary_line.tests:
+            if not test.status.is_error:
+                continue
             et = test.error_type
             test.is_sanitizer_issue = source_has_tag(et, "SANITIZER")
             test.is_verify_issue = source_has_tag(et, "VERIFY")

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -13,14 +13,15 @@ from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from get_test_history import get_test_history
 from error_type_utils import (
+    build_error_type_csv_for_storage,
     failure_row_from_test_result,
     get_debug_texts_from_cache,
     is_not_launched_issue,
-    is_sanitizer_classification,
+    is_possible_oom_issue,
     is_timeout_issue,
-    is_verify_classification,
     is_xfailed_issue,
     prefetch_text_cache_for_failure_rows,
+    source_has_tag,
 )
 
 _ANALYTICS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'analytics'))
@@ -556,19 +557,21 @@ def write_summary(summary: TestSummary):
         fp.close()
 
 
+def _list_build_results_report_files(path):
+    """Return paths to build-results-report JSON files."""
+    import glob
+
+    if os.path.isfile(path):
+        return [path]
+    files = glob.glob(os.path.join(path, "**/report.json"), recursive=True)
+    if not files:
+        files = glob.glob(os.path.join(path, "report.json"))
+    return files
+
+
 def iter_build_results_files(path):
     """Iterate over build-results-report JSON files"""
-    import glob
-    
-    if os.path.isfile(path):
-        files = [path]
-    else:
-        # If it's a directory, look for report.json files
-        files = glob.glob(os.path.join(path, "**/report.json"), recursive=True)
-        if not files:
-            files = glob.glob(os.path.join(path, "report.json"))
-    
-    for fn in files:
+    for fn in _list_build_results_report_files(path):
         try:
             with open(fn, 'r') as f:
                 report = json.load(f)
@@ -629,17 +632,27 @@ def _dmesg_has_oom(oom_dmesg_log):
         return False
 
 
-# Test runner reports `Process exit_code = -9` when the test process was killed
-# by SIGKILL — the typical signal the kernel OOM-killer sends. Flag such tests
-# as "possible OOM".
-_POSSIBLE_OOM_RE = re.compile(r'\bProcess exit_code\s*=\s*-9\b')
+def _apply_classified_error_types_to_reports(files_data, test_source_result, pairs, stderr_fetch_cache):
+    """Write merged error_type tags back into report JSON for upload_tests_results."""
+    for test, fr in pairs:
+        stderr_text, log_text = get_debug_texts_from_cache(fr, stderr_fetch_cache)
+        status_str = _status_string_for_error_utils(test.status)
+        new_error_type = build_error_type_csv_for_storage(
+            status_str,
+            test.status_description,
+            test.error_type,
+            stderr_text,
+            log_text,
+            status_name_for_not_launched=test.status.name,
+        )
+        test.error_type = new_error_type
+        _fn, result = test_source_result.get(id(test), (None, None))
+        if result is not None:
+            result["error_type"] = new_error_type
 
-
-def _is_possible_oom(status_description):
-    """True if status_description shows a SIGKILL exit (likely OOM)."""
-    if not status_description:
-        return False
-    return _POSSIBLE_OOM_RE.search(status_description) is not None
+    for fn, report in files_data.items():
+        with open(fn, "w", encoding="utf-8") as f:
+            json.dump(report, f, ensure_ascii=False)
 
 
 def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset, branch, pr_number=None, workflow_run_id=None, oom_dmesg_log=None):
@@ -658,10 +671,21 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset,
 
     for title, html_fn, path in paths:
         summary_line = TestSummaryLine(title)
+        files_data = {}
+        test_source_result = {}
 
-        for fn, result in iter_build_results_files(path):
-            test_result = TestResult.from_build_results_report(result)
-            summary_line.add(test_result)
+        for fn in _list_build_results_report_files(path):
+            with open(fn, encoding="utf-8") as f:
+                files_data[fn] = json.load(f)
+
+        for fn, report in files_data.items():
+            for result in report.get("results") or []:
+                if not result.get("status"):
+                    continue
+                test_result = TestResult.from_build_results_report(result)
+                summary_line.add(test_result)
+                if _status_string_for_error_utils(test_result.status):
+                    test_source_result[id(test_result)] = (fn, result)
 
         pairs = _failure_row_pairs_for_summary_tests(summary_line.tests)
         stderr_fetch_cache = prefetch_text_cache_for_failure_rows(
@@ -670,19 +694,17 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset,
             local_dir=public_dir,
             local_url_prefix=public_dir_url,
         )
-        # Set text-derived badge flags after prefetch.
-        for test, fr in pairs:
-            stderr_text, log_text = get_debug_texts_from_cache(fr, stderr_fetch_cache)
-            test.is_sanitizer_issue = is_sanitizer_classification(
-                test.status_description, stderr_text, log_text
+        if pairs:
+            _apply_classified_error_types_to_reports(
+                files_data, test_source_result, pairs, stderr_fetch_cache
             )
-            test.is_verify_issue = is_verify_classification(
-                test.status_description, stderr_text, log_text
-            )
-            # "Possible OOM": status_description has `Process exit_code = -9`
-            # (SIGKILL — most likely from the kernel OOM-killer).
-            test.is_possible_oom = _is_possible_oom(test.status_description)
-        
+        # Badge flags from merged error_type (same tags as YDB / report.json).
+        for test, _fr in pairs:
+            et = test.error_type
+            test.is_sanitizer_issue = source_has_tag(et, "SANITIZER")
+            test.is_verify_issue = source_has_tag(et, "VERIFY")
+            test.is_possible_oom = is_possible_oom_issue(et)
+
         if os.path.isabs(html_fn):
             html_fn = os.path.relpath(html_fn, public_dir)
         report_url = f"{public_dir_url}/{html_fn}"

--- a/.github/scripts/tests/transform_build_results.py
+++ b/.github/scripts/tests/transform_build_results.py
@@ -4,6 +4,7 @@
 # - adds links to logs in test results
 # - mutes tests
 # - adds user properties from test_dir
+# - merges VERIFY/SANITIZER/TIMEOUT/POSSIBLE_OOM tags into error_type for upload
 
 import argparse
 import json
@@ -15,6 +16,8 @@ import urllib.parse
 import zipfile
 from typing import Set
 from mute.mute_check import YaMuteCheck
+
+from error_type_utils import enrich_error_types_in_results
 
 
 def log_print(*args, **kwargs):
@@ -184,7 +187,7 @@ def mute_test_result(result):
 
 
 def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, log_out_dir, log_truncate_size,
-              test_stuff_out, test_stuff_prefix, test_dir):
+              test_stuff_out, test_stuff_prefix, test_dir, public_dir=None, public_dir_url=None):
     start_time = time.time()
     
     # Load JSON report
@@ -416,6 +419,15 @@ def transform(report_file, mute_check: YaMuteCheck, ya_out_dir, log_url_prefix, 
     rich_time = time.time() - rich_start
     log_print(f"Processed rich-snippet: {rich_time:.2f}s ({rich_count} results)")
 
+    enrich_start = time.time()
+    enrich_error_types_in_results(
+        filtered_results,
+        public_dir=public_dir,
+        public_dir_url=public_dir_url,
+    )
+    enrich_time = time.time() - enrich_start
+    log_print(f"Enriched error_type tags: {enrich_time:.2f}s")
+
     # Replace report results with filtered results only
     report["results"] = filtered_results
 
@@ -486,6 +498,8 @@ def main():
         test_stuff_out,
         test_stuff_prefix,
         args.test_dir,
+        public_dir=args.public_dir,
+        public_dir_url=args.public_dir_url,
     )
 
 

--- a/ydb/core/resource_pools/resource_pool_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_settings_ut.cpp
@@ -1,3 +1,4 @@
+// CI validation touch for #41894 (OOM error_type pipeline).
 #include "resource_pool_settings.h"
 
 #include <library/cpp/testing/unittest/registar.h>


### PR DESCRIPTION
## Summary

Stacked validation PR for #41894 — runs full PR CI with the OOM `error_type` pipeline changes plus a trivial `ydb/core` touch to trigger checks.

**Depends on:** #41894 (merge base PR first, then rebase this branch onto `main` or merge after #41894 lands).

**Not for merge as-is:** remove the `resource_pool_settings_ut.cpp` comment after validation (or drop this PR once #41894 is verified on main).

## Changes vs #41894

- Comment-only change in `ydb/core/resource_pools/resource_pool_settings_ut.cpp` to trigger `ya make` / test_ya.

## Test plan

- [ ] PR checks green with `POSSIBLE_OOM` / transform `error_type` path
- [ ] Close or rebase after #41894 merges

**Related:** #41894

Made with [Cursor](https://cursor.com)