### PR TITLE
viewer: add storage stats tablet debug options

### DIFF
--- a/ydb/core/viewer/viewer_storage_stats.h
+++ b/ydb/core/viewer/viewer_storage_stats.h
@@ -611,6 +611,17 @@ public:
         }
     }
 
+    void HandleHiveError(TTabletId hiveId, const TString& error) {
+        auto it = HiveInfoResponse.find(hiveId);
+        if (it != HiveInfoResponse.end()) {
+            if (it->second.Error(error)) {
+                RequestDone();
+            }
+        } else {
+            AddEvent("Unknown Hive request error");
+        }
+    }
+
     void Handle(TEvents::TEvUndelivered::TPtr& ev) {
         static const TString error = "Undelivered";
         AddProblem("data-incomplete");
@@ -624,6 +635,11 @@ public:
                 } else {
                     AddEvent("Unknown TEvUndelivered VDisk request");
                 }
+                break;
+            }
+            case TEvHive::EvRequestHiveInfo: {
+                TTabletId hiveId = ev->Cookie;
+                HandleHiveError(hiveId, error);
                 break;
             }
             case TEvWhiteboard::EvTabletStateRequest:

--- a/ydb/core/viewer/viewer_storage_stats.h
+++ b/ydb/core/viewer/viewer_storage_stats.h
@@ -58,6 +58,7 @@ class TJsonStorageStats : public TViewerPipeClient {
     TSubDomainKey SubDomainKey;
     std::vector<TString> Paths;
     EGroupBy GroupBy = EGroupBy::Path;
+    bool UseHiveTablets = false;
     std::unordered_set<TString> StoragePoolNames;
     NKikimrSysView::TStoragePoolEntry StaticStoragePool;
     std::unordered_map<TStoragePoolId, const NKikimrSysView::TStoragePoolEntry&> StoragePools;
@@ -66,6 +67,7 @@ class TJsonStorageStats : public TViewerPipeClient {
     TRequestResponse<TEvSysView::TEvGetGroupsResponse> GroupsResponse;
     TRequestResponse<TEvSysView::TEvGetStoragePoolsResponse> PoolsResponse;
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvTabletStateResponse>> TabletStateResponse;
+    std::unordered_map<TTabletId, TRequestResponse<TEvHive::TEvResponseHiveInfo>> HiveInfoResponse;
     std::unordered_map<TString, TRequestResponse<TEvSchemeShard::TEvDescribeSchemeResult>> SchemeShardResult;
     std::unordered_map<TGroupId, std::vector<TActorId>> GroupToVDiskActorId;
     std::unordered_map<TNodeId, std::vector<TActorId>> NodeToVDiskActorId;
@@ -171,6 +173,7 @@ public:
                 return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Invalid group_by value"));
             }
         }
+        UseHiveTablets = FromStringWithDefault<bool>(Params.Get("use_hive_tablets"), false);
         if (Paths.empty() && GroupBy == EGroupBy::Path) {
             return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "No path specified"));
         }
@@ -205,10 +208,43 @@ public:
             RequestSchemeShard(MakeFullPath(path));
         }
         if (Paths.empty() && GroupBy == EGroupBy::TabletType) {
-            RequestTabletInfo();
+            if (UseHiveTablets) {
+                RequestHiveTabletInfo();
+            } else {
+                RequestTabletInfo();
+            }
         }
         ProcessResponses(); // for cached responses
         Become(&TThis::StateRequestedDescribe, Timeout, new TEvents::TEvWakeup());
+    }
+
+    void RequestHiveTabletInfo() {
+        std::vector<TTabletId> hiveIds;
+        if (AppData()->DomainsInfo) {
+            TTabletId rootHiveId = AppData()->DomainsInfo->GetHive();
+            if (rootHiveId) {
+                hiveIds.push_back(rootHiveId);
+            }
+        }
+        if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {
+            const auto& resultSet = DatabaseNavigateResponse->Get()->Request->ResultSet;
+            if (!resultSet.empty()) {
+                const auto& entry = resultSet.front();
+                if (entry.DomainInfo && entry.DomainInfo->Params.HasHive()) {
+                    hiveIds.push_back(entry.DomainInfo->Params.GetHive());
+                }
+            }
+        }
+        std::ranges::sort(hiveIds);
+        auto duplicates = std::ranges::unique(hiveIds);
+        hiveIds.erase(duplicates.begin(), duplicates.end());
+        for (TTabletId hiveId : hiveIds) {
+            auto request = std::make_unique<TEvHive::TEvRequestHiveInfo>();
+            if (SubDomainKey) {
+                request->Record.MutableFilterTabletsByObjectDomain()->CopyFrom(SubDomainKey);
+            }
+            HiveInfoResponse.emplace(hiveId, MakeRequestToTablet<TEvHive::TEvResponseHiveInfo>(hiveId, request.release(), hiveId));
+        }
     }
 
     void RequestTabletInfo() {
@@ -434,6 +470,14 @@ public:
         }
     }
 
