### PR TITLE
schemeshard: table partitions format sweep fixes

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -1,5 +1,7 @@
 #include "schemeshard_impl.h"
 
+#include <ydb/core/tx/schemeshard/schemeshard__monitoring.h_serialized.h>  // for enum ESweepAlert support methods
+
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/protos/tx_datashard.pb.h>
 #include <ydb/core/tx/datashard/range_ops.h>
@@ -126,6 +128,7 @@ struct TCgi {
     static const TParam Pause;
     static const TParam Resume;
     static const TParam Cancel;
+    static const TParam SweepAlert;
 
     struct TPages {
         static constexpr TStringBuf MainPage = "Main";
@@ -170,6 +173,7 @@ const TCgi::TParam TCgi::Start = TStringBuf("Start");
 const TCgi::TParam TCgi::Pause = TStringBuf("Pause");
 const TCgi::TParam TCgi::Resume = TStringBuf("Resume");
 const TCgi::TParam TCgi::Cancel = TStringBuf("Cancel");
+const TCgi::TParam TCgi::SweepAlert = TStringBuf("sweepalert");
 const TCgi::TParam TCgi::Action = TStringBuf("Action");
 
 
@@ -491,7 +495,7 @@ public:
             NIceDb::TNiceDb db(txc.DB);
             db.NoMoreReadsForTx();
 
-            HandleAction(cgi.Get(TCgi::Action), db, cgi, ctx);
+            HandleAction(cgi.Get(TCgi::Action), db, ctx);
             return true;
         }
 
@@ -548,6 +552,7 @@ public:
         else if (page == TCgi::TPages::AdminPage)
         {
             OutputAdminPage(Answer);
+            OutputTablePartitionsFormatSweepSection(Answer);
         }
         else if (page == TCgi::TPages::BuildIndexInfo)
         {
@@ -607,6 +612,7 @@ private:
             str.clear();
 
             OutputAdminPage(templateAnswer);
+            OutputTablePartitionsFormatSweepSection(templateAnswer);
 
             auto func = [templateAnswer] (const TMap<TPathId, TSet<TString>>& done) -> NActors::IEventBase* {
                 TStringStream str = templateAnswer;
@@ -658,6 +664,7 @@ private:
             str.clear();
 
             OutputAdminPage(templateAnswer);
+            OutputTablePartitionsFormatSweepSection(templateAnswer);
 
             auto func = [templateAnswer] (const TMap<TPathId, TSet<TString>>& done) -> NActors::IEventBase* {
                 TStringStream str = templateAnswer;
@@ -732,6 +739,7 @@ private:
 
             str << "</pre>";
             OutputAdminPage(str);
+            OutputTablePartitionsFormatSweepSection(str);
 
             auto callback = [sender = Ev->Sender, str = std::move(str)] (const TString& log, const TActorContext& ctx) mutable {
                 str << "<pre>" << log << "</pre>";
@@ -783,12 +791,11 @@ private:
 
         const bool currentShardIdxFormat = (*tableInfoPtr)->PartitionsInShardIdxFormat;
         const TStringBuf format = currentShardIdxFormat ? "position" : "shardidx";
-        const TStringBuf label = currentShardIdxFormat ? "Switch to position" : "Switch to shardidx";
 
         // Duplicate params in query string in addition to form-urlencoded body
         // to give user clear knowledge what parameters were.
         // Params in the body are the actually used ones, query parameters will be ignored
-        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp, TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr))
         const TString actionUrl = TStringBuilder() << "app?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
             << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSwitch)
             << "&" << TCgi::OwnerPathId.AsCgiParam(pathId.OwnerId)
@@ -821,10 +828,12 @@ private:
         );
     }
 
-    void OutputTablePartitionsFormatSweepSection(TStringStream& str, const TString& sweepAlert) const {
+    void OutputTablePartitionsFormatSweepSection(TStringStream& str) const {
         const auto& sweep = Self->TablePartitionsFormatSweep;
 
-        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()
+            && (Self->Tables.size() > 0)
+        ;
 
         bool startEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle);
         bool pauseEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running);
@@ -834,17 +843,23 @@ private:
         // Duplicate params in query string in addition to form-urlencoded body
         // to give user clear knowledge what parameters were.
         // Params in the body are the actually used ones, query parameters will be ignored
