### PR TITLE
Support max_inflight_actions in CMS

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -814,12 +814,7 @@ public:
         cmsRequest->Record.SetAvailabilityMode(request.Request.GetAvailabilityMode());
 
         if (task.MaxConcurrentActions > 0) {
-            ui32 aliveCount = 0;
-            for (const auto& id : task.Permissions) {
-                if (cmsState->Permissions.contains(id)) {
-                    ++aliveCount;
-                }
-            }
+            const ui32 aliveCount = task.Permissions.size();
             const ui32 quota = task.MaxConcurrentActions > aliveCount
                 ? task.MaxConcurrentActions - aliveCount
                 : 0;

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -635,8 +635,8 @@ class TCreateMaintenanceTask
                                         && request.action_groups(0).actions().size() > 1;
         cmsRequest.SetPartialPermissionAllowed(!HasSingleCompositeActionGroup);
 
-        if (opts.max_concurrent_actions() > 0) {
-            cmsRequest.SetMaxPermissions(opts.max_concurrent_actions());
+        if (opts.max_inflight_actions() > 0) {
+            cmsRequest.SetMaxPermissions(opts.max_inflight_actions());
         }
 
         for (const auto& group : request.action_groups()) {
@@ -813,10 +813,10 @@ public:
         cmsRequest->Record.SetRequestId(task.RequestId);
         cmsRequest->Record.SetAvailabilityMode(request.Request.GetAvailabilityMode());
 
-        if (task.MaxConcurrentActions > 0) {
+        if (task.MaxInflightActions > 0) {
             const ui32 aliveCount = task.Permissions.size();
-            const ui32 quota = task.MaxConcurrentActions > aliveCount
-                ? task.MaxConcurrentActions - aliveCount
+            const ui32 quota = task.MaxInflightActions > aliveCount
+                ? task.MaxInflightActions - aliveCount
                 : 0;
             cmsRequest->Record.SetMaxPermissions(quota);
         }

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -635,6 +635,10 @@ class TCreateMaintenanceTask
                                         && request.action_groups(0).actions().size() > 1;
         cmsRequest.SetPartialPermissionAllowed(!HasSingleCompositeActionGroup);
 
+        if (opts.max_concurrent_actions() > 0) {
+            cmsRequest.SetMaxPermissions(opts.max_concurrent_actions());
+        }
+
         for (const auto& group : request.action_groups()) {
             Y_ABORT_UNLESS(HasSingleCompositeActionGroup || group.actions().size() == 1);
             for (const auto& action : group.actions()) {
@@ -808,6 +812,19 @@ public:
         cmsRequest->Record.SetUser(task.Owner);
         cmsRequest->Record.SetRequestId(task.RequestId);
         cmsRequest->Record.SetAvailabilityMode(request.Request.GetAvailabilityMode());
+
+        if (task.MaxConcurrentActions > 0) {
+            ui32 aliveCount = 0;
+            for (const auto& id : task.Permissions) {
+                if (cmsState->Permissions.contains(id)) {
+                    ++aliveCount;
+                }
+            }
+            const ui32 quota = task.MaxConcurrentActions > aliveCount
+                ? task.MaxConcurrentActions - aliveCount
+                : 0;
+            cmsRequest->Record.SetMaxPermissions(quota);
+        }
 
         Send(CmsActorId, std::move(cmsRequest));
         Become(&TThis::StateWork);

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -375,6 +375,10 @@ class TPermissionResponseProcessor
 protected:
     using TBase = TPermissionResponseProcessor<TDerived, TEvRequest>;
 
+    // Soft warnings collected during request processing that should be returned
+    // to the client alongside the successful response.
+    TVector<TString> Warnings;
+
 public:
     using TAdapterActor<TDerived, TEvRequest, TEvCms::TEvMaintenanceTaskResponse>::TAdapterActor;
 
@@ -451,6 +455,12 @@ public:
             for (const auto& action : request.Request.GetActions()) {
                 ConvertAction(action, *GetActionGroupState(result)->add_action_states());
             }
+        }
+
+        for (const auto& warning : Warnings) {
+            auto& issue = *response->Record.AddIssues();
+            issue.set_severity(NYql::TSeverityIds::S_WARNING);
+            issue.set_message(warning);
         }
 
         this->Reply(std::move(response));
@@ -530,20 +540,20 @@ class TCreateMaintenanceTask
             return false;
         }
 
-        const ui32 actionGroupsCount = request.action_groups().size();
+        const ui32 actionGroupCount = request.action_groups().size();
         for (const auto& group : request.action_groups()) {
-            const ui32 actionsCount = group.actions().size();
-            if (actionsCount < 1) {
+            const ui32 actionCount = group.actions().size();
+            if (actionCount < 1) {
                 Reply(Ydb::StatusIds::BAD_REQUEST, "Empty actions");
                 return false;
             }
 
-            if (!GetCmsState()->EnableSingleCompositeActionGroup && actionsCount > 1) {
+            if (!GetCmsState()->EnableSingleCompositeActionGroup && actionCount > 1) {
                 Reply(Ydb::StatusIds::UNSUPPORTED, "Feature flag EnableSingleCompositeActionGroup is off");
                 return false;
             }
 
-            if (actionGroupsCount > 1 && actionsCount > 1) {
+            if (actionGroupCount > 1 && actionCount > 1) {
                 Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder()
                     << "A task can have either a single composite action group or many action groups"
                     << " with only one action");
@@ -559,14 +569,14 @@ class TCreateMaintenanceTask
 
         const ui32 maxInflightActions = request.task_options().max_inflight_actions();
         if (maxInflightActions > 0) {
-            const bool hasSingleCompositeActionGroup = actionGroupsCount == 1
+            const bool hasSingleCompositeActionGroup = actionGroupCount == 1
                 && request.action_groups(0).actions().size() > 1;
             if (hasSingleCompositeActionGroup) {
-                LOG_WARN_S(*TlsActivationContext, NKikimrServices::CMS,
+                Warnings.emplace_back(
                     "max_inflight_actions is not applicable to a single composite action group:"
-                    << " actions within one group are granted atomically");
+                    " actions within one group are granted atomically");
             }
-            if (actionGroupsCount < maxInflightActions) {
+            if (actionGroupCount < maxInflightActions) {
                 LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS,
                     "max_inflight_actions is greater than the number of action groups");
             }

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -577,8 +577,10 @@ class TCreateMaintenanceTask
                     " actions within one group are granted atomically");
             }
             if (actionGroupCount < maxInflightActions) {
-                LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS,
-                    "max_inflight_actions is greater than the number of action groups");
+                Warnings.emplace_back(
+                    TStringBuilder()
+                    << "max_inflight_actions is greater than the number of action groups: "
+                    << maxInflightActions << " > " << actionGroupCount);
             }
         }
 

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -531,17 +531,19 @@ class TCreateMaintenanceTask
         }
 
         for (const auto& group : request.action_groups()) {
-            if (group.actions().size() < 1) {
+            const ui32 actionsCount = group.actions().size();
+            if (actionsCount < 1) {
                 Reply(Ydb::StatusIds::BAD_REQUEST, "Empty actions");
                 return false;
             }
 
-            if (!GetCmsState()->EnableSingleCompositeActionGroup && group.actions().size() > 1) {
+            if (!GetCmsState()->EnableSingleCompositeActionGroup && actionsCount > 1) {
                 Reply(Ydb::StatusIds::UNSUPPORTED, "Feature flag EnableSingleCompositeActionGroup is off");
                 return false;
             }
 
-            if (request.action_groups().size() > 1 && group.actions().size() > 1) {
+            const ui32 actionGroupsCount = request.action_groups().size();
+            if (actionGroupsCount > 1 && actionsCount > 1) {
                 Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder()
                     << "A task can have either a single composite action group or many action groups"
                     << " with only one action");
@@ -555,16 +557,16 @@ class TCreateMaintenanceTask
             }
         }
 
-        if (request.task_options().max_inflight_actions() > 0) {
-            const bool hasSingleCompositeActionGroup = request.action_groups().size() == 1
+        const ui32 maxInflightActions = request.task_options().max_inflight_actions();
+        if (maxInflightActions > 0) {
+            const bool hasSingleCompositeActionGroup = actionGroupsCount == 1
                 && request.action_groups(0).actions().size() > 1;
             if (hasSingleCompositeActionGroup) {
                 LOG_WARN_S(*TlsActivationContext, NKikimrServices::CMS,
                     "max_inflight_actions is not applicable to a single composite action group:"
                     << " actions within one group are granted atomically");
             }
-            if (static_cast<ui32>(request.action_groups().size())
-                    < request.task_options().max_inflight_actions()) {
+            if (actionGroupsCount < maxInflightActions) {
                 LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS,
                     "max_inflight_actions is greater than the number of action groups");
             }

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -530,6 +530,7 @@ class TCreateMaintenanceTask
             return false;
         }
 
+        const ui32 actionGroupsCount = request.action_groups().size();
         for (const auto& group : request.action_groups()) {
             const ui32 actionsCount = group.actions().size();
             if (actionsCount < 1) {
@@ -542,7 +543,6 @@ class TCreateMaintenanceTask
                 return false;
             }
 
-            const ui32 actionGroupsCount = request.action_groups().size();
             if (actionGroupsCount > 1 && actionsCount > 1) {
                 Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder()
                     << "A task can have either a single composite action group or many action groups"

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -665,7 +665,7 @@ class TCreateMaintenanceTask
         cmsRequest.SetPartialPermissionAllowed(!HasSingleCompositeActionGroup);
 
         if (opts.max_inflight_actions() > 0) {
-            cmsRequest.SetMaxPermissions(opts.max_inflight_actions());
+            cmsRequest.SetMaxPermissionCount(opts.max_inflight_actions());
         }
 
         for (const auto& group : request.action_groups()) {

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -555,6 +555,21 @@ class TCreateMaintenanceTask
             }
         }
 
+        if (request.task_options().max_inflight_actions() > 0) {
+            const bool hasSingleCompositeActionGroup = request.action_groups().size() == 1
+                && request.action_groups(0).actions().size() > 1;
+            if (hasSingleCompositeActionGroup) {
+                LOG_WARN_S(*TlsActivationContext, NKikimrServices::CMS,
+                    "max_inflight_actions is not applicable to a single composite action group:"
+                    << " actions within one group are granted atomically");
+            }
+            if (static_cast<ui32>(request.action_groups().size())
+                    < request.task_options().max_inflight_actions()) {
+                LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS,
+                    "max_inflight_actions is greater than the number of action groups");
+            }
+        }
+
         return true;
     }
 

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -828,14 +828,6 @@ public:
         cmsRequest->Record.SetRequestId(task.RequestId);
         cmsRequest->Record.SetAvailabilityMode(request.Request.GetAvailabilityMode());
 
-        if (task.MaxInflightActions > 0) {
-            const ui32 aliveCount = static_cast<ui32>(task.Permissions.size());
-            const ui32 quota = task.MaxInflightActions > aliveCount
-                ? task.MaxInflightActions - aliveCount
-                : 0;
-            cmsRequest->Record.SetMaxPermissions(quota);
-        }
-
         Send(CmsActorId, std::move(cmsRequest));
         Become(&TThis::StateWork);
     }

--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -829,7 +829,7 @@ public:
         cmsRequest->Record.SetAvailabilityMode(request.Request.GetAvailabilityMode());
 
         if (task.MaxInflightActions > 0) {
-            const ui32 aliveCount = task.Permissions.size();
+            const ui32 aliveCount = static_cast<ui32>(task.Permissions.size());
             const ui32 quota = task.MaxInflightActions > aliveCount
                 ? task.MaxInflightActions - aliveCount
                 : 0;

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -359,6 +359,9 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         if (request.HasPriority()) {
             scheduled.SetPriority(request.GetPriority());
         }
+        if (request.HasMaxPermissions()) {
+            scheduled.SetMaxPermissions(request.GetMaxPermissions());
+        }
     }
 
     LOG_INFO_S(ctx, NKikimrServices::CMS,
@@ -388,7 +391,28 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
     auto point = ClusterInfo->PushRollbackPoint();
     size_t storedIssues = 0;
     size_t processedActions = 0;
+    const bool capEnabled = allowPartial && request.HasMaxPermissions();
+    const ui32 maxPermissions = capEnabled ? request.GetMaxPermissions() : 0;
+    bool capHit = capEnabled && maxPermissions == 0;
+
+    if (capHit) {
+        response.MutableStatus()->SetCode(TStatus::DISALLOW_TEMP);
+        response.MutableStatus()->SetReason(
+            "MaxPermissions cap exhausted: complete in-flight actions before requesting new ones");
+        response.SetDeadline((TActivationContext::Now() + State->Config.DefaultRetryTime).GetValue());
+    }
+
     for (const auto &action : request.GetActions()) {
+        if (capHit) {
+            if (schedule) {
+                auto *scheduledAction = scheduled.AddActions();
+                scheduledAction->CopyFrom(action);
+                scheduledAction->ClearIssue();
+            }
+            ++processedActions;
+            continue;
+        }
+
         TDuration permissionDuration = State->Config.DefaultPermissionDuration;
         if (request.HasDuration())
             permissionDuration = TDuration::MicroSeconds(request.GetDuration());
@@ -421,6 +445,13 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
             AddPermissionExtensions(action, *permission);
 
             ClusterInfo->AddTempLocks(action, request.GetPriority(), requestId, &ctx);
+
+            if (capEnabled && response.PermissionsSize() >= maxPermissions) {
+                LOG_DEBUG(ctx, NKikimrServices::CMS,
+                          "MaxPermissions cap (%u) reached, deferring remaining actions",
+                          maxPermissions);
+                capHit = true;
+            }
         } else {
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Result: %s (reason: %s)",
                       ToString(error.Code).data(), error.Reason.GetMessage().data());
@@ -2242,6 +2273,12 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
 
     ClusterInfo->SetPriorityToCheck(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
+    // Per-call override of the scheduled request's MaxPermissions cap. Used
+    // by the maintenance API to dynamically enforce max_concurrent_actions
+    // taking into account already issued permissions.
+    if (rec.HasMaxPermissions()) {
+        request.Request.SetMaxPermissions(rec.GetMaxPermissions());
+    }
     bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, rec.GetRequestId(), ctx);
     ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -2273,9 +2273,6 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
 
     ClusterInfo->SetPriorityToCheck(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
-    // Per-call override of the scheduled request's MaxPermissions cap. Used
-    // by the maintenance API to dynamically enforce max_concurrent_actions
-    // taking into account already issued permissions.
     if (rec.HasMaxPermissions()) {
         request.Request.SetMaxPermissions(rec.GetMaxPermissions());
     }

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -403,6 +403,10 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
     }
 
     for (const auto &action : request.GetActions()) {
+        if (capHit) {
+            break;
+        }
+
         TDuration permissionDuration = State->Config.DefaultPermissionDuration;
         if (request.HasDuration())
             permissionDuration = TDuration::MicroSeconds(request.GetDuration());
@@ -441,7 +445,6 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
                           "MaxPermissions cap (%u) reached, deferring remaining actions",
                           maxPermissions);
                 capHit = true;
-                break;
             }
         } else {
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Result: %s (reason: %s)",

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -484,12 +484,11 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         const size_t from = processedActions;
 
         mutableActions->Reserve(mutableActions->size() + (allActions.size() - from));
-        std::for_each(allActions.begin() + from, allActions.end(),
-                      [mutableActions](const auto& action) {
-                          auto* scheduledAction = mutableActions->Add();
-                          scheduledAction->CopyFrom(action);
-                          scheduledAction->ClearIssue();
-                      });
+        std::for_each(allActions.begin() + from, allActions.end(), [mutableActions](const auto& action) {
+            auto* scheduledAction = mutableActions->Add();
+            scheduledAction->CopyFrom(action);
+            scheduledAction->ClearIssue();
+        });
         processedActions = allActions.size();
     }
 

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -446,7 +446,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
 
             ClusterInfo->AddTempLocks(action, request.GetPriority(), requestId, &ctx);
 
-            if (capEnabled && response.PermissionsSize() >= maxPermissions) {
+            if (capEnabled && static_cast<ui32>(response.PermissionsSize()) >= maxPermissions) {
                 LOG_DEBUG(ctx, NKikimrServices::CMS,
                           "MaxPermissions cap (%u) reached, deferring remaining actions",
                           maxPermissions);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -359,8 +359,8 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         if (request.HasPriority()) {
             scheduled.SetPriority(request.GetPriority());
         }
-        if (request.HasMaxPermissions()) {
-            scheduled.SetMaxPermissions(request.GetMaxPermissions());
+        if (request.HasMaxPermissionCount()) {
+            scheduled.SetMaxPermissionCount(request.GetMaxPermissionCount());
         }
     }
 
@@ -391,14 +391,14 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
     auto point = ClusterInfo->PushRollbackPoint();
     size_t storedIssues = 0;
     size_t processedActions = 0;
-    const bool capEnabled = allowPartial && request.HasMaxPermissions();
-    const ui32 maxPermissions = capEnabled ? request.GetMaxPermissions() : 0;
+    const bool capEnabled = allowPartial && request.HasMaxPermissionCount();
+    const ui32 maxPermissions = capEnabled ? request.GetMaxPermissionCount() : 0;
     bool capHit = capEnabled && maxPermissions == 0;
 
     if (capHit) {
         response.MutableStatus()->SetCode(TStatus::DISALLOW_TEMP);
         response.MutableStatus()->SetReason(
-            "MaxPermissions cap exhausted: complete in-flight actions before requesting new ones");
+            "MaxPermissionCount cap exhausted: complete in-flight actions before requesting new ones");
         response.SetDeadline((TActivationContext::Now() + State->Config.DefaultRetryTime).GetValue());
     }
 
@@ -442,7 +442,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
 
             if (capEnabled && static_cast<ui32>(response.PermissionsSize()) >= maxPermissions) {
                 LOG_DEBUG(ctx, NKikimrServices::CMS,
-                          "MaxPermissions cap (%u) reached, deferring remaining actions",
+                          "MaxPermissionCount cap (%u) reached, deferring remaining actions",
                           maxPermissions);
                 capHit = true;
             }
@@ -2291,9 +2291,9 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
             const ui32 quota = task.MaxInflightActions > aliveCount
                 ? task.MaxInflightActions - aliveCount
                 : 0;
-            request.Request.SetMaxPermissions(quota);
+            request.Request.SetMaxPermissionCount(quota);
         } else {
-            request.Request.ClearMaxPermissions();
+            request.Request.ClearMaxPermissionCount();
         }
     }
 

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -403,16 +403,6 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
     }
 
     for (const auto &action : request.GetActions()) {
-        if (capHit) {
-            if (schedule) {
-                auto *scheduledAction = scheduled.AddActions();
-                scheduledAction->CopyFrom(action);
-                scheduledAction->ClearIssue();
-            }
-            ++processedActions;
-            continue;
-        }
-
         TDuration permissionDuration = State->Config.DefaultPermissionDuration;
         if (request.HasDuration())
             permissionDuration = TDuration::MicroSeconds(request.GetDuration());
@@ -451,6 +441,7 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
                           "MaxPermissions cap (%u) reached, deferring remaining actions",
                           maxPermissions);
                 capHit = true;
+                break;
             }
         } else {
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Result: %s (reason: %s)",
@@ -483,6 +474,21 @@ bool TCms::CheckPermissionRequest(const TPermissionRequest &request,
         ++processedActions;
     }
     ClusterInfo->RollbackLocks(point);
+
+    if (capHit && schedule && processedActions < static_cast<size_t>(request.ActionsSize())) {
+        const auto& allActions = request.GetActions();
+        auto* mutableActions = scheduled.MutableActions();
+        const size_t from = processedActions;
+
+        mutableActions->Reserve(mutableActions->size() + (allActions.size() - from));
+        std::for_each(allActions.begin() + from, allActions.end(),
+                      [mutableActions](const auto& action) {
+                          auto* scheduledAction = mutableActions->Add();
+                          scheduledAction->CopyFrom(action);
+                          scheduledAction->ClearIssue();
+                      });
+        processedActions = allActions.size();
+    }
 
     // Handle partial permission and reject cases. Partial permission requires
     // removal of rejected action status. Reject means we have to clear all

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -2273,9 +2273,26 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
 
     ClusterInfo->SetPriorityToCheck(request.Priority);
     request.Request.SetAvailabilityMode(rec.GetAvailabilityMode());
-    if (rec.HasMaxPermissions()) {
+
+    if (auto mit = State->MaintenanceRequests.find(rec.GetRequestId());
+        mit != State->MaintenanceRequests.end())
+    {
+        const auto &task = State->MaintenanceTasks.at(mit->second);
+        if (task.MaxInflightActions > 0) {
+            const ui32 aliveCount = task.Permissions.size();
+            const ui32 quota = task.MaxInflightActions > aliveCount
+                ? task.MaxInflightActions - aliveCount
+                : 0;
+            request.Request.SetMaxPermissions(quota);
+        } else {
+            request.Request.ClearMaxPermissions();
+        }
+    } else if (rec.HasMaxPermissions()) {
         request.Request.SetMaxPermissions(rec.GetMaxPermissions());
+    } else {
+        request.Request.ClearMaxPermissions();
     }
+
     bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, rec.GetRequestId(), ctx);
     ClusterInfo->ResetPriorityToCheck();
     ClusterInfo->LogManager.RollbackOperations();

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -2287,10 +2287,6 @@ void TCms::Handle(TEvCms::TEvCheckRequest::TPtr &ev, const TActorContext &ctx)
         } else {
             request.Request.ClearMaxPermissions();
         }
