### PR TITLE
fq: fix breakage by empty-database-forbidden enforcement

### DIFF
--- a/ydb/core/fq/libs/compute/ydb/control_plane/cms_grpc_client_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/cms_grpc_client_actor.cpp
@@ -100,6 +100,7 @@ public:
         }
         forwardRequest->Request.set_path(request.Path);
         SetYdbRequestToken(*forwardRequest, CredentialsProvider->GetAuthInfo());
+        forwardRequest->Headers.emplace(NYdb::YDB_DATABASE_HEADER, request.BasePath);
         TEvPrivate::TEvCreateDatabaseRequest::TPtr forwardEvent = (NActors::TEventHandle<TEvPrivate::TEvCreateDatabaseRequest>*)new IEventHandle(SelfId(), SelfId(), forwardRequest.release(), 0, Cookie);
         MakeCall<TCreateDatabaseGrpcRequest>(std::move(forwardEvent));
         Requests[Cookie++] = ev;

--- a/ydb/core/fq/libs/compute/ydb/control_plane/cms_grpc_client_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/cms_grpc_client_actor.cpp
@@ -153,6 +153,8 @@ public:
     void Handle(TEvYdbCompute::TEvListDatabasesRequest::TPtr& ev) {
         auto forwardRequest = std::make_unique<TEvPrivate::TEvListDatabasesRequest>();
         SetYdbRequestToken(*forwardRequest, CredentialsProvider->GetAuthInfo());
+        forwardRequest->Headers.emplace(NYdb::YDB_DATABASE_HEADER, ev->Get()->Database);
+
         TEvPrivate::TEvListDatabasesRequest::TPtr forwardEvent = (NActors::TEventHandle<TEvPrivate::TEvListDatabasesRequest>*)new IEventHandle(SelfId(), SelfId(), forwardRequest.release(), 0, Cookie);
         MakeCall<TListDatabasesGrpcRequest>(std::move(forwardEvent));
         Requests[Cookie++] = ev;

--- a/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.cpp
@@ -413,7 +413,7 @@ public:
         for (const auto& config: mapping.GetCommon()) {
             auto databaseCounters = Counters->GetSubgroup("database", config.GetControlPlaneConnection().GetDatabase());
             const auto clientActor = Register(CreateCmsGrpcClientActor(CreateGrpcClientSettings(config), CredentialsProviderFactory(GetYdbCredentialSettings(config.GetControlPlaneConnection()))->CreateProvider()).release());
-            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters).release());
+            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters, config.GetControlPlaneConnection().GetDatabase()).release());
             TActorId databaseMonitoringActor;
             const NConfig::TLoadControlConfig& loadConfig = config.GetLoadControlConfig().GetEnable()
                 ? config.GetLoadControlConfig()
@@ -437,7 +437,7 @@ public:
         for (const auto& [scope, config]: mapping.GetScopeToComputeDatabase()) {
             auto databaseCounters = Counters->GetSubgroup("database", config.GetControlPlaneConnection().GetDatabase());
             const auto clientActor = Register(CreateCmsGrpcClientActor(CreateGrpcClientSettings(config), CredentialsProviderFactory(GetYdbCredentialSettings(config.GetControlPlaneConnection()))->CreateProvider()).release());
-            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters).release());
+            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters, config.GetControlPlaneConnection().GetDatabase()).release());
             TActorId databaseMonitoringActor;
             const NConfig::TLoadControlConfig& loadConfig = config.GetLoadControlConfig().GetEnable()
                 ? config.GetLoadControlConfig()
@@ -462,7 +462,7 @@ public:
         for (const auto& config: mapping.GetCommon()) {
             auto databaseCounters = Counters->GetSubgroup("database", config.GetControlPlaneConnection().GetDatabase());
             const auto clientActor = Register(CreateYdbcpGrpcClientActor(CreateGrpcClientSettings(config), CredentialsProviderFactory(GetYdbCredentialSettings(config.GetControlPlaneConnection()))->CreateProvider()).release());
-            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters).release());
+            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters, config.GetControlPlaneConnection().GetDatabase()).release());
             Clients->CommonDatabaseClients.push_back({clientActor, config, cacheActor, {}});
         }
 
@@ -471,7 +471,7 @@ public:
         for (const auto& [scope, config]: mapping.GetScopeToComputeDatabase()) {
             auto databaseCounters = Counters->GetSubgroup("database", config.GetControlPlaneConnection().GetDatabase());
             const auto clientActor = Register(CreateYdbcpGrpcClientActor(CreateGrpcClientSettings(config), CredentialsProviderFactory(GetYdbCredentialSettings(config.GetControlPlaneConnection()))->CreateProvider()).release());
-            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters).release());
+            const auto cacheActor = Register(CreateComputeDatabasesCacheActor(clientActor, databasesCacheReloadPeriod, databaseCounters, config.GetControlPlaneConnection().GetDatabase()).release());
             Clients->ScopeToDatabaseClient[scope] = {clientActor, config, cacheActor, {}};
         }
     }