-        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp, TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr)).
         const TString actionUrl = TStringBuilder() << "app"
             << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+            << "&" << TCgi::Page.AsCgiParam(TCgi::TPages::AdminPage)
             << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSweep)
         ;
 
         str << "<legend>Table partitions storage format sweep:</legend>" << Endl;
 
+        const TCgiParameters& params = Ev->Get()->Cgi();
+
         // Alert
-        if (sweepAlert) {
-            str << "<div class='alert alert-info' role='alert'>" << sweepAlert << "</div>" << Endl;
+        if (params.Has(TCgi::SweepAlert)) {
+            ui8 num;
+            if (TryFromString<ui8>(params.Get(TCgi::SweepAlert), num) && num < GetEnumItemsCount<ESweepAlert>()) {
+                str << "<div class='alert alert-info' role='alert'>" << ESweepAlert(num) << "</div>" << Endl;
+            }
         }
 
         // Current status
@@ -853,9 +868,8 @@ private:
         str << "Currently: <code>" << sweep.Status << "</code>";
         if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
             str << ", switch to format: <code>" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "</code>" << Endl;
-        } else {
-            str << "<br>" << Endl;
         }
+        str << "<br>" << Endl;
         str << "Tables:"
             << " " << Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() << " in <code>position</code>"
             << ", " << Self->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Get() << " in <code>shardidx</code>"
@@ -868,9 +882,9 @@ private:
             str << std::format(R"(
                     <div class='container col-md-12'>
                         <h4>Progress</h4>
-                        <div class='col-md-1'>Done: {}</div>
-                        <div class='col-md-1'>Skipped: {}</div>
-                        <div class='col-md-1'>Queued: {}</div>
+                        <div class='col-md-2'>Done: {}</div>
+                        <div class='col-md-2'>Skipped: {}</div>
+                        <div class='col-md-2'>Queued: {}</div>
                     </div>
                 )",
                 sweep.Done,
@@ -883,19 +897,20 @@ private:
         str << std::format(R"(
                 <div class='container col-md-12'>
                     <h4>Start sweep</h4>
-                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {7}>
+                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {9}>
                         <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                        <input type='hidden' id='Action' name='{3}' value='{4}' />
-                        <input type='hidden' id='Start' name='{6}' value='1'/>
+                        <input type='hidden' id='Page' name='{3}' value='{4}' />
+                        <input type='hidden' id='Action' name='{5}' value='{6}' />
+                        <input type='hidden' id='Start' name='{8}' value='1'/>
                         <div class='form-inline'>
-                            <input class='form-control' type='radio' id='shardidx' name='{5}' value='shardidx' aria-describedby='start-help' checked {7}>
+                            <input class='form-control' type='radio' id='shardidx' name='{7}' value='shardidx' aria-describedby='start-help' checked {9}>
                             <label class='control-label' for='shardidx'>shardidx</label>
-                            <input class='form-control' type='radio' id='position' name='{5}' value='position' aria-describedby='start-help' {7}>
+                            <input class='form-control' type='radio' id='position' name='{7}' value='position' aria-describedby='start-help' {9}>
                             <label class='control-label' for='position'>position</label>
                             <span id='start-help' class='help-block'>Tables will be converted to a selected partitions storage format.</span>
                         </div>
                         <div class='form-group col-md-12'>
-                            <input class='btn btn-primary btn-lg' type='submit' {7}>
+                            <input class='btn btn-primary btn-lg' type='submit' value='{8}' {9}>
                         </div>
                     </form>
                 </div>
@@ -903,11 +918,13 @@ private:
             /* {0} */ actionUrl,
             /* {1} */ TCgi::TabletID.Name,
             /* {2} */ Self->TabletID(),
-            /* {3} */ TCgi::Action.Name,
-            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
-            /* {5} */ TCgi::TablePartitionsFormat.Name,
-            /* {6} */ TCgi::Start.Name,
-            /* {7} */ AttrDisabled(startEnabled)
+            /* {3} */ TCgi::Page.Name,
+            /* {4} */ TCgi::TPages::AdminPage,
+            /* {5} */ TCgi::Action.Name,
+            /* {6} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {7} */ TCgi::TablePartitionsFormat.Name,
+            /* {8} */ TCgi::Start.Name,
+            /* {9} */ AttrDisabled(startEnabled)
         );
 
         // Control block
