### PR TITLE
kqp/ut/federated_query/datastreams: fix Auth=IAM test flakyness

### DIFF
--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1453,6 +1453,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         {
             NYdb::TDriver driver(
                 NYdb::TDriverConfig()
+                    .SetDiscoveryMode(NYdb::EDiscoveryMode::Async)
                     .SetEndpoint(location)
                     .SetDatabase(databasePath)
             );

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1458,8 +1458,15 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
                     .SetDatabase(databasePath)
             );
             NYdb::NTopic::TTopicClient topicClient(driver);
-            auto result = topicClient.CreateTopic(topicName).GetValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            WaitFor(TEST_OPERATION_TIMEOUT, "CreateTopic", [&](TString& error) {
+                auto result = topicClient.CreateTopic(topicName).GetValueSync();
+                if (result.IsSuccess()) {
+                   return true;
+                }
+                error = result.GetIssues().ToString();
+                UNIT_ASSERT_STRING_CONTAINS(error, "Database nodes resolve failed with no certain result");
+                return false;
+            });
             driver.Stop(true);
         }
 


### PR DESCRIPTION
Closes: #42219 

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Локально воспроизвести сложно, "на удачу" уменьшаю расхождение настроек с прочим кодом