-    } else if (rec.HasMaxPermissions()) {
-        request.Request.SetMaxPermissions(rec.GetMaxPermissions());
-    } else {
-        request.Request.ClearMaxPermissions();
     }
 
     bool ok = CheckPermissionRequest(request.Request, resp->Record, scheduled.Request, rec.GetRequestId(), ctx);

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -4,9 +4,92 @@
 
 #include <ydb/core/base/hive.h>
 
+#include <util/generic/algorithm.h>
+#include <util/random/fast.h>
+
 namespace NKikimr::NCmsTest {
 
 using namespace Ydb::Maintenance;
+
+namespace {
+
+void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
+    Y_ABORT_UNLESS(totalNodes > 0);
+    Y_ABORT_UNLESS(cap > 0);
+
+    TCmsTestEnv env(totalNodes);
+
+    auto ev = std::make_unique<NCms::TEvCms::TEvCreateMaintenanceTaskRequest>();
+    ev->Record.SetUserSID("test-user");
+    auto* req = ev->Record.MutableRequest();
+    req->mutable_task_options()->set_task_uid("task-1");
+    req->mutable_task_options()->set_availability_mode(
+        Ydb::Maintenance::AVAILABILITY_MODE_FORCE);
+    req->mutable_task_options()->set_max_concurrent_actions(cap);
+    for (ui32 i = 0; i < totalNodes; ++i) {
+        auto group = MakeActionGroup(
+            MakeLockAction(env.GetNodeId(i), TDuration::Minutes(10)));
+        req->add_action_groups()->CopyFrom(group);
+    }
+    env.SendToCms(ev.release());
+    auto createReply = env.GrabEdgeEvent<NCms::TEvCms::TEvMaintenanceTaskResponse>();
+    UNIT_ASSERT_VALUES_EQUAL(createReply->Record.GetStatus(), Ydb::StatusIds::SUCCESS);
+
+    auto split = [](const Ydb::Maintenance::MaintenanceTaskResult& r) {
+        TVector<Ydb::Maintenance::ActionUid> performed;
+        ui32 pending = 0;
+        for (const auto& group : r.action_group_states()) {
+            UNIT_ASSERT_VALUES_EQUAL(group.action_states().size(), 1);
+            const auto& s = group.action_states(0);
+            switch (s.status()) {
+                case ActionState::ACTION_STATUS_PERFORMED:
+                    performed.push_back(s.action_uid());
+                    break;
+                case ActionState::ACTION_STATUS_PENDING:
+                    ++pending;
+                    break;
+                default:
+                    UNIT_FAIL("Unexpected action status: " << static_cast<int>(s.status()));
+            }
+        }
+        return std::make_pair(std::move(performed), pending);
+    };
+
+    Ydb::Maintenance::MaintenanceTaskResult current = createReply->Record.GetResult();
+    TReallyFastRng32 rng(42);
+    ui32 totalCompleted = 0;
+    ui32 iterations = 0;
+
+    while (totalCompleted < totalNodes) {
+        auto [performed, pending] = split(current);
+        const ui32 total = performed.size() + pending;
+
+        UNIT_ASSERT_VALUES_EQUAL_C(total, totalNodes - totalCompleted,
+            "iter=" << iterations);
+        UNIT_ASSERT_VALUES_EQUAL_C(performed.size(), Min<ui32>(cap, total),
+            "iter=" << iterations);
+        UNIT_ASSERT_C(!performed.empty(),
+            "no progress: nothing PERFORMED at iter=" << iterations);
+
+        const ui32 toComplete = 1 + rng.Uniform(performed.size());
+        for (ui32 i = 0; i < toComplete; ++i) {
+            env.CheckCompleteAction(performed[i], Ydb::StatusIds::SUCCESS);
+        }
+        totalCompleted += toComplete;
+
+        if (totalCompleted < totalNodes) {
+            current = env.CheckMaintenanceTaskRefresh("task-1", Ydb::StatusIds::SUCCESS);
+        }
+
+        ++iterations;
+        UNIT_ASSERT_C(iterations <= totalNodes,
+            "too many iterations: " << iterations);
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(totalCompleted, totalNodes);
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
     Y_UNIT_TEST(ManyActionGroupsWithSingleAction) {
@@ -392,9 +475,6 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
     }
 
     Y_UNIT_TEST(MaxConcurrentActionsCapsInitialBatch) {
-        // Cap = 3, request 8 actions. Cluster checks are bypassed via FORCE mode
-        // so the cap is the only thing that decides how many permissions are
-        // issued in the initial create call.
         TCmsTestEnv env(8);
 
         auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
@@ -428,8 +508,6 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
     }
 
     Y_UNIT_TEST(MaxConcurrentActionsBlocksRefresh) {
-        // Without completing any of the issued permissions, refresh must not
-        // issue new ones. The cap stays at "alive = 3, quota = 0".
         TCmsTestEnv env(8);
 
         auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
@@ -468,8 +546,6 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
     }
 
     Y_UNIT_TEST(MaxConcurrentActionsReleasesQuotaOnCompleteAction) {
-        // Complete 2 of the initial 3 permissions, then refresh: CMS should
-        // top up so we again have 3 alive permissions (the cap).
         TCmsTestEnv env(8);
 
         auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
@@ -494,7 +570,6 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         }
         UNIT_ASSERT_VALUES_EQUAL(performed.size(), 3);
 
-        // Complete two of them; one should still be alive.
         env.CheckCompleteAction(performed[0], Ydb::StatusIds::SUCCESS);
         env.CheckCompleteAction(performed[1], Ydb::StatusIds::SUCCESS);
 
@@ -510,14 +585,23 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
                 ++refreshPending;
             }
         }
-        // 1 carryover + 2 freshly issued
         UNIT_ASSERT_VALUES_EQUAL(refreshPerformed, 3);
         UNIT_ASSERT_VALUES_EQUAL(refreshPending, 5 - 2);
     }
 
