### PR TITLE
Compatibility between versions 25-4 and 26-1

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -1422,10 +1422,10 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxCommit> ev, con
 {
     if (PlanStep.Defined() && TxId.Defined()) {
         if (GetStepAndTxId(*ev) < GetStepAndTxId(*PlanStep, *TxId)) {
-            LOG_D("Send TEvTxDone (commit)" <<
+            LOG_D("Stale TEvTxCommit: persist tx meta then TEvTxDone" <<
                      " Step " << ev->Step <<
                      ", TxId " << ev->TxId);
-            ctx.Send(TabletActorId, MakeTxDone(ev->Step, ev->TxId).Release());
+            EnqueueStaleTxMetaPersist(std::move(ev), ctx);
             return;
         }
     }
@@ -2629,6 +2629,8 @@ void TPartition::RunPersist() {
         PersistRequest = MakeHolder<TEvKeyValue::TEvRequest>();
     }
 
+    TryAppendStaleTxMetaWrites();
+
     if (ManageWriteTimestampEstimate) {
         WriteTimestampEstimate = now;
     }
@@ -2916,30 +2918,100 @@ bool TPartition::HasPendingCommitsOrPendingWrites() const
 
 void TPartition::TryAddCmdWriteForTransaction(const TTransaction& tx)
 {
-    Y_ENSURE(!IsSupportive());
+    PQ_ENSURE(!IsSupportive());
 
     if (!tx.SerializedTx.Defined()) {
         return;
     }
 
-    PQ_ENSURE(PersistRequest);
     TMaybe<ui64> txId = tx.GetTxId();
     PQ_ENSURE(txId.Defined());
+    PQ_ENSURE(tx.Tx);
 
-    TString value;
-    PQ_ENSURE(tx.SerializedTx->SerializeToString(&value));
+    TStaleTxMetaEntry entry;
+    entry.Step = tx.Tx->Step;
+    entry.TxId = *txId;
+    entry.SerializedTx = tx.SerializedTx;
+    entry.TabletConfig = tx.TabletConfig;
+    entry.BootstrapConfig = tx.BootstrapConfig;
+    entry.PartitionsData = tx.PartitionsData;
+    
+    AddCmdWritePersistStaleTxMeta(entry);
+}
 
-    auto command = PersistRequest->Record.AddCmdWrite();
-    command->SetKey(GetTxKey(*txId, Partition.OriginalPartitionId));
-    command->SetValue(value);
-    command->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
-
-    if (!tx.TabletConfig.Defined()) {
+void TPartition::EnqueueStaleTxMetaPersist(std::unique_ptr<TEvPQ::TEvTxCommit> ev, const TActorContext& ctx)
+{
+    if (!ev->SerializedTx.Defined()) {
+        ctx.Send(TabletActorId, MakeTxDone(ev->Step, ev->TxId).Release());
         return;
     }
 
+    TStaleTxMetaEntry entry;
+    entry.Step = ev->Step;
+    entry.TxId = ev->TxId;
+    entry.SerializedTx = std::move(ev->SerializedTx);
+    entry.TabletConfig = std::move(ev->TabletConfig);
+    entry.BootstrapConfig = std::move(ev->BootstrapConfig);
+    entry.PartitionsData = std::move(ev->PartitionsData);
+    StaleTxMetaPending[ev->TxId] = std::move(entry);
+
+    ProcessTxsAndUserActs(ctx);
+}
+
+void TPartition::TryAppendStaleTxMetaWrites()
+{
+    if (IsSupportive() || StaleTxMetaPending.empty()) {
+        return;
+    }
+
+    PQ_ENSURE(StaleTxMetaInFlight.empty())("StaleTxMetaInFlight", StaleTxMetaInFlight.size());
+
+    while (!StaleTxMetaPending.empty()) {
+        auto it = StaleTxMetaPending.begin();
+        const ui64 txId = it->first;
+        TStaleTxMetaEntry entry = std::move(it->second);
+        StaleTxMetaPending.erase(it);
+
+        AddCmdWritePersistStaleTxMeta(entry);
+        StaleTxMetaInFlight.emplace(txId, std::move(entry));
+    }
+}
+
+void TPartition::FlushStaleTxMetaDone(const TActorContext& ctx)
+{
+    for (const auto& [txId, entry] : StaleTxMetaInFlight) {
+        Y_UNUSED(txId);
+        ctx.Send(TabletActorId, MakeTxDone(entry.Step, entry.TxId).Release());
+    }
+    StaleTxMetaInFlight.clear();
+}
+
+void TPartition::AddCmdWritePersistStaleTxMeta(const TStaleTxMetaEntry& entry)
+{
+    PQ_ENSURE(!IsSupportive());
+
+    if (!entry.SerializedTx.Defined()) {
+        return;
+    }
+
+    PQ_ENSURE(PersistRequest);
+
+    TString value;
+    PQ_ENSURE(entry.SerializedTx->SerializeToString(&value));
+
+    auto command = PersistRequest->Record.AddCmdWrite();
+    command->SetKey(GetTxKey(entry.TxId, Partition.OriginalPartitionId));
+    command->SetValue(value);
+    command->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
+
+    if (!entry.TabletConfig.Defined()) {
+        return;
+    }
+
+    PQ_ENSURE(entry.BootstrapConfig.Defined() && entry.PartitionsData.Defined());
+
     value.clear();
-    PQ_ENSURE(tx.TabletConfig->SerializeToString(&value));
+    PQ_ENSURE(entry.TabletConfig->SerializeToString(&value));
 
     command = PersistRequest->Record.AddCmdWrite();
     command->SetKey("_config");
@@ -2948,9 +3020,9 @@ void TPartition::TryAddCmdWriteForTransaction(const TTransaction& tx)
 
     const TActorContext& ctx = ActorContext();
 
-    const auto graph = MakePartitionGraph(*tx.TabletConfig);
-    for (const auto& partition : tx.TabletConfig->GetPartitions()) {
-        const auto explicitMessageGroups = CreateExplicitMessageGroups(*tx.BootstrapConfig, *tx.PartitionsData, graph, partition.GetPartitionId());
+    const auto graph = MakePartitionGraph(*entry.TabletConfig);
+    for (const auto& partition : entry.TabletConfig->GetPartitions()) {
+        const auto explicitMessageGroups = CreateExplicitMessageGroups(*entry.BootstrapConfig, *entry.PartitionsData, graph, partition.GetPartitionId());
 
         TSourceIdWriter sourceIdWriter(ESourceIdFormat::Proto);
         for (const auto& [id, mg] : *explicitMessageGroups) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -2924,18 +2924,19 @@ void TPartition::TryAddCmdWriteForTransaction(const TTransaction& tx)
         return;
     }
 
-    TMaybe<ui64> txId = tx.GetTxId();
+    const TMaybe<ui64> txId = tx.GetTxId();
+    const TMaybe<ui64> step = tx.GetStep();
     PQ_ENSURE(txId.Defined());
-    PQ_ENSURE(tx.Tx);
+    PQ_ENSURE(step.Defined());
 
     TStaleTxMetaEntry entry;
-    entry.Step = tx.Tx->Step;
+    entry.Step = *step;
     entry.TxId = *txId;
     entry.SerializedTx = tx.SerializedTx;
     entry.TabletConfig = tx.TabletConfig;
     entry.BootstrapConfig = tx.BootstrapConfig;
     entry.PartitionsData = tx.PartitionsData;
-    
+
     AddCmdWritePersistStaleTxMeta(entry);
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -942,6 +942,20 @@ private:
     THashMap<ui64, TSimpleSharedPtr<TTransaction>> TransactionsInflight;
     THashMap<TActorId, TSimpleSharedPtr<TTransaction>> WriteInfosToTx;
 
+    // stable-25-4 -> stable-26-1: tablet may replay TEvTxCommit while partition PlanStep/TxId is already ahead.
+    // Persist SerializedTx (and optional config sub-writes) to KV before TEvTxDone so tablet recovery sees partition tx meta.
+    struct TStaleTxMetaEntry {
+        ui64 Step = 0;
+        ui64 TxId = 0;
+        TMaybe<NKikimrPQ::TTransaction> SerializedTx;
+        TMaybe<NKikimrPQ::TPQTabletConfig> TabletConfig;
+        TMaybe<NKikimrPQ::TBootstrapConfig> BootstrapConfig;
+        TMaybe<NKikimrPQ::TPartitions> PartitionsData;
+    };
+
+    THashMap<ui64, TStaleTxMetaEntry> StaleTxMetaPending;
+    THashMap<ui64, TStaleTxMetaEntry> StaleTxMetaInFlight;
+
     size_t ImmediateTxCount = 0;
     THashMap<TString, size_t> UserActCount;
     THashMap<TString, TUserInfoBase> PendingUsersInfo;
@@ -1296,6 +1310,11 @@ private:
     bool IsCommitOffsetForbiddenForMLPConsumer(const TString& consumer, bool explicitMLPAction) const;
 
     void TryAddCmdWriteForTransaction(const TTransaction& tx);
+
+    void EnqueueStaleTxMetaPersist(std::unique_ptr<TEvPQ::TEvTxCommit> ev, const TActorContext& ctx);
+    void TryAppendStaleTxMetaWrites();
+    void FlushStaleTxMetaDone(const TActorContext& ctx);
+    void AddCmdWritePersistStaleTxMeta(const TStaleTxMetaEntry& entry);
 };
 
 inline ui64 TPartition::GetStartOffset() const {

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -100,6 +100,15 @@ struct TTransaction {
         return {};
     }
 
+    TMaybe<ui64> GetStep() const {
+        if (Tx) {
+            return Tx->Step;
+        } else if (ProposeConfig) {
+            return ProposeConfig->Step;
+        }
+        return {};
+    }
+
     TSimpleSharedPtr<TEvPQ::TEvTxCalcPredicate> Tx;
     TMaybe<bool> Predicate;
     TActorId SupportivePartitionActor;

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -468,6 +468,8 @@ void TPartition::OnHandleWriteResponse(const TActorContext& ctx)
 {
     KVWriteInProgress = false;
 
+    FlushStaleTxMetaDone(ctx);
+
     for (auto& span : TxForPersistSpans) {
         span.End();
     }

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
+#include <ydb/core/persqueue/common/key.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/pqtablet/partition/partition.h>
 #include <ydb/core/persqueue/pqtablet/partition/blob_key_filter.h>
@@ -187,6 +188,15 @@ protected:
         TMaybe<TPartitionId> Partition;
     };
 
+    /// Optional payload for TEvTxCommit (defaults match the old SendCommitTx(step, txId) behaviour).
+    struct TSendCommitTxOptions {
+        TMaybe<NKikimrPQ::TTransaction> SerializedTx;
+        TMaybe<NKikimrPQ::TPQTabletConfig> TabletConfig;
+        TMaybe<NKikimrPQ::TBootstrapConfig> BootstrapConfig;
+        TMaybe<NKikimrPQ::TPartitions> PartitionsData;
+        TEvPQ::TMessageGroupsPtr ExplicitMessageGroups;
+    };
+
     struct TChangePartitionConfigMatcher {
         TMaybe<TPartitionId> Partition;
     };
@@ -282,7 +292,7 @@ protected:
                            const TActorId& suppPartitionId = {});
     void WaitCalcPredicateResult(const TCalcPredicateMatcher& matcher = TCalcPredicateMatcher::EmptyMatcher());
 
-    void SendCommitTx(ui64 step, ui64 txId);
+    void SendCommitTx(ui64 step, ui64 txId, const TSendCommitTxOptions& options = {});
     void SendRollbackTx(ui64 step, ui64 txId);
     void WaitCommitTxDone(const TTxDoneMatcher& matcher = {});
     void WaitRollbackTxDone(const TTxDoneMatcher& matcher = {});
@@ -1088,9 +1098,14 @@ void TPartitionFixture::WaitCalcPredicateResult(const TCalcPredicateMatcher& mat
     }
 }
 
-void TPartitionFixture::SendCommitTx(ui64 step, ui64 txId)
+void TPartitionFixture::SendCommitTx(ui64 step, ui64 txId, const TSendCommitTxOptions& options)
 {
-    auto event = MakeHolder<TEvPQ::TEvTxCommit>(step, txId);
+    TEvPQ::TMessageGroupsPtr explicitMessageGroups = options.ExplicitMessageGroups;
+    auto event = MakeHolder<TEvPQ::TEvTxCommit>(step, txId, std::move(explicitMessageGroups));
+    event->SerializedTx = options.SerializedTx;
+    event->TabletConfig = options.TabletConfig;
+    event->BootstrapConfig = options.BootstrapConfig;
+    event->PartitionsData = options.PartitionsData;
     Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, event.Release()));
 }
 
@@ -2328,6 +2343,8 @@ Y_UNIT_TEST_F(CorrectRange_Multiple_Consumers, TPartitionFixture)
 
 Y_UNIT_TEST_F(OldPlanStep, TPartitionFixture)
 {
+    // Partition meta is ahead of the commit (stale replay). Tablet always sends SerializedTx on commit;
+    // partition must persist tx KV before TEvTxDone (stable-25-4 -> stable-26-1).
     const TPartitionId partition{3};
     const ui64 begin = 0;
     const ui64 end = 10;
@@ -2337,7 +2354,41 @@ Y_UNIT_TEST_F(OldPlanStep, TPartitionFixture)
 
     CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=99999, .TxId=55555});
 
