### PR TITLE
25-4-1-e: Materialize indexes

### DIFF
--- a/ydb/core/backup/common/metadata.h
+++ b/ydb/core/backup/common/metadata.h
@@ -41,6 +41,11 @@ struct TChangefeedMetadata {
     TString Name;
 };
 
+struct TIndexMetadata {
+    TString ExportPrefix;
+    TString ImplTablePrefix;
+};
+
 class TMetadata {
 public:
     TMetadata() = default;
@@ -52,8 +57,12 @@ public:
     void SetVersion(ui64 version);
     bool HasVersion() const;
     ui64 GetVersion() const;
+
     void AddChangefeed(const TChangefeedMetadata& changefeed);
     const std::optional<std::vector<TChangefeedMetadata>>& GetChangefeeds() const;
+
+    void AddIndex(const TIndexMetadata& index);
+    const std::optional<std::vector<TIndexMetadata>>& GetIndexes() const;
 
     void SetEnablePermissions(bool enablePermissions = true);
     bool HasEnablePermissions() const;
@@ -73,6 +82,12 @@ private:
     // []: The export has no changefeeds
     // [...]: The export must have all changefeeds listed here
     std::optional<std::vector<TChangefeedMetadata>> Changefeeds;
+
+    // Indexes:
+    // Undefined (previous versions): we don't know if we see the export with _materialized_ indexes or without them, so list suitable S3 files to find out all materialized indexes
+    // []: The export has no materialized indexes
+    // [...]: The export must have all materialized indexes listed here
+    std::optional<std::vector<TIndexMetadata>> Indexes;
 
     // EnablePermissions:
     // Undefined (previous versions): we don't know if we see the export with permissions or without them, so check S3 for the permissions file existence

--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -85,6 +85,28 @@ TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const T
     return result;
 }
 
+std::optional<NKikimrSchemeOp::EIndexType> TryConvertIndexType(Ydb::Table::TableIndex::TypeCase type) {
+    switch (type) {
+        case Ydb::Table::TableIndex::TypeCase::TYPE_NOT_SET:
+        case Ydb::Table::TableIndex::TypeCase::kGlobalIndex:
+            return NKikimrSchemeOp::EIndexTypeGlobal;
+        case Ydb::Table::TableIndex::TypeCase::kGlobalAsyncIndex:
+            return NKikimrSchemeOp::EIndexTypeGlobalAsync;
+        case Ydb::Table::TableIndex::TypeCase::kGlobalUniqueIndex:
+            return NKikimrSchemeOp::EIndexTypeGlobalUnique;
+        case Ydb::Table::TableIndex::TypeCase::kGlobalVectorKmeansTreeIndex:
+            return NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree;
+        default:
+            return std::nullopt;
+    }
+}
+
+NKikimrSchemeOp::EIndexType ConvertIndexType(Ydb::Table::TableIndex::TypeCase type) {
+    const auto result = TryConvertIndexType(type);
+    Y_ENSURE(result);
+    return *result;
+}
+
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType indexType, const TTableColumns& table, const TIndexColumns& index, TString& explain) {
     if (const auto* broken = IsContains(table.Keys, table.Columns)) {
         explain = TStringBuilder()

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ydb/public/api/protos/ydb_value.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
+#include <ydb/public/api/protos/ydb_value.pb.h>
 #include <ydb/public/lib/scheme_types/scheme_type_id.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 
@@ -10,6 +10,7 @@
 #include <util/generic/string.h>
 #include <util/string/builder.h>
 
+#include <optional>
 #include <span>
 #include <string_view>
 
@@ -43,7 +44,11 @@ inline constexpr const char* ImplTable = "indexImplTable";
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index, TString& explain);
 TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index);
 
+std::optional<NKikimrSchemeOp::EIndexType> TryConvertIndexType(Ydb::Table::TableIndex::TypeCase type);
+NKikimrSchemeOp::EIndexType ConvertIndexType(Ydb::Table::TableIndex::TypeCase type);
+
 std::span<const std::string_view> GetImplTables(NKikimrSchemeOp::EIndexType indexType, std::span<const TString> indexKeys);
+
 bool IsImplTable(std::string_view tableName);
 bool IsBuildImplTable(std::string_view tableName);
 

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/api/protos/ydb_value.pb.h>
+#include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/scheme_types/scheme_type_id.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -240,6 +240,7 @@ message TFeatureFlags {
     optional bool EnableShuttingDownNodeState = 218 [default = false];
     optional bool EnableStreamingQueriesCounters = 219 [default = false];
     optional bool UseYdsTopicStorageMetering = 220 [default = false];
+    optional bool EnableIndexMaterialization = 221 [default = false];
     optional bool EnableFsBackups = 222 [default = false];
     optional bool EnableResourcePoolsScheduler = 224 [default = true]; // works only with EnableResourcePools = true
     optional bool EnableConditionalEraseResponseBatching = 229 [default = false];

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -86,6 +86,7 @@ public:
     FEATURE_FLAG_SETTER(EnableSecureScriptExecutions)
     FEATURE_FLAG_SETTER(DisableMissingDefaultColumnsInBulkUpsert)
     FEATURE_FLAG_SETTER(EnableTopicAutopartitioningForReplication)
+    FEATURE_FLAG_SETTER(EnableIndexMaterialization)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -6,6 +6,7 @@
 #include "extstorage_usage_config.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/core/backup/common/checksum.h>
@@ -975,6 +976,31 @@ IActor* TS3Export::CreateUploader(const TActorId& dataShard, ui64 txId) const {
                 .ExportPrefix = descr.Prefix,
                 .Name = descr.Name,
             });
