### PR TITLE
EXT-2243 Hive tablets allowed metrics config

### DIFF
--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -690,6 +690,28 @@ void THive::BuildCurrentConfig() {
     for (const NKikimrConfig::THiveTabletPreference& tabletPreference : CurrentConfig.GetDefaultTabletPreference()) {
         DefaultDataCentersPreference[tabletPreference.GetType()] = tabletPreference.GetDataCentersPreference();
     }
+    TabletTypeAllowedMetricsDefaults.clear();
+    auto setComputeMetric = [](TVector<i64>& metrics, i64 metricId, bool enabled) {
+        auto it = Find(metrics, metricId);
+        if (enabled && it == metrics.end()) {
+            metrics.emplace_back(metricId);
+        } else if (!enabled && it != metrics.end()) {
+            metrics.erase(it);
+        }
+    };
+    for (const auto& allowedMetrics : CurrentConfig.GetDefaultTabletAllowedMetrics()) {
+        for (auto t : allowedMetrics.GetTabletType()) {
+            const TTabletTypes::EType tabletType = TTabletTypes::EType(t);
+            if (!IsValidTabletType(tabletType)) {
+                continue;
+            }
+            TVector<i64> metricIds = GetDefaultAllowedMetricIdsForType(tabletType);
+            setComputeMetric(metricIds, NKikimrTabletBase::TMetrics::kCPUFieldNumber, allowedMetrics.GetCPU());
+            setComputeMetric(metricIds, NKikimrTabletBase::TMetrics::kMemoryFieldNumber, allowedMetrics.GetMemory());
+            setComputeMetric(metricIds, NKikimrTabletBase::TMetrics::kNetworkFieldNumber, allowedMetrics.GetNetwork());
+            TabletTypeAllowedMetricsDefaults.insert_or_assign(tabletType, std::move(metricIds));
+        }
+    }
     BalancerIgnoreTabletTypes.clear();
     for (auto i : CurrentConfig.GetBalancerIgnoreTabletTypes()) {
         const auto type = TTabletTypes::EType(i);
@@ -2453,7 +2475,7 @@ void THive::RemoveNodeFromSegments(TNodeInfo* node) {
         NodeSegments.erase(it);
     }
 }
- 
+
 void THive::RemoveNodeFromSegments(TNodeId nodeId) {
     if (auto* node = FindNode(nodeId)) {
         RemoveNodeFromSegments(node);
@@ -2846,12 +2868,15 @@ const TVector<i64>& THive::GetDefaultAllowedMetricIdsForType(TTabletTypes::EType
 }
 
 const TVector<i64>& THive::GetTabletTypeAllowedMetricIds(TTabletTypes::EType type) const {
-    const TVector<i64>& defaultAllowedMetricIds = GetDefaultAllowedMetricIdsForType(type);
     auto it = TabletTypeAllowedMetrics.find(type);
     if (it != TabletTypeAllowedMetrics.end()) {
         return it->second;
     }
-    return defaultAllowedMetricIds;
+    it = TabletTypeAllowedMetricsDefaults.find(type);
+    if (it != TabletTypeAllowedMetricsDefaults.end()) {
+        return it->second;
+    }
+    return GetDefaultAllowedMetricIdsForType(type);
 }
 
 THolder<TGroupFilter> THive::BuildGroupParametersForChannel(const TLeaderTabletInfo& tablet, ui32 channelId) {
@@ -4011,7 +4036,7 @@ bool THive::ReassignInactiveGroups(TStoragePoolInfo& pool) {
             return new TEvPrivate::TEvReassignInactiveGroupsComplete(PoolName);
         }
 
-        TShrinkPoolReassignCallback(const TString& poolName) 
+        TShrinkPoolReassignCallback(const TString& poolName)
             : PoolName(poolName)
         {}
     };

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -691,11 +691,14 @@ void THive::BuildCurrentConfig() {
         DefaultDataCentersPreference[tabletPreference.GetType()] = tabletPreference.GetDataCentersPreference();
     }
     TabletTypeAllowedMetricsDefaults.clear();
-    auto setComputeMetric = [](TVector<i64>& metrics, i64 metricId, bool enabled) {
+    auto setComputeMetric = [](TVector<i64>& metrics, i64 metricId, auto value) {
+        if (value == NKikimrConfig::THiveConfig::THiveTabletAllowedMetrics::Default) {
+            return;
+        }
         auto it = Find(metrics, metricId);
-        if (enabled && it == metrics.end()) {
+        if (value == NKikimrConfig::THiveConfig::THiveTabletAllowedMetrics::Enabled && it == metrics.end()) {
             metrics.emplace_back(metricId);
-        } else if (!enabled && it != metrics.end()) {
+        } else if (value == NKikimrConfig::THiveConfig::THiveTabletAllowedMetrics::Disabled && it != metrics.end()) {
             metrics.erase(it);
         }
     };

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -346,6 +346,7 @@ protected:
     std::unordered_map<TOwnerIdxType::TValueType, TTabletId> OwnerToTablet;
     std::unordered_map<TTabletCategoryId, TTabletCategoryInfo> TabletCategories;
     std::unordered_map<TTabletTypes::EType, TVector<i64>> TabletTypeAllowedMetrics;
+    std::unordered_map<TTabletTypes::EType, TVector<i64>> TabletTypeAllowedMetricsDefaults; // built from CurrentConfig
     std::unordered_map<TString, TStoragePoolInfo> StoragePools;
     std::unordered_map<TSubDomainKey, TDomainInfo> Domains;
     std::unordered_set<TOwnerId> BlockedOwners;

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -1278,9 +1278,9 @@ public:
         ShowConfig(out, "DataCenterChangeReactionPeriod");
 
         out << "<div class='row' style='margin-top:40px'>";
-        bool allowedMetricsLocalOverrided = !Self->TabletTypeAllowedMetrics.empty();
+        bool allowedMetricsLocalOverridden = !Self->TabletTypeAllowedMetrics.empty();
         out << "<div class='col-sm-2' style='padding-top:30px;text-align:right'><label for='allowedMetrics'";
-        if (!allowedMetricsLocalOverrided) {
+        if (!allowedMetricsLocalOverridden) {
             out << " style='font-weight:normal'";
         }
         out << ">AllowedMetrics:</label></div>";
@@ -1325,7 +1325,7 @@ public:
         }
         out << "</table></div>";
         out << "<div class='col-sm-1' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='applyTab(this);' disabled='true'>Apply</button></div>";
-        out << "<div class='col-sm-1' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='resetTab(this);' " << (allowedMetricsLocalOverrided ? "" : "disabled='true'") << ">Reset</button></div>";
+        out << "<div class='col-sm-1' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='resetTab(this);' " << (allowedMetricsLocalOverridden ? "" : "disabled='true'") << ">Reset</button></div>";
         out << "</div>";
 
         out << "</div>";

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -1274,6 +1274,7 @@ public:
              TTabletTypes::Mediator,
              TTabletTypes::SchemeShard,
              TTabletTypes::Hive,
+             TTabletTypes::Kesus,
              TTabletTypes::KeyValue,
              TTabletTypes::PersQueue,
              TTabletTypes::PersQueueReadBalancer,

--- a/ydb/core/mind/hive/monitoring.cpp
+++ b/ydb/core/mind/hive/monitoring.cpp
@@ -968,6 +968,19 @@ public:
             db.Table<Schema::State>().Key(TSchemeIds::State::DefaultState).Update<Schema::State::Config>(Self->DatabaseConfig);
             Self->ProcessWaitQueue();
         }
+        if (params.contains("resetAllowedMetrics")) {
+            ChangeRequest = true;
+            if (Event->GetMethod() != HTTP_METHOD_POST) {
+                Status = "error";
+                return true;
+            }
+            auto& jsonReset = jsonOperation["AllowedMetricsReset"];
+            for (const auto& [type, _] : Self->TabletTypeAllowedMetrics) {
+                jsonReset.AppendValue(GetTabletTypeShortName(type));
+                db.Table<Schema::TabletTypeMetrics>().Key(type).Delete();
+            }
+            Self->TabletTypeAllowedMetrics.clear();
+        }
         if (params.contains("allowedMetrics")) {
             auto& jsonAllowedMetrics = jsonOperation["AllowedMetricsUpdate"];
             TVector<TString> allowedMetrics = SplitString(params.Get("allowedMetrics"), ";");
@@ -1265,7 +1278,12 @@ public:
         ShowConfig(out, "DataCenterChangeReactionPeriod");
 
         out << "<div class='row' style='margin-top:40px'>";
-        out << "<div class='col-sm-2' style='padding-top:30px;text-align:right'><label for='allowedMetrics'>AllowedMetrics:</label></div>";
+        bool allowedMetricsLocalOverrided = !Self->TabletTypeAllowedMetrics.empty();
+        out << "<div class='col-sm-2' style='padding-top:30px;text-align:right'><label for='allowedMetrics'";
+        if (!allowedMetricsLocalOverrided) {
+            out << " style='font-weight:normal'";
+        }
+        out << ">AllowedMetrics:</label></div>";
         out << "<div class='col-sm-3' style='padding-top:5px'><table>";
         out << "<tr><th style='padding:2px 10px'>Tablet</th><th style='padding:2px 10px'>Cnt</th><th style='padding:2px 10px'>CPU</th><th style='padding:2px 10px'>Mem</th><th style='padding:2px 10px'>Net</th></tr>";
         for (TTabletTypes::EType tabletType : {
@@ -1306,7 +1324,8 @@ public:
             out << "</tr>";
         }
         out << "</table></div>";
-        out << "<div class='col-sm-2' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='applyTab(this);' disabled='true'>Apply</button></div>";
+        out << "<div class='col-sm-1' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='applyTab(this);' disabled='true'>Apply</button></div>";
+        out << "<div class='col-sm-1' style='padding-top:22px'><button type='button' class='btn' style='margin-top:5px' onclick='resetTab(this);' " << (allowedMetricsLocalOverrided ? "" : "disabled='true'") << ">Reset</button></div>";
         out << "</div>";
 
         out << "</div>";
@@ -1375,7 +1394,20 @@ public:
                    $.ajax({
                        type: 'POST',
                        url: document.URL + '&' + name + '=' + val,
-                       success: function() { $(button).prop('disabled', true).removeClass('btn-danger'); },
+                       success: function() {
+                         $(button).prop('disabled', true).removeClass('btn-danger');
+                         $(button).parent().next().children('button').prop('disabled', false);
+                         $(button).parent().parent().find('label').removeAttr('style');
+                       },
+                       error: function() { $(button).addClass('btn-danger'); }
+                   });
+               }
+
+               function resetTab(button) {
+                   $.ajax({
+                       type: 'POST',
+                       url: document.URL + '&resetAllowedMetrics=1',
+                       success: function() { document.location.reload(); },
                        error: function() { $(button).addClass('btn-danger'); }
                    });
                }

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2467,6 +2467,13 @@ message THiveConfig {
         optional double Priority = 2;
     }
 
+    message THiveTabletAllowedMetrics {
+        repeated NKikimrTabletBase.TTabletTypes.EType TabletType = 1;
+        optional bool CPU = 2;
+        optional bool Memory = 3;
+        optional bool Network = 4;
+    }
+
     optional uint64 MaxTabletsScheduled = 2 [default = 100];
     optional uint64 MaxResourceCounter = 3 [default = 100000000];
     optional uint64 MaxResourceCPU = 4 [default = 10000000];
@@ -2556,6 +2563,7 @@ message THiveConfig {
     optional bool LockedTabletsSendMetrics = 89 [default = false]; // if true then hive will process metrics from locked tablets
     optional uint64 MaxDeleteTabletInProgress = 90 [default = 100];
     optional uint64 DataCenterChangeReactionPeriod = 91 [default = 1]; // seconds
+    repeated THiveTabletAllowedMetrics DefaultTabletAllowedMetrics = 92;
 }
 
 message THealthCheckConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2468,10 +2468,16 @@ message THiveConfig {
     }
 
     message THiveTabletAllowedMetrics {
+        enum EAllowedMetricValue {
+            Default = 0;  // Not configured, take from hive defaults
+            Disabled = 1; // Explicitly disabled
+            Enabled = 2;  // Explicitly enabled
+        }
+
         repeated NKikimrTabletBase.TTabletTypes.EType TabletType = 1;
-        optional bool CPU = 2;
-        optional bool Memory = 3;
-        optional bool Network = 4;
+        optional EAllowedMetricValue CPU = 2;
+        optional EAllowedMetricValue Memory = 3;
+        optional EAllowedMetricValue Network = 4;
     }
 
     optional uint64 MaxTabletsScheduled = 2 [default = 100];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There are config parameters for almost all hive settings, so that they can be modified through regular deploy process.
Except `AllowedMetrics` table for every tablet type. I passed this settings to config as well.
Also I provided a reset button for this table as for any other hive setting (see a separate commit with the support in this PR).