-    SendCommitTx(step, txId);
+    NKikimrPQ::TTransaction serializedTxBody;
+    serializedTxBody.SetKind(NKikimrPQ::TTransaction::KIND_DATA);
+    serializedTxBody.SetTxId(txId);
+    serializedTxBody.SetState(NKikimrPQ::TTransaction::EXECUTED);
+    serializedTxBody.SetStep(step);
+    auto* op = serializedTxBody.AddOperations();
+    op->SetPartitionId(partition.InternalPartitionId);
+
+    SendCommitTx(step, txId, {.SerializedTx = std::move(serializedTxBody)});
+
+    // Wait > 0: absence of TEvTxDone must be observable, not "we polled for zero simulated time".
+    const TDuration noUnexpectedTxDoneWait = TDuration::MilliSeconds(200);
+
+    // TEvTxDone must not be emitted before the stale-meta KV write is answered.
+    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
+                  "TEvTxDone must not precede KV response for stale commit with SerializedTx");
+
+    auto kv = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
+    UNIT_ASSERT_C(kv, "expected KV request with stale tx meta persist");
+
+    const TString expectedTxKey = GetTxKey(txId, partition.OriginalPartitionId);
+    bool hasSerializedTxWrite = false;
+    for (ui32 i = 0; i < kv->Record.CmdWriteSize(); ++i) {
+        if (kv->Record.GetCmdWrite(i).GetKey() == expectedTxKey) {
+            hasSerializedTxWrite = true;
+            break;
+        }
+    }
+    UNIT_ASSERT_C(hasSerializedTxWrite, "missing CmdWrite for serialized tx key " << expectedTxKey);
+
+    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
+                  "TEvTxDone must not arrive before SendCmdWriteResponse");
+
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+
     WaitCommitTxDone({.TxId=txId, .Partition=TPartitionId(partition)});
 }
 

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2392,6 +2392,77 @@ Y_UNIT_TEST_F(OldPlanStep, TPartitionFixture)
     WaitCommitTxDone({.TxId=txId, .Partition=TPartitionId(partition)});
 }
 
