### PR TITLE
[EXT-2192] Add storage node support links

### DIFF
--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -42,3 +42,7 @@ meta:
           - ui-database
         folder:
           - 8a91d4c7-2e5b-4f13-9c6a-1b7e52d4f8a1
+    storage_node:
+      - source: grafana/dashboard
+        title: Storage Node Overview
+        url: /d/ydb_storage/overview

--- a/ydb/mvp/meta/meta_settings.cpp
+++ b/ydb/mvp/meta/meta_settings.cpp
@@ -35,6 +35,10 @@ TMetaSettings BuildMetaSettings(const NMvp::NMeta::TMetaConfig& config, NMvp::EA
         for (int i = 0; i < supportLinks.GetDatabase().size(); ++i) {
             settings.SupportLinks.DatabaseLinks.push_back(supportLinks.GetDatabase(i));
         }
+        settings.SupportLinks.StorageNodeLinks.reserve(supportLinks.GetStorageNode().size());
+        for (int i = 0; i < supportLinks.GetStorageNode().size(); ++i) {
+            settings.SupportLinks.StorageNodeLinks.push_back(supportLinks.GetStorageNode(i));
+        }
     }
 
     return settings;

--- a/ydb/mvp/meta/meta_settings.h
+++ b/ydb/mvp/meta/meta_settings.h
@@ -15,6 +15,7 @@ struct TSupportLinksSettings {
     TString GrafanaEndpoint;
     TVector<TSupportLinkEntryConfig> ClusterLinks;
     TVector<TSupportLinkEntryConfig> DatabaseLinks;
+    TVector<TSupportLinkEntryConfig> StorageNodeLinks;
 };
 
 struct TMetaSettings {

--- a/ydb/mvp/meta/meta_support_links.h
+++ b/ydb/mvp/meta/meta_support_links.h
@@ -25,6 +25,7 @@
 #include <util/generic/hash.h>
 #include <util/generic/vector.h>
 #include <memory>
+#include <optional>
 
 namespace NMVP {
 
@@ -37,6 +38,12 @@ public:
     using EEntityType = TSupportLinksResolver::EEntityType;
 
 protected:
+    struct TEntityIdentity {
+        std::optional<TString> Cluster;
+        std::optional<TString> Database;
+        std::optional<TString> StorageNode;
+    };
+
     NActors::TActorId HttpProxyId;
     const TYdbLocation& Location;
     const TMetaSettings Settings;
@@ -73,16 +80,72 @@ public:
         RequestClusterInfo();
     }
 
-    bool ValidateAndInitEntityType() {
-        const TString cluster = Request.Parameters["cluster"];
-        const TString database = Request.Parameters["database"];
-
-        if (cluster.empty()) {
-            AddCommonError("Invalid identity parameters. Supported entities: cluster requires 'cluster'; database requires 'cluster' and 'database'.");
-            return false;
+    std::optional<TString> ReadOptionalParameter(TStringBuf name) const {
+        if (!Request.Parameters.UrlParameters.Has(name)) {
+            return std::nullopt;
         }
-        EntityType = database.empty() ? EEntityType::Cluster : EEntityType::Database;
-        return true;
+        return Request.Parameters.UrlParameters[name];
+    }
+
+    TEntityIdentity ReadEntityIdentity() const {
+        return TEntityIdentity{
+            .Cluster = ReadOptionalParameter("cluster"),
+            .Database = ReadOptionalParameter("database"),
+            .StorageNode = ReadOptionalParameter("node"),
+        };
+    }
+
+    void InitEntityType(const TEntityIdentity& identity) {
+        if (identity.StorageNode) {
+            EntityType = EEntityType::StorageNode;
+            return;
+        }
+
+        if (identity.Database) {
+            EntityType = EEntityType::Database;
+            return;
+        }
+
+        EntityType = EEntityType::Cluster;
+    }
+
+    bool ValidateEntityParameters(const TEntityIdentity& identity) {
+        switch (EntityType) {
+            case EEntityType::Cluster:
+                if (!identity.Cluster || identity.Cluster->empty()) {
+                    AddCommonError("Invalid identity parameters. Parameter 'cluster' must not be empty.");
+                    return false;
+                }
+                return true;
+            case EEntityType::Database:
+                if (!identity.Cluster || identity.Cluster->empty()) {
+                    AddCommonError("Invalid identity parameters. Parameter 'cluster' must not be empty.");
+                    return false;
+                }
+                if (!identity.Database || identity.Database->empty()) {
+                    AddCommonError("Invalid identity parameters. Parameter 'database' must not be empty.");
+                    return false;
+                }
+                return true;
+            case EEntityType::StorageNode:
+                if (!identity.Cluster || identity.Cluster->empty()) {
+                    AddCommonError("Invalid identity parameters. Parameter 'cluster' must not be empty.");
+                    return false;
+                }
+                if (!identity.StorageNode || identity.StorageNode->empty()) {
+                    AddCommonError("Invalid identity parameters. Parameter 'node' must not be empty.");
+                    return false;
+                }
+                return true;
+        }
+        AddCommonError("Invalid identity parameters. Supported entities: cluster requires 'cluster'; database requires 'cluster' and 'database'; storage node requires 'cluster' and 'node'.");
+        return false;
+    }
+
+    bool ValidateAndInitEntityType() {
+        const TEntityIdentity identity = ReadEntityIdentity();
+        InitEntityType(identity);
+        return ValidateEntityParameters(identity);
     }
 
     virtual void RequestClusterInfo() {

--- a/ydb/mvp/meta/meta_support_links_ut.cpp
+++ b/ydb/mvp/meta/meta_support_links_ut.cpp
@@ -68,6 +68,10 @@ Y_UNIT_TEST_SUITE(MetaSupportLinks) {
             for (int i = 0; i < config.GetDatabase().size(); ++i) {
                 Settings.SupportLinks.DatabaseLinks.push_back(config.GetDatabase(i));
             }
+            Settings.SupportLinks.StorageNodeLinks.reserve(config.GetStorageNode().size());
+            for (int i = 0; i < config.GetStorageNode().size(); ++i) {
+                Settings.SupportLinks.StorageNodeLinks.push_back(config.GetStorageNode(i));
+            }
         }
 
         NActors::TActorId RegisterGet(
@@ -157,6 +161,15 @@ columns {
         return {};
     }
 
+    static NMVP::TSupportLinksConfig MakeStorageNodeConfig(TStringBuf source) {
+        NMVP::TSupportLinksConfig cfg;
+        auto* storageNode = cfg.AddStorageNode();
+        storageNode->SetSource(TString(source));
+        storageNode->SetTitle("mock");
+        storageNode->SetUrl("mock://source");
+        return cfg;
+    }
+
     Y_UNIT_TEST(SupportLinksReturnsBadRequestWhenClusterMissing) {
         TTestActorRuntime runtime;
         TAutoPtr<NActors::IEventHandle> handle;
@@ -177,7 +190,7 @@ columns {
         UNIT_ASSERT(json.Has("errors"));
         UNIT_ASSERT_VALUES_EQUAL(json["errors"].GetArray().size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(json["errors"][0]["source"].GetStringRobust(), "meta");
-        UNIT_ASSERT(json["errors"][0]["message"].GetStringRobust().Contains("Invalid identity parameters"));
+        UNIT_ASSERT(json["errors"][0]["message"].GetStringRobust().Contains("Parameter 'cluster' must not be empty"));
     }
 
     Y_UNIT_TEST(SupportLinksReturnsMethodNotAllowedForNonGet) {
@@ -240,6 +253,22 @@ columns {
         TSupportLinksTestContext context(MakeConfig("mock/async"));
 
         auto request = BuildHttpRequest("/meta/support_links?cluster=testing-global");
+        auto result = MakeClusterInfoResult();
+        context.RegisterGet(runtime, sender, request, std::move(result));
+
+        auto* response = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(response->Response->Status, "200");
+        AssertMockResponse(response->Response->Body);
+    }
+
+    Y_UNIT_TEST(UsesStorageNodeLinksForStorageNodeEntity) {
+        TTestActorRuntime runtime;
+        TAutoPtr<NActors::IEventHandle> handle;
+
+        auto sender = runtime.AllocateEdgeActor();
+        TSupportLinksTestContext context(MakeStorageNodeConfig("mock/sync"));
+
+        auto request = BuildHttpRequest("/meta/support_links?cluster=testing-global&node=static-1");
         auto result = MakeClusterInfoResult();
         context.RegisterGet(runtime, sender, request, std::move(result));
 

--- a/ydb/mvp/meta/meta_ut.cpp
+++ b/ydb/mvp/meta/meta_ut.cpp
@@ -174,4 +174,26 @@ meta:
         );
     }
 
+    Y_UNIT_TEST(UnsupportedSourceInStorageNodeConfigThrows) {
+        const TString yaml = R"(
+generic:
+  access_service_type: "yandex_v2"
+meta:
+  meta_api_endpoint: "grpc://meta.ydb.example.net:2135"
+  meta_database: "/Root/meta"
+  support_links:
+    storage_node:
+      - source: "unknown/source"
+        title: "Unknown"
+        url: "https://example.test"
+)";
+        const NMvp::NMeta::TMetaAppConfig appConfig = ParseConfig(yaml);
+        auto mvp = MakeTestMvp();
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            mvp.TryGetMetaOptionsFromConfig(appConfig),
+            yexception,
+            "unsupported support_links source: unknown/source"
+        );
+    }
+
 }

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -27,6 +27,8 @@ message TMetaConfig {
         repeated TSupportLinkEntry Cluster = 1;
         // Support links resolved for database entity.
         repeated TSupportLinkEntry Database = 2;
+        // Support links resolved for storage node entity.
+        repeated TSupportLinkEntry StorageNode = 3;
     }
 
     optional string MetaApiEndpoint = 1;
@@ -36,7 +38,7 @@ message TMetaConfig {
     optional bool DbUserTokenAccess = 5 [default = false];
     // Grafana integration settings used by Grafana-based support link sources.
     optional TGrafanaConfig Grafana = 6;
-    // Shared support links config reused across all clusters/databases.
+    // Shared support links config reused across all supported entities.
     optional TSupportLinksConfig SupportLinks = 7;
 }
 

--- a/ydb/mvp/meta/support_links/source.cpp
+++ b/ydb/mvp/meta/support_links/source.cpp
@@ -13,6 +13,9 @@ void ValidateSupportLinksConfig(const TSupportLinksConfig& supportLinks, const T
     for (int i = 0; i < supportLinks.GetDatabase().size(); ++i) {
         ValidateLinkSourceConfig(supportLinks.GetDatabase(i), metaSettings);
     }
+    for (int i = 0; i < supportLinks.GetStorageNode().size(); ++i) {
+        ValidateLinkSourceConfig(supportLinks.GetStorageNode(i), metaSettings);
+    }
 }
 
 void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {

--- a/ydb/mvp/meta/support_links/support_links_resolver.cpp
+++ b/ydb/mvp/meta/support_links/support_links_resolver.cpp
@@ -14,12 +14,24 @@ TVector<std::shared_ptr<ILinkSource>> BuildSources(const TSupportLinksResolver::
     if (!params.Settings) {
         ythrow yexception() << "support links settings are required";
     }
-    const auto& linkConfigs = params.EntityType == TSupportLinksResolver::EEntityType::Database
-        ? params.Settings->SupportLinks.DatabaseLinks
-        : params.Settings->SupportLinks.ClusterLinks;
+    const TVector<TSupportLinkEntryConfig>* linkConfigs = nullptr;
+    switch (params.EntityType) {
+        case TSupportLinksResolver::EEntityType::Cluster:
+            linkConfigs = &params.Settings->SupportLinks.ClusterLinks;
+            break;
+        case TSupportLinksResolver::EEntityType::Database:
+            linkConfigs = &params.Settings->SupportLinks.DatabaseLinks;
+            break;
+        case TSupportLinksResolver::EEntityType::StorageNode:
+            linkConfigs = &params.Settings->SupportLinks.StorageNodeLinks;
+            break;
+    }
+    if (!linkConfigs) {
+        ythrow yexception() << "unsupported support links entity type";
+    }
     TVector<std::shared_ptr<ILinkSource>> linkSources;
-    linkSources.reserve(linkConfigs.size());
-    for (const auto& linkConfig : linkConfigs) {
+    linkSources.reserve(linkConfigs->size());
+    for (const auto& linkConfig : *linkConfigs) {
         linkSources.push_back(params.LinkSourceFactory(linkConfig, *params.Settings));
     }
     return linkSources;

--- a/ydb/mvp/meta/support_links/support_links_resolver.h
+++ b/ydb/mvp/meta/support_links/support_links_resolver.h
@@ -16,6 +16,7 @@ public:
     enum class EEntityType {
         Cluster,
         Database,
+        StorageNode,
     };
 
     struct TParams {

--- a/ydb/tests/functional/mvp/meta/support_links_env.py
+++ b/ydb/tests/functional/mvp/meta/support_links_env.py
@@ -19,11 +19,11 @@ META_TABLE_PATH = "/Root/ydb/MasterClusterExt.db"
 GRAFANA_DASHBOARD_PATH = "/d/ydb/overview"
 ABSOLUTE_GRAFANA_DASHBOARD_URL = "https://external.example.test/d/ydb/overview"
 DATABASE_NAME = "/Root/db1"
+STORAGE_NODE_NAME = "storage-node-1"
 MISSING_CLUSTER_NAME = "missing-cluster"
 MISSING_CLUSTER_ERROR = f"Cluster '{MISSING_CLUSTER_NAME}' is not found in MasterClusterExt.db"
 MISSING_CLUSTER_PARAMETER_ERROR = (
-    "Invalid identity parameters. Supported entities: cluster requires 'cluster'; "
-    "database requires 'cluster' and 'database'."
+    "Invalid identity parameters. Parameter 'cluster' must not be empty."
 )
 
 
@@ -91,25 +91,27 @@ class MetaSupportLinksEnv(BaseHttpEnv):
         super().__init__(meta_service)
         self.meta_service = meta_service
 
-    def get_support_links(self, cluster_name=None, database=None):
+    def get_support_links(self, cluster_name=None, database=None, storage_node=None):
         params = {}
         if cluster_name is not None:
             params["cluster"] = cluster_name
         if database is not None:
             params["database"] = database
+        if storage_node is not None:
+            params["node"] = storage_node
         return self.get(
             "/meta/support_links",
             params=params,
             timeout=10,
         )
 
-    def get_ok_support_links_payload(self, cluster_name=None, database=None):
-        response = self.get_support_links(cluster_name=cluster_name, database=database)
+    def get_ok_support_links_payload(self, cluster_name=None, database=None, storage_node=None):
+        response = self.get_support_links(cluster_name=cluster_name, database=database, storage_node=storage_node)
         assert response.status_code == 200, response.text
         return response.json()
 
-    def get_bad_request_support_links_payload(self, cluster_name=None, database=None):
-        response = self.get_support_links(cluster_name=cluster_name, database=database)
+    def get_bad_request_support_links_payload(self, cluster_name=None, database=None, storage_node=None):
+        response = self.get_support_links(cluster_name=cluster_name, database=database, storage_node=storage_node)
         assert response.status_code == 400, response.text
         return response.json()
 
@@ -147,6 +149,10 @@ def write_meta_support_links_config(
         '        title: "Overview"',
         f'        url: "{url}"',
         "    database:",
+        '      - source: "grafana/dashboard"',
+        '        title: "Overview"',
+        f'        url: "{url}"',
+        "    storage_node:",
         '      - source: "grafana/dashboard"',
         '        title: "Overview"',
         f'        url: "{url}"',

--- a/ydb/tests/functional/mvp/meta/test_support_links.py
+++ b/ydb/tests/functional/mvp/meta/test_support_links.py
@@ -12,6 +12,7 @@ from support_links_env import (
     MISSING_CLUSTER_ERROR,
     MISSING_CLUSTER_NAME,
     MISSING_CLUSTER_PARAMETER_ERROR,
+    STORAGE_NODE_NAME,
     WORKSPACE_NAME,
     start_cluster_with_meta_table,
     start_meta_support_links_service,
@@ -89,6 +90,13 @@ def grafana_url_with_cluster(cluster_name=CLUSTER_NAME, extra_query=""):
     return url
 
 
+def grafana_url_with_storage_node(storage_node=STORAGE_NODE_NAME, extra_query=""):
+    query = f"var-node={storage_node}"
+    if extra_query:
+        query += f"&{extra_query}"
+    return grafana_url_with_cluster(extra_query=query)
+
+
 def external_grafana_url(extra_query=""):
     url = (
         "https://external.example.test/d/ydb/overview"
@@ -128,6 +136,16 @@ def test_meta_support_links_returns_grafana_link(meta_support_links_env, case):
     assert_support_links_response(
         meta_support_links_env.get_ok_support_links_payload(CLUSTER_NAME, database=case.database),
         case.expected_url,
+    )
+
+
+def test_meta_support_links_returns_grafana_link_for_storage_node(meta_support_links_env):
+    assert_support_links_response(
+        meta_support_links_env.get_ok_support_links_payload(
+            CLUSTER_NAME,
+            storage_node=STORAGE_NODE_NAME,
+        ),
+        grafana_url_with_storage_node(),
     )
 
 
@@ -190,4 +208,15 @@ def test_meta_support_links_requires_cluster_parameter(meta_support_links_env):
     assert_bad_request_response(
         meta_support_links_env.get_bad_request_support_links_payload(database=DATABASE_NAME),
         MISSING_CLUSTER_PARAMETER_ERROR,
+    )
+
+
+def test_meta_support_links_allows_extra_database_parameter_for_storage_node(meta_support_links_env):
+    assert_support_links_response(
+        meta_support_links_env.get_ok_support_links_payload(
+            cluster_name=CLUSTER_NAME,
+            database=DATABASE_NAME,
+            storage_node=STORAGE_NODE_NAME,
+        ),
+        grafana_url_with_storage_node(extra_query=f"var-database={DATABASE_NAME}"),
     )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR extends the MVP Meta /meta/support_links endpoint to support a new “storage node” entity type, allowing clients to request Grafana (and other) support links scoped to a specific storage node. It updates the Meta config schema and resolver logic accordingly, and adds both unit and functional tests to validate the new behavior.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
