### PR TITLE
[Backport stable-26-1-1] PR #40095: rewind committed offset in mirrorer if no data was read due to a read-from-timestamp cutoff

### DIFF
--- a/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
+++ b/ydb/core/persqueue/common/proxy/actor_persqueue_client_iface.h
@@ -57,6 +57,13 @@ public:
         std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory
     ) const = 0;
 
+    virtual NThreading::TFuture<NYdb::TStatus> CommitOffset(
+        const NKikimrPQ::TMirrorPartitionConfig& config,
+        std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory,
+        ui32 partition,
+        ui64 offset
+    ) const = 0;
+
     virtual ~IPersQueueMirrorReaderFactory() = default;
 
     TDeferredActorLogBackend::TSharedAtomicActorSystemPtr GetSharedActorSystem() const {
@@ -89,6 +96,18 @@ protected:
         }
     }
 
+    NYdb::NTopic::TTopicClient GetTopicClient(const NKikimrPQ::TMirrorPartitionConfig& config, std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory) const {
+        NYdb::NTopic::TTopicClientSettings clientSettings = NYdb::NTopic::TTopicClientSettings()
+            .DiscoveryEndpoint(TStringBuilder() << config.GetEndpoint() << ":" << config.GetEndpointPort())
+            .DiscoveryMode(NYdb::EDiscoveryMode::Async)
+            .CredentialsProviderFactory(std::move(credentialsProviderFactory))
+            .SslCredentials(NYdb::TSslCredentials(config.GetUseSecureConnection()));
+        if (config.HasDatabase()) {
+            clientSettings.Database(config.GetDatabase());
+        }
+        return NYdb::NTopic::TTopicClient(*Driver, clientSettings);
+    }
+
 public:
     std::shared_ptr<NYdb::NTopic::IReadSession> GetReadSession(
         const NKikimrPQ::TMirrorPartitionConfig& config,
@@ -97,15 +116,6 @@ public:
         ui64 maxMemoryUsageBytes,
         TMaybe<TLog> logger = Nothing()
     ) const override {
-        NYdb::NTopic::TTopicClientSettings clientSettings = NYdb::NTopic::TTopicClientSettings()
-            .DiscoveryEndpoint(TStringBuilder() << config.GetEndpoint() << ":" << config.GetEndpointPort())
-            .DiscoveryMode(NYdb::EDiscoveryMode::Async)
-            .CredentialsProviderFactory(credentialsProviderFactory)
-            .SslCredentials(NYdb::TSslCredentials(config.GetUseSecureConnection()));
-        if (config.HasDatabase()) {
-            clientSettings.Database(config.GetDatabase());
-        }
-
         NYdb::NTopic::TReadSessionSettings settings = NYdb::NTopic::TReadSessionSettings()
             .ConsumerName(config.GetConsumer())
             .MaxMemoryUsageBytes(maxMemoryUsageBytes)
@@ -122,7 +132,7 @@ public:
         topicSettings.AppendPartitionIds({partition});
         settings.AppendTopics(topicSettings);
 
-        NYdb::NTopic::TTopicClient topicClient(*Driver, clientSettings);
+        NYdb::NTopic::TTopicClient topicClient = GetTopicClient(config, std::move(credentialsProviderFactory));
         return topicClient.CreateReadSession(settings);
     }
 