@@ -916,24 +933,30 @@ private:
                     <h4>Controls</h4>
                     <div class='btn-toolbar'>
                         <div class='btn-group'>
-                            <form method='POST' action='{0}' {6}>
-                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
-                                <input class='btn btn-default' type='submit' value='{5}' {6}/>
-                            </form>
-                        </div>
-                        <div class='btn-group'>
                             <form method='POST' action='{0}' {8}>
                                 <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Pause' name='{7}' value='1'/>
                                 <input class='btn btn-default' type='submit' value='{7}' {8}/>
                             </form>
                         </div>
                         <div class='btn-group'>
-                            <form method='POST' action='{0}' {8}>
+                            <form method='POST' action='{0}' {10}>
                                 <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Resume' name='{9}' value='1'/>
                                 <input class='btn btn-default' type='submit' value='{9}' {10}/>
+                            </form>
+                        </div>
+                        <div class='btn-group'>
+                            <form method='POST' action='{0}' {12}>
+                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Cancel' name='{11}' value='1'/>
+                                <input class='btn btn-default' type='submit' value='{11}' {12}/>
                             </form>
                         </div>
                     </div>
@@ -942,14 +965,16 @@ private:
             /* {0} */ actionUrl,
             /* {1} */ TCgi::TabletID.Name,
             /* {2} */ Self->TabletID(),
-            /* {3} */ TCgi::Action.Name,
-            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
-            /* {5} */ TCgi::Pause.Name,
-            /* {6} */ AttrDisabled(pauseEnabled),
-            /* {7} */ TCgi::Resume.Name,
-            /* {8} */ AttrDisabled(resumeEnabled),
-            /* {9} */ TCgi::Cancel.Name,
-            /* {10} */ AttrDisabled(cancelEnabled)
+            /* {3} */ TCgi::Page.Name,
+            /* {4} */ TCgi::TPages::AdminPage,
+            /* {5} */ TCgi::Action.Name,
+            /* {6} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {7} */ TCgi::Pause.Name,
+            /* {8} */ AttrDisabled(pauseEnabled),
+            /* {9} */ TCgi::Resume.Name,
+            /* {10} */ AttrDisabled(resumeEnabled),
+            /* {11} */ TCgi::Cancel.Name,
+            /* {12} */ AttrDisabled(cancelEnabled)
         );
     }
 
@@ -1879,15 +1904,36 @@ private:
             TStringBuilder() << "HTTP/1.1 400 Bad Request\r\nConnection: Close\r\n\r\n" << details << "\r\n"));
     }
 
+    void SendRedirect(const TString& location, const TActorContext& ctx) {
+        ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+            TStringBuilder() << "HTTP/1.1 303 See Other\r\nLocation: " << location << "\r\n\r\n"
+        ));
+    }
+
 private:
-    void HandleAction(const TString& action, NIceDb::TNiceDb& db, const TCgiParameters& cgi, const TActorContext& ctx) {
+    void HandleAction(const TString& action, NIceDb::TNiceDb& db, const TActorContext& ctx) {
         if (Ev->Get()->GetMethod() != HTTP_METHOD_POST) {
             SendBadRequest("Action requires a POST method", ctx);
             return;
         }
 
+        TCgiParameters params;
+        {
+            const auto& request = *Ev->Get();
+            if (request.ExtendedQuery) {
+                for (const auto& i : request.ExtendedQuery->GetPostParams()) {
+                    params.emplace(i.GetKey(), i.GetValue());
+                }
+                for (const auto& i : request.ExtendedQuery->GetQueryParams()) {
+                    params.emplace(i.GetKey(), i.GetValue());
+                }
+            } else {
+                params = request.Cgi();
+            }
+        }
+
         if (action == TCgi::TActions::SplitOneToOne) {
-            TTabletId tabletId = TTabletId(TryParseTabletId(cgi.Get(TCgi::ShardID)));
+            TTabletId tabletId = TTabletId(TryParseTabletId(params.Get(TCgi::ShardID)));
             TShardIdx shardIdx = Self->GetShardIdx(tabletId);
             if (!shardIdx) {
                 SendBadRequest("Cannot find the specified shard", ctx);
@@ -1909,8 +1955,8 @@ private:
 
         } else if (action == TCgi::TActions::ForceDropUnsafe) {
             const TPathId pathId(
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::OwnerPathId), InvalidOwnerId),
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::LocalPathId), InvalidLocalPathId)
+                FromStringWithDefault<ui64>(params.Get(TCgi::OwnerPathId), InvalidOwnerId),
+                FromStringWithDefault<ui64>(params.Get(TCgi::LocalPathId), InvalidLocalPathId)
             );
 
             const auto path = TPath::Init(pathId, Self);
