### PR TITLE
Fix offload reader crash under PQ reboots

### DIFF
--- a/ydb/core/backup/impl/local_partition_reader.cpp
+++ b/ydb/core/backup/impl/local_partition_reader.cpp
@@ -76,8 +76,14 @@ private:
             Schedule(TDuration::Seconds(1), new NActors::TEvents::TEvWakeup);
             return;
         }
-        Y_VERIFY_S(record.GetErrorCode() == NPersQueue::NErrorCode::OK, "Unimplemented!");
-        Y_VERIFY_S(record.HasPartitionResponse() && record.GetPartitionResponse().HasCmdGetClientOffsetResult(), "Unimplemented!");
+        if (record.GetErrorCode() != NPersQueue::NErrorCode::OK
+                || !record.HasPartitionResponse()
+                || !record.GetPartitionResponse().HasCmdGetClientOffsetResult()) {
+            // Retry via worker
+            LOG_W("HandleInit unexpected response, leaving: " << ev->Get()->ToString());
+            Y_ABORT_UNLESS(Worker, "Worker is always set before any PQ response: the offset request is only sent from the handshake handler");
+            return Leave(TEvWorker::TEvGone::UNAVAILABLE);
+        }
         const auto& resp = record.GetPartitionResponse().GetCmdGetClientOffsetResult();
         Offset = resp.GetOffset();
         SentOffset = Offset;

--- a/ydb/core/backup/impl/local_partition_reader_ut.cpp
+++ b/ydb/core/backup/impl/local_partition_reader_ut.cpp
@@ -221,6 +221,48 @@ Y_UNIT_TEST_SUITE(LocalPartitionReader) {
         }
     }
 
+    // Reproduces ydb-platform/ydb#41295: during heavy tablet reboots the PQ
+    // tablet dispatcher answers CmdGetClientOffset with a code that is neither
+    // INITIALIZING nor OK (TABLET_IS_DROPPED when TabletState==EDropped, or
+    // WRONG_PARTITION_NUMBER when the partition is transiently absent from the
+    // Partitions map). HandleInit() has no handling for these and aborts the
+    // node via Y_VERIFY_S(..., "Unimplemented!") at local_partition_reader.cpp:79.
+    void ReproInitErrorCode(NPersQueue::NErrorCode::EErrorCode errorCode) {
+        TTestActorRuntime runtime;
+        runtime.Initialize(NKikimr::TAppPrepare().Unwrap());
+
+        TActorId pqtablet = runtime.AllocateEdgeActor();
+        TActorId reader = runtime.Register(CreateLocalPartitionReader(pqtablet, PARTITION));
+        runtime.EnableScheduleForActor(reader);
+        TActorId worker = runtime.AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+
+        runtime.Send(new IEventHandle(reader, worker, new TEvWorker::TEvHandshake));
+
+        GrabInitialPQRequest(runtime);
+
+        // The tablet is mid-reboot / dropped and replies with a non-OK,
+        // non-INITIALIZING error code.
+        auto* getOffsetResponse = new TEvPersQueue::TEvResponse;
+        getOffsetResponse->Record.SetStatus(NMsgBusProxy::MSTATUS_ERROR);
+        getOffsetResponse->Record.SetErrorCode(errorCode);
+        runtime.Send(new IEventHandle(reader, pqtablet, getOffsetResponse));
+
+        // Expected (post-fix): the reader gracefully reports it is gone so the
+        // Worker can recreate/retry it. On the current code this line is never
+        // reached because HandleInit aborts the process at the Y_VERIFY_S above.
+        auto gone = runtime.GrabEdgeEventRethrow<TEvWorker::TEvGone>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(gone->Status, TEvWorker::TEvGone::UNAVAILABLE);
+    }
+
+    Y_UNIT_TEST(TabletDroppedDuringInit) {
+        ReproInitErrorCode(NPersQueue::NErrorCode::TABLET_IS_DROPPED);
+    }
+
+    Y_UNIT_TEST(WrongPartitionNumberDuringInit) {
+        ReproInitErrorCode(NPersQueue::NErrorCode::WRONG_PARTITION_NUMBER);
+    }
+
     // TODO write tests with real PQ
 }
 


### PR DESCRIPTION
### Changelog entry

N/A

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Under heavy tablet reboots the PQ tablet could answer the offload reader's initial `CmdGetClientOffset` with `TABLET_IS_DROPPED` / `WRONG_PARTITION_NUMBER`, which tripped a `Y_VERIFY_S` in `TLocalPartitionReader::HandleInit` and crashed the node (#41295). `HandleInit` now reports `TEvGone(UNAVAILABLE)` on any non-OK/non-INITIALIZING reply so the Worker recreates and retries the reader instead of aborting.