+        }
+    }
+
+    if (scheme) {
+        int idx = changefeeds.size() + 1;
+        for (const auto& index : scheme->indexes()) {
+            const auto indexType = NTableIndex::ConvertIndexType(index.type_case());
+            const TVector<TString> indexColumns(index.index_columns().begin(), index.index_columns().end());
+
+            for (const auto& implTable : NTableIndex::GetImplTables(indexType, indexColumns)) {
+                const TString implTablePrefix = TStringBuilder() << index.name() << "/" << implTable;
+                TString exportPrefix;
+                if (encrypted) {
+                    std::stringstream prefix;
+                    prefix << std::setfill('0') << std::setw(3) << std::right << idx++;
+                    exportPrefix = prefix.str();
+                } else {
+                    exportPrefix = implTablePrefix;
+                }
+
+                metadata.AddIndex(TIndexMetadata{
+                    .ExportPrefix = exportPrefix,
+                    .ImplTablePrefix = implTablePrefix,
+                });
+            }
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4445,6 +4445,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     exportInfo->EndTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Exports::EndTime>());
                     exportInfo->EnableChecksums = rowset.GetValueOrDefault<Schema::Exports::EnableChecksums>(false);
                     exportInfo->EnablePermissions = rowset.GetValueOrDefault<Schema::Exports::EnablePermissions>(false);
+                    exportInfo->IncludeIndexData = rowset.GetValueOrDefault<Schema::Exports::IncludeIndexData>(false);
 
                     if (rowset.HaveValue<Schema::Exports::ExportMetadata>()) {
                         exportInfo->ExportMetadata = rowset.GetValue<Schema::Exports::ExportMetadata>();
@@ -4494,6 +4495,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     item.SourcePathId.OwnerId = rowset.GetValueOrDefault<Schema::ExportItems::SourceOwnerPathId>(selfId);
                     item.SourcePathId.LocalPathId = rowset.GetValue<Schema::ExportItems::SourcePathId>();
                     item.SourcePathType = rowset.GetValue<Schema::ExportItems::SourcePathType>();
+                    item.ParentIdx = rowset.GetValueOrDefault<Schema::ExportItems::ParentIndex>(Max<ui32>());
 
                     item.State = static_cast<TExportInfo::EState>(rowset.GetValue<Schema::ExportItems::State>());
                     item.WaitTxId = rowset.GetValueOrDefault<Schema::ExportItems::BackupTxId>(InvalidTxId);
@@ -4639,6 +4641,17 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     item.Issue = rowset.GetValueOrDefault<Schema::ImportItems::Issue>(TString());
                     item.SrcPrefix = rowset.GetValueOrDefault<Schema::ImportItems::SrcPrefix>(TString());
                     item.SrcPath = rowset.GetValueOrDefault<Schema::ImportItems::SrcPath>(TString());
+
+                    item.ParentIdx = rowset.GetValueOrDefault<Schema::ImportItems::ParentIndex>(Max<ui32>());
+                    if (item.ParentIdx != Max<ui32>()) {
+                        Y_VERIFY_S(item.ParentIdx < importInfo->Items.size(), "Invalid item's index"
+                                   << ": importId# " << importId
+                                   << ", itemIdx# " << item.ParentIdx);
+
+                        TImportInfo::TItem& parentItem = importInfo->Items[item.ParentIdx];
+                        parentItem.ChildItems.push_back(itemIdx);
+                    }
+
                     if (rowset.HaveValue<Schema::ImportItems::EncryptionIV>()) {
                         item.ExportItemIV = NBackup::TEncryptionIV::FromBinaryString(rowset.GetValue<Schema::ImportItems::EncryptionIV>());
                     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_restore_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_restore_common.h
@@ -578,6 +578,7 @@ public:
 
         const TString& parentPath = Transaction.GetWorkingDir();
         const TString name = TKind::GetTableName(Transaction);
+        const bool internal = Transaction.HasInternal() && Transaction.GetInternal();
 
         LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                      TKind::Name() << " Propose"
@@ -618,9 +619,13 @@ public:
                 .NotDeleted()
                 .IsTable()
                 .NotAsyncReplicaTable()
-                .NotUnderOperation()
-                .IsCommonSensePath() //forbid alter impl index tables
-                .CanBackupTable(); //forbid backup table with indexes
+                .NotUnderOperation();
+
+            if (!internal) {
+                checks
+                    .IsCommonSensePath() // forbid alter impl index tables
+                    .CanBackupTable(); // forbid backup table with indexes
+            }
 
             if (!checks) {
                 result->SetError(checks.GetStatus(), checks.GetError());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -39,8 +39,8 @@ static std::optional<NKikimrSchemeOp::TModifyScheme> CreateIndexTask(NKikimr::NS
 
     auto operation = scheme.MutableCreateTableIndex();
     operation->SetName(dst.LeafName());
-
     operation->SetType(indexInfo->Type);
+    operation->SetState(indexInfo->State);
 
     for (const auto& keyName: indexInfo->IndexKeys) {
         *operation->MutableKeyColumnNames()->Add() = keyName;
@@ -184,6 +184,7 @@ bool CreateConsistentCopyTables(
                                        TStringBuilder{} << "Consistent copy table doesn't support table with index type " << indexInfo->Type)};
                 return false;
             }
+            scheme->SetInternal(tx.GetInternal());
             result.push_back(CreateNewTableIndex(NextPartId(nextId, result), *scheme));
 
             for (const auto& [srcImplTableName, srcImplTablePathId] : srcIndexPath.Base()->GetChildren()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -825,6 +825,7 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
             auto operation = schema.MutableCreateTableIndex();
             operation->SetName(name);
             operation->SetType(indexInfo->Type);
+            operation->SetState(indexInfo->State);
             for (const auto& keyName: indexInfo->IndexKeys) {
                 *operation->MutableKeyColumnNames()->Add() = keyName;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
@@ -140,8 +140,7 @@ public:
                 .NotDeleted()
                 .NotUnderDeleting()
                 .IsCommonSensePath()
-                .IsTable()
-                .NotBackupTable();
+                .IsTable();
 
             if (!internal) {
                 checks.NotAsyncReplicaTable();
@@ -151,6 +150,8 @@ public:
                 checks
                     .IsUnderCreating(NKikimrScheme::StatusNameConflict)
                     .IsUnderTheSameOperation(OperationId.GetTxId()); //allow only as part of creating base table
+            } else {
+                checks.NotBackupTable(); // allow to create backup table with index, but not to build index on a backup table
             }
 
             if (!checks) {

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -153,6 +153,7 @@ void TSchemeShard::PersistCreateExport(NIceDb::TNiceDb& db, const TExportInfo& e
         NIceDb::TUpdate<Schema::Exports::Items>(exportInfo.Items.size()),
         NIceDb::TUpdate<Schema::Exports::EnableChecksums>(exportInfo.EnableChecksums),
         NIceDb::TUpdate<Schema::Exports::EnablePermissions>(exportInfo.EnablePermissions),
+        NIceDb::TUpdate<Schema::Exports::IncludeIndexData>(exportInfo.IncludeIndexData),
         NIceDb::TUpdate<Schema::Exports::PeerName>(exportInfo.PeerName),
         NIceDb::TUpdate<Schema::Exports::SanitizedToken>(exportInfo.SanitizedToken)
     );
@@ -171,7 +172,8 @@ void TSchemeShard::PersistCreateExport(NIceDb::TNiceDb& db, const TExportInfo& e
             NIceDb::TUpdate<Schema::ExportItems::SourceOwnerPathId>(item.SourcePathId.OwnerId),
             NIceDb::TUpdate<Schema::ExportItems::SourcePathId>(item.SourcePathId.LocalPathId),
             NIceDb::TUpdate<Schema::ExportItems::State>(static_cast<ui8>(item.State)),
-            NIceDb::TUpdate<Schema::ExportItems::SourcePathType>(item.SourcePathType)
+            NIceDb::TUpdate<Schema::ExportItems::SourcePathType>(item.SourcePathType),
+            NIceDb::TUpdate<Schema::ExportItems::ParentIndex>(item.ParentIdx)
         );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -30,6 +30,11 @@ bool IsPathTypeTable(const NKikimr::NSchemeShard::TExportInfo::TItem& item) {
     return item.SourcePathType == NKikimrSchemeOp::EPathTypeTable;
 }
 
+bool IsPathTypeTransferrable(const NKikimr::NSchemeShard::TExportInfo::TItem& item) {
+    return item.SourcePathType == NKikimrSchemeOp::EPathTypeTable
+        || item.SourcePathType == NKikimrSchemeOp::EPathTypeTableIndex;
+}
+
 }
 
 namespace NKikimr {
@@ -137,6 +142,15 @@ struct TSchemeShard::TExport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
                 exportInfo = new TExportInfo(id, uid, TExportInfo::EKind::S3, settings, domainPath.Base()->PathId, request.GetPeerName());
                 exportInfo->EnableChecksums = AppData()->FeatureFlags.GetEnableChecksumsExport();
                 exportInfo->EnablePermissions = AppData()->FeatureFlags.GetEnablePermissionsExport();
+                exportInfo->IncludeIndexData = settings.include_index_data();
+                if (exportInfo->IncludeIndexData && !AppData()->FeatureFlags.GetEnableIndexMaterialization()) {
+                    return Reply(
+                        std::move(response),
+                        Ydb::StatusIds::PRECONDITION_FAILED,
+                        "Index materialization is not enabled"
+                    );
+                }
+
                 TString explain;
                 if (!FillItems(*exportInfo, settings, explain)) {
                     return Reply(
@@ -221,6 +235,8 @@ private:
 
     template <typename TSettings>
     bool FillItems(TExportInfo& exportInfo, const TSettings& settings, TString& explain) {
+        TVector<TExportInfo::TItem> indexItems;
+
         exportInfo.Items.reserve(settings.items().size());
         for (ui32 itemIdx : xrange(settings.items().size())) {
             const auto& item = settings.items(itemIdx);
@@ -241,7 +257,30 @@ private:
             }
 
             exportInfo.Items.emplace_back(item.source_path(), path.Base()->PathId, path->PathType);
-            exportInfo.PendingItems.push_back(itemIdx);
+            exportInfo.PendingItems.push_back(exportInfo.Items.size() - 1);
+
+            if (exportInfo.IncludeIndexData && path.Base()->IsTable()) {
+                for (const auto& [childName, childPathId] : path.Base()->GetChildren()) {
+                    TVector<TString> childParts;
+                    childParts.push_back(childName);
+
+                    auto childPath = path.Child(childName);
+                    if (childPath.IsDeleted() || !childPath.IsTableIndex()) {
+                        continue;
+                    }
+                    for (const auto& [implTableName, implTablePathId] : childPath.Base()->GetChildren()) {
+                        const auto implTableRelPath = JoinPath(ChildPath(childParts, implTableName));
+                        indexItems.emplace_back(implTableRelPath, implTablePathId, childPath->PathType, itemIdx);
+                    }
+                }
+            }
+        }
+
+        // Add materialized index items to the end
+        exportInfo.Items.reserve(exportInfo.Items.size() + indexItems.size());
+        for (auto& item : indexItems) {
+            exportInfo.Items.push_back(std::move(item));
+            exportInfo.PendingItems.push_back(exportInfo.Items.size() - 1);
         }
 
         return true;
@@ -757,7 +796,7 @@ private:
                 const auto& item = exportInfo->Items.at(itemIdx);
 
                 if (item.WaitTxId == InvalidTxId) {
-                    if (item.SourcePathType == NKikimrSchemeOp::EPathTypeTable && item.State <= EState::Transferring) {
+                    if (IsPathTypeTransferrable(item) && item.State <= EState::Transferring) {
                         pendingTables.emplace_back(itemIdx);
                     } else {
                         UploadScheme(*exportInfo, itemIdx, ctx);
@@ -811,7 +850,7 @@ private:
                 for (ui32 itemIdx : xrange(exportInfo->Items.size())) {
                     const auto& item = exportInfo->Items.at(itemIdx);
 
-                    if (item.SourcePathType != NKikimrSchemeOp::EPathTypeTable || item.State != EState::Dropping) {
+                    if (!IsPathTypeTransferrable(item) || item.State != EState::Dropping) {
                         continue;
                     }
 
@@ -878,13 +917,13 @@ private:
                 return;
             }
             itemIdx = PopFront(exportInfo->PendingItems);
-            if (const auto type = exportInfo->Items.at(itemIdx).SourcePathType; type == NKikimrSchemeOp::EPathTypeTable) {
+            if (IsPathTypeTransferrable(exportInfo->Items.at(itemIdx))) {
                 TransferData(*exportInfo, itemIdx, txId);
             } else {
                 LOG_W("TExport::TTxProgress: OnAllocateResult allocated a needless txId for an item transferring"
                     << ": id# " << id
                     << ", itemIdx# " << itemIdx
-                    << ", type# " << type
+                    << ", type# " << exportInfo->Items.at(itemIdx).SourcePathType
                 );
                 return;
             }
@@ -1327,7 +1366,7 @@ private:
                 item.State = EState::Transferring;
                 Self->PersistExportItemState(db, *exportInfo, itemIdx);
 
-                if (item.SourcePathType == NKikimrSchemeOp::EPathTypeTable) {
+                if (IsPathTypeTransferrable(item)) {
                     tables.emplace_back(itemIdx);
                 } else {
                     UploadScheme(*exportInfo, itemIdx, ctx);
@@ -1348,7 +1387,7 @@ private:
             item.WaitTxId = InvalidTxId;
 
             bool itemHasIssues = false;
-            if (item.SourcePathType == NKikimrSchemeOp::EPathTypeTable) {
+            if (IsPathTypeTransferrable(item)) {
                 if (const auto issue = GetIssues(ItemPathId(Self, *exportInfo, itemIdx), txId)) {
                     item.Issue = *issue;
                     Cancel(*exportInfo, itemIdx, "issues during backing up");

--- a/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
@@ -3,10 +3,11 @@
 #include "schemeshard_path_describer.h"
 #include "schemeshard_xxport__helpers.h"
 
-#include <ydb/public/api/protos/ydb_export.pb.h>
-
+#include <ydb/core/base/path.h>
+#include <ydb/core/base/table_index.h>
 #include <ydb/core/protos/s3_settings.pb.h>
 #include <ydb/core/ydb_convert/compression.h>
+#include <ydb/public/api/protos/ydb_export.pb.h>
 
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -50,9 +51,6 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CopyTablesPropose(
     auto& copyTables = *modifyScheme.MutableCreateConsistentCopyTables()->MutableCopyTableDescriptions();
     copyTables.Reserve(exportInfo.Items.size());
 
-    const TPath exportPath = TPath::Init(exportInfo.ExportPathId, ss);
-    const TString& exportPathName = exportPath.PathString();
-
     for (ui32 itemIdx : xrange(exportInfo.Items.size())) {
         const auto& item = exportInfo.Items.at(itemIdx);
         if (item.SourcePathType != NKikimrSchemeOp::EPathTypeTable) {
@@ -61,8 +59,8 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CopyTablesPropose(
 
         auto& desc = *copyTables.Add();
         desc.SetSrcPath(item.SourcePathName);
-        desc.SetDstPath(ExportItemPathName(exportPathName, itemIdx));
-        desc.SetOmitIndexes(true);
+        desc.SetDstPath(ExportItemPathName(ss, exportInfo, itemIdx));
+        desc.SetOmitIndexes(!exportInfo.IncludeIndexData);
         desc.SetOmitFollowers(true);
         desc.SetIsBackup(true);
     }
@@ -70,46 +68,18 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CopyTablesPropose(
     return propose;
 }
 
-static void SetTableDescriptionOptions(NKikimrSchemeOp::TDescribeOptions& opts) {
+static NKikimrSchemeOp::TPathDescription GetDescription(TSchemeShard* ss, const TPathId& pathId) {
+    NKikimrSchemeOp::TDescribeOptions opts;
     opts.SetReturnPartitioningInfo(false);
     opts.SetReturnPartitionConfig(true);
     opts.SetReturnBoundaries(true);
     opts.SetReturnIndexTableBoundaries(true);
-}
-
-static void SetChangefeedDescriptionOptions(NKikimrSchemeOp::TDescribeOptions& opts) {
-    SetTableDescriptionOptions(opts);
     opts.SetShowPrivateTable(true);
-}
 
-static void SetTopicDescriptionOptions(NKikimrSchemeOp::TDescribeOptions& opts) {
-    SetTableDescriptionOptions(opts);
-    opts.SetShowPrivateTable(true);
-}
-
-static NKikimrSchemeOp::TPathDescription GetDescription(TSchemeShard* ss, const TPathId& pathId, NKikimrSchemeOp::TDescribeOptions& opts) {
     auto desc = DescribePath(ss, TlsActivationContext->AsActorContext(), pathId, opts);
     auto record = desc->GetRecord();
 
     return record.GetPathDescription();
-}
-
-static NKikimrSchemeOp::TPathDescription GetTableDescription(TSchemeShard* ss, const TPathId& pathId) {
-    NKikimrSchemeOp::TDescribeOptions opts;
-    SetTableDescriptionOptions(opts);
-    return GetDescription(ss, pathId, opts);
-}
-
-static NKikimrSchemeOp::TPathDescription GetChangefeedDescription(TSchemeShard* ss, const TPathId& pathId) {
-    NKikimrSchemeOp::TDescribeOptions opts;
-    SetChangefeedDescriptionOptions(opts);
-    return GetDescription(ss, pathId, opts);
-}
-
-static NKikimrSchemeOp::TPathDescription GetTopicDescription(TSchemeShard* ss, const TPathId& pathId) {
-    NKikimrSchemeOp::TDescribeOptions opts;
-    SetTopicDescriptionOptions(opts);
-    return GetDescription(ss, pathId, opts);
 }
 
 void FillSetValForSequences(TSchemeShard* ss, NKikimrSchemeOp::TTableDescription& description,
@@ -137,15 +107,35 @@ void FillSetValForSequences(TSchemeShard* ss, NKikimrSchemeOp::TTableDescription
 }
 
 void FillPartitioning(TSchemeShard* ss, NKikimrSchemeOp::TTableDescription& desc, const TPathId& exportItemPathId) {
-    NKikimrSchemeOp::TDescribeOptions opts;
-    opts.SetReturnPartitionConfig(true);
-    opts.SetReturnBoundaries(true);
-
-    auto copiedPath = DescribePath(ss, TlsActivationContext->AsActorContext(), exportItemPathId, opts);
-    const auto& copiedTable = copiedPath->GetRecord().GetPathDescription().GetTable();
+    auto copiedPath = GetDescription(ss, exportItemPathId);
+    const auto& copiedTable = copiedPath.GetTable();
 
     *desc.MutableSplitBoundary() = copiedTable.GetSplitBoundary();
     *desc.MutablePartitionConfig()->MutablePartitioningPolicy() = copiedTable.GetPartitionConfig().GetPartitioningPolicy();
+}
+
+void FillTableDescription(TSchemeShard* ss, NKikimrSchemeOp::TBackupTask& task, const TPath& sourcePath, const TPath& exportItemPath) {
+    if (!sourcePath.IsResolved() || !exportItemPath.IsResolved()) {
+        return;
+    }
+
+    auto sourceDescription = GetDescription(ss, sourcePath.Base()->PathId);
+    if (sourceDescription.HasTable()) {
+        FillSetValForSequences(
+            ss, *sourceDescription.MutableTable(), exportItemPath.Base()->PathId);
+        FillPartitioning(ss, *sourceDescription.MutableTable(), exportItemPath.Base()->PathId);
+        for (const auto& cdcStream : sourceDescription.GetTable().GetCdcStreams()) {
+            auto cdcPathDesc =  GetDescription(ss, TPathId::FromProto(cdcStream.GetPathId()));
+            for (const auto& child : cdcPathDesc.GetChildren()) {
+                if (child.GetPathType() == NKikimrSchemeOp::EPathTypePersQueueGroup) {
+                    *task.AddChangefeedUnderlyingTopics() =
+                        GetDescription(ss, TPathId(child.GetSchemeshardId(), child.GetPathId()));
+                }
+            }
+        }
+    }
+
+    task.MutableTable()->CopyFrom(sourceDescription);
 }
 
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
@@ -155,6 +145,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
     ui32 itemIdx
 ) {
     Y_ABORT_UNLESS(itemIdx < exportInfo.Items.size());
+    const auto& item = exportInfo.Items[itemIdx];
 
     auto propose = MakeModifySchemeTransaction(ss, txId, exportInfo);
     auto& record = propose->Record;
@@ -164,33 +155,33 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
     modifyScheme.SetInternal(true);
 
     const TPath exportPath = TPath::Init(exportInfo.ExportPathId, ss);
-    const TString& exportPathName = exportPath.PathString();
-    modifyScheme.SetWorkingDir(exportPathName);
-
     auto& task = *modifyScheme.MutableBackup();
-    task.SetTableName(ToString(itemIdx));
-    task.SetNeedToBill(!exportInfo.UserSID || !ss->SystemBackupSIDs.contains(*exportInfo.UserSID));
 
-    const TPath sourcePath = TPath::Init(exportInfo.Items[itemIdx].SourcePathId, ss);
-    const TPath exportItemPath = exportPath.Child(ToString(itemIdx));
-    if (sourcePath.IsResolved() && exportItemPath.IsResolved()) {
-        auto sourceDescription = GetTableDescription(ss, sourcePath.Base()->PathId);
-        if (sourceDescription.HasTable()) {
-            FillSetValForSequences(
-                ss, *sourceDescription.MutableTable(), exportItemPath.Base()->PathId);
-            FillPartitioning(ss, *sourceDescription.MutableTable(), exportItemPath.Base()->PathId);
-            for (const auto& cdcStream : sourceDescription.GetTable().GetCdcStreams()) {
-                auto cdcPathDesc =  GetChangefeedDescription(ss, TPathId::FromProto(cdcStream.GetPathId()));
-                for (const auto& child : cdcPathDesc.GetChildren()) {
-                    if (child.GetPathType() == NKikimrSchemeOp::EPathTypePersQueueGroup) {
-                        *task.AddChangefeedUnderlyingTopics() = GetTopicDescription(ss, TPathId(child.GetSchemeshardId(), child.GetPathId()));
-                    }
-                }
-            }
+    if (item.ParentIdx == Max<ui32>()) {
+        modifyScheme.SetWorkingDir(exportPath.PathString());
+        task.SetTableName(ToString(itemIdx));
+
+        FillTableDescription(ss, task, TPath::Init(item.SourcePathId, ss), exportPath.Child(ToString(itemIdx)));
+    } else {
+        auto parentPath = exportPath.Child(ToString(item.ParentIdx));
+
+        auto childParts = SplitPath(item.SourcePathName);
+        Y_ABORT_UNLESS(!childParts.empty());
+
+        auto childName = std::move(childParts.back());
+        childParts.pop_back();
+
+        for (const auto& part : childParts) {
+            parentPath.Dive(part);
         }
-        task.MutableTable()->CopyFrom(sourceDescription);
+
+        modifyScheme.SetWorkingDir(parentPath.PathString());
+        task.SetTableName(childName);
+
+        FillTableDescription(ss, task, TPath::Init(item.SourcePathId, ss), parentPath.Child(childName));
     }
 
+    task.SetNeedToBill(!exportInfo.UserSID || !ss->SystemBackupSIDs.contains(*exportInfo.UserSID));
     task.SetSnapshotStep(exportInfo.SnapshotStep);
     task.SetSnapshotTxId(exportInfo.SnapshotTxId);
 
@@ -205,8 +196,10 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
             backupSettings.SetHost(exportSettings.host());
             backupSettings.SetPort(exportSettings.port());
             backupSettings.SetToken(exportSettings.token());
-            backupSettings.SetTablePattern(exportSettings.items(itemIdx).destination_path());
             backupSettings.SetUseTypeV3(exportSettings.use_type_v3());
+
+            Y_ABORT_UNLESS(itemIdx < (ui32)exportSettings.items().size());
+            backupSettings.SetTablePattern(exportSettings.items(itemIdx).destination_path());
         }
         break;
 
@@ -221,9 +214,70 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
             backupSettings.SetBucket(exportSettings.bucket());
             backupSettings.SetAccessKey(exportSettings.access_key());
             backupSettings.SetSecretKey(exportSettings.secret_key());
-            backupSettings.SetObjectKeyPattern(exportSettings.items(itemIdx).destination_prefix());
             backupSettings.SetStorageClass(exportSettings.storage_class());
             backupSettings.SetUseVirtualAddressing(!exportSettings.disable_virtual_addressing());
+
+            TString dstPrefix;
+            if (item.ParentIdx == Max<ui32>()) {
+                Y_ABORT_UNLESS(itemIdx < (ui32)exportSettings.items().size());
+                dstPrefix = exportSettings.items(itemIdx).destination_prefix();
+            } else {
+                Y_ABORT_UNLESS(item.ParentIdx < (ui32)exportSettings.items().size());
+                dstPrefix = exportSettings.items(item.ParentIdx).destination_prefix();
+
+                if (dstPrefix && dstPrefix.back() != '/') {
+                    dstPrefix += '/';
+                }
+
+                std::stringstream itemPrefix;
+                if (exportSettings.has_encryption_settings()) {
+                    static constexpr int INVALID_IDX = 999;
+                    int idx = INVALID_IDX;
+                    bool found = false;
+
+                    Y_ABORT_UNLESS(item.ParentIdx < exportInfo.Items.size());
+                    const auto& parentItem = exportInfo.Items[item.ParentIdx];
+
+                    auto parentPath = TPath::Init(parentItem.SourcePathId, ss);
+                    TStringBuf indexName;
+                    TStringBuf implTableName;
+                    if (parentPath.IsResolved() && TStringBuf(item.SourcePathName).TrySplit('/', indexName, implTableName)) {
+                        const auto parentDescription = GetDescription(ss, parentPath.Base()->PathId);
+                        idx = parentDescription.GetTable().CdcStreamsSize() + 1;
+
+                        for (const auto& index : parentDescription.GetTable().GetTableIndexes()) {
+                            const TVector<TString> indexColumns(index.GetKeyColumnNames().begin(), index.GetKeyColumnNames().end());
+                            const auto implTables = NTableIndex::GetImplTables(index.GetType(), indexColumns);
+                            if (index.GetName() != indexName) {
+                                idx += implTables.size();
+                                continue;
+                            }
+
+                            for (const auto& implTable : implTables) {
+                                if (implTable != implTableName) {
+                                    ++idx;
+                                    continue;
+                                }
+
+                                found = true;
+                                break;
+                            }
+
+                            if (found) {
+                                break;
+                            }
+                        }
+                    }
+
+                    itemPrefix << std::setfill('0') << std::setw(3) << std::right << (found ? idx : INVALID_IDX);
+                } else {
+                    itemPrefix << item.SourcePathName;
+                }
+
+                dstPrefix += itemPrefix.str();
+            }
+
+            backupSettings.SetObjectKeyPattern(dstPrefix);
 
             switch (exportSettings.scheme()) {
             case Ydb::Export::ExportToS3Settings::HTTP:
@@ -318,12 +372,15 @@ THolder<TEvSchemeShard::TEvCancelTx> CancelPropose(
 }
 
 TString ExportItemPathName(TSchemeShard* ss, const TExportInfo& exportInfo, ui32 itemIdx) {
-    const TPath exportPath = TPath::Init(exportInfo.ExportPathId, ss);
-    return ExportItemPathName(exportPath.PathString(), itemIdx);
-}
+    Y_ABORT_UNLESS(itemIdx < exportInfo.Items.size());
+    const auto& item = exportInfo.Items[itemIdx];
 
-TString ExportItemPathName(const TString& exportPathName, ui32 itemIdx) {
-    return TStringBuilder() << exportPathName << "/" << itemIdx;
+    const TPath exportPath = TPath::Init(exportInfo.ExportPathId, ss);
+    if (item.ParentIdx == Max<ui32>()) {
+        return TStringBuilder() << exportPath.PathString() << "/" << itemIdx;
+    } else {
+        return TStringBuilder() << exportPath.PathString() << "/" << item.ParentIdx << "/" << item.SourcePathName;
+    }
 }
 
 void PrepareDropping(
@@ -345,7 +402,7 @@ void PrepareDropping(
         item.WaitTxId = InvalidTxId;
         item.State = TExportInfo::EState::Dropped;
         const TPath itemPath = TPath::Resolve(ExportItemPathName(ss, exportInfo, itemIdx), ss);
-        if (itemPath.IsResolved() && !itemPath.IsDeleted()) {
+        if (item.SourcePathType == NKikimrSchemeOp::EPathTypeTable && itemPath.IsResolved() && !itemPath.IsDeleted()) {
             item.State = TExportInfo::EState::Dropping;
             if (exportInfo.State == TExportInfo::EState::AutoDropping) {
                 func(itemIdx);

--- a/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.h
+++ b/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.h
@@ -45,7 +45,6 @@ THolder<TEvSchemeShard::TEvCancelTx> CancelPropose(
 );
 
 TString ExportItemPathName(TSchemeShard* ss, const TExportInfo& exportInfo, ui32 itemIdx);
-TString ExportItemPathName(const TString& exportPathName, ui32 itemIdx);
 
 void PrepareDropping(TSchemeShard* ss, TExportInfo& exportInfo, NIceDb::TNiceDb& db,
     TExportInfo::EState droppingState, std::function<void(ui64)> func);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1393,6 +1393,7 @@ public:
     void FromXxportInfo(NKikimrImport::TImport& exprt, const TImportInfo& importInfo);
 
     static void PersistCreateImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
+    static void PersistNewImportItem(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx);
     static void PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo& importInfo);
     static void PersistImportState(NIceDb::TNiceDb& db, const TImportInfo& importInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -132,15 +132,21 @@ void TSchemeShard::PersistCreateImport(NIceDb::TNiceDb& db, const TImportInfo& i
     }
 
     for (ui32 itemIdx : xrange(importInfo.Items.size())) {
-        const auto& item = importInfo.Items.at(itemIdx);
-
-        db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Update(
-            NIceDb::TUpdate<Schema::ImportItems::DstPathName>(item.DstPathName),
-            NIceDb::TUpdate<Schema::ImportItems::State>(static_cast<ui8>(item.State)),
-            NIceDb::TUpdate<Schema::ImportItems::SrcPrefix>(item.SrcPrefix),
-            NIceDb::TUpdate<Schema::ImportItems::SrcPath>(item.SrcPath)
-        );
+        PersistNewImportItem(db, importInfo, itemIdx);
     }
+}
+
+void TSchemeShard::PersistNewImportItem(NIceDb::TNiceDb& db, const TImportInfo& importInfo, ui32 itemIdx) {
+    Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
+    const auto& item = importInfo.Items.at(itemIdx);
+
+    db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Update(
+        NIceDb::TUpdate<Schema::ImportItems::DstPathName>(item.DstPathName),
+        NIceDb::TUpdate<Schema::ImportItems::State>(static_cast<ui8>(item.State)),
+        NIceDb::TUpdate<Schema::ImportItems::SrcPrefix>(item.SrcPrefix),
+        NIceDb::TUpdate<Schema::ImportItems::SrcPath>(item.SrcPath),
+        NIceDb::TUpdate<Schema::ImportItems::ParentIndex>(item.ParentIdx)
+    );
 }
 
 void TSchemeShard::PersistSchemaMappingImportFields(NIceDb::TNiceDb& db, const TImportInfo& importInfo) {
@@ -210,16 +216,19 @@ void TSchemeShard::PersistImportItemScheme(NIceDb::TNiceDb& db, const TImportInf
             NIceDb::TUpdate<Schema::ImportItems::Topic>(item.Topic->SerializeAsString())
         );
     }
+
     if (!item.CreationQuery.empty()) {
         record.Update(
             NIceDb::TUpdate<Schema::ImportItems::CreationQuery>(item.CreationQuery)
         );
     }
+
     if (item.Permissions.Defined()) {
         record.Update(
             NIceDb::TUpdate<Schema::ImportItems::Permissions>(item.Permissions->SerializeAsString())
         );
     }
+
     db.Table<Schema::ImportItems>().Key(importInfo.Id, itemIdx).Update(
         NIceDb::TUpdate<Schema::ImportItems::Metadata>(item.Metadata.Serialize())
     );
@@ -311,6 +320,22 @@ void TSchemeShard::LoadTableProfiles(const NKikimrConfig::TTableProfilesConfig* 
     auto waiters = std::move(TableProfilesWaiters);
     for (const auto& [importId, itemIdx] : waiters) {
         Execute(CreateTxProgressImport(importId, itemIdx), ctx);
+    }
+}
+
+bool NeedToBuildIndexes(const TImportInfo& importInfo, ui32 itemIdx) {
+    Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
+    auto& item = importInfo.Items.at(itemIdx);
+
+    switch (importInfo.Settings.index_population_mode()) {
+        case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD:
+            return true;
+        case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO:
+            return item.ChildItems.empty();
+        case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT:
+            return false;
+        default:
+            return true;
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -32,10 +32,6 @@ namespace {
 using TItem = TImportInfo::TItem;
 using EState = TImportInfo::EState;
 
-bool IsWaiting(const TItem& item) {
-    return item.State == EState::Waiting;
-}
-
 THashMap<EState, int> CountItemsByState(const TVector<TItem>& items) {
     THashMap<EState, int> counter;
     for (const auto& item : items) {
@@ -193,6 +189,20 @@ struct TSchemeShard::TImport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
 
                 if (!settings.source_prefix().empty() && AppData()->FeatureFlags.GetEnableEncryptedExport()) {
                     initialState = TImportInfo::EState::DownloadExportMetadata;
+                }
+
+                if (!AppData()->FeatureFlags.GetEnableIndexMaterialization()) {
+                    switch (settings.index_population_mode()) {
+                    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT:
+                    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO:
+                        return Reply(
+                            std::move(response),
+                            Ydb::StatusIds::PRECONDITION_FAILED,
+                            "Index materialization is not enabled"
+                        );
+                    default:
+                        break;
+                    }
                 }
 
                 importInfo = new TImportInfo(id, uid, TImportInfo::EKind::S3, settings, domainPath.Base()->PathId, request.GetPeerName());
@@ -498,7 +508,7 @@ private:
         TVector<ui32> retriedItems;
         for (ui32 itemIdx : xrange(importInfo.Items.size())) {
             auto& item = importInfo.Items[itemIdx];
-            if (IsWaiting(item) && IsCreatedByQuery(item)) {
+            if (item.State == EState::Waiting && IsCreatedByQuery(item)) {
                 item.SchemeQueryExecutor = ctx.Register(CreateSchemeQueryExecutor(
                     Self->SelfId(), importInfo.Id, itemIdx, item.CreationQuery, database
                 ));
@@ -1044,13 +1054,40 @@ private:
             }
         }
 
+        if (!IsCreatedByQuery(item)) {
+            AllocateTxId(*importInfo, msg.ItemIdx);
+        }
+
         Self->PersistImportItemScheme(db, *importInfo, msg.ItemIdx);
 
         item.State = EState::CreateSchemeObject;
         Self->PersistImportItemState(db, *importInfo, msg.ItemIdx);
-        if (!IsCreatedByQuery(item)) {
-            AllocateTxId(*importInfo, msg.ItemIdx);
+
+        const TString parentSrc = importInfo->GetItemSrcPrefix(msg.ItemIdx);
+        const TString parentDst = item.DstPathName;
+        auto materializedIndexes = std::move(item.MaterializedIndexes);
+        item.ChildItems.reserve(materializedIndexes.size());
+        importInfo->Items.reserve(importInfo->Items.size() + materializedIndexes.size());
+
+        for (auto& [indexMetadata, scheme] : materializedIndexes) {
+            auto src = TStringBuilder() << parentSrc << "/" << indexMetadata.ExportPrefix;
+            auto dst = TStringBuilder() << parentDst << "/" << indexMetadata.ImplTablePrefix;
+
+            auto& childItem = importInfo->Items.emplace_back(std::move(dst));
+            const ui32 childIdx = importInfo->Items.size() - 1;
+
+            importInfo->Items.at(msg.ItemIdx).ChildItems.push_back(childIdx);
+
+            childItem.SrcPrefix = std::move(src);
+            childItem.State = EState::Waiting;
+            childItem.ParentIdx = msg.ItemIdx;
+            childItem.Table = std::move(scheme);
+
+            Self->PersistNewImportItem(db, *importInfo, childIdx);
+            Self->PersistImportItemScheme(db, *importInfo, childIdx);
         }
+
+        Self->PersistImportState(db, *importInfo);
     }
 
     void OnSchemaMappingResult(TTransactionContext& txc, const TActorContext& ctx) {
@@ -1212,7 +1249,7 @@ private:
                 }
                 if (!Self->TableProfilesLoaded) {
                     Self->WaitForTableProfiles(id, i);
-                } else if (item.Table){
+                } else if (item.Table) {
                     CreateTable(*importInfo, i, txId);
                     itemIdx = i;
                 }
@@ -1311,7 +1348,6 @@ private:
             }
 
             if (txId == InvalidTxId) {
-
                 if (record.GetStatus() == NKikimrScheme::StatusAlreadyExists && item.State == EState::CreateChangefeed) {
                     if (item.ChangefeedState == TImportInfo::TItem::EChangefeedState::CreateChangefeed) {
                         item.ChangefeedState = TImportInfo::TItem::EChangefeedState::CreateConsumers;
@@ -1340,14 +1376,24 @@ private:
         }
 
         if (item.State == EState::CreateSchemeObject) {
-            auto createPath = TPath::Resolve(item.DstPathName, Self);
-            Y_ABORT_UNLESS(createPath);
-
-            item.DstPathId = createPath.Base()->PathId;
-            Self->PersistImportItemDstPathId(db, *importInfo, itemIdx);
+            UpdateItemDstPathId(db, *importInfo, itemIdx);
+            for (auto childIdx : item.ChildItems) {
+                UpdateItemDstPathId(db, *importInfo, childIdx);
+            }
         }
 
         SubscribeTx(*importInfo, itemIdx);
+    }
+
+    void UpdateItemDstPathId(NIceDb::TNiceDb& db, TImportInfo& importInfo, ui32 itemIdx) {
+        Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
+        auto& item = importInfo.Items.at(itemIdx);
+
+        auto path = TPath::Resolve(item.DstPathName, Self);
+        Y_ABORT_UNLESS(path);
+
+        item.DstPathId = path.Base()->PathId;
+        Self->PersistImportItemDstPathId(db, importInfo, itemIdx);
     }
 
     void OnCreateIndexResult(TTransactionContext& txc, const TActorContext&) {
@@ -1465,7 +1511,16 @@ private:
                 item.State = EState::Done;
                 break;
             }
-            if (!item.Table) {
+            if (item.Table) {
+                for (auto childIdx : item.ChildItems) {
+                    Y_ABORT_UNLESS(childIdx < importInfo->Items.size());
+                    auto& childItem = importInfo->Items.at(childIdx);
+
+                    childItem.State = EState::Transferring;
+                    Self->PersistImportItemState(db, *importInfo, childIdx);
+                    AllocateTxId(*importInfo, childIdx);
+                }
+            } else {
                 Y_ABORT("Create Scheme Object: schema objects are empty");
             }
             item.State = EState::Transferring;
@@ -1477,8 +1532,8 @@ private:
                 item.Issue = *issue;
                 Cancel(*importInfo, itemIdx, "issues during restore");
             } else {
-                Y_ABORT_UNLESS(item.Table);
-                if (item.NextIndexIdx < item.Table->indexes_size()) {
+                const auto needToBuildIndexes = NeedToBuildIndexes(*importInfo, itemIdx);
+                if (needToBuildIndexes && item.Table && item.NextIndexIdx < item.Table->indexes_size()) {
                     item.State = EState::BuildIndexes;
                     AllocateTxId(*importInfo, itemIdx);
                 } else if (item.NextChangefeedIdx < item.Changefeeds.changefeeds_size() &&
@@ -1496,8 +1551,7 @@ private:
                 item.Issue = *issue;
                 Cancel(*importInfo, itemIdx, "issues during index building");
             } else {
-                Y_ABORT_UNLESS(item.Table);
-                if (++item.NextIndexIdx < item.Table->indexes_size()) {
+                if (item.Table && ++item.NextIndexIdx < item.Table->indexes_size()) {
                     AllocateTxId(*importInfo, itemIdx);
                 } else if (item.NextChangefeedIdx < item.Changefeeds.changefeeds_size() &&
                            AppData()->FeatureFlags.GetEnableChangefeedsImport()) {

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -1,4 +1,5 @@
 #include "schemeshard_import_flow_proposals.h"
+#include "schemeshard_import_helpers.h"
 
 #include "schemeshard_path_describer.h"
 #include "schemeshard_xxport__helpers.h"
@@ -52,6 +53,10 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
         return nullptr;
     }
 
+    if (!NeedToBuildIndexes(importInfo, itemIdx) && !FillIndexDescription(*indexedTable, *item.Table, status, error)) {
+        return nullptr;
+    }
+
     for(const auto& column: item.Table->columns()) {
         switch (column.default_value_case()) {
             case Ydb::Table::ColumnMeta::kFromSequence: {
@@ -93,8 +98,15 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
     return CreateTablePropose(ss, txId, importInfo, itemIdx, unused);
 }
 
+template <typename TPath>
+static auto GetDescription(TSchemeShard* ss, const TPath& path) {
+    NKikimrSchemeOp::TDescribeOptions opts;
+    opts.SetShowPrivateTable(true);
+    return DescribePath(ss, TlsActivationContext->AsActorContext(), path, opts);
+}
+
 static NKikimrSchemeOp::TTableDescription GetTableDescription(TSchemeShard* ss, const TPathId& pathId) {
-    auto desc = DescribePath(ss, TlsActivationContext->AsActorContext(), pathId);
+    auto desc = GetDescription(ss, pathId);
     auto record = desc->GetRecord();
 
     Y_ABORT_UNLESS(record.HasPathDescription());
@@ -187,7 +199,13 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> RestoreTableDataPropose(
                 restoreSettings.SetRegion(region);
             }
 
-            if (!item.Metadata.HasVersion() || item.Metadata.GetVersion() > 0) {
+            const auto* metadata = &item.Metadata;
+            if (item.ParentIdx != Max<ui32>()) {
+                Y_ABORT_UNLESS(item.ParentIdx < importInfo.Items.size());
+                metadata = &importInfo.Items[item.ParentIdx].Metadata;
+            }
+
+            if (!metadata->HasVersion() || metadata->GetVersion() > 0) {
                 task.SetValidateChecksums(!importInfo.Settings.skip_checksum_validation());
             }
         }
@@ -359,13 +377,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateConsumersPropose(
 
     pqGroup.SetName("streamImpl");
 
-    NKikimrSchemeOp::TDescribeOptions opts;
-    opts.SetReturnPartitioningInfo(false);
-    opts.SetReturnPartitionConfig(true);
-    opts.SetReturnBoundaries(true);
-    opts.SetReturnIndexTableBoundaries(true);
-    opts.SetShowPrivateTable(true);
-    auto describeSchemeResult = DescribePath(ss, TlsActivationContext->AsActorContext(),changefeedPath + "/streamImpl", opts);
+    auto describeSchemeResult = GetDescription(ss, changefeedPath + "/streamImpl");
 
     const auto& response = describeSchemeResult->GetRecord().GetPathDescription();
     item.StreamImplPathId = {response.GetSelf().GetSchemeshardId(), response.GetSelf().GetPathId()};

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -3,18 +3,17 @@
 #include "schemeshard_import_helpers.h"
 #include "schemeshard_private.h"
 
-#include <ydb/public/api/protos/ydb_import.pb.h>
-#include <ydb/public/lib/ydb_cli/dump/files/files.h>
-
 #include <ydb/core/backup/common/checksum.h>
 #include <ydb/core/backup/common/encryption.h>
 #include <ydb/core/backup/common/metadata.h>
+#include <ydb/core/base/table_index.h>
 #include <ydb/core/wrappers/retry_policy.h>
 #include <ydb/core/wrappers/s3_storage_config.h>
 #include <ydb/core/wrappers/s3_wrapper.h>
-
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/public/api/protos/ydb_import.pb.h>
+#include <ydb/public/lib/ydb_cli/dump/files/files.h>
 
 #include <library/cpp/json/json_reader.h>
 
@@ -300,6 +299,11 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         return TStringBuilder() << importInfo.GetItemSrcPrefix(itemIdx) << "/permissions.pb";
     }
 
+    static TString MaterializedIndexSchemeKeyFromSettings(const TImportInfo& importInfo, ui32 itemIdx, const TString& indexImplTablePrefix) {
+        Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
+        return TStringBuilder() << importInfo.GetItemSrcPrefix(itemIdx) << "/" << indexImplTablePrefix << "/scheme.pb";
+    }
+
     static TString ChangefeedDescriptionKeyFromSettings(const TImportInfo& importInfo, ui32 itemIdx, const TString& changefeedPrefix) {
         Y_ABORT_UNLESS(itemIdx < importInfo.Items.size());
         return TStringBuilder() << importInfo.GetItemSrcPrefix(itemIdx) << "/" << changefeedPrefix << "/changefeed_description.pb";
@@ -382,7 +386,7 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
             Y_ABORT_UNLESS(ItemIdx < ImportInfo->Items.size());
             auto& item = ImportInfo->Items.at(ItemIdx);
             if (!item.Metadata.HasEnablePermissions()) {
-                StartDownloadingChangefeeds(); // permissions are optional if we don't know if they were created during export
+                return StartCheckingMaterializedIndexes(); // permissions are optional if we don't know if they were created during export
             } else {
                 return Reply(Ydb::StatusIds::BAD_REQUEST, "No permissions file found");
             }
@@ -392,6 +396,28 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         }
 
         GetObject(PermissionsKey, result.GetResult().GetContentLength());
+    }
+
+    void HandleIndex(TEvExternalStorage::TEvHeadObjectResponse::TPtr& ev) {
+        const auto& result = ev->Get()->Result;
+
+        LOG_D("HandleIndex TEvExternalStorage::TEvHeadObjectResponse"
+            << ": self# " << SelfId()
+            << ", result# " << result);
+
+        const bool canSkip = IndexPopulationMode != Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT;
+        if (canSkip && NoObjectFound(result.GetError().GetErrorType())) {
+            Y_ABORT_UNLESS(ItemIdx < ImportInfo->Items.size());
+            auto& item = ImportInfo->Items.at(ItemIdx);
+            item.MaterializedIndexes.clear();
+            return StartDownloadingChangefeeds();
+        } else if (!CheckResult(result, "HeadObject")) {
+            return;
+        }
+
+        Y_ABORT_UNLESS(IndexCheckedMaterializedIndexImplTable < IndexImplTablePrefixes.size());
+        GetObject(MaterializedIndexSchemeKeyFromSettings(*ImportInfo, ItemIdx,
+            IndexImplTablePrefixes[IndexCheckedMaterializedIndexImplTable].ExportPrefix), result.GetResult().GetContentLength());
     }
 
     void HandleChangefeed(TEvExternalStorage::TEvHeadObjectResponse::TPtr& ev) {
@@ -516,7 +542,7 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
             if (NeedDownloadPermissions) {
                 StartDownloadingPermissions();
             } else {
-                StartDownloadingChangefeeds();
+                StartCheckingMaterializedIndexes();
             }
         };
 
@@ -558,11 +584,62 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         item.Permissions = std::move(permissions);
 
         auto nextStep = [this]() {
-            StartDownloadingChangefeeds();
+            StartCheckingMaterializedIndexes();
         };
 
         if (NeedValidateChecksums) {
             StartValidatingChecksum(PermissionsKey, content, nextStep);
+        } else {
+            nextStep();
+        }
+    }
+
+    void HandleIndex(TEvExternalStorage::TEvGetObjectResponse::TPtr& ev) {
+        const auto& msg = *ev->Get();
+        const auto& result = msg.Result;
+
+        LOG_D("HandleIndex TEvExternalStorage::TEvGetObjectResponse"
+            << ": self# " << SelfId()
+            << ", result# " << result);
+
+        if (!CheckResult(result, "GetObject")) {
+            return;
+        }
+
+        TString content;
+        if (!MaybeDecrypt(msg.Body, content, NBackup::EBackupFileType::TableSchema, IndexCheckedMaterializedIndexImplTable)) {
+            return;
+        }
+
+        Y_ABORT_UNLESS(ItemIdx < ImportInfo->Items.size());
+        auto& item = ImportInfo->Items.at(ItemIdx);
+
+        LOG_T("Trying to parse index"
+            << ": self# " << SelfId()
+            << ", body# " << SubstGlobalCopy(content, "\n", "\\n"));
+
+        Ydb::Table::CreateTableRequest request;
+        if (!google::protobuf::TextFormat::ParseFromString(content, &request)) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, "Cannot parse index");
+        }
+
+        Y_ABORT_UNLESS(IndexCheckedMaterializedIndexImplTable < IndexImplTablePrefixes.size());
+        const auto& indexImplTablePrefix = IndexImplTablePrefixes[IndexCheckedMaterializedIndexImplTable];
+        item.MaterializedIndexes.emplace_back(indexImplTablePrefix, std::move(request));
+
+        auto nextStep = [this]() {
+            if (++IndexCheckedMaterializedIndexImplTable >= IndexImplTablePrefixes.size()) {
+                StartDownloadingChangefeeds();
+            } else {
+                Become(&TThis::StateCheckIndexes);
+                HeadObject(MaterializedIndexSchemeKeyFromSettings(*ImportInfo, ItemIdx,
+                    IndexImplTablePrefixes[IndexCheckedMaterializedIndexImplTable].ExportPrefix));
+            }
+        };
+
+        if (NeedValidateChecksums) {
+            StartValidatingChecksum(MaterializedIndexSchemeKeyFromSettings(*ImportInfo, ItemIdx,
+                IndexImplTablePrefixes[IndexCheckedMaterializedIndexImplTable].ExportPrefix), content, nextStep);
         } else {
             nextStep();
         }
@@ -714,6 +791,71 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         Download(PermissionsKey);
     }
 
+    static bool NeedToCheckMaterializedIndexes(Ydb::Import::ImportFromS3Settings::IndexPopulationMode mode) {
+        switch (mode) {
+        case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT:
+        case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    void CheckMaterializedIndexes() {
+        Become(&TThis::StateCheckIndexes);
+
+        Y_ABORT_UNLESS(ItemIdx < ImportInfo->Items.size());
+        auto& item = ImportInfo->Items.at(ItemIdx);
+
+        IndexImplTablePrefixes.clear();
+        IndexCheckedMaterializedIndexImplTable = 0;
+        item.MaterializedIndexes.clear();
+
+        if (const auto& indexes = item.Metadata.GetIndexes()) {
+            IndexImplTablePrefixes.reserve(indexes->size());
+            for (const auto& index : *indexes) {
+                IndexImplTablePrefixes.push_back(index);
+            }
+
+            DownloadMaterializedIndexes();
+        } else {
+            if (!Key) { // not encrypted
+                if (item.Table) {
+                    IndexImplTablePrefixes.reserve(item.Table->indexes_size());
+
+                    for (const auto& index : item.Table->indexes()) {
+                        const auto indexType = NTableIndex::TryConvertIndexType(index.type_case());
+                        if (!indexType) {
+                            return Reply(Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "Unsupported index"
+                                << ": name# " << index.name()
+                                << ": type# " << static_cast<int>(index.type_case()));
+                        }
+
+                        const TVector<TString> indexColumns(index.index_columns().begin(), index.index_columns().end());
+                        for (const auto& implTable : NTableIndex::GetImplTables(*indexType, indexColumns)) {
+                            const TString implTablePrefix = TStringBuilder() << index.name() << "/" << implTable;
+                            IndexImplTablePrefixes.push_back({implTablePrefix, implTablePrefix});
+                        }
+                    }
+                }
+
+                DownloadMaterializedIndexes();
+            } else {
+                Reply(Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "No indexes described in table metadata");
+            }
+        }
+    }
+
+    void DownloadMaterializedIndexes() {
+        if (!IndexImplTablePrefixes.empty()) {
+            Y_ABORT_UNLESS(IndexCheckedMaterializedIndexImplTable < IndexImplTablePrefixes.size());
+            HeadObject(MaterializedIndexSchemeKeyFromSettings(*ImportInfo, ItemIdx,
+                IndexImplTablePrefixes[IndexCheckedMaterializedIndexImplTable].ExportPrefix));
+        } else {
+            StartDownloadingChangefeeds();
+        }
+    }
+
     void DownloadChangefeeds() {
         Become(&TThis::StateDownloadChangefeeds);
         if (const auto& maybeChangefeeds = ImportInfo->Items[ItemIdx].Metadata.GetChangefeeds()) {
@@ -758,6 +900,15 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         Become(&TThis::StateDownloadPermissions);
     }
 
+    void StartCheckingMaterializedIndexes() {
+        ResetRetries();
+        if (NeedToCheckMaterializedIndexes(IndexPopulationMode)) {
+            CheckMaterializedIndexes();
+        } else {
+            StartDownloadingChangefeeds();
+        }
+    }
+
     void StartDownloadingChangefeeds() {
         ResetRetries();
         DownloadChangefeeds();
@@ -772,6 +923,7 @@ public:
         , MetadataKey(MetadataKeyFromSettings(*ImportInfo, itemIdx))
         , SchemeKey(SchemeKeyFromSettings(*ImportInfo, itemIdx, "scheme.pb"))
         , PermissionsKey(PermissionsKeyFromSettings(*ImportInfo, itemIdx))
+        , IndexPopulationMode(ImportInfo->Settings.index_population_mode())
         , NeedDownloadPermissions(!ImportInfo->Settings.no_acl())
         , NeedValidateChecksums(!ImportInfo->Settings.skip_checksum_validation())
     {
@@ -812,6 +964,16 @@ public:
         }
     }
 
+    STATEFN(StateCheckIndexes) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvExternalStorage::TEvHeadObjectResponse, HandleIndex);
+            hFunc(TEvExternalStorage::TEvGetObjectResponse, HandleIndex);
+
+            sFunc(TEvents::TEvWakeup, CheckMaterializedIndexes);
+            sFunc(TEvents::TEvPoisonPill, PassAway);
+        }
+    }
+
     STATEFN(StateDownloadChangefeeds) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvExternalStorage::TEvListObjectsResponse, HandleChangefeeds);
@@ -842,11 +1004,17 @@ private:
     TString SchemeKey;
     NBackup::EBackupFileType SchemeFileType = NBackup::EBackupFileType::TableSchema;
     const TString PermissionsKey;
+
     TVector<TString> ChangefeedsPrefixes;
     ui64 IndexDownloadedChangefeed = 0;
 
+    TVector<NBackup::TIndexMetadata> IndexImplTablePrefixes;
+    ui64 IndexCheckedMaterializedIndexImplTable = 0;
+    Ydb::Import::ImportFromS3Settings::IndexPopulationMode IndexPopulationMode;
+
     bool NeedDownloadPermissions = true;
     bool NeedValidateChecksums = true;
+
 }; // TSchemeGetter
 
 class TSchemaMappingGetter : public TGetterFromS3<TSchemaMappingGetter> {

--- a/ydb/core/tx/schemeshard/schemeshard_import_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_import_helpers.h
@@ -18,9 +18,17 @@
 #define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::IMPORT, stream)
 #define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::IMPORT, stream)
 
+namespace NKikimr::NSchemeShard {
+
 template <typename T>
 void AddIssue(T& response, const TString& message, NYql::TSeverityIds::ESeverityId severity = NYql::TSeverityIds::S_ERROR) {
     auto& issue = *response.AddIssues();
     issue.set_severity(severity);
     issue.set_message(message);
 }
+
+struct TImportInfo;
+
+bool NeedToBuildIndexes(const TImportInfo& importInfo, ui32 itemIdx);
+
+} // NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2770,6 +2770,7 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
         TString SourcePathName;
         TPathId SourcePathId;
         NKikimrSchemeOp::EPathType SourcePathType;
+        ui32 ParentIdx; // used by indexes
 
         EState State = EState::Waiting;
         ESubState SubState = ESubState::AllocateTxId;
@@ -2779,10 +2780,15 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
 
         TItem() = default;
 
-        explicit TItem(const TString& sourcePathName, const TPathId sourcePathId, NKikimrSchemeOp::EPathType sourcePathType)
+        explicit TItem(
+                const TString& sourcePathName,
+                const TPathId sourcePathId,
+                NKikimrSchemeOp::EPathType sourcePathType,
+                ui32 parentIdx = Max<ui32>())
             : SourcePathName(sourcePathName)
             , SourcePathId(sourcePathId)
             , SourcePathType(sourcePathType)
+            , ParentIdx(parentIdx)
         {
         }
 
@@ -2822,6 +2828,7 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
 
     bool EnableChecksums = false;
     bool EnablePermissions = false;
+    bool IncludeIndexData = false;
 
     NKikimrSchemeOp::TExportMetadata ExportMetadata;
     TActorId ExportMetadataUploader;
@@ -2954,6 +2961,7 @@ struct TImportInfo: public TSimpleRefCount<TImportInfo> {
         TMaybe<NKikimrSchemeOp::TModifyScheme> PreparedCreationQuery;
         TMaybeFail<Ydb::Scheme::ModifyPermissionsRequest> Permissions;
         NBackup::TMetadata Metadata;
+        TVector<std::pair<NBackup::TIndexMetadata, Ydb::Table::CreateTableRequest>> MaterializedIndexes;
         NKikimrSchemeOp::TImportTableChangefeeds Changefeeds;
 
         EState State = EState::GetScheme;
@@ -2967,6 +2975,9 @@ struct TImportInfo: public TSimpleRefCount<TImportInfo> {
         TString Issue;
         TPathId StreamImplPathId;
         TMaybe<NBackup::TEncryptionIV> ExportItemIV;
+
+        ui32 ParentIdx = Max<ui32>();
+        TVector<ui32> ChildItems;
 
         TItem() = default;
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1247,6 +1247,7 @@ struct Schema : NIceDb::Schema {
 
         struct EnableChecksums : Column<17, NScheme::NTypeIds::Bool> {};
         struct EnablePermissions : Column<18, NScheme::NTypeIds::Bool> {};
+        struct IncludeIndexData : Column<21, NScheme::NTypeIds::Bool> {};
 
         struct ExportMetadata : Column<19, NScheme::NTypeIds::String> { using Type = NKikimrSchemeOp::TExportMetadata; };
 
@@ -1271,7 +1272,8 @@ struct Schema : NIceDb::Schema {
             EnableChecksums,
             EnablePermissions,
             ExportMetadata,
-            SanitizedToken
+            SanitizedToken,
+            IncludeIndexData
         >;
     };
 
@@ -1286,6 +1288,7 @@ struct Schema : NIceDb::Schema {
         struct Issue : Column<7, NScheme::NTypeIds::Utf8> {};
         struct SourceOwnerPathId : Column<8, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
         struct SourcePathType : Column<9, NScheme::NTypeIds::Uint32> { using Type = NKikimrSchemeOp::EPathType; static constexpr Type Default = NKikimrSchemeOp::EPathTypeTable; };
+        struct ParentIndex : Column<10, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<ExportId, Index>;
         using TColumns = TableColumns<
@@ -1297,7 +1300,8 @@ struct Schema : NIceDb::Schema {
             BackupTxId,
             Issue,
             SourceOwnerPathId,
-            SourcePathType
+            SourcePathType,
+            ParentIndex
         >;
     };
 
@@ -1676,6 +1680,7 @@ struct Schema : NIceDb::Schema {
         struct SrcPrefix : Column<17, NScheme::NTypeIds::Utf8> {};
         struct EncryptionIV : Column<18, NScheme::NTypeIds::String> {};
         struct SrcPath : Column<19, NScheme::NTypeIds::Utf8> {};
+        struct ParentIndex : Column<21, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<ImportId, Index>;
         using TColumns = TableColumns<
@@ -1698,7 +1703,8 @@ struct Schema : NIceDb::Schema {
             SrcPrefix,
             EncryptionIV,
             SrcPath,
-            Topic
+            Topic,
+            ParentIndex
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -225,12 +225,20 @@ void FillIndexImplTableColumns(
     }
 }
 
+bool GetIsRestore(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
+    return tableInfo->IsRestore;
+}
+
 const auto& GetPartitionConfig(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
     return tableInfo->PartitionConfig();
 }
 
 const auto& GetColumns(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
     return tableInfo->Columns;
+}
+
+bool GetIsRestore(const NKikimrSchemeOp::TTableDescription& tableDescr) {
+    return tableDescr.GetIsRestore();
 }
 
 const auto& GetPartitionConfig(const NKikimrSchemeOp::TTableDescription& tableDescr) {
@@ -248,6 +256,7 @@ auto CalcImplTableDescImpl(
 {
     NKikimrSchemeOp::TTableDescription implTableDesc;
     implTableDesc.SetName(NTableIndex::ImplTable);
+    implTableDesc.SetIsRestore(GetIsRestore(baseTable));
     SetImplTablePartitionConfig(GetPartitionConfig(baseTable), indexTableDesc, implTableDesc);
     FillIndexImplTableColumns(GetColumns(baseTable), implTableColumns.Keys, implTableColumns.Columns, implTableDesc);
     if (indexTableDesc.HasReplicationConfig()) {

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -3980,6 +3980,66 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         env.TestWaitNotification(runtime, txId);
     }
 
+    Y_UNIT_TEST(CopyIndexedTablesForBackup) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Table"
+              Columns { Name: "key" Type: "Uint32"}
+              Columns { Name: "value" Type: "Utf8"}
+              KeyColumnNames: ["key"]
+            }
+            IndexDescription {
+              Name: "Index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable"), {
+            NLs::IsBackupTable(false),
+        });
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "CopyTable"
+            CopyFromTable: "/MyRoot/Table"
+            IsBackup: true
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/CopyTable/Index/indexImplTable"), {
+            NLs::IsBackupTable(true),
+        });
+    }
+
+    Y_UNIT_TEST(CreateIndexedTablesForRestore) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+              Name: "Table"
+              Columns { Name: "key" Type: "Uint32"}
+              Columns { Name: "value" Type: "Utf8"}
+              KeyColumnNames: ["key"]
+              IsRestore: true
+            }
+            IndexDescription {
+              Name: "Index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable"), {
+            NLs::IsRestoreTable(true),
+        });
+    }
+
     Y_UNIT_TEST(CreateIndexedTableAfterBackup) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -2,6 +2,7 @@
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 
 #include <ydb/core/backup/common/encryption.h>
+#include <ydb/core/base/table_index.h>
 #include <ydb/core/metering/metering.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tablet_flat/shared_cache_events.h>
@@ -2442,7 +2443,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "37c1d75e169ab5817fc0fd2de8fdacdf0dc4a9c4751f99f532746f5cb84b6882 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "7f26737c8c9e7abe6541c08c5e41681bd3574b305075aeffd243d57a0e169780 metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);
@@ -2509,7 +2510,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "37c1d75e169ab5817fc0fd2de8fdacdf0dc4a9c4751f99f532746f5cb84b6882 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "7f26737c8c9e7abe6541c08c5e41681bd3574b305075aeffd243d57a0e169780 metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);
@@ -3265,4 +3266,175 @@ state: STATE_ENABLED
         UNIT_ASSERT_C(HasS3File(permissionsPath), "Permissions file should exist");
     }
 
+    void IndexMaterialization(TTestEnv& env, TTestBasicRuntime& runtime, TS3Mock& s3Mock, ui16 s3Port, bool enabled, const TString& indexDesc) {
+        ui64 txId = 100;
+
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            TableDescription {
+              Name: "Table"
+              Columns { Name: "key" Type: "Uint32" }
+              Columns { Name: "embedding" Type: "String" }
+              Columns { Name: "prefix" Type: "String" }
+              Columns { Name: "value" Type: "Utf8" }
+              KeyColumnNames: ["key"]
+            }
+            %s
+        )", indexDesc.c_str()));
+        env.TestWaitNotification(runtime, txId);
+
+        const auto expectedStatus = enabled ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::PRECONDITION_FAILED;
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              include_index_data: true
+              items {
+                source_path: "/MyRoot/Table"
+                destination_prefix: ""
+              }
+            }
+        )", s3Port), "", "", expectedStatus);
+
+        if (!enabled) {
+            return;
+        }
+
+        env.TestWaitNotification(runtime, txId);
+
+        auto desc = DescribePrivatePath(runtime, "/MyRoot/Table/index");
+        const auto& tableIndex = desc.GetPathDescription().GetTableIndex();
+        const auto indexType = tableIndex.GetType();
+        const TVector<TString> indexColumns(tableIndex.GetKeyColumnNames().begin(), tableIndex.GetKeyColumnNames().end());
+
+        for (const auto implTable : NTableIndex::GetImplTables(indexType, indexColumns)) {
+            UNIT_ASSERT(s3Mock.GetData().FindPtr(TStringBuilder() << "/index/" << implTable << "/scheme.pb"));
+        }
+    }
+
+    Y_UNIT_TEST(IndexMaterializationDisabled) {
+        EnvOptions().EnableIndexMaterialization(false);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), false, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterialization) {
+        EnvOptions().EnableIndexMaterialization(true);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), true, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["value"]
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterializationGlobal) {
+        EnvOptions().EnableIndexMaterialization(true);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), true, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["value"]
+              Type: EIndexTypeGlobal
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterializationGlobalAsync) {
+        EnvOptions().EnableIndexMaterialization(true);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), true, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["value"]
+              Type: EIndexTypeGlobalAsync
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterializationGlobalVectorKmeansTree) {
+        EnvOptions().EnableIndexMaterialization(true);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), true, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["embedding"]
+              Type: EIndexTypeGlobalVectorKmeansTree
+              VectorIndexKmeansTreeDescription {
+                Settings {
+                  settings {
+                    metric: DISTANCE_COSINE
+                    vector_type: VECTOR_TYPE_FLOAT
+                    vector_dimension: 1024
+                  }
+                  clusters: 4
+                  levels: 5
+                }
+              }
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterializationGlobalVectorKmeansTreePrefix) {
+        EnvOptions().EnableIndexMaterialization(true);
+        IndexMaterialization(Env(), Runtime(), S3Mock(), S3Port(), true, R"(
+            IndexDescription {
+              Name: "index"
+              KeyColumnNames: ["prefix", "embedding"]
+              Type: EIndexTypeGlobalVectorKmeansTree
+              VectorIndexKmeansTreeDescription {
+                Settings {
+                  settings {
+                    metric: DISTANCE_COSINE
+                    vector_type: VECTOR_TYPE_FLOAT
+                    vector_dimension: 1024
+                  }
+                  clusters: 4
+                  levels: 5
+                }
+              }
+            }
+        )");
+    }
+
+    Y_UNIT_TEST(IndexMaterializationTwoTables) {
+        EnvOptions().EnableIndexMaterialization(true);
+        auto& env = Env();
+        auto& runtime = Runtime();
+        ui64 txId = 100;
+
+        for (const auto tableName : {"Table1", "Table2"}) {
+            TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                TableDescription {
+                  Name: "%s"
+                  Columns { Name: "key" Type: "Uint32" }
+                  Columns { Name: "value" Type: "Utf8" }
+                  KeyColumnNames: ["key"]
+                }
+                IndexDescription {
+                  Name: "index"
+                  KeyColumnNames: ["value"]
+                }
+            )", tableName));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              include_index_data: true
+              items {
+                source_path: "/MyRoot/Table1"
+                destination_prefix: "table1"
+              }
+              items {
+                source_path: "/MyRoot/Table2"
+                destination_prefix: "table2"
+              }
+            }
+        )", S3Port()));
+
+        env.TestWaitNotification(runtime, txId);
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -2443,7 +2443,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "7f26737c8c9e7abe6541c08c5e41681bd3574b305075aeffd243d57a0e169780 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "8a27ef8c9b24a7b3d79d6ba5e2695d22f2092df328931aad3890fdb5f5695fc8 metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);
@@ -2510,7 +2510,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "7f26737c8c9e7abe6541c08c5e41681bd3574b305075aeffd243d57a0e169780 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "8a27ef8c9b24a7b3d79d6ba5e2695d22f2092df328931aad3890fdb5f5695fc8 metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);

--- a/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
+++ b/ydb/core/tx/schemeshard/ut_export_reboots_s3/ut_export_reboots_s3.cpp
@@ -735,4 +735,34 @@ Y_UNIT_TEST_SUITE(TExportToS3WithRebootsTests) {
     Y_UNIT_TEST(ForgetShouldSucceedOnOnSingleTopic) {
         TestSingleTopic(&ForgetS3);
     }
+
+    Y_UNIT_TEST(IndexMaterialization) {
+        RunS3({
+            {
+                EPathTypeTableIndex,
+                R"(
+                    TableDescription {
+                      Name: "Table"
+                      Columns { Name: "key" Type: "Utf8" }
+                      Columns { Name: "value" Type: "Utf8" }
+                      KeyColumnNames: ["key"]
+                    }
+                    IndexDescription {
+                      Name: "index"
+                      KeyColumnNames: ["value"]
+                    }
+                )",
+            },
+        }, R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              include_index_data: true
+              items {
+                source_path: "/MyRoot/Table"
+                destination_prefix: ""
+              }
+            }
+        )", TTestEnvOptions().EnableIndexMaterialization(true));
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1233,6 +1233,12 @@ TCheckFunc IsBackupTable(bool value) {
     };
 }
 
+TCheckFunc IsRestoreTable(bool value) {
+    return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        UNIT_ASSERT_VALUES_EQUAL(value, record.GetPathDescription().GetTable().GetIsRestore());
+    };
+}
+
 TCheckFunc ReplicationMode(NKikimrSchemeOp::TTableReplicationConfig::EReplicationMode mode) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         const auto& table = record.GetPathDescription().GetTable();

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -151,6 +151,7 @@ namespace NLs {
         NKikimrSchemeOp::TTTLSettings::EUnit columnUnit = NKikimrSchemeOp::TTTLSettings::UNIT_AUTO);
     TCheckFunc HasTtlDisabled();
     TCheckFunc IsBackupTable(bool value);
+    TCheckFunc IsRestoreTable(bool value);
     TCheckFunc ReplicationMode(NKikimrSchemeOp::TTableReplicationConfig::EReplicationMode mode);
     TCheckFunc ReplicationState(NKikimrReplication::TReplicationState::StateCase state);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -622,6 +622,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.SetEnableSystemNamesProtection(opts.EnableSystemNamesProtection_);
     app.SetEnableRealSystemViewPaths(opts.EnableRealSystemViewPaths_);
     app.FeatureFlags.SetEnableAlterDatabase(opts.EnableAlterDatabase_);
+    app.SetEnableIndexMaterialization(opts.EnableIndexMaterialization_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -84,6 +84,7 @@ namespace NSchemeShardUT_Private {
         OPTION(ui32, NStoragePools, 2);
         OPTION(std::optional<ui32>, DataShardStatsReportIntervalSeconds, std::nullopt);
         OPTION(bool, EnableAlterDatabase, false);
+        OPTION(std::optional<bool>, EnableIndexMaterialization, std::nullopt);
         OPTION(bool, EnableConditionalEraseResponseBatching, false);
         OPTION(std::optional<ui32>, CondEraseResponseBatchSize, std::nullopt);
         OPTION(std::optional<ui32>, CondEraseResponseBatchMaxTimeMs, std::nullopt);

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -6083,6 +6083,130 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         UNIT_ASSERT(!issues.empty());
         UNIT_ASSERT_EQUAL(issues.begin()->message(), "Unsupported scheme object type");
     }
+
+    void MaterializedIndex(Ydb::Import::ImportFromS3Settings::IndexPopulationMode mode, const TString& metadata = R"({"version": 1})") {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableIndexMaterialization(true));
+
+        const auto a = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+            indexes {
+              name: "by_value"
+              index_columns: "value"
+              global_index {}
+            }
+        )", {{"a", 1}}, "", metadata);
+
+        const auto b = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "value"
+            primary_key: "key"
+        )", {{"b", 1}}, "", metadata);
+
+        Run(runtime, env, ConvertTestData({{"/a", a}, {"/a/by_value/indexImplTable", b}}), Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%%d"
+              scheme: HTTP
+              index_population_mode: %s
+              items {
+                source_prefix: "a"
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", Ydb::Import::ImportFromS3Settings::IndexPopulationMode_Name(mode).c_str()));
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IndexesCount(1),
+        });
+    }
+
+    Y_UNIT_TEST(MaterializedIndexBuild) {
+        MaterializedIndex(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD);
+    }
+
+    Y_UNIT_TEST(MaterializedIndexImport) {
+        MaterializedIndex(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT);
+    }
+
+    Y_UNIT_TEST(MaterializedIndexAuto) {
+        MaterializedIndex(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO);
+    }
+
+    Y_UNIT_TEST(MaterializedIndexOldMetadata) {
+        MaterializedIndex(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT, R"({"version": 0})");
+    }
+
+    void MaterializedIndexAbsent(Ydb::Import::ImportFromS3Settings::IndexPopulationMode mode, bool shouldFail) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableIndexMaterialization(true));
+
+        const auto a = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+            indexes {
+              name: "by_value"
+              index_columns: "value"
+              global_index {}
+            }
+        )", {{"a", 1}});
+
+        const auto expectedStatus = shouldFail ? Ydb::StatusIds::CANCELLED : Ydb::StatusIds::SUCCESS;
+        Run(runtime, env, ConvertTestData({{"/a", a}}), Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%%d"
+              scheme: HTTP
+              index_population_mode: %s
+              items {
+                source_prefix: "a"
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", Ydb::Import::ImportFromS3Settings::IndexPopulationMode_Name(mode).c_str()), expectedStatus);
+
+        if (shouldFail) {
+            return;
+        }
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IndexesCount(1),
+        });
+    }
+
+    Y_UNIT_TEST(MaterializedIndexAbsentBuild) {
+        MaterializedIndexAbsent(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD, false);
+    }
+
+    Y_UNIT_TEST(MaterializedIndexAbsentImport) {
+        MaterializedIndexAbsent(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT, true);
+    }
+
+    Y_UNIT_TEST(MaterializedIndexAbsentAuto) {
+        MaterializedIndexAbsent(Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO, false);
+    }
 }
 
 Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {
@@ -6684,5 +6808,76 @@ Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {
                 }
             }
         }, topic.GetImportRequest());
+    }
+
+    Y_UNIT_TEST(ShouldSucceedOnMaterializedIndex) {
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        const auto a = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+            indexes {
+              name: "by_value"
+              index_columns: "value"
+              global_index {}
+            }
+        )", {{"a", 1}});
+
+        const auto b = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "value"
+            primary_key: "key"
+        )", {{"b", 1}});
+
+        TS3Mock s3Mock(ConvertTestData({{"/a", a}, {"/a/by_value/indexImplTable", b}}), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+
+                runtime.SetLogPriority(NKikimrServices::DATASHARD_RESTORE, NActors::NLog::PRI_TRACE);
+                runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+                runtime.GetAppData().FeatureFlags.SetEnableIndexMaterialization(true);
+            }
+
+            const ui64 importId = ++t.TxId;
+            AsyncImport(runtime, importId, "/MyRoot", Sprintf(R"(
+                ImportFromS3Settings {
+                  endpoint: "localhost:%d"
+                  scheme: HTTP
+                  index_population_mode: INDEX_POPULATION_MODE_IMPORT
+                  items {
+                    source_prefix: "a"
+                    destination_path: "/MyRoot/Table"
+                  }
+                }
+            )", port));
+            t.TestEnv->TestWaitNotification(runtime, importId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestGetImport(runtime, importId, "/MyRoot", {
+                    Ydb::StatusIds::SUCCESS,
+                    Ydb::StatusIds::NOT_FOUND
+                });
+            }
+        });
     }
 }

--- a/ydb/public/api/protos/ydb_export.proto
+++ b/ydb/public/api/protos/ydb_export.proto
@@ -139,6 +139,12 @@ message ExportToS3Settings {
     // If encryption_settings field is not specified,
     // the resulting data will not be encrypted.
     EncryptionSettings encryption_settings = 15;
+
+    // Include index data or not.
+    // By default, only index metadata is uploaded and indexes are built during import — it saves space
+    // and reduces export time, but it can potentially increase the import time.
+    // Index data can be uploaded and downloaded back during import.
+    bool include_index_data = 16;
 }
 
 message ExportToS3Result {

--- a/ydb/public/api/protos/ydb_import.proto
+++ b/ydb/public/api/protos/ydb_import.proto
@@ -61,6 +61,17 @@ message ImportFromS3Settings {
         string destination_path = 2;
     }
 
+    enum IndexPopulationMode {
+        // If unspecified, use default - Build
+        INDEX_POPULATION_MODE_UNSPECIFIED = 0;
+        // Build index
+        INDEX_POPULATION_MODE_BUILD = 1;
+        // Import materialized index
+        INDEX_POPULATION_MODE_IMPORT = 2;
+        // Try to import materialized index, build otherwise
+        INDEX_POPULATION_MODE_AUTO = 3;
+    }
+
     string endpoint = 1 [(required) = true];
     Scheme scheme = 2; // HTTPS if not specified
     string bucket = 3 [(required) = true];
@@ -99,6 +110,10 @@ message ImportFromS3Settings {
     // If encryption_settings field is not specified,
     // the resulting data is considered not encrypted.
     Ydb.Export.EncryptionSettings encryption_settings = 15;
+
+    // Index population mode.
+    // If not specified, indexes will be built.
+    IndexPopulationMode index_population_mode = 16;
 }
 
 message ImportFromS3Result {

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
@@ -326,6 +326,18 @@ void TCommandExportToS3::Config(TConfig& config) {
         .RequiredArgument("BOOL").StoreResult<bool>(&UseVirtualAddressing).DefaultValue("true");
 
     {
+        TStringBuilder help;
+        help << "Include index data or not";
+        if (config.HelpCommandVerbosiltyLevel >= 2) {
+            help << Endl << "    By default, only index metadata is uploaded and indexes are built during import — it"
+                 << Endl << "    saves space and reduces export time, but it can potentially increase the import time."
+                 << Endl << "    Index data can be uploaded and downloaded back during import.";
+        }
+        config.Opts->AddLongOption("include-index-data", help)
+            .RequiredArgument("BOOL").StoreResult<bool>(&IncludeIndexData).DefaultValue("false");
+    }
+
+    {
         TStringBuilder encryptionAlgorithmHelp;
         encryptionAlgorithmHelp << "Encryption algorithm. Supported values: ";
         bool first = true;
@@ -418,6 +430,7 @@ int TCommandExportToS3::Run(TConfig& config) {
     settings.AccessKey(AwsAccessKey);
     settings.SecretKey(AwsSecretKey);
     settings.UseVirtualAddressing(UseVirtualAddressing);
+    settings.IncludeIndexData(IncludeIndexData);
 
     for (const auto& item : Items) {
         settings.AppendItem({item.Source, item.Destination});

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_export.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_export.h
@@ -74,6 +74,7 @@ private:
     ui32 NumberOfRetries = 10;
     TString Compression;
     bool UseVirtualAddressing = true;
+    bool IncludeIndexData = false;
     TString CommonSourcePath;
     TString CommonDestinationPrefix;
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -12,6 +12,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
 #include <ydb/library/backup/util.h>
 
+#include <util/generic/algorithm.h>
+#include <util/generic/serialized_enum.h>
 #include <util/string/builder.h>
 #include <util/string/join.h>
 #include <util/stream/format.h> // for SF_BYTES
@@ -91,6 +93,44 @@ void TCommandImportFromS3::Config(TConfig& config) {
 
     config.Opts->AddLongOption("retries", "Number of retries")
         .RequiredArgument("NUM").StoreResult(&NumberOfRetries).DefaultValue(NumberOfRetries);
+
+    {
+        TStringBuilder help;
+        help << "Index population mode. Supported values: ";
+        bool first = true;
+        for (auto mode : GetEnumAllValues<NImport::EIndexPopulationMode>()) {
+            if (mode == NImport::EIndexPopulationMode::Unknown) {
+                continue;
+            }
+
+            if (!first && config.HelpCommandVerbosiltyLevel < 2) {
+                help << ", ";
+            }
+
+            if (config.HelpCommandVerbosiltyLevel >= 2) {
+                help << Endl;
+                switch (mode) {
+                case NImport::EIndexPopulationMode::Build:
+                    help << "    - " << colors.BoldColor() << mode << colors.OldColor() << ": build index";
+                    break;
+                case NImport::EIndexPopulationMode::Import:
+                    help << "    - " << colors.BoldColor() << mode << colors.OldColor() << ": import index data";
+                    break;
+                case NImport::EIndexPopulationMode::Auto:
+                    help << "    - " << colors.BoldColor() << mode << colors.OldColor() << ": try to import index data, build otherwise";
+                    break;
+                case NImport::EIndexPopulationMode::Unknown:
+                    break;
+                }
+            } else {
+                help << colors.BoldColor() << mode << colors.OldColor();
+            }
+
+            first = false;
+        }
+        config.Opts->AddLongOption("index-population-mode", help)
+            .RequiredArgument("STRING").StoreResult(&IndexPopulationMode).DefaultValue(IndexPopulationMode);
+    }
 
     config.Opts->AddLongOption("use-virtual-addressing", TStringBuilder()
             << "Sets bucket URL style. Value "
@@ -192,6 +232,8 @@ void TCommandImportFromS3::FillItemsFromItemParam(NYdb::NImport::TImportFromS3Se
             if (item.Destination.empty() || item.Destination.back() != '/') {
                 item.Destination += "/";
             }
+
+            TVector<NImport::TImportFromS3Settings::TItem> items;
             do {
                 auto listResult = s3Client->ListObjectKeys(item.Source, token);
                 token = listResult.NextToken;
@@ -204,10 +246,27 @@ void TCommandImportFromS3::FillItemsFromItemParam(NYdb::NImport::TImportFromS3Se
                         } else {
                             destination = NormalizePath(item.Destination);
                         }
-                        settings.AppendItem({TString(key), std::move(destination)});
+                        items.push_back({TString(key), std::move(destination)});
                     }
                 }
             } while (token);
+
+            Sort(items, [](const auto& a, const auto& b) {
+                return a.Src < b.Src;
+            });
+
+            THashSet<TString> seen;
+            for (auto& item : items) {
+                TStringBuf key = item.Src;
+                // try to skip /<index_name>/<indexImplTable>
+                key.RNextTok('/');
+                key.RNextTok('/');
+                if (seen.contains(key)) {
+                    continue;
+                }
+                seen.insert(TString{item.Src});
+                settings.AppendItem(std::move(item));
+            }
         }
     } catch (...) {
         ShutdownAwsAPI();
@@ -263,6 +322,7 @@ TSettings TCommandImportFromS3::MakeSettings() {
         }
 
         settings.NumberOfRetries(NumberOfRetries);
+        settings.IndexPopulationMode(IndexPopulationMode);
         settings.NoACL(NoACL);
         settings.SkipChecksumValidation(SkipChecksumValidation);
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
@@ -46,6 +46,7 @@ private:
     TVector<TString> IncludePaths;
     TString Description;
     ui32 NumberOfRetries = 10;
+    NImport::EIndexPopulationMode IndexPopulationMode = NImport::EIndexPopulationMode::Build;
     bool UseVirtualAddressing = true;
     bool NoACL = false;
     bool SkipChecksumValidation = false;

--- a/ydb/public/lib/ydb_cli/common/print_operation.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_operation.cpp
@@ -164,6 +164,7 @@ namespace {
         TStringBuilder freeText;
 
         if constexpr (std::is_same_v<NExport::TExportToS3Response, T>) {
+            freeText << "Include index data: " << (settings.IncludeIndexData_ ? "true" : "false") << Endl;
             freeText << "StorageClass: " << settings.StorageClass_ << Endl;
             if (settings.Compression_) {
                 freeText << "Compression: " << *settings.Compression_ << Endl;
@@ -171,6 +172,8 @@ namespace {
         }
 
         if constexpr (std::is_same_v<NImport::TImportFromS3Response, T>) {
+            freeText << "Index population mode: " << settings.IndexPopulationMode_ << Endl;
+
             if (settings.NoACL_) {
                 freeText << "NoACL: " << *settings.NoACL_ << Endl;
             }

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/export/export.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/export/export.h
@@ -97,6 +97,7 @@ struct TExportToS3Settings : public TOperationRequestSettings<TExportToS3Setting
     FLUENT_SETTING_OPTIONAL(std::string, Compression);
     FLUENT_SETTING_OPTIONAL(std::string, SourcePath);
     FLUENT_SETTING_OPTIONAL(std::string, DestinationPrefix);
+    FLUENT_SETTING_DEFAULT(bool, IncludeIndexData, false);
 
     TSelf& SymmetricEncryption(const std::string& algorithm, const std::string& key) {
         EncryptionAlgorithm_ = algorithm;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
@@ -2,7 +2,6 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/operation/operation.h>
-
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/s3_settings.h>
 
 namespace Ydb::Import {
@@ -25,6 +24,14 @@ enum class EImportProgress {
     Cancellation = 5,
     Cancelled = 6,
     CreateChangefeeds = 7,
+
+    Unknown = std::numeric_limits<int>::max(),
+};
+
+enum class EIndexPopulationMode {
+    Build = 0,
+    Import = 1,
+    Auto = 2,
 
     Unknown = std::numeric_limits<int>::max(),
 };
@@ -64,6 +71,7 @@ struct TImportFromS3Settings : public TOperationRequestSettings<TImportFromS3Set
     FLUENT_SETTING_OPTIONAL(std::string, SourcePrefix);
     FLUENT_SETTING_OPTIONAL(std::string, DestinationPath);
     FLUENT_SETTING_OPTIONAL(std::string, SymmetricKey);
+    FLUENT_SETTING_DEFAULT(EIndexPopulationMode, IndexPopulationMode, EIndexPopulationMode::Build);
 };
 
 class TImportFromS3Response : public TOperation {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h
@@ -73,6 +73,8 @@ public:
     static NExport::TExportToS3Settings::EStorageClass FromProto(Ydb::Export::ExportToS3Settings::StorageClass value);
     static NExport::EExportProgress FromProto(Ydb::Export::ExportProgress::Progress value);
     static NImport::EImportProgress FromProto(Ydb::Import::ImportProgress::Progress value);
+    static Ydb::Import::ImportFromS3Settings::IndexPopulationMode GetProto(NImport::EIndexPopulationMode value);
+    static NImport::EIndexPopulationMode FromProto(Ydb::Import::ImportFromS3Settings::IndexPopulationMode value);
 };
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/export/export.cpp
+++ b/ydb/public/sdk/cpp/src/client/export/export.cpp
@@ -94,6 +94,7 @@ TExportToS3Response::TExportToS3Response(TStatus&& status, Ydb::Operations::Oper
 
     Metadata_.Settings.Description(metadata.settings().description());
     Metadata_.Settings.NumberOfRetries(metadata.settings().number_of_retries());
+    Metadata_.Settings.IncludeIndexData(metadata.settings().include_index_data());
 
     if (!metadata.settings().compression().empty()) {
         Metadata_.Settings.Compression(metadata.settings().compression());
@@ -207,6 +208,7 @@ TFuture<TExportToS3Response> TExportClient::ExportToS3(const TExportToS3Settings
     }
 
     request.mutable_settings()->set_disable_virtual_addressing(!settings.UseVirtualAddressing_);
+    request.mutable_settings()->set_include_index_data(settings.IncludeIndexData_);
 
     if (settings.EncryptionAlgorithm_.empty() != settings.SymmetricKey_.empty()) {
         throw TContractViolation("Encryption algorithm and symmetric key must be set together");

--- a/ydb/public/sdk/cpp/src/client/import/import.cpp
+++ b/ydb/public/sdk/cpp/src/client/import/import.cpp
@@ -77,6 +77,7 @@ TImportFromS3Response::TImportFromS3Response(TStatus&& status, Ydb::Operations::
 
     Metadata_.Settings.Description(metadata.settings().description());
     Metadata_.Settings.NumberOfRetries(metadata.settings().number_of_retries());
+    Metadata_.Settings.IndexPopulationMode(TProtoAccessor::FromProto(metadata.settings().index_population_mode()));
 
     // progress
     Metadata_.Progress = TProtoAccessor::FromProto(metadata.progress());
@@ -273,6 +274,8 @@ TAsyncImportFromS3Response TImportClient::ImportFromS3(const TImportFromS3Settin
     if (settings.DestinationPath_) {
         settingsProto.set_destination_path(settings.DestinationPath_.value());
     }
+
+    settingsProto.set_index_population_mode(TProtoAccessor::GetProto(settings.IndexPopulationMode_));
 
     return Impl_->ImportFromS3(std::move(request), settings);
 }

--- a/ydb/public/sdk/cpp/src/client/proto/accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/proto/accessor.cpp
@@ -137,4 +137,31 @@ NImport::EImportProgress TProtoAccessor::FromProto(Ydb::Import::ImportProgress::
     }
 }
 
+Ydb::Import::ImportFromS3Settings::IndexPopulationMode TProtoAccessor::GetProto(NImport::EIndexPopulationMode value) {
+    switch (value) {
+    case NImport::EIndexPopulationMode::Build:
+        return Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD;
+    case NImport::EIndexPopulationMode::Import:
+        return Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT;
+    case NImport::EIndexPopulationMode::Auto:
+        return Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO;
+    default:
+        return Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_UNSPECIFIED;
+    }
+}
+
+NImport::EIndexPopulationMode TProtoAccessor::FromProto(Ydb::Import::ImportFromS3Settings::IndexPopulationMode value) {
+    switch (value) {
+    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_UNSPECIFIED:
+    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_BUILD:
+        return NImport::EIndexPopulationMode::Build;
+    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_IMPORT:
+        return NImport::EIndexPopulationMode::Import;
+    case Ydb::Import::ImportFromS3Settings::INDEX_POPULATION_MODE_AUTO:
+        return NImport::EIndexPopulationMode::Auto;
+    default:
+        return NImport::EIndexPopulationMode::Unknown;
+    }
+}
+
 } // namespace NYdb

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -3268,6 +3268,11 @@
                 "ColumnId": 20,
                 "ColumnName": "SanitizedToken",
                 "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 21,
+                "ColumnName": "IncludeIndexData",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
@@ -3293,7 +3298,8 @@
                     17,
                     18,
                     19,
-                    20
+                    20,
+                    21
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -3366,6 +3372,11 @@
                 "ColumnId": 9,
                 "ColumnName": "SourcePathType",
                 "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 10,
+                "ColumnName": "ParentIndex",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -3380,7 +3391,8 @@
                     6,
                     7,
                     8,
-                    9
+                    9,
+                    10
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -6471,6 +6483,11 @@
                 "ColumnId": 20,
                 "ColumnName": "Topic",
                 "ColumnType": "String"
+            },
+            {
+                "ColumnId": 21,
+                "ColumnName": "ParentIndex",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -6496,7 +6513,8 @@
                     17,
                     18,
                     19,
-                    20
+                    20,
+                    21
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Materialize indexes: api (#30213)
- Materialize indexes: sdk & cli (#30321)
- Materialize indexes (#30212)
- Save the value of the `IsRestore` flag for index tables (#34260)
- Rename materialized index options (#31210)
- Fix materialized index export (#31392)
- Materialized index inherits parent table's metadata (#31563)