@@ -1929,8 +1975,8 @@ private:
             }
 
             const TPathId pathId(
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::OwnerPathId), InvalidOwnerId),
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::LocalPathId), InvalidLocalPathId)
+                FromStringWithDefault<ui64>(params.Get(TCgi::OwnerPathId), InvalidOwnerId),
+                FromStringWithDefault<ui64>(params.Get(TCgi::LocalPathId), InvalidLocalPathId)
             );
 
             const auto path = TPath::Init(pathId, Self);
@@ -1943,7 +1989,7 @@ private:
                 return;
             }
 
-            const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+            const TString input = params.Get(TCgi::TablePartitionsFormat);
             bool formatShardIdx = false;
             if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
                 Self->Execute(Self->CreateTxTablePartitionsFormatSwitch(std::move(Ev), pathId, formatShardIdx), ctx);
@@ -1955,59 +2001,68 @@ private:
             }
 
         } else if (action == TCgi::TActions::TablePartitionsFormatSweep) {
-            TStringBuilder sweepAlert;
+            ESweepAlert sweepAlert = ESweepAlert::NONE;
 
             const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
             if (switchEnabled) {
                 const auto& sweep = Self->TablePartitionsFormatSweep;
 
-                if (cgi.Has(TCgi::Start)) {
+                if (params.Has(TCgi::Start)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
-                        const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+                        const TString input = params.Get(TCgi::TablePartitionsFormat);
                         bool formatShardIdx = false;
                         if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
                             Self->StartTablePartitionsFormatSweep(db, formatShardIdx);
-                            sweepAlert << TStringBuf(TCgi::Start) << ": OK";
+                            sweepAlert = ESweepAlert::START_OK;
                         } else {
-                            sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: invalid format '" << input << "', expected 'shardidx' or 'position'.";
+                            sweepAlert = ESweepAlert::START_ERROR_1;
                         }
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: sweep already running or paused. Cancel first.";
+                        sweepAlert = ESweepAlert::START_ERROR_2;
                     }
 
-                } else if (cgi.Has(TCgi::Pause)) {
+                } else if (params.Has(TCgi::Pause)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running) {
                         Self->PauseTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Pause) << ": OK";
+                        sweepAlert = ESweepAlert::PAUSE_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Pause) << ": ERROR: sweep is not running.";
+                        sweepAlert = ESweepAlert::PAUSE_ERROR;
                     }
 
-                } else if (cgi.Has(TCgi::Resume)) {
+                } else if (params.Has(TCgi::Resume)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Paused) {
                         Self->ResumeTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Resume) << ": OK";
+                        sweepAlert = ESweepAlert::RESUME_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Resume) << ": ERROR: sweep is not paused.";
+                        sweepAlert = ESweepAlert::RESUME_ERROR;
                     }
 
-                } else if (cgi.Has(TCgi::Cancel)) {
+                } else if (params.Has(TCgi::Cancel)) {
                     if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
                         Self->CancelTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Cancel) << ": OK";
+                        sweepAlert = ESweepAlert::CANCEL_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Cancel) << ": ERROR: no current sweep.";
+                        sweepAlert = ESweepAlert::CANCEL_ERROR;
                     }
                 }
                 // else: return current status
 
             } else {
-                sweepAlert << "ERROR: format switching is disabled.";
+                sweepAlert = ESweepAlert::ERROR_DISABLED;
             }
 
