### PR TITLE
MonPages: BsController added admin path handling and tests accordingly 

### DIFF
--- a/ydb/core/base/mon_auth.cpp
+++ b/ydb/core/base/mon_auth.cpp
@@ -33,6 +33,7 @@ bool UsesTabletDevUiSecurePath(const TAppData* appData, TTabletTypes::EType type
         TTabletTypes::DataShard,
         TTabletTypes::Hive,
         TTabletTypes::GraphShard,
+        TTabletTypes::BSController,
         TTabletTypes::SchemeShard,
     };
 

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -914,7 +914,7 @@ void TBlobStorageController::ProcessPostQuery(const NActorsProto::TRemoteHttpInf
     }
 }
 
-bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) {
+bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext&) {
     if (!Executor() || !Executor()->GetStats().IsActive) {
         return false;
     }

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -11,7 +11,7 @@ namespace NBsController {
 
 namespace {
 
-bool IsBsControllerDevUiAdminRequest(const TCgiParameters& cgi, const TActorContext& ctx) {
+bool IsBsControllerDevUiAdminRequest(const TCgiParameters& cgi) {
     if (cgi.Has("exec")) {
         return true;
     }
@@ -815,7 +815,7 @@ void TBlobStorageController::ProcessPostQuery(const NActorsProto::TRemoteHttpInf
             AppData(),
             query.GetPath(),
             query.GetUserToken(),
-            !IsBsControllerDevUiAdminRequest(params, TActivationContext::AsActorContext())))
+            !IsBsControllerDevUiAdminRequest(params)))
     {
         Send(sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPFORBIDDEN));
         return;
@@ -926,7 +926,7 @@ bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr e
             AppData(),
             ev->Get()->PathInfo(),
             ev->Get()->GetUserToken(),
-            !IsBsControllerDevUiAdminRequest(cgi, ctx)))
+            !IsBsControllerDevUiAdminRequest(cgi)))
     {
         Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPFORBIDDEN));
         return true;

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -3,10 +3,58 @@
 
 #include <library/cpp/json/json_writer.h>
 #include <google/protobuf/util/json_util.h>
