### PR TITLE
docs: mount custom config at default local-ydb path

### DIFF
--- a/ydb/docs/en/core/reference/docker/start.md
+++ b/ydb/docs/en/core/reference/docker/start.md
@@ -48,10 +48,11 @@ For more information about stopping and deleting a Docker container with {{ ydb-
 
 ### Overriding the configuration file
 
-By default, when starting a Docker container for {{ ydb-short-name }}, a built-in [configuration file](../configuration/index.md) is used, which provides standard operating parameters. To override the configuration file when starting the container, you can use the `--config-path` parameter, specifying the path to your configuration file, which has been pre-mounted in the container:
+By default, when starting a Docker container for {{ ydb-short-name }}, a built-in [configuration file](../configuration/index.md) is used, which provides standard operating parameters. To use your own config, mount it at `/ydb_data/cluster/kikimr_configs/config.yaml`:
 
 ```bash
-docker run "${docker_args[@]}" --config-path /path/to/your/config/file
+docker run "${docker_args[@]}" \
+  -v $(pwd)/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
 ```
 
 For users who are not experienced with Docker, it's important to understand how to properly mount a configuration file into the container. Below is a step-by-step example:
@@ -87,7 +88,7 @@ For users who are not experienced with Docker, it's important to understand how 
 
 4. Edit the copied configuration file `ydb_config/my-ydb-config.yaml` as needed.
 
-5. When running the container, use the `-v` flag to mount the directory with your configuration file into the container:
+5. When running the container, mount the edited configuration file at `/ydb_data/cluster/kikimr_configs/config.yaml`:
 
    ```bash
    docker_args=(
@@ -100,21 +101,15 @@ For users who are not experienced with Docker, it's important to understand how 
        -p 2136:2136
        -p 8765:8765
        -v $(pwd)/ydb_data:/ydb_data
-       -v $(pwd)/ydb_config:/ydb_config
        -v $(pwd)/ydb_certs:/ydb_certs
+       -v $(pwd)/ydb_config/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
        -e GRPC_TLS_PORT=2135
        -e GRPC_PORT=2136
        -e MON_PORT=8765
        {{ ydb_local_docker_image}}:{{ ydb_local_docker_image_tag }}
    )
    
-   docker run "${docker_args[@]}" --config-path /ydb_config/my-ydb-config.yaml
+   docker run "${docker_args[@]}"
    ```
 
-In this example:
-
- - `$(pwd)/ydb_config` - the local directory on your computer with the configuration file
- - `/ydb_config` - directory inside the container where your local directory will be mounted
- - `/ydb_config/my-ydb-config.yaml` - path to the configuration file inside the container
-
-This way, your local configuration file becomes accessible inside the container at the specified path.
+In this example, the local file `ydb_config/my-ydb-config.yaml` replaces the default configuration inside the container.

--- a/ydb/docs/en/core/reference/docker/start.md
+++ b/ydb/docs/en/core/reference/docker/start.md
@@ -52,7 +52,7 @@ By default, when starting a Docker container for {{ ydb-short-name }}, a built-i
 
 ```bash
 docker run "${docker_args[@]}" \
-  -v $(pwd)/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
+  -v $(pwd)/ydb_config/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
 ```
 
 For users who are not experienced with Docker, it's important to understand how to properly mount a configuration file into the container. Below is a step-by-step example:

--- a/ydb/docs/ru/core/reference/docker/start.md
+++ b/ydb/docs/ru/core/reference/docker/start.md
@@ -48,10 +48,11 @@ docker run "${docker_args[@]}"
 
 ### Переопределение файла конфигурации
 
-По умолчанию при запуске контейнера Docker для {{ ydb-short-name }} используется встроенный [файл конфигурации](../configuration/index.md), который обеспечивает стандартные параметры работы. Для переопределения файла конфигурации при запуске контейнера можно использовать аргумент `--config-path`, указав путь к своему файлу конфигурации, который предварительно примонтирован в контейнер:
+По умолчанию при запуске контейнера Docker для {{ ydb-short-name }} используется встроенный [файл конфигурации](../configuration/index.md), который обеспечивает стандартные параметры работы. Чтобы использовать свой конфиг, смонтируйте его в `/ydb_data/cluster/kikimr_configs/config.yaml`:
 
 ```bash
-docker run "${docker_args[@]}" --config-path /path/to/your/config/file
+docker run "${docker_args[@]}" \
+  -v $(pwd)/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
 ```
 
 Для пользователей, не имеющих опыта работы с Docker, важно понимать, как правильно монтировать файл конфигурации в контейнер. Ниже приведен пошаговый пример:
@@ -87,7 +88,7 @@ docker run "${docker_args[@]}" --config-path /path/to/your/config/file
 
 4. Отредактируйте скопированный файл конфигурации `ydb_config/my-ydb-config.yaml` по своему усмотрению.
 
-5. При запуске контейнера используйте флаг `-v` для монтирования директории с вашим файлом конфигурации в контейнер:
+5. При запуске контейнера смонтируйте отредактированный файл конфигурации в `/ydb_data/cluster/kikimr_configs/config.yaml`:
 
    ```bash
    docker_args=(
@@ -101,20 +102,14 @@ docker run "${docker_args[@]}" --config-path /path/to/your/config/file
        -p 8765:8765
        -v $(pwd)/ydb_certs:/ydb_certs
        -v $(pwd)/ydb_data:/ydb_data
-       -v $(pwd)/ydb_config:/ydb_config
+       -v $(pwd)/ydb_config/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
        -e GRPC_TLS_PORT=2135
        -e GRPC_PORT=2136
        -e MON_PORT=8765
        {{ ydb_local_docker_image}}:{{ ydb_local_docker_image_tag }}
    )
    
-   docker run "${docker_args[@]}" --config-path /ydb_config/my-ydb-config.yaml
+   docker run "${docker_args[@]}"
    ```
 
-В этом примере:
-
-- `$(pwd)/ydb_config` - локальная директория на вашем компьютере с файлом конфигурации
-- `/ydb_config` - директория внутри контейнера, куда будет смонтирована ваша локальная директория
-- `/ydb_config/my-ydb-config.yaml` - путь к файлу конфигурации внутри контейнера
-
-Таким образом, ваш локальный файл конфигурации становится доступным внутри контейнера по указанному пути.
+В этом примере локальный файл `ydb_config/my-ydb-config.yaml` подменяет конфигурацию по умолчанию внутри контейнера.

--- a/ydb/docs/ru/core/reference/docker/start.md
+++ b/ydb/docs/ru/core/reference/docker/start.md
@@ -52,7 +52,7 @@ docker run "${docker_args[@]}"
 
 ```bash
 docker run "${docker_args[@]}" \
-  -v $(pwd)/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
+  -v $(pwd)/ydb_config/my-ydb-config.yaml:/ydb_data/cluster/kikimr_configs/config.yaml
 ```
 
 Для пользователей, не имеющих опыта работы с Docker, важно понимать, как правильно монтировать файл конфигурации в контейнер. Ниже приведен пошаговый пример:


### PR DESCRIPTION
## Summary

Documentation-only follow-up for #42277.

Updates Docker `start.md` (ru/en): the supported way to override the local-ydb config is to bind-mount your file at `/ydb_data/cluster/kikimr_configs/config.yaml` instead of using `--config-path`.

## Depends on

- #42277 — code change must be merged and published in the Docker image before this documentation is accurate.

## Test plan

- [x] Merge #42277 and wait for nightly Docker image
- [x] Verify bind-mount at `/ydb_data/cluster/kikimr_configs/config.yaml` works as documented
- [x] Mark this PR ready for review and merge


Made with [Cursor](https://cursor.com)