### PR TITLE
Hybrid search via `HybridRank` fusing fulltext and vector indexes

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -51,6 +51,7 @@ PEERDIR(
     ydb/library/pdisk_io
     ydb/library/security
     ydb/library/yql/udfs/common/clickhouse/client
+    ydb/library/yql/udfs/common/hybrid_search
     ydb/library/yql/udfs/common/knn
     ydb/library/yql/udfs/common/roaring
     ydb/library/yql/udfs/statistics_internal

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -1310,6 +1310,15 @@ private:
             operatorId = Visit(maybeReadRanges.Cast(), planNode);
         } else if (auto maybeLookup = TMaybeNode<TKqlLookupTableBase>(node)) {
             operatorId = Visit(maybeLookup.Cast(), planNode);
+        } else if (node->IsCallable({"Map", "FlatMap", "OrderedMap", "OrderedFlatMap"}) && node->ChildrenSize() >= 2
+            && FindNode(node->ChildPtr(1), [](const TExprNode::TPtr& n) {
+                   auto udf = TMaybeNode<TCoUdf>(n);
+                   return udf && udf.Cast().MethodName().Value().StartsWith("HybridSearch.");
+               })) {
+            // The Reciprocal Rank Fusion step uniquely identifies a hybrid-search (HybridRank) query.
+            TOperator op;
+            op.Properties["Name"] = "HybridSearch";
+            operatorId = AddOperator(planNode, "HybridSearch", std::move(op));
         } else if (auto maybeFilter = TMaybeNode<TCoFilterBase>(node)) {
             operatorId = Visit(maybeFilter.Cast(), planNode);
         } else if (auto maybeMapJoin = TMaybeNode<TCoMapJoinCore>(node)) {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -36,6 +36,7 @@ public:
         , Config(config)
     {
 #define HNDL(name) "KqpLogical-"#name, Hndl(&TKqpLogicalOptTransformer::name)
+        AddHandler(0, &TCoTopBase::Match, HNDL(RewriteHybridRankTopSort));
         AddHandler(0, &TCoTop::Match, HNDL(TopSortSelectIndex));
         AddHandler(0, &TCoTopSort::Match, HNDL(TopSortSelectIndex));
         AddHandler(0, &TCoFlatMapBase::Match, HNDL(PushExtractedPredicateToReadTable));
@@ -302,6 +303,16 @@ protected:
     TMaybeNode<TExprBase> RewriteTopSortOverIndexRead(TExprBase node, TExprContext& ctx, const TGetParents& getParents) {
         TExprBase output = KqpRewriteTopSortOverIndexRead(node, ctx, TypesCtx, KqpCtx, *getParents());
         DumpAppliedRule("RewriteTopSortOverIndexRead", node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> RewriteHybridRankTopSort(TExprBase node, TExprContext& ctx) {
+        auto output = KqpRewriteHybridRankTopSort(node, ctx, KqpCtx);
+        if (!output.IsValid()) {
+            return {};
+        }
+
+        DumpAppliedRule("RewriteHybridRankTopSort", node.Ptr(), output.Cast().Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -2110,6 +2110,765 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverJsonRead(const NYql::NNodes::TExprBas
         .Done();
 }
 
+// Rewrites a hybrid search query:
+//
+//   SELECT ... FROM t
+//   ORDER BY HybridRank(FullTextScore(c1, $q), Knn::CosineDistance(c2, $v)) [DESC]
+//   LIMIT k
+//
+// into two independent index sub-queries (a fulltext relevance scan and a vector kmeans-tree scan),
+// each bounded to an internal limit, whose results are fused with Reciprocal Rank Fusion (RRF).
+//
+// Unlike the standalone fulltext/vector rewrites this query names no index via VIEW (it needs two),
+// so the rule resolves the indexes from the table metadata by matching the scored columns: the
+// FullTextScore column selects the GlobalFulltextRelevance index, the Knn column selects the
+// GlobalSyncVectorKMeansTree index. (An explicit ("ft_idx","vec_idx") AS Indexes override is a
+// follow-up.) On any misuse it raises a precise error; queries it cannot rewrite fall through to the
+// peephole HybridRank stub, which fails with a clear message rather than returning wrong results.
+TMaybeNode<TExprBase> KqpRewriteHybridRankTopSort(const TExprBase& node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx)
+{
+    if (!node.Maybe<TCoTopBase>()) {
+        return node;
+    }
+    auto top = node.Cast<TCoTopBase>();
+
+    // The sort key of a hybrid query is HybridRank(...). Find that marker callable in the key selector.
+    TExprNode::TPtr hybridRank;
+    VisitExpr(top.KeySelectorLambda().Body().Ptr(), [&](const TExprNode::TPtr& n) {
+        if (hybridRank) {
+            return false;
+        }
+        if (n->IsCallable("HybridRank")) {
+            hybridRank = n;
+            return false;
+        }
+        return true;
+    });
+    if (!hybridRank) {
+        return node;
+    }
+
+    auto addError = [&](const TString& message) -> TMaybeNode<TExprBase> {
+        TIssue issue{ctx.GetPosition(hybridRank->Pos()), TStringBuilder() << "HybridRank: " << message};
+        SetIssueCode(EYqlIssueCode::TIssuesIds_EIssueCode_KIKIMR_BAD_REQUEST, issue);
+        ctx.AddError(issue);
+        return {};
+    };
+
+    if (top.KeySelectorLambda().Body().Ptr() != hybridRank) {
+        return addError("must be the entire ORDER BY key; it cannot be negated or combined with other expressions");
+    }
+
+    if (hybridRank->ChildrenSize() < 2) {
+        return addError("expects at least 2 arguments: a fulltext score and a vector distance");
+    }
+
+    auto findFulltextScore = [](const TExprNode::TPtr& root) -> TExprNode::TPtr {
+        TExprNode::TPtr found;
+        VisitExpr(root, [&](const TExprNode::TPtr& n) {
+            if (found) {
+                return false;
+            }
+            if (n->IsCallable("FulltextScore")) {
+                found = n;
+                return false;
+            }
+            return true;
+        });
+        return found;
+    };
+    // Match the Knn distance/similarity functions, not helpers like Knn::ToBinaryString* which may also
+    // appear in the vector argument (e.g. when the search target is packed inline). Distances rank
+    // smaller-is-better, similarities larger-is-better; the branch is sorted in the matching direction and
+    // linear fusion normalizes accordingly (see vecIsSimilarity below).
+    static const THashSet<TStringBuf> knnDistanceMethods = {
+        "Knn.CosineDistance", "Knn.ManhattanDistance", "Knn.EuclideanDistance",
+    };
+    static const THashSet<TStringBuf> knnSimilarityMethods = {
+        "Knn.CosineSimilarity", "Knn.InnerProductSimilarity",
+    };
+    auto findKnnApply = [](const TExprNode::TPtr& root) -> TMaybeNode<TCoApply> {
+        TMaybeNode<TCoApply> found;
+        VisitExpr(root, [&](const TExprNode::TPtr& n) {
+            if (found.IsValid()) {
+                return false;
+            }
+            if (auto apply = TExprBase(n).Maybe<TCoApply>()) {
+                if (auto udf = apply.Cast().Callable().Maybe<TCoUdf>(); udf
+                    && (knnDistanceMethods.contains(udf.Cast().MethodName().Value())
+                        || knnSimilarityMethods.contains(udf.Cast().MethodName().Value()))) {
+                    found = apply.Cast();
+                    return false;
+                }
+            }
+            return true;
+        });
+        return found;
+    };
+
+    // Positional args are HybridRank(ftScore, vecDistance). Optional named tuple arguments override
+    // index selection and per-branch candidate limits: ("ft_idx","vec_idx") AS Indexes, (n,m) AS Limits.
+    // With named args present the node becomes (HybridRank (List ft vec) (AsStruct '(name value) ...)).
+    TExprNode::TPtr ftExpr;
+    TExprNode::TPtr vecExpr;
+    TMaybe<TString> ftIndexOverride;
+    TMaybe<TString> vecIndexOverride;
+    TMaybe<ui64> ftLimitOverride;
+    TMaybe<ui64> vecLimitOverride;
+    TMaybe<double> kOverride;
+    TString fusionMode = "rrf";  // 'rrf' (Reciprocal Rank Fusion) or 'linear' (min-max normalized scores)
+    double ftWeight = 1.0;       // per-direction weights, (w_ft, w_vec) AS Weights; default equal
+    double vecWeight = 1.0;
+    TMaybe<bool> normalizeOverride;  // linear-only; default true (min-max normalize before fusing)
+    const bool hasNamedArgs = hybridRank->Head().GetTypeAnn()
+        && hybridRank->Head().GetTypeAnn()->GetKind() == ETypeAnnotationKind::Tuple;
+    if (hasNamedArgs) {
+        const auto positional = hybridRank->ChildPtr(0);
+        if (positional->ChildrenSize() != 2) {
+            return addError("expects exactly 2 positional arguments (a fulltext score and a vector distance)");
+        }
+        ftExpr = positional->ChildPtr(0);
+        vecExpr = positional->ChildPtr(1);
+
+        const auto getStringElem = [](const TExprNode::TPtr& n) -> TMaybe<TString> {
+            if (n->IsCallable("String") && n->ChildrenSize() >= 1 && n->Head().IsAtom()) {
+                return TString(n->Head().Content());
+            }
+            return {};
+        };
+        const auto getIntElem = [](const TExprNode::TPtr& n) -> TMaybe<ui64> {
+            ui64 v = 0;
+            if (n->ChildrenSize() >= 1 && n->Head().IsAtom() && TryFromString<ui64>(n->Head().Content(), v)) {
+                return v;
+            }
+            return {};
+        };
+        const auto getDoubleElem = [](const TExprNode::TPtr& n) -> TMaybe<double> {
+            double v = 0;
+            if (n->ChildrenSize() >= 1 && n->Head().IsAtom() && TryFromString<double>(n->Head().Content(), v)) {
+                return v;  // accepts both integer (2) and double (0.2) numeric literals
+            }
+            return {};
+        };
+
+        for (const auto& member : hybridRank->Child(1)->Children()) {
+            if (member->ChildrenSize() != 2 || !member->Head().IsAtom()) {
+                continue;
+            }
+            const auto name = member->Head().Content();
+            const auto value = member->ChildPtr(1);
+            if (name == "Indexes") {
+                if (value->ChildrenSize() != 2) {
+                    return addError("Indexes must be a tuple of two index names: (\"ft_idx\", \"vec_idx\")");
+                }
+                ftIndexOverride = getStringElem(value->ChildPtr(0));
+                vecIndexOverride = getStringElem(value->ChildPtr(1));
+                if (!ftIndexOverride || !vecIndexOverride) {
+                    return addError("Indexes must be a tuple of two string literals: (\"ft_idx\", \"vec_idx\")");
+                }
+            } else if (name == "Limits") {
+                if (value->ChildrenSize() != 2) {
+                    return addError("Limits must be a tuple of two integers: (ft_limit, vec_limit)");
+                }
+                ftLimitOverride = getIntElem(value->ChildPtr(0));
+                vecLimitOverride = getIntElem(value->ChildPtr(1));
+                if (!ftLimitOverride || !vecLimitOverride) {
+                    return addError("Limits must be a tuple of two positive integer literals: (ft_limit, vec_limit)");
+                }
+            } else if (name == "K" || name == "k") {
+                double kv = 0;
+                if (value->ChildrenSize() < 1 || !value->Head().IsAtom() || !TryFromString<double>(value->Head().Content(), kv)) {
+                    return addError("K must be a numeric literal (the RRF constant), e.g. 60.0 AS K");
+                }
+                kOverride = kv;
+            } else if (name == "Mode") {
+                if (!value->IsCallable("String") || value->ChildrenSize() < 1 || !value->Head().IsAtom()) {
+                    return addError("Mode must be a string literal: \"rrf\" or \"linear\"");
+                }
+                TString modeStr{value->Head().Content()};
+                modeStr.to_lower();  // accept "RRF"/"Linear" too
+                fusionMode = modeStr;
+                if (fusionMode != "rrf" && fusionMode != "linear") {
+                    return addError(TStringBuilder() << "unknown Mode '" << value->Head().Content() << "'; expected \"rrf\" or \"linear\"");
+                }
+            } else if (name == "Weights") {
+                if (value->ChildrenSize() != 2) {
+                    return addError("Weights must be a tuple of two numbers: (ft_weight, vec_weight)");
+                }
+                const auto w0 = getDoubleElem(value->ChildPtr(0));
+                const auto w1 = getDoubleElem(value->ChildPtr(1));
+                if (!w0 || !w1) {
+                    return addError("Weights must be a tuple of two numeric literals: (ft_weight, vec_weight)");
+                }
+                ftWeight = *w0;
+                vecWeight = *w1;
+            } else if (name == "Normalize") {
+                if (!value->IsCallable("Bool") || value->ChildrenSize() < 1 || !value->Head().IsAtom()) {
+                    return addError("Normalize must be a boolean literal: true or false");
+                }
+                normalizeOverride = (value->Head().Content() == "true");
+            } else {
+                return addError(TStringBuilder() << "unknown named argument '" << name << "'; expected Indexes, Limits, K, Mode, Weights or Normalize");
+            }
+        }
+    } else {
+        ftExpr = hybridRank->ChildPtr(0);
+        vecExpr = hybridRank->ChildPtr(1);
+    }
+
+    auto ftScore = findFulltextScore(ftExpr);
+    auto knnApply = findKnnApply(vecExpr);
+    if (!ftScore || !knnApply.IsValid()) {
+        if (findFulltextScore(vecExpr) && findKnnApply(ftExpr).IsValid()) {
+            return addError("arguments appear reversed; expected HybridRank(FullTextScore(...), Knn::Distance(...))");
+        }
+        return addError("expected the first argument to be FullTextScore(column, query) and the second to be a "
+                        "Knn distance over a column, e.g. Knn::CosineDistance(embedding, $target)");
+    }
+
+    bool vecIsSimilarity = false;
+    if (auto knnUdf = knnApply.Cast().Callable().Maybe<TCoUdf>()) {
+        vecIsSimilarity = knnSimilarityMethods.contains(knnUdf.Cast().MethodName().Value());
+    }
+
+    // Extract the fulltext column from FullTextScore(<column>, <query>, ...).
+    auto ftColumnMember = TExprBase(ftScore->ChildPtr(0)).Maybe<TCoMember>();
+    if (!ftColumnMember) {
+        return addError("the first argument of FullTextScore must reference a table column");
+    }
+    const TString ftColumn = ftColumnMember.Cast().Name().StringValue();
+
+    // Extract the vector column: the table-column Member referenced anywhere in the vector expression.
+    // A nullable column wraps the Knn call in an automap FlatMap, so the Member lives in the wider
+    // vector expression (as the FlatMap input), not inside the Knn apply itself.
+    TString vecColumn;
+    VisitExpr(vecExpr, [&](const TExprNode::TPtr& n) {
+        if (!vecColumn.empty()) {
+            return false;
+        }
+        if (auto member = TExprBase(n).Maybe<TCoMember>()) {
+            vecColumn = member.Cast().Name().StringValue();
+            return false;
+        }
+        return true;
+    });
+    if (vecColumn.empty()) {
+        return addError("the Knn distance argument must reference a table column, e.g. Knn::CosineDistance(embedding, $target)");
+    }
+
+    // The input under the TopSort must be a plain main-table read (optionally wrapped in a projection/filter FlatMap).
+    auto input = top.Input();
+    auto maybeFlatMap = input.Maybe<TCoFlatMap>();
+    TExprBase readBase = maybeFlatMap ? maybeFlatMap.Cast().Input() : input;
+    auto maybeRead = readBase.Maybe<TKqlReadTableRanges>();
+    if (!maybeRead) {
+        // Not a shape we can rewrite yet (e.g. already an index read); leave it for the peephole stub.
+        return node;
+    }
+    auto read = maybeRead.Cast();
+
+    const auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, read.Table().Path());
+    YQL_ENSURE(tableDesc.Metadata);
+
+    auto columnInList = [](const TVector<TString>& cols, const TString& name) {
+        for (const auto& c : cols) {
+            if (c == name) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Resolve the fulltext (relevance) and vector indexes: an explicit ("ft_idx","vec_idx") AS Indexes
+    // override if given, otherwise auto-detect by matching the scored columns.
+    TString ftIndexName;
+    TString vecIndexName;
+    if (ftIndexOverride) {
+        const TIndexDescription* ftIdx = nullptr;
+        const TIndexDescription* vecIdx = nullptr;
+        for (const auto& idx : tableDesc.Metadata->Indexes) {
+            if (idx.Name == *ftIndexOverride) {
+                ftIdx = &idx;
+            }
+            if (idx.Name == *vecIndexOverride) {
+                vecIdx = &idx;
+            }
+        }
+        if (!ftIdx) {
+            return addError(TStringBuilder() << "fulltext index '" << *ftIndexOverride << "' was not found");
+        }
+        if (ftIdx->State != TIndexDescription::EIndexState::Ready) {
+            return addError(TStringBuilder() << "fulltext index '" << *ftIndexOverride << "' is not ready");
+        }
+        if (ftIdx->Type != TIndexDescription::EType::GlobalFulltextRelevance) {
+            return addError(TStringBuilder() << "index '" << *ftIndexOverride << "' is not a fulltext relevance index");
+        }
+        if (!columnInList(ftIdx->KeyColumns, ftColumn)) {
+            return addError(TStringBuilder() << "fulltext index '" << *ftIndexOverride
+                << "' is not built on the FullTextScore column '" << ftColumn << "'");
+        }
+        if (!vecIdx) {
+            return addError(TStringBuilder() << "vector index '" << *vecIndexOverride << "' was not found");
+        }
+        if (vecIdx->State != TIndexDescription::EIndexState::Ready) {
+            return addError(TStringBuilder() << "vector index '" << *vecIndexOverride << "' is not ready");
+        }
+        if (vecIdx->Type != TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+            return addError(TStringBuilder() << "index '" << *vecIndexOverride << "' is not a vector kmeans-tree index");
+        }
+        if (vecIdx->KeyColumns.empty() || vecIdx->KeyColumns.back() != vecColumn) {
+            return addError(TStringBuilder() << "vector index '" << *vecIndexOverride
+                << "' is not built on the Knn distance column '" << vecColumn << "'");
+        }
+        if (vecIdx->KeyColumns.size() != 1) {
+            return addError(TStringBuilder() << "vector index '" << *vecIndexOverride
+                << "' is a prefixed vector index, which HybridRank does not support yet");
+        }
+        ftIndexName = *ftIndexOverride;
+        vecIndexName = *vecIndexOverride;
+    } else {
+        ui32 ftMatches = 0;
+        ui32 vecMatches = 0;
+        for (const auto& idx : tableDesc.Metadata->Indexes) {
+            if (idx.State != TIndexDescription::EIndexState::Ready) {
+                continue;
+            }
+            if (idx.Type == TIndexDescription::EType::GlobalFulltextRelevance && columnInList(idx.KeyColumns, ftColumn)) {
+                ftIndexName = idx.Name;
+                ++ftMatches;
+            }
+            if (idx.Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree
+                && idx.KeyColumns.size() == 1 && idx.KeyColumns.back() == vecColumn) {
+                vecIndexName = idx.Name;
+                ++vecMatches;
+            }
+        }
+
+        if (ftMatches == 0) {
+            return addError(TStringBuilder() << "no ready fulltext relevance index found on column '" << ftColumn << "'");
+        }
+        if (ftMatches > 1) {
+            return addError(TStringBuilder() << "multiple fulltext relevance indexes match column '" << ftColumn
+                << "'; name it explicitly via ((\"ft_idx\", \"vec_idx\") AS Indexes)");
+        }
+        if (vecMatches == 0) {
+            return addError(TStringBuilder() << "no ready vector (kmeans-tree) index found on column '" << vecColumn << "'");
+        }
+        if (vecMatches > 1) {
+            return addError(TStringBuilder() << "multiple vector indexes match column '" << vecColumn
+                << "'; name it explicitly via ((\"ft_idx\", \"vec_idx\") AS Indexes)");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Build the two index branches and fuse them with Reciprocal Rank Fusion (RRF).
+    // ---------------------------------------------------------------------------------------------
+    const auto pos = node.Pos();
+
+    const auto& pkColumns = tableDesc.Metadata->KeyColumnNames;
+    if (pkColumns.size() != 1) {
+        return addError("hybrid search currently supports only a single-column primary key");
+    }
+    const TString pkCol = pkColumns[0];
+
+    // Reconstruct the WHERE predicate and projection to apply on top of the fused, looked-up rows.
+    // A projecting FlatMap (from a WHERE clause or an explicit projection) provides them; without one
+    // the TopSort reads the table directly and its output schema is simply the read's columns.
+    TExprNode::TPtr origArg;
+    TExprNode::TPtr origPred;   // over origArg; null => no WHERE filter
+    TExprNode::TPtr origProj;   // AsStruct over origArg; null => emit the read columns as-is
+    if (maybeFlatMap) {
+        const auto origLambda = maybeFlatMap.Cast().Lambda();
+        origArg = origLambda.Args().Arg(0).Ptr();
+        const auto origBody = origLambda.Body();
+        if (auto optIf = origBody.Maybe<TCoOptionalIf>()) {
+            origPred = optIf.Cast().Predicate().Ptr();
+            origProj = optIf.Cast().Value().Ptr();
+        } else if (auto just = origBody.Maybe<TCoJust>()) {
+            origProj = just.Cast().Input().Ptr();
+        } else {
+            return node;
+        }
+        if (!TExprBase(origProj).Maybe<TCoAsStruct>()) {
+            return node;
+        }
+    }
+
+    // The HybridRank sub-expressions reference the TopSort key-selector row argument; we rebind it to
+    // each branch's own row when reusing those sub-expressions (which preserves the exact Knn shape,
+    // automap wrapper and all, that the vector rewrite expects).
+    const auto rowArg = top.KeySelectorLambda().Args().Arg(0).Ptr();
+    const auto ftQuery = ftScore->ChildPtr(1);
+
+    const TString relevanceCol{NTableIndex::NFulltext::FullTextRelevanceColumn};
+    const TString distCol = "__ydb_hybrid_distance";
+    const TString rrfCol = "__ydb_hybrid_rrf";
+
+    auto uint64Node = [&](ui64 v) {
+        return ctx.Builder(pos).Callable("Uint64").Atom(0, ToString(v), TNodeFlags::Default).Seal().Build();
+    };
+    // Per-branch internal candidate limit: an explicit (n, m) AS Limits override, otherwise
+    // LIMIT * HybridSearchFactor (pragma, default 10), built as a runtime expression so it tracks a
+    // parameterised LIMIT.
+    TExprNode::TPtr ftN;
+    TExprNode::TPtr vecN;
+    if (ftLimitOverride) {
+        ftN = uint64Node(*ftLimitOverride);
+        vecN = uint64Node(*vecLimitOverride);
+    } else {
+        // The fulltext ItemsLimit and the vector TopLimit must be literals, so the per-branch candidate
+        // count is LIMIT * HybridSearchFactor computed at optimize time. A non-literal (e.g. parameterised)
+        // LIMIT cannot be sized safely -- a fixed fallback smaller than the runtime LIMIT would silently
+        // drop rows from the final TopSort -- so reject it and ask for an explicit Limits override.
+        const ui64 factor = kqpCtx.Config->HybridSearchFactor.Get().GetOrElse(10);
+        ui64 limitVal = 0;
+        bool literalLimit = false;
+        const auto& countNode = top.Count().Ref();
+        if (countNode.IsCallable() && countNode.ChildrenSize() == 1 && countNode.Head().IsAtom()) {
+            literalLimit = TryFromString<ui64>(countNode.Head().Content(), limitVal);
+        }
+        if (!literalLimit) {
+            return addError("requires a literal LIMIT; for a parameterised LIMIT pass explicit per-branch "
+                            "candidate counts via ((n, m) AS Limits)");
+        }
+        ftN = vecN = uint64Node(limitVal * factor);
+    }
+    // Rank assigned to a document absent from one branch: a large sentinel, so its contribution from
+    // that branch is ~0 (the intended "missing from this result set" behaviour).
+    const auto penaltyRank = uint64Node(4000000000ull);
+    const double kValue = kOverride.GetOrElse(kqpCtx.Config->HybridSearchK.Get().GetOrElse(60.0));
+    const auto kConst = ctx.Builder(pos).Callable("Double").Atom(0, ToString(kValue), TNodeFlags::Default).Seal().Build();
+
+    const auto mainTableMeta = BuildTableMeta(*tableDesc.Metadata, pos, ctx);
+
+    // ---- Fulltext relevance branch: top-N {pk, relevance} ordered by relevance DESC ----
+    // Emitted as the canonical FlatMap-over-index-read shape; the existing fulltext rules
+    // (RewriteFlatMapOverFullTextMatch + PushLimitOverFullText) lower it.
+    // Build the fulltext relevance read directly (as KqpSelectJsonIndex does for JSON) rather than emit a
+    // synthetic FlatMap and rely on RewriteFlatMapOverFullTextMatch to fire on it. The read returns
+    // {pk, __ydb_full_text_relevance} ranked by relevance, capped at N_internal via ItemsLimit.
+    TKqpReadTableFullTextIndexSettings ftSettings;
+    ftSettings.SetItemsLimit(ftN);
+    const auto ftRead = Build<TKqlReadTableFullTextIndex>(ctx, pos)
+        .Table(mainTableMeta)
+        .Index().Build(ftIndexName)
+        .Columns(BuildKeyColumnsList(pos, ctx, TVector<TString>{pkCol, relevanceCol}))
+        .Query<TExprList>().Add(TExprBase(ftQuery)).Build()
+        .QueryColumns(BuildKeyColumnsList(pos, ctx, TVector<TString>{ftColumn}))
+        .Settings(ftSettings.BuildNode(ctx, pos))
+        .Done().Ptr();
+    const auto ftList = Build<TDqPrecompute>(ctx, pos).Input(TExprBase(ftRead)).Done().Ptr();
+
+    // ---- Vector branch: top-N {pk, score} ordered best-first (distance ASC, similarity DESC) ----
+    // Emitted as a synthetic TopSort over the vector index read; RewriteTopSortOverIndexRead
+    // (DoRewriteTopSortOverKMeansTree) lowers it into the kmeans-tree lookup chain. CanUseVectorIndex
+    // matches the function + this sort direction against the index metric (e.g. cosine accepts
+    // CosineDistance ASC or CosineSimilarity DESC).
+    const auto vecRead = Build<TKqlReadTableIndexRanges>(ctx, pos)
+        .Table(mainTableMeta)
+        .Ranges<TCoVoid>().Build()
+        .ExplainPrompt().Build()
+        .Columns(BuildKeyColumnsList(pos, ctx, TVector<TString>{pkCol, vecColumn}))
+        .Settings().Build()
+        .Index().Build(vecIndexName)
+        .Done().Ptr();
+
+    const auto vecRowArg = ctx.NewArgument(pos, "vecRow");
+    const auto distShared = ctx.ReplaceNode(TExprNode::TPtr(vecExpr), *rowArg, vecRowArg);
+    const auto vecFlatMapBody = ctx.Builder(pos)
+        .Callable("Just")
+            .Callable(0, "AsStruct")
+                .List(0)
+                    .Atom(0, pkCol)
+                    .Callable(1, "Member").Add(0, vecRowArg).Atom(1, pkCol).Seal()
+                .Seal()
+                .List(1)
+                    .Atom(0, distCol)
+                    .Add(1, distShared)
+                .Seal()
+            .Seal()
+        .Seal()
+        .Build();
+    const auto vecBranch = ctx.Builder(pos)
+        .Callable("TopSort")
+            .Callable(0, "FlatMap")
+                .Add(0, vecRead)
+                .Add(1, ctx.NewLambda(pos, ctx.NewArguments(pos, {vecRowArg}), TExprNode::TPtr(vecFlatMapBody)))
+            .Seal()
+            .Add(1, vecN)
+            .Callable(2, "Bool").Atom(0, vecIsSimilarity ? "false" : "true", TNodeFlags::Default).Seal()
+            .Lambda(3)
+                .Param("r")
+                .Callable("Member").Arg(0, "r").Atom(1, distCol).Seal()
+            .Seal()
+        .Seal()
+        .Build();
+    const auto vecList = Build<TDqPrecompute>(ctx, pos).Input(TExprBase(vecBranch)).Done().Ptr();
+
+    // ---- Fuse: per-candidate hybrid score (RRF over ranks, or min-max linear over scores) ----
+    const auto pkArg = ctx.NewArgument(pos, "pk");
+    const auto emptyStruct = ctx.MakeType<TStructExprType>(TVector<const TItemExprType*>{});
+    const auto emptyTuple = ctx.MakeType<TTupleExprType>(TTypeAnnotationNode::TListType{});
+
+    // Distinct candidate primary keys across both branches (independent of the payload dicts).
+    auto pkListOf = [&](const TExprNode::TPtr& list) {
+        return ctx.Builder(pos)
+            .Callable("Map").Add(0, list)
+                .Lambda(1).Param("r").Callable("Member").Arg(0, "r").Atom(1, pkCol).Seal().Seal()
+            .Seal().Build();
+    };
+    const auto allKeys = ctx.Builder(pos)
+        .Callable("DictKeys")
+            .Callable(0, "ToDict")
+                .Callable(0, "Extend").Add(0, pkListOf(ftList)).Add(1, pkListOf(vecList)).Seal()
+                .Lambda(1).Param("k").Arg("k").Seal()
+                .Lambda(2).Param("k").Callable("Void").Seal().Seal()
+                .List(3).Atom(0, "One", TNodeFlags::Default).Atom(1, "Hashed", TNodeFlags::Default).Seal()
+            .Seal()
+        .Seal()
+        .Build();
+
+    // Per-direction weights and (linear-only) normalization flag, passed to the fusion UDF as constants.
+    const bool normalize = normalizeOverride.GetOrElse(true);
+    const auto wFtConst = ctx.Builder(pos).Callable("Double").Atom(0, ToString(ftWeight), TNodeFlags::Default).Seal().Build();
+    const auto wVecConst = ctx.Builder(pos).Callable("Double").Atom(0, ToString(vecWeight), TNodeFlags::Default).Seal().Build();
+    const auto normConst = ctx.Builder(pos).Callable("Bool").Atom(0, normalize ? "true" : "false", TNodeFlags::Default).Seal().Build();
+    const auto vecSimConst = ctx.Builder(pos).Callable("Bool").Atom(0, vecIsSimilarity ? "true" : "false", TNodeFlags::Default).Seal().Build();
+
+    TExprNode::TPtr scoreApply;  // the hybrid score for the candidate `pkArg`
+    if (fusionMode == "linear") {
+        // A score field of an item node, cast to a (non-optional) Double.
+        auto castDouble = [&](const TExprNode::TPtr& itArg, const TString& col) {
+            return ctx.Builder(pos)
+                .Callable("Coalesce")
+                    .Callable(0, "SafeCast")
+                        .Callable(0, "Member").Add(0, itArg).Atom(1, col).Seal()
+                        .Callable(1, "DataType").Atom(0, "Double", TNodeFlags::Default).Seal()
+                    .Seal()
+                    .Callable(1, "Double").Atom(0, "0", TNodeFlags::Default).Seal()
+                .Seal().Build();
+        };
+        auto lambda1 = [&](const TExprNode::TPtr& argNode, const TExprNode::TPtr& body) {
+            return ctx.NewLambda(pos, ctx.NewArguments(pos, {argNode}), TExprNode::TPtr(body));
+        };
+        auto scoreDictOf = [&](const TExprNode::TPtr& list, const TString& col) {
+            const auto keyArg = ctx.NewArgument(pos, "it");
+            const auto payArg = ctx.NewArgument(pos, "it");
+            return ctx.Builder(pos).Callable("ToDict")
+                .Add(0, list)
+                .Add(1, lambda1(keyArg, ctx.Builder(pos).Callable("Member").Add(0, keyArg).Atom(1, pkCol).Seal().Build()))
+                .Add(2, lambda1(payArg, castDouble(payArg, col)))
+                .List(3).Atom(0, "One", TNodeFlags::Default).Atom(1, "Hashed", TNodeFlags::Default).Seal()
+                .Seal().Build();
+        };
+        // min/max of a branch's scores across the candidate set (a scalar; loop-invariant).
+        auto minMaxOf = [&](const TExprNode::TPtr& list, const TString& col, const char* op) {
+            const auto mArg = ctx.NewArgument(pos, "it");
+            const auto mapped = ctx.Builder(pos).Callable("Map").Add(0, list)
+                .Add(1, lambda1(mArg, castDouble(mArg, col)))
+                .Seal().Build();
+            return ctx.Builder(pos)
+                .Callable("Coalesce")
+                    .Callable(0, op).Add(0, mapped).Seal()
+                    .Callable(1, "Double").Atom(0, "0", TNodeFlags::Default).Seal()
+                .Seal().Build();
+        };
+        const auto ftScoreDict = scoreDictOf(ftList, relevanceCol);
+        const auto vecScoreDict = scoreDictOf(vecList, distCol);
+        const auto ftMin = minMaxOf(ftList, relevanceCol, "ListMin");
+        const auto ftMax = minMaxOf(ftList, relevanceCol, "ListMax");
+        const auto vecMin = minMaxOf(vecList, distCol, "ListMin");
+        const auto vecMax = minMaxOf(vecList, distCol, "ListMax");
+        // Missing from a branch -> the value that maps to a 0 contribution: ftMin for fulltext; for the
+        // vector branch the "worst" end, which is vecMax for a distance and vecMin for a similarity.
+        auto scoreOrDefault = [&](const TExprNode::TPtr& dict, const TExprNode::TPtr& dflt) {
+            return ctx.Builder(pos).Callable("Coalesce")
+                .Callable(0, "Lookup").Add(0, dict).Add(1, pkArg).Seal()
+                .Add(1, dflt)
+            .Seal().Build();
+        };
+        // Arg types: 8 Doubles (ftScore, ftMin, ftMax, vecScore, vecMin, vecMax, wFt, wVec) + 2 Bools
+        // (normalize, vecSimilarity).
+        TTypeAnnotationNode::TListType linArgs(8, ctx.MakeType<TDataExprType>(EDataSlot::Double));
+        linArgs.push_back(ctx.MakeType<TDataExprType>(EDataSlot::Bool));
+        linArgs.push_back(ctx.MakeType<TDataExprType>(EDataSlot::Bool));
+        const auto linUdfType = ctx.MakeType<TTupleExprType>(TTypeAnnotationNode::TListType{
+            ctx.MakeType<TTupleExprType>(linArgs),
+            emptyStruct, emptyTuple,
+        });
+        const auto linUdf = Build<TCoUdf>(ctx, pos)
+            .MethodName().Build("HybridSearch.LinearFuse")
+            .RunConfigValue<TCoVoid>().Build()
+            .UserType(ExpandType(pos, *linUdfType, ctx))
+            .Done().Ptr();
+        scoreApply = ctx.Builder(pos)
+            .Callable("Apply")
+                .Add(0, linUdf)
+                .Add(1, scoreOrDefault(ftScoreDict, ftMin))
+                .Add(2, ftMin)
+                .Add(3, ftMax)
+                .Add(4, scoreOrDefault(vecScoreDict, vecIsSimilarity ? vecMin : vecMax))
+                .Add(5, vecMin)
+                .Add(6, vecMax)
+                .Add(7, wFtConst)
+                .Add(8, wVecConst)
+                .Add(9, normConst)
+                .Add(10, vecSimConst)
+            .Seal()
+            .Build();
+    } else {
+        // RRF over 1-based ranks within each (already-sorted) branch.
+        auto buildRankDict = [&](const TExprNode::TPtr& list) {
+            return ctx.Builder(pos).Callable("ToDict")
+                .Callable(0, "Enumerate").Add(0, list)
+                    .Callable(1, "Uint64").Atom(0, "1", TNodeFlags::Default).Seal()
+                    .Callable(2, "Uint64").Atom(0, "1", TNodeFlags::Default).Seal()
+                .Seal()
+                .Lambda(1).Param("p").Callable("Member").Callable(0, "Nth").Arg(0, "p").Atom(1, 1U).Seal().Atom(1, pkCol).Seal().Seal()
+                .Lambda(2).Param("p").Callable("Nth").Arg(0, "p").Atom(1, 0U).Seal().Seal()
+                .List(3).Atom(0, "One", TNodeFlags::Default).Atom(1, "Hashed", TNodeFlags::Default).Seal()
+                .Seal().Build();
+        };
+        const auto ftDict = buildRankDict(ftList);
+        const auto vecDict = buildRankDict(vecList);
+        auto rankOrPenalty = [&](const TExprNode::TPtr& dict) {
+            return ctx.Builder(pos).Callable("Coalesce")
+                .Callable(0, "Lookup").Add(0, dict).Add(1, pkArg).Seal()
+                .Add(1, penaltyRank)
+            .Seal().Build();
+        };
+        const auto rrfUdfType = ctx.MakeType<TTupleExprType>(TTypeAnnotationNode::TListType{
+            ctx.MakeType<TTupleExprType>(TTypeAnnotationNode::TListType{
+                ctx.MakeType<TDataExprType>(EDataSlot::Uint64),
+                ctx.MakeType<TDataExprType>(EDataSlot::Uint64),
+                ctx.MakeType<TDataExprType>(EDataSlot::Double),
+                ctx.MakeType<TDataExprType>(EDataSlot::Double),
+                ctx.MakeType<TDataExprType>(EDataSlot::Double),
+            }),
+            emptyStruct, emptyTuple,
+        });
+        const auto rrfUdf = Build<TCoUdf>(ctx, pos)
+            .MethodName().Build("HybridSearch.RRF")
+            .RunConfigValue<TCoVoid>().Build()
+            .UserType(ExpandType(pos, *rrfUdfType, ctx))
+            .Done().Ptr();
+        scoreApply = ctx.Builder(pos)
+            .Callable("Apply").Add(0, rrfUdf)
+                .Add(1, rankOrPenalty(ftDict)).Add(2, rankOrPenalty(vecDict)).Add(3, kConst)
+                .Add(4, wFtConst).Add(5, wVecConst)
+            .Seal().Build();
+    }
+
+    // rrfRows: { pk, __ydb_hybrid_rrf } for each candidate (the column holds whichever fused score).
+    const auto rrfRowBody = ctx.Builder(pos)
+        .Callable("AsStruct")
+            .List(0).Atom(0, pkCol).Add(1, pkArg).Seal()
+            .List(1).Atom(0, rrfCol).Add(1, scoreApply).Seal()
+        .Seal()
+        .Build();
+    const auto rrfRows = ctx.Builder(pos)
+        .Callable("Map")
+            .Add(0, allKeys)
+            .Add(1, ctx.NewLambda(pos, ctx.NewArguments(pos, {pkArg}), TExprNode::TPtr(rrfRowBody)))
+        .Seal()
+        .Build();
+
+    // ---- Look up the main table by the fused candidate keys ----
+    const auto lookupKeys = ctx.Builder(pos)
+        .Callable("Map")
+            .Add(0, rrfRows)
+            .Lambda(1)
+                .Param("r")
+                .Callable("AsStruct")
+                    .List(0).Atom(0, pkCol).Callable(1, "Member").Arg(0, "r").Atom(1, pkCol).Seal().Seal()
+                .Seal()
+            .Seal()
+        .Seal()
+        .Build();
+
+    const auto mainColumns = MergeColumns(read.Columns(), TVector<TString>{pkCol}, ctx);
+
+    TKqpStreamLookupSettings lookupSettings;
+    lookupSettings.Strategy = EStreamLookupStrategyType::LookupRows;
+    const auto mainRows = Build<TKqlStreamLookupTable>(ctx, pos)
+        .Table(mainTableMeta)
+        .LookupKeys(TExprBase(lookupKeys))
+        .Columns(mainColumns)
+        .Settings(lookupSettings.BuildNode(ctx, pos))
+        .Done().Ptr();
+
+    // ---- Re-apply WHERE, attach RRF, re-rank by RRF DESC, take LIMIT, project ----
+    const auto rrfDict = ctx.Builder(pos)
+        .Callable("ToDict")
+            .Add(0, rrfRows)
+            .Lambda(1).Param("r").Callable("Member").Arg(0, "r").Atom(1, pkCol).Seal().Seal()
+            .Lambda(2).Param("r").Callable("Member").Arg(0, "r").Atom(1, rrfCol).Seal().Seal()
+            .List(3).Atom(0, "One", TNodeFlags::Default).Atom(1, "Hashed", TNodeFlags::Default).Seal()
+        .Seal()
+        .Build();
+
+    const auto mrowArg = ctx.NewArgument(pos, "mrow");
+    const auto predOverMrow = origPred
+        ? ctx.ReplaceNode(TExprNode::TPtr(origPred), *origArg, mrowArg)
+        : ctx.Builder(pos).Callable("Bool").Atom(0, "true", TNodeFlags::Default).Seal().Build();
+    const auto rrfForMrow = ctx.Builder(pos)
+        .Callable("Coalesce")
+            .Callable(0, "Lookup")
+                .Add(0, rrfDict)
+                .Callable(1, "Member").Add(0, mrowArg).Atom(1, pkCol).Seal()
+            .Seal()
+            .Callable(1, "Double").Atom(0, "0", TNodeFlags::Default).Seal()
+        .Seal()
+        .Build();
+    const auto augBody = ctx.Builder(pos)
+        .Callable("OptionalIf")
+            .Add(0, predOverMrow)
+            .Callable(1, "AddMember")
+                .Add(0, mrowArg)
+                .Atom(1, rrfCol)
+                .Add(2, rrfForMrow)
+            .Seal()
+        .Seal()
+        .Build();
+    const auto augmented = ctx.Builder(pos)
+        .Callable("FlatMap")
+            .Add(0, mainRows)
+            .Add(1, ctx.NewLambda(pos, ctx.NewArguments(pos, {mrowArg}), TExprNode::TPtr(augBody)))
+        .Seal()
+        .Build();
+
+    const auto frArg = ctx.NewArgument(pos, "fr");
+    TExprNode::TPtr projOverFr;
+    if (origProj) {
+        projOverFr = ctx.ReplaceNode(TExprNode::TPtr(origProj), *origArg, frArg);
+    } else {
+        // No explicit projection: emit the read's columns (dropping the synthetic RRF field).
+        TExprNode::TListType members;
+        for (const auto& col : read.Columns()) {
+            members.push_back(ctx.Builder(pos)
+                .List()
+                    .Atom(0, col.Value())
+                    .Callable(1, "Member").Add(0, frArg).Atom(1, col.Value()).Seal()
+                .Seal()
+                .Build());
+        }
+        projOverFr = ctx.NewCallable(pos, "AsStruct", std::move(members));
+    }
+    const auto result = ctx.Builder(pos)
+        .Callable("Map")
+            .Callable(0, "TopSort")
+                .Add(0, augmented)
+                .Add(1, top.Count().Ptr())
+                .Callable(2, "Bool").Atom(0, "false", TNodeFlags::Default).Seal()
+                .Lambda(3).Param("r").Callable("Member").Arg(0, "r").Atom(1, rrfCol).Seal().Seal()
+            .Seal()
+            .Add(1, ctx.NewLambda(pos, ctx.NewArguments(pos, {frArg}), TExprNode::TPtr(projOverFr)))
+        .Seal()
+        .Build();
+
+    return TExprBase(result);
+}
+
 // The index and main table have same number of rows, so we can push a copy of TCoTopSort or TCoTake
 // through TKqlLookupTable.
 // The simplest way is to match TopSort or Take over TKqlReadTableIndex.

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_rules.h
@@ -73,6 +73,9 @@ NYql::NNodes::TMaybeNode<NYql::NNodes::TExprBase> KqpRewriteFlatMapOverJsonRead(
 
 NYql::NNodes::TExprBase KqpRewriteTopSortOverFlatMap(const NYql::NNodes::TExprBase& node, NYql::TExprContext& ctx);
 
+NYql::NNodes::TMaybeNode<NYql::NNodes::TExprBase> KqpRewriteHybridRankTopSort(const NYql::NNodes::TExprBase& node,
+    NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx);
+
 NYql::NNodes::TExprBase KqpRewriteTakeOverIndexRead(const NYql::NNodes::TExprBase& node, NYql::TExprContext&,
     const TKqpOptimizeContext& kqpCtx, const NYql::TParentsMap& parentsMap);
 

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -143,6 +143,8 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, MaxSequentialReadsInFlight);
 
     REGISTER_SETTING(*this, KMeansTreeSearchTopSize);
+    REGISTER_SETTING(*this, HybridSearchFactor);
+    REGISTER_SETTING(*this, HybridSearchK);
     REGISTER_SETTING(*this, DisableCheckpoints);
 
     REGISTER_SETTING(*this, DefaultTxMode).Parser(

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -111,6 +111,8 @@ public:
     NCommon::TConfSetting<ui32, Static> MaxSequentialReadsInFlight;
 
     NCommon::TConfSetting<ui32, Static> KMeansTreeSearchTopSize;
+    NCommon::TConfSetting<ui64, Static> HybridSearchFactor;
+    NCommon::TConfSetting<double, Static> HybridSearchK;
     NCommon::TConfSetting<bool, Static> DisableCheckpoints;
 
     NCommon::TConfSetting<NKqpProto::EIsolationLevel, Static> DefaultTxMode;

--- a/ydb/core/kqp/ut/indexes/hybrid/kqp_hybrid_search_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/hybrid/kqp_hybrid_search_ut.cpp
@@ -1,0 +1,515 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
+
+#include <library/cpp/json/json_reader.h>
+
+namespace NKikimr::NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NQuery;
+
+namespace {
+
+TKikimrRunner MakeRunner() {
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableFulltextIndex(true);
+    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    return TKikimrRunner(settings);
+}
+
+void ExecOk(TQueryClient& db, const TString& sql) {
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+}
+
+// 2D uint8 vectors packed into the Knn binary format. Target is [250,10]; distances to target rank:
+//   Doc2 (exact) < Doc1 (near) < Doc4 (mid) < Doc3 (opposite).
+// Fulltext "cats" matches only Doc1 ("cats" x3) and Doc3 ("cats" x1); Doc2/Doc4 are absent from the
+// fulltext branch and so get the penalty rank there. The fusion therefore puts the text-relevant docs
+// {1,3} above the text-irrelevant {2,4} — even though Doc2 is the nearest vector match — which is the
+// whole point. (The order *within* each group depends on the approximate k-means ranking and is not
+// asserted; see FusesBothBranches.)
+const char* Vec(int idx) {
+    switch (idx) {
+        case 1: return "[240, 15]";
+        case 2: return "[250, 10]";
+        case 3: return "[10, 250]";
+        case 4: return "[200, 60]";
+    }
+    return "[0, 0]";
+}
+
+TString Emb(int idx) {
+    return Sprintf(R"(Untag(Knn::ToBinaryStringUint8(Cast(%s AS List<Uint8>)), "Uint8Vector"))", Vec(idx));
+}
+
+void CreateDocs(TQueryClient& db) {
+    ExecOk(db, R"sql(
+        CREATE TABLE `/Root/Docs` (
+            Key Uint64,
+            Text Utf8,
+            Embedding String,
+            Category Utf8,
+            PRIMARY KEY (Key)
+        );
+    )sql");
+}
+
+void UpsertDocs(TQueryClient& db) {
+    ExecOk(db, Sprintf(R"sql(
+        UPSERT INTO `/Root/Docs` (Key, Text, Embedding, Category) VALUES
+            (1u, "cats cats cats love", %s, "a"),
+            (2u, "dogs and foxes run",  %s, "a"),
+            (3u, "cats sleep",          %s, "b"),
+            (4u, "birds fly high",      %s, "b");
+    )sql", Emb(1).c_str(), Emb(2).c_str(), Emb(3).c_str(), Emb(4).c_str()));
+}
+
+void AddFulltextIndex(TQueryClient& db, const TString& table = "/Root/Docs", const TString& name = "ft_idx") {
+    ExecOk(db, Sprintf(R"sql(
+        ALTER TABLE `%s` ADD INDEX %s
+            GLOBAL USING fulltext_relevance
+            ON (Text)
+            WITH (tokenizer=standard, use_filter_lowercase=true);
+    )sql", table.c_str(), name.c_str()));
+}
+
+void AddVectorIndex(TQueryClient& db, const TString& table = "/Root/Docs", const TString& name = "vec_idx") {
+    ExecOk(db, Sprintf(R"sql(
+        ALTER TABLE `%s` ADD INDEX %s
+            GLOBAL USING vector_kmeans_tree
+            ON (Embedding)
+            WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+    )sql", table.c_str(), name.c_str()));
+}
+
+// A prefixed vector index (a prefix column before the vector column). HybridRank does not support these
+// yet (the kmeans-tree lowering needs an OptionalIf prefix predicate the rewrite doesn't build).
+void AddPrefixedVectorIndex(TQueryClient& db, const TString& table = "/Root/Docs", const TString& name = "vp_idx") {
+    ExecOk(db, Sprintf(R"sql(
+        ALTER TABLE `%s` ADD INDEX %s
+            GLOBAL USING vector_kmeans_tree
+            ON (Category, Embedding)
+            WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+    )sql", table.c_str(), name.c_str()));
+}
+
+// The standard fixture used by most tests: 4 docs with a fulltext and a (non-prefixed) vector index.
+void SetupDocs(TQueryClient& db) {
+    CreateDocs(db);
+    UpsertDocs(db);
+    AddFulltextIndex(db);
+    AddVectorIndex(db);
+}
+
+const TString TargetDecl = R"sql(
+    $target = Untag(Knn::ToBinaryStringUint8(Cast([250, 10] AS List<Uint8>)), "Uint8Vector");
+)sql";
+
+std::vector<ui64> RunKeys(TQueryClient& db, const TString& sql) {
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    std::vector<ui64> keys;
+    TResultSetParser parser(result.GetResultSet(0));
+    while (parser.TryNextRow()) {
+        keys.push_back(*parser.ColumnParser("Key").GetOptionalUint64());
+    }
+    return keys;
+}
+
+TString RunFailIssues(TQueryClient& db, const TString& sql) {
+    auto result = db.ExecuteQuery(sql, TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_C(result.GetStatus() != EStatus::SUCCESS, "expected the query to fail, but it succeeded");
+    return result.GetIssues().ToString();
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(KqpHybridSearch) {
+
+    // Core RRF behaviour. Docs 1 and 3 contain "cats" => present in BOTH the fulltext and vector result
+    // sets; docs 2 and 4 have no text match => present in the vector set only (penalised in fulltext) —
+    // and doc 2 is even the exact (nearest) vector match. RRF must still rank the in-both docs {1,3}
+    // above the in-one docs {2,4}: fusing the fulltext signal is the whole point. (The order within each
+    // group depends on the approximate k-means ranking, which is rebuilt non-deterministically per test
+    // instance, so only the group membership is asserted — never a fixed permutation.)
+    Y_UNIT_TEST(FusesBothBranches) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto keys = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_VALUES_EQUAL(keys.size(), 4u);
+        UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "the fused result is the union of both branches");
+        UNIT_ASSERT_C((std::set<ui64>{keys[0], keys[1]} == std::set<ui64>{1u, 3u}),
+            "docs present in both branches must take the top positions");
+        UNIT_ASSERT_C((std::set<ui64>{keys[2], keys[3]} == std::set<ui64>{2u, 4u}),
+            "docs present in only one branch must rank below the in-both docs");
+    }
+
+    // Alternative fusion: weighted linear combination of scores instead of RRF, with and without min-max
+    // normalization. A text-relevant doc must still lead under the (default) normalized variant.
+    Y_UNIT_TEST(LinearModeFuses) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto normalized = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                "linear" AS Mode)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_C((std::set<ui64>(normalized.begin(), normalized.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "normalized linear fusion returns the union of both branches");
+        UNIT_ASSERT_C(normalized[0] == 1u || normalized[0] == 3u,
+            "a text-relevant doc must lead under linear fusion too");
+
+        // Without normalization the raw scores are fused (the magnitudes are not comparable, but the path
+        // must still run and produce the candidate union).
+        auto raw = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                "linear" AS Mode, (0.2, 0.8) AS Weights, false AS Normalize)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_C((std::set<ui64>(raw.begin(), raw.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "raw (non-normalized) linear fusion with weights must run and fuse both branches");
+    }
+
+    // The vector signal may be a similarity (larger = better) instead of a distance: the branch is sorted
+    // descending and fusion normalizes accordingly. Over a cosine index, CosineSimilarity ranks the same
+    // way as CosineDistance, so the fused result matches.
+    Y_UNIT_TEST(SimilarityFunctionFuses) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        for (const TString& mode : {TString("rrf"), TString("linear")}) {
+            auto keys = RunKeys(db, TargetDecl + Sprintf(R"sql(
+                SELECT Key FROM `/Root/Docs`
+                ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineSimilarity(Embedding, $target),
+                    "%s" AS Mode)
+                LIMIT 4;
+            )sql", mode.c_str()));
+            UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+                TStringBuilder() << "CosineSimilarity (" << mode << ") must fuse both branches");
+            UNIT_ASSERT_C(keys[0] == 1u || keys[0] == 3u,
+                TStringBuilder() << "a text-relevant doc must lead with CosineSimilarity (" << mode << ")");
+        }
+    }
+
+    // Weights take effect: a zero vector weight reduces the score to the fulltext term alone (1/(k+ftRank)
+    // for RRF, normFt for linear), so ranking follows the fulltext signal and the highest-BM25 doc 1 leads
+    // deterministically — in both modes.
+    Y_UNIT_TEST(WeightsBiasRanking) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto rrf = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                (1, 0) AS Weights)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_VALUES_EQUAL_C(rrf[0], 1u, "RRF, vec weight 0 => ranked by fulltext => doc 1 (max BM25) leads");
+        UNIT_ASSERT_C((std::set<ui64>{rrf[0], rrf[1]} == std::set<ui64>{1u, 3u}),
+            "the two fulltext-matching docs still take the top positions");
+
+        auto linear = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                "Linear" AS Mode, (1, 0) AS Weights)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_VALUES_EQUAL_C(linear[0], 1u, "linear, vec weight 0 => ranked by normFt => doc 1 (max BM25) leads");
+    }
+
+    // The spec writes Mode as "RRF"/"Linear"; the parser must accept that casing (not only lowercase).
+    Y_UNIT_TEST(ModeAcceptsCanonicalCasing) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        for (const TString& mode : {TString("RRF"), TString("Linear")}) {
+            auto keys = RunKeys(db, TargetDecl + Sprintf(R"sql(
+                SELECT Key FROM `/Root/Docs`
+                ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                    "%s" AS Mode)
+                LIMIT 4;
+            )sql", mode.c_str()));
+            UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+                TStringBuilder() << "capitalized Mode \"" << mode << "\" must be accepted and fuse both branches");
+        }
+    }
+
+    Y_UNIT_TEST(PlanShowsHybridSearch) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto explainSettings = TExecuteQuerySettings().ExecMode(EExecMode::Explain);
+        auto result = db.ExecuteQuery(TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 4;
+        )sql", TTxControl::NoTx(), explainSettings).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT(result.GetStats());
+        auto planOpt = result.GetStats()->GetPlan();
+        UNIT_ASSERT(planOpt.has_value());
+
+        NJson::TJsonValue plan;
+        NJson::ReadJsonTree(*planOpt, &plan, true);
+        auto hybrid = FindPlanNodeByKv(plan, "Name", "HybridSearch");
+        UNIT_ASSERT_C(hybrid.IsDefined(), TStringBuilder() << "HybridSearch operator not found in plan:\n" << *planOpt);
+    }
+
+    // LIMIT smaller than the candidate set: only the top fused docs are returned.
+    Y_UNIT_TEST(RespectsLimit) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto keys = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 2;
+        )sql");
+        UNIT_ASSERT_VALUES_EQUAL_C(keys.size(), 2u, "LIMIT 2 must cap the fused result at two rows");
+        // The top two are exactly the in-both docs {1,3} (their internal order is vector-rank dependent
+        // and so non-deterministic — see FusesBothBranches); the point here is that LIMIT keeps the
+        // top-scoring pair and drops the in-one docs {2,4}.
+        UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 3u}),
+            "LIMIT 2 must return the two top-scoring (in-both) docs");
+    }
+
+    // WHERE on a main-table column is re-applied after the fused lookup.
+    Y_UNIT_TEST(AppliesWherePredicate) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto keys = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            WHERE Category = "a"
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 10;
+        )sql");
+        // Only docs 1 and 2 are category "a"; the WHERE is re-applied after the fused lookup.
+        UNIT_ASSERT_C(!keys.empty(), "expected at least one category-a doc in the fused result");
+        for (ui64 k : keys) {
+            UNIT_ASSERT_C(k == 1u || k == 2u,
+                TStringBuilder() << "WHERE must filter out category-b docs, but got key " << k);
+        }
+    }
+
+    // A non-indexed column (Text) must be fetched via the main-table lookup.
+    Y_UNIT_TEST(ProjectsNonKeyColumn) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto result = db.ExecuteQuery(TargetDecl + R"sql(
+            SELECT Key, Text FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 1;
+        )sql", TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        const THashMap<ui64, TString> textByKey = {
+            {1u, "cats cats cats love"}, {2u, "dogs and foxes run"},
+            {3u, "cats sleep"}, {4u, "birds fly high"},
+        };
+        TResultSetParser parser(result.GetResultSet(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        const ui64 key = *parser.ColumnParser("Key").GetOptionalUint64();
+        const TString text{*parser.ColumnParser("Text").GetOptionalUtf8()};
+        UNIT_ASSERT_C(textByKey.contains(key), TStringBuilder() << "unexpected key " << key);
+        // The non-indexed Text column must be fetched correctly via the main-table lookup.
+        UNIT_ASSERT_VALUES_EQUAL(text, textByKey.at(key));
+    }
+
+    Y_UNIT_TEST(NamedIndexesOverride) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto keys = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(
+                FullTextScore(Text, "cats"),
+                Knn::CosineDistance(Embedding, $target),
+                ("ft_idx", "vec_idx") AS Indexes,
+                (100, 200) AS Limits,
+                60.0 AS K)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "explicit indexes produce the same fused union");
+        UNIT_ASSERT_C(keys[0] == 1u || keys[0] == 3u, "a text-relevant doc must rank first");
+    }
+
+    Y_UNIT_TEST(NamedIndexesDisambiguate) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        CreateDocs(db);
+        UpsertDocs(db);
+        AddFulltextIndex(db, "/Root/Docs", "ft_idx");
+        AddFulltextIndex(db, "/Root/Docs", "ft_idx2");  // second fulltext index on the same column
+        AddVectorIndex(db);
+
+        // Auto-detect is ambiguous now (two fulltext indexes match column Text).
+        auto issues = RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_STRING_CONTAINS(issues, "multiple fulltext relevance indexes");
+
+        // An explicit AS Indexes override resolves the ambiguity.
+        auto keys = RunKeys(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                ("ft_idx2", "vec_idx") AS Indexes)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "the explicit index disambiguates and produces the fused result");
+    }
+
+    // Malformed HybridRank usages that share the standard fixture must each fail with a clear message.
+    Y_UNIT_TEST(RejectsMalformedQueries) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        // Arguments in the wrong order (vector first, fulltext second).
+        UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(Knn::CosineDistance(Embedding, $target), FullTextScore(Text, "cats"))
+            LIMIT 3;
+        )sql"), "reversed");
+
+        // HybridRank nested inside a larger sort expression (would silently change the ordering).
+        UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY -HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 4;
+        )sql"), "must be the entire ORDER BY key");
+
+        // Weights tuple of the wrong arity.
+        UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                (1, 2, 3) AS Weights)
+            LIMIT 4;
+        )sql"), "Weights must be a tuple of two");
+
+        // An explicit index name that does not exist.
+        UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                ("does_not_exist", "vec_idx") AS Indexes)
+            LIMIT 4;
+        )sql"), "fulltext index 'does_not_exist' was not found");
+
+        // A parameterised (non-literal) LIMIT cannot size the branch candidate pools.
+        auto params = TParamsBuilder().AddParam("$lim").Uint64(3).Build().Build();
+        auto limitResult = db.ExecuteQuery("DECLARE $lim AS Uint64;\n" + TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT $lim;
+        )sql", TTxControl::NoTx(), params).ExtractValueSync();
+        UNIT_ASSERT_C(limitResult.GetStatus() != EStatus::SUCCESS, "expected failure for a parameterised LIMIT");
+        UNIT_ASSERT_STRING_CONTAINS(limitResult.GetIssues().ToString(), "requires a literal LIMIT");
+    }
+
+    // HybridRank needs both a fulltext relevance index and a vector index; missing either is an error.
+    Y_UNIT_TEST(RejectsWhenIndexMissing) {
+        const TString query = TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 3;
+        )sql";
+        {   // vector index only -> no fulltext relevance index
+            auto kikimr = MakeRunner();
+            auto db = kikimr.GetQueryClient();
+            CreateDocs(db);
+            UpsertDocs(db);
+            AddVectorIndex(db);
+            UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, query), "no ready fulltext relevance index");
+        }
+        {   // fulltext index only -> no vector index
+            auto kikimr = MakeRunner();
+            auto db = kikimr.GetQueryClient();
+            CreateDocs(db);
+            UpsertDocs(db);
+            AddFulltextIndex(db);
+            UNIT_ASSERT_STRING_CONTAINS(RunFailIssues(db, query), "no ready vector");
+        }
+    }
+
+    // Prefixed vector indexes are not supported yet: auto-detect skips them; an explicit reference errors.
+    Y_UNIT_TEST(ErrorWhenPrefixedVectorIndex) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        CreateDocs(db);
+        UpsertDocs(db);
+        AddFulltextIndex(db);
+        AddPrefixedVectorIndex(db);  // only a prefixed vector index exists
+
+        // Auto-detect filters out the prefixed index, so no usable vector index is found.
+        auto issues = RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target))
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_STRING_CONTAINS(issues, "no ready vector");
+
+        // Naming it explicitly reports the unsupported shape precisely.
+        auto issues2 = RunFailIssues(db, TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                ("ft_idx", "vp_idx") AS Indexes)
+            LIMIT 4;
+        )sql");
+        UNIT_ASSERT_STRING_CONTAINS(issues2, "prefixed vector index");
+    }
+
+    // An explicit Limits override is the escape hatch: it lets a parameterised LIMIT work.
+    Y_UNIT_TEST(ParameterizedLimitWithExplicitLimits) {
+        auto kikimr = MakeRunner();
+        auto db = kikimr.GetQueryClient();
+        SetupDocs(db);
+
+        auto params = TParamsBuilder().AddParam("$lim").Uint64(4).Build().Build();
+        auto result = db.ExecuteQuery("DECLARE $lim AS Uint64;\n" + TargetDecl + R"sql(
+            SELECT Key FROM `/Root/Docs`
+            ORDER BY HybridRank(FullTextScore(Text, "cats"), Knn::CosineDistance(Embedding, $target),
+                (100, 200) AS Limits)
+            LIMIT $lim;
+        )sql", TTxControl::NoTx(), params).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        std::vector<ui64> keys;
+        TResultSetParser parser(result.GetResultSet(0));
+        while (parser.TryNextRow()) {
+            keys.push_back(*parser.ColumnParser("Key").GetOptionalUint64());
+        }
+        UNIT_ASSERT_C((std::set<ui64>(keys.begin(), keys.end()) == std::set<ui64>{1u, 2u, 3u, 4u}),
+            "explicit Limits allow a parameterised LIMIT and still fuse both branches");
+    }
+
+    // Note: the composite-primary-key guard in the optimizer is defensive only. A fulltext-relevance
+    // index cannot be created on a composite-PK table at all, so a hybrid query never reaches it
+    // (auto-detect fails to find a fulltext index first); there is no valid setup to exercise it here.
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/indexes/hybrid/ya.make
+++ b/ydb/core/kqp/ut/indexes/hybrid/ya.make
@@ -1,15 +1,12 @@
 UNITTEST_FOR(ydb/core/kqp)
 
 FORK_SUBTESTS()