+Y_UNIT_TEST_F(OldPlanStep_SecondStaleCommitWhileKvInflight, TPartitionFixture)
+{
+    // Two stale commits: second arrives while first KV response is still pending — must not crash
+    // (TryAppendStaleTxMetaWrites runs again only after InFlight is cleared on write complete).
+    const TPartitionId partition{3};
+    const ui64 begin = 0;
+    const ui64 end = 10;
+    const ui64 step = 12345;
+    const ui64 txId1 = 67890;
+    const ui64 txId2 = 67891;
+
+    CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=99999, .TxId=55555});
+
+    const TDuration noUnexpectedTxDoneWait = TDuration::MilliSeconds(200);
+
+    auto makeSerializedBody = [&](ui64 tid) -> NKikimrPQ::TTransaction {
+        NKikimrPQ::TTransaction tx;
+        tx.SetKind(NKikimrPQ::TTransaction::KIND_DATA);
+        tx.SetTxId(tid);
+        tx.SetState(NKikimrPQ::TTransaction::EXECUTED);
+        tx.SetStep(step);
+        auto* operation = tx.AddOperations();
+        operation->SetPartitionId(partition.InternalPartitionId);
+        return tx;
+    };
+
+    NKikimrPQ::TTransaction body1 = makeSerializedBody(txId1);
+    SendCommitTx(step, txId1, {.SerializedTx = std::move(body1)});
+
+    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
+                  "TEvTxDone before first KV");
+
+    auto kv1 = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
+    UNIT_ASSERT_C(kv1, "expected first stale-meta KV request");
+    const TString key1 = GetTxKey(txId1, partition.OriginalPartitionId);
+    bool found1 = false;
+    for (ui32 i = 0; i < kv1->Record.CmdWriteSize(); ++i) {
+        if (kv1->Record.GetCmdWrite(i).GetKey() == key1) {
+            found1 = true;
+            break;
+        }
+    }
+    UNIT_ASSERT_C(found1, "first KV must contain tx key " << key1);
+
+    NKikimrPQ::TTransaction body2 = makeSerializedBody(txId2);
+    SendCommitTx(step, txId2, {.SerializedTx = std::move(body2)});
+
+    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
+                  "TEvTxDone must not appear while first KV unanswered");
+
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+
+    WaitCommitTxDone({.TxId=txId1, .Partition=TPartitionId(partition)});
+
+    auto kv2 = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
+    UNIT_ASSERT_C(kv2, "expected second stale-meta KV after first completes");
+    const TString key2 = GetTxKey(txId2, partition.OriginalPartitionId);
+    bool found2 = false;
+    for (ui32 i = 0; i < kv2->Record.CmdWriteSize(); ++i) {
+        if (kv2->Record.GetCmdWrite(i).GetKey() == key2) {
+            found2 = true;
+            break;
+        }
+    }
+    UNIT_ASSERT_C(found2, "second KV must contain tx key " << key2);
+
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+
+    WaitCommitTxDone({.TxId=txId2, .Partition=TPartitionId(partition)});
+}
+
 Y_UNIT_TEST_F(IncorrectRange, TPartitionFixture)
 {
     const TPartitionId partition{3};

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -337,6 +337,27 @@ protected:
                                const TActorId& suppPartitionId);
     void WaitForCalcPredicateResult(ui64 txId, bool predicate);
 
