### PR TITLE
schemeshard: measure TTableInfo::VerifyConsistency() time

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -478,6 +478,9 @@ enum ECumulativeCounters {
     COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN = 142 [(CounterOpts) = {Name: "SplitMergePartitionsRewritten"}];
 
     COUNTER_FINISHED_OPS_TxCreateFullBackupOp = 143 [(CounterOpts) = {Name: "FinishedOps/CreateFullBackupOp"}];
+
+    // How much time TTableInfo::VerifyConsistency() call takes, in nanoseconds
+    COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS = 144 [(CounterOpts) = {Name: "TablePartitionsConsistencyCheckTimeNs"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -315,4 +315,5 @@ message TFeatureFlags {
     optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
     optional bool EnableTopicMessagesBatching = 274 [default = false];
     optional bool EnableTopicWriteOffsetDeltaInKeys = 275 [default = false];
+    optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -275,6 +275,9 @@ public:
             Y_ABORT_UNLESS(context.SS->Tables.contains(srcPath.Base()->PathId));
 
             TTableInfo::TPtr tableInfo = TTableInfo::DeepCopy(*context.SS->Tables.at(srcPath.Base()->PathId));
+            // report TTableInfo::VerifyConsistency() time
+            context.SS->TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
+
             tableInfo->ResetDescriptionCache();
             tableInfo->AlterVersion += 1;
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -8100,6 +8100,9 @@ void TSchemeShard::SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, T
     Send(SysPartitionStatsCollector, ev.Release());
 
     tableInfo->SetPartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
@@ -8129,6 +8132,9 @@ void TSchemeShard::MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, 
     }
 
     tableInfo->MovePartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
@@ -8152,6 +8158,9 @@ void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, 
     }
 
     tableInfo->CopyPartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::ApplySplitMerge(
@@ -8178,6 +8187,9 @@ void TSchemeShard::ApplySplitMerge(
     }
 
     tableInfo->ApplySplitMerge(std::move(dstPartitions), removedShards, splitStartIdx, now);
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 
     TVector<std::pair<ui64, ui64>> shardIndices;
     shardIndices.reserve(tableInfo->GetPartitions().size());

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2047,6 +2047,14 @@ void TTableInfo::ApplySplitMerge(
 }
 
 void TTableInfo::VerifyConsistency() const {
+    // AppData is absent in lowlevel unit tests
+    if (HasAppData() && !AppData()->FeatureFlags.GetEnableTablePartitionsConsistencyCheck()) {
+        LastVerifyConsistencyTime = 0;
+        return;
+    }
+
+    THPTimer cpuTimer;
+
     Y_ABORT_UNLESS(PartitionStore.size() == Partitions.size());
     Y_ABORT_UNLESS(Stats.PartitionStats.size() == Partitions.size());
     Y_ABORT_UNLESS(Stats.Aggregated.PartCount == Partitions.size());
@@ -2077,6 +2085,8 @@ void TTableInfo::VerifyConsistency() const {
         Y_ABORT_UNLESS(CondEraseSchedule.Empty());
         Y_ABORT_UNLESS(InFlightCondErase.empty());
     }
+
+    LastVerifyConsistencyTime = ui64(1e9 * cpuTimer.PassedReset());
 }
 
 void TTableAggregatedStats::RemoveShardStats(const TVector<TShardIdx>& keys, TInstant now) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -848,6 +848,8 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
 
     bool IsExternalBlobsEnabled = false;
 
+    mutable ui64 LastVerifyConsistencyTime = 0;
+
     const NKikimrSchemeOp::TPartitionConfig& PartitionConfig() const { return TableDescription.GetPartitionConfig(); }
     NKikimrSchemeOp::TPartitionConfig& MutablePartitionConfig() { return *TableDescription.MutablePartitionConfig(); }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -58,6 +58,20 @@ void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 va
     UNIT_ASSERT_VALUES_EQUAL(value, GetSimpleCounter(runtime, name));
 }
 
+ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name) {
+    const auto counters = GetCounters(runtime);
+    for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetCumulativeCounters()) {
+        if (name != counter.GetName()) {
+            continue;
+        }
+
+        return counter.GetValue();
+    }
+
+    UNIT_ASSERT_C(false, "Cumulative counter not found: " << name);
+    return 0; // unreachable
+}
+
 ui64 GetPercentileCounter(const auto& counters, const TString& range) {
     for (ui32 i = 0; i < counters.RangesSize(); ++i) {
         if (range != counters.GetRanges(i)) {

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -14,6 +14,7 @@ using namespace NActors;
 
 ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
 void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
+ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name);
 ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
 void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
 

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
 #include <ydb/public/lib/value/value.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>  // for Y_UNIT_TEST_FLAGS_N
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
@@ -2891,5 +2892,113 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitMergeValidation) {
             SourceTabletId: 72075186233409546
             SourceTabletId: 72075186233409546
         )", {{NKikimrScheme::StatusInvalidParameter, "Duplicate SourceTabletId"}});
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardConsistencyCheckCounter) {
+    // COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS accumulates the wall-clock
+    // nanoseconds spent in TTableInfo::VerifyConsistency(), gated by the
+    // EnableTablePartitionsConsistencyCheck feature flag (default on).
+    static constexpr const char* CounterName = "SchemeShard/TablePartitionsConsistencyCheckTimeNs";
+
+    Y_UNIT_TEST(ZeroWhenFlagOff) {
+        // With the check disabled, VerifyConsistency() returns early and resets
+        // LastVerifyConsistencyTime to 0, so every report site increments by 0
+        // and the cumulative counter stays exactly 0.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsConsistencyCheck(false);
+
+        // Many partitions: a verify here would be measurable if it ran at all.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 200
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Exercise ApplySplitMerge as well (the first shard of a uniform table).
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+            SourceTabletId: %lu
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 1 } } } }
+        )", TTestTxConfig::FakeHiveTablets + 0));
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCumulativeCounter(runtime, CounterName), 0u);
+    }
+
+    Y_UNIT_TEST(ReportedWhenFlagOn) {
+        // With the check enabled (default), the cumulative counter accumulates a
+        // non-zero time across the partitioning report sites. A 200-partition
+        // verify reliably exceeds 1us, so create/copy/move alone guarantee > 0;
+        // split and merge additionally cover the ApplySplitMerge report sites and
+        // assert the verification invariants hold on real operation results.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsConsistencyCheck(true);
+
+        // Small table with explicit, predictable shard ids for split/merge.
+        // Partitions: (-inf,"A") -> F+0, ["A","B") -> F+1, ["B",+inf) -> F+2.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "SplitMe"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "A" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "B" } } } }
+            PartitionConfig {
+                PartitioningPolicy { MinPartitionsCount: 1 SizeToSplit: 100500 }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Split the first partition -> ApplySplitMerge (split).
+        TestSplitTable(runtime, ++txId, "/MyRoot/SplitMe", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "0" } } } }
+            )",
+            TTestTxConfig::FakeHiveTablets + 0
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        // Merge the two non-first partitions F+1, F+2 -> ApplySplitMerge (merge).
+        TestSplitTable(runtime, ++txId, "/MyRoot/SplitMe", Sprintf(R"(
+                SourceTabletId: %lu
+                SourceTabletId: %lu
+            )",
+            TTestTxConfig::FakeHiveTablets + 1,
+            TTestTxConfig::FakeHiveTablets + 2
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        // Big table to force a measurable verify time.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "BigTable"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 200
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Copy -> SetPartitioning on the new table.
+        TestCopyTable(runtime, ++txId, "/MyRoot", "BigCopy", "/MyRoot/BigTable");
+        env.TestWaitNotification(runtime, txId);
+
+        // Move -> MovePartitioning + the move_table report site.
+        TestMoveTable(runtime, ++txId, "/MyRoot/BigTable", "/MyRoot/BigMoved");
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_GT(GetCumulativeCounter(runtime, CounterName), 0u);
     }
 }


### PR DESCRIPTION
Follow-up to:
- https://github.com/ydb-platform/ydb/pull/38803
- https://github.com/ydb-platform/ydb/pull/38804

The schemeshard runs an O(N) consistency check over a table's partitions on every partitioning change (create, copy, move, split, merge). On tables with many partitions this cost was invisible.

This PR makes it observable and controllable:

- New cumulative counter `SchemeShard/TablePartitionsConsistencyCheckTimeNs` accumulates the time spent in the check.
- New feature flag `EnableTablePartitionsConsistencyCheck` (default on) to turn the check off entirely if needed.

Tests cover the counter being zero when the flag is off and non-zero across create/copy/move/split/merge when on.