+    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchNormal) {
+        RunRollingRestartSimulation(100, 5);
+    }
+
+    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchMin) {
+        RunRollingRestartSimulation(100, 1);
+    }
+
+    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchFull) {
+        RunRollingRestartSimulation(100, 100);
+    }
+
     Y_UNIT_TEST(MaxConcurrentActionsZeroMeansUnlimited) {
-        // Cap = 0 is the legacy behavior: CMS issues as many permissions as
-        // cluster constraints allow (here: all of them, thanks to FORCE mode).
         TCmsTestEnv env(8);
 
         auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -391,6 +391,156 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         env.CheckMaintenanceTaskDrop("task-1", Ydb::StatusIds::SUCCESS);
     }
 
+    Y_UNIT_TEST(MaxConcurrentActionsCapsInitialBatch) {
+        // Cap = 3, request 8 actions. Cluster checks are bypassed via FORCE mode
+        // so the cap is the only thing that decides how many permissions are
+        // issued in the initial create call.
+        TCmsTestEnv env(8);
+
+        auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            /* maxConcurrentActions = */ 3u,
+            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10)))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(response.action_group_states().size(), 8);
+
+        ui32 performed = 0;
+        ui32 pending = 0;
+        for (const auto& group : response.action_group_states()) {
+            UNIT_ASSERT_VALUES_EQUAL(group.action_states().size(), 1);
+            const auto& state = group.action_states(0);
+            if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
+                ++performed;
+            } else if (state.status() == ActionState::ACTION_STATUS_PENDING) {
+                ++pending;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(performed, 3);
+        UNIT_ASSERT_VALUES_EQUAL(pending, 5);
+    }
+
+    Y_UNIT_TEST(MaxConcurrentActionsBlocksRefresh) {
+        // Without completing any of the issued permissions, refresh must not
+        // issue new ones. The cap stays at "alive = 3, quota = 0".
+        TCmsTestEnv env(8);
+
+        auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            /* maxConcurrentActions = */ 3u,
+            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10)))
+        );
+
+        ui32 createPerformed = 0;
+        for (const auto& group : createResult.action_group_states()) {
+            if (group.action_states(0).status() == ActionState::ACTION_STATUS_PERFORMED) {
+                ++createPerformed;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(createPerformed, 3);
+
+        auto refreshResult = env.CheckMaintenanceTaskRefresh("task-1", Ydb::StatusIds::SUCCESS);
+
+        ui32 refreshPerformed = 0;
+        ui32 refreshPending = 0;
+        for (const auto& group : refreshResult.action_group_states()) {
+            const auto& state = group.action_states(0);
+            if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
+                ++refreshPerformed;
+            } else if (state.status() == ActionState::ACTION_STATUS_PENDING) {
+                ++refreshPending;
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(refreshPerformed, 3);
+        UNIT_ASSERT_VALUES_EQUAL(refreshPending, 3);
+    }
+
+    Y_UNIT_TEST(MaxConcurrentActionsReleasesQuotaOnCompleteAction) {
+        // Complete 2 of the initial 3 permissions, then refresh: CMS should
+        // top up so we again have 3 alive permissions (the cap).
+        TCmsTestEnv env(8);
+
+        auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            /* maxConcurrentActions = */ 3u,
+            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10)))
+        );
+
+        TVector<Ydb::Maintenance::ActionUid> performed;
+        for (const auto& group : createResult.action_group_states()) {
+            const auto& state = group.action_states(0);
+            if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
+                performed.push_back(state.action_uid());
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(performed.size(), 3);
+
+        // Complete two of them; one should still be alive.
+        env.CheckCompleteAction(performed[0], Ydb::StatusIds::SUCCESS);
+        env.CheckCompleteAction(performed[1], Ydb::StatusIds::SUCCESS);
+
+        auto refreshResult = env.CheckMaintenanceTaskRefresh("task-1", Ydb::StatusIds::SUCCESS);
+
+        ui32 refreshPerformed = 0;
+        ui32 refreshPending = 0;
+        for (const auto& group : refreshResult.action_group_states()) {
+            const auto& state = group.action_states(0);
+            if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
+                ++refreshPerformed;
+            } else if (state.status() == ActionState::ACTION_STATUS_PENDING) {
+                ++refreshPending;
+            }
+        }
+        // 1 carryover + 2 freshly issued
+        UNIT_ASSERT_VALUES_EQUAL(refreshPerformed, 3);
+        UNIT_ASSERT_VALUES_EQUAL(refreshPending, 5 - 2);
+    }
+
+    Y_UNIT_TEST(MaxConcurrentActionsZeroMeansUnlimited) {
+        // Cap = 0 is the legacy behavior: CMS issues as many permissions as
+        // cluster constraints allow (here: all of them, thanks to FORCE mode).
+        TCmsTestEnv env(8);
+
+        auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            /* maxConcurrentActions = */ 0u,
+            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10)))
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(response.action_group_states().size(), 8);
+        for (size_t i = 0; i < 8; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(response.action_group_states(i).action_states().size(), 1);
+            const auto& state = response.action_group_states(i).action_states(0);
+            UNIT_ASSERT_VALUES_EQUAL(state.status(), ActionState::ACTION_STATUS_PERFORMED);
+        }
+    }
+
     Y_UNIT_TEST(DisableMaintenance) {
         TCmsTestEnv env(16);
 

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -25,7 +25,7 @@ void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
     req->mutable_task_options()->set_task_uid("task-1");
     req->mutable_task_options()->set_availability_mode(
         Ydb::Maintenance::AVAILABILITY_MODE_FORCE);
-    req->mutable_task_options()->set_max_concurrent_actions(cap);
+    req->mutable_task_options()->set_max_inflight_actions(cap);
     for (ui32 i = 0; i < totalNodes; ++i) {
         auto group = MakeActionGroup(
             MakeLockAction(env.GetNodeId(i), TDuration::Minutes(10)));
@@ -474,12 +474,12 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         env.CheckMaintenanceTaskDrop("task-1", Ydb::StatusIds::SUCCESS);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsCapsInitialBatch) {
+    Y_UNIT_TEST(MaxInflightActionsCapsInitialBatch) {
         TCmsTestEnv env(8);
 
         auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
             Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
-            /* maxConcurrentActions = */ 3u,
+            /* maxInflightActions = */ 3u,
             MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
@@ -507,12 +507,12 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         UNIT_ASSERT_VALUES_EQUAL(pending, 5);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsBlocksRefresh) {
+    Y_UNIT_TEST(MaxInflightActionsBlocksRefresh) {
         TCmsTestEnv env(8);
 
         auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
             Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
-            /* maxConcurrentActions = */ 3u,
+            /* maxInflightActions = */ 3u,
             MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
@@ -545,12 +545,12 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         UNIT_ASSERT_VALUES_EQUAL(refreshPending, 3);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsReleasesQuotaOnCompleteAction) {
+    Y_UNIT_TEST(MaxInflightActionsReleasesQuotaOnCompleteAction) {
         TCmsTestEnv env(8);
 
         auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
             Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
-            /* maxConcurrentActions = */ 3u,
+            /* maxInflightActions = */ 3u,
             MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
@@ -589,24 +589,24 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         UNIT_ASSERT_VALUES_EQUAL(refreshPending, 5 - 2);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchNormal) {
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchNormal) {
         RunRollingRestartSimulation(100, 5);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchMin) {
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchMin) {
         RunRollingRestartSimulation(100, 1);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsRollingRestartBatchFull) {
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchFull) {
         RunRollingRestartSimulation(100, 100);
     }
 
-    Y_UNIT_TEST(MaxConcurrentActionsZeroMeansUnlimited) {
+    Y_UNIT_TEST(MaxInflightActionsZeroMeansUnlimited) {
         TCmsTestEnv env(8);
 
         auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
             Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
-            /* maxConcurrentActions = */ 0u,
+            /* maxInflightActions = */ 0u,
             MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
             MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -474,39 +474,6 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         env.CheckMaintenanceTaskDrop("task-1", Ydb::StatusIds::SUCCESS);
     }
 
-    Y_UNIT_TEST(MaxInflightActionsCapsInitialBatch) {
-        TCmsTestEnv env(8);
-
-        auto response = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
-            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
-            /* maxInflightActions = */ 3u,
-            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))),
-            MakeActionGroup(MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10)))
-        );
-
-        UNIT_ASSERT_VALUES_EQUAL(response.action_group_states().size(), 8);
-
-        ui32 performed = 0;
-        ui32 pending = 0;
-        for (const auto& group : response.action_group_states()) {
-            UNIT_ASSERT_VALUES_EQUAL(group.action_states().size(), 1);
-            const auto& state = group.action_states(0);
-            if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
-                ++performed;
-            } else if (state.status() == ActionState::ACTION_STATUS_PENDING) {
-                ++pending;
-            }
-        }
-        UNIT_ASSERT_VALUES_EQUAL(performed, 3);
-        UNIT_ASSERT_VALUES_EQUAL(pending, 5);
-    }
-
     Y_UNIT_TEST(MaxInflightActionsBlocksRefresh) {
         TCmsTestEnv env(8);
 

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -620,6 +620,57 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         }
     }
 