+    // OldPlanStep*: partition meta ahead of commit (stale SerializedTx persist before TEvTxDone).
+    static constexpr ui64 StaleReplayMetaPlanStep = 99999;
+    static constexpr ui64 StaleReplayMetaTxId = 55555;
+
+    void CreatePartitionStaleReplayAhead(const TPartitionId& partition, ui64 begin, ui64 end);
+
+    NKikimrPQ::TTransaction MakeStaleSerializedTxBody(
+        const TPartitionId& partition,
+        ui64 step,
+        ui64 txId) const;
+
+    void AssertNoUnexpectedStaleMetaTxDone(const TString& reason) const;
+
+    THolder<TEvKeyValue::TEvRequest> GrabStaleMetaKvRequest(const TString& failReason) const;
+
+    void AssertStaleMetaKvHasTxKey(
+        const TEvKeyValue::TEvRequest& kv,
+        ui64 txId,
+        ui32 originalPartitionId,
+        const TString& failCtx) const;
+
     TMaybe<TTestContext> Ctx;
     TMaybe<TFinalizer> Finalizer;
 
@@ -1134,6 +1155,60 @@ void TPartitionFixture::WaitCommitTxDone(const TTxDoneMatcher& matcher)
 void TPartitionFixture::WaitRollbackTxDone(const TTxDoneMatcher& matcher)
 {
     WaitCommitTxDone(matcher);
+}
+
+void TPartitionFixture::CreatePartitionStaleReplayAhead(const TPartitionId& partition, ui64 begin, ui64 end)
+{
+    CreatePartition({
+        .Partition = partition,
+        .Begin = begin,
+        .End = end,
+        .PlanStep = StaleReplayMetaPlanStep,
+        .TxId = StaleReplayMetaTxId,
+    });
+}
+
+NKikimrPQ::TTransaction TPartitionFixture::MakeStaleSerializedTxBody(
+    const TPartitionId& partition,
+    ui64 step,
+    ui64 txId) const
+{
+    NKikimrPQ::TTransaction tx;
+    tx.SetKind(NKikimrPQ::TTransaction::KIND_DATA);
+    tx.SetTxId(txId);
+    tx.SetState(NKikimrPQ::TTransaction::EXECUTED);
+    tx.SetStep(step);
+    auto* operation = tx.AddOperations();
+    operation->SetPartitionId(partition.InternalPartitionId);
+    return tx;
+}
+
+void TPartitionFixture::AssertNoUnexpectedStaleMetaTxDone(const TString& reason) const
+{
+    // Poll > 0 sim time: absence of TEvTxDone must be observable, not "instant Grab".
+    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(TDuration::MilliSeconds(200)), reason);
+}
+
+THolder<TEvKeyValue::TEvRequest> TPartitionFixture::GrabStaleMetaKvRequest(const TString& failReason) const
+{
+    auto kv = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
+    UNIT_ASSERT_C(kv, failReason);
+    return kv;
+}
+
+void TPartitionFixture::AssertStaleMetaKvHasTxKey(
+    const TEvKeyValue::TEvRequest& kv,
+    ui64 txId,
+    ui32 originalPartitionId,
+    const TString& failCtx) const
+{
+    const TString expectedKey = GetTxKey(txId, originalPartitionId);
+    for (ui32 i = 0; i < kv.Record.CmdWriteSize(); ++i) {
+        if (kv.Record.GetCmdWrite(i).GetKey() == expectedKey) {
+            return;
+        }
+    }
+    UNIT_ASSERT_C(false, failCtx << ": missing CmdWrite for serialized tx key " << expectedKey);
 }
 
 void TPartitionFixture::SendChangePartitionConfig(const TConfigParams& config)
