### PR TITLE
Auto-trigger docs rebuild for translation PRs

### DIFF
--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -55,3 +55,24 @@ jobs:
           revision: "pr-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"
           src-root: "./ydb/docs"
           cli-version: stable
+
+      # docs-build-action writes github.event.number to inputs/pr-number.
+      # For workflow_dispatch this field is empty, so patch the artifact.
+      - name: Download inputs artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/download-artifact@v4
+        with:
+          name: inputs
+          path: ./inputs
+
+      - name: Save PR number to inputs artifact
+        if: github.event_name == 'workflow_dispatch'
+        run: printf '%s' '${{ inputs.pull_number }}' > ./inputs/pr-number
+
+      - name: Upload inputs artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: inputs
+          path: ./inputs/
+          overwrite: true

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Save PR number to inputs artifact
         if: github.event_name == 'workflow_dispatch'
-        run: printf '%s' '${{ inputs.pull_number }}' > ./inputs/pr-number
+        env:
+          PULL_NUMBER: ${{ inputs.pull_number }}
+        run: printf '%s' "$PULL_NUMBER" > ./inputs/pr-number
 
       - name: Upload inputs artifact
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -18,16 +18,33 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Check PR has docs changes
+        id: docs-changes
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const hasDocs = files.some((f) => f.filename.startsWith('ydb/docs/'));
+            core.setOutput('has_docs', hasDocs ? 'true' : 'false');
+
       - name: Checkout
+        if: steps.docs-changes.outputs.has_docs == 'true'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get commit SHA
         id: sha
+        if: steps.docs-changes.outputs.has_docs == 'true'
         run: echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build
+        if: steps.docs-changes.outputs.has_docs == 'true'
         uses: diplodoc-platform/docs-build-action@v3
         with:
           revision: "pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -3,6 +3,8 @@ name: Rebuild documentation
 on:
   pull_request_target:
     types: [labeled]
+    paths:
+      - 'ydb/docs/**'
 
 jobs:
   build-docs:
@@ -13,6 +15,9 @@ jobs:
       group: docs-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -29,3 +34,21 @@ jobs:
           revision: "pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"
           src-root: "./ydb/docs"
           cli-version: stable
+
+      - name: Remove rebuild_docs label
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'rebuild_docs',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -1,0 +1,31 @@
+name: Rebuild documentation
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  build-docs:
+    if: |
+      github.event.label.name == 'rebuild_docs' &&
+      github.event.pull_request.state == 'open'
+    concurrency:
+      group: docs-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get commit SHA
+        id: sha
+        run: echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build
+        uses: diplodoc-platform/docs-build-action@v3
+        with:
+          revision: "pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"
+          src-root: "./ydb/docs"
+          cli-version: stable

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -3,8 +3,6 @@ name: Rebuild documentation
 on:
   pull_request_target:
     types: [labeled]
-    paths:
-      - 'ydb/docs/**'
 
 jobs:
   build-docs:
@@ -18,6 +16,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -40,6 +39,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            // Always clear trigger label so manual re-run is a single re-add.
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - Build documentation
+      - Rebuild documentation
     types:
       - completed
 

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -12,7 +12,7 @@ jobs:
   post-build:
     permissions: write-all
     concurrency:
-      group: preview-documentation-${{ github.ref }}
+      group: preview-documentation-${{ github.event.workflow_run.id }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Trigger docs rebuild for translation PR
         uses: actions/github-script@v8
         with:
+          github-token: ${{ secrets.YDBDOC_PUSH_PAT }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -81,7 +82,7 @@ jobs:
             }
 
             if (!translationPr) {
-              core.setFailed(`Open translation PR not found for head ${head}`);
+              core.warning(`Open translation PR not found for head ${head}. rebuild_docs was not added; rebuild can be triggered manually.`);
               return;
             }
             await github.rest.issues.addLabels({

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -57,25 +57,63 @@ jobs:
             const repo = context.repo.repo;
             const sourcePr = context.payload.pull_request.number;
             const head = `${owner}:ydbdoc-review/pr-${sourcePr}`;
+            let translationPr = null;
 
-            const { data: pulls } = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'open',
-              head,
-              per_page: 1,
-            });
+            // Translation PR creation can lag a bit right after doc_translate push.
+            for (let attempt = 1; attempt <= 6; attempt++) {
+              const { data: pulls } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head,
+                per_page: 1,
+              });
 
-            if (!pulls[0]) {
+              if (pulls[0]) {
+                translationPr = pulls[0];
+                break;
+              }
+
+              if (attempt < 6) {
+                core.info(`Translation PR not found yet (${attempt}/6), retrying...`);
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+              }
+            }
+
+            if (!translationPr) {
               core.setFailed(`Open translation PR not found for head ${head}`);
               return;
             }
