### PR TITLE
schemeshard: disable EnableTablePartitionsFormatShardIdx* flags

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -310,8 +310,8 @@ message TFeatureFlags {
     // Use TablePartitionsByShardIdx (keyed by ShardIdx) instead of TablePartitions
     // (keyed by positional index) for local tables.  When ON, split/merge writes only
     // O(k) rows (src+dst shards) instead of O(N) rows (all partitions after srcFirstIdx).
-    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = true];
-    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = true];
+    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = false];
+    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = false];
     optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
     optional bool EnableTopicMessagesBatching = 274 [default = false];
     optional bool EnableTopicWriteOffsetDeltaInKeys = 275 [default = false];


### PR DESCRIPTION
Follow-up to:
- https://github.com/ydb-platform/ydb/pull/38804

Revert EnableTablePartitionsFormatShardIdx{,ByDefault} flags to their intended disabled state. These flags introduce version incompatibility and must go through the proper rollout procedure (waiting for the next stable release).