@@ -2346,46 +2421,20 @@ Y_UNIT_TEST_F(OldPlanStep, TPartitionFixture)
     // Partition meta is ahead of the commit (stale replay). Tablet always sends SerializedTx on commit;
     // partition must persist tx KV before TEvTxDone (stable-25-4 -> stable-26-1).
     const TPartitionId partition{3};
-    const ui64 begin = 0;
-    const ui64 end = 10;
-
     const ui64 step = 12345;
     const ui64 txId = 67890;
 
-    CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=99999, .TxId=55555});
+    CreatePartitionStaleReplayAhead(partition, 0, 10);
 
-    NKikimrPQ::TTransaction serializedTxBody;
-    serializedTxBody.SetKind(NKikimrPQ::TTransaction::KIND_DATA);
-    serializedTxBody.SetTxId(txId);
-    serializedTxBody.SetState(NKikimrPQ::TTransaction::EXECUTED);
-    serializedTxBody.SetStep(step);
-    auto* op = serializedTxBody.AddOperations();
-    op->SetPartitionId(partition.InternalPartitionId);
-
+    auto serializedTxBody = MakeStaleSerializedTxBody(partition, step, txId);
     SendCommitTx(step, txId, {.SerializedTx = std::move(serializedTxBody)});
 
-    // Wait > 0: absence of TEvTxDone must be observable, not "we polled for zero simulated time".
-    const TDuration noUnexpectedTxDoneWait = TDuration::MilliSeconds(200);
+    AssertNoUnexpectedStaleMetaTxDone("TEvTxDone must not precede KV response for stale commit with SerializedTx");
 
