### PR TITLE
Fix flaky kernel liveness test wait

### DIFF
--- a/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
@@ -264,14 +264,12 @@ Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
         const TActorId sender21Id = cluster.RegisterActor(sender21, 1);
 
         WaitForCondition(TDuration::Seconds(20), [&] {
-            // NodeConnected notifications can briefly flap around reconnect races.
-            // Require that each sender has observed at least one connect and the current
-            // interconnect sockets are established on both directions.
-            return sender12->GetConnects() > 0 &&
-                sender21->GetConnects() > 0 &&
-                TryGetSessionSocketFd(cluster, 1, 2) >= 0 &&
+            // NodeConnected notifications can briefly flap around simultaneous handshake races.
+            // The flood itself does not depend on these subscriptions, so wait for the actual
+            // interconnect sockets that will be blackholed below.
+            return TryGetSessionSocketFd(cluster, 1, 2) >= 0 &&
                 TryGetSessionSocketFd(cluster, 2, 1) >= 0;
-        }, "senders connected to peer");
+        }, "interconnect sockets connected to peer");
 
         UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), 1ULL);
         UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

More reliable way to wait connections to start test

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
