### PR TITLE
Fix dstool cluster balance to address VDisk and PDisk size in units

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -9,7 +9,6 @@ It can operate in several modes:
 
 1. Overpopulated PDisk mode (--only-from-overpopulated-pdisks):
    Moves VDisks from PDisks that exceed their expected slot count to less populated PDisks.
-   VDisks whose GroupSizeInUnits does not match the PDisk SlotSizeInUnits are relocated first.
 
 2. Slot-based balancing (--sort-by=slots, default):
    Redistributes VDisks to equalize slot usage across PDisks.
@@ -284,7 +283,8 @@ class BalancingStrategy(IBalancingStrategy):
 
         weight_from = self.cluster_info.get_vslot_weight_on_pdisk(vslot.GroupId, pdisk_id)
 
-        common.print_if_verbose(self.args, 'Checking to relocate vdisk from vslot %s on pdisk %s with slot usage %d, try_blocking=%s' % (vslot_id, pdisk_id, pdisk_usage[pdisk_id], try_blocking), file=sys.stdout)
+        common.print_if_verbose(self.args, 'Checking to relocate vdisk from vslot %s on pdisk %s with slot usage %d, try_blocking=%s' %
+                                (vslot_id, pdisk_id, pdisk_usage[pdisk_id], try_blocking), file=sys.stdout)
 
         current_usage = pdisk_usage[pdisk_id]
         if not self.args.only_from_overpopulated_pdisks:
@@ -570,12 +570,12 @@ class GroupVSlotsBalancingStrategy(BalancingStrategy):
 def is_vslot_size_mismatch(vslot, cluster_info):
     pdisk_id = common.get_pdisk_id(vslot.VSlotId)
     slot_size_in_units = cluster_info.pdisk_slot_size_in_units_map.get(pdisk_id, 0)
-    
+
     group = cluster_info.group_map.get(vslot.GroupId)
     group_size_in_units = group.GroupSizeInUnits if group is not None else 0
 
-    pu = slot_size_in_units if slot_size_in_units else 1
-    vu = group_size_in_units if group_size_in_units else 1
+    pu = slot_size_in_units or 1
+    vu = group_size_in_units or 1
     return pu != vu
 
 
@@ -604,12 +604,18 @@ def balance_iteration(args, strategy, iteration_number):
         time.sleep(Constants.WAITING_TIME)
         return None
 
-    mismatch_vslots = [v for v in candidate_vslots if is_vslot_size_mismatch(v, strategy.cluster_info)]
-    regular_vslots = [v for v in candidate_vslots if not is_vslot_size_mismatch(v, strategy.cluster_info)]
-    if mismatch_vslots:
+    mismatching_vslots = []
+    matching_vslots = []
+    for v in candidate_vslots:
+        if is_vslot_size_mismatch(v, strategy.cluster_info):
+            mismatching_vslots.append(v)
+        else:
+            matching_vslots.append(v)
+
+    if mismatching_vslots:
         vslots_ordered_groups_to_reassign = (
-            strategy.order_candidate_vslots(mismatch_vslots) +
-            strategy.order_candidate_vslots(regular_vslots)
+            strategy.order_candidate_vslots(mismatching_vslots) +
+            strategy.order_candidate_vslots(matching_vslots)
         )
     else:
         vslots_ordered_groups_to_reassign = strategy.order_candidate_vslots(candidate_vslots)

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -9,6 +9,7 @@ It can operate in several modes:
 
 1. Overpopulated PDisk mode (--only-from-overpopulated-pdisks):
    Moves VDisks from PDisks that exceed their expected slot count to less populated PDisks.
+   VDisks whose GroupSizeInUnits does not match the PDisk SlotSizeInUnits are relocated first.
 
 2. Slot-based balancing (--sort-by=slots, default):
    Redistributes VDisks to equalize slot usage across PDisks.
@@ -283,7 +284,7 @@ class BalancingStrategy(IBalancingStrategy):
 
         weight_from = self.cluster_info.get_vslot_weight_on_pdisk(vslot.GroupId, pdisk_id)
 
