### PR TITLE
Stabilize in-tx DDL completion test using hints instead of TAB.

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ut/yql_completer_ut.cpp
@@ -28,6 +28,14 @@ THashSet<std::string> AsSet(const THints& hints) {
     return set;
 }
 
+THashSet<std::string> SupportedInteractiveModeNames() {
+    THashSet<std::string> set;
+    for (auto mode : GetSupportedTxModeNames()) {
+        set.insert(TString(mode));
+    }
+    return set;
+}
+
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(TclCompleter) {
@@ -60,14 +68,10 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
         const auto set = AsSet(hints);
         UNIT_ASSERT(set.contains("TRANSACTION"));
-        UNIT_ASSERT(!set.contains("WORK"));
-        UNIT_ASSERT(set.contains("serializable-rw"));
-        UNIT_ASSERT(set.contains("read-committed-rw"));
-        UNIT_ASSERT(set.contains("snapshot-ro"));
-        UNIT_ASSERT(set.contains("snapshot-rw"));
-        // online-ro / stale-ro are NOT supported as interactive modes.
-        UNIT_ASSERT(!set.contains("online-ro"));
-        UNIT_ASSERT(!set.contains("stale-ro"));
+        for (const auto& mode : SupportedInteractiveModeNames()) {
+            UNIT_ASSERT(set.contains(mode));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(set.size(), SupportedInteractiveModeNames().size() + 1);
     }
 
     Y_UNIT_TEST(NextWordAfterBeginPartialT) {
@@ -78,8 +82,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         UNIT_ASSERT_VALUES_EQUAL(contextLen, 1);
         const auto set = AsSet(hints);
         UNIT_ASSERT(set.contains("TRANSACTION"));
-        UNIT_ASSERT(!set.contains("WORK"));
-        UNIT_ASSERT(!set.contains("serializable-rw"));
+        UNIT_ASSERT_VALUES_EQUAL(set.size(), 1u);
     }
 
     Y_UNIT_TEST(NextWordAfterBeginPartialS) {
@@ -103,32 +106,27 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
         auto hints = completer->ApplyLight(text, std::string(text), contextLen);
         UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
         const auto set = AsSet(hints);
-        UNIT_ASSERT(set.contains("serializable-rw"));
-        UNIT_ASSERT(set.contains("read-committed-rw"));
-        UNIT_ASSERT(set.contains("snapshot-ro"));
-        UNIT_ASSERT(set.contains("snapshot-rw"));
-        UNIT_ASSERT(!set.contains("online-ro"));
-        UNIT_ASSERT(!set.contains("stale-ro"));
+        for (const auto& mode : SupportedInteractiveModeNames()) {
+            UNIT_ASSERT(set.contains(mode));
+        }
+        UNIT_ASSERT_VALUES_EQUAL(set.size(), SupportedInteractiveModeNames().size());
         UNIT_ASSERT(!set.contains("TRANSACTION"));
-        UNIT_ASSERT(!set.contains("WORK"));
     }
 
-    Y_UNIT_TEST(NoOnlineRoSuggestion) {
+    Y_UNIT_TEST(NoModeSuggestionForUnknownPrefix) {
         auto completer = MakeTclOnlyCompleter();
         int contextLen = -1;
         const TString text = "BEGIN o";
         auto hints = completer->ApplyLight(text, std::string(text), contextLen);
-        // No mode starts with 'o' anymore (online-ro removed).
         UNIT_ASSERT(hints.empty());
     }
 
-    Y_UNIT_TEST(NoInconsistentReadsModifier) {
+    Y_UNIT_TEST(NoSuggestionAfterCompleteBeginLine) {
         auto completer = MakeTclOnlyCompleter();
         int contextLen = -1;
         for (auto text : {TString("BEGIN snapshot-ro "), TString("BEGIN snapshot-rw ")}) {
             auto hints = completer->ApplyLight(text, std::string(text), contextLen);
-            const auto set = AsSet(hints);
-            UNIT_ASSERT(!set.contains("INCONSISTENT"));
+            UNIT_ASSERT(hints.empty());
         }
     }
 
@@ -147,7 +145,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
             UNIT_ASSERT_VALUES_EQUAL(contextLen, 0);
             const auto set = AsSet(hints);
             UNIT_ASSERT(set.contains("TRANSACTION"));
-            UNIT_ASSERT(!set.contains("WORK"));
+            UNIT_ASSERT_VALUES_EQUAL(set.size(), 1u);
         }
     }
 
@@ -165,7 +163,7 @@ Y_UNIT_TEST_SUITE(TclCompleter) {
             auto hints = completer->ApplyLight(text, std::string(text), contextLen);
             const auto set = AsSet(hints);
             UNIT_ASSERT(set.contains("TRANSACTION"));
-            UNIT_ASSERT(!set.contains("WORK"));
+            UNIT_ASSERT_VALUES_EQUAL(set.size(), 1u);
         }
     }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -233,10 +233,10 @@ namespace {
     //
     // Given the user's input split into completed tokens and a partial last
     // token, the completer scans a precomputed list of "full TCL commands"
-    // (e.g. "BEGIN TRANSACTION online-ro INCONSISTENT READS") and for every
-    // match returns only the *next word* — never the whole tail. This produces
-    // the same UX as the YQL completer (e.g. typing `BEGIN T<TAB>` proposes
-    // `TRANSACTION`, not `TRANSACTION online-ro INCONSISTENT READS`).
+    // (e.g. "BEGIN TRANSACTION serializable-rw") and for every match returns
+    // only the *next word* — never the whole tail. This produces the same UX
+    // as the YQL completer (e.g. typing `BEGIN T<TAB>` proposes `TRANSACTION`,
+    // not `TRANSACTION serializable-rw`).
     class TTclCompleter {
     public:
         explicit TTclCompleter(const std::vector<TString>& commands) {

--- a/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/session/sql_session_runner.cpp
@@ -240,7 +240,7 @@ public:
         auto txSettings = ParseBeginTransactionIsolation(line);
         if (!txSettings) {
             const auto modeToken = ExtractBeginModeToken(line);
-            if (modeToken && IsOneShotOnlyTxMode(*modeToken)) {
+            if (modeToken && IsOneShotOnlyTxMode(*modeToken) && !HasTrailingBeginTokens(line)) {
                 Cerr << Colors.Red()
                      << "\nMode \"" << *modeToken
                      << "\" cannot be used with BEGIN — the Query service does"

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.cpp
@@ -197,6 +197,15 @@ bool IsOneShotOnlyTxMode(TStringBuf mode) {
     return normalized == "online-ro" || normalized == "stale-ro";
 }
 
+bool HasTrailingBeginTokens(TStringBuf line) {
+    const auto tokens = TokenizeUpper(line);
+    const size_t skip = MatchBeginPrefix(tokens);
+    if (skip == 0 || skip >= tokens.size()) {
+        return false;
+    }
+    return skip + 1 < tokens.size();
+}
+
 bool IsBeginCommand(TStringBuf line) {
     const auto tokens = TokenizeUpper(line);
     return MatchBeginPrefix(tokens) > 0;

--- a/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
+++ b/ydb/public/lib/ydb_cli/common/tx_mode_utils.h
@@ -50,8 +50,8 @@ std::optional<NQuery::TTxSettings> ParseBeginTransactionIsolation(TStringBuf lin
 
 // Extracts the user-facing mode token from a BEGIN line, if any.
 //
-// Returns the lowercased mode token (e.g. "online-ro") for inputs like
-// "BEGIN online-ro" or "BEGIN TRANSACTION snapshot-ro".
+// Returns the lowercased mode token (e.g. "snapshot-ro") for inputs like
+// "BEGIN snapshot-ro" or "BEGIN TRANSACTION read-committed-rw".
 // Returns std::nullopt if the line is not a BEGIN command or has no mode
 // token after the prefix. Used to produce targeted diagnostics for known but
 // unsupported modes.
@@ -61,6 +61,11 @@ std::optional<TString> ExtractBeginModeToken(TStringBuf line);
 // tx_control (--tx-mode), not as an open interactive transaction. Today:
 // online-ro and stale-ro.
 bool IsOneShotOnlyTxMode(TStringBuf mode);
+
+// True if a BEGIN line has tokens after the mode (e.g. "BEGIN serializable-rw
+// extra"). Such lines are rejected as malformed rather than with the
+// one-shot-mode hint.
+bool HasTrailingBeginTokens(TStringBuf line);
 
 // Human-readable list of supported mode names for help / error messages.
 TString GetTxModeNamesForHelp();

--- a/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/tx_mode_utils_ut.cpp
@@ -14,22 +14,20 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
 
     Y_UNIT_TEST(SupportedNamesContainExpectedModes) {
         const auto names = GetSupportedTxModeNames();
+        UNIT_ASSERT_VALUES_EQUAL(names.size(), 4u);
         const THashSet<TStringBuf> set(names.begin(), names.end());
         UNIT_ASSERT(set.contains("serializable-rw"));
         UNIT_ASSERT(set.contains("snapshot-ro"));
         UNIT_ASSERT(set.contains("snapshot-rw"));
         UNIT_ASSERT(set.contains("read-committed-rw"));
-        // online-ro and stale-ro are not interactive-able.
-        UNIT_ASSERT(!set.contains("online-ro"));
-        UNIT_ASSERT(!set.contains("stale-ro"));
     }
 
     Y_UNIT_TEST(HelpStringMatchesSupportedNames) {
         const TString help = GetTxModeNamesForHelp();
         UNIT_ASSERT(help.Contains("serializable-rw"));
+        UNIT_ASSERT(help.Contains("snapshot-ro"));
+        UNIT_ASSERT(help.Contains("snapshot-rw"));
         UNIT_ASSERT(help.Contains("read-committed-rw"));
-        UNIT_ASSERT(!help.Contains("online-ro"));
-        UNIT_ASSERT(!help.Contains("stale-ro"));
     }
 
     // ------------------------------------------------------------------
@@ -48,11 +46,6 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(ParseTxModeName("SNAPSHOT-RO"));
     }
 
-    Y_UNIT_TEST(ParseModeRejectsOneShotModes) {
-        UNIT_ASSERT(!ParseTxModeName("online-ro"));
-        UNIT_ASSERT(!ParseTxModeName("stale-ro"));
-    }
-
     Y_UNIT_TEST(ParseModeRejectsUnknown) {
         UNIT_ASSERT(!ParseTxModeName(""));
         UNIT_ASSERT(!ParseTxModeName("garbage"));
@@ -67,7 +60,6 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("begin"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION"));
-        UNIT_ASSERT(!ParseBeginTransactionIsolation("START TRANSACTION"));
     }
 
     Y_UNIT_TEST(BeginAllowsTrailingSemicolon) {
@@ -79,15 +71,6 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
     Y_UNIT_TEST(BeginParsesMode) {
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN serializable-rw"));
         UNIT_ASSERT(ParseBeginTransactionIsolation("BEGIN TRANSACTION snapshot-ro"));
-        UNIT_ASSERT(!ParseBeginTransactionIsolation("START TRANSACTION read-committed-rw"));
-    }
-
-    Y_UNIT_TEST(BeginRejectsOneShotModes) {
-        // online-ro and stale-ro are not openable interactively even though
-        // they are valid YDB tx modes.
-        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN online-ro"));
-        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN stale-ro"));
-        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN online-ro INCONSISTENT READS"));
     }
 
     Y_UNIT_TEST(BeginRejectsUnknownMode) {
@@ -96,9 +79,7 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
 
     Y_UNIT_TEST(BeginRejectsTrailingTokens) {
         UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN serializable-rw extra"));
-        // The PostgreSQL-style ISOLATION LEVEL form is intentionally rejected.
-        UNIT_ASSERT(!ParseBeginTransactionIsolation(
-            "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED"));
+        UNIT_ASSERT(!ParseBeginTransactionIsolation("BEGIN snapshot-ro extra"));
     }
 
     Y_UNIT_TEST(BeginRejectsNonBeginInput) {
@@ -108,29 +89,27 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
     }
 
     // ------------------------------------------------------------------
-    // ExtractBeginModeToken / IsOneShotOnlyTxMode
+    // ExtractBeginModeToken / HasTrailingBeginTokens
     // ------------------------------------------------------------------
 
     Y_UNIT_TEST(ExtractBeginModeToken) {
-        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN online-ro"), "online-ro");
-        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("begin Stale-RO"), "stale-ro");
-        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN TRANSACTION snapshot-ro"), "snapshot-ro");
-        UNIT_ASSERT(!ExtractBeginModeToken("START TRANSACTION serializable-rw"));
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN snapshot-ro"), "snapshot-ro");
+        UNIT_ASSERT_VALUES_EQUAL(
+            *ExtractBeginModeToken("BEGIN TRANSACTION read-committed-rw"),
+            "read-committed-rw");
+        UNIT_ASSERT_VALUES_EQUAL(*ExtractBeginModeToken("BEGIN garbage-mode"), "garbage-mode");
         UNIT_ASSERT(!ExtractBeginModeToken("BEGIN"));
         UNIT_ASSERT(!ExtractBeginModeToken("BEGIN TRANSACTION"));
         UNIT_ASSERT(!ExtractBeginModeToken("SELECT 1"));
     }
 
-    Y_UNIT_TEST(IsOneShotOnlyTxMode) {
-        UNIT_ASSERT(IsOneShotOnlyTxMode("online-ro"));
-        UNIT_ASSERT(IsOneShotOnlyTxMode("ONLINE-RO"));
-        UNIT_ASSERT(IsOneShotOnlyTxMode("stale-ro"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode("serializable-rw"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode("snapshot-ro"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode("snapshot-rw"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode("read-committed-rw"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode("garbage"));
-        UNIT_ASSERT(!IsOneShotOnlyTxMode(""));
+    Y_UNIT_TEST(HasTrailingBeginTokens) {
+        UNIT_ASSERT(HasTrailingBeginTokens("BEGIN serializable-rw extra"));
+        UNIT_ASSERT(HasTrailingBeginTokens("BEGIN snapshot-ro extra"));
+        UNIT_ASSERT(!HasTrailingBeginTokens("BEGIN serializable-rw"));
+        UNIT_ASSERT(!HasTrailingBeginTokens("BEGIN snapshot-ro"));
+        UNIT_ASSERT(!HasTrailingBeginTokens("BEGIN"));
+        UNIT_ASSERT(!HasTrailingBeginTokens("SELECT 1"));
     }
 
     // ------------------------------------------------------------------
@@ -141,26 +120,20 @@ Y_UNIT_TEST_SUITE(TxModeUtils) {
         UNIT_ASSERT(IsBeginCommand("BEGIN"));
         UNIT_ASSERT(IsBeginCommand("begin transaction"));
         UNIT_ASSERT(IsBeginCommand("Begin Transaction serializable-rw"));
-        UNIT_ASSERT(!IsBeginCommand("START TRANSACTION"));
         UNIT_ASSERT(IsBeginCommand("BEGIN;"));
         UNIT_ASSERT(!IsBeginCommand(""));
         UNIT_ASSERT(!IsBeginCommand("SELECT 1"));
         UNIT_ASSERT(!IsBeginCommand("BEGINNING"));
-        UNIT_ASSERT(!IsBeginCommand("START"));
     }
 
     Y_UNIT_TEST(IsCommitCommand) {
         UNIT_ASSERT(IsCommitCommand("COMMIT"));
         UNIT_ASSERT(IsCommitCommand("commit transaction"));
-        UNIT_ASSERT(!IsCommitCommand("COMMIT WORK"));
-        UNIT_ASSERT(!IsCommitCommand("END"));
-        UNIT_ASSERT(!IsCommitCommand("END TRANSACTION"));
         UNIT_ASSERT(!IsCommitCommand("COMMIT FOO"));
     }
 
     Y_UNIT_TEST(IsRollbackCommand) {
         UNIT_ASSERT(IsRollbackCommand("ROLLBACK"));
-        UNIT_ASSERT(!IsRollbackCommand("rollback work"));
         UNIT_ASSERT(IsRollbackCommand("ROLLBACK TRANSACTION;"));
         UNIT_ASSERT(!IsRollbackCommand("ROLLBACK FOO"));
     }

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1091,15 +1091,17 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "--tx-mode" in combined
         assert "COMMIT" not in result.stdout
 
-    def test_inconsistent_reads_modifier_rejected(self):
-        """The INCONSISTENT READS modifier is no longer supported in BEGIN."""
+    def test_begin_rejects_trailing_tokens(self):
+        """Extra tokens after a supported mode must not open a transaction."""
         result = self.run_interactive_session(
-            ["BEGIN online-ro INCONSISTENT READS", "exit"],
+            ["BEGIN serializable-rw extra", "exit"],
             self.tmp_path,
         )
         assert result.exit_code == 0
         combined = result.stdout + result.stderr
         assert "unknown" in combined.lower() or "malformed" in combined.lower()
+        assert "COMMIT" not in result.stdout
+        assert "Supported modes:" in combined
 
     # ------------------------------------------------------------------
     # Negative parsing: rejected forms

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -960,6 +960,44 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             exit_code=execution.exit_code,
         )
 
+    @staticmethod
+    def _combined_output(result: "BaseInteractiveTest.ExecutionResult") -> str:
+        return result.stdout + result.stderr
+
+    @classmethod
+    def _combined_lower(cls, result: "BaseInteractiveTest.ExecutionResult") -> str:
+        return cls._combined_output(result).lower()
+
+    def _assert_show_create_table_ran(self, result: "BaseInteractiveTest.ExecutionResult") -> None:
+        """SHOW CREATE TABLE returned DDL for the fixture table (see create_table)."""
+        combined = self._combined_lower(result)
+        assert "cannot be executed inside an interactive transaction" not in combined
+        assert "create table" in combined
+        assert "`id`" in combined
+        assert "`name`" in combined
+        assert "primary key" in combined
+        assert self.tmp_path.name.lower() in combined
+
+    @staticmethod
+    def _assert_stdout_contains(result: "BaseInteractiveTest.ExecutionResult", *values: str) -> None:
+        for value in values:
+            assert value in result.stdout
+
+    @staticmethod
+    def _assert_combined_has_error(combined_lower: str) -> None:
+        """YDB/CLI errors are wording-dependent; match a small stable set."""
+        assert any(
+            marker in combined_lower
+            for marker in (
+                "error",
+                "failed",
+                "not found",
+                "does not exist",
+                "path not found",
+                "unknown",
+            )
+        )
+
     # ------------------------------------------------------------------
     # Happy path: BEGIN / COMMIT / ROLLBACK forms
     # ------------------------------------------------------------------
@@ -1077,7 +1115,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         # "unknown mode" path (which would imply the user mistyped).
         assert "online-ro" in combined
         assert "--tx-mode" in combined
-        assert "COMMIT" not in result.stdout
+        assert "BEGIN" not in result.stdout
 
     def test_stale_ro_rejected_as_interactive_mode(self):
         """stale-ro is one-shot only; BEGIN must reject it client-side with a hint."""
@@ -1089,7 +1127,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         combined = result.stdout + result.stderr
         assert "stale-ro" in combined
         assert "--tx-mode" in combined
-        assert "COMMIT" not in result.stdout
+        assert "BEGIN" not in result.stdout
 
     def test_begin_rejects_trailing_tokens(self):
         """Extra tokens after a supported mode must not open a transaction."""
@@ -1098,10 +1136,10 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             self.tmp_path,
         )
         assert result.exit_code == 0
-        combined = result.stdout + result.stderr
-        assert "unknown" in combined.lower() or "malformed" in combined.lower()
-        assert "COMMIT" not in result.stdout
-        assert "Supported modes:" in combined
+        combined = self._combined_lower(result)
+        assert "unknown" in combined or "malformed" in combined
+        assert "BEGIN" not in result.stdout
+        assert "Supported modes:" in self._combined_output(result)
 
     # ------------------------------------------------------------------
     # Negative parsing: rejected forms
@@ -1113,8 +1151,9 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             self.tmp_path,
         )
         assert result.exit_code == 0
-        combined = result.stdout + result.stderr
-        assert "unknown" in combined.lower() or "malformed" in combined.lower()
+        combined = self._combined_lower(result)
+        assert "unknown" in combined or "malformed" in combined
+        assert "BEGIN" not in result.stdout
 
     def test_psql_isolation_level_syntax_rejected(self):
         """The PostgreSQL-style "ISOLATION LEVEL READ COMMITTED" form is not supported.
@@ -1130,10 +1169,9 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             self.tmp_path,
         )
         assert result.exit_code == 0
-        combined = result.stdout + result.stderr
-        assert "unknown" in combined.lower() or "malformed" in combined.lower()
-        # Nothing actually got committed.
-        assert "COMMIT" not in result.stdout
+        combined = self._combined_lower(result)
+        assert "unknown" in combined or "malformed" in combined
+        assert "BEGIN" not in result.stdout
 
     def test_draft_tcl_keywords_from_pr_41859_not_supported(self):
         """Legacy TCL from the draft PR must not open or commit interactive transactions."""
@@ -1296,6 +1334,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert result.stdout.count("BEGIN") >= 3
         assert result.stdout.count("COMMIT") >= 2
         assert result.stdout.count("ROLLBACK") >= 1
+        self._assert_stdout_contains(result, "51", "52", "53")
 
     def test_ddl_rejected_inside_transaction(self):
         """CREATE TABLE must not be sent to the server while a transaction is open."""
@@ -1311,9 +1350,11 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             self.tmp_path,
         )
         assert result.exit_code == 0
-        combined = (result.stdout + result.stderr).lower()
+        combined = self._combined_lower(result)
         assert "cannot be executed inside an interactive transaction" in combined
         assert "ROLLBACK" in result.stdout
+        # CREATE was blocked; the table must not exist for the post-ROLLBACK scan.
+        self._assert_combined_has_error(combined)
 
     def test_show_create_allowed_inside_transaction(self):
         """SHOW CREATE TABLE is read-only DDL and must pass through inside a transaction."""
@@ -1327,8 +1368,7 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
             self.tmp_path,
         )
         assert result.exit_code == 0
-        combined = (result.stdout + result.stderr).lower()
-        assert "cannot be executed inside an interactive transaction" not in combined
+        self._assert_show_create_table_ran(result)
         assert "ROLLBACK" in result.stdout
 
     def test_failed_query_invalidates_transaction(self):

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1135,6 +1135,48 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         # Nothing actually got committed.
         assert "COMMIT" not in result.stdout
 
+    def test_draft_tcl_keywords_from_pr_41859_not_supported(self):
+        """Legacy TCL from the draft PR must not open or commit interactive transactions."""
+        # Not recognized as BEGIN — goes to YQL, no TCL BEGIN acknowledgement.
+        result = self.run_interactive_session(
+            ["START TRANSACTION", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "BEGIN" not in result.stdout
+
+        # Parsed as BEGIN with unknown mode token WORK.
+        result = self.run_interactive_session(
+            ["BEGIN WORK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = result.stdout + result.stderr
+        assert "unknown" in combined.lower() or "malformed" in combined.lower()
+        assert "BEGIN" not in result.stdout
+
+        # END / COMMIT WORK / ROLLBACK WORK are not COMMIT/ROLLBACK aliases.
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "END", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" not in result.stdout
+
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "COMMIT WORK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "COMMIT" not in result.stdout
+
+        result = self.run_interactive_session(
+            ["BEGIN", "SELECT 1;", "ROLLBACK WORK", "exit"],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        assert "ROLLBACK" not in result.stdout
+
     def test_begin_word_boundary(self):
         """An identifier starting with the letters BEGIN must not be parsed as BEGIN."""
         result = self.run_interactive_session(

--- a/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_interactive_sql.py
@@ -1271,6 +1271,22 @@ class TestInteractiveTransactions(BaseSqlInteractiveTest):
         assert "cannot be executed inside an interactive transaction" in combined
         assert "ROLLBACK" in result.stdout
 
+    def test_show_create_allowed_inside_transaction(self):
+        """SHOW CREATE TABLE is read-only DDL and must pass through inside a transaction."""
+        result = self.run_interactive_session(
+            [
+                "BEGIN",
+                "SHOW CREATE TABLE `{}`;".format(self.table_path),
+                "ROLLBACK",
+                "exit",
+            ],
+            self.tmp_path,
+        )
+        assert result.exit_code == 0
+        combined = (result.stdout + result.stderr).lower()
+        assert "cannot be executed inside an interactive transaction" not in combined
+        assert "ROLLBACK" in result.stdout
+
     def test_failed_query_invalidates_transaction(self):
         """After a failed in-tx query the CLI must drop local tx state (server auto-rollback)."""
         result = self.run_interactive_session(
@@ -1354,22 +1370,27 @@ class TestInteractiveTransactionsAutocomplete(BaseSqlInteractiveTest):
         child.send("\r")
 
     def test_no_ddl_completion_inside_transaction(self):
-        """Inside a transaction TAB must hide destructive DDL but keep SHOW CREATE."""
+        """Inside a transaction, hints hide destructive DDL but keep SHOW CREATE.
+
+        TAB completion lists are not rendered reliably in a pty (replxx may use
+        inline completion only), so we use the same hint-based checks as
+        test_hints_showed_for_ambiguous_prefix. Check CRE before S so that a
+        prior SHOW CREATE hint does not pollute the negative assertion.
+        """
         child = self.spawn_interactive()
         try:
             child.expect("Welcome to YDB CLI", timeout=15)
             self._wait_for_prompt(child)
             self._send_line(child, "BEGIN")
             self._wait_for_ready_after_begin(child)
-            child.send("S")
-            child.send("\t")
-            # Replxx may split rendered keywords with ANSI escapes (ELECT ... S ... HOW CREATE).
-            self._expect_keyword(child, "ELECT")
-            self._expect_keyword(child, "HOW CREATE")
-            child.sendcontrol("u")
+
             child.send("CRE")
-            child.send("\t")
-            self._expect_no_keyword(child, "CREATE")
+            self._expect_no_keyword(child, "CREATE", timeout=2)
+
+            child.sendcontrol("u")
+            child.send("S")
+            child.expect("SELECT", timeout=self.COMPLETION_TIMEOUT)
+            child.expect("SHOW CREATE", timeout=self.COMPLETION_TIMEOUT)
         finally:
             self._discard_and_exit(child)
             child.close()


### PR DESCRIPTION
Replxx often does not echo TAB candidate lists into the pty buffer; use hint-based checks like other completion tests. Assert CRE before S to avoid false positives from SHOW CREATE. Add stdin test that SHOW CREATE TABLE is allowed inside a transaction.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed issues: #41984 #42144

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
