### PR TITLE
Make checks_integrated status link to PR-check run

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
-            -d '{"state":"pending","description":"Waiting for relevant checks to complete","context":"checks_integrated"}'
+            -d '{"state":"pending","description":"Waiting for relevant checks to complete","context":"checks_integrated","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
 
       - name: Check if running tests is allowed
         id: check-ownership-membership
@@ -284,4 +284,4 @@ jobs:
           fi
           curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
-            -d '{"state":"'$integrated_status'","description":"All checks completed","context":"checks_integrated"}'
+            -d '{"state":"'$integrated_status'","description":"All checks completed","context":"checks_integrated","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'


### PR DESCRIPTION
## Summary
- add `target_url` to the pending `checks_integrated` commit status in `PR-check`
- add `target_url` to the final `checks_integrated` status update as well
- point both statuses to the current workflow run URL so the required status is clickable in PR UI

## Test plan
- [x] Validate workflow YAML diff locally
- [x] Confirm both status POST payloads now include `target_url`
- [ ] Verify on a PR that `checks_integrated` links to the corresponding Actions run

Made with [Cursor](https://cursor.com)