### PR TITLE
Add interconnect queue depth histogram NBYDB-2260

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -314,6 +314,10 @@ namespace {
             InterconnectQueueTimeHistogram->Collect(value);
         }
 
+        void UpdateNumEventsInQueueHistogram(ui64 value) override {
+            NumEventsInQueueHistogram->Collect(value);
+        }
+
         void UpdateRdmaReadTimeHistogram(ui64 value) override {
             RdmaReadTimeHistogram->Collect(value);
         }
@@ -398,6 +402,8 @@ namespace {
                     "PingTimeUs", NMonitoring::ExponentialHistogram(18, 2, 125));
                 InterconnectQueueTimeHistogram = AdaptiveCounters->GetHistogram(
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
+                NumEventsInQueueHistogram = AdaptiveCounters->GetHistogram(
+                    "NumEventsInQueue", NMonitoring::ExplicitHistogram({0, 1, 2, 6, 24, 120}));
                 RdmaReadTimeHistogram = AdaptiveCounters->GetHistogram(
 +                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents = AdaptiveCounters->GetCounter("RdmaMultipartEvents", true);
@@ -497,6 +503,7 @@ namespace {
         NMonitoring::TDynamicCounters::TCounterPtr SpuriousWriteWakeups;
         NMonitoring::THistogramPtr PingTimeHistogram;
         NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
+        NMonitoring::THistogramPtr NumEventsInQueueHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
         NMonitoring::TDynamicCounters::TCounterPtr RdmaMultipartEvents;
 
@@ -757,6 +764,10 @@ namespace {
             InterconnectQueueTimeHistogram_->Record(value);
         }
 
+        void UpdateNumEventsInQueueHistogram(ui64 value) override {
+            NumEventsInQueueHistogram_->Record(value);
+        }
+
         void UpdateRdmaReadTimeHistogram(ui64 value) override {
             RdmaReadTimeHistogram_->Record(value);
         }
@@ -859,6 +870,8 @@ namespace {
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_us"}}), NMonitoring::ExponentialHistogram(18, 2, 125));
                 InterconnectQueueTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
+                NumEventsInQueueHistogram_ = AdaptiveMetrics_->HistogramRate(
+                        NMonitoring::MakeLabels({{"sensor", "interconnect.num_events_in_queue"}}), NMonitoring::ExplicitHistogram({0, 1, 2, 6, 24, 120}));
                 RdmaReadTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.rdma_read_time_us"}}), NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents_ = createRate(AdaptiveMetrics_, "interconnect.rdma_multipart_events");
@@ -990,6 +1003,7 @@ namespace {
 
         NMonitoring::IHistogram* PingTimeHistogram_;
         NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
+        NMonitoring::IHistogram* NumEventsInQueueHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;
         NMonitoring::IRate* RdmaMultipartEvents_;
 

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -46,6 +46,7 @@ public:
     virtual void AddTotalBytesRead(ui64 value) = 0;
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;
     virtual void UpdateIcQueueTimeHistogram(ui64 value) = 0;
+    virtual void UpdateNumEventsInQueueHistogram(ui64 value) = 0;
     virtual void UpdateRdmaReadTimeHistogram(ui64 value) = 0;
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -202,6 +202,7 @@ namespace NActors {
         }
 
         SetOutputStuckFlag(true);
+        Proxy->Metrics->UpdateNumEventsInQueueHistogram(NumEventsInQueue);
         ++NumEventsInQueue;
         if (State == EState::Idle) {
             UpdateState(EState::Utilized);

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -71,6 +71,16 @@ ui64 GetHistogramSamples(const NMonitoring::THistogramPtr& histogram) {
     return samples;
 }
 
+ui64 GetHistogramBucketSamples(const NMonitoring::THistogramPtr& histogram, NMonitoring::TBucketBound upperBound) {
+    auto snapshot = histogram->Snapshot();
+    for (ui32 i = 0; i < snapshot->Count(); ++i) {
+        if (snapshot->UpperBound(i) == upperBound) {
+            return snapshot->Value(i);
+        }
+    }
+    return 0;
+}
+
 template <typename TCallback>
 void WaitForCondition(TDuration timeout, TCallback&& callback, TStringBuf description) {
     const TInstant deadline = TInstant::Now() + timeout;
@@ -697,6 +707,31 @@ Y_UNIT_TEST_SUITE(Interconnect) {
 
     Y_UNIT_TEST(KernelLivenessReconnectLocalFallbackNotAppliedRdma) {
         RunKernelLivenessReconnectLocalFallbackNotApplied(true);
+    }
+
+    Y_UNIT_TEST(NumEventsInQueueHistogram) {
+        constexpr size_t messages = 32;
+        constexpr size_t payloadSize = 64;
+
+        TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, TTestICCluster::DISABLE_RDMA);
+
+        auto* recipientPtr = new TDropRecipientActor;
+        const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+        cluster.RegisterActor(new TBurstSenderActor(recipient, messages, payloadSize), 2);
+
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            return recipientPtr->GetReceived() >= messages;
+        }, "one-way delivery for NumEventsInQueue histogram");
+
+        auto nodeCounters = cluster.GetCounters()->FindSubgroup("nodeId", "2");
+        UNIT_ASSERT_C(nodeCounters, "nodeId=2 counters were not created");
+        auto peerCounters = nodeCounters->FindSubgroup("peer");
+        UNIT_ASSERT_C(peerCounters, "peer counters were not created");
+
+        auto histogram = peerCounters->FindHistogram("NumEventsInQueue");
+        UNIT_ASSERT_C(histogram, "NumEventsInQueue histogram was not created");
+        UNIT_ASSERT_GE(GetHistogramSamples(histogram), messages);
+        UNIT_ASSERT_GT(GetHistogramBucketSamples(histogram, 0), 0ULL);
     }
 
     Y_UNIT_TEST(UnavailableNodeOutgoingHandshakeLogCount) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Interconnect has batching feature. But if we have no events in queue the additional round through actor activation can cause additional delay. This metric allows to investigate penalty from batching feature

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