-            LinkToMain(Answer);
-            OutputAdminPage(Answer);
-            OutputTablePartitionsFormatSweepSection(Answer, sweepAlert);
+            // make redirect with location relative to the original request url (path)
+            TStringBuilder location;
+            location << "app"
+                << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+                << "&" << TCgi::Page.AsCgiParam(TCgi::TPages::AdminPage)
+            ;
+            if (sweepAlert != ESweepAlert::NONE) {
+                // output an underlying number, not an associated string value
+                location << "&" << TCgi::SweepAlert.AsCgiParam(ToString(ui8(sweepAlert)));
+            }
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxMonitoring.Execute: redirect to " << location);
+            SendRedirect(location, ctx);
 
         } else {
             SendBadRequest("Action not supported", ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.h
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <util/system/types.h>  // for ui8
+
+
+namespace NKikimr::NSchemeShard {
+
+// GENERATE_ENUM_SERIALIZATION_WITH_HEADER macro generates
+// support methods and string messages from comments for this enum.
+enum class ESweepAlert : ui8 {
+    NONE = 0,
+    START_OK = 1           /* "Start: OK." */,
+    START_ERROR_1 = 2      /* "Start: ERROR: invalid format, expected 'shardidx' or 'position'." */,
+    START_ERROR_2 = 3      /* "Start: ERROR: sweep already running or paused. Cancel first." */,
+    PAUSE_OK = 4           /* "Pause: OK." */,
+    PAUSE_ERROR = 5        /* "Pause: ERROR: sweep not running." */,
+    RESUME_OK = 6          /* "Resume: OK." */,
+    RESUME_ERROR = 7       /* "Resume: ERROR: sweep not paused." */,
+    CANCEL_OK = 8          /* "Cancel: OK." */,
+    CANCEL_ERROR = 9       /* "Cancel: ERROR: no current sweep." */,
+    ERROR_DISABLED = 10     /* "ERROR: format switching is disabled." */,
+};
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
@@ -118,11 +118,10 @@ struct TSchemeShard::TTxTablePartitionsFormatSweepStep : public TTransactionBase
 
         NIceDb::TNiceDb db(txc.DB);
 
-        // Self-cancel if the live flag diverged from the captured target.
-        const bool liveTarget = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
-        if (liveTarget != sweep.TargetIsShardIdx) {
+        // Self-cancel if shardidx format support is disabled during the sweep.
+        if (!AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()) {
             LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep step:"
-                << " flag EnableTablePartitionsFormatShardIdx flipped during sweep, cancelling"
+                << " flag EnableTablePartitionsFormatShardIdx turned off during sweep, cancelling"
             );
             Self->CancelTablePartitionsFormatSweep(db);
             return true;
@@ -204,6 +203,14 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressTablePartitionsFormatSweep::TPt
 void TSchemeShard::StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool targetIsShardIdx) {
     auto& sweep = TablePartitionsFormatSweep;
 
+    if (!AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()) {
+        LOG_ERROR_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TablePartitionsFormatSweep start: cannot start as EnableTablePartitionsFormatShardIdx is disabled"
+            << ", schemeshardId: " << TabletID()
+        );
+        return;
+    }
+
     sweep.Status = TTablePartitionsFormatSweepState::EStatus::Running;
     sweep.TargetIsShardIdx = targetIsShardIdx;
     sweep.Done = 0;
@@ -214,6 +221,16 @@ void TSchemeShard::StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool tar
         if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
             sweep.Queue.push_back(pathId);
         }
+    }
+
+    if (sweep.Queue.empty()) {
+        LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TablePartitionsFormatSweep start: no tables to process"
+            << ", schemeshardId: " << TabletID()
+        );
+        sweep.Status = TTablePartitionsFormatSweepState::EStatus::Idle;
+        sweep.Queue.clear();
+        return;
     }
 
     LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
@@ -301,16 +318,17 @@ void TSchemeShard::ClearTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
 void TSchemeShard::InitializeTablePartitionsFormatSweep() {
     auto& sweep = TablePartitionsFormatSweep;
 
-    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Running) {
+    if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Idle) {
+        // sweep running or paused
         ContinueTablePartitionsFormatSweep();
 
-    } else if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle
+    } else if (AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()
         && AppData()->FeatureFlags.GetEnableTablePartitionsFormatAutoConvert()
         && (TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() > 0)
     ) {
+        // sweep on idle but should be started
         Execute(CreateTxTablePartitionsFormatSweepAutoStart());
     }