@@ -130,16 +140,18 @@ public:
         const NKikimrPQ::TMirrorPartitionConfig& config,
         std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory
     ) const override {
-        NYdb::NTopic::TTopicClientSettings clientSettings = NYdb::NTopic::TTopicClientSettings()
-            .DiscoveryEndpoint(TStringBuilder() << config.GetEndpoint() << ":" << config.GetEndpointPort())
-            .DiscoveryMode(NYdb::EDiscoveryMode::Async)
-            .CredentialsProviderFactory(credentialsProviderFactory)
-            .SslCredentials(NYdb::TSslCredentials(config.GetUseSecureConnection()));
-        if (config.HasDatabase()) {
-            clientSettings.Database(config.GetDatabase());
-        }
-        NYdb::NTopic::TTopicClient topicClient(*Driver, clientSettings);
+        NYdb::NTopic::TTopicClient topicClient = GetTopicClient(config, std::move(credentialsProviderFactory));
         return topicClient.DescribeTopic(config.GetTopic());
+    }
+
+    NThreading::TFuture<NYdb::TStatus> CommitOffset(
+        const NKikimrPQ::TMirrorPartitionConfig& config,
+        std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory,
+        ui32 partition,
+        ui64 offset
+    ) const override {
+        NYdb::NTopic::TTopicClient topicClient = GetTopicClient(config, std::move(credentialsProviderFactory));
+        return topicClient.CommitOffset(config.GetTopic(), partition, config.GetConsumer(), offset);
     }
 };
 

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -227,6 +227,10 @@ struct TEvPQ {
         EvMLPPurgeResponse,
         EvMLPConsumerStatus,
         EvUpdateReadMetrics,
+        EvMLPUpdateExternalLockedMessageGroupsId,
+        EvMLPGetRuntimeAttributesRequest,
+        EvMLPGetRuntimeAttributesResponse,
+        EvRewindCommitResult,
         EvEnd,
     };
 
@@ -1729,6 +1733,15 @@ struct TEvPQ {
             Record.SetMessages(messages);
             Record.SetUseForReading(useForReading);
         }
+    };
+
+    struct TEvRewindCommitResult: public TEventLocal<TEvRewindCommitResult, EvRewindCommitResult> {
+        explicit TEvRewindCommitResult(NYdb::TStatus status)
+            : Status(std::move(status))
+        {
+        }
+
+        NYdb::TStatus Status;
     };
 };
 

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -21,6 +21,9 @@ constexpr NKikimrServices::TActivity::EType TMirrorer::ActorActivityType() {
     return NKikimrServices::TActivity::PERSQUEUE_MIRRORER;
 }
 
+static constexpr TDuration DEFAULT_REWIND_COMMIT_OFFSET_DELAY = TDuration::Minutes(15);
+static constexpr TDuration REWIND_COMMIT_INTERVAL = TDuration::Minutes(4);
+
 TMirrorer::TMirrorer(
     ui64 tabletId,
     TActorId tabletActor,
@@ -564,7 +567,7 @@ void TMirrorer::ScheduleConsumerCreation(const TActorContext& ctx) {
 
     Become(&TThis::StateInitConsumer);
 
-    LOG_N(GetLogPrefix() << " schedule consumer creation");
+    LOG_N("schedule consumer creation");
     ScheduleWithIncreasingTimeout<TEvPQ::TEvCreateConsumer>(SelfId(), ConsumerInitInterval, CONSUMER_INIT_INTERVAL_MAX, ctx);
 }
 
@@ -681,7 +684,7 @@ void TMirrorer::DoProcessNextReaderEvent(const TActorContext& ctx, bool wakeup) 
             && PartitionStream->GetPartitionSessionId() == streamStatus->GetPartitionSession()->GetPartitionSessionId()
         ) {
             StreamStatus = MakeHolder<TPersQueueReadEvent::TPartitionSessionStatusEvent>(*streamStatus);
-
+            TryRewindCommittedOffset(ctx);
             ctx.Schedule(TDuration::Seconds(1), new TEvPQ::TEvRequestPartitionStatus);
             TryUpdateWriteTimetsamp(ctx);
         }
@@ -706,6 +709,58 @@ void TMirrorer::DoProcessNextReaderEvent(const TActorContext& ctx, bool wakeup) 
 
     Send(SelfId(), new TEvents::TEvWakeup());
     ConsumerInitInterval = CONSUMER_INIT_INTERVAL_START;
