### PR TITLE
(cli) ydb_int interactive tx: TCL cleanup, DDL guard, auto-reset on error

### DIFF
--- a/ydb/apps/ydb_int/README.md
+++ b/ydb/apps/ydb_int/README.md
@@ -50,13 +50,13 @@ Syntax (case-insensitive, trailing semicolon allowed):
 
 ```sql
 -- Begin a transaction. Default mode: serializable-rw.
-BEGIN [TRANSACTION | WORK] [<mode>]
-START TRANSACTION              [<mode>]
+BEGIN [TRANSACTION] [<mode>]
+START TRANSACTION   [<mode>]
 
 -- Commit / rollback:
-COMMIT [TRANSACTION | WORK]
+COMMIT [TRANSACTION]
 END    [TRANSACTION]
-ROLLBACK [TRANSACTION | WORK]
+ROLLBACK [TRANSACTION]
 ```
 
 Supported `<mode>` values are the YDB-native mode names also accepted by

--- a/ydb/apps/ydb_int/README.md
+++ b/ydb/apps/ydb_int/README.md
@@ -51,11 +51,9 @@ Syntax (case-insensitive, trailing semicolon allowed):
 ```sql
 -- Begin a transaction. Default mode: serializable-rw.
 BEGIN [TRANSACTION] [<mode>]
-START TRANSACTION   [<mode>]
 
 -- Commit / rollback:
 COMMIT [TRANSACTION]
-END    [TRANSACTION]
 ROLLBACK [TRANSACTION]
 ```
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.cpp
@@ -238,6 +238,12 @@ public:
         Prompt = prompt;
     }
 
+    void SetExcludeSchemeQueryCompletion(bool exclude) final {
+        if (YQLCompleter) {
+            YQLCompleter->SetExcludeSchemeQueryCompletion(exclude);
+        }
+    }
+
 private:
     void InitReplxx(bool enableYqlCompletion) {
         EnableYqlCompletion = enableYqlCompletion;

--- a/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/common/line_reader.h
@@ -36,6 +36,9 @@ public:
 
     virtual void SetPrompt(const TString& prompt) = 0;
 
+    // Omit scheme (DDL) keywords from YQL TAB-completion (interactive transaction mode).
+    virtual void SetExcludeSchemeQueryCompletion(bool exclude) = 0;
+
     virtual ~ILineReader() = default;
 };
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -52,15 +52,6 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT(AsSet(hints).contains("BEGIN"));
     }
 
-    Y_UNIT_TEST(SuggestsStartOnPrefix) {
-        auto completer = MakeTclOnlyCompleter();
-        int contextLen = -1;
-        const TString text = "STA";
-        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
-        UNIT_ASSERT_VALUES_EQUAL(contextLen, 3);
-        UNIT_ASSERT(AsSet(hints).contains("START"));
-    }
-
     Y_UNIT_TEST(NextWordAfterBeginSpace) {
         auto completer = MakeTclOnlyCompleter();
         int contextLen = -1;
@@ -122,20 +113,6 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT(!set.contains("WORK"));
     }
 
-    Y_UNIT_TEST(NextWordAfterStartTransactionSpace) {
-        auto completer = MakeTclOnlyCompleter();
-        int contextLen = -1;
-        const TString text = "START TRANSACTION ";
-        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
-        UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
-        const auto set = AsSet(hints);
-        UNIT_ASSERT(set.contains("serializable-rw"));
-        UNIT_ASSERT(set.contains("snapshot-ro"));
-        // Repeated phrase must NOT be proposed.
-        UNIT_ASSERT(!set.contains("START TRANSACTION serializable-rw"));
-        UNIT_ASSERT(!set.contains("TRANSACTION"));
-    }
-
     Y_UNIT_TEST(NoOnlineRoSuggestion) {
         auto completer = MakeTclOnlyCompleter();
         int contextLen = -1;
@@ -190,16 +167,6 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
             UNIT_ASSERT(set.contains("TRANSACTION"));
             UNIT_ASSERT(!set.contains("WORK"));
         }
-    }
-
-    Y_UNIT_TEST(EndForms) {
-        auto completer = MakeTclOnlyCompleter();
-        int contextLen = -1;
-        const TString text = "END ";
-        auto hints = completer->ApplyLight(text, std::string(text), contextLen);
-        const auto set = AsSet(hints);
-        UNIT_ASSERT(set.contains("TRANSACTION"));
-        UNIT_ASSERT(!set.contains("WORK"));
     }
 
     Y_UNIT_TEST(NoTclSuggestionsForUnrelatedInput) {

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -41,7 +41,6 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT(AsSet(hints).contains("BEGIN"));
         // Must not propose tail words yet.
         UNIT_ASSERT(!AsSet(hints).contains("TRANSACTION"));
-        UNIT_ASSERT(!AsSet(hints).contains("WORK"));
     }
 
     Y_UNIT_TEST(SuggestsBeginOnPrefixLowerCase) {
@@ -70,7 +69,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
         const auto set = AsSet(hints);
         UNIT_ASSERT(set.contains("TRANSACTION"));
-        UNIT_ASSERT(set.contains("WORK"));
+        UNIT_ASSERT(!set.contains("WORK"));
         UNIT_ASSERT(set.contains("serializable-rw"));
         UNIT_ASSERT(set.contains("read-committed-rw"));
         UNIT_ASSERT(set.contains("snapshot-ro"));
@@ -171,7 +170,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
             UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
             const auto set = AsSet(hints);
             UNIT_ASSERT(set.contains("TRANSACTION"));
-            UNIT_ASSERT(set.contains("WORK"));
+            UNIT_ASSERT(!set.contains("WORK"));
         }
     }
 
@@ -189,7 +188,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
             auto hints = completer->ApplyLight(text, std::string(text), contextLen);
             const auto set = AsSet(hints);
             UNIT_ASSERT(set.contains("TRANSACTION"));
-            UNIT_ASSERT(set.contains("WORK"));
+            UNIT_ASSERT(!set.contains("WORK"));
         }
     }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -3,6 +3,7 @@
 #include "ydb_schema.h"
 
 #include <ydb/public/lib/ydb_cli/commands/interactive/highlight/color/schema.h>
+#include <ydb/public/lib/ydb_cli/common/scheme_query_utils.h>
 
 #include <yql/essentials/sql/v1/complete/sql_complete.h>
 #include <yql/essentials/sql/v1/complete/name/cache/local/cache.h>
@@ -18,6 +19,7 @@
 #include <util/charset/utf8.h>
 #include <util/generic/hash_set.h>
 
+#include <algorithm>
 #include <cctype>
 #include <vector>
 
@@ -37,6 +39,10 @@ namespace {
             , LightEngine(std::move(lightEngine))
             , Color(std::move(color))
         {
+        }
+
+        void SetExcludeSchemeQueryCompletion(bool exclude) override {
+            ExcludeSchemeQueryCompletion = exclude;
         }
 
         TCompletions ApplyHeavy(TStringBuf text, const std::string& prefix, int& contextLen) override {
@@ -72,7 +78,31 @@ namespace {
                 });
             }
 
+            if (ExcludeSchemeQueryCompletion) {
+                FilterSchemeQueryCandidates(completion.Candidates, text, prefix.length());
+            }
+
             return ReplxxCompletionsOf(std::move(completion.Candidates));
