### PR TITLE
Stop ActorSystem after YqSharedResources

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -2406,12 +2406,12 @@ void TKikimrRunner::KikimrStop(bool graceful) {
         StopGRpcServers(GRpcServersWrapper, true);
     }
 
-    if (ActorSystem) {
-        ActorSystem->Stop();
-    }
-
     if (YqSharedResources) {
         YqSharedResources->Stop();
+    }
+
+    if (ActorSystem) {
+        ActorSystem->Stop();
     }
 
     if (ModuleFactories) {


### PR DESCRIPTION
Closes: #42192

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Driver from YqSharedResources calls future completion, and in turn `ActorSystem->Send()`; see referenced issue for TSAN backtraces
Concern: is not it same for `YdbDriver` (which is stopped even later?)