### PR TITLE
Support proper SyncLog keeper out-of-space handling

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -792,6 +792,7 @@ struct TEvBlobStorage {
         EvReleaseVDiskOperationToken,
         EvStartupDataSyncDone,
         EvPhantomFlagExtractedFromChunk,
+        EvSyncLogDiskOutOfSpace,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -215,6 +215,24 @@ namespace NKikimr {
                 PerformActions(ctx);
             }
 
+            void Handle(TEvSyncLogDiskOutOfSpace::TPtr &ev, const TActorContext &ctx) {
+                auto *msg = ev->Get();
+                LOG_NOTICE(ctx, BS_SYNCLOG,
+                          VDISKP(SlCtx->VCtx->VDiskLogPrefix,
+                                "KEEPER: TEvSyncLogDiskOutOfSpace: disposing disk sync log;"
+                                " allocatedChunks# %s", FormatList(msg->AllocatedChunks).data()));
+
+                Sublog.Log() << ToStringLocalTimeUpToSeconds(ctx.Now())
+                    << " Disk sync log disposed due to OUT_OF_SPACE\n";
+
+                // committer aborted the commit
+                CommitterId = TActorId();
+                KeepState.DisposeDiskSyncLog(std::move(msg->AllocatedChunks));
+
+                // start the disposal commit (and any other delayed actions)
+                PerformActions(ctx);
+            }
+
             void Handle(TEvSyncLogSnapshot::TPtr &ev, const TActorContext &ctx) {
                 ++SlCtx->IFaceMonGroup.SyncLogGetSnapshot();
                 auto snap = KeepState.GetSyncLogSnapshot();
@@ -297,6 +315,7 @@ namespace NKikimr {
                 HFunc(TEvSyncLogTrim, Handle)
                 HFunc(TEvSyncLogFreeChunk, Handle)
                 HFunc(TEvSyncLogCommitDone, Handle)
+                HFunc(TEvSyncLogDiskOutOfSpace, Handle)
                 HFunc(TEvSyncLogSnapshot, Handle)
                 HFunc(TEvSyncLogLocalStatus, Handle)
                 HFunc(TEvBlobStorage::TEvVBaldSyncLog, Handle)

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.cpp
@@ -119,6 +119,24 @@ namespace NKikimr {
             void Handle(NPDisk::TEvChunkWriteResult::TPtr &ev, const TActorContext &ctx) {
                 LOG_DEBUG(ctx, BS_SYNCLOG,
                         VDISKP(SlCtx->VCtx->VDiskLogPrefix, "COMMITTER: write done"));
+
+                if (ev->Get()->Status == NKikimrProto::OUT_OF_SPACE) {
+                    // We tried to allocate a new chunk for the sync log, but PDisk is out
+                    // of space (only fresh chunk allocation, i.e. chunkIdx == 0, can return
+                    // this status). The persistent sync log is not essential for data
+                    // persistence: peers requesting old lsns will simply fall back to full
+                    // sync. So instead of switching the VDisk to a terminal state, ask the
+                    // keeper to dispose of the whole disk sync log. CommitRecord.CommitChunks
+                    // holds all chunks we have managed to write during this commit.
+                    LOG_NOTICE(ctx, NKikimrServices::BS_VDISK_OTHER,
+                            VDISKP(SlCtx->VCtx->VDiskLogPrefix,
+                                "COMMITTER: OUT_OF_SPACE on chunk write, disposing disk sync log; %s",
+                                ev->Get()->ToString().data()));
+                    ctx.Send(NotifyID, new TEvSyncLogDiskOutOfSpace(std::move(CommitRecord.CommitChunks)));
+                    Die(ctx);
+                    return;
+                }
+
                 CHECK_PDISK_RESPONSE(SlCtx->VCtx, ev, ctx);
 
                 // chunk is written, apply index update

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.h
@@ -86,6 +86,22 @@ namespace NKikimr {
         };
 
         ////////////////////////////////////////////////////////////////////////////
+        // TEvSyncLogDiskOutOfSpace
+        // Sent by the committer to the keeper when a sync log chunk write returns
+        // OUT_OF_SPACE. Carries the chunks that were allocated during the aborted
+        // commit so the keeper can dispose of them together with the whole disk log.
+        ////////////////////////////////////////////////////////////////////////////
+        struct TEvSyncLogDiskOutOfSpace
+            : public TEventLocal<TEvSyncLogDiskOutOfSpace, TEvBlobStorage::EvSyncLogDiskOutOfSpace>
+        {
+            TVector<ui32> AllocatedChunks;
+
+            TEvSyncLogDiskOutOfSpace(TVector<ui32>&& allocatedChunks)
+                : AllocatedChunks(std::move(allocatedChunks))
+            {}
+        };
+
+        ////////////////////////////////////////////////////////////////////////////
         // TSyncLogKeeperCommitData
         ////////////////////////////////////////////////////////////////////////////
         struct TSyncLogKeeperCommitData {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -369,6 +369,51 @@ namespace NKikimr {
             return firstLsnToKeep;
         }
 
+        void TSyncLogKeeperState::DisposeDiskSyncLog(TVector<ui32> allocatedChunks) {
+            // Drop every chunk currently in the disk sync log. These chunks may still
+            // be referenced by outstanding snapshots, so TrimLogByRemovingChunks attaches
+            // a notifier to each of them; the chunk is actually forgotten (TEvChunkForget)
+            // only once the last snapshot referencing it is released (see FreeChunkEvent).
+            THashSet<ui32> existing;
+            const ui32 numChunks = SyncLogPtr->GetSizeInChunks();
+            if (numChunks > 0) {
+                for (const TDeletedChunk& chunk : SyncLogPtr->TrimLogByRemovingChunks(numChunks, Notifier)) {
+                    existing.insert(chunk.ChunkIdx);
+                }
+            }
+
+            LOG_NOTICE(*LoggerCtx, BS_SYNCLOG,
+                    VDISKP(SlCtx->VCtx->VDiskLogPrefix,
+                        "KEEPER: DisposeDiskSyncLog: droppedChunks# %s allocatedChunks# %s",
+                        FormatList(existing).data(), FormatList(allocatedChunks).data()));
+
+            // Existing chunks: schedule them for deletion through the regular machinery.
+            ChunksToDelete.insert(ChunksToDelete.end(), existing.begin(), existing.end());
+            DeletedChunksPending.insert(existing.begin(), existing.end());
+
+            // Orphan chunks: written by the aborted commit but never part of the disk log
+            // (and not referenced by any snapshot). Pre-seed them into ChunksToForgetPending
+            // so that ApplyCommitResult routes them straight to ChunksToForget once the
+            // disposal commit confirms their deletion. No TEvSyncLogFreeChunk will arrive
+            // for these chunks since the keeper holds no TOneChunk object for them.
+            for (ui32 chunkIdx : allocatedChunks) {
+                if (!existing.contains(chunkIdx)) {
+                    ChunksToDelete.push_back(chunkIdx);
+                    const auto [it, inserted] = ChunksToForgetPending.insert(chunkIdx);
+                    Y_ABORT_UNLESS(inserted, "%s chunkIdx# %" PRIu32,
+                            SlCtx->VCtx->VDiskLogPrefix.data(), chunkIdx);
+                }
+            }
+
+            if (!ChunksToDelete.empty()) {
+                DelayedActions.DeleteChunk = true;
+            }
+
+            // Do not try to swap memory to disk in the disposal commit, otherwise it
+            // would just hit OUT_OF_SPACE again.
+            SuppressSwapToDisk = true;
+        }
+
         // Fix Disk overflow, i.e. remove some chunks from SyncLog
         TVector<TDeletedChunk> TSyncLogKeeperState::FixDiskOverflow(ui32 numChunksToAdd) {
             // prepare disk write
@@ -386,6 +431,16 @@ namespace NKikimr {
         }
 
         TMemRecLogSnapshotPtr TSyncLogKeeperState::BuildSwapSnap() {
+            // One-shot suppression: the disposal commit (triggered on OUT_OF_SPACE) must
+            // not swap memory to disk, otherwise it would hit OUT_OF_SPACE again.
+            if (SuppressSwapToDisk) {
+                SuppressSwapToDisk = false;
+                LOG_DEBUG(*LoggerCtx, BS_LOGCUTTER,
+                        VDISKP(SlCtx->VCtx->VDiskLogPrefix,
+                            "KEEPER: BuildSwapSnap: swap suppressed for disposal commit"));
+                return {};
+            }
+
             // find mem pages to write to disk
             const bool stillMemOverflow = SyncLogPtr->GetNumberOfPagesInMemory() > MaxMemPages;
             const ui64 firstLsnToKeep = CalculateFirstLsnToKeep();

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -84,6 +84,14 @@ namespace NKikimr {
             // applies commit result and returns first lsn to keep
             ui64 ApplyCommitResult(TEvSyncLogCommitDone *msg);
 
+            // Dispose the whole on-disk sync log after a chunk write returned
+            // OUT_OF_SPACE. Drops all disk chunks (scheduling them for deletion) and
+            // suppresses swapping memory to disk for the next (disposal) commit.
+            // allocatedChunks are the chunks the committer managed to write during the
+            // aborted commit; the ones not already owned by the disk log are orphans
+            // that have to be deleted and forgotten as well.
+            void DisposeDiskSyncLog(TVector<ui32> allocatedChunks);
+
             void ListChunks(const THashSet<TChunkIdx>& chunksOfInterest, THashSet<TChunkIdx>& chunks);
 
             void UpdateNeighbourSyncedLsn(ui32 orderNumber, ui64 syncedLsn);
@@ -131,6 +139,9 @@ namespace NKikimr {
             const ui64 SyncLogMaxEntryPointSize;
             // does it need initial commit?
             bool NeedsInitialCommit;
+            // one-shot flag: when set, the next commit must not swap memory to disk
+            // (used by the disposal commit triggered on OUT_OF_SPACE)
+            bool SuppressSwapToDisk = false;
             // Id of Keeper actor which possesses the state
             TActorId SelfId;
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -4,6 +4,8 @@
 
 #include <util/stream/null.h>
 
+#include <algorithm>
+
 #define STR Cnull
 
 namespace NKikimr {
@@ -60,6 +62,8 @@ namespace NKikimr {
         void PrintStatus(const TString &str = {}) {
             ::NKikimr::PrintStatus(State.get(), str);
         }
+        void RunDisposeTest();
+
     private:
         std::unique_ptr<TSyncLogKeeperState> State;
         TPayloadWriter PayloadWriter;
@@ -182,6 +186,124 @@ namespace NKikimr {
         std::unique_ptr<TSyncLogKeeperCommitData> CommitData;
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    // TCommitWithSwap
+    // Simulates the committer writing the swap snapshot to disk (assigning fresh
+    // chunk indices) and applies the commit result to the keeper state.
+    ////////////////////////////////////////////////////////////////////////////
+    class TCommitWithSwap {
+    public:
+        void Start(TSyncLogKeeperState *state, ui64 recoveryLogConfirmedLsn) {
+            CommitData = std::make_unique<TSyncLogKeeperCommitData>(state->PrepareCommitData(recoveryLogConfirmedLsn));
+            STR << "Swap commit started\n";
+        }
+
+        bool HasSwap() const {
+            return CommitData->SwapSnap && !CommitData->SwapSnap->Empty();
+        }
+
+        TVector<ui32> GetChunksToDelete() const {
+            return CommitData->ChunksToDelete;
+        }
+
+        void Finish(TSyncLogKeeperState *state, ui64 commitLsn, ui32 firstChunkIdx, TVector<ui32> *writtenChunks) {
+            auto snap = CommitData->SyncLogSnap;
+            const ui32 indexBulk = snap->DiskSnapPtr->IndexBulk;
+            const ui32 pagesInChunk = snap->DiskSnapPtr->PagesInChunk;
+
+            TDeltaToDiskRecLog delta(indexBulk);
+            auto &swap = CommitData->SwapSnap;
+            ui32 chunkIdx = firstChunkIdx;
+            if (swap && !swap->Empty()) {
+                ui32 total = swap->Size();
+                ui32 pos = 0;
+                while (pos < total) {
+                    ui32 m = Min(pagesInChunk, total - pos);
+                    TVector<TSyncLogPageSnap> pages;
+                    for (ui32 i = 0; i < m; ++i) {
+                        pages.push_back((*swap)[pos + i]);
+                    }
+                    delta.Append(chunkIdx, pages);
+                    if (writtenChunks) {
+                        writtenChunks->push_back(chunkIdx);
+                    }
+                    ++chunkIdx;
+                    pos += m;
+                }
+            }
+
+            TEntryPointSerializer entryPointSerializer(snap, {}, CommitData->RecoveryLogConfirmedLsn);
+            entryPointSerializer.Serialize(delta);
+            TCommitHistory commitHistory(TInstant(), commitLsn, CommitData->RecoveryLogConfirmedLsn);
+            TEvSyncLogCommitDone commitDone(commitHistory, entryPointSerializer.GetEntryPointDbgInfo(),
+                std::move(delta), std::move(CommitData->ChunksToDelete));
+            state->ApplyCommitResult(&commitDone);
+            STR << "Swap commit finished lsn# " << commitLsn << "\n";
+        }
+
+    private:
+        std::unique_ptr<TSyncLogKeeperCommitData> CommitData;
+    };
+
+    static bool Contains(const TVector<ui32> &v, ui32 x) {
+        return std::find(v.begin(), v.end(), x) != v.end();
+    }
+
+    void TSyncLogKeeperTest::RunDisposeTest() {
+        CreateState(TEntryPointPair{TString(), 0});
+
+        // write sample payload
+        ui64 lsn = 0;
+        for (ui64 i = 0; i < 10; ++i) {
+            PayloadWriter.WriteToLog(State.get(), &lsn);
+        }
+
+        // Force a swap-to-disk commit so the disk sync log gets some chunks.
+        bool commit = CutLog(100);
+        Y_ABORT_UNLESS(commit);
+
+        TCommitWithSwap swapCommit;
+        swapCommit.Start(State.get(), 0);
+        Y_ABORT_UNLESS(swapCommit.HasSwap());
+        TVector<ui32> writtenChunks;
+        swapCommit.Finish(State.get(), 11, 1000, &writtenChunks);
+        Y_ABORT_UNLESS(!writtenChunks.empty());
+
+        // disk sync log must be non-empty now
+        UNIT_ASSERT(!State->GetSyncLogSnapshot()->DiskSnapPtr->Empty());
+
+        // Simulate OUT_OF_SPACE disposal. Report one orphan chunk (allocated during
+        // the aborted commit but not part of the disk log).
+        const ui32 orphanChunk = 2000;
+        State->DisposeDiskSyncLog({orphanChunk});
+
+        // disk log must be dropped immediately
+        UNIT_ASSERT(State->GetSyncLogSnapshot()->DiskSnapPtr->Empty());
+
+        // Drive the disposal commit: swap must be suppressed and all disk chunks +
+        // orphan must be scheduled for deletion.
+        TCommitWithSwap disposalCommit;
+        disposalCommit.Start(State.get(), 11);
+        UNIT_ASSERT(!disposalCommit.HasSwap());
+
+        TVector<ui32> chunksToDelete = disposalCommit.GetChunksToDelete();
+        for (ui32 c : writtenChunks) {
+            UNIT_ASSERT_C(Contains(chunksToDelete, c), "disk chunk# " << c << " not scheduled for deletion");
+        }
+        UNIT_ASSERT_C(Contains(chunksToDelete, orphanChunk), "orphan chunk not scheduled for deletion");
+
+        TVector<ui32> nothingWritten;
+        disposalCommit.Finish(State.get(), 12, 3000, &nothingWritten);
+        UNIT_ASSERT(nothingWritten.empty());
+
+        // disk log stays empty after the disposal commit
+        UNIT_ASSERT(State->GetSyncLogSnapshot()->DiskSnapPtr->Empty());
+
+        // the orphan chunk must be ready to be forgotten
+        TVector<ui32> toForget = State->GetChunksToForget();
+        UNIT_ASSERT_C(Contains(toForget, orphanChunk), "orphan chunk not ready to forget");
+    }
+
     void TSyncLogKeeperTest::Run() {
         TEntryPointPair entryPointPair;
         CreateState(TEntryPointPair{TString(), 0});
@@ -258,6 +380,11 @@ namespace NKikimr {
         Y_UNIT_TEST(CutLog_EntryPointNewFormat) {
             TSyncLogKeeperTest test;
             test.Run();
+        }
+
+        Y_UNIT_TEST(DisposeDiskSyncLogOnOutOfSpace) {
+            TSyncLogKeeperTest test;
+            test.RunDisposeTest();
         }
 
         Y_UNIT_TEST(WhatsNextReadsMemoryWhenCacheStartsBeforeDisk) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support proper SyncLog keeper out-of-space handling

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows SyncLogKeeper to handle OUT\_OF\_SPACE error without breaking VDisk itself.
