### PR TITLE
Split PR-check analytics marts by build_type for release-asan

### DIFF
--- a/.github/scripts/analytics/data_mart_queries/pr_check_failures_by_attempt.sql
+++ b/.github/scripts/analytics/data_mart_queries/pr_check_failures_by_attempt.sql
@@ -1,8 +1,10 @@
--- PR-check: все падения тестов в окне lookback для пары (pr_number, branch) — и прошлые job'ы, и текущий last.
+-- PR-check: все падения тестов в окне lookback для пары (pr_number, branch, build_type).
 -- Разрез по attempt (1/2/3 из pull). Не rich-фильтр — любой failure.
 --
--- is_last_run_in_pr: 1 если job_id = последний PR-check по (pr_number, branch) в окне
---   (MAX_BY(job_id, run_timestamp) по всем PR-check строкам, как в pr_blocked_by_failed_tests_rich), иначе 0.
+-- is_last_run_in_pr: 1 если job_id = последний PR-check по (pr_number, branch, build_type) в окне
+--   (MAX_BY(job_id, run_timestamp) по PR-check строкам этого build_type), иначе 0.
+--
+-- relwithdebinfo и release-asan считаются отдельно: matrix-джобы делят один workflow run_id.
 --
 -- Отличается от pr_with_test_failures / pr_blocked_by_tests:
 --   там последний job исторически считался по строкам с attempt = 3; здесь last_job считается по всем attempt.
@@ -22,6 +24,7 @@
 PRAGMA AnsiInForEmptyOrNullableItemsCollections;
 
 $pr_check_lookback_days = 30;