-    // TEvTxDone must not be emitted before the stale-meta KV write is answered.
-    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
-                  "TEvTxDone must not precede KV response for stale commit with SerializedTx");
+    auto kv = GrabStaleMetaKvRequest("expected KV request with stale tx meta persist");
+    AssertStaleMetaKvHasTxKey(*kv, txId, partition.OriginalPartitionId, "first KV");
 
-    auto kv = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
-    UNIT_ASSERT_C(kv, "expected KV request with stale tx meta persist");
-
-    const TString expectedTxKey = GetTxKey(txId, partition.OriginalPartitionId);
-    bool hasSerializedTxWrite = false;
-    for (ui32 i = 0; i < kv->Record.CmdWriteSize(); ++i) {
-        if (kv->Record.GetCmdWrite(i).GetKey() == expectedTxKey) {
-            hasSerializedTxWrite = true;
-            break;
-        }
-    }
-    UNIT_ASSERT_C(hasSerializedTxWrite, "missing CmdWrite for serialized tx key " << expectedTxKey);
-
-    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
-                  "TEvTxDone must not arrive before SendCmdWriteResponse");
+    AssertNoUnexpectedStaleMetaTxDone("TEvTxDone must not arrive before SendCmdWriteResponse");
 
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
@@ -2397,66 +2446,31 @@ Y_UNIT_TEST_F(OldPlanStep_SecondStaleCommitWhileKvInflight, TPartitionFixture)
     // Two stale commits: second arrives while first KV response is still pending — must not crash
     // (TryAppendStaleTxMetaWrites runs again only after InFlight is cleared on write complete).
     const TPartitionId partition{3};
-    const ui64 begin = 0;
-    const ui64 end = 10;
     const ui64 step = 12345;
     const ui64 txId1 = 67890;
     const ui64 txId2 = 67891;
 