+    Y_UNIT_TEST(MaxInflightActionsSurvivesCmsRestart) {
+        TCmsTestEnv env(8);
+
+        auto createResult = env.CheckMaintenanceTaskCreate("task-1", Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            /* maxInflightActions = */ 3u,
+            MakeActionGroup(MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))),
+            MakeActionGroup(MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10)))
+        );
+
+        auto countStatuses = [](const Ydb::Maintenance::MaintenanceTaskResult& r) {
+            TVector<Ydb::Maintenance::ActionUid> performed;
+            ui32 pending = 0;
+            for (const auto& group : r.action_group_states()) {
+                UNIT_ASSERT_VALUES_EQUAL(group.action_states().size(), 1);
+                const auto& state = group.action_states(0);
+                if (state.status() == ActionState::ACTION_STATUS_PERFORMED) {
+                    performed.push_back(state.action_uid());
+                } else if (state.status() == ActionState::ACTION_STATUS_PENDING) {
+                    ++pending;
+                }
+            }
+            return std::make_pair(std::move(performed), pending);
+        };
+
+        auto [createPerformed, createPending] = countStatuses(createResult);
+        UNIT_ASSERT_VALUES_EQUAL(createPerformed.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(createPending, 5);
+
+        env.RestartCms();
+
+        auto refreshAfterRestart = env.CheckMaintenanceTaskRefresh("task-1", Ydb::StatusIds::SUCCESS);
+        auto [postRestartPerformed, postRestartPending] = countStatuses(refreshAfterRestart);
+        UNIT_ASSERT_VALUES_EQUAL(postRestartPerformed.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(postRestartPending, 5);
+
+        env.CheckCompleteAction(postRestartPerformed[0], Ydb::StatusIds::SUCCESS);
+        env.CheckCompleteAction(postRestartPerformed[1], Ydb::StatusIds::SUCCESS);
+
+        auto refreshAfterCompletion = env.CheckMaintenanceTaskRefresh("task-1", Ydb::StatusIds::SUCCESS);
+        auto [completionPerformed, completionPending] = countStatuses(refreshAfterCompletion);
+        UNIT_ASSERT_VALUES_EQUAL(completionPerformed.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(completionPending, 3);
+    }
+
     Y_UNIT_TEST(DisableMaintenance) {
         TCmsTestEnv env(16);
 

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -1,4 +1,5 @@
 #include "cms_ut_common.h"
+#include "cms_maintenance_api_ut_enums.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -13,9 +14,22 @@ using namespace Ydb::Maintenance;
 
 namespace {
 
-void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
+Ydb::Maintenance::AvailabilityMode ToAvailabilityMode(EAvailabilityCase mode) {
+    switch (mode) {
+        case EAvailabilityCase::Strong:
+            return Ydb::Maintenance::AVAILABILITY_MODE_STRONG;
+        case EAvailabilityCase::KeepAvailable:
+            return Ydb::Maintenance::AVAILABILITY_MODE_WEAK;
+        case EAvailabilityCase::Force:
+            return Ydb::Maintenance::AVAILABILITY_MODE_FORCE;
+    }
+}
+
+void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap, EAvailabilityCase availabilityCase) {
     Y_ABORT_UNLESS(totalNodes > 0);
     Y_ABORT_UNLESS(cap > 0);
+
+    const auto availabilityMode = ToAvailabilityMode(availabilityCase);
 
     TCmsTestEnv env(totalNodes);
 
@@ -23,8 +37,7 @@ void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
     ev->Record.SetUserSID("test-user");
     auto* req = ev->Record.MutableRequest();
     req->mutable_task_options()->set_task_uid("task-1");
-    req->mutable_task_options()->set_availability_mode(
-        Ydb::Maintenance::AVAILABILITY_MODE_FORCE);
+    req->mutable_task_options()->set_availability_mode(availabilityMode);
     req->mutable_task_options()->set_max_inflight_actions(cap);
     for (ui32 i = 0; i < totalNodes; ++i) {
         auto group = MakeActionGroup(
@@ -65,11 +78,21 @@ void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
         const ui32 total = performed.size() + pending;
 
         UNIT_ASSERT_VALUES_EQUAL_C(total, totalNodes - totalCompleted,
-            "iter=" << iterations);
-        UNIT_ASSERT_VALUES_EQUAL_C(performed.size(), Min<ui32>(cap, total),
-            "iter=" << iterations);
+            "iter=" << iterations << " mode=" << ToString(availabilityCase));
+
+        if (availabilityCase == EAvailabilityCase::Force) {
+            UNIT_ASSERT_VALUES_EQUAL_C(performed.size(), Min<ui32>(cap, total),
+                "iter=" << iterations << " mode=" << ToString(availabilityCase));
+        } else {
+            UNIT_ASSERT_C(performed.size() <= Min<ui32>(cap, total),
+                "cap exceeded: performed=" << performed.size()
+                << " cap=" << cap << " total=" << total
+                << " iter=" << iterations
+                << " mode=" << ToString(availabilityCase));
+        }
         UNIT_ASSERT_C(!performed.empty(),
-            "no progress: nothing PERFORMED at iter=" << iterations);
+            "no progress: nothing PERFORMED at iter=" << iterations
+            << " mode=" << ToString(availabilityCase));
 
         const ui32 toComplete = 1 + rng.Uniform(performed.size());
         for (ui32 i = 0; i < toComplete; ++i) {
@@ -83,7 +106,8 @@ void RunRollingRestartSimulation(ui32 totalNodes, ui32 cap) {
 
         ++iterations;
         UNIT_ASSERT_C(iterations <= totalNodes,
-            "too many iterations: " << iterations);
+            "too many iterations: " << iterations
+            << " mode=" << ToString(availabilityCase));
     }
 
     UNIT_ASSERT_VALUES_EQUAL(totalCompleted, totalNodes);
@@ -556,16 +580,20 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         UNIT_ASSERT_VALUES_EQUAL(refreshPending, 5 - 2);
     }
 
-    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchNormal) {
-        RunRollingRestartSimulation(100, 5);
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchNormal, EAvailabilityCase) {
+        RunRollingRestartSimulation(100, 5, Arg<0>());
     }
 
-    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchMin) {
-        RunRollingRestartSimulation(100, 1);
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchMin, EAvailabilityCase) {
+        RunRollingRestartSimulation(100, 1, Arg<0>());
     }
 
-    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchFull) {
-        RunRollingRestartSimulation(100, 100);
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchFull, EAvailabilityCase) {
+        RunRollingRestartSimulation(100, 100, Arg<0>());
+    }
+
+    Y_UNIT_TEST(MaxInflightActionsRollingRestartBatchOverCap, EAvailabilityCase) {
+        RunRollingRestartSimulation(10, 20, Arg<0>());
     }
 
     Y_UNIT_TEST(MaxInflightActionsZeroMeansUnlimited) {

--- a/ydb/core/cms/cms_maintenance_api_ut_enums.h
+++ b/ydb/core/cms/cms_maintenance_api_ut_enums.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace NKikimr::NCmsTest {
+
+enum class EAvailabilityCase {
+    Strong,
+    KeepAvailable,
+    Force,
+};
+
+} // namespace NKikimr::NCmsTest

--- a/ydb/core/cms/cms_state.h
+++ b/ydb/core/cms/cms_state.h
@@ -18,6 +18,7 @@ struct TTaskInfo {
     bool HasSingleCompositeActionGroup = false;
     TInstant CreateTime;
     TInstant LastRefreshTime;
+    ui32 MaxConcurrentActions = 0;
 
     TString ToString() const {
         return TStringBuilder() << "{"
@@ -28,6 +29,7 @@ struct TTaskInfo {
             << " HasSingleCompositeActionGroup: " << HasSingleCompositeActionGroup
             << " CreateTime: " << CreateTime
             << " LastRefreshTime: " << LastRefreshTime
+            << " MaxConcurrentActions: " << MaxConcurrentActions
             << " }";
     }
 };

--- a/ydb/core/cms/cms_state.h
+++ b/ydb/core/cms/cms_state.h
@@ -18,7 +18,7 @@ struct TTaskInfo {
     bool HasSingleCompositeActionGroup = false;
     TInstant CreateTime;
     TInstant LastRefreshTime;
-    ui32 MaxConcurrentActions = 0;
+    ui32 MaxInflightActions = 0;
 
     TString ToString() const {
         return TStringBuilder() << "{"
@@ -29,7 +29,7 @@ struct TTaskInfo {
             << " HasSingleCompositeActionGroup: " << HasSingleCompositeActionGroup
             << " CreateTime: " << CreateTime
             << " LastRefreshTime: " << LastRefreshTime
-            << " MaxConcurrentActions: " << MaxConcurrentActions
+            << " MaxInflightActions: " << MaxInflightActions
             << " }";
     }
 };

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -143,8 +143,8 @@ public:
             bool hasSingleCompositeActionGroup = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>();
             ui64 createTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::CreateTime>();
             ui64 lastRefreshTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::LastRefreshTime>();
-            ui32 maxConcurrentActions =
-                maintenanceTasksRowset.GetValueOrDefault<Schema::MaintenanceTasks::MaxConcurrentActions>(0);
+            ui32 maxInflightActions =
+                maintenanceTasksRowset.GetValueOrDefault<Schema::MaintenanceTasks::MaxInflightActions>(0);
 
             state->MaintenanceRequests.emplace(requestId, taskId);
             state->MaintenanceTasks.emplace(taskId, TTaskInfo{
@@ -154,7 +154,7 @@ public:
                 .HasSingleCompositeActionGroup = hasSingleCompositeActionGroup,
                 .CreateTime = TInstant::MicroSeconds(createTime),
                 .LastRefreshTime = TInstant::MicroSeconds(lastRefreshTime),
-                .MaxConcurrentActions = maxConcurrentActions
+                .MaxInflightActions = maxInflightActions
             });
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded maintenance task %s mapped to request %s",

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -143,6 +143,8 @@ public:
             bool hasSingleCompositeActionGroup = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>();
             ui64 createTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::CreateTime>();
             ui64 lastRefreshTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::LastRefreshTime>();
+            ui32 maxConcurrentActions =
+                maintenanceTasksRowset.GetValueOrDefault<Schema::MaintenanceTasks::MaxConcurrentActions>(0);
 
             state->MaintenanceRequests.emplace(requestId, taskId);
             state->MaintenanceTasks.emplace(taskId, TTaskInfo{
@@ -151,7 +153,8 @@ public:
                 .Owner = owner,
                 .HasSingleCompositeActionGroup = hasSingleCompositeActionGroup,
                 .CreateTime = TInstant::MicroSeconds(createTime),
-                .LastRefreshTime = TInstant::MicroSeconds(lastRefreshTime)
+                .LastRefreshTime = TInstant::MicroSeconds(lastRefreshTime),
+                .MaxConcurrentActions = maxConcurrentActions
             });
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded maintenance task %s mapped to request %s",

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -39,6 +39,8 @@ public:
         if (MaintenanceTaskId) {
             Y_ABORT_UNLESS(Scheduled);
 
+            const ui32 maxConcurrentActions = Scheduled->Request.GetMaxPermissions();
+
             Self->State->MaintenanceRequests.emplace(Scheduled->RequestId, *MaintenanceTaskId);
             Self->State->MaintenanceTasks.emplace(*MaintenanceTaskId, TTaskInfo{
                 .TaskId = *MaintenanceTaskId,
@@ -46,7 +48,8 @@ public:
                 .Owner = Scheduled->Owner,
                 .HasSingleCompositeActionGroup = !Scheduled->Request.GetPartialPermissionAllowed(),
                 .CreateTime = now,
-                .LastRefreshTime = now
+                .LastRefreshTime = now,
+                .MaxConcurrentActions = maxConcurrentActions
             });
 
             db.Table<Schema::MaintenanceTasks>().Key(*MaintenanceTaskId).Update(
@@ -54,7 +57,8 @@ public:
                 NIceDb::TUpdate<Schema::MaintenanceTasks::Owner>(Scheduled->Owner),
                 NIceDb::TUpdate<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>(!Scheduled->Request.GetPartialPermissionAllowed()),
                 NIceDb::TUpdate<Schema::MaintenanceTasks::CreateTime>(now.MicroSeconds()),
-                NIceDb::TUpdate<Schema::MaintenanceTasks::LastRefreshTime>(now.MicroSeconds())
+                NIceDb::TUpdate<Schema::MaintenanceTasks::LastRefreshTime>(now.MicroSeconds()),
+                NIceDb::TUpdate<Schema::MaintenanceTasks::MaxConcurrentActions>(maxConcurrentActions)
             );
         } else if (Scheduled != nullptr && Self->State->MaintenanceRequests.contains(Scheduled->RequestId)) {
             const auto& taskId = Self->State->MaintenanceRequests[Scheduled->RequestId];

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -39,7 +39,7 @@ public:
         if (MaintenanceTaskId) {
             Y_ABORT_UNLESS(Scheduled);
 
-            const ui32 maxConcurrentActions = Scheduled->Request.GetMaxPermissions();
+            const ui32 maxInflightActions = Scheduled->Request.GetMaxPermissions();
 
             Self->State->MaintenanceRequests.emplace(Scheduled->RequestId, *MaintenanceTaskId);
             Self->State->MaintenanceTasks.emplace(*MaintenanceTaskId, TTaskInfo{
@@ -49,7 +49,7 @@ public:
                 .HasSingleCompositeActionGroup = !Scheduled->Request.GetPartialPermissionAllowed(),
                 .CreateTime = now,
                 .LastRefreshTime = now,
-                .MaxConcurrentActions = maxConcurrentActions
+                .MaxInflightActions = maxInflightActions
             });
 
             db.Table<Schema::MaintenanceTasks>().Key(*MaintenanceTaskId).Update(
@@ -58,7 +58,7 @@ public:
                 NIceDb::TUpdate<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>(!Scheduled->Request.GetPartialPermissionAllowed()),
                 NIceDb::TUpdate<Schema::MaintenanceTasks::CreateTime>(now.MicroSeconds()),
                 NIceDb::TUpdate<Schema::MaintenanceTasks::LastRefreshTime>(now.MicroSeconds()),
-                NIceDb::TUpdate<Schema::MaintenanceTasks::MaxConcurrentActions>(maxConcurrentActions)
+                NIceDb::TUpdate<Schema::MaintenanceTasks::MaxInflightActions>(maxInflightActions)
             );
         } else if (Scheduled != nullptr && Self->State->MaintenanceRequests.contains(Scheduled->RequestId)) {
             const auto& taskId = Self->State->MaintenanceRequests[Scheduled->RequestId];

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -39,7 +39,7 @@ public:
         if (MaintenanceTaskId) {
             Y_ABORT_UNLESS(Scheduled);
 
-            const ui32 maxInflightActions = Scheduled->Request.GetMaxPermissions();
+            const ui32 maxInflightActions = Scheduled->Request.GetMaxPermissionCount();
 
             Self->State->MaintenanceRequests.emplace(Scheduled->RequestId, *MaintenanceTaskId);
             Self->State->MaintenanceTasks.emplace(*MaintenanceTaskId, TTaskInfo{

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -509,7 +509,7 @@ public:
             const TString &taskUid,
             Ydb::StatusIds::StatusCode code,
             Ydb::Maintenance::AvailabilityMode availabilityMode,
-            ui32 maxConcurrentActions,
+            ui32 maxInflightActions,
             const Ts&... actionGroups)
     {
         auto ev = std::make_unique<NCms::TEvCms::TEvCreateMaintenanceTaskRequest>();
@@ -518,8 +518,8 @@ public:
         auto *req = ev->Record.MutableRequest();
         req->mutable_task_options()->set_task_uid(taskUid);
         req->mutable_task_options()->set_availability_mode(availabilityMode);
-        if (maxConcurrentActions > 0) {
-            req->mutable_task_options()->set_max_concurrent_actions(maxConcurrentActions);
+        if (maxInflightActions > 0) {
+            req->mutable_task_options()->set_max_inflight_actions(maxInflightActions);
         }
         AddActionGroups(*req, actionGroups...);
 

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -509,7 +509,8 @@ public:
             const TString &taskUid,
             Ydb::StatusIds::StatusCode code,
             Ydb::Maintenance::AvailabilityMode availabilityMode,
-            const Ts&... actionGroups) 
+            ui32 maxConcurrentActions,
+            const Ts&... actionGroups)
     {
         auto ev = std::make_unique<NCms::TEvCms::TEvCreateMaintenanceTaskRequest>();
         ev->Record.SetUserSID("test-user");
@@ -517,6 +518,9 @@ public:
         auto *req = ev->Record.MutableRequest();
         req->mutable_task_options()->set_task_uid(taskUid);
         req->mutable_task_options()->set_availability_mode(availabilityMode);
+        if (maxConcurrentActions > 0) {
+            req->mutable_task_options()->set_max_concurrent_actions(maxConcurrentActions);
+        }
         AddActionGroups(*req, actionGroups...);
 
         SendToPipe(CmsId, Sender, ev.release(), 0, GetPipeConfigWithRetries());
@@ -532,9 +536,19 @@ public:
     Ydb::Maintenance::MaintenanceTaskResult CheckMaintenanceTaskCreate(
             const TString &taskUid,
             Ydb::StatusIds::StatusCode code,
+            Ydb::Maintenance::AvailabilityMode availabilityMode,
+            const Ts&... actionGroups)
+    {
+        return CheckMaintenanceTaskCreate(taskUid, code, availabilityMode, 0u, actionGroups...);
+    }
+
+    template <typename... Ts>
+    Ydb::Maintenance::MaintenanceTaskResult CheckMaintenanceTaskCreate(
+            const TString &taskUid,
+            Ydb::StatusIds::StatusCode code,
             const Ts&... actionGroups) 
     {   
-        return CheckMaintenanceTaskCreate(taskUid, code, Ydb::Maintenance::AVAILABILITY_MODE_STRONG, actionGroups...);
+        return CheckMaintenanceTaskCreate(taskUid, code, Ydb::Maintenance::AVAILABILITY_MODE_STRONG, 0u, actionGroups...);
     }
 
     Ydb::Maintenance::ManageActionResult CheckCompleteAction(

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -141,6 +141,7 @@ struct Schema : NIceDb::Schema {
         struct HasSingleCompositeActionGroup : Column<4, NScheme::NTypeIds::Bool> {};
         struct CreateTime : Column<5, NScheme::NTypeIds::Uint64> {};
         struct LastRefreshTime : Column<6, NScheme::NTypeIds::Uint64> {};
+        struct MaxConcurrentActions : Column<7, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<TaskID>;
         using TColumns = TableColumns<
@@ -149,7 +150,8 @@ struct Schema : NIceDb::Schema {
             Owner,
             HasSingleCompositeActionGroup,
             CreateTime,
-            LastRefreshTime
+            LastRefreshTime,
+            MaxConcurrentActions
         >;
     };
 

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -141,7 +141,7 @@ struct Schema : NIceDb::Schema {
         struct HasSingleCompositeActionGroup : Column<4, NScheme::NTypeIds::Bool> {};
         struct CreateTime : Column<5, NScheme::NTypeIds::Uint64> {};
         struct LastRefreshTime : Column<6, NScheme::NTypeIds::Uint64> {};
-        struct MaxConcurrentActions : Column<7, NScheme::NTypeIds::Uint32> {};
+        struct MaxInflightActions : Column<7, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<TaskID>;
         using TColumns = TableColumns<
@@ -151,7 +151,7 @@ struct Schema : NIceDb::Schema {
             HasSingleCompositeActionGroup,
             CreateTime,
             LastRefreshTime,
-            MaxConcurrentActions
+            MaxInflightActions
         >;
     };
 

--- a/ydb/core/cms/ut/ya.make
+++ b/ydb/core/cms/ut/ya.make
@@ -14,6 +14,8 @@ PEERDIR(
 
 YQL_LAST_ABI_VERSION()
 
+GENERATE_ENUM_SERIALIZATION(cms_maintenance_api_ut_enums.h)
+
 SRCS(
     cluster_info_ut.cpp
     cms_ut.cpp

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -185,6 +185,14 @@ message TPermissionRequest {
   // Evit vdisks before granting permission
   optional bool EvictVDisks = 11 [default = false];
   optional int32 Priority = 12;
+  // Maximum number of permissions that may be issued by a single check of
+  // this request. Excess actions that would have been allowed are instead
+  // pushed back into the scheduled request and reported as DISALLOW_TEMP.
+  // 0 means unlimited. Used to implement Ydb.Maintenance.MaintenanceTaskOptions
+  // .max_concurrent_actions: the maintenance adapter recomputes the effective
+  // cap as (max_concurrent_actions - currently_active_permissions) on every
+  // RefreshMaintenanceTask call.
+  optional uint32 MaxPermissions = 13 [default = 0];
 }
 
 enum EExtensionType {
@@ -246,6 +254,10 @@ message TCheckRequest {
   optional string   RequestId = 2;
   optional bool     DryRun = 3;
   optional EAvailabilityMode AvailabilityMode = 4 [default = MODE_MAX_AVAILABILITY];
+  // Per-call override of TPermissionRequest.MaxPermissions for the underlying
+  // scheduled request. Used by the maintenance API adapter to enforce the
+  // task-level max_concurrent_actions limit on every refresh.
+  optional uint32 MaxPermissions = 5 [default = 0];
 }
 
 message TManagePermissionRequest {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -188,10 +188,6 @@ message TPermissionRequest {
   // Maximum number of permissions that may be issued by a single check of
   // this request. Excess actions that would have been allowed are instead
   // pushed back into the scheduled request and reported as DISALLOW_TEMP.
-  // 0 means unlimited. Used to implement Ydb.Maintenance.MaintenanceTaskOptions
-  // .max_concurrent_actions: the maintenance adapter recomputes the effective
-  // cap as (max_concurrent_actions - currently_active_permissions) on every
-  // RefreshMaintenanceTask call.
   optional uint32 MaxPermissions = 13 [default = 0];
 }
 
@@ -255,8 +251,7 @@ message TCheckRequest {
   optional bool     DryRun = 3;
   optional EAvailabilityMode AvailabilityMode = 4 [default = MODE_MAX_AVAILABILITY];
   // Per-call override of TPermissionRequest.MaxPermissions for the underlying
-  // scheduled request. Used by the maintenance API adapter to enforce the
-  // task-level max_concurrent_actions limit on every refresh.
+  // scheduled request.
   optional uint32 MaxPermissions = 5 [default = 0];
 }
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -187,7 +187,7 @@ message TPermissionRequest {
   optional int32 Priority = 12;
   // Maximum number of permissions that may be issued by a single check of this request.
   // Unset means "no cap", 0 means "cap is zero".
-  optional uint32 MaxPermissions = 13 [default = 0];
+  optional uint32 MaxPermissionCount = 13 [default = 0];
 }
 
 enum EExtensionType {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -185,9 +185,7 @@ message TPermissionRequest {
   // Evit vdisks before granting permission
   optional bool EvictVDisks = 11 [default = false];
   optional int32 Priority = 12;
-  // Maximum number of permissions that may be issued by a single check of
-  // this request. Excess actions that would have been allowed are instead
-  // pushed back into the scheduled request and reported as DISALLOW_TEMP.
+  // Maximum number of permissions that may be issued by a single check of this request.
   optional uint32 MaxPermissions = 13 [default = 0];
 }
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -186,6 +186,7 @@ message TPermissionRequest {
   optional bool EvictVDisks = 11 [default = false];
   optional int32 Priority = 12;
   // Maximum number of permissions that may be issued by a single check of this request.
+  // Unset means "no cap", 0 means "cap is zero".
   optional uint32 MaxPermissions = 13 [default = 0];
 }
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -248,8 +248,6 @@ message TCheckRequest {
   optional string   RequestId = 2;
   optional bool     DryRun = 3;
   optional EAvailabilityMode AvailabilityMode = 4 [default = MODE_MAX_AVAILABILITY];
-  // Per-call override of TPermissionRequest.MaxPermissions for the underlying scheduled request.
-  optional uint32 MaxPermissions = 5 [default = 0];
 }
 
 message TManagePermissionRequest {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -248,8 +248,7 @@ message TCheckRequest {
   optional string   RequestId = 2;
   optional bool     DryRun = 3;
   optional EAvailabilityMode AvailabilityMode = 4 [default = MODE_MAX_AVAILABILITY];
-  // Per-call override of TPermissionRequest.MaxPermissions for the underlying
-  // scheduled request.
+  // Per-call override of TPermissionRequest.MaxPermissions for the underlying scheduled request.
   optional uint32 MaxPermissions = 5 [default = 0];
 }
 

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -102,10 +102,7 @@ message MaintenanceTaskOptions {
     // for this task. CMS will not issue new locks beyond this limit; remaining
     // actions stay in PENDING until clients call CompleteAction on already
     // performed ones. 0 means unlimited (default behavior).
-    //
-    // Intended to keep the number of in-flight permissions bounded so that
-    // they cannot expire before the client manages to use them.
-    uint32 max_concurrent_actions = 6;
+    uint32 max_inflight_actions = 6;
 }
 
 // Used to describe the scope of a single action.

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -98,6 +98,14 @@ message MaintenanceTaskOptions {
     bool dry_run = 4;
     // Priority of the task. Lower value indicates higher priority.
     int32 priority = 5 [(value) = "[-100; 100]"];
+    // Maximum number of actions that may be in the PERFORMED state simultaneously
+    // for this task. CMS will not issue new locks beyond this limit; remaining
+    // actions stay in PENDING until clients call CompleteAction on already
+    // performed ones. 0 means unlimited (default behavior).
+    //
+    // Intended to keep the number of in-flight permissions bounded so that
+    // they cannot expire before the client manages to use them.
+    uint32 max_concurrent_actions = 6;
 }
 
 // Used to describe the scope of a single action.

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -102,6 +102,12 @@ message MaintenanceTaskOptions {
     // for this task. CMS will not issue new locks beyond this limit; remaining
     // actions stay in PENDING until clients call CompleteAction on already
     // performed ones. 0 means unlimited (default behavior).
+    // Note: this option is honored only when actions can be granted
+    // independently — i.e. when the task contains more than one action_group
+    // or its single action_group contains exactly one action. For a task that
+    // consists of a single action_group with multiple actions (a "composite"
+    // group) actions within the group are granted atomically (all or nothing)
+    // and the cap is ignored — CMS will emit a warning in this case.
     uint32 max_inflight_actions = 6;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added support for the max_inflight_actions field in CMS to limit the maximum number of granted permissions per single request

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