-        common.print_if_verbose(self.args, 'Checking to relocate vdisk from vslot %s on pdisk %s with slot usage %d' % (vslot_id, pdisk_id, pdisk_usage[pdisk_id]), file=sys.stdout)
+        common.print_if_verbose(self.args, 'Checking to relocate vdisk from vslot %s on pdisk %s with slot usage %d, try_blocking=%s' % (vslot_id, pdisk_id, pdisk_usage[pdisk_id], try_blocking), file=sys.stdout)
 
         current_usage = pdisk_usage[pdisk_id]
         if not self.args.only_from_overpopulated_pdisks:
@@ -566,6 +567,18 @@ class GroupVSlotsBalancingStrategy(BalancingStrategy):
         return True
 
 
+def is_vslot_size_mismatch(vslot, cluster_info):
+    pdisk_id = common.get_pdisk_id(vslot.VSlotId)
+    slot_size_in_units = cluster_info.pdisk_slot_size_in_units_map.get(pdisk_id, 0)
+    
+    group = cluster_info.group_map.get(vslot.GroupId)
+    group_size_in_units = group.GroupSizeInUnits if group is not None else 0
+
+    pu = slot_size_in_units if slot_size_in_units else 1
+    vu = group_size_in_units if group_size_in_units else 1
+    return pu != vu
+
+
 def balance_iteration(args, strategy, iteration_number):
     if strategy.calculate_extra_info():
         common.print_status(args, success=False, error_reason='Failed to calculate extra info')
@@ -591,7 +604,15 @@ def balance_iteration(args, strategy, iteration_number):
         time.sleep(Constants.WAITING_TIME)
         return None
 
-    vslots_ordered_groups_to_reassign = strategy.order_candidate_vslots(candidate_vslots)
+    mismatch_vslots = [v for v in candidate_vslots if is_vslot_size_mismatch(v, strategy.cluster_info)]
+    regular_vslots = [v for v in candidate_vslots if not is_vslot_size_mismatch(v, strategy.cluster_info)]
+    if mismatch_vslots:
+        vslots_ordered_groups_to_reassign = (
+            strategy.order_candidate_vslots(mismatch_vslots) +
+            strategy.order_candidate_vslots(regular_vslots)
+        )
+    else:
+        vslots_ordered_groups_to_reassign = strategy.order_candidate_vslots(candidate_vslots)
     common.print_if_verbose(args, f"Found {len(candidate_vslots)} candidate vslots, {len(vslots_ordered_groups_to_reassign)} groups to reassign", file=sys.stdout)
     was_sent = False
     for vslots in vslots_ordered_groups_to_reassign:

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -19,6 +19,14 @@
             "uri": "file://test_canonical_requests.Test.test_cluster_balance/results.txt.0"
         }
     ],