+$pr_check_build_types = ('relwithdebinfo', 'release-asan');
 
 $raw_pr_check = (
     SELECT
@@ -76,7 +79,7 @@ $raw_pr_check = (
     FROM
         `test_results/test_runs_column`
     WHERE
-        build_type = 'relwithdebinfo'
+        build_type IN $pr_check_build_types
         AND job_name = 'PR-check'
         AND run_timestamp > CurrentUtcDate() - $pr_check_lookback_days * Interval("P1D")
         AND pull IS NOT NULL
@@ -88,32 +91,36 @@ $raw_pr_check = (
         AND test_name IS NOT NULL
 );
 
--- Один timestamp на (job_id, pr_number, branch) — как в pr_blocked_by_failed_tests_rich.$all_pr_check_runs
+-- Один timestamp на (job_id, pr_number, branch, build_type)
 $job_ts = (
     SELECT
         job_id,
         pr_number,
         branch,
+        build_type,
         MAX(run_timestamp) AS run_timestamp
     FROM
         $raw_pr_check
     GROUP BY
         job_id,
         pr_number,
-        branch
+        branch,
+        build_type
 );
 
 $last_job_per_pr_branch = (
     SELECT
         pr_number,
         branch,
+        build_type,
         MAX_BY(job_id, run_timestamp) AS last_job_id,
         MAX(run_timestamp) AS last_job_run_timestamp
     FROM
         $job_ts
     GROUP BY
         pr_number,
-        branch
+        branch,
+        build_type
 );
 
 $pr_latest = (
@@ -165,7 +172,7 @@ $monitor_today = (
     FROM
         `test_results/analytics/tests_monitor`
     WHERE
-        build_type = 'relwithdebinfo'
+        build_type IN $pr_check_build_types
         AND date_window = CurrentUtcDate()
 );
 
@@ -179,7 +186,7 @@ $monitor_run_day = (
     FROM
         `test_results/analytics/tests_monitor`
     WHERE
-        build_type = 'relwithdebinfo'
+        build_type IN $pr_check_build_types
         AND date_window >= CurrentUtcDate() - $pr_check_lookback_days * Interval("P1D")
         AND date_window <= CurrentUtcDate()
 );
@@ -227,6 +234,7 @@ LEFT JOIN
 ON
     f.pr_number = lj.pr_number
     AND f.branch = lj.branch
+    AND f.build_type = lj.build_type
 INNER JOIN
     $pr_latest AS pr
 ON

--- a/.github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql
+++ b/.github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql
@@ -2,16 +2,18 @@
 --
 -- Logic:
 --   1. Take all PRs from github_data/pull_requests (deduplicate by latest exported_at).
---   2. For each PR find the latest PR-check run within $test_lookback_days days.
---   3. Determine if PR is blocked by tests:
+--   2. For each PR and build_type find the latest PR-check run within $test_lookback_days days.
+--      relwithdebinfo and release-asan are tracked separately (same workflow run_id / job_id
+--      is shared across matrix jobs, so build_type must be in all aggregations).
+--   3. Determine if PR is blocked by tests (per build_type):
 --      - is_pr_blocked_by_tests_in_last_run_and_try = 1 if the latest run
 --        has failures on the third attempt (attempt = 3).
---      - Third attempt is final; if a test failed there, PR is blocked.
+--      - Third attempt is final; if a test failed there, PR is blocked for that build_type.
 --   4. LEFT JOIN to detailed info for each failed test:
 --      full_name, job_id, branch, logs, owners, etc.
 --
--- Result: one row per (PR, failed test) pair. PRs with no failures are included
--- (with empty test fields).
+-- Result: one row per (PR, build_type, failed test) pair. PRs with no failures are included
+-- (with empty test fields) per build_type that had a PR-check run.
 --
 -- Parameters:
 --   $test_lookback_days — test selection window (days). Limits scanning of
@@ -21,6 +23,7 @@
 PRAGMA AnsiInForEmptyOrNullableItemsCollections;
 
 $test_lookback_days = 65;
+$pr_check_build_types = ('relwithdebinfo', 'release-asan');
 
 SELECT 
     pr.pr_number AS pr_number,
@@ -72,6 +75,7 @@ SELECT
     END AS pr_status,
     COALESCE(block.is_pr_blocked_by_tests_in_last_run_and_try, 0) AS is_pr_blocked_by_tests_in_last_run_and_try,
     block.last_run_url AS last_run_url,
+    COALESCE(t.build_type, block.build_type, CAST("" AS Utf8)) AS build_type,
     COALESCE(t.full_name, CAST("" AS Utf8)) AS full_name,
     t.suite_folder AS suite_folder,
     t.test_name AS test_name,
@@ -79,7 +83,6 @@ SELECT
     t.run_url AS run_url,
     COALESCE(t.last_run_timestamp, Timestamp("1970-01-01T00:00:00.000000Z")) AS last_run_timestamp,
     t.branch AS branch,
-    t.build_type AS build_type,
     t.status_description AS status_description,
     t.attempt_number AS attempt_number,
     t.is_last_run_in_pr AS is_last_run_in_pr,
@@ -189,20 +192,23 @@ LEFT JOIN
     (
         SELECT 
             pr_number,
+            build_type,
             CASE WHEN attempt_number = 3 AND has_failure = 1 THEN 1 ELSE 0 END AS is_pr_blocked_by_tests_in_last_run_and_try,
             CASE WHEN attempt_number = 3 AND has_failure = 1 THEN 'https://github.com/ydb-platform/ydb/actions/runs/' || CAST(job_id AS UTF8) ELSE NULL END AS last_run_url
         FROM (
             SELECT 
                 pr_number,
+                build_type,
                 job_id,
                 run_timestamp,
                 attempt_number,
                 has_failure,
-                ROW_NUMBER() OVER (PARTITION BY pr_number ORDER BY run_timestamp DESC) AS rn
+                ROW_NUMBER() OVER (PARTITION BY pr_number, build_type ORDER BY run_timestamp DESC) AS rn
             FROM (
                 SELECT 
                     r.job_id AS job_id,
                     r.pr_number AS pr_number,
+                    r.build_type AS build_type,
                     MAX(r.run_timestamp) AS run_timestamp,
                     MAX_BY(r.attempt_number, r.run_timestamp) AS attempt_number,
                     MAX(CASE WHEN r.status = 'failure' AND r.attempt_number = la.last_attempt THEN 1 ELSE 0 END) AS has_failure
@@ -210,6 +216,7 @@ LEFT JOIN
                     SELECT 
                         job_id,
                         run_timestamp,
+                        build_type,
                         ListHead(
                             Unicode::SplitToList(
                                 CASE 
@@ -239,7 +246,7 @@ LEFT JOIN
                     FROM 
                         `test_results/test_runs_column`
                     WHERE 
-                        build_type = 'relwithdebinfo'
+                        build_type IN $pr_check_build_types
                         AND job_name = 'PR-check'
                         AND run_timestamp > CurrentUtcDate() - $test_lookback_days * Interval("P1D")
                         AND pull IS NOT NULL
@@ -251,11 +258,13 @@ LEFT JOIN
                     SELECT 
                         job_id,
                         pr_number,
+                        build_type,
                         MAX_BY(attempt_number, run_timestamp) AS last_attempt
                     FROM (
                         SELECT 
                             job_id,
                             run_timestamp,
+                            build_type,
                             ListHead(
                                 Unicode::SplitToList(
                                     CASE 
@@ -284,7 +293,7 @@ LEFT JOIN
                         FROM 
                             `test_results/test_runs_column`
                         WHERE 
-                            build_type = 'relwithdebinfo'
+                            build_type IN $pr_check_build_types
                             AND job_name = 'PR-check'
                             AND run_timestamp > CurrentUtcDate() - $test_lookback_days * Interval("P1D")
                             AND pull IS NOT NULL
@@ -294,12 +303,14 @@ LEFT JOIN
                     ) AS pr_check_runs
                     GROUP BY 
                         job_id,
-                        pr_number
+                        pr_number,
+                        build_type
                 ) AS la
-                ON r.job_id = la.job_id AND r.pr_number = la.pr_number
+                ON r.job_id = la.job_id AND r.pr_number = la.pr_number AND r.build_type = la.build_type
                 GROUP BY 
                     r.job_id,
-                    r.pr_number
+                    r.pr_number,
+                    r.build_type
             ) AS job_agg
         ) AS last_run_per_pr
         WHERE 
@@ -308,9 +319,10 @@ LEFT JOIN
     ON block.pr_number = CAST(pr.pr_number AS Utf8)
 LEFT JOIN 
     (
-        -- All failed tests from last job_id per PR (attempt 3)
+        -- All failed tests from last job_id per PR and build_type (attempt 3)
         SELECT 
             tests.pr_number AS pr_number,
+            tests.build_type AS build_type,
             tests.full_name AS full_name,
             tests.suite_folder AS suite_folder,
             tests.test_name AS test_name,
@@ -318,7 +330,6 @@ LEFT JOIN
             'https://github.com/ydb-platform/ydb/actions/runs/' || CAST(tests.job_id AS UTF8) AS run_url,
             tests.run_timestamp AS last_run_timestamp,
             tests.branch AS branch,
-            'relwithdebinfo' AS build_type,
             COALESCE(tests.status_description, '') AS status_description,
             tests.attempt_number AS attempt_number,
             1 AS is_last_run_in_pr,
@@ -335,6 +346,7 @@ LEFT JOIN
             SELECT 
                 job_id,
                 run_timestamp,
+                build_type,
                 suite_folder,
                 test_name,
                 suite_folder || '/' || test_name AS full_name,
@@ -376,7 +388,7 @@ LEFT JOIN
             FROM 
                 `test_results/test_runs_column`
             WHERE 
-                build_type = 'relwithdebinfo'
+                build_type IN $pr_check_build_types
                 AND job_name = 'PR-check'
                 AND status = 'failure'
                 AND run_timestamp > CurrentUtcDate() - $test_lookback_days * Interval("P1D")
@@ -393,14 +405,16 @@ LEFT JOIN
             ON o.suite_folder = tests.suite_folder
             AND o.test_name = tests.test_name
         INNER JOIN (
-            -- Last job_id for each PR (attempt 3)
+            -- Last job_id for each PR and build_type (attempt 3)
             SELECT 
                 pr_number,
+                build_type,
                 MAX_BY(job_id, run_timestamp) AS last_job_id
             FROM (
                 SELECT 
                     job_id,
                     run_timestamp,
+                    build_type,
                     ListHead(
                         Unicode::SplitToList(
                             CASE 
@@ -429,7 +443,7 @@ LEFT JOIN
                 FROM 
                     `test_results/test_runs_column`
                 WHERE 
-                    build_type = 'relwithdebinfo'
+                    build_type IN $pr_check_build_types
                     AND job_name = 'PR-check'
                     AND run_timestamp > CurrentUtcDate() - $test_lookback_days * Interval("P1D")
                     AND pull IS NOT NULL
@@ -438,14 +452,17 @@ LEFT JOIN
                     AND job_id IS NOT NULL
             ) AS all_runs
             WHERE attempt_number = 3
-            GROUP BY pr_number
+            GROUP BY pr_number, build_type
         ) AS last_job
         ON tests.pr_number = last_job.pr_number 
+        AND tests.build_type = last_job.build_type
         AND tests.job_id = last_job.last_job_id
         WHERE tests.attempt_number = 3
     ) AS t
     ON CAST(t.pr_number AS Uint64) = pr.pr_number
+    AND t.build_type = block.build_type
 ORDER BY 
     pr.pr_number,
+    build_type,
     t.last_run_timestamp DESC,
     t.full_name

--- a/.github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql
+++ b/.github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql
@@ -67,20 +67,22 @@ SELECT
     pr.merged_by_url AS pr_merged_by_url,
     pr.info AS pr_info,
     pr.exported_at AS pr_exported_at,
-    CASE 
-        WHEN pr.merged = 1 THEN 'merged'
-        WHEN pr.state = 'OPEN' THEN 'open'
-        WHEN pr.state = 'CLOSED' THEN 'closed'
-        ELSE COALESCE(pr.state, 'unknown')
-    END AS pr_status,
+    CAST(
+        CASE
+            WHEN pr.merged = 1 THEN 'merged'
+            WHEN pr.state = 'OPEN' THEN 'open'
+            WHEN pr.state = 'CLOSED' THEN 'closed'
+            ELSE COALESCE(pr.state, 'unknown')
+        END AS String
+    ) AS pr_status,
     COALESCE(block.is_pr_blocked_by_tests_in_last_run_and_try, 0) AS is_pr_blocked_by_tests_in_last_run_and_try,
-    block.last_run_url AS last_run_url,
-    COALESCE(t.build_type, block.build_type, CAST("" AS Utf8)) AS build_type,
-    COALESCE(t.full_name, CAST("" AS Utf8)) AS full_name,
+    CAST(block.last_run_url AS String) AS last_run_url,
+    CAST(COALESCE(t.build_type, block.build_type, CAST("" AS String)) AS String) AS build_type,
+    CAST(COALESCE(t.full_name, CAST("" AS String)) AS String) AS full_name,
     t.suite_folder AS suite_folder,
     t.test_name AS test_name,
     COALESCE(t.job_id, 0UL) AS job_id,
-    t.run_url AS run_url,
+    CAST(t.run_url AS String) AS run_url,
     COALESCE(t.last_run_timestamp, Timestamp("1970-01-01T00:00:00.000000Z")) AS last_run_timestamp,
     t.branch AS branch,
     t.status_description AS status_description,

--- a/.github/workflows/collect_analytics_fast.yml
+++ b/.github/workflows/collect_analytics_fast.yml
@@ -113,10 +113,10 @@ jobs:
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_blocked_by_failed_tests_rich_with_pr_and_mute_all_runs_on_last_commit.sql --table_path test_results/analytics/pr_blocked_by_failed_tests_rich_all_runs_on_last_commit --store_type column --partition_keys run_timestamp --primary_keys run_timestamp full_name pr_number branch job_id
     - name: Upload PR with test failures (any failures, 1 day)
       continue-on-error: true
-      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql --table_path test_results/analytics/pr_blocked_by_tests --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id
+      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_with_test_failures.sql --table_path test_results/analytics/pr_blocked_by_tests --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id build_type
     - name: Upload PR check failures by attempt (all jobs in window, is_last_run_in_pr flag)
       continue-on-error: true
-      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_check_failures_by_attempt.sql --table_path test_results/analytics/pr_check_failures_by_attempt --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number branch job_id attempt_number
+      run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_check_failures_by_attempt.sql --table_path test_results/analytics/pr_check_failures_by_attempt --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number branch job_id attempt_number build_type
     - name: Upload PR failed in attempt but not run in next data mart
       continue-on-error: true
       run: python3 .github/scripts/analytics/data_mart_executor.py --query_path .github/scripts/analytics/data_mart_queries/pr_failed_in_attempt_but_not_run_in_next.sql --table_path test_results/analytics/pr_failed_in_attempt_but_not_run_in_next --store_type column --partition_keys last_run_timestamp --primary_keys last_run_timestamp full_name pr_number job_id gap_type


### PR DESCRIPTION
## Summary
- Track `relwithdebinfo` and `release-asan` separately in `pr_blocked_by_tests` and `pr_check_failures_by_attempt` SQL marts (shared workflow `run_id` no longer mixes matrix jobs).
- Add `build_type` to primary keys in `collect_analytics_fast` so preset rows do not overwrite each other.
- Prepare monitoring for ASAN before it is added to the merge gate; existing DataLens views can keep `build_type = 'relwithdebinfo'`.

## Test plan
- [x] Drop/recreate YDB marts (`pr_blocked_by_tests`, `pr_check_failures_by_attempt`) before the first run with the new PK
- [x] Run `collect_analytics_fast` and verify rows for both `relwithdebinfo` and `release-asan`
- [x] Confirm no duplicate PK rows and `is_last_run_in_pr` / blocked flags are correct per build_type


Made with [Cursor](https://cursor.com)