-    // else: sweep paused -- do nothing
 }
 
 // ContinueTablePartitionsFormatSweep -- continue running sweep on reboot.
@@ -318,7 +336,7 @@ void TSchemeShard::InitializeTablePartitionsFormatSweep() {
 void TSchemeShard::ContinueTablePartitionsFormatSweep() {
     auto& sweep = TablePartitionsFormatSweep;
 
-    if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Running) {
+    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle) {
         return;
     }
 
@@ -328,6 +346,10 @@ void TSchemeShard::ContinueTablePartitionsFormatSweep() {
         if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
             sweep.Queue.push_back(pathId);
         }
+    }
+
+    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Paused) {
+        return;
     }
 
     LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
 #include <ydb/library/actors/core/mon.h>
+#include <ydb/library/actors/http/http.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -33,15 +34,22 @@ namespace {
 
 TString PostSweepAction(TTestActorRuntime& runtime, ui64 schemeShard, const TString& params) {
     auto sender = runtime.AllocateEdgeActor();
-    const TString query = TStringBuilder()
-        << "/app?TabletID=" << schemeShard
-        << "&Action=TablePartitionsFormatSweep"
-        << params
-    ;
-    auto req = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(query, HTTP_METHOD_POST);
-    runtime.SendToPipe(schemeShard, sender, req.release(), 0, {});
-    auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
-    return r->Get()->Html;
+    TString redirectLocation;
+    {
+        const TString query = TStringBuilder() << "/app?TabletID=" << schemeShard << "&Action=TablePartitionsFormatSweep" << params;
+        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_POST), 0, {});
+        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteBinaryInfoRes>(sender);
+        NHttp::THttpParser<NHttp::THttpResponse> parser(r->Get()->Blob);
+        NHttp::THeaders headers(parser.Headers);
+        redirectLocation = headers.Get("Location");
+    }
+    // `Location` is relative to the original query base, needs adding `/` prefix.
+    {
+        const TString query = TStringBuilder() << "/" << redirectLocation;
+        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_GET), 0, {});
+        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
+        return r->Get()->Html;
+    }
 }
 
 // Get table partitions format counters by parsing AdminRequest mon page.
@@ -274,11 +282,9 @@ Y_UNIT_TEST_SUITE(TTablePartitionsFormat) {
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
         UNIT_ASSERT_C(r.Contains("Tables: 0 in <code>position</code>, 0 in <code>shardidx</code>, total 0"), r);
 
+        // Nothing will be run on zero tables
         r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
         UNIT_ASSERT_C(r.Contains("Start: OK"), r);
-        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
-
-        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
     }
 
@@ -309,10 +315,6 @@ Y_UNIT_TEST_SUITE(TTablePartitionsFormat) {
         // Try to run sweep when all tables already converted
         r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
         UNIT_ASSERT_C(r.Contains("Start: OK"), r);
-        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
-        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
-
-        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
         UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
     }

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -109,6 +109,7 @@ SRCS(
     schemeshard__login_finalize.cpp
     schemeshard__make_access_database_no_inheritable.cpp
     schemeshard__monitoring.cpp
+    schemeshard__monitoring.h
     schemeshard__notify.cpp
     schemeshard__op_traits.h
     schemeshard__operation.cpp
@@ -327,6 +328,8 @@ GENERATE_ENUM_SERIALIZATION(schemeshard_types.h)
 GENERATE_ENUM_SERIALIZATION(schemeshard_impl.h)
 
 GENERATE_ENUM_SERIALIZATION(operation_queue_timer.h)
+
+GENERATE_ENUM_SERIALIZATION_WITH_HEADER(schemeshard__monitoring.h)  # for ESweepAlert
 
 PEERDIR(
     contrib/libs/protobuf


### PR DESCRIPTION
Follow-up to:
- https://github.com/ydb-platform/ydb/pull/38804

Changes:
- fix self-cancel on turning `EnableTablePartitionsFormatShardIdx` off during sweep
- fix format sweep actual form posting
- fix format sweep section rendering issues
- fix pause action
- add POST-redirect-GET pattern for format sweep action (instead of returning admin page directly by POST)