+}
+
+static TDuration GetRewindCommitDelay(const TActorContext& ctx) {
+    const auto& mirrorConfig = AppData(ctx)->PQConfig.GetMirrorConfig();
+    if (!mirrorConfig.HasRewindCommitDelaySeconds()) {
+        return DEFAULT_REWIND_COMMIT_OFFSET_DELAY;
+    }
+    return TDuration::Seconds(mirrorConfig.GetRewindCommitDelaySeconds());
+}
+
+bool TMirrorer::TryRewindCommittedOffset(const TActorContext& ctx) {
+    LOG_T("TryRewindCommittedOffset " << LabeledOutput(OffsetToRead, StreamStatus->GetCommittedOffset(),  StreamStatus->GetReadOffset(), StreamStatus->GetEndOffset(), (ctx.Now() - LastInitStageTimestamp).Seconds(), (ctx.Now() - LastRewindCommitTimestamp).Seconds()));
+    if (!(OffsetToRead == 0 /* never seen any data */
+        && StreamStatus->GetCommittedOffset() < StreamStatus->GetEndOffset()
+        && StreamStatus->GetCommittedOffset() == 0 /* new mirror rule */
+        && StreamStatus->GetReadOffset() == StreamStatus->GetEndOffset())) {
+        return false;
+    }
+    const auto now = ctx.Now();
+    if (now - LastInitStageTimestamp <= GetRewindCommitDelay(ctx)) {
+        return false;
+    }
+    if (now - LastRewindCommitTimestamp <= REWIND_COMMIT_INTERVAL) {
+        return false;
+    }
+    LastRewindCommitTimestamp = now;
+    LOG_I("topic contains only old messages. Rewinding committed offset forward" << " from " << StreamStatus->GetCommittedOffset() << " to " << StreamStatus->GetEndOffset());
+    auto* factory = AppData(ctx)->PersQueueMirrorReaderFactory;
+    PQ_ENSURE(factory);
+    auto future = factory->CommitOffset(Config, CredentialsProvider, Partition, StreamStatus->GetEndOffset());
+    future.Subscribe(
+        [actorSystem = ctx.ActorSystem(), selfId = SelfId()](const NThreading::TFuture<NYdb::TStatus>& result) {
+            NYdb::TStatus status{NYdb::EStatus::SUCCESS, {}};
+            try {
+                status = result.GetValue();
+            } catch (...) {
+                TString error = CurrentExceptionMessage();
+                status = NYdb::TStatus{NYdb::EStatus::INTERNAL_ERROR, NYdb::NIssue::TIssues({NYdb::NIssue::TIssue(std::move(error)),})};
+            }
+            actorSystem->Send(new NActors::IEventHandle(selfId, selfId, new TEvPQ::TEvRewindCommitResult(std::move(status))));
+        }
+    );
+    return true;
+}
+
+void TMirrorer::HandleRewindCommit(TEvPQ::TEvRewindCommitResult::TPtr& ev, const TActorContext& ctx) {
+    LOG_I("Rewind committed offset result: " << ev->Get()->Status);
+    if (!ev->Get()->Status.IsSuccess()) {
+        ProcessError(ctx, TStringBuilder() << "failed to rewind committed offset: " << ev->Get()->Status);
+        return;
+    }
+    ScheduleConsumerCreation(ctx);
 }
 
 NActors::IActor* CreateMirrorer(const ui64 tabletId,

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.h
@@ -55,6 +55,7 @@ private:
             HFuncTraced(TEvPQ::TEvRetryWrite, HandleRetryWrite);
             HFuncTraced(TEvPersQueue::TEvResponse, Handle);
             HFuncTraced(TEvPQ::TEvUpdateCounters, Handle);
+            HFuncTraced(TEvPQ::TEvRewindCommitResult, HandleRewindCommit);
             HFuncTraced(TEvents::TEvPoisonPill, Handle);
         default:
             break;
@@ -74,6 +75,7 @@ private:
             HFuncTraced(TEvPersQueue::TEvResponse, Handle);
             HFuncTraced(TEvPQ::TEvUpdateCounters, Handle);
             HFuncTraced(TEvPQ::TEvReaderEventArrived, ProcessNextReaderEvent);
+            HFuncTraced(TEvPQ::TEvRewindCommitResult, HandleRewindCommit);
             HFuncTraced(TEvents::TEvPoisonPill, Handle);
         default:
             break;
@@ -106,6 +108,8 @@ private:
     void ProcessNextReaderEvent(TEvPQ::TEvReaderEventArrived::TPtr& ev, const TActorContext& ctx);
     void DoProcessNextReaderEvent(const TActorContext& ctx, bool wakeup=false);
 
+    bool TryRewindCommittedOffset(const TActorContext& ctx);
+
     TString BuildLogPrefix() const override;
 
     TString GetCurrentState() const;
@@ -136,6 +140,7 @@ public:
     void HandleRetryWrite(TEvPQ::TEvRetryWrite::TPtr& ev, const TActorContext& ctx);
     void HandleWakeup(const TActorContext& ctx);
     void CreateConsumer(TEvPQ::TEvCreateConsumer::TPtr& ev, const TActorContext& ctx);
+    void HandleRewindCommit(TEvPQ::TEvRewindCommitResult::TPtr& ev, const TActorContext& ctx);
     void RequestSourcePartitionStatus(TEvPQ::TEvRequestPartitionStatus::TPtr& ev, const TActorContext& ctx);
     void RequestSourcePartitionStatus();
     void TryUpdateWriteTimetsamp(const TActorContext &ctx);
@@ -160,6 +165,7 @@ private:
     std::optional<NYdb::NTopic::TReadSessionEvent::TEndPartitionSessionEvent> EndPartitionSessionEvent;
     TDuration WriteRetryTimeout = WRITE_RETRY_TIMEOUT_START;
     TInstant WriteRequestTimestamp;
+    TInstant LastRewindCommitTimestamp;
     NYdb::TCredentialsProviderFactoryPtr CredentialsProvider;
     std::shared_ptr<NYdb::NTopic::IReadSession> ReadSession;
     ui64 ReaderGeneration = 0;

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -7,6 +7,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/generic/size_literals.h>
+
 namespace NKikimr::NPersQueueTests {
 
 Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
@@ -336,6 +338,181 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
                 break;
             }
         }