-    CreatePartition({.Partition=partition, .Begin=begin, .End=end, .PlanStep=99999, .TxId=55555});
+    CreatePartitionStaleReplayAhead(partition, 0, 10);
 
-    const TDuration noUnexpectedTxDoneWait = TDuration::MilliSeconds(200);
+    auto body = MakeStaleSerializedTxBody(partition, step, txId1);
+    SendCommitTx(step, txId1, {.SerializedTx = std::move(body)});
 
-    auto makeSerializedBody = [&](ui64 tid) -> NKikimrPQ::TTransaction {
-        NKikimrPQ::TTransaction tx;
-        tx.SetKind(NKikimrPQ::TTransaction::KIND_DATA);
-        tx.SetTxId(tid);
-        tx.SetState(NKikimrPQ::TTransaction::EXECUTED);
-        tx.SetStep(step);
-        auto* operation = tx.AddOperations();
-        operation->SetPartitionId(partition.InternalPartitionId);
-        return tx;
-    };
+    AssertNoUnexpectedStaleMetaTxDone("TEvTxDone before first KV");
 
-    NKikimrPQ::TTransaction body1 = makeSerializedBody(txId1);
-    SendCommitTx(step, txId1, {.SerializedTx = std::move(body1)});
+    auto kv = GrabStaleMetaKvRequest("expected first stale-meta KV request");
+    AssertStaleMetaKvHasTxKey(*kv, txId1, partition.OriginalPartitionId, "first KV");
 
-    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
-                  "TEvTxDone before first KV");
+    body = MakeStaleSerializedTxBody(partition, step, txId2);
+    SendCommitTx(step, txId2, {.SerializedTx = std::move(body)});
 
-    auto kv1 = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
-    UNIT_ASSERT_C(kv1, "expected first stale-meta KV request");
-    const TString key1 = GetTxKey(txId1, partition.OriginalPartitionId);
-    bool found1 = false;
-    for (ui32 i = 0; i < kv1->Record.CmdWriteSize(); ++i) {
-        if (kv1->Record.GetCmdWrite(i).GetKey() == key1) {
-            found1 = true;
-            break;
-        }
-    }
-    UNIT_ASSERT_C(found1, "first KV must contain tx key " << key1);
-
-    NKikimrPQ::TTransaction body2 = makeSerializedBody(txId2);
-    SendCommitTx(step, txId2, {.SerializedTx = std::move(body2)});
-
-    UNIT_ASSERT_C(!Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvTxDone>(noUnexpectedTxDoneWait),
-                  "TEvTxDone must not appear while first KV unanswered");
+    AssertNoUnexpectedStaleMetaTxDone("TEvTxDone must not appear while first KV unanswered");
 
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
     WaitCommitTxDone({.TxId=txId1, .Partition=TPartitionId(partition)});
 
-    auto kv2 = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>(TDuration::Seconds(10));
-    UNIT_ASSERT_C(kv2, "expected second stale-meta KV after first completes");
-    const TString key2 = GetTxKey(txId2, partition.OriginalPartitionId);
-    bool found2 = false;
-    for (ui32 i = 0; i < kv2->Record.CmdWriteSize(); ++i) {
-        if (kv2->Record.GetCmdWrite(i).GetKey() == key2) {
-            found2 = true;
-            break;
-        }
-    }
-    UNIT_ASSERT_C(found2, "second KV must contain tx key " << key2);
+    kv = GrabStaleMetaKvRequest("expected second stale-meta KV after first completes");
+    AssertStaleMetaKvHasTxKey(*kv, txId2, partition.OriginalPartitionId, "second KV");
 
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

#40703 

This PR addresses a compatibility break between stable-25-4 and stable-26-1 in PersQueue Topic transaction handling. The change ensures that when a tablet replays a stale TEvTxCommit (partition PlanStep/TxId already ahead), the partition persists the transaction metadata (notably SerializedTx) to KV before emitting TEvTxDone, so recovery can observe consistent partition tx meta.

Changes:

- Add a “stale commit meta persist” path: stale TEvTxCommit is queued for KV persistence and acknowledged (TEvTxDone) only after the KV write completes.
- Extend KV persist pipeline to append stale-tx meta writes and flush deferred TEvTxDone on write completion.
- Add/extend a unit test (OldPlanStep) to assert TEvTxDone is not emitted before the KV write response for a stale replay commit that carries SerializedTx.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