-SPLIT_FACTOR(50)
 
 REQUIREMENTS(cpu:2)
 SIZE(MEDIUM)
 
 SRCS(
-    kqp_indexes_multishard_ut.cpp
-    kqp_indexes_ut.cpp
-    kqp_stream_indexes_ut.cpp
+    kqp_hybrid_search_ut.cpp
 )
 
 PEERDIR(
@@ -18,6 +15,7 @@ PEERDIR(
     ydb/core/kqp/ut/common
     ydb/library/yql/providers/common/http_gateway
     ydb/library/yql/udfs/common/knn
+    ydb/library/yql/udfs/common/hybrid_search
     yql/essentials/sql/pg_dummy
     ydb/public/sdk/cpp/adapters/issue
 )
@@ -25,11 +23,3 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 END()
-
-RECURSE_FOR_TESTS(
-    fulltext
-    hybrid
-    json
-    prefixed_vector
-    vector
-)

--- a/ydb/library/yql/udfs/common/hybrid_search/hybrid_search.cpp
+++ b/ydb/library/yql/udfs/common/hybrid_search/hybrid_search.cpp
@@ -1,0 +1,74 @@
+#include <yql/essentials/public/udf/udf_helpers.h>
+
+using namespace NYql;
+using namespace NYql::NUdf;
+
+// HybridSearch::RRF(ftRank: Uint64, vecRank: Uint64, k, wFt, wVec: Double) -> Double
+//
+// Reciprocal Rank Fusion score contributed by a single document:
+//     wFt / (k + ftRank) + wVec / (k + vecRank)
+//
+// Ranks are 1-based positions inside each per-index result set. A document that is
+// absent from one result set is passed the penalty rank (N_internal + 1) by the KQP
+// optimizer (RewriteHybridRankTopSort) before this UDF is called, so both rank
+// arguments are always concrete (the optimizer Coalesces them ahead of the call).
+// wFt/wVec are the per-direction weights (default 1.0 each); since a missing branch
+// already gets the penalty rank, its ~0 contribution is unaffected by its weight.
+SIMPLE_STRICT_UDF(TRRF, double(ui64, ui64, double, double, double)) {
+    Y_UNUSED(valueBuilder);
+    const ui64 ftRank = args[0].Get<ui64>();
+    const ui64 vecRank = args[1].Get<ui64>();
+    const double k = args[2].Get<double>();
+    const double wFt = args[3].Get<double>();
+    const double wVec = args[4].Get<double>();
+    const double score = wFt / (k + static_cast<double>(ftRank))
+                       + wVec / (k + static_cast<double>(vecRank));
+    return TUnboxedValuePod(score);
+}
+
+// HybridSearch::LinearFuse(ftScore, ftMin, ftMax, vecScore, vecMin, vecMax, wFt, wVec: Double,
+//                          normalize, vecSimilarity: Bool) -> Double
+//
+// Weighted linear fusion (the 'linear' alternative to RRF): wFt*normFt + wVec*normVec, where both branches
+// are mapped to "higher = better".
+//   vecSimilarity tells whether the vector score is a similarity (larger = better, e.g. CosineSimilarity)
+//     or a distance (smaller = better, e.g. CosineDistance).
+//   normalize = true  (default): each branch score is min-max scaled to [0,1] over the observed candidate
+//     min/max; a distance is additionally inverted (1 - scaled) so smaller distances score higher. When a
+//     branch's max == min (no spread) that branch contributes 0 rather than dividing by zero.
+//   normalize = false: raw scores. normFt = ftScore as-is; normVec = vecScore for a similarity, -vecScore
+//     for a distance (negated so a larger fused score still means "better"). Raw fulltext and vector
+//     magnitudes are not comparable, which is exactly why normalization is the default.
+// The optimizer passes a document absent from a branch the branch min/max that maps to a 0 contribution
+// (fulltext min; vector max for a distance / min for a similarity).
+SIMPLE_STRICT_UDF(TLinearFuse, double(double, double, double, double, double, double, double, double, bool, bool)) {
+    Y_UNUSED(valueBuilder);
+    const double ftScore       = args[0].Get<double>();
+    const double ftMin         = args[1].Get<double>();
+    const double ftMax         = args[2].Get<double>();
+    const double vecScore      = args[3].Get<double>();
+    const double vecMin        = args[4].Get<double>();
+    const double vecMax        = args[5].Get<double>();
+    const double wFt           = args[6].Get<double>();
+    const double wVec          = args[7].Get<double>();
+    const bool   normalize     = args[8].Get<bool>();
+    const bool   vecSimilarity = args[9].Get<bool>();
+    double normFt, normVec;
+    if (normalize) {
+        normFt = (ftMax > ftMin) ? (ftScore - ftMin) / (ftMax - ftMin) : 0.0;
+        const double vecSpan = vecMax - vecMin;
+        normVec = (vecSpan <= 0.0) ? 0.0
+                : vecSimilarity    ? (vecScore - vecMin) / vecSpan          // larger similarity = better
+                                   : 1.0 - (vecScore - vecMin) / vecSpan;    // smaller distance = better
+    } else {
+        normFt  = ftScore;
+        normVec = vecSimilarity ? vecScore : -vecScore;
+    }
+    return TUnboxedValuePod(wFt * normFt + wVec * normVec);
+}
+
+SIMPLE_MODULE(THybridSearchModule,
+              TRRF,
+              TLinearFuse)
+
+REGISTER_MODULES(THybridSearchModule)

--- a/ydb/library/yql/udfs/common/hybrid_search/ya.make
+++ b/ydb/library/yql/udfs/common/hybrid_search/ya.make
@@ -1,0 +1,13 @@
+YQL_UDF_YDB(hybrid_search_udf)
+
+YQL_ABI_VERSION(
+    2
+    35
+    0
+)
+
+SRCS(
+    hybrid_search.cpp
+)
+
+END()

--- a/yql/essentials/core/peephole_opt/yql_opt_peephole_physical.cpp
+++ b/yql/essentials/core/peephole_opt/yql_opt_peephole_physical.cpp
@@ -8859,6 +8859,25 @@ TExprNode::TPtr ExpandFulltextBuiltin(const TExprNode::TPtr& node, TExprContext&
         .Build();
 }
 
+TExprNode::TPtr ExpandHybridRankBuiltin(const TExprNode::TPtr& node, TExprContext& ctx) {
+    // Reaching peephole means the KQP optimizer did not rewrite HybridRank into the RRF merge stage.
+    // Fail with a clear error instead of silently returning a wrong (unranked) result.
+    TString error = "HybridRank could not be rewritten: it requires a fulltext index and a vector index "
+        "on the table (named via the Indexes argument) matching the FullTextScore and Knn distance columns";
+    auto nullNode = ctx.NewCallable(node->Pos(), "Nothing", {
+        ctx.NewCallable(node->Pos(), "OptionalType", {
+            ctx.NewCallable(node->Pos(), "DataType", {ctx.NewAtom(node->Pos(), "Double", TNodeFlags::Default) }) }) });
+
+    auto message = ctx.Builder(node->Pos()).Callable("String").Atom(0, error).Seal().Build();
+
+    return ctx.Builder(node->Pos())
+        .Callable("Unwrap")
+            .Add(0, nullNode)
+            .Add(1, message)
+        .Seal()
+        .Build();
+}
+
 template <bool Equals, bool IsDistinct>
 TExprNode::TPtr ExpandSqlEqual(const TExprNode::TPtr& node, TExprContext& ctx) {
     const auto lType = node->Head().GetTypeAnn();
@@ -9370,6 +9389,7 @@ struct TPeepHoleRules {
         {"ToFlow", &DropToFlowDeps},
         {"FulltextScore", &ExpandFulltextBuiltin<true>},
         {"FulltextMatch", &ExpandFulltextBuiltin<false>},
+        {"HybridRank", &ExpandHybridRankBuiltin},
         {"CheckedAdd", &ExpandCheckedAdd},
         {"CheckedSub", &ExpandCheckedSub},
         {"CheckedMul", &ExpandCheckedMul},

--- a/yql/essentials/core/type_ann/type_ann_core.cpp
+++ b/yql/essentials/core/type_ann/type_ann_core.cpp
@@ -3941,6 +3941,43 @@ namespace NTypeAnnImpl {
         return IGraphTransformer::TStatus::Ok;
     }
 
+    IGraphTransformer::TStatus HybridRankBuiltinWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx) {
+        YQL_ENSURE(output);
+
+        // HybridRank(ft_score, vec_distance [, ("ft_idx","vec_idx") AS Indexes] [, (n, m) AS Limits] [, k AS K])
+        // It is a pure marker consumed by the KQP optimizer (RewriteHybridRankTopSort). Here we only validate
+        // the two positional arguments and assign the Double result type; the named arguments (index names,
+        // per-branch limits, RRF constant) are cross-checked against the table metadata in the optimizer.
+        if (!EnsureMinArgsCount(*input, 2, ctx.Expr)) {
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        TExprNode::TPtr positionalArguments = input;
+        if (input->Head().GetTypeAnn() && input->Head().GetTypeAnn()->GetKind() == ETypeAnnotationKind::Tuple) {
+            if (!EnsureArgsCount(*input, 2, ctx.Expr)) {
+                return IGraphTransformer::TStatus::Error;
+            }
+
+            positionalArguments = input->ChildPtr(0);
+        }
+
+        if (positionalArguments->ChildrenSize() != 2) {
+            ctx.Expr.AddError(TIssue(ctx.Expr.GetPosition(positionalArguments->Pos()), TStringBuilder() <<
+                "HybridRank expects exactly 2 positional arguments (fulltext score and vector distance), but got " <<
+                positionalArguments->ChildrenSize()));
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        for (ui32 i = 0; i < positionalArguments->ChildrenSize(); ++i) {
+            if (!EnsureComputable(*positionalArguments->Child(i), ctx.Expr)) {
+                return IGraphTransformer::TStatus::Error;
+            }
+        }
+
+        input->SetTypeAnn(ctx.Expr.MakeType<TDataExprType>(EDataSlot::Double));
+        return IGraphTransformer::TStatus::Ok;
+    }
+
     IGraphTransformer::TStatus SqlConcatWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx) {
         if (!IsBackwardCompatibleFeatureAvailable(ctx.Types.LangVer, MakeLangVersion(2025, 04), ctx.Types.BackportMode)) {
             ctx.Expr.AddError(TIssue(ctx.Expr.GetPosition(input->Pos()), "Concat function is not available before version 2025.04"));
@@ -15857,6 +15894,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["AggrConcat"] = &AggrConcatWrapper;
         ExtFunctions["FulltextMatch"] = &FullTextBuiltinWrapper<false>;
         ExtFunctions["FulltextScore"] = &FullTextBuiltinWrapper<true>;
+        ExtFunctions["HybridRank"] = &HybridRankBuiltinWrapper;
         ExtFunctions["SqlConcat"] = &SqlConcatWrapper;
         ExtFunctions["Substring"] = &SubstringWrapper;
         ExtFunctions["Find"] = &FindWrapper;

--- a/yql/essentials/sql/v1/builtin.cpp
+++ b/yql/essentials/sql/v1/builtin.cpp
@@ -4247,6 +4247,11 @@ TNodeResult BuildBuiltinFunc(
             }
             auto fulltextBuiltinName = normalizedName == "fulltextmatch" ? "FulltextMatch" : "FulltextScore";
             return TNonNull(TNodePtr(new TCallNodeImpl(pos, fulltextBuiltinName, args)));
+        } else if (normalizedName == "hybridrank") {
+            if (mustUseNamed && *mustUseNamed) {
+                *mustUseNamed = false;
+            }
+            return TNonNull(TNodePtr(new TCallNodeImpl(pos, "HybridRank", args)));
         } else if (normalizedName == "asstruct" || normalizedName == "structtype") {
             if (args.empty()) {
                 return TNonNull(TNodePtr(new TCallNodeImpl(pos, normalizedName == "asstruct" ? "AsStruct" : "StructType", 0, 0, args)));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds a `HybridRank` construct for `ORDER BY` that fuses a fulltext-relevance index
and a vector (kmeans-tree) index into a single ranking — turning a hybrid query into
one statement instead of manual `UNION ALL` + `GROUP BY` + `JOIN`:

```sql
SELECT id, body FROM documents
WHERE category = 'engineering'
ORDER BY HybridRank(
    FullTextScore(body, $q),
    Knn::CosineDistance(embedding, $v))
LIMIT 10;
```

Capabilities:
* Fusion modes (`AS Mode`, case-insensitive): `"RRF"` (default, Reciprocal Rank Fusion) and `"Linear"` (min-max normalized score combination).
* Params: `K` (RRF constant), `Weights` (per-direction), `Normalize` (linear), and `Indexes`/`Limits` overrides — indexes are otherwise auto-detected by column.
* `WHERE` is re-applied after the fused lookup; non-key columns are projected.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
