### PR TITLE
NBYDB-1732: uniform distribution of the recalculation ration  of SSTs

### DIFF
--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hullstorageratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hullstorageratio.h
@@ -127,14 +127,25 @@ namespace NKikimr {
         ////////////////////////////////////////////////////////////////////////////
         class TSstRatioThreadSafeHolder {
         public:
-            void Set(TSstRatioPtr ratio) {
-                TGuard<TSpinLock> g(Lock);
-                Ratio = ratio;
+            void Set(TSstRatioPtr ratio, TInstant calculationTime) {
+                {
+                    TGuard<TSpinLock> g(Lock);
+                    Ratio = ratio;
+                }
+                CalculationTime = calculationTime;
             }
 
             TSstRatioPtr Get() const {
                 TGuard<TSpinLock> g(Lock);
                 return Ratio;
+            }
+
+            void SetCalculationTime(TInstant calculationTime) {
+                CalculationTime = calculationTime;
+            }
+
+            TInstant GetCalculationTime() const {
+                return CalculationTime;
             }
 
             void OutputProto(NKikimrVDisk::StorageRatio* proto) const {
@@ -157,6 +168,7 @@ namespace NKikimr {
         private:
             TSpinLock Lock;
             TIntrusivePtr<TSstRatio> Ratio;
+            TInstant CalculationTime = TInstant::Zero();
         };
 
 

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
@@ -108,7 +108,16 @@ namespace NKikimr {
 
                 // calculate storage ratio, don't spend much time on it, skip ssts that are actualized
                 for (const auto &x : vec) {
-                    const TInstant time = x.LevelSstPtr.SstPtr->StorageRatio.GetTime();
+                    TInstant time = x.LevelSstPtr.SstPtr->StorageRatio.GetTime();
+                    if (time == TInstant::Zero()) {
+                        const ui64 jitterUs = calcPeriod.MicroSeconds() > 0
+                            ? RandomNumber<ui64>(calcPeriod.MicroSeconds())
+                            : 0;
+                        time = startTime - calcPeriod + TDuration::MicroSeconds(jitterUs);
+                        TSstRatioPtr placeholder = MakeIntrusive<TSstRatio>(time);
+                        x.LevelSstPtr.SstPtr->StorageRatio.Set(placeholder);
+                    }
+
                     if (startTime >= time + calcPeriod) {
                         TSstRatioPtr newRatio = CalculateSstRatio(x.LevelSstPtr.SstPtr, startTime);
                         x.LevelSstPtr.SstPtr->StorageRatio.Set(newRatio);

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
@@ -85,31 +85,54 @@ namespace NKikimr {
                 }
             };
 
-            static TDuration GetRecalculationDelay(const TLevelSstPtr &p, TDuration calcPeriod) {
+            static ui64 GetSstId(const TLevelSstPtr &p) {
+                return p.SstPtr->AssignedSstId ? p.SstPtr->AssignedSstId : p.SstPtr->VolatileOrderId;
+            }
+
+            static TDuration GetInitialRecalculationAge(const TLevelSstPtr &p, TDuration calcPeriod) {
                 const ui64 calcPeriodUs = calcPeriod.MicroSeconds();
                 if (!calcPeriodUs) {
                     return calcPeriod;
                 }
 
-                const ui64 sstId = p.SstPtr->AssignedSstId ? p.SstPtr->AssignedSstId : p.SstPtr->VolatileOrderId;
-                const ui64 jitterUs = IntHash(sstId) % calcPeriodUs;
-                return TDuration::MicroSeconds(calcPeriodUs / 2 + jitterUs);
+                return TDuration::MicroSeconds(IntHash(GetSstId(p)) % calcPeriodUs);
             }
 
-            static TInstant GetNextCalculationTime(const TLevelSstPtr &p, TDuration calcPeriod) {
-                const TInstant time = p.SstPtr->StorageRatio.GetTime();
-                return time == TInstant::Zero()
-                    ? time
-                    : time + GetRecalculationDelay(p, calcPeriod);
+            static TInstant GetInitialCalculationTime(const TLevelSstPtr &p, TInstant startTime, TDuration calcPeriod) {
+                const TInstant createTime = p.SstPtr->Info.CTime;
+                if (createTime != TInstant::Zero() && startTime < createTime + calcPeriod) {
+                    return createTime;
+                }
+
+                return startTime - GetInitialRecalculationAge(p, calcPeriod);
             }
 
-            void OrderSstByStorageRatioTime(TVector<TTimeSst> &vec, TDuration calcPeriod) {
+            static TInstant GetCalculationTime(const TLevelSstPtr &p, TInstant startTime, TDuration calcPeriod) {
+                TSstRatioPtr ratio = p.SstPtr->StorageRatio.Get();
+                if (!ratio) {
+                    return TInstant::Zero();
+                }
+
+                if (ratio->Time == TInstant::Zero()) {
+                    ratio = MakeIntrusive<TSstRatio>(*ratio);
+                    ratio->Time = GetInitialCalculationTime(p, startTime, calcPeriod);
+                    p.SstPtr->StorageRatio.Set(ratio);
+                }
+
+                return ratio->Time;
+            }
+
+            static TInstant GetNextCalculationTime(const TLevelSstPtr &p, TInstant startTime, TDuration calcPeriod) {
+                return GetCalculationTime(p, startTime, calcPeriod) + calcPeriod;
+            }
+
+            void OrderSstByStorageRatioTime(TVector<TTimeSst> &vec, TInstant startTime, TDuration calcPeriod) {
                 vec.clear();
                 TSstIterator it(&LevelSnap.SliceSnap);
                 it.SeekToFirst();
                 while (it.Valid()) {
                     TLevelSstPtr p = it.Get();
-                    vec.push_back(TTimeSst(GetNextCalculationTime(p, calcPeriod), p));
+                    vec.push_back(TTimeSst(GetNextCalculationTime(p, startTime, calcPeriod), p));
                     it.Next();
                 }
                 Sort(vec.begin(), vec.end());
@@ -122,7 +145,7 @@ namespace NKikimr {
                 // order all ssts (including level 0) by storage ratio calculation time
                 TVector<TTimeSst> vec;
                 vec.reserve(1000u);
-                OrderSstByStorageRatioTime(vec, calcPeriod);
+                OrderSstByStorageRatioTime(vec, startTime, calcPeriod);
 
                 // calculate storage ratio, don't spend much time on it, skip ssts that are actualized
                 for (const auto &x : vec) {

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
@@ -121,11 +121,10 @@ namespace NKikimr {
                 }
 
                 if (ratio->Time == TInstant::Zero()) {
-                    ratio = MakeIntrusive<TSstRatio>(*ratio);
-                    ratio->Time = initialCalculationTime;
+                    return TInstant::Zero();
                 }
 
-                p.SstPtr->StorageRatio.Set(ratio, ratio->Time);
+                p.SstPtr->StorageRatio.SetCalculationTime(ratio->Time);
                 return ratio->Time;
             }
 

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
@@ -90,12 +90,12 @@ namespace NKikimr {
             }
 
             static TDuration GetInitialRecalculationAge(const TLevelSstPtr &p, TDuration calcPeriod) {
-                const ui64 calcPeriodUs = calcPeriod.MicroSeconds();
-                if (!calcPeriodUs) {
+                const ui64 calcPeriodSeconds = calcPeriod.Seconds();
+                if (!calcPeriodSeconds) {
                     return calcPeriod;
                 }
 
-                return TDuration::MicroSeconds(IntHash(GetSstId(p)) % calcPeriodUs);
+                return TDuration::Seconds(IntHash(GetSstId(p)) % calcPeriodSeconds);
             }
 
             static TInstant GetInitialCalculationTime(const TLevelSstPtr &p, TInstant startTime, TDuration calcPeriod) {
@@ -108,17 +108,24 @@ namespace NKikimr {
             }
 
             static TInstant GetCalculationTime(const TLevelSstPtr &p, TInstant startTime, TDuration calcPeriod) {
+                TInstant calculationTime = p.SstPtr->StorageRatio.GetCalculationTime();
+                if (calculationTime != TInstant::Zero()) {
+                    return calculationTime;
+                }
+
                 TSstRatioPtr ratio = p.SstPtr->StorageRatio.Get();
+                const TInstant initialCalculationTime = GetInitialCalculationTime(p, startTime, calcPeriod);
                 if (!ratio) {
-                    return TInstant::Zero();
+                    p.SstPtr->StorageRatio.SetCalculationTime(initialCalculationTime);
+                    return initialCalculationTime;
                 }
 
                 if (ratio->Time == TInstant::Zero()) {
                     ratio = MakeIntrusive<TSstRatio>(*ratio);
-                    ratio->Time = GetInitialCalculationTime(p, startTime, calcPeriod);
-                    p.SstPtr->StorageRatio.Set(ratio);
+                    ratio->Time = initialCalculationTime;
                 }
 
+                p.SstPtr->StorageRatio.Set(ratio, ratio->Time);
                 return ratio->Time;
             }
 
@@ -151,7 +158,7 @@ namespace NKikimr {
                 for (const auto &x : vec) {
                     if (startTime >= x.NextCalculationTime) {
                         TSstRatioPtr newRatio = CalculateSstRatio(x.LevelSstPtr.SstPtr, startTime);
-                        x.LevelSstPtr.SstPtr->StorageRatio.Set(newRatio);
+                        x.LevelSstPtr.SstPtr->StorageRatio.Set(newRatio, newRatio->Time);
                         stat.SstsChecked++;
                     } else {
                         stat.BreakedActualRatio = true;

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_ratio.h
@@ -4,6 +4,7 @@
 #include "hulldb_compstrat_defs.h"
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullmergeits.h>
+#include <util/digest/numeric.h>
 
 namespace NKikimr {
     namespace NHullComp {
@@ -71,27 +72,44 @@ namespace NKikimr {
             };
 
             struct TTimeSst {
-                ui64 Seconds;
+                TInstant NextCalculationTime;
                 TLevelSstPtr LevelSstPtr;
 
-                TTimeSst(ui64 seconds, const TLevelSstPtr &p)
-                    : Seconds(seconds)
+                TTimeSst(TInstant nextCalculationTime, const TLevelSstPtr &p)
+                    : NextCalculationTime(nextCalculationTime)
                     , LevelSstPtr(p)
                 {}
 
                 bool operator < (const TTimeSst &s) const {
-                    return Seconds < s.Seconds;
+                    return NextCalculationTime < s.NextCalculationTime;
                 }
             };
 
-            void OrderSstByStorageRatioTime(TVector<TTimeSst> &vec) {
+            static TDuration GetRecalculationDelay(const TLevelSstPtr &p, TDuration calcPeriod) {
+                const ui64 calcPeriodUs = calcPeriod.MicroSeconds();
+                if (!calcPeriodUs) {
+                    return calcPeriod;
+                }
+
+                const ui64 sstId = p.SstPtr->AssignedSstId ? p.SstPtr->AssignedSstId : p.SstPtr->VolatileOrderId;
+                const ui64 jitterUs = IntHash(sstId) % calcPeriodUs;
+                return TDuration::MicroSeconds(calcPeriodUs / 2 + jitterUs);
+            }
+
+            static TInstant GetNextCalculationTime(const TLevelSstPtr &p, TDuration calcPeriod) {
+                const TInstant time = p.SstPtr->StorageRatio.GetTime();
+                return time == TInstant::Zero()
+                    ? time
+                    : time + GetRecalculationDelay(p, calcPeriod);
+            }
+
+            void OrderSstByStorageRatioTime(TVector<TTimeSst> &vec, TDuration calcPeriod) {
                 vec.clear();
                 TSstIterator it(&LevelSnap.SliceSnap);
                 it.SeekToFirst();
                 while (it.Valid()) {
                     TLevelSstPtr p = it.Get();
-                    ui64 seconds = p.SstPtr->StorageRatio.GetTime().Seconds();
-                    vec.push_back(TTimeSst(seconds, p));
+                    vec.push_back(TTimeSst(GetNextCalculationTime(p, calcPeriod), p));
                     it.Next();
                 }
                 Sort(vec.begin(), vec.end());
@@ -104,21 +122,11 @@ namespace NKikimr {
                 // order all ssts (including level 0) by storage ratio calculation time
                 TVector<TTimeSst> vec;
                 vec.reserve(1000u);
-                OrderSstByStorageRatioTime(vec);
+                OrderSstByStorageRatioTime(vec, calcPeriod);
 
                 // calculate storage ratio, don't spend much time on it, skip ssts that are actualized
                 for (const auto &x : vec) {
-                    TInstant time = x.LevelSstPtr.SstPtr->StorageRatio.GetTime();
-                    if (time == TInstant::Zero()) {
-                        const ui64 jitterUs = calcPeriod.MicroSeconds() > 0
-                            ? RandomNumber<ui64>(calcPeriod.MicroSeconds())
-                            : 0;
-                        time = startTime - calcPeriod + TDuration::MicroSeconds(jitterUs);
-                        TSstRatioPtr placeholder = MakeIntrusive<TSstRatio>(time);
-                        x.LevelSstPtr.SstPtr->StorageRatio.Set(placeholder);
-                    }
-
-                    if (startTime >= time + calcPeriod) {
+                    if (startTime >= x.NextCalculationTime) {
                         TSstRatioPtr newRatio = CalculateSstRatio(x.LevelSstPtr.SstPtr, startTime);
                         x.LevelSstPtr.SstPtr->StorageRatio.Set(newRatio);
                         stat.SstsChecked++;

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwriteindexsst.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwriteindexsst.h
@@ -60,12 +60,12 @@ protected:
 
         LevelSegment->AssignedSstId = SstId;
 
-        auto ratio = MakeIntrusive<NHullComp::TSstRatio>();
+        auto ratio = MakeIntrusive<NHullComp::TSstRatio>(info.CTime);
         ratio->IndexItemsTotal = ratio->IndexItemsKeep = info.Items;
         ratio->IndexBytesTotal = ratio->IndexBytesKeep = info.IdxTotalSize;
         ratio->InplacedDataTotal = ratio->InplacedDataKeep = 0;
         ratio->HugeDataTotal = ratio->HugeDataKeep = 0;
-        LevelSegment->StorageRatio.Set(ratio);
+        LevelSegment->StorageRatio.Set(ratio, info.CTime);
 
         TIdxDiskPlaceHolder placeHolder(SstId);
         placeHolder.Info = info;

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwriteindexsst.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwriteindexsst.h
@@ -60,12 +60,12 @@ protected:
 
         LevelSegment->AssignedSstId = SstId;
 
-        auto ratio = MakeIntrusive<NHullComp::TSstRatio>(info.CTime);
+        auto ratio = MakeIntrusive<NHullComp::TSstRatio>();
         ratio->IndexItemsTotal = ratio->IndexItemsKeep = info.Items;
         ratio->IndexBytesTotal = ratio->IndexBytesKeep = info.IdxTotalSize;
         ratio->InplacedDataTotal = ratio->InplacedDataKeep = 0;
         ratio->HugeDataTotal = ratio->HugeDataKeep = 0;
-        LevelSegment->StorageRatio.Set(ratio, info.CTime);
+        LevelSegment->StorageRatio.Set(ratio, TInstant::Zero());
 
         TIdxDiskPlaceHolder placeHolder(SstId);
         placeHolder.Info = info;

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
@@ -676,12 +676,12 @@ namespace NKikimr {
             LevelSegment->AssignedSstId = SstId;
 
             // fill in storage ratio
-            auto ratio = MakeIntrusive<NHullComp::TSstRatio>();
+            auto ratio = MakeIntrusive<NHullComp::TSstRatio>(info.CTime);
             ratio->IndexItemsTotal = ratio->IndexItemsKeep = info.Items;
             ratio->IndexBytesTotal = ratio->IndexBytesKeep = info.IdxTotalSize;
             ratio->InplacedDataTotal = ratio->InplacedDataKeep = info.InplaceDataTotalSize;
             ratio->HugeDataTotal = ratio->HugeDataKeep = info.HugeDataTotalSize;
-            LevelSegment->StorageRatio.Set(ratio);
+            LevelSegment->StorageRatio.Set(ratio, info.CTime);
 
             // write out place holder
             TIdxDiskPlaceHolder placeHolder(SstId);

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst.h
@@ -676,12 +676,12 @@ namespace NKikimr {
             LevelSegment->AssignedSstId = SstId;
 
             // fill in storage ratio
-            auto ratio = MakeIntrusive<NHullComp::TSstRatio>(info.CTime);
+            auto ratio = MakeIntrusive<NHullComp::TSstRatio>();
             ratio->IndexItemsTotal = ratio->IndexItemsKeep = info.Items;
             ratio->IndexBytesTotal = ratio->IndexBytesKeep = info.IdxTotalSize;
             ratio->InplacedDataTotal = ratio->InplacedDataKeep = info.InplaceDataTotalSize;
             ratio->HugeDataTotal = ratio->HugeDataKeep = info.HugeDataTotalSize;
-            LevelSegment->StorageRatio.Set(ratio, info.CTime);
+            LevelSegment->StorageRatio.Set(ratio, TInstant::Zero());
 
             // write out place holder
             TIdxDiskPlaceHolder placeHolder(SstId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

uniform distribution of the recalculation ration of SSTs' ratio
it is necessary to prevent a one-time recalculation of SSTs' ratio and spikes in the CPU consumption

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
