### PR TITLE
[YQ-5334] Implement pretty output for `ydb scheme describe` of external data so…

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* `ydb scheme describe` now prints a human-readable description for external data sources (source type, location, auth method, database, properties and creation time) instead of empty output.
 * Added `--partition-max-inflight-bytes` option to `ydb topic workload`
 * Added `--partition-write-speed-mps` and `--partition-write-burst-messages` options to `ydb topic create` and `ydb topic alter` commands.
 * Added CPU Time statistics to benchmarks run commands.

--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -14,8 +14,10 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/accessor.h>
 #include <ydb/public/api/protos/ydb_scheme.pb.h>
 #include <ydb/public/api/protos/ydb_secret.pb.h>
+#include <ydb/public/api/protos/ydb_table.pb.h>
 
 #include <util/generic/hash.h>
+#include <util/generic/map.h>
 #include <util/stream/format.h>
 #include <util/string/join.h>
 
@@ -1142,8 +1144,57 @@ int TDescribeLogic::DescribeExternalDataSource(const TString& path, EDataFormat 
     }
 }
 
-int TDescribeLogic::PrintExternalDataSourceResponsePretty(const NYdb::NTable::TExternalDataSourceDescription& /*result*/) const {
-    // to do
+int TDescribeLogic::PrintExternalDataSourceResponsePretty(const NYdb::NTable::TExternalDataSourceDescription& result) const {
+    const auto& proto = NYdb::TProtoAccessor::GetProto(result);
+
+    Out << Endl << "Source type: " << proto.source_type();
+    Out << Endl << "Location: " << proto.location();
+
+    // Properties is a flat string map that also carries the auth method and the
+    // (optional) managed database reference. Pull the well-known fields out so they
+    // are shown as dedicated lines and the rest goes into the properties table below.
+    TMap<TString, TString> properties(proto.properties().begin(), proto.properties().end());
+
+    // Pulls a well-known field out of the properties map. The key is always removed
+    // (so it does not also appear in the properties table), but an empty value is
+    // reported as absent: the server stores AUTH_METHOD with an empty value when the
+    // auth identity is not set, and "Auth method: " with nothing after it is confusing.
+    auto extract = [&properties](TStringBuf key) -> std::optional<TString> {
+        auto it = properties.find(TString(key));
+        if (it == properties.end()) {
+            return std::nullopt;
+        }
+        TString value = std::move(it->second);
+        properties.erase(it);
+        if (value.empty()) {
+            return std::nullopt;
+        }
+        return value;
+    };
+
+    if (auto authMethod = extract("AUTH_METHOD")) {
+        Out << Endl << "Auth method: " << *authMethod;
+    }
+    if (auto database = extract("DATABASE_NAME")) {
+        Out << Endl << "Database: " << *database;
+    }
+    if (auto databaseId = extract("DATABASE_ID")) {
+        Out << Endl << "Database id: " << *databaseId;
+    }
+
+    Out << Endl << "Created: " << FormatTime(TInstant::MilliSeconds(proto.self().created_at().plan_step()));
+
+    if (!properties.empty()) {
+        TPrettyTable table({ "Name", "Value" }, TPrettyTableConfig().WithoutRowDelimiters());
+        for (const auto& [name, value] : properties) {
+            table.AddRow()
+                .Column(0, name)
+                .Column(1, value);
+        }
+        Out << Endl << "Properties: " << Endl << table;
+    }
+
+    Out << Endl;
     return EXIT_SUCCESS;
 }
 

--- a/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
@@ -84,6 +84,26 @@ class TestSchemeDescribe:
         self.tmp_path = tmp_path
         set_ydb_cli_test_canondata_root()
 
+    def test_describe_external_data_source(self, ydb_cluster, ydb_database, ydb_client_session):
+        database_path = ydb_database
+        external_data_source = "external_data_source"
+        session_pool = ydb_client_session(database_path)
+        with session_pool.checkout() as session:
+            create_external_data_source(session, external_data_source)
+
+            output = execute_ydb_cli_command(
+                ydb_cluster.nodes[1],
+                database_path,
+                ["scheme", "describe", external_data_source],
+            )
+            # The pretty output is non-deterministic (it carries a creation timestamp),
+            # so assert on the rendered fields rather than comparing against canondata.
+            assert "<external-data-source> " + external_data_source in output
+            assert "Source type: ObjectStorage" in output
+            assert "Location: localhost:1" in output
+            assert "Auth method: NONE" in output
+            assert "Created:" in output
+
     def test_describe_external_table_references_json(self, ydb_cluster, ydb_database, ydb_client_session):
         database_path = ydb_database
         external_data_source = "external_data_source"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->
 Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
PrintExternalDataSourceResponsePretty() was a stub returning empty output. Render source type, location, auth method, database/database id, creation time and a properties table, matching the style of the other describe handlers. Add an integration test in the CLI describe tests and a changelog entry.