+    }
+
+    void SkipMessagesWithObsoleteTimestampImpl(TMaybe<TDuration> retentionPeriod) {
+        NKikimrConfig::TFeatureFlags ff;
+        ff.SetEnableSkipMessagesWithObsoleteTimestamp(true);
+
+        auto pqSettings = NKikimr::NPersQueueTests::PQSettings(0);
+        pqSettings.SetFeatureFlags(ff);
+        pqSettings.PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+        pqSettings.PQConfig.MutableCompactionConfig()->SetBlobsSize(8_MB);
+        pqSettings.PQConfig.MutableMirrorConfig()->SetRewindCommitDelaySeconds(3);
+
+        NPersQueue::TTestServer server(pqSettings);
+
+        const auto& mirrorSettings = server.CleverServer->GetRuntime()->GetAppData().PQConfig.GetMirrorConfig().GetPQLibSettings();
+        auto fabric = std::make_shared<NKikimr::NPQ::TPersQueueMirrorReaderFactory>();
+        fabric->Initialize(server.CleverServer->GetRuntime()->GetAnyNodeActorSystem(), mirrorSettings);
+        for (ui32 nodeId = 0; nodeId < server.CleverServer->GetRuntime()->GetNodeCount(); ++nodeId) {
+            server.CleverServer->GetRuntime()->GetAppData(nodeId).PersQueueMirrorReaderFactory = fabric.get();
+        }
+        server.EnableLogs({NKikimrServices::PQ_READ_PROXY, NKikimrServices::PQ_MIRRORER, NKikimrServices::PERSQUEUE});
+
+        constexpr ui32 nMsg = 1000;
+        constexpr ui32 messageSize = 90_KB;
+        const TString srcTopic = "src_topic";
+        const TString dstTopic = "dst_topic";
+        const TString srcTopicFullName = "rt3.dc1--" + srcTopic;
+        const TString dstTopicFullName = "rt3.dc1--" + dstTopic;
+        const TString mirrorConsumer = "mirror_consumer";
+
+        server.AnnoyingClient->CreateTopic(
+            srcTopicFullName,
+            /*partitionsCount =*/ 1,
+            /*lowWatermark =*/ 8_MB,
+            /*lifetimeS =*/ retentionPeriod.GetOrElse(TDuration::Hours(24)).Seconds(),
+            /*writeSpeed =*/ 20000000,
+            /*user =*/ "",
+            /*readSpeed =*/ 200000000,
+            /*rr =*/ {mirrorConsumer}
+        );
+
+        auto driver = server.AnnoyingClient->GetDriver();
+
+
+        // Write nMsg messages to the source topic.
+        {
+            auto writer = CreateSimpleWriter(*driver, srcTopic, "src_writer", 1, "raw");
+            ui64 seqNo = writer->GetInitSeqNo();
+            for (ui32 i = 0; i < nMsg; ++i) {
+                UNIT_ASSERT(writer->Write(TString("payload-") + ToString(i) + TString(messageSize, '-'), ++seqNo));
+            }
+            UNIT_ASSERT(writer->Close(TDuration::Seconds(10)));
+        }
+
+        NYdb::NTopic::TTopicClient topicClient(*driver);
+        if (!retentionPeriod.Empty()) {
+            const TInstant describeDeadline = TDuration::Seconds(30).ToDeadLine();
+            bool shiftedStartOffset = false;
+            while (TInstant::Now() < describeDeadline) {
+                Cerr << "Waiting for blobs cleanup\n";
+                auto descr = topicClient.DescribePartition(
+                                            "/Root/PQ/" + srcTopicFullName,
+                                            0,
+                                            NYdb::NTopic::TDescribePartitionSettings().IncludeStats(true))
+                                 .GetValueSync();
+                if (!descr.IsSuccess()) {
+                    Cerr << "DescribeConsumer failed: " << descr.GetIssues().ToString() << Endl;
+                    Sleep(TDuration::Seconds(1));
+                    continue;
+                }
+
+                const auto& stats = descr.GetPartitionDescription().GetPartition().GetPartitionStats();
+                UNIT_ASSERT(stats.has_value());
+
+                Cerr << "PartitionStats: " << LabeledOutput(stats->GetStartOffset(), stats->GetEndOffset(), stats->GetStoreSizeBytes()) << "\n";
+                if (stats->GetStartOffset() != 0) {
+                    shiftedStartOffset = true;
+                    break;
+                }
+                Sleep(TDuration::MilliSeconds(250));
+            }
+            UNIT_ASSERT_C(shiftedStartOffset, "Start offset not changed");
+        }
+
+        Sleep(TDuration::Seconds(2));
+        const TInstant readFromTs = TInstant::Now() + TDuration::Seconds(1);
+
+        NKikimrPQ::TMirrorPartitionConfig mirrorFrom;
+        mirrorFrom.SetEndpoint("localhost");
+        mirrorFrom.SetEndpointPort(server.GrpcPort);
+        mirrorFrom.SetTopic(srcTopic);
+        mirrorFrom.SetConsumer(mirrorConsumer);
+        mirrorFrom.SetSyncWriteTime(true);
+        mirrorFrom.SetReadFromTimestampsMs(readFromTs.MilliSeconds());
+
+        server.AnnoyingClient->CreateTopic(
+            dstTopicFullName,
+            /*partitionsCount =*/ 1,
+            /*lowWatermark =*/ 8_MB,
+            /*lifetimeS =*/ 86400,
+            /*writeSpeed =*/ 20000000,
+            /*user =*/ "",
+            /*readSpeed =*/ 200000000,
+            /*rr =*/ {"reader"},
+            /*important =*/ {},
+            mirrorFrom
+        );
+
+        // Repeatedly Describe the source topic until the mirror_consumer commits all messages.
+        const TInstant describeDeadline = TDuration::Seconds(180).ToDeadLine();
+        bool committed = false;
+        while (TInstant::Now() < describeDeadline) {
+            auto descr = topicClient.DescribeConsumer(
+                "/Root/PQ/" + srcTopicFullName,
+                mirrorConsumer,
+                NYdb::NTopic::TDescribeConsumerSettings().IncludeStats(true)
+            ).GetValueSync();
+            if (!descr.IsSuccess()) {
+                Cerr << "DescribeConsumer failed: " << descr.GetIssues().ToString() << Endl;
+                Sleep(TDuration::Seconds(1));
+                continue;
+            }
+            const auto& partitions = descr.GetConsumerDescription().GetPartitions();
+            UNIT_ASSERT_VALUES_EQUAL(partitions.size(), 1);
+            const auto& stats = partitions[0].GetPartitionConsumerStats();
+            if (stats) {
+                Cerr << "ConsumerStats: reader=" << stats->GetReaderName()
+                     << " committed=" << stats->GetCommittedOffset() << Endl;
+                if (!stats->GetReaderName().empty() && stats->GetCommittedOffset() == nMsg) {
+                    committed = true;
+                    break;
+                }
+            }
+            Sleep(TDuration::MilliSeconds(250));
+        }
+        UNIT_ASSERT_C(committed, "mirror_consumer did not commit all skipped messages within timeout");
+
+        // Read from the destination topic; nothing must be there.
+        auto dstReader = topicClient.CreateReadSession(
+            NYdb::NTopic::TReadSessionSettings()
+                .AppendTopics(NYdb::NTopic::TTopicReadSettings(dstTopic).AppendPartitionIds(0))
+                .ConsumerName("reader")
+        );
+
+        size_t messageCount = 0;
+        TInstant dstDeadline = TInstant::Max();
+        while (TInstant::Now() < dstDeadline) {
+            if (!dstReader->WaitEvent().Wait(dstDeadline)) {
+                break;
+            }
+            auto event = dstReader->GetEvent(false);
+            if (!event) {
+                continue;
+            }
+            if (auto* data = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
+                messageCount += data->GetMessagesCount();
+            } else if (auto* start = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event)) {
+                start->Confirm();
+                dstDeadline = TDuration::Seconds(10).ToDeadLine();
+            } else if (auto* stop = std::get_if<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>(&*event)) {
+                stop->Confirm();
+            } else if (std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event)) {
+                break;
+            }
+        }
+        dstReader->Close(TDuration::Zero());
+        UNIT_ASSERT_VALUES_EQUAL(messageCount, 0);
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestamp) {
+        SkipMessagesWithObsoleteTimestampImpl(Nothing());
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRetention) {
+        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1));
     }
 }
 } // NKikimr::NPersQueueTests

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -120,6 +120,7 @@ message TPQConfig {
     message TMirrorConfig {
         optional bool Enabled = 1 [default = true];
         optional TPQLibSettings PQLibSettings = 2;
+        optional uint32 RewindCommitDelaySeconds = 3;
     }
 
     optional TMirrorConfig MirrorConfig = 29;


### PR DESCRIPTION
rewind committed offset in mirrorer if no data was read due to a read-from-timestamp cutoff: LOGBROKER-9908

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


#### Original PR(s)
* PR https://github.com/ydb-platform/ydb/pull/40095

