### PR TITLE
viewer: remove check for static groups

### DIFF
--- a/ydb/core/viewer/viewer_cluster.h
+++ b/ydb/core/viewer/viewer_cluster.h
@@ -1012,9 +1012,6 @@ private:
             for (const NKikimrSysView::TGroupEntry& entry : GroupsResponse->Get()->Record.GetEntries()) {
                 const NKikimrSysView::TGroupKey& key = entry.GetKey();
                 const NKikimrSysView::TGroupInfo& info = entry.GetInfo();
-                if (TGroupID(key.GetGroupId()).ConfigurationType() == EGroupConfigurationType::Static) {
-                    continue; // ignore static groups
-                }
                 if (proxyGroups.count(key.GetGroupId())) {
                     continue; // ignore proxy groups
                 }


### PR DESCRIPTION
Removed the check for static groups in `TJsonCluster::ReplyAndPassAway`. This allows static groups to be included in the group info and status counts.