+#include <ydb/core/base/mon_auth.h>
 
 
 namespace NKikimr {
 namespace NBsController {
+
+namespace {
+
+bool IsBsControllerDevUiAdminRequest(const TCgiParameters& cgi, const TActorContext& ctx) {
+    if (cgi.Has("exec")) {
+        return true;
+    }
+
+    const TString page = cgi.Has("page") ? cgi.Get("page") : TString();
+    if (page.empty()
+        || page == "GetDown"
+        || page == "OperationLog"
+        || page == "OperationLogEntry"
+        || page == "HealthEvents"
+        || page == "Groups"
+        || page == "GroupDetail"
+        || page == "Scrub"
+        || page == "InternalTables"
+        || page == "Bridge"
+        || page == "VirtualGroups")
+    {
+        return false;
+    }
+
+    if (page == "SelfHeal") {
+        const bool isDisableSelfHealAction = cgi.Get("disable") == "1"
+            && cgi.Has("action") && cgi.Get("action") == "disableSelfHeal";
+        return isDisableSelfHealAction;
+    }
+
+    if (page == "Shred") {
+        return cgi.Has("startshred");
+    }
+
+    if (page == "SetDown"
+        || page == "StopGivingGroups"
+        || page == "StartGivingGroups")
+    {
+        return true;
+    }
+
+    STLOG(PRI_WARN, BS_CONTROLLER, BSCTXMO03, "BlobStorageController DevUI request to unknown page",
+        (Page, page), (Cgi, cgi.Print()));
+    return true;
+}
+
+} // namespace
 
 static const char *DataSizeSuffix[] = {"B", "KiB", "MiB", "GiB", nullptr};
 
@@ -763,6 +811,16 @@ void TBlobStorageController::ProcessPostQuery(const NActorsProto::TRemoteHttpInf
         params.emplace(param.GetKey(), param.GetValue());
     }
 
+    if (!IsTabletDevUiAccessAllowed(
+            AppData(),
+            query.GetPath(),
+            query.GetUserToken(),
+            !IsBsControllerDevUiAdminRequest(params, TActivationContext::AsActorContext())))
+    {
+        Send(sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPFORBIDDEN));
+        return;
+    }
+
     auto sendResponse = [&](TString message, TString contentType, TString content) {
         Send(sender, new NMon::TEvRemoteBinaryInfoRes(TStringBuilder() << "HTTP/1.1 " << message << "\r\n"
             "Content-Type: " << contentType << "\r\n"
@@ -856,11 +914,21 @@ void TBlobStorageController::ProcessPostQuery(const NActorsProto::TRemoteHttpInf
     }
 }
 
-bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext&) {
+bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) {
     if (!Executor() || !Executor()->GetStats().IsActive) {
         return false;
     }
     if (!ev) {
+        return true;
+    }
+    const TCgiParameters& cgi(ev->Get()->Cgi());
+    if (!IsTabletDevUiAccessAllowed(
+            AppData(),
+            ev->Get()->PathInfo(),
+            ev->Get()->GetUserToken(),
+            !IsBsControllerDevUiAdminRequest(cgi, ctx)))
+    {
+        Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPFORBIDDEN));
         return true;
     }
     if (const auto& ext = ev->Get()->ExtendedQuery; ext && ext->GetMethod() == HTTP_METHOD_POST) {
@@ -870,7 +938,6 @@ bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr e
 
     THolder<TTransactionBase<TBlobStorageController>> tx;
     TStringStream str;
-    const TCgiParameters& cgi(ev->Get()->Cgi());
 
     if (!cgi.count("page")) {
         RenderMonPage(str);
@@ -1012,15 +1079,15 @@ void TBlobStorageController::RenderFooter(IOutputStream& out) {
 void TBlobStorageController::RenderMonPage(IOutputStream& out) {
     RenderHeader(out);
 
-    out << "<a href='app?TabletID=" << TabletID() << "&page=OperationLog'>Operation Log</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=SelfHeal'>Self Heal Status</a> (" <<
+    out << "<a href='?TabletID=" << TabletID() << "&page=OperationLog'>Operation Log</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=SelfHeal'>Self Heal Status</a> (" <<
         (SelfHealEnable ? "enabled" : "disabled") << ")<br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=HealthEvents'>Health events</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=Scrub'>Scrub state</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=Shred'>Shred state</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=Bridge'>Bridge state</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=VirtualGroups'>Virtual groups</a><br>";
-    out << "<a href='app?TabletID=" << TabletID() << "&page=InternalTables'>Internal tables</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=HealthEvents'>Health events</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=Scrub'>Scrub state</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=Shred'>Shred state</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=Bridge'>Bridge state</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=VirtualGroups'>Virtual groups</a><br>";
+    out << "<a href='?TabletID=" << TabletID() << "&page=InternalTables'>Internal tables</a><br>";
 
     HTML(out) {
         DIV_CLASS("panel panel-info") {
@@ -1144,7 +1211,7 @@ void TBlobStorageController::RenderInternalTables(IOutputStream& out, const TStr
 
     auto gen_li = [&](const TString& component) {
         out << "<li" << (component == table ? " class='active'" : "") << ">";
-        out << "<a href='app?TabletID=" << TabletID() << "&page=InternalTables&table=" << component << "'>";
+        out << "<a href='?TabletID=" << TabletID() << "&page=InternalTables&table=" << component << "'>";
         out << component << "</a>";
         out << "</li>";
     };

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -6,6 +6,7 @@
 #include "layout_helpers.h"
 
 #include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
+#include <ydb/core/base/mon_auth.h>
 #include <ydb/core/debug_tools/operation_log.h>
 
 namespace NKikimr::NBsController {
@@ -758,13 +759,11 @@ namespace NKikimr::NBsController {
                         out << (selfHealEnabled ? "Enabled" : "Disabled");
                         if (selfHealEnabled) {
                             out << "<br/>" << Endl;
-                            out << "<form method='POST'>" << Endl;
-                            out << "<input type='hidden' name='TabletID' value='" << TabletId << "'>" << Endl;
-                            out << "<input type='hidden' name='page' value='SelfHeal'>" << Endl;
-                            out << "<input type='hidden' name='disable' value='1'>" << Endl;
-                            out << "<input type='hidden' name='action' value='disableSelfHeal'>" << Endl;
-                            out << "<input class='btn btn-primary' type='submit' value='DISABLE NOW'/>" << Endl;
-                            out << "</form>";
+                            const TStringBuf tabletAppPath = UsesTabletDevUiSecurePath(AppData(), TTabletTypes::BSController)
+                                ? TABLET_DEV_UI_SECURE_MON_RELATIVE_PATH
+                                : TStringBuf("app");
+                            out << "<a class='btn btn-primary' href='" << tabletAppPath << "?TabletID=" << TabletId
+                                << "&page=SelfHeal&disable=1&action=disableSelfHeal'>DISABLE NOW</a>";
                         }
                     }
                 }

--- a/ydb/core/mind/bscontroller/shred.cpp
+++ b/ydb/core/mind/bscontroller/shred.cpp
@@ -1,6 +1,8 @@
 #include "impl.h"
 #include "config.h"
 
+#include <ydb/core/base/mon_auth.h>
+
 namespace NKikimr::NBsController {
 
     class TBlobStorageController::TTxUpdateShred : public TTransactionBase<TBlobStorageController> {
@@ -230,7 +232,10 @@ namespace NKikimr::NBsController {
                         str << "Start new shredding iteration";
                     }
                     DIV_CLASS("panel-body") {
-						FORM_CLASS("form-horizontal") {
+                        const TStringBuf tabletAppPath = UsesTabletDevUiSecurePath(AppData(), TTabletTypes::BSController)
+                            ? TABLET_DEV_UI_SECURE_MON_RELATIVE_PATH
+                            : TStringBuf("app");
+						str << "<form action='" << tabletAppPath << "' class='form-horizontal'>";
 							DIV_CLASS("control-group") {
 								LABEL_CLASS_FOR("control-label", "generation") { str << "Shred generation"; }
 								DIV_CLASS("controls") {
@@ -261,7 +266,7 @@ namespace NKikimr::NBsController {
 									str << "<button type='submit' name='startshred' class='btn btn-default'>Start</button>";
 								}
 							}
-						}
+						str << "</form>";
 
                     }
                 }

--- a/ydb/tests/functional/security/test_tablets_dev_ui_mon_auth.py
+++ b/ydb/tests/functional/security/test_tablets_dev_ui_mon_auth.py
@@ -12,6 +12,9 @@ from security_test_helpers import (
 )
 from ydb.tests.oss.ydb_sdk_import import ydb
 
+# MakeBSControllerID(): (1 << 56) | 0x1001
+BSC_TABLET_ID = 72057594037932033
+
 
 def _is_valid_tablet_id(tablet_id):
     return tablet_id not in (None, 0)
@@ -585,6 +588,245 @@ def test_schemeshard_new_action_with_enforce_user_token_and_secure_path_mode(
             f'Expected GET {endpoint_path} with token={_schemeshard_token_desc(token)} '
             f'to return {expected_status}, got {status}'
         )
+
+
+def _bscontroller_endpoint_cases(endpoint_paths, token_statuses):
+    return [
+        (endpoint_path, token, expected_status)
+        for endpoint_path in endpoint_paths
+        for token, expected_status in token_statuses.items()
+    ]
+
+
+def _bscontroller_token_desc(token):
+    return token if token is not None else 'null'
+
+
+def _bscontroller_mon_base_url(cluster):
+    node = cluster.nodes[1]
+    return f'https://{node.host}:{node.mon_port}'
+
+
+def _bscontroller_get_status(cluster, endpoint_path, token=None):
+    headers = {}
+    if token is not None:
+        headers['Authorization'] = token
+    response = requests.get(
+        f'{_bscontroller_mon_base_url(cluster)}{endpoint_path}',
+        headers=headers,
+        verify=False,
+    )
+    return response.status_code
+
+
+def _bscontroller_monitoring_page_access_cases(
+    tablet_id,
+    pages=(
+        ('Main', ''),
+        ('OperationLog', 'page=OperationLog'),
+        ('OperationLogEntry', 'page=OperationLogEntry'),
+        ('HealthEvents', 'page=HealthEvents'),
+        ('Groups', 'page=Groups'),
+        ('GroupDetail', 'page=GroupDetail'),
+        ('Scrub', 'page=Scrub'),
+        ('InternalTables', 'page=InternalTables'),
+        ('Bridge', 'page=Bridge'),
+        ('VirtualGroups', 'page=VirtualGroups'),
+        ('GetDown', 'page=GetDown'),
+        ('SelfHeal', 'page=SelfHeal'),
+        ('Shred', 'page=Shred'),
+    ),
+):
+    q_base = f'TabletID={tablet_id}'
+    _, monitoring_allowed, _ = tablet_devui_sid_matrix()
+    cases = []
+    for _page_name, query_suffix in pages:
+        q = q_base if not query_suffix else f'{q_base}&{query_suffix}'
+        cases.extend(_bscontroller_endpoint_cases([f'/tablets/app?{q}'], monitoring_allowed))
+    cases.extend(_bscontroller_endpoint_cases([f'/tablets?{q_base}'], monitoring_allowed))
+    return cases
+
+
+def _bscontroller_admin_page_access_cases(
+    tablet_id,
+    secure_path_mode,
+    pages=(
+        ('SetDown', 'page=SetDown&group=0&down=1'),
+        ('SelfHealDisable', 'page=SelfHeal&disable=1&action=disableSelfHeal'),
+        ('ShredStart', 'page=Shred&startshred=1&generation=0'),
+        ('StopGivingGroups', 'page=StopGivingGroups'),
+        ('StartGivingGroups', 'page=StartGivingGroups'),
+        ('NewAction', 'page=NewAction'),
+    ),
+):
+    q_base = f'TabletID={tablet_id}'
+    all_forbidden, monitoring_allowed, admin_allowed = tablet_devui_sid_matrix()
+    expected_on_app = tablet_devui_expected_on_app(secure_path_mode, monitoring_allowed, all_forbidden)
+    cases = []
+    for _page_name, query_suffix in pages:
+        q = f'{q_base}&{query_suffix}'
+        cases.extend(_bscontroller_endpoint_cases([f'/tablets/app?{q}'], expected_on_app))
+        cases.extend(_bscontroller_endpoint_cases([f'/tablets/app/secure?{q}'], admin_allowed))
+    return cases
+
+
+def _bscontroller_post_exec_paths(tablet_id):
+    q = f'TabletID={tablet_id}&exec=1'
+    all_forbidden, _, admin_allowed_sids_ok = tablet_devui_sid_matrix()
+    return {
+        f'/tablets/app?{q}': all_forbidden,
+        f'/tablets/app/secure?{q}': admin_allowed_sids_ok,
+    }
+
+
+def test_bscontroller_tablet_devui_mon_paths_with_enforce_user_token(
+    ydb_cluster_with_enforce_user_token,
+):
+    cluster = ydb_cluster_with_enforce_user_token
+    cases = (
+        _bscontroller_monitoring_page_access_cases(BSC_TABLET_ID)
+        + _bscontroller_admin_page_access_cases(BSC_TABLET_ID, secure_path_mode=False)
+    )
+
+    for endpoint_path, token, expected_status in cases:
+        status = _bscontroller_get_status(cluster, endpoint_path, token)
+        assert status == expected_status, (
+            f'Expected GET {endpoint_path} with token={_bscontroller_token_desc(token)} '
+            f'to return {expected_status}, got {status}'
+        )
+
+
+def test_bscontroller_tablet_devui_mon_paths_with_enforce_user_token_and_secure_path_mode(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    cases = (
+        _bscontroller_monitoring_page_access_cases(BSC_TABLET_ID)
+        + _bscontroller_admin_page_access_cases(BSC_TABLET_ID, secure_path_mode=True)
+    )
+
+    for endpoint_path, token, expected_status in cases:
+        status = _bscontroller_get_status(cluster, endpoint_path, token)
+        assert status == expected_status, (
+            f'Expected GET {endpoint_path} with token={_bscontroller_token_desc(token)} '
+            f'to return {expected_status}, got {status}'
+        )
+
+
+def test_bscontroller_post_exec_with_enforce_user_token_and_secure_path_mode(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+    base_url = f'https://{host}:{mon_port}'
+    for endpoint_path, expected_statuses in _bscontroller_post_exec_paths(BSC_TABLET_ID).items():
+        endpoint_url = f'{base_url}{endpoint_path}'
+        for token, expected_status in expected_statuses.items():
+            headers = {'Content-Type': 'application/json'}
+            if token is not None:
+                headers['Authorization'] = token
+            response = requests.post(endpoint_url, headers=headers, data='{}', verify=False)
+            token_desc = token if token is not None else 'null'
+            if endpoint_path.startswith('/tablets/app/secure') and token == 'root@builtin':
+                # Auth passed; empty config body may be rejected later with 400.
+                assert response.status_code in (200, 400), (
+                    f'Expected POST {endpoint_path} with token={token_desc} to pass auth, got {response.status_code}'
+                )
+            else:
+                assert response.status_code == expected_status, (
+                    f'Expected POST {endpoint_path} with token={token_desc} to return {expected_status}, '
+                    f'got {response.status_code}'
+                )
+
+
+def test_bscontroller_shred_form_uses_secure_path(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+    url = f'https://{host}:{mon_port}/tablets/app?TabletID={BSC_TABLET_ID}&page=Shred'
+    response = requests.get(url, headers={'Authorization': 'monitoring@builtin'}, verify=False)
+    assert response.status_code == 200, response.text
+    assert "action='app/secure'" in response.text or 'action="app/secure"' in response.text
+    assert 'name=\'startshred\'' in response.text or 'name="startshred"' in response.text
+
+
+def test_bscontroller_self_heal_disable_link_uses_secure_path(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+    url = f'https://{host}:{mon_port}/tablets/app?TabletID={BSC_TABLET_ID}&page=SelfHeal'
+    response = requests.get(url, headers={'Authorization': 'monitoring@builtin'}, verify=False)
+    assert response.status_code == 200, response.text
+    if 'DISABLE NOW' in response.text:
+        assert 'app/secure?TabletID=' in response.text
+        assert 'action=disableSelfHeal' in response.text
+
+
+def test_bscontroller_read_only_links_keep_current_app_path(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+
+    response = requests.get(
+        f'https://{host}:{mon_port}/tablets/app?TabletID={BSC_TABLET_ID}',
+        headers={'Authorization': 'monitoring@builtin'},
+        verify=False,
+    )
+    assert response.status_code == 200, response.text
+    assert f"href='?TabletID={BSC_TABLET_ID}&page=OperationLog'" in response.text
+    assert f"href='?TabletID={BSC_TABLET_ID}&page=SelfHeal'" in response.text
+    assert f"href='app?TabletID={BSC_TABLET_ID}" not in response.text
+
+    response = requests.get(
+        f'https://{host}:{mon_port}/tablets/app?TabletID={BSC_TABLET_ID}&page=InternalTables',
+        headers={'Authorization': 'monitoring@builtin'},
+        verify=False,
+    )
+    assert response.status_code == 200, response.text
+    assert f"href='?TabletID={BSC_TABLET_ID}&page=InternalTables&table=pdisks'" in response.text
+    assert f"href='app?TabletID={BSC_TABLET_ID}" not in response.text
+
+
+def test_bscontroller_self_heal_disable_redirect_keeps_current_app_path(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    cluster = ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag
+    host = cluster.nodes[1].host
+    mon_port = cluster.nodes[1].mon_port
+    response = requests.get(
+        f'https://{host}:{mon_port}/tablets/app/secure'
+        f'?TabletID={BSC_TABLET_ID}&page=SelfHeal&disable=1&action=disableSelfHeal',
+        headers={'Authorization': 'root@builtin'},
+        verify=False,
+    )
+    assert response.status_code == 200, response.text
+    assert f'content="0; ?TabletID={BSC_TABLET_ID}&page=SelfHeal"' in response.text
+    assert 'content="0; app' not in response.text
+
+
+def test_bscontroller_new_action_with_enforce_user_token(
+    ydb_cluster_with_enforce_user_token,
+):
+    _test_endpoints(
+        ydb_cluster_with_enforce_user_token,
+        tablet_devui_new_action_paths(BSC_TABLET_ID, 'page=NewAction', secure_path_mode=False),
+    )
+
+
+def test_bscontroller_new_action_with_enforce_user_token_and_secure_path_mode(
+    ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+):
+    _test_endpoints(
+        ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag,
+        tablet_devui_new_action_paths(BSC_TABLET_ID, 'page=NewAction', secure_path_mode=True),
+    )
 
 
 def _graph_shard_devui_mon_paths(graph_shard_tablet_id, secure_path_mode):


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Ticket: https://nda.ya.ru/t/dI2H5k6H7aFTEY

## Goal

Harden BSController tablet monitoring DevUI by applying the secure tablet subtree model to BSController pages and actions: keep read-only monitoring pages accessible at monitoring level, route mutating operations through `/app/secure`, and require cluster administrator privileges for sensitive BSController DevUI requests when `EnableTabletDevUiSecurePath` is enabled.

## What Changed

- Added BSController DevUI access control in `ydb/core/mind/bscontroller/monitoring.cpp`:
  - `IsPublicBsControllerDevUiRequest()` whitelists monitoring-level pages/actions:
    - read-only pages: `GetDown`, `OperationLog`, `OperationLogEntry`, `HealthEvents`, `Groups`, `GroupDetail`, `Scrub`, `InternalTables`, `Bridge`, `VirtualGroups`;
    - read-only `SelfHeal` and `Shred` views (without `disable=1&action=disableSelfHeal` and without `startshred`);
  - `CheckBsControllerDevUiAccess()` enforces that non-public requests in secure-path mode require both:
    - request path under `/app/secure`;
    - cluster administrator privileges via `IsAdministrator()` and forwarded user token;
  - access checks are applied in both `OnRenderAppHtmlPage()` and `ProcessPostQuery()`;
  - `exec=1` POST requests are treated as non-public and require admin access on the secure path.

- Extended BSController tablet DevUI routing in `ydb/core/tablet_flat/tablet_flat_executed.cpp`:
  - when `EnableTabletDevUiSecurePath` is enabled, BSController app rendering is allowed through `/app/secure` in addition to legacy `/app`;
  - aligns BSController with the existing DataShard secure-path routing model.

- Updated BSController HTML/link generation for sensitive actions:
  - `self_heal.cpp`: `DISABLE NOW` action link is generated under `app/secure` when the feature flag is enabled;
  - `shred.cpp`: shred start form posts to `app/secure` when the feature flag is enabled.

- Refactored BSController navigation links to relative paths:
  - `RenderMonPage()` and `RenderInternalTables()` now use `?TabletID=...&page=...` instead of `app?TabletID=...`;
  - avoids hardcoded `app` prefixes in read-only navigation and keeps links on the current tablet DevUI path.

- Extended functional security test coverage in `ydb/tests/functional/security/test_tablets_dev_ui_mon_auth.py`:
  - added BSController tablet id constant;
  - added SID matrix coverage for BSController DevUI endpoints in secure-path mode and legacy mode;
  - verified admin-only access for sensitive pages/actions on `/tablets/app/secure`;
  - verified monitoring-level access for read-only BSController pages on `/tablets/app` and `/tablets`;
  - verified POST `exec=1` auth behavior;
  - verified secure-path link generation for SelfHeal disable and Shred start forms;
  - verified read-only links stay on the current app path and do not revert to deprecated absolute `app?...` links.

## Testing

- Started a local YDB cluster and verified BSController DevUI navigation manually.
- Checked link navigation and action access as a monitoring user and as an admin user.
- Verified behavior with [`EnableTabletDevUiSecurePath`](ydb/core/protos/feature_flags.proto:306) disabled: BSController DevUI links and actions continue to use the legacy tablet app path with monitoring-level access.
- Verified behavior with [`EnableTabletDevUiSecurePath`](ydb/core/protos/feature_flags.proto:306) enabled:
  - read-only BSController pages remain available to monitoring users on `/tablets/app`;
  - sensitive BSController actions are routed through `/tablets/app/secure` and require admin privileges;
  - legacy `/tablets/app?...` routes for sensitive actions are denied.
- Ran functional security tests for BSController DevUI auth paths.

## Result

- Sensitive BSController DevUI routes can be served from:

  `/tablets/app/secure?TabletID=...`

- Non-admin users are forbidden on sensitive BSController actions under `/tablets/app/secure`.
- With `EnableTabletDevUiSecurePath=true`:
  - read-only BSController DevUI pages keep monitoring-level access on `/tablets/app`;
  - mutating BSController DevUI actions require `/app/secure` and admin privileges;
  - SelfHeal disable and Shred start UI point to the secure path.
- With the flag disabled, BSController DevUI behavior stays on the legacy `app` path with monitoring-level access for all pages.
- General BSController summary pages (`/tablets?...`) keep monitoring-level access.
- Unknown/new BSController pages default to admin-only in secure-path mode, following the whitelist model.