### PR TITLE
Fix path to GlobalPoolTotalBytes and others

### DIFF
--- a/ydb/core/base/pool_stats_collector.cpp
+++ b/ydb/core/base/pool_stats_collector.cpp
@@ -24,7 +24,7 @@ public:
         ::NMonitoring::TDynamicCounterPtr counters)
         : NActors::TStatsCollectingActor(intervalSec, setup, GetServiceCounters(counters, "utils"))
     {
-        MiniKQLPoolStats.Init(counters.Get());
+        MiniKQLPoolStats.Init(GetActorSystemCounters().Group.Get());
     }
 
 private:


### PR DESCRIPTION
Fix zero sensor values of:

- GlobalPoolTotalBytes
- TotalMmappedBytes
- TotalFreeListBytes

Seems to be always zero after optimization #29667 due to use of non-canonical label path (missed counters=utils part)

After fix:

<img width="1070" height="626" alt="image" src="https://github.com/user-attachments/assets/0ca45336-06c1-4e6c-b5fc-a57dbaa8f0a9" />