+    void ProcessHiveInfo(const TEvHive::TEvResponseHiveInfo& hiveInfo) {
+        for (const auto& tabletInfo : hiveInfo.Record.GetTablets()) {
+            TTabletId tabletId = tabletInfo.GetTabletID();
+            auto& tabletStorageInfo = TabletStorageInfo[tabletId];
+            tabletStorageInfo.Type = tabletInfo.GetTabletType();
+        }
+    }
+
     void ProcessVDiskResponse(size_t requestIndex) {
         const auto& vDiskInfo(VDiskRequests[requestIndex]);
         for (const auto& record : vDiskInfo.VDiskRequest->Record.stat().tablets()) {
@@ -454,6 +498,7 @@ public:
             hFunc(TEvSysView::TEvGetStoragePoolsResponse, Handle);
             hFunc(TEvGetLogoBlobIndexStatResponse, Handle);
             hFunc(TEvWhiteboard::TEvTabletStateResponse, Handle);
+            hFunc(TEvHive::TEvResponseHiveInfo, Handle);
             hFunc(TEvents::TEvUndelivered, Handle);
             hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
             hFunc(TEvSchemeShard::TEvDescribeSchemeResult, Handle);
@@ -501,6 +546,18 @@ public:
             }
         } else {
             AddEvent("Unknown TEvGetLogoBlobIndexStatResponse");
+        }
+    }
+
+    void Handle(TEvHive::TEvResponseHiveInfo::TPtr& ev) {
+        auto it = HiveInfoResponse.find(ev->Cookie);
+        if (it != HiveInfoResponse.end()) {
+            if (it->second.Set(std::move(ev))) {
+                ProcessHiveInfo(it->second.GetRef());
+                RequestDone();
+            }
+        } else {
+            AddEvent("Unknown TEvResponseHiveInfo");
         }
     }
 
@@ -590,6 +647,7 @@ public:
         bool returnGroups = FromStringWithDefault<bool>(Params.Get("groups"), returnEverything);
         bool returnTablets = FromStringWithDefault<bool>(Params.Get("tablets"), returnEverything);
         bool returnMedia = FromStringWithDefault<bool>(Params.Get("media"), returnEverything);
+        bool debug = FromStringWithDefault<bool>(Params.Get("debug"), false);
         NJson::TJsonValue json;
         if (!Problems.empty()) {
             NJson::TJsonValue& jsonProblems(json["Problems"]);
@@ -604,11 +662,15 @@ public:
                 jsonTablets.SetType(NJson::JSON_ARRAY);
             }
             std::map<TTabletTypes::EType, TTabletStorageInfo> tabletTypeAccumulated;
+            std::map<TTabletTypes::EType, std::vector<TTabletId>> tabletIdsByType;
             for (const auto& [tabletId, tabletStorageInfo] : TabletStorageInfo) {
                 auto& typeAccumulated = tabletTypeAccumulated[tabletStorageInfo.Type];
                 typeAccumulated.TabletCount += 1;
                 typeAccumulated.DataSize += tabletStorageInfo.DataSize;
                 typeAccumulated.IndexSize += tabletStorageInfo.IndexSize;
+                if (debug) {
+                    tabletIdsByType[tabletStorageInfo.Type].push_back(tabletId);
+                }
                 for (const auto& [groupId, groupStorageInfo] : tabletStorageInfo.Groups) {
                     typeAccumulated.Groups[groupId].StorageSize += groupStorageInfo.StorageSize;
                     typeAccumulated.Groups[groupId].StorageCount += groupStorageInfo.StorageCount;
@@ -653,6 +715,15 @@ public:
                 jsonTablet["StorageCount"] = tabletStorageCount;
                 if (tabletStorageInfo.TabletCount) {
                     jsonTablet["TabletCount"] = tabletStorageInfo.TabletCount;
+                }
+                if (debug) {
+                    NJson::TJsonValue& jsonTabletIds(jsonTablet["TabletIds"]);
+                    jsonTabletIds.SetType(NJson::JSON_ARRAY);
+                    auto& tabletIds = tabletIdsByType[tabletType];
+                    std::ranges::sort(tabletIds);
+                    for (TTabletId tabletId : tabletIds) {
+                        jsonTabletIds.AppendValue(TStringBuilder() << tabletId);
+                    }
                 }
                 NJson::TJsonValue& jsonMedia(jsonTablet["Media"]);
                 if (returnMedia) {
@@ -802,6 +873,16 @@ public:
         yaml.AddParameter({
             .Name = "media",
             .Description = "return media kind info",
+            .Type = "boolean",
+        });
+        yaml.AddParameter({
+            .Name = "use_hive_tablets",
+            .Description = "use Hive instead of whiteboard to collect tablets",
+            .Type = "boolean",
+        });
+        yaml.AddParameter({
+            .Name = "debug",
+            .Description = "return tablet ids for group_by=tablet_type",
             .Type = "boolean",
         });
         return yaml;


### PR DESCRIPTION
Adds storage stats options for tablet type grouping:

- `use_hive_tablets=true` collects tablet ids and types from Hive (`TEvRequestHiveInfo`) instead of whiteboard when grouping by `tablet_type` without paths.
- `debug=true` adds `TabletIds` to each tablet type aggregate.
- Documents both parameters in the handler Swagger metadata.

Validation:
- `./ya make --build relwithdebinfo ydb/core/viewer`