### PR TITLE
use drain timeout from shutdown config in local and in test

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1311,6 +1311,10 @@ void TLocalServiceInitializer::InitializeServices(
     addToLocalConfig(TTabletTypes::BlockStorePartitionDirect, &NYdb::NBS::NBlockStore::NStorage::NPartitionDirect::CreatePartitionTablet, TMailboxType::ReadAsFilled, appData->UserPoolId);
 #endif
 
+    if (Config.GetShutdownConfig().HasDrainTimeoutSeconds()) {
+        localConfig->DrainNodeTimeout = TDuration::Seconds(Config.GetShutdownConfig().GetDrainTimeoutSeconds());
+    }
+
     TTenantPoolConfig::TPtr tenantPoolConfig = new TTenantPoolConfig(Config.GetTenantPoolConfig(), localConfig);
     if (!tenantPoolConfig->IsEnabled && !tenantPoolConfig->StaticSlots.empty())
         Y_ABORT("Tenant slots are not allowed in disabled pool");

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -106,7 +106,6 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     TDuration LastSendTabletMetricsDuration = {};
     constexpr static TDuration TABLET_METRICS_BATCH_INTERVAL = TDuration::MilliSeconds(5000);
     constexpr static TDuration UPDATE_SYSTEM_USAGE_INTERVAL = TDuration::MilliSeconds(1000);
-    constexpr static TDuration DRAIN_NODE_TIMEOUT = TDuration::MilliSeconds(15000);
     ui64 UserPoolUsage = 0; // (usage uS x threads) / sec
     ui64 UserPoolLimit = 0; // PotentialMaxThreadCount of UserPool
     ui64 MemUsage = 0;
@@ -911,7 +910,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         LastDrainRequest->OnSend();
         UpdateEstimate();
         NTabletPipe::SendData(ctx, HivePipeClient, new TEvHive::TEvDrainNode(SelfId().NodeId()));
-        ctx.Schedule(DRAIN_NODE_TIMEOUT, new TEvPrivate::TEvLocalDrainTimeout());
+        ctx.Schedule(Config->DrainNodeTimeout, new TEvPrivate::TEvLocalDrainTimeout());
     }
 
     void HandleDrain(TEvLocal::TEvLocalDrainNode::TPtr &ev, const TActorContext &ctx) {

--- a/ydb/core/mind/local.h
+++ b/ydb/core/mind/local.h
@@ -377,6 +377,7 @@ struct TLocalConfig : public TThrRefBase {
     };
 
     TMap<TTabletTypes::EType, TTabletClassInfo> TabletClassInfo;
+    TDuration DrainNodeTimeout = TDuration::Seconds(30);
 };
 
 IActor* CreateLocal(TLocalConfig *config);

--- a/ydb/tests/functional/hive/test_drain.py
+++ b/ydb/tests/functional/hive/test_drain.py
@@ -34,6 +34,7 @@ class TestHive(object):
                     'object_imbalance_to_balance': 100,
                 },
                 extra_feature_flags=['enable_drain_on_shutdown'],
+                shutdown_config={'drain_timeout_seconds': 1000000},
             )
         )
         cls.cluster.start()

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -208,7 +208,7 @@ class KikimrConfigGenerator(object):
             enable_nbs=False,
             nbs_database_name="/Root/NBS",
             enable_topic_cloud_events=False,
-            shutdown_config = None,
+            shutdown_config=None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -208,6 +208,7 @@ class KikimrConfigGenerator(object):
             enable_nbs=False,
             nbs_database_name="/Root/NBS",
             enable_topic_cloud_events=False,
+            shutdown_config = None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -684,6 +685,9 @@ class KikimrConfigGenerator(object):
 
         if system_tablet_backup_config:
             self.yaml_config["system_tablet_backup_config"] = system_tablet_backup_config
+
+        if shutdown_config:
+            self.yaml_config["shutdown_config"] = shutdown_config
 
         if metadata_section:
             self.full_config["metadata"] = metadata_section


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

supposedly fixes https://github.com/ydb-platform/ydb/issues/40209, except the fail rate is so low I couldn't even get the test to fail locally, so... 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