+    "test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units": [
+        {
+            "uri": "file://test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt"
+        },
+        {
+            "uri": "file://test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0"
+        }
+    ],
     "test_canonical_requests.Test.test_cluster_get_set": [
         {
             "uri": "file://test_canonical_requests.Test.test_cluster_get_set/results.txt"

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
@@ -4,15 +4,43 @@ Exit Status: 0
 
 Start balancing iteration 1
 Number of used slots -> number pdisks: 0=>1 9=>1
-Found 2 candidate vslots, 1 groups to reassign
-Checking to relocate vdisk from vslot (1, 1001, 1001) on pdisk (1, 1001) with slot usage 9
+Found 2 candidate vslots, 2 groups to reassign
+Checking to relocate vdisk from vslot (1, 1001, 1000) on pdisk (1, 1001) with slot usage 9, try_blocking=False
+Checking to relocate vdisk from vslot (1, 1001, 1000) on pdisk (1, 1001) with slot usage 9, try_blocking=True
+Checking to relocate vdisk from vslot (1, 1001, 1001) on pdisk (1, 1001) with slot usage 9, try_blocking=False
 Relocated vdisk from pdisk [1:1001] to pdisk [1:1002] with slot usages (9 -> 0)
 
 ===== stderr =====
 INFO: using random hosts
 INFO: using random hosts
+INFO: using random hosts
+INFO: using random hosts
 
 ===== grpc_calls =====
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483649
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483649
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
 === Invoke BlobStorageConfig ===
 Domain: 1
 Request {

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
@@ -1,0 +1,305 @@
+dstool -e <endpoint> --mon-port <mon_port> --verbose cluster balance --only-from-overpopulated-pdisks --storage-pool=test-pool --max-iterations=1
+Exit Status: 0
+===== stdout =====
+
+Start balancing iteration 1
+Number of used slots -> number pdisks: 0=>1 9=>1
+Found 8 candidate vslots, 2 groups to reassign
+Checking to relocate vdisk from vslot (1, 1001, 1005) on pdisk (1, 1001) with slot usage 9, try_blocking=False
+Relocated vdisk from pdisk [1:1001] to pdisk [1:1002] with slot usages (9 -> 0)
+
+===== stderr =====
+INFO: using random hosts
+INFO: using random hosts
+
+===== grpc_calls =====
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483653
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483653
+      GroupGeneration: 1
+    }
+  }
+}
+
+===== http_calls =====
+GET viewer/json/vdiskinfo?... (mocked)
+GET viewer/json/vdiskinfo?... (mocked)
+
+===== mock_base_config =====
+
+TBaseConfig {
+PDisk {
+  NodeId: 1
+  PDiskId: 1001
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 1
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 1
+  }
+}
+PDisk {
+  NodeId: 1
+  PDiskId: 1002
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 1
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 1
+  }
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  GroupId: 2147483649
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1002
+  }
+  GroupId: 2147483650
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1003
+  }
+  GroupId: 2147483651
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1004
+  }
+  GroupId: 2147483652
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1005
+  }
+  GroupId: 2147483653
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1006
+  }
+  GroupId: 2147483654
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1007
+  }
+  GroupId: 2147483655
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1008
+  }
+  GroupId: 2147483656
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+Group {
+  GroupId: 2147483649
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  BoxId: 1
+  StoragePoolId: 1
+}
+Group {
+  GroupId: 2147483650
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1002
+  }
+  BoxId: 1
+  StoragePoolId: 1
+}
+Group {
+  GroupId: 2147483651
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1003
+  }
+  BoxId: 1
+  StoragePoolId: 1
+}
+Group {
+  GroupId: 2147483652
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1004
+  }
+  BoxId: 1
+  StoragePoolId: 1
+}
+Group {
+  GroupId: 2147483653
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1005
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483654
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1006
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Group {
+  GroupId: 2147483655
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1007
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Group {
+  GroupId: 2147483656
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1008
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Node {
+  NodeId: 1
+  HostKey {
+    Fqdn: "localhost"
+    IcPort: 19001
+  }
+}
+}
+
+DefineStoragePool {
+BoxId: 1
+StoragePoolId: 1
+Name: "test-pool"
+ErasureSpecies: "none"
+Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
@@ -1,0 +1,336 @@
+dstool -e <endpoint> --mon-port <mon_port> --verbose cluster balance --only-from-overpopulated-pdisks --storage-pool=test-pool --max-iterations=1
+Exit Status: 0
+===== stdout =====
+
+Start balancing iteration 1
+Number of used slots -> number pdisks: 0=>1 9=>1
+Found 9 candidate vslots, 2 groups to reassign
+Checking to relocate vdisk from vslot (1, 1001, 1005) on pdisk (1, 1001) with slot usage 9, try_blocking=False
+Relocated vdisk from pdisk [1:1001] to pdisk [1:1002] with slot usages (9 -> 0)
+
+===== stderr =====
+INFO: using random hosts
+INFO: using random hosts
+
+===== grpc_calls =====
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483653
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483653
+      GroupGeneration: 1
+    }
+  }
+}
+
+===== http_calls =====
+GET viewer/json/vdiskinfo?... (mocked)
+GET viewer/json/vdiskinfo?... (mocked)
+
+===== mock_base_config =====
+
+TBaseConfig {
+PDisk {
+  NodeId: 1
+  PDiskId: 1001
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 2
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 2
+  }
+}
+PDisk {
+  NodeId: 1
+  PDiskId: 1002
+  PDiskConfig {
+    ExpectedSlotCount: 8
+    SlotSizeInUnits: 2
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 8
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 8
+    SlotSizeInUnits: 2
+  }
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  GroupId: 2147483649
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1002
+  }
+  GroupId: 2147483650
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1003
+  }
+  GroupId: 2147483651
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1004
+  }
+  GroupId: 2147483652
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1005
+  }
+  GroupId: 2147483653
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1006
+  }
+  GroupId: 2147483654
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1007
+  }
+  GroupId: 2147483655
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1008
+  }
+  GroupId: 2147483656
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1009
+  }
+  GroupId: 2147483657
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+  }
+  Status: "READY"
+}
+Group {
+  GroupId: 2147483649
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483650
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1002
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483651
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1003
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483652
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1004
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483653
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1005
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Group {
+  GroupId: 2147483654
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1006
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483655
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1007
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483656
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1008
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Group {
+  GroupId: 2147483657
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1009
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 2
+}
+Node {
+  NodeId: 1
+  HostKey {
+    Fqdn: "localhost"
+    IcPort: 19001
+  }
+}
+}
+
+DefineStoragePool {
+BoxId: 1
+StoragePoolId: 1
+Name: "test-pool"
+ErasureSpecies: "none"
+Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -527,3 +527,39 @@ class Test(TestBase):
             builder.update_group(group_id=0x80000001, group_size_in_units=8) and None,
             _trace_cluster_balance('--only-from-overpopulated-pdisks', pending_reassigns={0x80000002: (1, 1002, 1000)}),
         ]
+
+    def test_cluster_balance_mismatching_size_in_units(self):
+        def make_builder(pu, vu_list):
+            builder = (
+                BaseConfigBuilder()
+                .add_node(node_id=1)
+                .add_pdisk(node_id=1, pdisk_id=1001, expected_slot_count=8, slot_size_in_units=pu)
+                .add_pdisk(node_id=1, pdisk_id=1002, expected_slot_count=8, slot_size_in_units=pu)
+                .add_storage_pool(name='test-pool', erasure_species='none', kind='hdd')
+            )
+            for i, vu in enumerate(vu_list):
+                group_id = 0x80000001 + i
+                vslot_id = 1001 + i
+                builder.add_group(group_id=group_id, vslot_ids=[(1, 1001, vslot_id)], group_size_in_units=vu)
+                builder.add_vslot(node_id=1, pdisk_id=1001, vslot_id=vslot_id, group_id=group_id, group_generation=1)
+            return builder
+
+        def _trace_cluster_balance(builder, pending_reassigns=None):
+            base_config = builder.build()
+            if pending_reassigns is None:
+                pending_reassigns = {}
+            fake_grpc_handler = FakeReassignGroupDiskHandler(pending_reassigns, base_config)
+            return self._trace('--verbose', 'cluster', 'balance', '--only-from-overpopulated-pdisks',
+                               '--storage-pool=test-pool', '--max-iterations=1',
+                               with_grpc_calls=True, allow_http_fetch=True,
+                               mock_base_config=base_config,
+                               fake_grpc_handler=fake_grpc_handler)
+
+        return [
+            _trace_cluster_balance(
+                builder=make_builder(1, [0, 0, 0, 0, 2, 1, 1, 1]),
+                pending_reassigns={0x80000005: (1, 1002, 1000)}),
+            _trace_cluster_balance(
+                builder=make_builder(2, [2, 2, 2, 2, 1, 2, 2, 2, 2]),
+                pending_reassigns={0x80000005: (1, 1002, 1000)}),
+        ]


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes `dstool cluster balance` to respect GroupSizeInUnits and PDisk.SlotSizeInUnits.

In all modes, VDisks whose GroupSizeInUnits does not match the PDisk SlotSizeInUnits are relocated first.