### PR TITLE
Introduce streaming protocol for obtaining PhantomFlagStorage snapshot

### DIFF
--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_syncfull.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_syncfull.cpp
@@ -38,6 +38,13 @@ namespace NKikimr {
     ////////////////////////////////////////////////////////////////////////////
     class THullSyncFullBase {
     protected:
+        enum class ERunStagesResult : ui8 {
+            PortionComplete,
+            Yield,
+            WaitForEvent,
+        };
+
+    protected:
         TIntrusivePtr<TVDiskConfig> Config;
         TIntrusivePtr<THullCtx> HullCtx;
         const TActorId ParentId;
@@ -96,6 +103,7 @@ namespace NKikimr {
         static const ui32 EmptyFlag = 0x1;
         static const ui32 MsgFullFlag = 0x2;
         static const ui32 YieldedFlag = 0x4;
+        static const ui32 WaitFlag = 0x8;
 
         template <class TKey, class TMemRec, class TFilter>
         ui32 Process(
@@ -144,7 +152,7 @@ namespace NKikimr {
         virtual ui32 ProcessPhantomFlags(TString* data) = 0;
         virtual NKikimrBlobStorage::EFullSyncProtocol GetProtocol() = 0;
 
-        bool RunStages() {
+        ERunStagesResult RunStages() {
             if (!Result) {
                 Result = std::make_unique<TEvBlobStorage::TEvVSyncFullResult>(NKikimrProto::OK, SelfVDiskId,
                         SyncState, CurrentEvent->Get()->Record.GetCookie(), TActivationContext::Now(),
@@ -162,7 +170,7 @@ namespace NKikimr {
                     if (pres & MsgFullFlag) {
                         break;
                     } else if (pres & YieldedFlag) {
-                        return false;
+                        return ERunStagesResult::Yield;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
                     [[fallthrough]];
@@ -172,7 +180,7 @@ namespace NKikimr {
                     if (pres & MsgFullFlag) {
                         break;
                     } else if (pres & YieldedFlag) {
-                        return false;
+                        return ERunStagesResult::Yield;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
                     [[fallthrough]];
@@ -182,7 +190,7 @@ namespace NKikimr {
                     if (pres & MsgFullFlag) {
                         break;
                     } else if (pres & YieldedFlag) {
-                        return false;
+                        return ERunStagesResult::Yield;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
                     [[fallthrough]];
@@ -191,7 +199,9 @@ namespace NKikimr {
                     if (pres & MsgFullFlag) {
                         break;
                     } else if (pres & YieldedFlag) {
-                        return false;
+                        return ERunStagesResult::Yield;
+                    } else if (pres & WaitFlag) {
+                        return ERunStagesResult::WaitForEvent;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
                     break;
@@ -218,7 +228,7 @@ namespace NKikimr {
             LogoBlobIDFromLogoBlobID(KeyLogoBlob.LogoBlobID(), Result->Record.MutableLogoBlobFrom());
             Result->Record.SetBlockTabletFrom(KeyBlock.TabletId);
             KeyBarrier.Serialize(*Result->Record.MutableBarrierFrom());
-            return true;
+            return ERunStagesResult::PortionComplete;
         }
 
     public:
@@ -275,15 +285,22 @@ namespace NKikimr {
         }
 
         void Run() {
-            bool portionCompleted = RunStages();
-            if (portionCompleted) {
+            ERunStagesResult portionCompleted = RunStages();
+            switch (portionCompleted) {
+            case ERunStagesResult::PortionComplete:
                 SendVDiskResponse(TActivationContext::AsActorContext(), CurrentEvent->Sender,
                         Result.release(), 0, HullCtx->VCtx, {});
                 // notify parent about death
                 Send(ParentId, new TEvents::TEvGone);
                 PassAway();
-            } else {
+                return;
+            case ERunStagesResult::WaitForEvent:
+                break;
+            case ERunStagesResult::Yield:
                 Schedule(TDuration::Zero(), new TEvents::TEvWakeup);
+                break;
+            default:
+                Y_ABORT();
             }
         }
 
@@ -333,8 +350,8 @@ namespace NKikimr {
     public:
         void Bootstrap() {
             ++FullSyncGroup->UnorderedDataProtocolActorsCreated();
-            Become(&TThis::StateInit);
-            RequestNextSnapshotBatch();
+            Become(&TThis::StateFunc);
+            Run();
         }
 
         static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -391,9 +408,8 @@ namespace NKikimr {
             // Queue drained.  If more batches are still coming, request the
             // next one and yield until it arrives.
             if (!StreamFinished) {
-                Become(&TThis::StateInit);
                 RequestNextSnapshotBatch();
-                return YieldedFlag;
+                return WaitFlag;
             }
 
             return EmptyFlag;
@@ -409,8 +425,8 @@ namespace NKikimr {
         }
 
         void Run() {
-            bool portionCompleted = RunStages();
-            if (portionCompleted) {
+            switch (RunStages()) {
+            case ERunStagesResult::PortionComplete: {
                 bool finished = Result->Record.GetFinished();
                 // send reply
                 SendVDiskResponse(TActivationContext::AsActorContext(), CurrentEvent->Sender, Result.release(),
@@ -420,30 +436,30 @@ namespace NKikimr {
                     Send(ParentId, new TEvents::TEvGone);
                     ++FullSyncGroup->UnorderedDataProtocolActorsTerminated();
                     PassAway();
+                    return;
                 }
-            } else {
+                break;
+            }
+            case ERunStagesResult::Yield:
                 Schedule(TDuration::Zero(), new TEvents::TEvWakeup);
+                break;
+            case ERunStagesResult::WaitForEvent:
+                break;
+            default:
+                Y_ABORT();
             }
         }
 
         void Handle(NSyncLog::TEvPhantomFlagStorageGetSnapshotResult::TPtr& ev) {
             auto* msg = ev->Get();
-            for (auto& flag : msg->Flags) {
-                PhantomFlagsQueue.push_back(flag);
-            }
+            std::move(msg->Flags.begin(), msg->Flags.end(), std::back_inserter(PhantomFlagsQueue));
             ProcessedChunks = std::move(msg->ProcessedChunks);
             StreamFinished = msg->Eof;
-            Become(&TThis::StateFunc);
             Run();
         }
 
-        STRICT_STFUNC(StateInit,
-            hFunc(NSyncLog::TEvPhantomFlagStorageGetSnapshotResult, Handle)
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway)
-            cFunc(TEvents::TEvWakeup::EventType, Run)
-        )
-
         STRICT_STFUNC(StateFunc,
+            hFunc(NSyncLog::TEvPhantomFlagStorageGetSnapshotResult, Handle)
             hFunc(TEvBlobStorage::TEvVSyncFull, Handle)
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway)
             cFunc(TEvents::TEvWakeup::EventType, Run)

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_syncfull.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_syncfull.cpp
@@ -95,7 +95,7 @@ namespace NKikimr {
 
         static const ui32 EmptyFlag = 0x1;
         static const ui32 MsgFullFlag = 0x2;
-        static const ui32 LongProcessing = 0x4;
+        static const ui32 YieldedFlag = 0x4;
 
         template <class TKey, class TMemRec, class TFilter>
         ui32 Process(
@@ -126,7 +126,7 @@ namespace NKikimr {
                 }
 
                 if (timer.Check()) {
-                    return LongProcessing;
+                    return YieldedFlag;
                 }
 
                 if (filter.Check(key, it.GetMemRec(), HullCtx->AllowKeepFlags, true /*allowGarbageCollection*/))
@@ -161,7 +161,7 @@ namespace NKikimr {
                     pres = Process(FullSnap.LogoBlobsSnap, KeyLogoBlob, LogoBlobFilter, data);
                     if (pres & MsgFullFlag) {
                         break;
-                    } else if (pres & LongProcessing) {
+                    } else if (pres & YieldedFlag) {
                         return false;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
@@ -171,7 +171,7 @@ namespace NKikimr {
                     pres = Process(FullSnap.BlocksSnap, KeyBlock, FakeFilter, data);
                     if (pres & MsgFullFlag) {
                         break;
-                    } else if (pres & LongProcessing) {
+                    } else if (pres & YieldedFlag) {
                         return false;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
@@ -181,7 +181,7 @@ namespace NKikimr {
                     pres = Process(FullSnap.BarriersSnap, KeyBarrier, FakeFilter, data);
                     if (pres & MsgFullFlag) {
                         break;
-                    } else if (pres & LongProcessing) {
+                    } else if (pres & YieldedFlag) {
                         return false;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
@@ -190,7 +190,7 @@ namespace NKikimr {
                     pres = ProcessPhantomFlags(data);
                     if (pres & MsgFullFlag) {
                         break;
-                    } else if (pres & LongProcessing) {
+                    } else if (pres & YieldedFlag) {
                         return false;
                     }
                     Y_VERIFY_S(pres & EmptyFlag, HullCtx->VCtx->VDiskLogPrefix);
@@ -334,7 +334,7 @@ namespace NKikimr {
         void Bootstrap() {
             ++FullSyncGroup->UnorderedDataProtocolActorsCreated();
             Become(&TThis::StateInit);
-            Send(SyncLogActorId, new NSyncLog::TEvPhantomFlagStorageGetSnapshot);
+            RequestNextSnapshotBatch();
         }
 
         static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -376,26 +376,27 @@ namespace NKikimr {
                 data->reserve(Config->MaxResponseSize);
             }
 
-            // copy data until we have some space
-            ui32 result = 0;
-            for (; PhantomFlagIterator != PhantomFlagStorageSnapshot->Flags.end(); ++PhantomFlagIterator) {
+            // Drain the current batch.
+            while (!PhantomFlagsQueue.empty()) {
                 if (data->size() + NSyncLog::MaxRecFullSize > data->capacity()) {
                     return MsgFullFlag;
                 }
-
                 if (timer.Check()) {
-                    return LongProcessing;
+                    return YieldedFlag;
                 }
-
-                Serialize(data, *PhantomFlagIterator);
+                Serialize(data, PhantomFlagsQueue.front());
+                PhantomFlagsQueue.pop_front();
             }
 
-            // key points to the last seen key
-            if (PhantomFlagIterator == PhantomFlagStorageSnapshot->Flags.end()) {
-                result |= EmptyFlag;
+            // Queue drained.  If more batches are still coming, request the
+            // next one and yield until it arrives.
+            if (!StreamFinished) {
+                Become(&TThis::StateInit);
+                RequestNextSnapshotBatch();
+                return YieldedFlag;
             }
 
-            return result;
+            return EmptyFlag;
         }
 
         NKikimrBlobStorage::EFullSyncProtocol GetProtocol() override {
@@ -426,8 +427,12 @@ namespace NKikimr {
         }
 
         void Handle(NSyncLog::TEvPhantomFlagStorageGetSnapshotResult::TPtr& ev) {
-            PhantomFlagStorageSnapshot = std::move(ev->Get()->Snapshot);
-            PhantomFlagIterator = PhantomFlagStorageSnapshot->Flags.begin();
+            auto* msg = ev->Get();
+            for (auto& flag : msg->Flags) {
+                PhantomFlagsQueue.push_back(flag);
+            }
+            ProcessedChunks = std::move(msg->ProcessedChunks);
+            StreamFinished = msg->Eof;
             Become(&TThis::StateFunc);
             Run();
         }
@@ -445,9 +450,17 @@ namespace NKikimr {
         )
 
     private:
+        void RequestNextSnapshotBatch() {
+            auto req = std::make_unique<NSyncLog::TEvPhantomFlagStorageGetSnapshot>();
+            req->ProcessedChunks = ProcessedChunks;
+            Send(SyncLogActorId, req.release());
+        }
+
+    private:
         const TActorId SyncLogActorId;
-        std::optional<NSyncLog::TPhantomFlagStorageSnapshot> PhantomFlagStorageSnapshot;
-        NSyncLog::TPhantomFlags::iterator PhantomFlagIterator;
+        std::deque<NSyncLog::TLogoBlobRec> PhantomFlagsQueue;
+        std::unordered_set<ui32> ProcessedChunks;
+        bool StreamFinished = false;
     };
 
     IActor *CreateHullSyncFullActorLegacyProtocol(

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.cpp
@@ -14,8 +14,14 @@ namespace NKikimr {
         TEvSyncLogSnapshotResult::~TEvSyncLogSnapshotResult() = default;
 
         TEvPhantomFlagStorageGetSnapshotResult::TEvPhantomFlagStorageGetSnapshotResult(
-                TPhantomFlagStorageSnapshot&& snapshot)
-            : Snapshot(std::move(snapshot))
+                TPhantomFlags&& flags,
+                TPhantomFlagThresholds&& thresholds,
+                std::unordered_set<ui32>&& processedChunks,
+                bool eof)
+            : Flags(std::move(flags))
+            , Thresholds(std::move(thresholds))
+            , ProcessedChunks(std::move(processedChunks))
+            , Eof(eof)
         {}
 
         TEvPhantomFlagStorageWriteItems::TEvPhantomFlagStorageWriteItems(

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.h
@@ -5,8 +5,11 @@
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_data.h>
 #include <ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_snapshot.h>
+#include <ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_thresholds.h>
 #include <ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flags.h>
 #include <ydb/core/base/blobstorage.h>
+
+#include <unordered_set>
 
 namespace NKikimr {
     namespace NSyncLog {
@@ -91,17 +94,29 @@ namespace NKikimr {
                 : public TEventLocal<TEvPhantomFlagStorageGetSnapshot,
                                      TEvBlobStorage::EvPhantomFlagStorageGetSnapshot>
         {
-            // Persistent PhantomFlagStorage  also includes flags from the main synclog
+            // Persistent PhantomFlagStorage also includes flags from the main synclog
+            // (delivered during the builder phase as the final batch).
             TSyncLogSnapshotPtr SyncLogSnapshot;
+            // Chunks the requester has already received and consumed.  Empty on the
+            // very first request of a stream.
+            std::unordered_set<ui32> ProcessedChunks;
         };
 
         struct TEvPhantomFlagStorageGetSnapshotResult
                 : public TEventLocal<TEvPhantomFlagStorageGetSnapshotResult,
                                      TEvBlobStorage::EvPhantomFlagStorageGetSnapshotResult>
         {
-            TEvPhantomFlagStorageGetSnapshotResult(TPhantomFlagStorageSnapshot&& snapshot);
+            TEvPhantomFlagStorageGetSnapshotResult(TPhantomFlags&& flags,
+                    TPhantomFlagThresholds&& thresholds,
+                    std::unordered_set<ui32>&& processedChunks,
+                    bool eof);
 
-            TPhantomFlagStorageSnapshot Snapshot;
+            TPhantomFlags Flags;
+            TPhantomFlagThresholds Thresholds;
+            // Updated set of chunks the requester has now received, to be echoed back
+            // on the next request.  Empty for the volatile in-memory path.
+            std::unordered_set<ui32> ProcessedChunks;
+            bool Eof;
         };
 
         struct TEvSyncLogUpdateNeighbourSyncedLsn

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -286,7 +286,13 @@ namespace NKikimr {
             void Handle(const TEvPhantomFlagStorageGetSnapshotResult::TPtr& ev) {
                 // This actor only requests PhantomFlagStorage snapshot on restart
                 // to rebuild ThresholdsStructure
-                KeepState.RecoverPhantomFlagStorage(std::move(ev->Get()->Snapshot));
+                auto* msg = ev->Get();
+                KeepState.RecoverPhantomFlagStorage(std::move(msg->Thresholds), msg->Eof);
+                if (!msg->Eof) {
+                    auto next = std::make_unique<TEvPhantomFlagStorageGetSnapshot>();
+                    next->ProcessedChunks = std::move(msg->ProcessedChunks);
+                    KeepState.ContinuePhantomFlagStorageSnapshot(std::move(next));
+                }
             }
 
             void Handle(const TEvLocalSyncData::TPtr& ev) {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -544,8 +544,8 @@ namespace NKikimr {
             PhantomFlagStorageState.FinishInitialBuilding(std::move(flags), std::move(thresholds), PhantomFlagStorageLimit);
         }
 
-        void TSyncLogKeeperState::RecoverPhantomFlagStorage(TPhantomFlagStorageSnapshot&& snapshot) {
-            PhantomFlagStorageState.Recover(std::move(snapshot));
+        void TSyncLogKeeperState::RecoverPhantomFlagStorage(TPhantomFlagThresholds&& thresholdsBatch, bool eof) {
+            PhantomFlagStorageState.Recover(std::move(thresholdsBatch), eof);
         }
 
         void TSyncLogKeeperState::RequestPhantomFlagStorageSnapshot(TEvPhantomFlagStorageGetSnapshot::TPtr request) const {
@@ -553,6 +553,14 @@ namespace NKikimr {
                 request->Get()->SyncLogSnapshot = SyncLogPtr->GetSnapshot();
             }
             PhantomFlagStorageState.RequestSnapshot(request);
+        }
+
+        void TSyncLogKeeperState::ContinuePhantomFlagStorageSnapshot(
+                std::unique_ptr<TEvPhantomFlagStorageGetSnapshot> request) const {
+            Y_ABORT_UNLESS(PhantomFlagStorageState.IsPersistent());
+            request->SyncLogSnapshot = SyncLogPtr->GetSnapshot();
+            TActivationContext::Send(new IEventHandle(
+                    PhantomFlagStorageState.GetProcessorId(), SelfId, request.release()));
         }
 
         void TSyncLogKeeperState::ProcessLocalSyncData(ui32 orderNumber, const TString& data) {

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -98,8 +98,11 @@ namespace NKikimr {
 
             // Add flags from cut sync log snapshot
             void FinishPhantomFlagStorageBuilder(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds);
-            void RecoverPhantomFlagStorage(TPhantomFlagStorageSnapshot&& snapshot);
+            void RecoverPhantomFlagStorage(TPhantomFlagThresholds&& thresholdsBatch, bool eof);
             void RequestPhantomFlagStorageSnapshot(TEvPhantomFlagStorageGetSnapshot::TPtr request) const;
+            // Re-issue snapshot request to the persistent processor (used during
+            // streaming recovery to fetch the next chunk).
+            void ContinuePhantomFlagStorageSnapshot(std::unique_ptr<TEvPhantomFlagStorageGetSnapshot> request) const;
             void UpdatePhantomFlagStorageData(std::optional<TPhantomFlagStorageData>&& data);
             void RetireExtractedChunks(const std::vector<ui32>& chunkIdxs);
             void ProcessLocalSyncData(ui32 orderNumber, const TString& data);

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_processor.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_processor.cpp
@@ -24,7 +24,6 @@ public:
             TPhantomFlagStorageProcessorContext&& ctx)
         : Ctx(std::move(ctx))
         , Data(std::move(data))
-        , PendingRead(Ctx.SyncLogCtx->VCtx->Top->GType)
     {}
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -40,6 +39,32 @@ public:
         RequestInFlight = true;
         Become(&TThis::StateInit);
     }
+
+private:
+    struct TGetSnapshot {
+        TActorId Requester;
+        TSyncLogSnapshotPtr Snapshot;
+        std::unordered_set<ui32> ProcessedChunks;
+    };
+
+    struct TDeleteChunk {
+        ui32 ChunkIdx;
+    };
+
+    using TRequest = std::variant<TGetSnapshot, TDeleteChunk>;
+
+    struct TWriteBatch {
+        std::optional<ui32> SourceChunkIdx; // nullopt for the initial build
+        std::deque<TPhantomFlagStorageItem> Items;
+    };
+
+    struct TActiveSnapshotRequest {
+        TActorId Requester;
+        TSyncLogSnapshotPtr Snapshot;
+        std::unordered_set<ui32> ProcessedChunks;
+        std::optional<ui32> ReadingChunkIdx;
+        bool BuilderRunning;
+    };
 
 private:
     //////////////////////////////////////////////////////////////////////
@@ -199,19 +224,25 @@ private:
                 "Handle TEvChunkReadResult"),
                 (Event, ev->Get()->ToString()));
         CHECK_PDISK_RESPONSE(Ctx.SyncLogCtx->VCtx, ev, TActivationContext::AsActorContext());
+        Y_ABORT_UNLESS(ActiveSnapshotRequest);
         ui32 chunkIdx = ev->Get()->ChunkIdx;
-        PendingRead.ChunksToRead.erase(chunkIdx);
-        ProcessReadBuffer(ev->Get()->Data, chunkIdx);
-        if (PendingRead.ChunksToRead.empty()) {
-            Register(CreatePhantomFlagStorageBuilderActor(Ctx.SyncLogCtx, SelfId(),
-                    std::move(PendingRead.SyncLogSnapshot), false));
-        }
+        Y_ABORT_UNLESS(ActiveSnapshotRequest->ReadingChunkIdx == chunkIdx);
+
+        TPhantomFlags flags;
+        TPhantomFlagThresholds thresholds(Ctx.SyncLogCtx->VCtx->Top->GType);
+        DecodeChunk(ev->Get()->Data, chunkIdx, flags, thresholds);
+
+        ActiveSnapshotRequest->ProcessedChunks.insert(chunkIdx);
+        SendSnapshotBatch(std::move(flags), std::move(thresholds), /*eof=*/false);
+        FinishSnapshotStep();
     }
 
     void Handle(const TEvPhantomFlagStorageGetSnapshot::TPtr& ev) {
         STLOG(PRI_NOTICE, BS_PHANTOM_FLAG_PROCESSOR, BSPFP08, VDISKP(Ctx.SyncLogCtx->VCtx,
-                "Handle TEvPhantomFlagStorageGetSnapshot"));
-        EnqueueGetSnapshot(ev->Sender, std::move(ev->Get()->SyncLogSnapshot));
+                "Handle TEvPhantomFlagStorageGetSnapshot"),
+                (ProcessedChunkCount, ev->Get()->ProcessedChunks.size()));
+        EnqueueGetSnapshot(ev->Sender, std::move(ev->Get()->SyncLogSnapshot),
+                std::move(ev->Get()->ProcessedChunks));
         ProcessQueues();
     }
 
@@ -234,11 +265,14 @@ private:
 
     void Handle(const TEvPhantomFlagStorageFinishBuilder::TPtr& ev) {
         TPhantomFlags& flags = ev->Get()->Flags;
+        TPhantomFlagThresholds& thresholds = ev->Get()->Thresholds;
         STLOG(PRI_INFO, BS_PHANTOM_FLAG_PROCESSOR, BSPFP13, VDISKP(Ctx.SyncLogCtx->VCtx,
                 "Handle TEvPhantomFlagStorageFinishBuilder"),
                 (FlagCount, flags.size()));
-        std::move(flags.begin(), flags.end(), std::back_inserter(PendingRead.Flags));
-        FinalizeRead();
+        Y_ABORT_UNLESS(ActiveSnapshotRequest);
+        Y_ABORT_UNLESS(ActiveSnapshotRequest->BuilderRunning);
+        SendSnapshotBatch(std::move(flags), std::move(thresholds), /*eof=*/true);
+        FinishSnapshotStep();
     }
 
     void HandlePoison(const TEvents::TEvPoisonPill::TPtr&, const TActorContext&) {
@@ -264,18 +298,23 @@ private:
         RequestQueue.emplace_back(TDeleteChunk{chunkIdx});
     }
 
-    void EnqueueGetSnapshot(TActorId requester, TSyncLogSnapshotPtr&& snapshot) {
-        RequestQueue.emplace_front(TGetSnapshot{requester, std::move(snapshot)});
+    void EnqueueGetSnapshot(TActorId requester, TSyncLogSnapshotPtr&& snapshot,
+            std::unordered_set<ui32>&& processedChunks) {
+        RequestQueue.emplace_front(TGetSnapshot{
+                .Requester = requester,
+                .Snapshot = std::move(snapshot),
+                .ProcessedChunks = std::move(processedChunks),
+        });
     }
 
     void ProcessQueues() {
         while (!RequestInFlight && !RequestQueue.empty()) {
-            TRequest request = RequestQueue.front();
+            TRequest request = std::move(RequestQueue.front());
             RequestQueue.pop_front();
             RequestInFlight = true;
             std::visit(TOverloaded{
                 [&](const std::monostate&) {},
-                [&](TGetSnapshot& req) { GetSnapshot(req.Requester, std::move(req.Snapshot)); },
+                [&](TGetSnapshot& req) { ServeSnapshotRequest(std::move(req)); },
                 [&](const TDeleteChunk& req) { DeleteChunk(req.ChunkIdx); },
             }, request);
             return;
@@ -345,35 +384,105 @@ private:
         }
     }
 
-    void GetSnapshot(TActorId requester, TSyncLogSnapshotPtr&& snapshot) {
-        RequestInFlight = true;
-        PendingRead.Reset(requester, std::move(snapshot));
-        for (const auto [chunkIdx, chunk] : Data.Chunks) {
-            if (chunk.DataSize > 0) {
-                Send(Ctx.SyncLogCtx->PDiskCtx->PDiskId,
-                        new NPDisk::TEvChunkRead(Ctx.SyncLogCtx->PDiskCtx->Dsk->Owner, Ctx.SyncLogCtx->PDiskCtx->Dsk->OwnerRound,
-                                                 chunkIdx, 0, chunk.DataSize, NPriWrite::SyncLog, nullptr));
-                PendingRead.ChunksToRead.insert(chunkIdx);
+    //////////////////////////////////////////////////////////////////////
+    // Snapshot streaming
+    //////////////////////////////////////////////////////////////////////
+
+    std::optional<ui32> PickNextChunkToRead(const std::unordered_set<ui32>& processedChunks) const {
+        for (const auto& [chunkIdx, chunk] : Data.Chunks) {
+            if (chunk.DataSize > 0 && !processedChunks.contains(chunkIdx)) {
+                return chunkIdx;
             }
         }
-        STLOG(PRI_NOTICE, BS_PHANTOM_FLAG_PROCESSOR, BSPFP10, VDISKP(Ctx.SyncLogCtx->VCtx,
-                "Start reading snapshot"),
-                (ChunkToReadCount, PendingRead.ChunksToRead.size()));
-        if (PendingRead.ChunksToRead.empty()) {
+        return std::nullopt;
+    }
+
+    void ServeSnapshotRequest(TGetSnapshot&& req) {
+        Y_ABORT_UNLESS(!ActiveSnapshotRequest);
+        std::optional<ui32> nextChunk = PickNextChunkToRead(req.ProcessedChunks);
+
+        ActiveSnapshotRequest.emplace(TActiveSnapshotRequest{
+            .Requester = req.Requester,
+            .Snapshot = std::move(req.Snapshot),
+            .ProcessedChunks = std::move(req.ProcessedChunks),
+            .ReadingChunkIdx = nextChunk,
+            .BuilderRunning = false,
+        });
+
+        if (nextChunk) {
+            // Read exactly one chunk's worth of bytes and bound memory to that.
+            const auto& chunk = Data.Chunks.at(*nextChunk);
+            Send(Ctx.SyncLogCtx->PDiskCtx->PDiskId,
+                    new NPDisk::TEvChunkRead(Ctx.SyncLogCtx->PDiskCtx->Dsk->Owner,
+                            Ctx.SyncLogCtx->PDiskCtx->Dsk->OwnerRound,
+                            *nextChunk, 0, chunk.DataSize, NPriRead::SyncLog, nullptr));
+            STLOG(PRI_DEBUG, BS_PHANTOM_FLAG_PROCESSOR, BSPFP14, VDISKP(Ctx.SyncLogCtx->VCtx,
+                    "Snapshot: reading chunk"),
+                    (ChunkIdx, *nextChunk),
+                    (DataSize, chunk.DataSize));
+        } else {
+            // All persistent chunks have been delivered to this requester;
+            // run the builder against the synclog snapshot to produce the
+            // final batch (which also carries Eof=true).
+            ActiveSnapshotRequest->BuilderRunning = true;
+            STLOG(PRI_NOTICE, BS_PHANTOM_FLAG_PROCESSOR, BSPFP10, VDISKP(Ctx.SyncLogCtx->VCtx,
+                    "Snapshot: invoking builder for final batch"));
             Register(CreatePhantomFlagStorageBuilderActor(Ctx.SyncLogCtx, SelfId(),
-                    std::move(PendingRead.SyncLogSnapshot), false));
+                    std::move(ActiveSnapshotRequest->Snapshot), false));
         }
     }
 
-    void FinalizeRead() {
-        RequestInFlight = false;
+    void SendSnapshotBatch(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds, bool eof) {
+        Y_ABORT_UNLESS(ActiveSnapshotRequest);
         STLOG(PRI_NOTICE, BS_PHANTOM_FLAG_PROCESSOR, BSPFP09, VDISKP(Ctx.SyncLogCtx->VCtx,
-                "Send Snapshot"),
-                (FlagCount, PendingRead.Flags.size()));
-        Send(PendingRead.Requester, new TEvPhantomFlagStorageGetSnapshotResult(
-                TPhantomFlagStorageSnapshot(std::move(PendingRead.Flags),
-                                            std::move(PendingRead.Thresholds))));
+                "Send snapshot batch"),
+                (FlagCount, flags.size()),
+                (Eof, eof),
+                (ProcessedChunkCount, ActiveSnapshotRequest->ProcessedChunks.size()));
+        Send(ActiveSnapshotRequest->Requester, new TEvPhantomFlagStorageGetSnapshotResult(
+                std::move(flags),
+                std::move(thresholds),
+                std::move(ActiveSnapshotRequest->ProcessedChunks),
+                eof));
+    }
+
+    void FinishSnapshotStep() {
+        ActiveSnapshotRequest.reset();
+        RequestInFlight = false;
         ProcessQueues();
+    }
+
+    void DecodeChunk(class TBufferWithGaps& bufferWithGaps, ui32 chunkIdx,
+            TPhantomFlags& flags, TPhantomFlagThresholds& thresholds) const {
+        if (!bufferWithGaps.IsReadable()) {
+            return;
+        }
+        TRcBuf buffer = bufferWithGaps.ToString();
+        const ui64 dataSize = Data.Chunks.at(chunkIdx).DataSize;
+        ui64 offset = 0;
+        while (offset < dataSize) {
+            TPhantomFlagStorageItem item = TPhantomFlagStorageItem::DeserializeFromRaw(
+                    buffer.Data() + offset);
+            switch (item.GetType()) {
+            case EPhantomFlagStorageItem::Flag:
+                flags.push_back(item.GetFlag().Record);
+                break;
+            case EPhantomFlagStorageItem::Threshold: {
+                TPhantomFlagStorageItem::TThreshold threshold = item.GetThreshold();
+                thresholds.AddBlob(threshold.OrderNumber, threshold.TabletId,
+                        threshold.Channel, threshold.Generation, threshold.Step);
+                break;
+            }
+            case EPhantomFlagStorageItem::Skip:
+            case EPhantomFlagStorageItem::SkipOneByte:
+                break;
+            }
+
+            if (item.SerializedSize() == 0) {
+                return;
+            }
+            offset += item.SerializedSize();
+        }
     }
 
     void AllocateNewChunk() {
@@ -400,74 +509,6 @@ private:
                                        *TailChunkIdx, offset, parts, nullptr, true, NPriWrite::SyncLog));
     }
 
-    void ProcessReadBuffer(class TBufferWithGaps& bufferWithGaps, ui32 chunkIdx) {
-        if (!bufferWithGaps.IsReadable()) {
-            return;
-        }
-        TRcBuf buffer = bufferWithGaps.ToString();
-        ui64 offset = 0;
-        while (offset < Data.Chunks[chunkIdx].DataSize) {
-            TPhantomFlagStorageItem item = TPhantomFlagStorageItem::DeserializeFromRaw(
-                    buffer.Data() + offset);
-            switch (item.GetType()) {
-            case EPhantomFlagStorageItem::Flag:
-                PendingRead.Flags.push_back(item.GetFlag().Record);
-                break;
-            case EPhantomFlagStorageItem::Threshold: {
-                TPhantomFlagStorageItem::TThreshold threshold = item.GetThreshold();
-                PendingRead.Thresholds.AddBlob(threshold.OrderNumber, threshold.TabletId,
-                        threshold.Channel, threshold.Generation, threshold.Step);
-                break;
-            }
-            case EPhantomFlagStorageItem::Skip:
-            case EPhantomFlagStorageItem::SkipOneByte:
-                break;
-            }
-
-            offset += item.SerializedSize();
-            if (item.SerializedSize() == 0) {
-                return;
-            }
-        }
-    }
-
-private:
-    struct TGetSnapshot {
-        TActorId Requester;
-        TSyncLogSnapshotPtr Snapshot;
-    };
-
-    struct TDeleteChunk {
-        ui32 ChunkIdx;
-    };
-
-    using TRequest = std::variant<TGetSnapshot, TDeleteChunk>;
-
-    struct TWriteBatch {
-        std::optional<ui32> SourceChunkIdx; // nullopt for the initial build
-        std::deque<TPhantomFlagStorageItem> Items;
-    };
-
-    struct TReaderInfo {
-        TReaderInfo(const TBlobStorageGroupType& gtype)
-            : Thresholds(gtype)
-        {}
-
-        std::unordered_set<ui32> ChunksToRead;
-        TPhantomFlags Flags;
-        TPhantomFlagThresholds Thresholds;
-        TActorId Requester = TActorId{};
-        TSyncLogSnapshotPtr SyncLogSnapshot;
-
-        void Reset(TActorId requester, TSyncLogSnapshotPtr&& snapshot) {
-            ChunksToRead.clear();
-            Flags.clear();
-            Thresholds.Clear();
-            Requester = requester;
-            SyncLogSnapshot = std::move(snapshot);
-        }
-    };
-
 private:
     static constexpr NKikimrVDiskData::TChunkKeeperEntryPoint::ESubsystem SubsystemId =
             NKikimrVDiskData::TChunkKeeperEntryPoint::PhantomFlagStorage;
@@ -483,7 +524,8 @@ private:
     std::vector<ui32> PendingRetiredChunks;
     TString PendingWrite;
     ui32 PendingWriteSize = 0;
-    TReaderInfo PendingRead;
+
+    std::optional<TActiveSnapshotRequest> ActiveSnapshotRequest;
 
     std::optional<ui32> TailChunkIdx;
     ui64 TailAvailableSize = 0;

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
@@ -122,11 +122,14 @@ void TPhantomFlagStorageState::FinishInitialBuilding(TPhantomFlags&& flags, TPha
     Building = false;
 }
 
-void TPhantomFlagStorageState::Recover(TPhantomFlagStorageSnapshot&& snapshot) {
+void TPhantomFlagStorageState::Recover(TPhantomFlagThresholds&& thresholdsBatch, bool eof) {
     STLOG(PRI_DEBUG, BS_PHANTOM_FLAG_STORAGE, BSPFS10,
-            VDISKP(SlCtx->VCtx, "Recovering PhantomFlagStorage"));
-    Building = false;
-    Thresholds.Merge(std::move(snapshot.Thresholds));
+            VDISKP(SlCtx->VCtx, "Recovering PhantomFlagStorage"),
+            (Eof, eof));
+    Thresholds.Merge(std::move(thresholdsBatch));
+    if (eof) {
+        Building = false;
+    }
 }
 
 void TPhantomFlagStorageState::Deactivate() {
@@ -150,7 +153,11 @@ void TPhantomFlagStorageState::RequestSnapshot(TEvPhantomFlagStorageGetSnapshot:
         STLOG(PRI_DEBUG, BS_PHANTOM_FLAG_STORAGE, BSPFS05,
                 VDISKP(SlCtx->VCtx, "Acquiring snapshot"),
                 (FlagsCount, StoredFlags.size()));
-        auto res = std::make_unique<TEvPhantomFlagStorageGetSnapshotResult>(TPhantomFlagStorageSnapshot(StoredFlags, Thresholds));
+        auto res = std::make_unique<TEvPhantomFlagStorageGetSnapshotResult>(
+                TPhantomFlags(StoredFlags),
+                TPhantomFlagThresholds(Thresholds),
+                std::unordered_set<ui32>{},
+                /*eof=*/true);
         TActivationContext::Send(new IEventHandle(ev->Sender, ev->Recipient, res.release()));
     }
 }

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
@@ -29,7 +29,7 @@ public:
     // Note: in some obscure cases there may be two active builders simultaneously
     // It shouldn't make any difference though, we just add more flags
     void FinishInitialBuilding(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds, ui64 sizeLimit);
-    void Recover(TPhantomFlagStorageSnapshot&& snapshot);
+    void Recover(TPhantomFlagThresholds&& thresholdsBatch, bool eof);
     void Deactivate();
 
     // Read everything from storage


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce new streaming protocol for obtaining PhantomFlagStorage snapshot. New protocol will allow to avoid memory consumption spikes from the materialization of DoNotKeep flags on snapshot creation

### Changelog category <!-- remove all except one -->

* Improvement