--- a/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.h
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.h
@@ -26,7 +26,7 @@ std::unique_ptr<NActors::IActor> CreateYdbcpGrpcClientActor(const NGrpcActorClie
 
 std::unique_ptr<NActors::IActor> CreateCmsGrpcClientActor(const NGrpcActorClient::TGrpcClientSettings& settings, const NYdb::TCredentialsProviderPtr& credentialsProvider);
 
-std::unique_ptr<NActors::IActor> CreateComputeDatabasesCacheActor(const NActors::TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters);
+std::unique_ptr<NActors::IActor> CreateComputeDatabasesCacheActor(const NActors::TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters, const TString& database);
 
 std::unique_ptr<NActors::IActor> CreateMonitoringGrpcClientActor(const NGrpcActorClient::TGrpcClientSettings& settings, const NYdb::TCredentialsProviderPtr& credentialsProvider);
 std::unique_ptr<NActors::IActor> CreateMonitoringRestClientActor(const TString& endpoint, const TString& database, const NYdb::TCredentialsProviderPtr& credentialsProvider);

--- a/ydb/core/fq/libs/compute/ydb/control_plane/compute_databases_cache.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/compute_databases_cache.cpp
@@ -181,7 +181,7 @@ private:
     bool InFlight = false;
     bool Ready = false;
     const TDuration DatabasesCacheReloadPeriod = TDuration::Seconds(30);
-    const TString& Database;
+    const TString Database;
 };
 
 std::unique_ptr<NActors::IActor> CreateComputeDatabasesCacheActor(const TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters, const TString& database) {

--- a/ydb/core/fq/libs/compute/ydb/control_plane/compute_databases_cache.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/compute_databases_cache.cpp
@@ -66,11 +66,12 @@ class TComputeDatabasesCacheActor : public NActors::TActorBootstrapped<TComputeD
 
 public:
     using TBase =NActors::TActorBootstrapped<TComputeDatabasesCacheActor>;
-    TComputeDatabasesCacheActor(const TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters)
+    TComputeDatabasesCacheActor(const TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters, const TString& database)
         : StartCacheReload(TInstant::Now())
         , DatabaseClientActorId(databaseClientActorId)
         , Counters(counters)
         , DatabasesCacheReloadPeriod(GetDuration(databasesCacheReloadPeriod, TDuration::Seconds(30)))
+        , Database(database)
     {}
 
     static constexpr char ActorName[] = "FQ_COMPUTE_DATABASES_CACHE_ACTOR";
@@ -79,7 +80,7 @@ public:
         LOG_E("Cache Bootstrap, client " << DatabaseClientActorId.ToString());
         InFlight = true;
         Counters.CacheReload.InFly->Inc();
-        Send(DatabaseClientActorId, new TEvYdbCompute::TEvListDatabasesRequest());
+        Send(DatabaseClientActorId, new TEvYdbCompute::TEvListDatabasesRequest(Database));
         Become(&TComputeDatabasesCacheActor::StateFunc, DatabasesCacheReloadPeriod, new NActors::TEvents::TEvWakeup());
     }
 
@@ -146,7 +147,7 @@ public:
             Counters.CacheReload.InFly->Inc();
             InFlight = true;
             StartCacheReload = TInstant::Now();
-            Send(DatabaseClientActorId, new TEvYdbCompute::TEvListDatabasesRequest());
+            Send(DatabaseClientActorId, new TEvYdbCompute::TEvListDatabasesRequest(Database));
         }
         Schedule(DatabasesCacheReloadPeriod, new NActors::TEvents::TEvWakeup());
     }
@@ -180,10 +181,11 @@ private:
     bool InFlight = false;
     bool Ready = false;
     const TDuration DatabasesCacheReloadPeriod = TDuration::Seconds(30);
+    const TString& Database;
 };
 
-std::unique_ptr<NActors::IActor> CreateComputeDatabasesCacheActor(const TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters) {
-    return std::make_unique<TComputeDatabasesCacheActor>(databaseClientActorId, databasesCacheReloadPeriod, counters);
+std::unique_ptr<NActors::IActor> CreateComputeDatabasesCacheActor(const TActorId& databaseClientActorId, const TString& databasesCacheReloadPeriod, const ::NMonitoring::TDynamicCounterPtr& counters, const TString& database) {
+    return std::make_unique<TComputeDatabasesCacheActor>(databaseClientActorId, databasesCacheReloadPeriod, counters, database);
 }
 
 }

--- a/ydb/core/fq/libs/compute/ydb/events/events.h
+++ b/ydb/core/fq/libs/compute/ydb/events/events.h
@@ -259,7 +259,7 @@ struct TEvYdbCompute {
     };
 
     struct TEvListDatabasesRequest : public NActors::TEventLocal<TEvListDatabasesRequest, EvListDatabasesRequest> {
-        TEvListDatabasesRequest(const TString& database = {})
+        explicit TEvListDatabasesRequest(const TString& database)
             : Database(database)
         {}
         TString Database;

--- a/ydb/core/fq/libs/compute/ydb/events/events.h
+++ b/ydb/core/fq/libs/compute/ydb/events/events.h
@@ -259,6 +259,10 @@ struct TEvYdbCompute {
     };
 
     struct TEvListDatabasesRequest : public NActors::TEventLocal<TEvListDatabasesRequest, EvListDatabasesRequest> {
+        TEvListDatabasesRequest(const TString& database = {})
+            : Database(database)
+        {}
+        TString Database;
     };
 
     struct TEvListDatabasesResponse : public NActors::TEventLocal<TEvListDatabasesResponse, EvListDatabasesResponse> {


### PR DESCRIPTION
Adds database header to ListDatabases and CreateDatabase call

Regression by 56f7066edf5439a8ac34e668e0e9be05355825d3 ("fixing" tests without fixing actual users was really bad idea)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-5359
Likely incomplete and similar fixes required to other calls