+            const rebuildLabel = {
+              name: 'rebuild_docs',
+              color: '0e8a16',
+              description: 'Trigger docs rebuild workflow',
+            };
 
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: pulls[0].number,
-              labels: ['rebuild_docs'],
-            });
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: translationPr.number,
+                labels: [rebuildLabel.name],
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(`Label ${rebuildLabel.name} was not found, creating it...`);
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  ...rebuildLabel,
+                });
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: translationPr.number,
+                  labels: [rebuildLabel.name],
+                });
+              } else {
+                throw error;
+              }
+            }
 
-            core.info(`Added rebuild_docs to PR #${pulls[0].number}`);
+            core.info(`Added rebuild_docs to PR #${translationPr.number}`);

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -84,36 +84,11 @@ jobs:
               core.setFailed(`Open translation PR not found for head ${head}`);
               return;
             }
-            const rebuildLabel = {
-              name: 'rebuild_docs',
-              color: '0e8a16',
-              description: 'Trigger docs rebuild workflow',
-            };
-
-            try {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: translationPr.number,
-                labels: [rebuildLabel.name],
-              });
-            } catch (error) {
-              if (error.status === 404) {
-                core.info(`Label ${rebuildLabel.name} was not found, creating it...`);
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  ...rebuildLabel,
-                });
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: translationPr.number,
-                  labels: [rebuildLabel.name],
-                });
-              } else {
-                throw error;
-              }
-            }
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: translationPr.number,
+              labels: ['rebuild_docs'],
+            });
 
             core.info(`Added rebuild_docs to PR #${translationPr.number}`);

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -48,3 +48,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PUSH_TOKEN: ${{ secrets.YDBDOC_PUSH_PAT }}  # секрет YDBDOC_PUSH_PAT → env для приложения
           YDBDOC_REPO_PATH: ${{ github.workspace }}
+
+      - name: Trigger docs rebuild for translation PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sourcePr = context.payload.pull_request.number;
+            const head = `${owner}:ydbdoc-review/pr-${sourcePr}`;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head,
+              per_page: 1,
+            });
+
+            if (!pulls[0]) {
+              core.setFailed(`Open translation PR not found for head ${head}`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pulls[0].number,
+              labels: ['rebuild_docs'],
+            });
+
+            core.info(`Added rebuild_docs to PR #${pulls[0].number}`);

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -50,6 +50,7 @@ jobs:
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
       - name: Trigger docs rebuild for translation PR
+        if: ${{ !cancelled() }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.YDBDOC_PUSH_PAT }}


### PR DESCRIPTION
## Summary
- Fixes a real case where translation PRs created by `ydbdoc-review (doc_translate label)` did not automatically start docs build/preview on PR creation.
- Adds dedicated rebuild workflow `.github/workflows/docs_build_rebuild.yaml`, triggered by `rebuild_docs` label.
- Updates `.github/workflows/ydbdoc-review.yml` to find the auto-created translation PR (`ydbdoc-review/pr-<source_pr_number>`) and apply `rebuild_docs` using `YDBDOC_PUSH_PAT`.
- Extends `.github/workflows/docs_preview.yaml` to process both `Build documentation` and `Rebuild documentation` runs.
- Keeps `workflow_dispatch` path working by patching `inputs/pr-number` in `.github/workflows/docs_build.yaml`.

## Problem
When translation PRs are created by automation, the normal `pull_request_target` docs build path may not fire at PR creation time. This leaves no docs preview/comment until a later manual push/rebase.

## What Changed
1. `doc_translate` flow now triggers rebuild labeling for the generated translation PR.
2. Rebuild workflow runs docs build for labeled open PRs and removes `rebuild_docs` label after run (so re-trigger is a single re-add).
3. Rebuild workflow gates heavy steps (checkout/build) with an explicit docs-file precheck (`ydb/docs/**`) via PR files API.
4. Preview concurrency changed to `workflow_run.id` to avoid cross-PR cancellations.
5. Dispatch artifact patch writes PR number via env-safe interpolation (`PULL_NUMBER`) before re-uploading `inputs`.

## Risks / Trade-offs
- Rebuild and normal build remain two workflows with duplicated build steps (intentional for small blast radius in this incident fix); reusable `workflow_call` extraction can follow later.
- Labeling step retries translation PR discovery, but if the PR is still not visible after retries it emits warning and rebuild is skipped for that run.
- Label-based rebuild still relies on collaborators not misusing `rebuild_docs`; docs-file precheck prevents actual docs build execution on non-docs PRs.

## Test Plan
- [ ] On a docs source PR, add `doc_translate` and verify a translation PR is created.
- [ ] Confirm `ydbdoc-review (doc_translate label)` adds `rebuild_docs` to that translation PR.
- [ ] Confirm `Rebuild documentation` workflow runs for translation PR.
- [ ] Confirm `Preview documentation` runs and posts preview/comment for rebuild run.
- [ ] Manually run `Build documentation` via `workflow_dispatch` and verify preview comment works (no missing `pr-number`).