+        }
+
+        static void FilterSchemeQueryCandidates(
+            TVector<NSQLComplete::TCandidate>& candidates,
+            TStringBuf text,
+            size_t cursorPos)
+        {
+            const TStringBuf textBeforeCursor = text.SubStr(0, cursorPos);
+            candidates.erase(
+                std::remove_if(
+                    candidates.begin(),
+                    candidates.end(),
+                    [&](const NSQLComplete::TCandidate& candidate) {
+                        if (candidate.Kind != NSQLComplete::ECandidateKind::Keyword) {
+                            return false;
+                        }
+                        return IsExcludedSchemeQueryCompletionKeyword(
+                            candidate.Content, textBeforeCursor);
+                    }),
+                candidates.end());
         }
 
         NSQLComplete::ISqlCompletionEngine::TPtr& GetEngine(bool light) {
@@ -124,6 +154,7 @@ namespace {
 
         NSQLComplete::ISqlCompletionEngine::TPtr HeavyEngine;
         NSQLComplete::ISqlCompletionEngine::TPtr LightEngine;
+        bool ExcludeSchemeQueryCompletion = false;
         TColorSchema Color;
     };
 
@@ -305,6 +336,12 @@ namespace {
                 ? MakeYQLCompleter(*config.YqlCompleterConfig)
                 : nullptr)
         {}
+
+        void SetExcludeSchemeQueryCompletion(bool exclude) final {
+            if (YQLCompleter) {
+                YQLCompleter->SetExcludeSchemeQueryCompletion(exclude);
+            }
+        }
 
         TCompletions ApplyHeavy(TStringBuf text, const std::string& prefix, int& contextLen) final {
             const TStringBuf prefixView(prefix.data(), prefix.size());

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -131,7 +131,7 @@ namespace {
     // interactive transaction control line.
     static const std::vector<TString>& TclKeywords() {
         static const std::vector<TString> kKeywords = {
-            "BEGIN", "START", "COMMIT", "END", "ROLLBACK",
+            "BEGIN", "COMMIT", "ROLLBACK",
         };
         return kKeywords;
     }

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.h
@@ -19,6 +19,10 @@ namespace NYdb::NConsoleClient {
 
         virtual TCompletions ApplyHeavy(TStringBuf text, const std::string& prefix, int& contextLen) = 0;
         virtual THints ApplyLight(TStringBuf text, const std::string& prefix, int& contextLen) = 0;
+
+        // When true, scheme (DDL) statement keywords are omitted from YQL completion.
+        virtual void SetExcludeSchemeQueryCompletion(bool /*exclude*/) {}
+
         virtual ~IYQLCompleter() = default;
     };
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -85,12 +85,14 @@ std::vector<ISessionRunner::TPtr> SetupSessions(
     TInteractiveConfigurationManager::TPtr configManager,
     TLazyDriver::TPtr completerLazyDriver,
     TLazyDriver::TPtr sqlLazyDriver,
+    TLazyDriver::TPtr sqlTxLazyDriver,
     TLazyDriver::TPtr aiLazyDriver)
 {
     std::vector<ISessionRunner::TPtr> sessions;
 
     sessions.push_back(CreateSqlSessionRunner({
         .SqlLazyDriver = std::move(sqlLazyDriver),
+        .SqlTxLazyDriver = std::move(sqlTxLazyDriver),
         .CompleterLazyDriver = std::move(completerLazyDriver),
         .Database = config.Database,
         .EnableAiInteractive = config.EnableAiInteractive,
@@ -168,17 +170,20 @@ int TInteractiveCLI::Run(TClientCommand::TConfig& config) {
         [&config] { return TDriver(config.CreateDriverConfig()); });
     auto sqlLazyDriver = std::make_shared<TLazyDriver>(
         [&config] { return TDriver(config.CreateDriverConfigWithBuildInfo("interactive-sql")); });
+    auto sqlTxLazyDriver = std::make_shared<TLazyDriver>(
+        [&config] { return TDriver(config.CreateDriverConfigWithBuildInfo("interactive-sql-transaction")); });
     auto aiLazyDriver = std::make_shared<TLazyDriver>(
         [&config] { return TDriver(config.CreateDriverConfigWithBuildInfo("interactive-ai")); });
 
     Y_DEFER {
         aiLazyDriver->Stop(true);
+        sqlTxLazyDriver->Stop(true);
         sqlLazyDriver->Stop(true);
         completerLazyDriver->Stop(true);
     };
 
     ui64 activeSession = static_cast<ui64>(configManager->GetInteractiveMode());
-    const auto& sessions = SetupSessions(config, configManager, completerLazyDriver, sqlLazyDriver, aiLazyDriver);
+    const auto& sessions = SetupSessions(config, configManager, completerLazyDriver, sqlLazyDriver, sqlTxLazyDriver, aiLazyDriver);
     Y_VALIDATE(activeSession < sessions.size(), "Invalid active session: " << activeSession);
 
     ILineReader::TPtr lineReader;

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -421,17 +421,12 @@ private:
                 text("]: start an interactive transaction (Query service session).")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("START TRANSACTION"), text(" ["), CreateEntityName("MODE"),
-                text("]: alias of BEGIN TRANSACTION.")
-            })));
-            elements.emplace_back(CreateListItem(hbox({
                 text("  "), CreateEntityName("MODE"), text(": "), CreateEntityName(GetTxModeNamesForHelp()),
                 text(" (default: "), CreateEntityName(TString(kTxModeSerializableRw)), text(").")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("COMMIT"), text(" | "), keyword("COMMIT TRANSACTION"), text(" | "),
-                keyword("END"), text(" | "),
-                keyword("END TRANSACTION"), text(": commit the current transaction.")
+                keyword("COMMIT"), text(" ["), keyword("TRANSACTION"),
+                text("]: commit the current transaction.")
             })));
             elements.emplace_back(CreateListItem(hbox({
                 keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"),

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -430,8 +430,8 @@ private:
                 text("]: commit the current transaction.")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"),
-                text(": rollback the current transaction.")
+                keyword("ROLLBACK"), text(" ["), keyword("TRANSACTION"),
+                text("]: rollback the current transaction.")
             })));
             elements.emplace_back(CreateListItem(hbox({
                 text("DDL (CREATE, ALTER, DROP, ...) is not supported inside a transaction; a failed"

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -22,7 +22,7 @@ namespace NYdb::NConsoleClient {
 
 namespace {
 
-constexpr NYdb::NIssue::TIssueCode KikimrTransactionNotFoundIssueCode = 2015;
+constexpr NYdb::NIssue::TIssueCode KikimrTransactionNotFoundIssueCode = 2015; // NYql::TIssuesIds::KIKIMR_TRANSACTION_NOT_FOUND
 
 bool IsStaleInteractiveTransactionError(const TStatus& status) {
     if (NStatusHelpers::StatusContainsIssueWithCode(status, KikimrTransactionNotFoundIssueCode)) {

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -104,11 +104,13 @@ public:
         : TBase(CreateSessionSettings(settings))
         , QueryPlanPrinter(EDataFormat::Default)
         , SqlLazyDriver(settings.SqlLazyDriver)
+        , SqlTxLazyDriver(settings.SqlTxLazyDriver)
         , EnableAiInteractive(settings.EnableAiInteractive)
         , EnableInteractiveTransactions(settings.EnableInteractiveTransactions)
         , BasePrompt(Settings.Prompt)
     {
         Y_VALIDATE(SqlLazyDriver, "TSqlSessionRunner requires a non-null SqlLazyDriver");
+        Y_VALIDATE(SqlTxLazyDriver, "TSqlSessionRunner requires a non-null SqlTxLazyDriver");
         Y_VALIDATE(settings.CompleterLazyDriver, "TSqlSessionRunner requires a non-null CompleterLazyDriver");
     }
 
@@ -122,12 +124,13 @@ public:
 
     void HandleLine(const TString& line) final {
         Y_DEFER { ResetInterrupted(); };
-        // Stop the driver at the end of the line iff no transaction is active.
+        // Stop the drivers at the end of the line if no transaction is active.
         // The flag is re-evaluated at scope exit (after BEGIN/COMMIT/ROLLBACK
-        // mutate the state) so the driver lives across queries inside a tx.
+        // mutate the state) so the tx driver lives across queries inside a tx.
         Y_DEFER {
             if (!IsInteractiveTransactionActive()) {
                 SqlLazyDriver->Stop(true);
+                SqlTxLazyDriver->Stop(true);
             }
         };
 
@@ -341,7 +344,7 @@ public:
         }
 
         try {
-            TExecuteGenericQuery executeRunner(SqlLazyDriver->Get());
+            TExecuteGenericQuery executeRunner(SqlTxLazyDriver->Get());
             executeRunner.Execute(line, {
                 .Settings = settings,
                 .AddIndent = true,
@@ -527,7 +530,7 @@ private:
         if (Session) {
             return;
         }
-        QueryClient = NQuery::TQueryClient(SqlLazyDriver->Get());
+        QueryClient = NQuery::TQueryClient(SqlTxLazyDriver->Get());
         auto sessionResult = QueryClient->GetSession().GetValueSync();
         NStatusHelpers::ThrowOnErrorOrPrintIssues(sessionResult);
         Session = sessionResult.GetSession();
@@ -615,6 +618,7 @@ private:
 private:
     TQueryPlanPrinter QueryPlanPrinter;
     TLazyDriver::TPtr SqlLazyDriver;
+    TLazyDriver::TPtr SqlTxLazyDriver;
     NQuery::EStatsMode CollectStatsMode = NQuery::EStatsMode::None;
     std::string ResourcePool;
     bool EnableAiInteractive;

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -10,6 +10,7 @@
 #include <ydb/public/lib/ydb_cli/common/tx_mode_utils.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/query_stats/stats.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
 
 #include <util/folder/path.h>
 #include <util/generic/scope.h>
@@ -19,6 +20,26 @@
 namespace NYdb::NConsoleClient {
 
 namespace {
+
+constexpr NYdb::NIssue::TIssueCode KikimrTransactionNotFoundIssueCode = 2015;
+
+bool IsStaleInteractiveTransactionError(const TStatus& status) {
+    if (NStatusHelpers::StatusContainsIssueWithCode(status, KikimrTransactionNotFoundIssueCode)) {
+        return true;
+    }
+    if (status.GetStatus() == EStatus::NOT_FOUND) {
+        for (const auto& issue : status.GetIssues()) {
+            if (issue.GetMessage().contains("Transaction not found")) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool IsStaleInteractiveTransactionError(TStringBuf text) {
+    return text.find("Transaction not found") != TStringBuf::npos;
+}
 
 class TSqlSessionRunner final : public TSessionRunnerBase, public TInterruptableCommand {
     using TBase = TSessionRunnerBase;
@@ -236,6 +257,7 @@ public:
             auto beginResult = Session->BeginTransaction(*txSettings).GetValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(beginResult);
             Transaction = beginResult.GetTransaction();
+            InteractiveTxActive = true;
             UpdateTransactionPrompt();
             Cout << "BEGIN" << Endl;
         } catch (NStatusHelpers::TYdbErrorException& error) {
@@ -253,17 +275,22 @@ public:
             return;
         }
 
+        Y_DEFER { ResetTransactionState(); };
+
         try {
             auto commitResult = Transaction->Commit().GetValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(commitResult);
             Cout << "COMMIT" << Endl;
-            ResetTransactionState();
         } catch (NStatusHelpers::TYdbErrorException& error) {
             PrintTcError("Failed to commit transaction", ToString(error));
-            // Keep the transaction state so the user can retry the COMMIT or
-            // explicitly ROLLBACK. The destructor rolls it back if needed.
+            if (IsStaleInteractiveTransactionError(error.GetStatus())) {
+                PrintBeginAgainHint();
+            }
         } catch (std::exception& error) {
             PrintTcError("Failed to commit transaction", error.what());
+            if (IsStaleInteractiveTransactionError(TStringBuf(error.what()))) {
+                PrintBeginAgainHint();
+            }
         }
     }
 
@@ -273,15 +300,22 @@ public:
             return;
         }
 
+        Y_DEFER { ResetTransactionState(); };
+
         try {
             auto rollbackResult = Transaction->Rollback().GetValueSync();
             NStatusHelpers::ThrowOnErrorOrPrintIssues(rollbackResult);
             Cout << "ROLLBACK" << Endl;
-            ResetTransactionState();
         } catch (NStatusHelpers::TYdbErrorException& error) {
             PrintTcError("Failed to rollback transaction", ToString(error));
+            if (IsStaleInteractiveTransactionError(error.GetStatus())) {
+                PrintBeginAgainHint();
+            }
         } catch (std::exception& error) {
             PrintTcError("Failed to rollback transaction", error.what());
+            if (IsStaleInteractiveTransactionError(TStringBuf(error.what()))) {
+                PrintBeginAgainHint();
+            }
         }
     }
 
@@ -302,9 +336,23 @@ public:
                 .TxControl = NQuery::TTxControl::Tx(*Transaction),
             });
         } catch (NStatusHelpers::TYdbErrorException& error) {
+            const bool staleTx = IsStaleInteractiveTransactionError(error.GetStatus());
+            if (staleTx) {
+                InvalidateInteractiveTransaction();
+            }
             Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
+            if (staleTx) {
+                PrintBeginAgainHint();
+            }
         } catch (std::exception& error) {
+            const bool staleTx = IsStaleInteractiveTransactionError(TStringBuf(error.what()));
+            if (staleTx) {
+                InvalidateInteractiveTransaction();
+            }
             Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
+            if (staleTx) {
+                PrintBeginAgainHint();
+            }
         }
     }
 
@@ -368,8 +416,8 @@ private:
 
         if (enableInteractiveTransactions) {
             elements.emplace_back(CreateListItem(hbox({
-                keyword("BEGIN"), text(" ["), keyword("TRANSACTION"), text(" | "),
-                keyword("WORK"), text("] ["), CreateEntityName("MODE"),
+                keyword("BEGIN"), text(" ["), keyword("TRANSACTION"), text("] ["),
+                CreateEntityName("MODE"),
                 text("]: start an interactive transaction (Query service session).")
             })));
             elements.emplace_back(CreateListItem(hbox({
@@ -382,12 +430,12 @@ private:
             })));
             elements.emplace_back(CreateListItem(hbox({
                 keyword("COMMIT"), text(" | "), keyword("COMMIT TRANSACTION"), text(" | "),
-                keyword("COMMIT WORK"), text(" | "), keyword("END"), text(" | "),
+                keyword("END"), text(" | "),
                 keyword("END TRANSACTION"), text(": commit the current transaction.")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"), text(" | "),
-                keyword("ROLLBACK WORK"), text(": rollback the current transaction.")
+                keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"),
+                text(": rollback the current transaction.")
             })));
         }
 
@@ -485,7 +533,17 @@ private:
     }
 
     bool IsInteractiveTransactionActive() const {
-        return EnableInteractiveTransactions && Transaction && Transaction->IsActive();
+        return EnableInteractiveTransactions && InteractiveTxActive;
+    }
+
+    void PrintBeginAgainHint() const {
+        Cerr << Colors.Yellow()
+             << "No open interactive transaction. Issue BEGIN to start a new one."
+             << Colors.OldColor() << Endl;
+    }
+
+    void InvalidateInteractiveTransaction() {
+        ResetTransactionState();
     }
 
     void PrintTcError(TStringBuf prefix, TStringBuf details) {
@@ -506,6 +564,7 @@ private:
     }
 
     void ResetTransactionState() {
+        InteractiveTxActive = false;
         Transaction.reset();
         Session.reset();
         QueryClient.reset();
@@ -514,15 +573,17 @@ private:
 
     // Rollback any transaction left open at shutdown. Errors are swallowed.
     void RollbackOpenTransaction(bool silent) {
-        if (!Transaction || !Transaction->IsActive()) {
+        if (!InteractiveTxActive) {
             ResetTransactionState();
             return;
         }
-        try {
-            Transaction->Rollback().GetValueSync();
-        } catch (...) {
-            if (!silent) {
-                throw;
+        if (Transaction) {
+            try {
+                Transaction->Rollback().GetValueSync();
+            } catch (...) {
+                if (!silent) {
+                    throw;
+                }
             }
         }
         ResetTransactionState();
@@ -540,6 +601,7 @@ private:
     std::optional<NQuery::TQueryClient> QueryClient;
     std::optional<NQuery::TSession> Session;
     std::optional<NQuery::TTransaction> Transaction;
+    bool InteractiveTxActive = false;
 };
 
 } // anonymous namespace

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -7,6 +7,7 @@
 #include <ydb/public/lib/ydb_cli/common/format.h>
 #include <ydb/public/lib/ydb_cli/common/ftxui.h>
 #include <ydb/public/lib/ydb_cli/common/query_utils.h>
+#include <ydb/public/lib/ydb_cli/common/scheme_query_utils.h>
 #include <ydb/public/lib/ydb_cli/common/tx_mode_utils.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/query_stats/stats.h>
@@ -259,6 +260,7 @@ public:
             Transaction = beginResult.GetTransaction();
             InteractiveTxActive = true;
             UpdateTransactionPrompt();
+            UpdateSchemeQueryCompletionMode();
             Cout << "BEGIN" << Endl;
         } catch (NStatusHelpers::TYdbErrorException& error) {
             PrintTcError("Failed to begin transaction", ToString(error));
@@ -320,6 +322,17 @@ public:
     }
 
     void ExecuteInTransaction(const TString& line) {
+        if (LooksLikeSchemeQuery(line)) {
+            Cerr << Colors.Yellow()
+                 << "\nDDL statements (CREATE, ALTER, DROP, etc.) cannot be executed inside an"
+                    " interactive transaction."
+                 << Colors.OldColor() << Endl;
+            Cerr << "COMMIT or ROLLBACK the transaction first, then run the DDL outside of a"
+                    " transaction."
+                 << Endl;
+            return;
+        }
+
         NQuery::TExecuteQuerySettings settings;
         settings.StatsMode(CollectStatsMode);
         settings.ConcurrentResultSets(false);
@@ -336,23 +349,11 @@ public:
                 .TxControl = NQuery::TTxControl::Tx(*Transaction),
             });
         } catch (NStatusHelpers::TYdbErrorException& error) {
-            const bool staleTx = IsStaleInteractiveTransactionError(error.GetStatus());
-            if (staleTx) {
-                InvalidateInteractiveTransaction();
-            }
             Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(ToString(error)) << Endl;
-            if (staleTx) {
-                PrintBeginAgainHint();
-            }
+            InvalidateInteractiveTransactionAfterQueryError();
         } catch (std::exception& error) {
-            const bool staleTx = IsStaleInteractiveTransactionError(TStringBuf(error.what()));
-            if (staleTx) {
-                InvalidateInteractiveTransaction();
-            }
             Cerr << Colors.Red() << "\nFailed to execute query:" << Colors.OldColor() << Endl << Strip(error.what()) << Endl;
-            if (staleTx) {
-                PrintBeginAgainHint();
-            }
+            InvalidateInteractiveTransactionAfterQueryError();
         }
     }
 
@@ -431,6 +432,11 @@ private:
             elements.emplace_back(CreateListItem(hbox({
                 keyword("ROLLBACK"), text(" | "), keyword("ROLLBACK TRANSACTION"),
                 text(": rollback the current transaction.")
+            })));
+            elements.emplace_back(CreateListItem(hbox({
+                text("DDL (CREATE, ALTER, DROP, ...) is not supported inside a transaction; a failed"
+                     " query ends the transaction on the server — the CLI clears local state"
+                     " automatically.")
             })));
         }
 
@@ -537,8 +543,29 @@ private:
              << Colors.OldColor() << Endl;
     }
 
+    void PrintTransactionAutoRolledBackNotice() const {
+        Cerr << Colors.Yellow()
+             << "Transaction was automatically rolled back after the error."
+             << Colors.OldColor() << Endl;
+        PrintBeginAgainHint();
+    }
+
     void InvalidateInteractiveTransaction() {
         ResetTransactionState();
+    }
+
+    void InvalidateInteractiveTransactionAfterQueryError() {
+        if (!IsInteractiveTransactionActive()) {
+            return;
+        }
+        InvalidateInteractiveTransaction();
+        PrintTransactionAutoRolledBackNotice();
+    }
+
+    void UpdateSchemeQueryCompletionMode() {
+        if (LineReader && EnableInteractiveTransactions) {
+            LineReader->SetExcludeSchemeQueryCompletion(IsInteractiveTransactionActive());
+        }
     }
 
     void PrintTcError(TStringBuf prefix, TStringBuf details) {
@@ -564,6 +591,7 @@ private:
         Session.reset();
         QueryClient.reset();
         ResetTransactionPrompt();
+        UpdateSchemeQueryCompletionMode();
     }
 
     // Rollback any transaction left open at shutdown. Errors are swallowed.

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -330,8 +330,8 @@ public:
                  << "\nDDL statements (CREATE, ALTER, DROP, etc.) cannot be executed inside an"
                     " interactive transaction."
                  << Colors.OldColor() << Endl;
-            Cerr << "COMMIT or ROLLBACK the transaction first, then run the DDL outside of a"
-                    " transaction."
+            Cerr << "SHOW CREATE TABLE/VIEW is allowed. COMMIT or ROLLBACK the transaction first,"
+                    " then run other DDL outside of a transaction."
                  << Endl;
             return;
         }
@@ -437,9 +437,9 @@ private:
                 text("]: rollback the current transaction.")
             })));
             elements.emplace_back(CreateListItem(hbox({
-                text("DDL (CREATE, ALTER, DROP, ...) is not supported inside a transaction; a failed"
-                     " query ends the transaction on the server — the CLI clears local state"
-                     " automatically.")
+                text("Destructive DDL (CREATE, ALTER, DROP, ...) is not supported inside a"
+                     " transaction; SHOW CREATE TABLE/VIEW is allowed. A failed query ends the"
+                     " transaction on the server — the CLI clears local state automatically.")
             })));
         }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.h
@@ -11,6 +11,11 @@ struct TSqlSessionSettings {
     // every HandleLine and re-created on the next turn.
     TLazyDriver::TPtr SqlLazyDriver;
 
+    // Lazy driver dedicated to interactive transactions: a Query service
+    // session opened on BEGIN lives on this driver until COMMIT/ROLLBACK
+    // (or an error that closes the transaction).
+    TLazyDriver::TPtr SqlTxLazyDriver;
+
     // Lazy driver used by the YQL completer for schema lookups; must be set,
     // since SQL session always enables YQL completion.
     TLazyDriver::TPtr CompleterLazyDriver;

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
@@ -1,0 +1,125 @@
+#include "scheme_query_utils.h"
+
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
+
+#include <cctype>
+
+namespace NYdb::NConsoleClient {
+
+namespace {
+
+TVector<TString> TokenizeUpper(TStringBuf line) {
+    TVector<TString> tokens;
+    TString current;
+    auto flush = [&]() {
+        if (!current.empty()) {
+            tokens.push_back(std::move(current));
+            current.clear();
+        }
+    };
+    for (char c : line) {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if (std::isspace(uc) || c == ';') {
+            flush();
+        } else {
+            current.push_back(static_cast<char>(std::toupper(uc)));
+        }
+    }
+    flush();
+    return tokens;
+}
+
+const THashSet<TString>& SchemeQueryLeadingKeywords() {
+    static const THashSet<TString> kKeywords = {
+        "ALTER",
+        "ANALYZE",
+        "BACKUP",
+        "CREATE",
+        "DISCARD",
+        "DROP",
+        "EXPORT",
+        "GRANT",
+        "IMPORT",
+        "RESTORE",
+        "REVOKE",
+        "SHOW",
+        "TRUNCATE",
+        "USE",
+    };
+    return kKeywords;
+}
+
+size_t SkipExplainPrefix(const TVector<TString>& tokens) {
+    size_t i = 0;
+    if (i < tokens.size() && tokens[i] == "EXPLAIN") {
+        ++i;
+        if (i < tokens.size() && tokens[i] == "QUERY") {
+            ++i;
+            if (i < tokens.size() && tokens[i] == "PLAN") {
+                ++i;
+            }
+        }
+    }
+    return i;
+}
+
+const THashSet<TString>& SchemeQueryTopLevelCompletionKeywords() {
+    static const THashSet<TString> kKeywords = {
+        "ALTER",
+        "ANALYZE",
+        "BACKUP",
+        "CREATE",
+        "DISCARD",
+        "DROP",
+        "EXPORT",
+        "GRANT",
+        "IMPORT",
+        "RESTORE",
+        "REVOKE",
+        "SHOW CREATE",
+        "TRUNCATE TABLE",
+        "USE",
+    };
+    return kKeywords;
+}
+
+TString ToUpperAscii(TStringBuf text) {
+    TString result{text};
+    for (char& c : result) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return result;
+}
+
+} // anonymous namespace
+
+TStringBuf GetCurrentStatementPrefix(TStringBuf textBeforeCursor) {
+    const size_t lastSemi = textBeforeCursor.rfind(';');
+    if (lastSemi == TStringBuf::npos) {
+        return textBeforeCursor;
+    }
+    return textBeforeCursor.SubStr(lastSemi + 1);
+}
+
+bool LooksLikeSchemeQuery(TStringBuf line) {
+    const auto tokens = TokenizeUpper(line);
+    const size_t i = SkipExplainPrefix(tokens);
+    if (i >= tokens.size()) {
+        return false;
+    }
+    return SchemeQueryLeadingKeywords().contains(tokens[i]);
+}
+
+bool IsSchemeQueryCompletionContext(TStringBuf textBeforeCursor) {
+    return LooksLikeSchemeQuery(GetCurrentStatementPrefix(textBeforeCursor));
+}
+
+bool IsExcludedSchemeQueryCompletionKeyword(TStringBuf keywordContent, TStringBuf textBeforeCursor) {
+    if (IsSchemeQueryCompletionContext(textBeforeCursor)) {
+        return true;
+    }
+    return SchemeQueryTopLevelCompletionKeywords().contains(ToUpperAscii(keywordContent));
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
@@ -92,6 +92,29 @@ TString ToUpperAscii(TStringBuf text) {
     return result;
 }
 
+TStringBuf StripOuterWhitespace(TStringBuf text) {
+    while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+        text.Skip(1);
+    }
+    while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+        text.Chop(1);
+    }
+    return text;
+}
+
+bool LooksLikeSchemeQueryStatement(TStringBuf statement) {
+    statement = StripOuterWhitespace(statement);
+    if (statement.empty()) {
+        return false;
+    }
+    const auto tokens = TokenizeUpper(statement);
+    const size_t i = SkipExplainPrefix(tokens);
+    if (i >= tokens.size()) {
+        return false;
+    }
+    return SchemeQueryLeadingKeywords().contains(tokens[i]);
+}
+
 } // anonymous namespace
 
 TStringBuf GetCurrentStatementPrefix(TStringBuf textBeforeCursor) {
@@ -103,12 +126,19 @@ TStringBuf GetCurrentStatementPrefix(TStringBuf textBeforeCursor) {
 }
 
 bool LooksLikeSchemeQuery(TStringBuf line) {
-    const auto tokens = TokenizeUpper(line);
-    const size_t i = SkipExplainPrefix(tokens);
-    if (i >= tokens.size()) {
-        return false;
+    TStringBuf rest = line;
+    while (true) {
+        const size_t semi = rest.find(';');
+        const TStringBuf segment = semi == TStringBuf::npos ? rest : rest.SubStr(0, semi);
+        if (LooksLikeSchemeQueryStatement(segment)) {
+            return true;
+        }
+        if (semi == TStringBuf::npos) {
+            break;
+        }
+        rest = rest.SubStr(semi + 1);
     }
-    return SchemeQueryLeadingKeywords().contains(tokens[i]);
+    return false;
 }
 
 bool IsSchemeQueryCompletionContext(TStringBuf textBeforeCursor) {

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
@@ -76,7 +76,6 @@ const THashSet<TString>& SchemeQueryTopLevelCompletionKeywords() {
         "IMPORT",
         "RESTORE",
         "REVOKE",
-        "SHOW CREATE",
         "TRUNCATE TABLE",
         "USE",
     };
@@ -111,7 +110,27 @@ bool LooksLikeSchemeQueryStatement(TStringBuf statement) {
     if (i >= tokens.size()) {
         return false;
     }
+    if (tokens[i] == "SHOW" && i + 1 < tokens.size() && tokens[i + 1] == "CREATE") {
+        return false;
+    }
     return SchemeQueryLeadingKeywords().contains(tokens[i]);
+}
+
+bool IsShowCreateStatementPrefix(TStringBuf textBeforeCursor) {
+    const size_t lastSemi = textBeforeCursor.rfind(';');
+    if (lastSemi != TStringBuf::npos) {
+        textBeforeCursor = textBeforeCursor.SubStr(lastSemi + 1);
+    }
+    textBeforeCursor = StripOuterWhitespace(textBeforeCursor);
+    if (textBeforeCursor.empty()) {
+        return false;
+    }
+    const auto tokens = TokenizeUpper(textBeforeCursor);
+    const size_t i = SkipExplainPrefix(tokens);
+    if (i >= tokens.size() || tokens[i] != "SHOW") {
+        return false;
+    }
+    return i + 1 == tokens.size() || (i + 2 <= tokens.size() && tokens[i + 1] == "CREATE");
 }
 
 } // anonymous namespace
@@ -145,6 +164,9 @@ bool IsSchemeQueryCompletionContext(TStringBuf textBeforeCursor) {
 }
 
 bool IsExcludedSchemeQueryCompletionKeyword(TStringBuf keywordContent, TStringBuf textBeforeCursor) {
+    if (IsShowCreateStatementPrefix(textBeforeCursor)) {
+        return false;
+    }
     if (IsSchemeQueryCompletionContext(textBeforeCursor)) {
         return true;
     }

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
@@ -43,7 +43,6 @@ const THashSet<TString>& SchemeQueryLeadingKeywords() {
         "IMPORT",
         "RESTORE",
         "REVOKE",
-        "SHOW",
         "TRUNCATE",
         "USE",
     };
@@ -77,7 +76,6 @@ const THashSet<TString>& SchemeQueryTopLevelCompletionKeywords() {
         "IMPORT",
         "RESTORE",
         "REVOKE",
-        "SHOW CREATE",
         "TRUNCATE TABLE",
         "USE",
     };

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.cpp
@@ -76,6 +76,7 @@ const THashSet<TString>& SchemeQueryTopLevelCompletionKeywords() {
         "IMPORT",
         "RESTORE",
         "REVOKE",
+        "SHOW CREATE",
         "TRUNCATE TABLE",
         "USE",
     };

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.h
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <util/generic/strbuf.h>
+
+namespace NYdb::NConsoleClient {
+
+// True if the line starts with a YDB scheme (DDL) statement.
+//
+// Recognizes the leading keyword after optional EXPLAIN [QUERY PLAN].
+// Used to block DDL inside interactive transactions before sending to the server.
+bool LooksLikeSchemeQuery(TStringBuf line);
+
+// Text of the current statement (segment after the last ';' before the cursor).
+TStringBuf GetCurrentStatementPrefix(TStringBuf textBeforeCursor);
+
+// True when TAB-completion is inside a scheme (DDL) statement.
+bool IsSchemeQueryCompletionContext(TStringBuf textBeforeCursor);
+
+// True if a keyword completion candidate must be hidden in interactive tx mode.
+bool IsExcludedSchemeQueryCompletionKeyword(TStringBuf keywordContent, TStringBuf textBeforeCursor);
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils.h
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils.h
@@ -4,10 +4,10 @@
 
 namespace NYdb::NConsoleClient {
 
-// True if the line starts with a YDB scheme (DDL) statement.
+// True if the line starts with a YDB scheme (DDL) statement that must not run
+// inside an interactive transaction.
 //
-// Recognizes the leading keyword after optional EXPLAIN [QUERY PLAN].
-// Used to block DDL inside interactive transactions before sending to the server.
+// SHOW CREATE TABLE/VIEW is intentionally allowed (read-only DDL).
 bool LooksLikeSchemeQuery(TStringBuf line);
 
 // Text of the current statement (segment after the last ';' before the cursor).

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
@@ -28,6 +28,12 @@ Y_UNIT_TEST_SUITE(SchemeQueryUtils) {
         UNIT_ASSERT(!LooksLikeSchemeQuery("EXPLAIN SELECT 1;"));
     }
 
+    Y_UNIT_TEST(MultiStatementWithDdl) {
+        UNIT_ASSERT(LooksLikeSchemeQuery(
+            "SELECT 1; CREATE TABLE t (id Uint64, PRIMARY KEY (id))"));
+        UNIT_ASSERT(!LooksLikeSchemeQuery("SELECT 1; SELECT 2"));
+    }
+
     Y_UNIT_TEST(CompletionContextAndKeywords) {
         UNIT_ASSERT_VALUES_EQUAL(GetCurrentStatementPrefix("SELECT 1; CRE"), " CRE");
         UNIT_ASSERT(IsSchemeQueryCompletionContext("ALTER "));

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
@@ -1,0 +1,42 @@
+#include <ydb/public/lib/ydb_cli/common/scheme_query_utils.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::NConsoleClient {
+
+Y_UNIT_TEST_SUITE(SchemeQueryUtils) {
+
+    Y_UNIT_TEST(CreateTable) {
+        UNIT_ASSERT(LooksLikeSchemeQuery("CREATE TABLE t (id Uint64, PRIMARY KEY (id));"));
+        UNIT_ASSERT(LooksLikeSchemeQuery("create table t (id Uint64);"));
+    }
+
+    Y_UNIT_TEST(AlterDropTruncate) {
+        UNIT_ASSERT(LooksLikeSchemeQuery("ALTER TABLE `/local/t` ADD COLUMN x Int32;"));
+        UNIT_ASSERT(LooksLikeSchemeQuery("DROP TABLE `/local/t`;"));
+        UNIT_ASSERT(LooksLikeSchemeQuery("TRUNCATE TABLE `/local/t`;"));
+    }
+
+    Y_UNIT_TEST(ExplainSchemeQuery) {
+        UNIT_ASSERT(LooksLikeSchemeQuery("EXPLAIN CREATE TABLE t (id Uint64, PRIMARY KEY (id));"));
+        UNIT_ASSERT(LooksLikeSchemeQuery("EXPLAIN QUERY PLAN ALTER TABLE t DROP COLUMN x;"));
+    }
+
+    Y_UNIT_TEST(DmlNotScheme) {
+        UNIT_ASSERT(!LooksLikeSchemeQuery("SELECT 1;"));
+        UNIT_ASSERT(!LooksLikeSchemeQuery("UPSERT INTO t (id) VALUES (1);"));
+        UNIT_ASSERT(!LooksLikeSchemeQuery("EXPLAIN SELECT 1;"));
+    }
+
+    Y_UNIT_TEST(CompletionContextAndKeywords) {
+        UNIT_ASSERT_VALUES_EQUAL(GetCurrentStatementPrefix("SELECT 1; CRE"), " CRE");
+        UNIT_ASSERT(IsSchemeQueryCompletionContext("ALTER "));
+        UNIT_ASSERT(!IsSchemeQueryCompletionContext("SELECT "));
+        UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("CREATE", ""));
+        UNIT_ASSERT(!IsExcludedSchemeQueryCompletionKeyword("SELECT", ""));
+        UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("TABLE", "ALTER "));
+    }
+
+} // Y_UNIT_TEST_SUITE
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
@@ -28,6 +28,13 @@ Y_UNIT_TEST_SUITE(SchemeQueryUtils) {
         UNIT_ASSERT(!LooksLikeSchemeQuery("EXPLAIN SELECT 1;"));
     }
 
+    Y_UNIT_TEST(ShowCreateAllowed) {
+        UNIT_ASSERT(!LooksLikeSchemeQuery("SHOW CREATE TABLE `/local/t`;"));
+        UNIT_ASSERT(!LooksLikeSchemeQuery("SHOW CREATE VIEW `/local/v`;"));
+        UNIT_ASSERT(!IsExcludedSchemeQueryCompletionKeyword("SHOW CREATE", ""));
+        UNIT_ASSERT(!IsExcludedSchemeQueryCompletionKeyword("CREATE", "SHOW "));
+    }
+
     Y_UNIT_TEST(MultiStatementWithDdl) {
         UNIT_ASSERT(LooksLikeSchemeQuery(
             "SELECT 1; CREATE TABLE t (id Uint64, PRIMARY KEY (id))"));
@@ -39,7 +46,6 @@ Y_UNIT_TEST_SUITE(SchemeQueryUtils) {
         UNIT_ASSERT(IsSchemeQueryCompletionContext("ALTER "));
         UNIT_ASSERT(!IsSchemeQueryCompletionContext("SELECT "));
         UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("CREATE", ""));
-        UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("SHOW CREATE", ""));
         UNIT_ASSERT(!IsExcludedSchemeQueryCompletionKeyword("SELECT", ""));
         UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("TABLE", "ALTER "));
     }

--- a/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/scheme_query_utils_ut.cpp
@@ -39,6 +39,7 @@ Y_UNIT_TEST_SUITE(SchemeQueryUtils) {
         UNIT_ASSERT(IsSchemeQueryCompletionContext("ALTER "));
         UNIT_ASSERT(!IsSchemeQueryCompletionContext("SELECT "));
         UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("CREATE", ""));
+        UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("SHOW CREATE", ""));
         UNIT_ASSERT(!IsExcludedSchemeQueryCompletionKeyword("SELECT", ""));
         UNIT_ASSERT(IsExcludedSchemeQueryCompletionKeyword("TABLE", "ALTER "));
     }

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
@@ -56,14 +56,11 @@ bool TokensStartWith(const TVector<TString>& tokens, std::initializer_list<TStri
     return true;
 }
 
-// How many leading tokens form the BEGIN/START preamble. Returns 0 if the
-// line does not start with a BEGIN-style preamble.
+// How many leading tokens form the BEGIN preamble. Returns 0 if the line does
+// not start with a BEGIN-style preamble.
 size_t MatchBeginPrefix(const TVector<TString>& tokens) {
     if (tokens.empty()) {
         return 0;
-    }
-    if (TokensStartWith(tokens, {"START", "TRANSACTION"})) {
-        return 2;
     }
     if (TokensStartWith(tokens, {"BEGIN", "TRANSACTION"})) {
         return 2;
@@ -129,11 +126,10 @@ TString GetTxModeNamesForHelp() {
 TVector<TString> GetTransactionControlCompletions() {
     TVector<TString> result;
 
-    // Every BEGIN / START prefix can optionally be followed by a tx mode.
+    // Every BEGIN prefix can optionally be followed by a tx mode.
     static constexpr TStringBuf kBeginPrefixes[] = {
         "BEGIN",
         "BEGIN TRANSACTION",
-        "START TRANSACTION",
     };
     const auto modes = GetSupportedTxModeNames();
     for (auto prefix : kBeginPrefixes) {
@@ -146,8 +142,6 @@ TVector<TString> GetTransactionControlCompletions() {
     static constexpr TStringBuf kCommitForms[] = {
         "COMMIT",
         "COMMIT TRANSACTION",
-        "END",
-        "END TRANSACTION",
     };
     for (auto form : kCommitForms) {
         result.emplace_back(form);
@@ -171,7 +165,7 @@ std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf lin
         return {};
     }
 
-    // Bare BEGIN/START TRANSACTION/etc. defaults to SerializableRW.
+    // Bare BEGIN/BEGIN TRANSACTION defaults to SerializableRW.
     if (skip == tokens.size()) {
         return NQuery::TTxSettings::SerializableRW();
     }
@@ -211,9 +205,7 @@ bool IsBeginCommand(TStringBuf line) {
 bool IsCommitCommand(TStringBuf line) {
     const auto tokens = TokenizeUpper(line);
     return MatchExactCommand(tokens, {"COMMIT"})
-        || MatchExactCommand(tokens, {"COMMIT", "TRANSACTION"})
-        || MatchExactCommand(tokens, {"END"})
-        || MatchExactCommand(tokens, {"END", "TRANSACTION"});
+        || MatchExactCommand(tokens, {"COMMIT", "TRANSACTION"});
 }
 
 bool IsRollbackCommand(TStringBuf line) {

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
@@ -68,9 +68,6 @@ size_t MatchBeginPrefix(const TVector<TString>& tokens) {
     if (TokensStartWith(tokens, {"BEGIN", "TRANSACTION"})) {
         return 2;
     }
-    if (TokensStartWith(tokens, {"BEGIN", "WORK"})) {
-        return 2;
-    }
     if (tokens.front() == "BEGIN") {
         return 1;
     }
@@ -136,7 +133,6 @@ TVector<TString> GetTransactionControlCompletions() {
     static constexpr TStringBuf kBeginPrefixes[] = {
         "BEGIN",
         "BEGIN TRANSACTION",
-        "BEGIN WORK",
         "START TRANSACTION",
     };
     const auto modes = GetSupportedTxModeNames();
@@ -150,7 +146,6 @@ TVector<TString> GetTransactionControlCompletions() {
     static constexpr TStringBuf kCommitForms[] = {
         "COMMIT",
         "COMMIT TRANSACTION",
-        "COMMIT WORK",
         "END",
         "END TRANSACTION",
     };
@@ -161,7 +156,6 @@ TVector<TString> GetTransactionControlCompletions() {
     static constexpr TStringBuf kRollbackForms[] = {
         "ROLLBACK",
         "ROLLBACK TRANSACTION",
-        "ROLLBACK WORK",
     };
     for (auto form : kRollbackForms) {
         result.emplace_back(form);
@@ -218,7 +212,6 @@ bool IsCommitCommand(TStringBuf line) {
     const auto tokens = TokenizeUpper(line);
     return MatchExactCommand(tokens, {"COMMIT"})
         || MatchExactCommand(tokens, {"COMMIT", "TRANSACTION"})
-        || MatchExactCommand(tokens, {"COMMIT", "WORK"})
         || MatchExactCommand(tokens, {"END"})
         || MatchExactCommand(tokens, {"END", "TRANSACTION"});
 }
@@ -226,8 +219,7 @@ bool IsCommitCommand(TStringBuf line) {
 bool IsRollbackCommand(TStringBuf line) {
     const auto tokens = TokenizeUpper(line);
     return MatchExactCommand(tokens, {"ROLLBACK"})
-        || MatchExactCommand(tokens, {"ROLLBACK", "TRANSACTION"})
-        || MatchExactCommand(tokens, {"ROLLBACK", "WORK"});
+        || MatchExactCommand(tokens, {"ROLLBACK", "TRANSACTION"});
 }
 
 } // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
@@ -34,14 +34,12 @@ TVector<TStringBuf> GetSupportedTxModeNames();
 // (online-ro / stale-ro are not interactive — see GetSupportedTxModeNames).
 std::optional<NQuery::TTxSettings> ParseTxModeName(TStringBuf mode);
 
-// Parse the isolation specification of a BEGIN / START TRANSACTION command line.
+// Parse the isolation specification of a BEGIN command line.
 //
 // Accepted forms (case-insensitive, trailing semicolon allowed):
 //   BEGIN
 //   BEGIN TRANSACTION
-//   START TRANSACTION
 //   BEGIN [TRANSACTION] <mode>
-//   START TRANSACTION <mode>
 //
 // Returns:
 //   - SerializableRW() for the bare command (no mode specified);
@@ -53,7 +51,7 @@ std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf lin
 // Extracts the user-facing mode token from a BEGIN line, if any.
 //
 // Returns the lowercased mode token (e.g. "online-ro") for inputs like
-// "BEGIN online-ro" or "START TRANSACTION online-ro INCONSISTENT READS".
+// "BEGIN online-ro" or "BEGIN TRANSACTION snapshot-ro".
 // Returns std::nullopt if the line is not a BEGIN command or has no mode
 // token after the prefix. Used to produce targeted diagnostics for known but
 // unsupported modes.

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
@@ -38,10 +38,9 @@ std::optional<NQuery::TTxSettings> ParseTxModeName(TStringBuf mode);
 //
 // Accepted forms (case-insensitive, trailing semicolon allowed):
 //   BEGIN
-//   BEGIN WORK
 //   BEGIN TRANSACTION
 //   START TRANSACTION
-//   BEGIN [TRANSACTION | WORK] <mode>
+//   BEGIN [TRANSACTION] <mode>
 //   START TRANSACTION <mode>
 //
 // Returns:

--- a/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
@@ -67,7 +67,6 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("begin"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION"));
-        UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN WORK"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("START TRANSACTION"));
     }
 
@@ -141,7 +140,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
     Y_UNIT_TEST(IsBeginCommand) {
         UNIT_ASSERT(IsBeginCommand("BEGIN"));
         UNIT_ASSERT(IsBeginCommand("begin transaction"));
-        UNIT_ASSERT(IsBeginCommand("Begin Work serializable-rw"));
+        UNIT_ASSERT(IsBeginCommand("Begin Transaction serializable-rw"));
         UNIT_ASSERT(IsBeginCommand("START TRANSACTION"));
         UNIT_ASSERT(IsBeginCommand("BEGIN;"));
         UNIT_ASSERT(!IsBeginCommand(""));
@@ -153,7 +152,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
     Y_UNIT_TEST(IsCommitCommand) {
         UNIT_ASSERT(IsCommitCommand("COMMIT"));
         UNIT_ASSERT(IsCommitCommand("commit transaction"));
-        UNIT_ASSERT(IsCommitCommand("COMMIT WORK;"));
+        UNIT_ASSERT(!IsCommitCommand("COMMIT WORK"));
         UNIT_ASSERT(IsCommitCommand("END"));
         UNIT_ASSERT(IsCommitCommand("END TRANSACTION"));
         UNIT_ASSERT(!IsCommitCommand("COMMIT FOO"));
@@ -162,7 +161,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
 
     Y_UNIT_TEST(IsRollbackCommand) {
         UNIT_ASSERT(IsRollbackCommand("ROLLBACK"));
-        UNIT_ASSERT(IsRollbackCommand("rollback work"));
+        UNIT_ASSERT(!IsRollbackCommand("rollback work"));
         UNIT_ASSERT(IsRollbackCommand("ROLLBACK TRANSACTION;"));
         UNIT_ASSERT(!IsRollbackCommand("ROLLBACK FOO"));
     }

--- a/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
@@ -67,7 +67,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("begin"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION"));
-        UNIT_ASSERT(ParseBeginTransactionIsolation("START TRANSACTION"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("START TRANSACTION"));
     }
 
     Y_UNIT_TEST(BeginAllowsTrailingSemicolon) {
@@ -79,7 +79,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
     Y_UNIT_TEST(BeginParsesMode) {
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN serializable-rw"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION snapshot-ro"));
-        UNIT_ASSERT(ParseBeginTransactionIsolation("START TRANSACTION read-committed-rw"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("START TRANSACTION read-committed-rw"));
     }
 
     Y_UNIT_TEST(BeginRejectsOneShotModes) {
@@ -115,7 +115,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN online-ro"), "online-ro");
         UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("begin Stale-RO"), "stale-ro");
         UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN TRANSACTION snapshot-ro"), "snapshot-ro");
-        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("START TRANSACTION serializable-rw"), "serializable-rw");
+        UNIT_ASSERT(!ExtractBeginModeToken("START TRANSACTION serializable-rw"));
         UNIT_ASSERT(!ExtractBeginModeToken("BEGIN"));
         UNIT_ASSERT(!ExtractBeginModeToken("BEGIN TRANSACTION"));
         UNIT_ASSERT(!ExtractBeginModeToken("SELECT 1"));
@@ -141,22 +141,21 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(IsBeginCommand("BEGIN"));
         UNIT_ASSERT(IsBeginCommand("begin transaction"));
         UNIT_ASSERT(IsBeginCommand("Begin Transaction serializable-rw"));
-        UNIT_ASSERT(IsBeginCommand("START TRANSACTION"));
+        UNIT_ASSERT(!IsBeginCommand("START TRANSACTION"));
         UNIT_ASSERT(IsBeginCommand("BEGIN;"));
         UNIT_ASSERT(!IsBeginCommand(""));
         UNIT_ASSERT(!IsBeginCommand("SELECT 1"));
         UNIT_ASSERT(!IsBeginCommand("BEGINNING"));
-        UNIT_ASSERT(!IsBeginCommand("START "));  // START alone is not BEGIN
+        UNIT_ASSERT(!IsBeginCommand("START"));
     }
 
     Y_UNIT_TEST(IsCommitCommand) {
         UNIT_ASSERT(IsCommitCommand("COMMIT"));
         UNIT_ASSERT(IsCommitCommand("commit transaction"));
         UNIT_ASSERT(!IsCommitCommand("COMMIT WORK"));
-        UNIT_ASSERT(IsCommitCommand("END"));
-        UNIT_ASSERT(IsCommitCommand("END TRANSACTION"));
+        UNIT_ASSERT(!IsCommitCommand("END"));
+        UNIT_ASSERT(!IsCommitCommand("END TRANSACTION"));
         UNIT_ASSERT(!IsCommitCommand("COMMIT FOO"));
-        UNIT_ASSERT(!IsCommitCommand("END WORK"));  // END WORK is not a thing
     }
 
     Y_UNIT_TEST(IsRollbackCommand) {

--- a/ydb/public/lib/ydb_cli/common/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ut/ya.make
@@ -10,6 +10,7 @@ SRCS(
     pg_dump_parser_ut.cpp
     print_utils_ut.cpp
     recursive_remove_ut.cpp
+    scheme_query_utils_ut.cpp
     tabbed_table_ut.cpp
     tx_mode_utils_ut.cpp
 )

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -37,6 +37,7 @@ SRCS(
     progress_indication.cpp
     query_stats.cpp
     query_utils.cpp
+    scheme_query_utils.cpp
     tx_mode_utils.cpp
     recursive_list.cpp
     recursive_remove.cpp

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1334,8 +1334,12 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         )
         child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
 
-    def _wait_for_tx_prompt(self, child):
-        child.expect("YQL\033\\[22;39m>\\* ", timeout=self.PROMPT_TIMEOUT)
+    def _wait_for_ready_after_begin(self, child):
+        """Wait until BEGIN finished and replxx is ready for the next line."""
+        child.expect("BEGIN", timeout=15)
+        # Replxx may not echo the full colored prompt into the pty buffer; the empty-line
+        # placeholder is a reliable readiness signal (same as other completion tests).
+        child.expect("Type YQL query", timeout=self.PROMPT_TIMEOUT)
 
     def _send_line(self, child, line: str):
         child.send(line)
@@ -1348,8 +1352,7 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             child.expect("Welcome to YDB CLI", timeout=15)
             self._wait_for_prompt(child)
             self._send_line(child, "BEGIN")
-            child.expect("BEGIN", timeout=15)
-            self._wait_for_tx_prompt(child)
+            self._wait_for_ready_after_begin(child)
             child.send("S")
             child.send("\t")
             child.expect("SELECT", timeout=self.COMPLETION_TIMEOUT)

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1335,7 +1335,7 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
 
     def _wait_for_tx_prompt(self, child):
-        child.expect(r"YQL\033\\[22;39m>\* ", timeout=self.PROMPT_TIMEOUT)
+        child.expect("YQL\033\\[22;39m>\\* ", timeout=self.PROMPT_TIMEOUT)
 
     def _send_line(self, child, line: str):
         child.send(line)

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1253,6 +1253,41 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert result.stdout.count("COMMIT") >= 2
         assert result.stdout.count("ROLLBACK") >= 1
 
+    def test_ddl_rejected_inside_transaction(self):
+        """CREATE TABLE must not be sent to the server while a transaction is open."""
+        ddl_table = f"ddl_blocked_{uuid.uuid4().hex}"
+        result = self.run_interactive_session(
+            [
+                "BEGIN",
+                f"CREATE TABLE `{ddl_table}` (id Uint64, PRIMARY KEY (id));",
+                "ROLLBACK",
+                f"SELECT COUNT(*) FROM `{ddl_table}`;",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = (result.stdout + result.stderr).lower()
+        assert "cannot be executed inside an interactive transaction" in combined
+        assert "ROLLBACK" in result.stdout
+
+    def test_failed_query_invalidates_transaction(self):
+        """After a failed in-tx query the CLI must drop local tx state (server auto-rollback)."""
+        result = self.run_interactive_session(
+            [
+                "BEGIN",
+                "SELECT * FROM `/path/that/does/not/exist`;",
+                "SELECT 2;",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "automatically rolled back" in combined
+        assert "Transaction not found" not in combined
+        assert "2" in result.stdout
+
 
 class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
     """
@@ -1298,6 +1333,34 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             + ".*".join("snapshot-rw")
         )
         child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
+
+    def _wait_for_tx_prompt(self, child):
+        child.expect(r"YQL\033\\[22;39m>\* ", timeout=self.PROMPT_TIMEOUT)
+
+    def _send_line(self, child, line: str):
+        child.send(line)
+        child.send("\r")
+
+    def test_no_ddl_completion_inside_transaction(self):
+        """Inside a transaction TAB must not propose CREATE / ALTER / DROP."""
+        child = self.spawn_interactive()
+        try:
+            child.expect("Welcome to YDB CLI", timeout=15)
+            self._wait_for_prompt(child)
+            self._send_line(child, "BEGIN")
+            child.expect("BEGIN", timeout=15)
+            self._wait_for_tx_prompt(child)
+            child.send("S")
+            child.send("\t")
+            child.expect("SELECT", timeout=self.COMPLETION_TIMEOUT)
+            try:
+                child.expect("CREATE", timeout=1)
+                raise AssertionError("CREATE must not be suggested inside a transaction")
+            except pexpect.TIMEOUT:
+                pass
+        finally:
+            self._discard_and_exit(child)
+            child.close()
 
     def test_tab_completes_beg_to_begin(self):
         """`BEG<TAB>` should expand to BEGIN."""

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -996,41 +996,6 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "BEGIN" in result.stdout
         assert "COMMIT" in result.stdout
 
-    def test_start_transaction(self):
-        result = self.run_interactive_session(
-            ["START TRANSACTION", "SELECT 6;", "COMMIT", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "BEGIN" in result.stdout
-        assert "COMMIT" in result.stdout
-
-    def test_start_transaction_with_mode(self):
-        result = self.run_interactive_session(
-            ["START TRANSACTION snapshot-ro", "SELECT 7;", "COMMIT", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "BEGIN" in result.stdout
-        assert "COMMIT" in result.stdout
-
-    def test_end_aliases_commit(self):
-        result = self.run_interactive_session(
-            ["BEGIN", "SELECT 8;", "END", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "BEGIN" in result.stdout
-        assert "COMMIT" in result.stdout
-
-    def test_end_transaction_aliases_commit(self):
-        result = self.run_interactive_session(
-            ["BEGIN", "SELECT 9;", "END TRANSACTION", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "COMMIT" in result.stdout
-
     def test_rollback(self):
         result = self.run_interactive_session(
             ["BEGIN", "SELECT 4;", "ROLLBACK", "exit"],
@@ -1374,19 +1339,6 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             # Single expect: avoid false positives on "Server" in the welcome
             # banner (s.*e.*r matches) and require the full candidate list.
             self._expect_s_prefixed_tx_modes(child, "BEGIN s")
-        finally:
-            self._discard_and_exit(child)
-            child.close()
-
-    def test_tab_after_start_transaction_proposes_modes(self):
-        """`START TRANSACTION s<TAB>` proposes s-prefixed modes (no phrase repetition)."""
-        child = self.spawn_interactive()
-        try:
-            child.expect("Welcome to YDB CLI", timeout=15)
-            self._wait_for_prompt(child)
-            child.send("START TRANSACTION s")
-            child.send("\t")
-            self._expect_s_prefixed_tx_modes(child, "START TRANSACTION s")
         finally:
             self._discard_and_exit(child)
             child.close()

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -996,16 +996,6 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "BEGIN" in result.stdout
         assert "COMMIT" in result.stdout
 
-    def test_begin_work_commit(self):
-        result = self.run_interactive_session(
-            ["BEGIN WORK", "SELECT 5;", "COMMIT WORK", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "BEGIN" in result.stdout
-        assert "COMMIT" in result.stdout
-        assert "5" in result.stdout
-
     def test_start_transaction(self):
         result = self.run_interactive_session(
             ["START TRANSACTION", "SELECT 6;", "COMMIT", "exit"],
@@ -1053,14 +1043,6 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
     def test_rollback_transaction(self):
         result = self.run_interactive_session(
             ["BEGIN", "SELECT 41;", "ROLLBACK TRANSACTION", "exit"],
-            self.tmp_path,
-        )
-        assert result.exit_code == 0
-        assert "ROLLBACK" in result.stdout
-
-    def test_rollback_work(self):
-        result = self.run_interactive_session(
-            ["BEGIN", "SELECT 42;", "ROLLBACK WORK", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
@@ -1256,6 +1238,18 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert result.exit_code == 0
         assert "ROLLBACK" in result.stdout
         assert marker_name not in result.stdout
+
+    def test_select_after_rollback_runs_outside_transaction(self):
+        """After ROLLBACK the REPL must not reuse the closed transaction id."""
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "ROLLBACK", "SELECT 2;", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "Transaction not found" not in combined
+        assert "ROLLBACK" in result.stdout
+        assert "2" in result.stdout
 
     def test_commit_actually_persists_dml(self):
         """COMMIT after UPSERT must persist the row."""

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1354,7 +1354,7 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         child.send("\r")
 
     def test_no_ddl_completion_inside_transaction(self):
-        """Inside a transaction TAB must not propose CREATE / ALTER / DROP."""
+        """Inside a transaction TAB must hide destructive DDL but keep SHOW CREATE."""
         child = self.spawn_interactive()
         try:
             child.expect("Welcome to YDB CLI", timeout=15)
@@ -1365,7 +1365,11 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             child.send("\t")
             # Replxx may split rendered keywords with ANSI escapes (ELECT ... S ... HOW CREATE).
             self._expect_keyword(child, "ELECT")
-            self._expect_no_keyword(child, "HOW CREATE")
+            self._expect_keyword(child, "HOW CREATE")
+            child.sendcontrol("u")
+            child.send("CRE")
+            child.send("\t")
+            self._expect_no_keyword(child, "CREATE")
         finally:
             self._discard_and_exit(child)
             child.close()

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1334,6 +1334,14 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         )
         child.expect(pattern, timeout=self.COMPLETION_TIMEOUT)
 
+    def _expect_no_keyword(self, child, keyword: str, *, timeout: float = 1):
+        pattern = ".*".join(keyword)
+        try:
+            child.expect(pattern, timeout=timeout)
+            raise AssertionError(f"{keyword!r} must not appear in completions")
+        except pexpect.TIMEOUT:
+            pass
+
     def _wait_for_ready_after_begin(self, child):
         """Wait until BEGIN finished and replxx is ready for the next line."""
         child.expect("BEGIN", timeout=15)
@@ -1355,12 +1363,9 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
             self._wait_for_ready_after_begin(child)
             child.send("S")
             child.send("\t")
-            child.expect("SELECT", timeout=self.COMPLETION_TIMEOUT)
-            try:
-                child.expect("CREATE", timeout=1)
-                raise AssertionError("CREATE must not be suggested inside a transaction")
-            except pexpect.TIMEOUT:
-                pass
+            # Replxx may split rendered keywords with ANSI escapes (ELECT ... S ... HOW CREATE).
+            self._expect_keyword(child, "ELECT")
+            self._expect_no_keyword(child, "HOW CREATE")
         finally:
             self._discard_and_exit(child)
             child.close()


### PR DESCRIPTION
## Summary

Follow-up improvements for interactive transactions in `ydb_int` (Query service session).

- Simplify TCL syntax: drop `WORK`, `START TRANSACTION`, `END` aliases; fix stale transaction state after `COMMIT`/`ROLLBACK` and `NOT_FOUND`.
- Block DDL (`CREATE`, `ALTER`, `DROP`, …) inside an open transaction before sending to the server.
- Hide DDL keywords in YQL TAB-completion while a transaction is open (client-side post-filter in `ydb_cli`, no changes to `yql/essentials`).
- On any failed in-tx query, clear local transaction state and notify that the server rolled the transaction back automatically.

### Changelog entry

Not for changelog (`ydb_int` experimental CLI only).

### Changelog category

* Not for changelog (changelog entry is not required)

### Supported TCL syntax

| Action | Forms |
|--------|--------|
| Begin | `BEGIN`, `BEGIN TRANSACTION`, `BEGIN <mode>`, `BEGIN TRANSACTION <mode>` |
| Commit | `COMMIT`, `COMMIT TRANSACTION` |
| Rollback | `ROLLBACK`, `ROLLBACK TRANSACTION` |

Removed psql-style aliases: `BEGIN WORK`, `COMMIT WORK`, `ROLLBACK WORK`, `START TRANSACTION`, `END`, `END TRANSACTION`.

### Stale transaction state

After `COMMIT`/`ROLLBACK` or a server-side tx close, the REPL no longer keeps `YQL> *` or reuses a dead `TxId` (`NOT_FOUND` / «Transaction not found»).

### DDL inside a transaction

YDB does not support scheme queries in open transactions. The CLI rejects them locally (`scheme_query_utils`) and omits DDL completion candidates while `YQL> *` is active.

### Failed query in a transaction

The server auto-rolls back on error; the next request with the same `TxId` yields `NOT_FOUND`. The CLI invalidates local state after any failed in-tx execute and prints a hint to run `BEGIN` again.

### Commits

1. Remove `WORK` keyword + fix forgetting tx in interactive mode
2. Drop `START`/`END TRANSACTION` aliases
3. Block DDL in open interactive transactions and reset tx on query errors

## Test plan

- [ ] `BEGIN` → query → `ROLLBACK` → query (no `YQL> *`, no NOT_FOUND)
- [ ] `BEGIN` → query → `COMMIT` → query
- [ ] `BEGIN` → `CREATE TABLE …` → warning, query not sent
- [ ] `BEGIN` → failing query → `SELECT 2` succeeds without NOT_FOUND
- [ ] In tx: `S<TAB>` suggests `SELECT`, not `CREATE`
- [ ] CI: `TestInteractiveTransactions*` on Linux