### PR TITLE
26-2: schemeshard: optimize split/merge local db update

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -478,6 +478,9 @@ enum ECumulativeCounters {
     COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN = 142 [(CounterOpts) = {Name: "SplitMergePartitionsRewritten"}];
 
     COUNTER_FINISHED_OPS_TxCreateFullBackupOp = 143 [(CounterOpts) = {Name: "FinishedOps/CreateFullBackupOp"}];
+
+    // How much time TTableInfo::VerifyConsistency() call takes, in nanoseconds
+    COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS = 144 [(CounterOpts) = {Name: "TablePartitionsConsistencyCheckTimeNs"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -291,4 +291,10 @@ message TFeatureFlags {
     optional bool DisableOnlineRO = 263 [default = false];
     optional bool EnableUserAttributesInTopicQuery = 264 [default = false];
     optional bool EnableTopicsPredicatePushdown = 266 [default = false];
+    // Use TablePartitionsByShardIdx (keyed by ShardIdx) instead of TablePartitions
+    // (keyed by positional index) for local tables.  When ON, split/merge writes only
+    // O(k) rows (src+dst shards) instead of O(N) rows (all partitions after srcFirstIdx).
+    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = true];
+    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = true];
+    optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -297,4 +297,5 @@ message TFeatureFlags {
     optional bool EnableTablePartitionsFormatShardIdx = 271 [default = false];
     optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = false];
     optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
+    optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -294,7 +294,7 @@ message TFeatureFlags {
     // Use TablePartitionsByShardIdx (keyed by ShardIdx) instead of TablePartitions
     // (keyed by positional index) for local tables.  When ON, split/merge writes only
     // O(k) rows (src+dst shards) instead of O(N) rows (all partitions after srcFirstIdx).
-    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = true];
-    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = true];
+    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = false];
+    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = false];
     optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1407,6 +1407,28 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             Self->IsOldArgonHashFormatMigrationCompleted = isOldArgonHashFormatMigrationCompletedVal;
         }
 
+        {
+            ui64 sweepStatusVal = 0;
+            RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_TablePartitionsFormatSweepStatus, sweepStatusVal));
+            switch (sweepStatusVal) {
+                case 1:
+                    Self->TablePartitionsFormatSweep.Status = TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running;
+                    break;
+                case 2:
+                    Self->TablePartitionsFormatSweep.Status = TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Paused;
+                    break;
+                default:
+                    Self->TablePartitionsFormatSweep.Status = TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle;
+                    break;
+            }
+        }
+
+        if (Self->TablePartitionsFormatSweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
+            ui64 sweepTargetVal = 0;
+            RETURN_IF_NO_PRECHARGED(Self->ReadSysValue(db, Schema::SysParam_TablePartitionsFormatSweepTarget, sweepTargetVal));
+            Self->TablePartitionsFormatSweep.TargetIsShardIdx = (sweepTargetVal != 0);
+        }
+
 #undef RETURN_IF_NO_PRECHARGED
 
         if (!Self->IsSchemeShardConfigured()) {
@@ -2381,6 +2403,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                         Self->SetPartitioning(prevTableId, tableInfo, std::move(partitions));
                         partitions.clear();
+                        Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Add(1);
                     }
 
                     prevTableId = tableId;
@@ -2413,7 +2436,110 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
                 TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                 Self->SetPartitioning(prevTableId, tableInfo, std::move(partitions));
+                partitions.clear();
+                Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Add(1);
             }
+        }
+
+        // Read partitions from ShardIdx-keyed format (new tables only, mutually exclusive with above)
+        // Depends on TTableInfo::Columns filled.
+        {
+            auto rowSet = db.Table<Schema::TablePartitionsByShardIdx>().Range().Select();
+            if (!rowSet.IsReady()) {
+                return false;
+            }
+
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxInit for TablePartitionsByShardIdx" << ", at schemeshard: " << Self->TabletID());
+
+            auto flushPartitions = [this](const TPathId& tablePathId, TVector<TTableShardInfo>&& partitions) {
+                if (!tablePathId) {
+                    return;
+                }
+                Y_ABORT_UNLESS(!partitions.empty(), "tablePathId %s", ToString(tablePathId).c_str());
+                Y_ABORT_UNLESS(Self->Tables.contains(tablePathId), "tablePathId %s", ToString(tablePathId).c_str());
+                TTableInfo::TPtr tableInfo = Self->Tables.at(tablePathId);
+                Y_ABORT_UNLESS(!tableInfo->Columns.empty(), "tablePathId %s", ToString(tablePathId).c_str());
+                // tables must not have mixed format partitions
+                Y_ABORT_UNLESS(tableInfo->GetPartitions().empty(), "tablePathId %s", ToString(tablePathId).c_str());
+
+                // Build key column type list for border comparison
+                TVector<NScheme::TTypeInfo> keyColTypeIds;
+                for (const auto& [colId, col] : tableInfo->Columns) {
+                    if (col.KeyOrder == (ui32)-1) {
+                        continue;
+                    }
+                    if (keyColTypeIds.size() <= col.KeyOrder) {
+                        keyColTypeIds.resize(col.KeyOrder + 1);
+                    }
+                    keyColTypeIds[col.KeyOrder] = col.PType;
+                }
+
+                // Sort by RangeEnd; empty EndOfRange = last partition, goes to the end
+                std::sort(partitions.begin(), partitions.end(),
+                    [&](const TTableShardInfo& a, const TTableShardInfo& b) {
+                        if (a.EndOfRange.empty()) {
+                            return false;
+                        }
+                        if (b.EndOfRange.empty()) {
+                            return true;
+                        }
+                        TSerializedCellVec ca(a.EndOfRange);
+                        TSerializedCellVec cb(b.EndOfRange);
+                        return CompareBorders<true, true>(ca.GetCells(), cb.GetCells(), true, true, keyColTypeIds) < 0;
+                    }
+                );
+
+                Self->SetPartitioning(tablePathId, tableInfo, std::move(partitions));
+                tableInfo->PartitionsInShardIdxFormat = true;
+                Self->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Add(1);
+            };
+
+            const auto now = ctx.Now();
+
+            TPathId prevPathId;
+            TVector<TTableShardInfo> partitions;
+
+            while (!rowSet.EndOfSet()) {
+                const TPathId pathId(
+                    rowSet.GetValue<Schema::TablePartitionsByShardIdx::OwnerPathId>(),
+                    rowSet.GetValue<Schema::TablePartitionsByShardIdx::LocalPathId>()
+                );
+                const TShardIdx shardIdx(
+                    rowSet.GetValue<Schema::TablePartitionsByShardIdx::OwnerShardIdx>(),
+                    rowSet.GetValue<Schema::TablePartitionsByShardIdx::LocalShardIdx>()
+                );
+
+                if (pathId != prevPathId) {
+                    flushPartitions(prevPathId, std::move(partitions));
+                    partitions.clear();
+                    prevPathId = pathId;
+                }
+
+                TString rangeEnd = rowSet.GetValue<Schema::TablePartitionsByShardIdx::RangeEnd>();
+                ui64 lastCondErase = rowSet.GetValueOrDefault<Schema::TablePartitionsByShardIdx::LastCondErase>(0);
+                ui64 nextCondErase = rowSet.GetValueOrDefault<Schema::TablePartitionsByShardIdx::NextCondErase>(0);
+
+                TTableShardInfo shardInfo(shardIdx, rangeEnd, lastCondErase, nextCondErase);
+
+                if (Self->TTLEnabledTables.contains(pathId)) {
+                    auto& lag = shardInfo.LastCondEraseLag;
+                    if (now >= shardInfo.LastCondErase) {
+                        lag = now - shardInfo.LastCondErase;
+                    } else {
+                        lag = TDuration::Zero();
+                    }
+                    Self->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
+                }
+
+                partitions.push_back(std::move(shardInfo));
+
+                if (!rowSet.Next()) {
+                    return false;
+                }
+            }
+            // for the last table
+            flushPartitions(prevPathId, std::move(partitions));
+            partitions.clear();
         }
 
         // Read partition config patches
@@ -2560,6 +2686,113 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
             if (prevTableId) {
                 Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
+                TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
+                if (!tableInfo->IsBackup && !tableInfo->IsShardsStatsDetached()) {
+                    Self->ResolveDomainInfo(prevTableId)->AggrDiskSpaceUsage(Self, tableInfo->GetStats().Aggregated);
+                }
+            }
+        }
+
+        // Read partition stats (ShardIdx format)
+        {
+            using T = Schema::TablePartitionStatsByShardIdx;
+            auto rowSet = db.Table<T>().Range().Select();
+            if (!rowSet.IsReady()) {
+                return false;
+            }
+
+            TPathId prevTableId;
+            TInstant now = AppData()->TimeProvider->Now();
+            while (!rowSet.EndOfSet()) {
+                const TPathId tableId = TPathId(
+                    rowSet.GetValue<T::OwnerPathId>(),
+                    rowSet.GetValue<T::LocalPathId>());
+                const TShardIdx shardIdx = TShardIdx(
+                    rowSet.GetValue<T::OwnerShardIdx>(),
+                    rowSet.GetValue<T::LocalShardIdx>());
+
+                if (tableId != prevTableId) {
+                    // Aggregate the previous table's newly updated stats.
+                    // (Tables also processed by the positional block get re-aggregated here;
+                    // that is acceptable since the domain aggregate will self-correct on the
+                    // first live stats update from any shard.)
+                    if (prevTableId && Self->Tables.contains(prevTableId)) {
+                        TTableInfo::TPtr prevTableInfo = Self->Tables.at(prevTableId);
+                        if (!prevTableInfo->IsBackup && !prevTableInfo->IsShardsStatsDetached()) {
+                            Self->ResolveDomainInfo(prevTableId)->AggrDiskSpaceUsage(Self, prevTableInfo->GetStats().Aggregated);
+                        }
+                    }
+                    prevTableId = tableId;
+                }
+
+                if (!Self->Tables.contains(tableId)) {
+                    if (!rowSet.Next()) {
+                        return false;
+                    }
+                    continue;
+                }
+                TTableInfo::TPtr tableInfo = Self->Tables.at(tableId);
+                if (!tableInfo->GetPartitionStore().contains(shardIdx)) {
+                    if (!rowSet.Next()) {
+                        return false;
+                    }
+                    continue;
+                }
+
+                TPartitionStats stats;
+                stats.SeqNo = TMessageSeqNo(
+                    rowSet.GetValue<T::SeqNoGeneration>(),
+                    rowSet.GetValue<T::SeqNoRound>());
+                stats.RowCount = rowSet.GetValue<T::RowCount>();
+                stats.DataSize = rowSet.GetValue<T::DataSize>();
+                stats.IndexSize = rowSet.GetValue<T::IndexSize>();
+                stats.ByKeyFilterSize = rowSet.GetValue<T::ByKeyFilterSize>();
+                if (rowSet.HaveValue<T::StoragePoolsStats>()) {
+                    NKikimrTableStats::TStoragePoolsStats proto;
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(proto, rowSet.GetValue<T::StoragePoolsStats>()));
+                    for (const auto& poolUsage : proto.GetPoolsUsage()) {
+                        stats.StoragePoolsStats.emplace(
+                            poolUsage.GetPoolKind(),
+                            TPartitionStats::TStoragePoolStats{poolUsage.GetDataSize(), poolUsage.GetIndexSize()});
+                    }
+                }
+                stats.LastAccessTime = TInstant::FromValue(rowSet.GetValue<T::LastAccessTime>());
+                stats.LastUpdateTime = TInstant::FromValue(rowSet.GetValue<T::LastUpdateTime>());
+                stats.ImmediateTxCompleted = rowSet.GetValue<T::ImmediateTxCompleted>();
+                stats.PlannedTxCompleted = rowSet.GetValue<T::PlannedTxCompleted>();
+                stats.TxRejectedByOverload = rowSet.GetValue<T::TxRejectedByOverload>();
+                stats.TxRejectedBySpace = rowSet.GetValue<T::TxRejectedBySpace>();
+                stats.TxCompleteLag = TDuration::FromValue(rowSet.GetValue<T::TxCompleteLag>());
+                stats.InFlightTxCount = rowSet.GetValue<T::InFlightTxCount>();
+                stats.RowUpdates = rowSet.GetValue<T::RowUpdates>();
+                stats.RowDeletes = rowSet.GetValue<T::RowDeletes>();
+                stats.RowReads = rowSet.GetValue<T::RowReads>();
+                stats.RangeReads = rowSet.GetValue<T::RangeReads>();
+                stats.RangeReadRows = rowSet.GetValue<T::RangeReadRows>();
+                stats.SetCurrentRawCpuUsage(rowSet.GetValue<T::CPU>(), now);
+                stats.Memory = rowSet.GetValue<T::Memory>();
+                stats.Network = rowSet.GetValue<T::Network>();
+                stats.Storage = rowSet.GetValue<T::Storage>();
+                stats.ReadThroughput = rowSet.GetValue<T::ReadThroughput>();
+                stats.WriteThroughput = rowSet.GetValue<T::WriteThroughput>();
+                stats.ReadIops = rowSet.GetValue<T::ReadIops>();
+                stats.WriteIops = rowSet.GetValue<T::WriteIops>();
+                stats.SearchHeight = rowSet.GetValueOrDefault<T::SearchHeight>();
+                stats.FullCompactionTs = rowSet.GetValueOrDefault<T::FullCompactionTs>();
+                stats.MemDataSize = rowSet.GetValueOrDefault<T::MemDataSize>();
+                stats.LocksAcquired = rowSet.GetValueOrDefault<T::LocksAcquired>();
+                stats.LocksWholeShard = rowSet.GetValueOrDefault<T::LocksWholeShard>();
+                stats.LocksBroken = rowSet.GetValueOrDefault<T::LocksBroken>();
+
+                TDiskSpaceUsageDelta unusedDelta;
+                tableInfo->UpdateShardStats(&unusedDelta, shardIdx, stats, now);
+
+                if (!rowSet.Next()) {
+                    return false;
+                }
+            }
+
+            if (prevTableId && Self->Tables.contains(prevTableId)) {
                 TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                 if (!tableInfo->IsBackup && !tableInfo->IsShardsStatsDetached()) {
                     Self->ResolveDomainInfo(prevTableId)->AggrDiskSpaceUsage(Self, tableInfo->GetStats().Aggregated);

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -11,7 +11,29 @@
 
 #include <util/string/cast.h>
 
-static ui64 TryParseTabletId(TStringBuf tabletIdParam) {
+#include <format>
+
+namespace std {
+
+// Inherit TString* formatters from std::string* ones.
+template <>
+struct std::formatter<TString> : std::formatter<std::string> {
+    auto format(const TString& s, std::format_context& ctx) const {
+        return std::formatter<std::string>::format(s, ctx);
+    }
+};
+template <>
+struct std::formatter<TStringBuf> : std::formatter<std::string_view> {
+    auto format(const TStringBuf& s, std::format_context& ctx) const {
+        return std::formatter<std::string_view>::format(s, ctx);
+    }
+};
+
+}  // namespace std
+
+namespace {
+
+ui64 TryParseTabletId(TStringBuf tabletIdParam) {
     ui64 tabletId = ui64(NKikimr::NSchemeShard::InvalidTabletId);
     if (tabletIdParam.StartsWith("0x")) {
         TryIntFromString<16>(tabletIdParam.substr(2), tabletId);
@@ -20,6 +42,19 @@ static ui64 TryParseTabletId(TStringBuf tabletIdParam) {
     }
     return tabletId;
 }
+
+bool ParseTablePartitionsFormat(const TStringBuf& input, bool* result) {
+    if (input == "shardidx") {
+        *result = true;
+        return true;
+    } else if (input == "position") {
+        *result = false;
+        return true;
+    }
+    return false;
+}
+
+}  // anonymous namespace
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -86,6 +121,11 @@ struct TCgi {
     static const TParam UpdateCoordinatorsConfig;
     static const TParam UpdateCoordinatorsConfigDryRun;
     static const TParam Action;
+    static const TParam TablePartitionsFormat;
+    static const TParam Start;
+    static const TParam Pause;
+    static const TParam Resume;
+    static const TParam Cancel;
 
     struct TPages {
         static constexpr TStringBuf MainPage = "Main";
@@ -102,6 +142,8 @@ struct TCgi {
     struct TActions {
         static constexpr TStringBuf SplitOneToOne = "SplitOneToOne";
         static constexpr TStringBuf ForceDropUnsafe = "ForceDropUnsafe";
+        static constexpr TStringBuf TablePartitionsFormatSwitch = "TablePartitionsFormatSwitch";
+        static constexpr TStringBuf TablePartitionsFormatSweep = "TablePartitionsFormatSweep";
     };
 };
 
@@ -123,6 +165,11 @@ const TCgi::TParam TCgi::Page = TStringBuf("Page");
 const TCgi::TParam TCgi::BuildIndexId = TStringBuf("BuildIndexId");
 const TCgi::TParam TCgi::UpdateCoordinatorsConfig = TStringBuf("UpdateCoordinatorsConfig");
 const TCgi::TParam TCgi::UpdateCoordinatorsConfigDryRun = TStringBuf("UpdateCoordinatorsConfigDryRun");
+const TCgi::TParam TCgi::TablePartitionsFormat = TStringBuf("format");
+const TCgi::TParam TCgi::Start = TStringBuf("Start");
+const TCgi::TParam TCgi::Pause = TStringBuf("Pause");
+const TCgi::TParam TCgi::Resume = TStringBuf("Resume");
+const TCgi::TParam TCgi::Cancel = TStringBuf("Cancel");
 const TCgi::TParam TCgi::Action = TStringBuf("Action");
 
 
@@ -441,7 +488,10 @@ public:
         LOG_DEBUG(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, TStringBuilder() << "TTxMonitoring.Execute: " << cgi.Print());
 
         if (cgi.Has(TCgi::Action)) {
-            HandleAction(cgi.Get(TCgi::Action), cgi, ctx);
+            NIceDb::TNiceDb db(txc.DB);
+            db.NoMoreReadsForTx();
+
+            HandleAction(cgi.Get(TCgi::Action), db, cgi, ctx);
             return true;
         }
 
@@ -693,13 +743,15 @@ private:
             ctx.Register(new TUpdateCoordinatorsConfigActor(std::move(items), std::move(callback), valueDryRun));
             return;
         }
-
-        OutputAdminPage(str);
     }
 
-    TString SubmitButton(const TStringBuf value) const {
+    TString AttrDisabled(bool enabled) const {
+        return (enabled ? "" : "disabled='disabled'");
+    };
+
+    TString SubmitButton(const TStringBuf value, bool enabled = true) const {
         return TStringBuilder()
-            << "<div class=\"col-md-4\"><input class=\"btn btn-default\" type=\"submit\" value=\"" << value << "\"></div>" << Endl;
+            << "<div class='col-md-4'><input class='btn btn-default' type='submit' value='" << value << "'" << AttrDisabled(enabled) << "></div>" << Endl;
     }
 
     void ActionForceDropUnsafe(const TPathId pathId, TStringStream& str) const {
@@ -719,6 +771,186 @@ private:
         str << TCgi::LocalPathId.AsHiddenInput(pathId.LocalPathId);
         str << R"(<div style='display: flex; align-items: center;'>)" << SubmitButton("ForceDropUnsafe") << "</div>";
         str << "</form>" << Endl;
+    }
+
+    void ActionSwitchTablePartitionsFormat(const TPathId pathId, TStringStream& str) const {
+        auto* tableInfoPtr = Self->Tables.FindPtr(pathId);
+        if (!tableInfoPtr) {
+            return;
+        }
+
+        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+
+        const bool currentShardIdxFormat = (*tableInfoPtr)->PartitionsInShardIdxFormat;
+        const TStringBuf format = currentShardIdxFormat ? "position" : "shardidx";
+        const TStringBuf label = currentShardIdxFormat ? "Switch to position" : "Switch to shardidx";
+
+        // Duplicate params in query string in addition to form-urlencoded body
+        // to give user clear knowledge what parameters were.
+        // Params in the body are the actually used ones, query parameters will be ignored
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        const TString actionUrl = TStringBuilder() << "app?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+            << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSwitch)
+            << "&" << TCgi::OwnerPathId.AsCgiParam(pathId.OwnerId)
+            << "&" << TCgi::LocalPathId.AsCgiParam(pathId.LocalPathId)
+            << "&" << TCgi::TablePartitionsFormat.AsCgiParam(format)
+        ;
+
+        str << "Current table partitions storage format: <code>" << (currentShardIdxFormat ? "shardidx" : "position") << "</code><br>" << Endl;
+
+        str << std::format(R"(
+                <div class='container col-md-12'>
+                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {7}>
+                        <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                        <input type='hidden' id='Action' name='{3}' value='{4}' />
+                        <input type='hidden' id='format' name='{5}' value='{6}'/>
+                        <div class='form-group col-md-12'>
+                            <input class='btn btn-primary btn-lg' type='submit' {7}>
+                        </div>
+                    </form>
+                </div>
+            )",
+            /* {0} */ actionUrl,
+            /* {1} */ TCgi::TabletID.Name,
+            /* {2} */ Self->TabletID(),
+            /* {3} */ TCgi::Action.Name,
+            /* {4} */ TCgi::TActions::TablePartitionsFormatSwitch,
+            /* {5} */ TCgi::TablePartitionsFormat.Name,
+            /* {6} */ format,
+            /* {7} */ AttrDisabled(switchEnabled)
+        );
+    }
+
+    void OutputTablePartitionsFormatSweepSection(TStringStream& str, const TString& sweepAlert) const {
+        const auto& sweep = Self->TablePartitionsFormatSweep;
+
+        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+
+        bool startEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle);
+        bool pauseEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running);
+        bool resumeEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Paused);
+        bool cancelEnabled = switchEnabled && (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle);
+
+        // Duplicate params in query string in addition to form-urlencoded body
+        // to give user clear knowledge what parameters were.
+        // Params in the body are the actually used ones, query parameters will be ignored
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        const TString actionUrl = TStringBuilder() << "app"
+            << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+            << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSweep)
+        ;
+
+        str << "<legend>Table partitions storage format sweep:</legend>" << Endl;
+
+        // Alert
+        if (sweepAlert) {
+            str << "<div class='alert alert-info' role='alert'>" << sweepAlert << "</div>" << Endl;
+        }
+
+        // Current status
+        str << "<div class='container col-md-12'>" << Endl;
+        str << "<h4>Status</h4>" << Endl;
+        str << "Currently: <code>" << sweep.Status << "</code>";
+        if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
+            str << ", switch to format: <code>" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "</code>" << Endl;
+        } else {
+            str << "<br>" << Endl;
+        }
+        str << "Tables:"
+            << " " << Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() << " in <code>position</code>"
+            << ", " << Self->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Get() << " in <code>shardidx</code>"
+            << ", total " << Self->Tables.size()
+            << "<br>" << Endl;
+        str << "</div>" << Endl;
+
+        // Progress
+        if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
+            str << std::format(R"(
+                    <div class='container col-md-12'>
+                        <h4>Progress</h4>
+                        <div class='col-md-1'>Done: {}</div>
+                        <div class='col-md-1'>Skipped: {}</div>
+                        <div class='col-md-1'>Queued: {}</div>
+                    </div>
+                )",
+                sweep.Done,
+                sweep.Skipped,
+                sweep.Queue.size()
+            );
+        }
+
+        // Start block
+        str << std::format(R"(
+                <div class='container col-md-12'>
+                    <h4>Start sweep</h4>
+                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {7}>
+                        <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                        <input type='hidden' id='Action' name='{3}' value='{4}' />
+                        <input type='hidden' id='Start' name='{6}' value='1'/>
+                        <div class='form-inline'>
+                            <input class='form-control' type='radio' id='shardidx' name='{5}' value='shardidx' aria-describedby='start-help' checked {7}>
+                            <label class='control-label' for='shardidx'>shardidx</label>
+                            <input class='form-control' type='radio' id='position' name='{5}' value='position' aria-describedby='start-help' {7}>
+                            <label class='control-label' for='position'>position</label>
+                            <span id='start-help' class='help-block'>Tables will be converted to a selected partitions storage format.</span>
+                        </div>
+                        <div class='form-group col-md-12'>
+                            <input class='btn btn-primary btn-lg' type='submit' {7}>
+                        </div>
+                    </form>
+                </div>
+            )",
+            /* {0} */ actionUrl,
+            /* {1} */ TCgi::TabletID.Name,
+            /* {2} */ Self->TabletID(),
+            /* {3} */ TCgi::Action.Name,
+            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {5} */ TCgi::TablePartitionsFormat.Name,
+            /* {6} */ TCgi::Start.Name,
+            /* {7} */ AttrDisabled(startEnabled)
+        );
+
+        // Control block
+        str << std::format(R"(
+                <div class='container col-md-12'>
+                    <h4>Controls</h4>
+                    <div class='btn-toolbar'>
+                        <div class='btn-group'>
+                            <form method='POST' action='{0}' {6}>
+                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input class='btn btn-default' type='submit' value='{5}' {6}/>
+                            </form>
+                        </div>
+                        <div class='btn-group'>
+                            <form method='POST' action='{0}' {8}>
+                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input class='btn btn-default' type='submit' value='{7}' {8}/>
+                            </form>
+                        </div>
+                        <div class='btn-group'>
+                            <form method='POST' action='{0}' {8}>
+                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input class='btn btn-default' type='submit' value='{9}' {10}/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            )",
+            /* {0} */ actionUrl,
+            /* {1} */ TCgi::TabletID.Name,
+            /* {2} */ Self->TabletID(),
+            /* {3} */ TCgi::Action.Name,
+            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {5} */ TCgi::Pause.Name,
+            /* {6} */ AttrDisabled(pauseEnabled),
+            /* {7} */ TCgi::Resume.Name,
+            /* {8} */ AttrDisabled(resumeEnabled),
+            /* {9} */ TCgi::Cancel.Name,
+            /* {10} */ AttrDisabled(cancelEnabled)
+        );
     }
 
     void OutputAdminPage(TStringStream& str) const {
@@ -1593,6 +1825,9 @@ private:
 
             TAG(TH3) {str << "Admin actions:";}
             ActionForceDropUnsafe(pathId, str);
+            if (path->IsTable()) {
+                ActionSwitchTablePartitionsFormat(pathId, str);
+            }
         }
     }
     void OutputShardInfoPageByShardIdx(TShardIdx shardIdx, TStringStream& str) const {
@@ -1645,7 +1880,7 @@ private:
     }
 
 private:
-    void HandleAction(const TString& action, const TCgiParameters& cgi, const TActorContext& ctx) {
+    void HandleAction(const TString& action, NIceDb::TNiceDb& db, const TCgiParameters& cgi, const TActorContext& ctx) {
         if (Ev->Get()->GetMethod() != HTTP_METHOD_POST) {
             SendBadRequest("Action requires a POST method", ctx);
             return;
@@ -1671,7 +1906,6 @@ private:
             }
 
             ctx.Register(new TMonitoringShardSplitOneToOne(std::move(Ev), Self->TabletID(), pathId, tabletId));
-            return;
 
         } else if (action == TCgi::TActions::ForceDropUnsafe) {
             const TPathId pathId(
@@ -1686,10 +1920,98 @@ private:
             }
 
             ctx.Register(new TMonitoringForceDropUnsafe(std::move(Ev), Self->TabletID(), path.PathString()));
-            return;
-        }
 
-        SendBadRequest("Action not supported", ctx);
+        } else if (action == TCgi::TActions::TablePartitionsFormatSwitch) {
+            const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+            if (!switchEnabled) {
+                SendBadRequest("Format switching is disabled", ctx);
+                return;
+            }
+
+            const TPathId pathId(
+                FromStringWithDefault<ui64>(cgi.Get(TCgi::OwnerPathId), InvalidOwnerId),
+                FromStringWithDefault<ui64>(cgi.Get(TCgi::LocalPathId), InvalidLocalPathId)
+            );
+
+            const auto path = TPath::Init(pathId, Self);
+            if (!path) {
+                SendBadRequest(TStringBuilder() << "Cannot find path with PathId " << pathId, ctx);
+                return;
+            }
+            if (!Self->Tables.FindPtr(pathId)) {
+                SendBadRequest(TStringBuilder() << "PathId " << pathId << " is not a table", ctx);
+                return;
+            }
+
+            const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+            bool formatShardIdx = false;
+            if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
+                Self->Execute(Self->CreateTxTablePartitionsFormatSwitch(std::move(Ev), pathId, formatShardIdx), ctx);
+            } else {
+                SendBadRequest(
+                    TStringBuilder() << "Invalid target '" << input << "', expected 'position' or 'shardidx'",
+                    ctx
+                );
+            }
+
+        } else if (action == TCgi::TActions::TablePartitionsFormatSweep) {
+            TStringBuilder sweepAlert;
+
+            const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+            if (switchEnabled) {
+                const auto& sweep = Self->TablePartitionsFormatSweep;
+
+                if (cgi.Has(TCgi::Start)) {
+                    if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
+                        const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+                        bool formatShardIdx = false;
+                        if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
+                            Self->StartTablePartitionsFormatSweep(db, formatShardIdx);
+                            sweepAlert << TStringBuf(TCgi::Start) << ": OK";
+                        } else {
+                            sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: invalid format '" << input << "', expected 'shardidx' or 'position'.";
+                        }
+                    } else {
+                        sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: sweep already running or paused. Cancel first.";
+                    }
+
+                } else if (cgi.Has(TCgi::Pause)) {
+                    if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running) {
+                        Self->PauseTablePartitionsFormatSweep(db);
+                        sweepAlert << TStringBuf(TCgi::Pause) << ": OK";
+                    } else {
+                        sweepAlert << TStringBuf(TCgi::Pause) << ": ERROR: sweep is not running.";
+                    }
+
+                } else if (cgi.Has(TCgi::Resume)) {
+                    if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Paused) {
+                        Self->ResumeTablePartitionsFormatSweep(db);
+                        sweepAlert << TStringBuf(TCgi::Resume) << ": OK";
+                    } else {
+                        sweepAlert << TStringBuf(TCgi::Resume) << ": ERROR: sweep is not paused.";
+                    }
+
+                } else if (cgi.Has(TCgi::Cancel)) {
+                    if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
+                        Self->CancelTablePartitionsFormatSweep(db);
+                        sweepAlert << TStringBuf(TCgi::Cancel) << ": OK";
+                    } else {
+                        sweepAlert << TStringBuf(TCgi::Cancel) << ": ERROR: no current sweep.";
+                    }
+                }
+                // else: return current status
+
+            } else {
+                sweepAlert << "ERROR: format switching is disabled.";
+            }
+
+            LinkToMain(Answer);
+            OutputAdminPage(Answer);
+            OutputTablePartitionsFormatSweepSection(Answer, sweepAlert);
+
+        } else {
+            SendBadRequest("Action not supported", ctx);
+        }
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -1,6 +1,8 @@
 #include "schemeshard_impl.h"
 #include "schemeshard_index_build_info.h"
 
+#include <ydb/core/tx/schemeshard/schemeshard__monitoring.h_serialized.h>  // for enum ESweepAlert support methods
+
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/protos/tx_datashard.pb.h>
 #include <ydb/core/tx/datashard/range_ops.h>
@@ -126,6 +128,7 @@ struct TCgi {
     static const TParam Pause;
     static const TParam Resume;
     static const TParam Cancel;
+    static const TParam SweepAlert;
 
     struct TPages {
         static constexpr TStringBuf MainPage = "Main";
@@ -170,6 +173,7 @@ const TCgi::TParam TCgi::Start = TStringBuf("Start");
 const TCgi::TParam TCgi::Pause = TStringBuf("Pause");
 const TCgi::TParam TCgi::Resume = TStringBuf("Resume");
 const TCgi::TParam TCgi::Cancel = TStringBuf("Cancel");
+const TCgi::TParam TCgi::SweepAlert = TStringBuf("sweepalert");
 const TCgi::TParam TCgi::Action = TStringBuf("Action");
 
 
@@ -491,7 +495,7 @@ public:
             NIceDb::TNiceDb db(txc.DB);
             db.NoMoreReadsForTx();
 
-            HandleAction(cgi.Get(TCgi::Action), db, cgi, ctx);
+            HandleAction(cgi.Get(TCgi::Action), db, ctx);
             return true;
         }
 
@@ -548,6 +552,7 @@ public:
         else if (page == TCgi::TPages::AdminPage)
         {
             OutputAdminPage(Answer);
+            OutputTablePartitionsFormatSweepSection(Answer);
         }
         else if (page == TCgi::TPages::BuildIndexInfo)
         {
@@ -607,6 +612,7 @@ private:
             str.clear();
 
             OutputAdminPage(templateAnswer);
+            OutputTablePartitionsFormatSweepSection(templateAnswer);
 
             auto func = [templateAnswer] (const TMap<TPathId, TSet<TString>>& done) -> NActors::IEventBase* {
                 TStringStream str = templateAnswer;
@@ -658,6 +664,7 @@ private:
             str.clear();
 
             OutputAdminPage(templateAnswer);
+            OutputTablePartitionsFormatSweepSection(templateAnswer);
 
             auto func = [templateAnswer] (const TMap<TPathId, TSet<TString>>& done) -> NActors::IEventBase* {
                 TStringStream str = templateAnswer;
@@ -732,6 +739,7 @@ private:
 
             str << "</pre>";
             OutputAdminPage(str);
+            OutputTablePartitionsFormatSweepSection(str);
 
             auto callback = [sender = Ev->Sender, str = std::move(str)] (const TString& log, const TActorContext& ctx) mutable {
                 str << "<pre>" << log << "</pre>";
@@ -783,12 +791,11 @@ private:
 
         const bool currentShardIdxFormat = (*tableInfoPtr)->PartitionsInShardIdxFormat;
         const TStringBuf format = currentShardIdxFormat ? "position" : "shardidx";
-        const TStringBuf label = currentShardIdxFormat ? "Switch to position" : "Switch to shardidx";
 
         // Duplicate params in query string in addition to form-urlencoded body
         // to give user clear knowledge what parameters were.
         // Params in the body are the actually used ones, query parameters will be ignored
-        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp, TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr))
         const TString actionUrl = TStringBuilder() << "app?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
             << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSwitch)
             << "&" << TCgi::OwnerPathId.AsCgiParam(pathId.OwnerId)
@@ -821,10 +828,12 @@ private:
         );
     }
 
-    void OutputTablePartitionsFormatSweepSection(TStringStream& str, const TString& sweepAlert) const {
+    void OutputTablePartitionsFormatSweepSection(TStringStream& str) const {
         const auto& sweep = Self->TablePartitionsFormatSweep;
 
-        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+        const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()
+            && (Self->Tables.size() > 0)
+        ;
 
         bool startEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle);
         bool pauseEnabled = switchEnabled && (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running);
@@ -834,17 +843,23 @@ private:
         // Duplicate params in query string in addition to form-urlencoded body
         // to give user clear knowledge what parameters were.
         // Params in the body are the actually used ones, query parameters will be ignored
-        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp).
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp, TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr)).
         const TString actionUrl = TStringBuilder() << "app"
             << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+            << "&" << TCgi::Page.AsCgiParam(TCgi::TPages::AdminPage)
             << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::TablePartitionsFormatSweep)
         ;
 
         str << "<legend>Table partitions storage format sweep:</legend>" << Endl;
 
+        const TCgiParameters& params = Ev->Get()->Cgi();
+
         // Alert
-        if (sweepAlert) {
-            str << "<div class='alert alert-info' role='alert'>" << sweepAlert << "</div>" << Endl;
+        if (params.Has(TCgi::SweepAlert)) {
+            ui8 num;
+            if (TryFromString<ui8>(params.Get(TCgi::SweepAlert), num) && num < GetEnumItemsCount<ESweepAlert>()) {
+                str << "<div class='alert alert-info' role='alert'>" << ESweepAlert(num) << "</div>" << Endl;
+            }
         }
 
         // Current status
@@ -853,9 +868,8 @@ private:
         str << "Currently: <code>" << sweep.Status << "</code>";
         if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
             str << ", switch to format: <code>" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "</code>" << Endl;
-        } else {
-            str << "<br>" << Endl;
         }
+        str << "<br>" << Endl;
         str << "Tables:"
             << " " << Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() << " in <code>position</code>"
             << ", " << Self->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Get() << " in <code>shardidx</code>"
@@ -868,9 +882,9 @@ private:
             str << std::format(R"(
                     <div class='container col-md-12'>
                         <h4>Progress</h4>
-                        <div class='col-md-1'>Done: {}</div>
-                        <div class='col-md-1'>Skipped: {}</div>
-                        <div class='col-md-1'>Queued: {}</div>
+                        <div class='col-md-2'>Done: {}</div>
+                        <div class='col-md-2'>Skipped: {}</div>
+                        <div class='col-md-2'>Queued: {}</div>
                     </div>
                 )",
                 sweep.Done,
@@ -883,19 +897,20 @@ private:
         str << std::format(R"(
                 <div class='container col-md-12'>
                     <h4>Start sweep</h4>
-                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {7}>
+                    <form method='POST' class='form-horizontal col-md-12' action='{0}' {9}>
                         <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                        <input type='hidden' id='Action' name='{3}' value='{4}' />
-                        <input type='hidden' id='Start' name='{6}' value='1'/>
+                        <input type='hidden' id='Page' name='{3}' value='{4}' />
+                        <input type='hidden' id='Action' name='{5}' value='{6}' />
+                        <input type='hidden' id='Start' name='{8}' value='1'/>
                         <div class='form-inline'>
-                            <input class='form-control' type='radio' id='shardidx' name='{5}' value='shardidx' aria-describedby='start-help' checked {7}>
+                            <input class='form-control' type='radio' id='shardidx' name='{7}' value='shardidx' aria-describedby='start-help' checked {9}>
                             <label class='control-label' for='shardidx'>shardidx</label>
-                            <input class='form-control' type='radio' id='position' name='{5}' value='position' aria-describedby='start-help' {7}>
+                            <input class='form-control' type='radio' id='position' name='{7}' value='position' aria-describedby='start-help' {9}>
                             <label class='control-label' for='position'>position</label>
                             <span id='start-help' class='help-block'>Tables will be converted to a selected partitions storage format.</span>
                         </div>
                         <div class='form-group col-md-12'>
-                            <input class='btn btn-primary btn-lg' type='submit' {7}>
+                            <input class='btn btn-primary btn-lg' type='submit' value='{8}' {9}>
                         </div>
                     </form>
                 </div>
@@ -903,11 +918,13 @@ private:
             /* {0} */ actionUrl,
             /* {1} */ TCgi::TabletID.Name,
             /* {2} */ Self->TabletID(),
-            /* {3} */ TCgi::Action.Name,
-            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
-            /* {5} */ TCgi::TablePartitionsFormat.Name,
-            /* {6} */ TCgi::Start.Name,
-            /* {7} */ AttrDisabled(startEnabled)
+            /* {3} */ TCgi::Page.Name,
+            /* {4} */ TCgi::TPages::AdminPage,
+            /* {5} */ TCgi::Action.Name,
+            /* {6} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {7} */ TCgi::TablePartitionsFormat.Name,
+            /* {8} */ TCgi::Start.Name,
+            /* {9} */ AttrDisabled(startEnabled)
         );
 
         // Control block
@@ -916,24 +933,30 @@ private:
                     <h4>Controls</h4>
                     <div class='btn-toolbar'>
                         <div class='btn-group'>
-                            <form method='POST' action='{0}' {6}>
-                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
-                                <input class='btn btn-default' type='submit' value='{5}' {6}/>
-                            </form>
-                        </div>
-                        <div class='btn-group'>
                             <form method='POST' action='{0}' {8}>
                                 <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Pause' name='{7}' value='1'/>
                                 <input class='btn btn-default' type='submit' value='{7}' {8}/>
                             </form>
                         </div>
                         <div class='btn-group'>
-                            <form method='POST' action='{0}' {8}>
+                            <form method='POST' action='{0}' {10}>
                                 <input type='hidden' id='TabletID' name='{1}' value='{2}' />
-                                <input type='hidden' id='Action' name='{3}' value='{4}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Resume' name='{9}' value='1'/>
                                 <input class='btn btn-default' type='submit' value='{9}' {10}/>
+                            </form>
+                        </div>
+                        <div class='btn-group'>
+                            <form method='POST' action='{0}' {12}>
+                                <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                                <input type='hidden' id='Page' name='{3}' value='{4}' />
+                                <input type='hidden' id='Action' name='{5}' value='{6}' />
+                                <input type='hidden' id='Cancel' name='{11}' value='1'/>
+                                <input class='btn btn-default' type='submit' value='{11}' {12}/>
                             </form>
                         </div>
                     </div>
@@ -942,14 +965,16 @@ private:
             /* {0} */ actionUrl,
             /* {1} */ TCgi::TabletID.Name,
             /* {2} */ Self->TabletID(),
-            /* {3} */ TCgi::Action.Name,
-            /* {4} */ TCgi::TActions::TablePartitionsFormatSweep,
-            /* {5} */ TCgi::Pause.Name,
-            /* {6} */ AttrDisabled(pauseEnabled),
-            /* {7} */ TCgi::Resume.Name,
-            /* {8} */ AttrDisabled(resumeEnabled),
-            /* {9} */ TCgi::Cancel.Name,
-            /* {10} */ AttrDisabled(cancelEnabled)
+            /* {3} */ TCgi::Page.Name,
+            /* {4} */ TCgi::TPages::AdminPage,
+            /* {5} */ TCgi::Action.Name,
+            /* {6} */ TCgi::TActions::TablePartitionsFormatSweep,
+            /* {7} */ TCgi::Pause.Name,
+            /* {8} */ AttrDisabled(pauseEnabled),
+            /* {9} */ TCgi::Resume.Name,
+            /* {10} */ AttrDisabled(resumeEnabled),
+            /* {11} */ TCgi::Cancel.Name,
+            /* {12} */ AttrDisabled(cancelEnabled)
         );
     }
 
@@ -1879,15 +1904,36 @@ private:
             TStringBuilder() << "HTTP/1.1 400 Bad Request\r\nConnection: Close\r\n\r\n" << details << "\r\n"));
     }
 
+    void SendRedirect(const TString& location, const TActorContext& ctx) {
+        ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+            TStringBuilder() << "HTTP/1.1 303 See Other\r\nLocation: " << location << "\r\n\r\n"
+        ));
+    }
+
 private:
-    void HandleAction(const TString& action, NIceDb::TNiceDb& db, const TCgiParameters& cgi, const TActorContext& ctx) {
+    void HandleAction(const TString& action, NIceDb::TNiceDb& db, const TActorContext& ctx) {
         if (Ev->Get()->GetMethod() != HTTP_METHOD_POST) {
             SendBadRequest("Action requires a POST method", ctx);
             return;
         }
 
+        TCgiParameters params;
+        {
+            const auto& request = *Ev->Get();
+            if (request.ExtendedQuery) {
+                for (const auto& i : request.ExtendedQuery->GetPostParams()) {
+                    params.emplace(i.GetKey(), i.GetValue());
+                }
+                for (const auto& i : request.ExtendedQuery->GetQueryParams()) {
+                    params.emplace(i.GetKey(), i.GetValue());
+                }
+            } else {
+                params = request.Cgi();
+            }
+        }
+
         if (action == TCgi::TActions::SplitOneToOne) {
-            TTabletId tabletId = TTabletId(TryParseTabletId(cgi.Get(TCgi::ShardID)));
+            TTabletId tabletId = TTabletId(TryParseTabletId(params.Get(TCgi::ShardID)));
             TShardIdx shardIdx = Self->GetShardIdx(tabletId);
             if (!shardIdx) {
                 SendBadRequest("Cannot find the specified shard", ctx);
@@ -1909,8 +1955,8 @@ private:
 
         } else if (action == TCgi::TActions::ForceDropUnsafe) {
             const TPathId pathId(
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::OwnerPathId), InvalidOwnerId),
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::LocalPathId), InvalidLocalPathId)
+                FromStringWithDefault<ui64>(params.Get(TCgi::OwnerPathId), InvalidOwnerId),
+                FromStringWithDefault<ui64>(params.Get(TCgi::LocalPathId), InvalidLocalPathId)
             );
 
             const auto path = TPath::Init(pathId, Self);
@@ -1929,8 +1975,8 @@ private:
             }
 
             const TPathId pathId(
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::OwnerPathId), InvalidOwnerId),
-                FromStringWithDefault<ui64>(cgi.Get(TCgi::LocalPathId), InvalidLocalPathId)
+                FromStringWithDefault<ui64>(params.Get(TCgi::OwnerPathId), InvalidOwnerId),
+                FromStringWithDefault<ui64>(params.Get(TCgi::LocalPathId), InvalidLocalPathId)
             );
 
             const auto path = TPath::Init(pathId, Self);
@@ -1943,7 +1989,7 @@ private:
                 return;
             }
 
-            const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+            const TString input = params.Get(TCgi::TablePartitionsFormat);
             bool formatShardIdx = false;
             if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
                 Self->Execute(Self->CreateTxTablePartitionsFormatSwitch(std::move(Ev), pathId, formatShardIdx), ctx);
@@ -1955,59 +2001,68 @@ private:
             }
 
         } else if (action == TCgi::TActions::TablePartitionsFormatSweep) {
-            TStringBuilder sweepAlert;
+            ESweepAlert sweepAlert = ESweepAlert::NONE;
 
             const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
             if (switchEnabled) {
                 const auto& sweep = Self->TablePartitionsFormatSweep;
 
-                if (cgi.Has(TCgi::Start)) {
+                if (params.Has(TCgi::Start)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
-                        const TString input = cgi.Get(TCgi::TablePartitionsFormat);
+                        const TString input = params.Get(TCgi::TablePartitionsFormat);
                         bool formatShardIdx = false;
                         if (ParseTablePartitionsFormat(input, &formatShardIdx)) {
                             Self->StartTablePartitionsFormatSweep(db, formatShardIdx);
-                            sweepAlert << TStringBuf(TCgi::Start) << ": OK";
+                            sweepAlert = ESweepAlert::START_OK;
                         } else {
-                            sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: invalid format '" << input << "', expected 'shardidx' or 'position'.";
+                            sweepAlert = ESweepAlert::START_ERROR_1;
                         }
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Start) << ": ERROR: sweep already running or paused. Cancel first.";
+                        sweepAlert = ESweepAlert::START_ERROR_2;
                     }
 
-                } else if (cgi.Has(TCgi::Pause)) {
+                } else if (params.Has(TCgi::Pause)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Running) {
                         Self->PauseTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Pause) << ": OK";
+                        sweepAlert = ESweepAlert::PAUSE_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Pause) << ": ERROR: sweep is not running.";
+                        sweepAlert = ESweepAlert::PAUSE_ERROR;
                     }
 
-                } else if (cgi.Has(TCgi::Resume)) {
+                } else if (params.Has(TCgi::Resume)) {
                     if (sweep.Status == TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Paused) {
                         Self->ResumeTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Resume) << ": OK";
+                        sweepAlert = ESweepAlert::RESUME_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Resume) << ": ERROR: sweep is not paused.";
+                        sweepAlert = ESweepAlert::RESUME_ERROR;
                     }
 
-                } else if (cgi.Has(TCgi::Cancel)) {
+                } else if (params.Has(TCgi::Cancel)) {
                     if (sweep.Status != TSchemeShard::TTablePartitionsFormatSweepState::EStatus::Idle) {
                         Self->CancelTablePartitionsFormatSweep(db);
-                        sweepAlert << TStringBuf(TCgi::Cancel) << ": OK";
+                        sweepAlert = ESweepAlert::CANCEL_OK;
                     } else {
-                        sweepAlert << TStringBuf(TCgi::Cancel) << ": ERROR: no current sweep.";
+                        sweepAlert = ESweepAlert::CANCEL_ERROR;
                     }
                 }
                 // else: return current status
 
             } else {
-                sweepAlert << "ERROR: format switching is disabled.";
+                sweepAlert = ESweepAlert::ERROR_DISABLED;
             }
 
-            LinkToMain(Answer);
-            OutputAdminPage(Answer);
-            OutputTablePartitionsFormatSweepSection(Answer, sweepAlert);
+            // make redirect with location relative to the original request url (path)
+            TStringBuilder location;
+            location << "app"
+                << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+                << "&" << TCgi::Page.AsCgiParam(TCgi::TPages::AdminPage)
+            ;
+            if (sweepAlert != ESweepAlert::NONE) {
+                // output an underlying number, not an associated string value
+                location << "&" << TCgi::SweepAlert.AsCgiParam(ToString(ui8(sweepAlert)));
+            }
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxMonitoring.Execute: redirect to " << location);
+            SendRedirect(location, ctx);
 
         } else {
             SendBadRequest("Action not supported", ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.h
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <util/system/types.h>  // for ui8
+
+
+namespace NKikimr::NSchemeShard {
+
+// GENERATE_ENUM_SERIALIZATION_WITH_HEADER macro generates
+// support methods and string messages from comments for this enum.
+enum class ESweepAlert : ui8 {
+    NONE = 0,
+    START_OK = 1           /* "Start: OK." */,
+    START_ERROR_1 = 2      /* "Start: ERROR: invalid format, expected 'shardidx' or 'position'." */,
+    START_ERROR_2 = 3      /* "Start: ERROR: sweep already running or paused. Cancel first." */,
+    PAUSE_OK = 4           /* "Pause: OK." */,
+    PAUSE_ERROR = 5        /* "Pause: ERROR: sweep not running." */,
+    RESUME_OK = 6          /* "Resume: OK." */,
+    RESUME_ERROR = 7       /* "Resume: ERROR: sweep not paused." */,
+    CANCEL_OK = 8          /* "Cancel: OK." */,
+    CANCEL_ERROR = 9       /* "Cancel: ERROR: no current sweep." */,
+    ERROR_DISABLED = 10     /* "ERROR: format switching is disabled." */,
+};
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -191,7 +191,7 @@ void PrepareChanges(TOperationId opId, TPathElement::TPtr path, TTableInfo::TPtr
             : TTxState::ConfigureParts;
 
     txState.Shards.reserve(table->GetPartitionStore().size());
-    for (auto& [shardIdx, shard] : table->GetPartitionStore()) {
+    for (const auto& shardIdx : table->GetPartitionStore() | std::views::keys) {
         TShardInfo& shardInfo = context.SS->ShardInfos[shardIdx];
 
         auto shardOp = commonShardOp;
@@ -394,7 +394,7 @@ public:
             table->ScheduleAllCondErase();
 
             const auto now = context.Ctx.Now();
-            for (const auto& [_, shard] : table->GetPartitionStore()) {
+            for (const auto& shard : table->GetPartitionStore() | std::views::values) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
@@ -406,7 +406,7 @@ public:
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Sub(1);
             table->ClearCondEraseSchedule();
 
-            for (const auto& [_, shard] : table->GetPartitionStore()) {
+            for (const auto& shard : table->GetPartitionStore() | std::views::values) {
                 if (auto& lag = shard.LastCondEraseLag) {
                     context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
                     lag.Clear();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -257,13 +257,19 @@ public:
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
 
             const auto now = context.Ctx.Now();
-            for (const auto& [_, shard] : table->GetPartitionStore()) {
+            for (const auto& shard : table->GetPartitionStore() | std::views::values) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
                 lag = now - shard.LastCondErase;
                 context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
             }
+        }
+
+        if (table->PartitionsInShardIdxFormat) {
+            context.SS->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Add(1);
+        } else {
+            context.SS->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Add(1);
         }
 
         auto parentDir = context.SS->PathsById.at(path->ParentPathId);
@@ -762,6 +768,9 @@ public:
         TTableInfo::TPtr tableInfo = new TTableInfo(std::move(*alterData));
         alterData.Reset();
 
+        // Preserve table partitions storage format from source table.
+        tableInfo->PartitionsInShardIdxFormat = srcTableInfo->PartitionsInShardIdxFormat;
+
         TChannelsBindings channelsBinding;
         bool storePerShardConfig = false;
         NKikimrSchemeOp::TPartitionConfig perShardConfig;
@@ -851,7 +860,7 @@ public:
         if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
             context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
         }
-        for (const auto& [shardIdx, shard] : tableInfo->GetPartitionStore()) {
+        for (const auto& shardIdx : tableInfo->GetPartitionStore() | std::views::keys) {
             Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shardIdx), "shard info is set before");
             if (storePerShardConfig) {
                 tableInfo->PerShardPartitionConfig[shardIdx].CopyFrom(perShardConfig);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -324,7 +324,7 @@ public:
             context.SS->TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Add(1);
 
             const auto now = context.Ctx.Now();
-            for (const auto& [_, shard] : table->GetPartitionStore()) {
+            for (const auto& shard : table->GetPartitionStore() | std::views::values) {
                 auto& lag = shard.LastCondEraseLag;
                 Y_DEBUG_ABORT_UNLESS(!lag.Defined());
 
@@ -333,6 +333,12 @@ public:
             }
         }
         context.SS->PersistTableCreated(db, pathId);
+
+        if (table->PartitionsInShardIdxFormat) {
+            context.SS->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Add(1);
+        } else {
+            context.SS->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Add(1);
+        }
 
         auto parentDir = context.SS->PathsById.at(path->ParentPathId);
         if (parentDir->IsDirectory() || parentDir->IsDomainRoot()) {
@@ -622,6 +628,10 @@ public:
         TTableInfo::TPtr tableInfo = new TTableInfo(std::move(*alterData));
         alterData.Reset();
 
+        if (AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx() && AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdxByDefault()) {
+            tableInfo->PartitionsInShardIdxFormat = true;
+        }
+
         TVector<TTableShardInfo> partitions;
 
         if (!DoInitPartitioning(tableInfo, schema, typeRegistry, errStr, partitions)) {
@@ -726,7 +736,7 @@ public:
         context.SS->PersistUpdateNextPathId(db);
         context.SS->PersistUpdateNextShardIdx(db);
         // Persist new shards info
-        for (const auto& [shardIdx, shard] : tableInfo->GetPartitionStore()) {
+        for (const auto& shardIdx : tableInfo->GetPartitionStore() | std::views::keys) {
             Y_ABORT_UNLESS(context.SS->ShardInfos.contains(shardIdx), "shard info is set before");
             auto tabletType = context.SS->ShardInfos[shardIdx].TabletType;
             const auto& bindedChannels = context.SS->ShardInfos[shardIdx].BindedChannels;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -275,6 +275,9 @@ public:
             Y_ABORT_UNLESS(context.SS->Tables.contains(srcPath.Base()->PathId));
 
             TTableInfo::TPtr tableInfo = TTableInfo::DeepCopy(*context.SS->Tables.at(srcPath.Base()->PathId));
+            // report TTableInfo::VerifyConsistency() time
+            context.SS->TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
+
             tableInfo->ResetDescriptionCache();
             tableInfo->AlterVersion += 1;
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -281,7 +281,7 @@ public:
             // copy table info
             context.SS->Tables[dstPath.Base()->PathId] = tableInfo;
             context.SS->PersistTable(db, dstPath.Base()->PathId);
-            context.SS->PersistTablePartitionStats(db, dstPath.Base()->PathId, tableInfo);
+            context.SS->PersistAllTablePartitionStats(db, dstPath.Base()->PathId, tableInfo);
             {
                 TVector<TTableShardInfo> newParts;
                 newParts.reserve(tableInfo->GetPartitions().size());
@@ -517,6 +517,12 @@ public:
                     lag = now - shard->LastCondErase;
                     context.SS->TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].IncrementFor(lag->Seconds());
                 }
+            }
+
+            if (tableInfo->PartitionsInShardIdxFormat) {
+                context.SS->TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Add(1);
+            } else {
+                context.SS->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Add(1);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
@@ -291,26 +291,47 @@ public:
             srcFirstIdx = Min(srcFirstIdx, p->Position);
         }
         Y_ABORT_UNLESS(srcFirstIdx != Max<ui64>());
-        const ui64 splitStartIdx = AppData()->FeatureFlags.GetEnableSplitMergePartialPersistence()
-            ? srcFirstIdx
-            : 0;
 
-        context.SS->PersistTablePartitioningDeletion(db, tableId, tableInfo, splitStartIdx);
-        context.SS->ApplySplitMerge(tableId, tableInfo, std::move(dstPartitions), allSrcShardIdxs, srcFirstIdx);
-        context.SS->ProcessForcedCompactionOnSplitMerge(db, tableId, allSrcShardIdxs, newShardsIdx);
-        if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
-            context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
+        ui64 partitionsSkipped = 0;
+        ui64 partitionsRewritten = 0;
+
+        if (tableInfo->PartitionsInShardIdxFormat) {
+            // O(k) fast path: touch only src/dst rows in TablePartitionsByShardIdx.
+            const auto kAdded = newShardsIdx.size();
+
+            context.SS->PersistTablePartitioningByShardIdxDelete(db, tableId, tableInfo, allSrcShardIdxs);
+            context.SS->ApplySplitMerge(tableId, tableInfo, std::move(dstPartitions), allSrcShardIdxs, srcFirstIdx);
+            context.SS->PersistTablePartitioningByShardIdxInsert(db, tableId, tableInfo, srcFirstIdx, kAdded);
+            context.SS->PersistTablePartitioningVersion(db, tableId, tableInfo);
+
+            const ui64 newPartitionCount = tableInfo->GetPartitions().size();
+            partitionsSkipped = newPartitionCount - kAdded;
+            partitionsRewritten = kAdded;
+        } else {
+            // O(N) slow path: full or partial rewrite in TablePartitions.
+            ui64 splitStartIdx = AppData()->FeatureFlags.GetEnableSplitMergePartialPersistence() ? srcFirstIdx : 0;
+
+            context.SS->PersistTablePartitioningDeletion(db, tableId, tableInfo, splitStartIdx);
+            context.SS->ApplySplitMerge(tableId, tableInfo, std::move(dstPartitions), allSrcShardIdxs, srcFirstIdx);
+            context.SS->PersistTablePartitioning(db, tableId, tableInfo, splitStartIdx);
+            context.SS->PersistAllTablePartitionStats(db, tableId, tableInfo, splitStartIdx);
+
+            const ui64 newPartitionCount = tableInfo->GetPartitions().size();
+            partitionsSkipped = splitStartIdx;
+            partitionsRewritten = newPartitionCount - splitStartIdx;
         }
-        context.SS->PersistTablePartitioning(db, tableId, tableInfo, splitStartIdx);
-        context.SS->PersistTablePartitionStats(db, tableId, tableInfo, splitStartIdx);
 
-        // Partial persistence counters: skipped = [0, splitStartIdx), rewritten = [splitStartIdx, end).
-        const ui64 newPartitionCount = tableInfo->GetPartitions().size();
-        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_SKIPPED].Increment(splitStartIdx);
-        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN].Increment(newPartitionCount - splitStartIdx);
+        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_SKIPPED].Increment(partitionsSkipped);
+        context.SS->TabletCounters->Cumulative()[COUNTER_SPLIT_MERGE_PARTITIONS_REWRITTEN].Increment(partitionsRewritten);
 
         context.SS->TabletCounters->Simple()[COUNTER_TABLE_SHARD_ACTIVE_COUNT].Sub(allSrcShardIdxs.size());
         context.SS->TabletCounters->Simple()[COUNTER_TABLE_SHARD_INACTIVE_COUNT].Add(allSrcShardIdxs.size());
+
+        context.SS->ProcessForcedCompactionOnSplitMerge(db, tableId, allSrcShardIdxs, newShardsIdx);
+
+        if (context.SS->EnableShred && context.SS->TenantShredManager->GetStatus() == EShredStatus::IN_PROGRESS) {
+            context.OnComplete.Send(context.SS->SelfId(), new TEvPrivate::TEvAddNewShardToShred(std::move(newShardsIdx)));
+        }
 
         if (!tableInfo->IsBackup && !tableInfo->IsShardsStatsDetached()) {
             auto newAggrStats = tableInfo->GetStats().Aggregated;

--- a/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
@@ -1,0 +1,379 @@
+#include "schemeshard_impl.h"
+
+namespace NKikimr::NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+
+// Conversion between table partition storage formats in the local db.
+//
+// TablePartitions (`position` format): shards keyed by position in the table.
+// TablePartitionsByShardIdx (`shardidx` format): shards keyed by ShardIdx.
+//
+// Both TTxTablePartitionsFormatSwitch (single table, manual) and
+// TTxTablePartitionsFormatSweepStep (all tables, background) call
+// SwitchTablePartitionsFormat() to perform the conversion.
+// They are kept separate to simplify logic and allow manual switching
+// independently of automatic sweeping.
+
+
+// TablePartitionsFormatSwitch -- single table conversion
+
+struct TSchemeShard::TTxTablePartitionsFormatSwitch : public TTransactionBase<TSchemeShard> {
+    NMon::TEvRemoteHttpInfo::TPtr Ev;
+    TPathId PathId;
+    TString PathStr;
+    bool ShardIdxFormat = false;
+    EFormatSwitchStatus Status = EFormatSwitchStatus::Ok;
+
+    TTxTablePartitionsFormatSwitch(TSelf* self, NMon::TEvRemoteHttpInfo::TPtr ev, TPathId pathId, bool shardIdxFormat)
+        : TTransactionBase<TSchemeShard>(self)
+        , Ev(std::move(ev))
+        , PathId(pathId)
+        , ShardIdxFormat(shardIdxFormat)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_TABLE_PARTITIONS_STORAGE_FORMAT_SWITCH;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        NIceDb::TNiceDb db(txc.DB);
+        PathStr = TPath::Init(PathId, Self).PathString();
+        Status = Self->SwitchTablePartitionsFormat(db, PathId, ShardIdxFormat);
+
+        LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxTablePartitionsFormatSwitch: "
+            << " path " << PathStr << " " << PathId
+            << ", switch to format '" << (ShardIdxFormat ? "shardidx" : "position") << "'"
+            << ", result " << Status
+            << ", schemeshardId: " << Self->TabletID()
+        );
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        TStringStream body;
+        switch (Status) {
+            case EFormatSwitchStatus::Ok:
+                body << "OK\n"
+                     << PathStr << "\n"
+                     << PathId << "\n"
+                     << "Switched to format '" << (ShardIdxFormat ? "shardidx" : "position") << "'.";
+                break;
+            case EFormatSwitchStatus::AlreadyDone:
+                body << "ALREADY_DONE\n"
+                     << PathStr << "\n"
+                     << PathId << "\n"
+                     << "Already in format '" << (ShardIdxFormat ? "shardidx" : "position") << "'.";
+                break;
+            case EFormatSwitchStatus::Busy:
+                body << "BUSY\n"
+                     << PathStr << "\n"
+                     << PathId << "\n"
+                     << "Under another operation. Retry later.";
+                break;
+            case EFormatSwitchStatus::NotATable:
+                body << "NOT_A_TABLE\n"
+                     << PathStr << "\n"
+                     << PathId << "\n"
+                     << "Not a table.";
+                break;
+        }
+        ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+            TStringBuilder()
+                << "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+                << body.Str()
+                << "\n"
+        ));
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxTablePartitionsFormatSwitch(
+    NMon::TEvRemoteHttpInfo::TPtr ev, TPathId pathId, bool shardIdxFormat
+) {
+    return new TTxTablePartitionsFormatSwitch(this, std::move(ev), pathId, shardIdxFormat);
+}
+
+
+// TablePartitionsFormatSweepStep -- conversion sweep over all tables
+
+struct TSchemeShard::TTxTablePartitionsFormatSweepStep : public TTransactionBase<TSchemeShard> {
+    TDuration DelayNext;
+
+    TTxTablePartitionsFormatSweepStep(TSelf* self)
+        : TTransactionBase<TSchemeShard>(self)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_TABLE_PARTITIONS_STORAGE_FORMAT_SWEEP_STEP;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        auto& sweep = Self->TablePartitionsFormatSweep;
+
+        if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Running) {
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+
+        // Self-cancel if the live flag diverged from the captured target.
+        const bool liveTarget = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
+        if (liveTarget != sweep.TargetIsShardIdx) {
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep step:"
+                << " flag EnableTablePartitionsFormatShardIdx flipped during sweep, cancelling"
+            );
+            Self->CancelTablePartitionsFormatSweep(db);
+            return true;
+        }
+
+        if (sweep.Queue.empty()) {
+            Self->ClearTablePartitionsFormatSweep(db);
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep complete:"
+                << " done " << sweep.Done
+                << ", skipped " << sweep.Skipped
+                << ", schemeshardId: " << Self->TabletID()
+            );
+            return true;
+        }
+
+        const TPathId pathId = sweep.Queue.front();
+        sweep.Queue.pop_front();
+
+        // Cap overall time fraction taken by format switching to 10%.
+        // That is a throughput guarantee, not a latency guarantee.
+        const auto timeStart = ctx.Monotonic();
+        const auto status = Self->SwitchTablePartitionsFormat(db, pathId, sweep.TargetIsShardIdx);
+        DelayNext = Max(TDuration::MilliSeconds(100), (ctx.Monotonic() - timeStart) * 9);
+
+        switch (status) {
+            case EFormatSwitchStatus::Ok:
+                ++sweep.Done;
+                break;
+            case EFormatSwitchStatus::AlreadyDone:
+                ++sweep.Skipped;
+                break;
+            case EFormatSwitchStatus::Busy:
+                sweep.Queue.push_back(pathId);
+                break;
+            case EFormatSwitchStatus::NotATable:
+                break;
+        }
+
+        const auto pathStr = TPath::Init(pathId, Self).PathString();
+        LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep step:"
+            << " path " << pathStr << " " << pathId
+            << ", switch to format '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+            << ", result " << status
+            << ", schemeshardId: " << Self->TabletID()
+        );
+
+        if (sweep.Queue.empty()) {
+            Self->ClearTablePartitionsFormatSweep(db);
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep complete:"
+                << " done " << sweep.Done
+                << ", skipped " << sweep.Skipped
+                << ", schemeshardId: " << Self->TabletID()
+            );
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        auto& sweep = Self->TablePartitionsFormatSweep;
+
+        if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Running) {
+            ctx.Schedule(DelayNext, new TEvPrivate::TEvProgressTablePartitionsFormatSweep);
+        }
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxTablePartitionsFormatSweepStep() {
+    return new TTxTablePartitionsFormatSweepStep(this);
+}
+
+
+// TSchemeShard methods
+
+void TSchemeShard::Handle(TEvPrivate::TEvProgressTablePartitionsFormatSweep::TPtr&, const TActorContext& ctx) {
+    Execute(CreateTxTablePartitionsFormatSweepStep(), ctx);
+}
+
+void TSchemeShard::StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool targetIsShardIdx) {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    sweep.Status = TTablePartitionsFormatSweepState::EStatus::Running;
+    sweep.TargetIsShardIdx = targetIsShardIdx;
+    sweep.Done = 0;
+    sweep.Skipped = 0;
+    sweep.Queue.clear();
+
+    for (const auto& [pathId, tableInfoPtr] : Tables) {
+        if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
+            sweep.Queue.push_back(pathId);
+        }
+    }
+
+    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "TablePartitionsFormatSweep start:"
+        << " tables to process " << sweep.Queue.size()
+        << ", tables total " << Tables.size()
+        << ", switch to '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+        << ", schemeshardId: " << TabletID()
+    );
+
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepStatus)
+        .Update(NIceDb::TUpdate<Schema::SysParams::Value>("1"))
+    ;
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepTarget)
+        .Update(NIceDb::TUpdate<Schema::SysParams::Value>(targetIsShardIdx ? "1" : "0"))
+    ;
+
+    Send(SelfId(), new TEvPrivate::TEvProgressTablePartitionsFormatSweep);
+}
+
+void TSchemeShard::PauseTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "TablePartitionsFormatSweep pause:"
+        << " tables to process " << sweep.Queue.size()
+        << ", tables total " << Tables.size()
+        << ", switch to '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+        << ", schemeshardId: " << TabletID()
+    );
+
+    sweep.Status = TTablePartitionsFormatSweepState::EStatus::Paused;
+
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepStatus)
+        .Update(NIceDb::TUpdate<Schema::SysParams::Value>("2"))
+    ;
+}
+
+void TSchemeShard::ResumeTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "TablePartitionsFormatSweep resume:"
+        << " tables to process " << sweep.Queue.size()
+        << ", tables total " << Tables.size()
+        << ", switch to '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+        << ", schemeshardId: " << TabletID()
+    );
+
+    sweep.Status = TTablePartitionsFormatSweepState::EStatus::Running;
+
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepStatus)
+        .Update(NIceDb::TUpdate<Schema::SysParams::Value>("1"))
+    ;
+
+    Send(SelfId(), new TEvPrivate::TEvProgressTablePartitionsFormatSweep);
+}
+
+void TSchemeShard::CancelTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "TablePartitionsFormatSweep cancel:"
+        << " tables to process " << sweep.Queue.size()
+        << ", tables total " << Tables.size()
+        << ", switch to '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+        << ", schemeshardId: " << TabletID()
+    );
+
+    ClearTablePartitionsFormatSweep(db);
+}
+
+void TSchemeShard::ClearTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    sweep.Status = TTablePartitionsFormatSweepState::EStatus::Idle;
+    sweep.Queue.clear();
+
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepStatus).Delete();
+    db.Table<Schema::SysParams>().Key(Schema::SysParam_TablePartitionsFormatSweepTarget).Delete();
+}
+
+// InitializeTablePartitionsFormatSweep -- (re)init sweep state on reboot.
+
+void TSchemeShard::InitializeTablePartitionsFormatSweep() {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Running) {
+        ContinueTablePartitionsFormatSweep();
+
+    } else if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle
+        && AppData()->FeatureFlags.GetEnableTablePartitionsFormatAutoConvert()
+        && (TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() > 0)
+    ) {
+        Execute(CreateTxTablePartitionsFormatSweepAutoStart());
+    }
+    // else: sweep paused -- do nothing
+}
+
+// ContinueTablePartitionsFormatSweep -- continue running sweep on reboot.
+
+void TSchemeShard::ContinueTablePartitionsFormatSweep() {
+    auto& sweep = TablePartitionsFormatSweep;
+
+    if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Running) {
+        return;
+    }
+
+    // Rebuild queue after restart: walk all tables, enqueue those not yet converted.
+    sweep.Queue.clear();
+    for (const auto& [pathId, tableInfoPtr] : Tables) {
+        if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
+            sweep.Queue.push_back(pathId);
+        }
+    }
+
+    LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+        "TablePartitionsFormatSweep continue:"
+        << " tables to process " << sweep.Queue.size()
+        << ", tables total " << Tables.size()
+        << ", switch to '" << (sweep.TargetIsShardIdx ? "shardidx" : "position") << "'"
+        << ", schemeshardId: " << TabletID()
+    );
+
+    Send(SelfId(), new TEvPrivate::TEvProgressTablePartitionsFormatSweep);
+}
+
+// TablePartitionsFormatSweepAutoStart -- auto start on reboot.
+// Single way only: position -> shardidx.
+
+struct TSchemeShard::TTxTablePartitionsFormatSweepAutoStart : public TTransactionBase<TSchemeShard> {
+
+    TTxTablePartitionsFormatSweepAutoStart(TSelf* self)
+        : TTransactionBase<TSchemeShard>(self)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_TABLE_PARTITIONS_STORAGE_FORMAT_SWEEP_AUTO_START;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        auto& sweep = Self->TablePartitionsFormatSweep;
+
+        // same check, just in case
+        if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle
+            && AppData()->FeatureFlags.GetEnableTablePartitionsFormatAutoConvert()
+            && (Self->TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() > 0)
+        ) {
+            NIceDb::TNiceDb db(txc.DB);
+            Self->StartTablePartitionsFormatSweep(db, /*targetIsShardIdx*/ true);
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext&) override {}
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxTablePartitionsFormatSweepAutoStart() {
+    return new TTxTablePartitionsFormatSweepAutoStart(this);
+}
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_partitions_format.cpp
@@ -118,11 +118,10 @@ struct TSchemeShard::TTxTablePartitionsFormatSweepStep : public TTransactionBase
 
         NIceDb::TNiceDb db(txc.DB);
 
-        // Self-cancel if the live flag diverged from the captured target.
-        const bool liveTarget = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
-        if (liveTarget != sweep.TargetIsShardIdx) {
+        // Self-cancel if shardidx format support is disabled during the sweep.
+        if (!AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()) {
             LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TablePartitionsFormatSweep step:"
-                << " flag EnableTablePartitionsFormatShardIdx flipped during sweep, cancelling"
+                << " flag EnableTablePartitionsFormatShardIdx turned off during sweep, cancelling"
             );
             Self->CancelTablePartitionsFormatSweep(db);
             return true;
@@ -204,6 +203,14 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressTablePartitionsFormatSweep::TPt
 void TSchemeShard::StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool targetIsShardIdx) {
     auto& sweep = TablePartitionsFormatSweep;
 
+    if (!AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()) {
+        LOG_ERROR_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TablePartitionsFormatSweep start: cannot start as EnableTablePartitionsFormatShardIdx is disabled"
+            << ", schemeshardId: " << TabletID()
+        );
+        return;
+    }
+
     sweep.Status = TTablePartitionsFormatSweepState::EStatus::Running;
     sweep.TargetIsShardIdx = targetIsShardIdx;
     sweep.Done = 0;
@@ -214,6 +221,16 @@ void TSchemeShard::StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool tar
         if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
             sweep.Queue.push_back(pathId);
         }
+    }
+
+    if (sweep.Queue.empty()) {
+        LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TablePartitionsFormatSweep start: no tables to process"
+            << ", schemeshardId: " << TabletID()
+        );
+        sweep.Status = TTablePartitionsFormatSweepState::EStatus::Idle;
+        sweep.Queue.clear();
+        return;
     }
 
     LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,
@@ -301,16 +318,17 @@ void TSchemeShard::ClearTablePartitionsFormatSweep(NIceDb::TNiceDb& db) {
 void TSchemeShard::InitializeTablePartitionsFormatSweep() {
     auto& sweep = TablePartitionsFormatSweep;
 
-    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Running) {
+    if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Idle) {
+        // sweep running or paused
         ContinueTablePartitionsFormatSweep();
 
-    } else if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle
+    } else if (AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx()
         && AppData()->FeatureFlags.GetEnableTablePartitionsFormatAutoConvert()
         && (TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Get() > 0)
     ) {
+        // sweep on idle but should be started
         Execute(CreateTxTablePartitionsFormatSweepAutoStart());
     }
-    // else: sweep paused -- do nothing
 }
 
 // ContinueTablePartitionsFormatSweep -- continue running sweep on reboot.
@@ -318,7 +336,7 @@ void TSchemeShard::InitializeTablePartitionsFormatSweep() {
 void TSchemeShard::ContinueTablePartitionsFormatSweep() {
     auto& sweep = TablePartitionsFormatSweep;
 
-    if (sweep.Status != TTablePartitionsFormatSweepState::EStatus::Running) {
+    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Idle) {
         return;
     }
 
@@ -328,6 +346,10 @@ void TSchemeShard::ContinueTablePartitionsFormatSweep() {
         if (tableInfoPtr->PartitionsInShardIdxFormat != sweep.TargetIsShardIdx) {
             sweep.Queue.push_back(pathId);
         }
+    }
+
+    if (sweep.Status == TTablePartitionsFormatSweepState::EStatus::Paused) {
+        return;
     }
 
     LOG_NOTICE_S(TlsActivationContext->AsActorContext(), NKikimrServices::FLAT_TX_SCHEMESHARD,

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -245,6 +245,8 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
 
     SubscribeToTempTableOwners();
 
+    InitializeTablePartitionsFormatSweep();
+
     Become(&TThis::StateWork);
 }
 
@@ -2783,10 +2785,28 @@ void TSchemeShard::PersistChannelsBinding(NIceDb::TNiceDb& db, const TShardIdx s
     }
 }
 
+void TSchemeShard::PersistTablePartitioningVersion(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo) {
+    if (IsLocalId(pathId)) {
+        db.Table<Schema::Tables>().Key(pathId.LocalPathId).Update(
+            NIceDb::TUpdate<Schema::Tables::PartitioningVersion>(++tableInfo->PartitioningVersion));
+    } else {
+        db.Table<Schema::MigratedTables>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
+            NIceDb::TUpdate<Schema::MigratedTables::PartitioningVersion>(++tableInfo->PartitioningVersion));
+    }
+}
+
 void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
     for (ui64 pi = startIdx; pi < tableInfo->GetPartitions().size(); ++pi) {
         const auto* partition = tableInfo->GetPartitions()[pi];
-        if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
+        if (tableInfo->PartitionsInShardIdxFormat) {
+            db.Table<Schema::TablePartitionsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId,
+                     partition->ShardIdx.GetOwnerId(), partition->ShardIdx.GetLocalId())
+                .Update(
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::RangeEnd>(partition->EndOfRange),
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::LastCondErase>(partition->LastCondErase.GetValue()),
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::NextCondErase>(partition->NextCondErase.GetValue()));
+        } else if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
             db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Update(
                 NIceDb::TUpdate<Schema::TablePartitions::RangeEnd>(partition->EndOfRange),
                 NIceDb::TUpdate<Schema::TablePartitions::DatashardIdx>(partition->ShardIdx.GetLocalId()),
@@ -2820,17 +2840,36 @@ void TSchemeShard::PersistTablePartitioning(NIceDb::TNiceDb& db, const TPathId p
 void TSchemeShard::PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
     const auto& partitions = tableInfo->GetPartitions();
     for (ui64 pi = startIdx; pi < partitions.size(); ++pi) {
-        if (IsLocalId(pathId)) {
-            db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Delete();
+        if (tableInfo->PartitionsInShardIdxFormat) {
+            const auto& partition = partitions[pi];
+            db.Table<Schema::TablePartitionsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId,
+                     partition->ShardIdx.GetOwnerId(), partition->ShardIdx.GetLocalId())
+                .Delete();
+            db.Table<Schema::TablePartitionStatsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId,
+                     partition->ShardIdx.GetOwnerId(), partition->ShardIdx.GetLocalId())
+                .Delete();
+        } else {
+            if (IsLocalId(pathId)) {
+                db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Delete();
+            }
+            db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Delete();
         }
-        db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Delete();
         db.Table<Schema::TablePartitionStats>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Delete();
     }
 }
 
-void TSchemeShard::PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, const TTableShardInfo* partition, [[maybe_unused]] const TTableInfo::TPtr tableInfo) {
+void TSchemeShard::PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, const TTableShardInfo* partition, const TTableInfo::TPtr tableInfo) {
     const ui64 id = partition->Position;
-    if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
+    if (tableInfo->PartitionsInShardIdxFormat) {
+        db.Table<Schema::TablePartitionsByShardIdx>()
+            .Key(pathId.OwnerId, pathId.LocalPathId,
+                 partition->ShardIdx.GetOwnerId(), partition->ShardIdx.GetLocalId())
+            .Update(
+                NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::LastCondErase>(partition->LastCondErase.GetValue()),
+                NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::NextCondErase>(partition->NextCondErase.GetValue()));
+    } else if (IsLocalId(pathId) && IsLocalId(partition->ShardIdx)) {
         db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, id).Update(
             NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(partition->LastCondErase.GetValue()),
             NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(partition->NextCondErase.GetValue()));
@@ -2845,69 +2884,199 @@ void TSchemeShard::PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPa
     }
 }
 
-void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, ui64 partitionId, const TPartitionStats& stats) {
-    if (!AppData()->FeatureFlags.GetEnablePersistentPartitionStats()) {
-        return;
+void TSchemeShard::PersistTablePartitioningByShardIdxDelete(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, const TVector<TShardIdx>& srcShardIdxs) {
+    for (const TShardIdx& idx : srcShardIdxs) {
+        db.Table<Schema::TablePartitionsByShardIdx>()
+            .Key(pathId.OwnerId, pathId.LocalPathId, idx.GetOwnerId(), idx.GetLocalId())
+            .Delete();
+        db.Table<Schema::TablePartitionStatsByShardIdx>()
+            .Key(pathId.OwnerId, pathId.LocalPathId, idx.GetOwnerId(), idx.GetLocalId())
+            .Delete();
+    }
+    // TablePartitionStats is position-keyed: use Position for O(k) lookup.
+    for (const TShardIdx& idx : srcShardIdxs) {
+        const auto* p = tableInfo->GetPartitionStore().FindPtr(idx);
+        Y_ABORT_UNLESS(p);
+        db.Table<Schema::TablePartitionStats>()
+            .Key(pathId.OwnerId, pathId.LocalPathId, p->Position)
+            .Delete();
+    }
+}
+
+void TSchemeShard::PersistTablePartitioningByShardIdxInsert(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 srcFirstIdx, ui64 kAdded) {
+    const auto& partitions = tableInfo->GetPartitions();
+    for (ui64 i = srcFirstIdx; i < srcFirstIdx + kAdded; ++i) {
+        const auto* p = partitions[i];
+        db.Table<Schema::TablePartitionsByShardIdx>()
+            .Key(pathId.OwnerId, pathId.LocalPathId, p->ShardIdx.GetOwnerId(), p->ShardIdx.GetLocalId())
+            .Update(
+                NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::RangeEnd>(p->EndOfRange),
+                NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::LastCondErase>(p->LastCondErase.GetValue()),
+                NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::NextCondErase>(p->NextCondErase.GetValue()));
+        PersistTablePartitionStats(db, pathId, p->ShardIdx, tableInfo);
+    }
+}
+
+void TSchemeShard::PersistTablePartitioningInFormat(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, bool shardIdxFormat) {
+    Y_ABORT_UNLESS(tableInfo->PartitionsInShardIdxFormat != shardIdxFormat,
+        "PersistTablePartitioningInFormat called when format already matches target"
+    );
+
+    const auto& partitions = tableInfo->GetPartitions();
+    for (ui64 pi = 0; pi < partitions.size(); ++pi) {
+        const auto* p = partitions[pi];
+
+        if (shardIdxFormat) {
+            // position -> shardidx
+            db.Table<Schema::TablePartitionsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId, p->ShardIdx.GetOwnerId(), p->ShardIdx.GetLocalId())
+                .Update(
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::RangeEnd>(p->EndOfRange),
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::LastCondErase>(p->LastCondErase.GetValue()),
+                    NIceDb::TUpdate<Schema::TablePartitionsByShardIdx::NextCondErase>(p->NextCondErase.GetValue())
+                );
+            if (IsLocalId(pathId)) {
+                db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Delete();
+            }
+            db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Delete();
+            db.Table<Schema::TablePartitionStats>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Delete();
+        } else {
+            // shardidx -> position
+            if (IsLocalId(pathId) && IsLocalId(p->ShardIdx)) {
+                db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pi).Update(
+                    NIceDb::TUpdate<Schema::TablePartitions::RangeEnd>(p->EndOfRange),
+                    NIceDb::TUpdate<Schema::TablePartitions::DatashardIdx>(p->ShardIdx.GetLocalId()),
+                    NIceDb::TUpdate<Schema::TablePartitions::LastCondErase>(p->LastCondErase.GetValue()),
+                    NIceDb::TUpdate<Schema::TablePartitions::NextCondErase>(p->NextCondErase.GetValue())
+                );
+            } else {
+                if (IsLocalId(pathId)) {
+                    BumpIncompatibleChanges(db, 1);
+                }
+                db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pi).Update(
+                    NIceDb::TUpdate<Schema::MigratedTablePartitions::RangeEnd>(p->EndOfRange),
+                    NIceDb::TUpdate<Schema::MigratedTablePartitions::OwnerShardIdx>(p->ShardIdx.GetOwnerId()),
+                    NIceDb::TUpdate<Schema::MigratedTablePartitions::LocalShardIdx>(p->ShardIdx.GetLocalId()),
+                    NIceDb::TUpdate<Schema::MigratedTablePartitions::LastCondErase>(p->LastCondErase.GetValue()),
+                    NIceDb::TUpdate<Schema::MigratedTablePartitions::NextCondErase>(p->NextCondErase.GetValue())
+                );
+            }
+            db.Table<Schema::TablePartitionsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId, p->ShardIdx.GetOwnerId(), p->ShardIdx.GetLocalId())
+                .Delete();
+            db.Table<Schema::TablePartitionStatsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId, p->ShardIdx.GetOwnerId(), p->ShardIdx.GetLocalId())
+                .Delete();
+        }
+    }
+}
+
+TSchemeShard::EFormatSwitchStatus TSchemeShard::SwitchTablePartitionsFormat(NIceDb::TNiceDb& db, TPathId pathId, bool shardIdxFormat) {
+    auto* tableInfoPtr = Tables.FindPtr(pathId);
+    if (!tableInfoPtr) {
+        return EFormatSwitchStatus::NotATable;
+    }
+    auto& tableInfo = *tableInfoPtr;
+    if (tableInfo->PartitionsInShardIdxFormat == shardIdxFormat) {
+        return EFormatSwitchStatus::AlreadyDone;
+    }
+    if (TPath::Init(pathId, this).IsUnderOperation()) {
+        return EFormatSwitchStatus::Busy;
     }
 
-    auto persistedStats = db.Table<Schema::TablePartitionStats>().Key(tableId.OwnerId, tableId.LocalPathId, partitionId);
-    persistedStats.Update(
-        NIceDb::TUpdate<Schema::TablePartitionStats::SeqNoGeneration>(stats.SeqNo.Generation),
-        NIceDb::TUpdate<Schema::TablePartitionStats::SeqNoRound>(stats.SeqNo.Round),
+    PersistTablePartitioningInFormat(db, pathId, tableInfo, shardIdxFormat);
+    tableInfo->PartitionsInShardIdxFormat = shardIdxFormat;
+    // Re-write stats rows in the new format (PersistAllTablePartitionStats is a
+    // no-op when EnablePersistentPartitionStats is off).
+    PersistAllTablePartitionStats(db, pathId, tableInfo, 0);
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::RowCount>(stats.RowCount),
-        NIceDb::TUpdate<Schema::TablePartitionStats::DataSize>(stats.DataSize),
-        NIceDb::TUpdate<Schema::TablePartitionStats::IndexSize>(stats.IndexSize),
-        NIceDb::TUpdate<Schema::TablePartitionStats::ByKeyFilterSize>(stats.ByKeyFilterSize),
+    auto prevFormatCounter = shardIdxFormat ? COUNTER_FORMAT_POSITION_TABLE_COUNT : COUNTER_FORMAT_SHARDIDX_TABLE_COUNT;
+    auto nextFormatCounter = shardIdxFormat ? COUNTER_FORMAT_SHARDIDX_TABLE_COUNT : COUNTER_FORMAT_POSITION_TABLE_COUNT;
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::LastAccessTime>(stats.LastAccessTime.GetValue()),
-        NIceDb::TUpdate<Schema::TablePartitionStats::LastUpdateTime>(stats.LastUpdateTime.GetValue()),
+    TabletCounters->Simple()[prevFormatCounter].Sub(1);
+    TabletCounters->Simple()[nextFormatCounter].Add(1);
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::ImmediateTxCompleted>(stats.ImmediateTxCompleted),
-        NIceDb::TUpdate<Schema::TablePartitionStats::PlannedTxCompleted>(stats.PlannedTxCompleted),
-        NIceDb::TUpdate<Schema::TablePartitionStats::TxRejectedByOverload>(stats.TxRejectedByOverload),
-        NIceDb::TUpdate<Schema::TablePartitionStats::TxRejectedBySpace>(stats.TxRejectedBySpace),
-        NIceDb::TUpdate<Schema::TablePartitionStats::TxCompleteLag>(stats.TxCompleteLag.GetValue()),
-        NIceDb::TUpdate<Schema::TablePartitionStats::InFlightTxCount>(stats.InFlightTxCount),
+    return EFormatSwitchStatus::Ok;
+}
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::RowUpdates>(stats.RowUpdates),
-        NIceDb::TUpdate<Schema::TablePartitionStats::RowDeletes>(stats.RowDeletes),
-        NIceDb::TUpdate<Schema::TablePartitionStats::RowReads>(stats.RowReads),
-        NIceDb::TUpdate<Schema::TablePartitionStats::RangeReads>(stats.RangeReads),
-        NIceDb::TUpdate<Schema::TablePartitionStats::RangeReadRows>(stats.RangeReadRows),
+namespace {
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::CPU>(stats.GetCurrentRawCpuUsage()),
-        NIceDb::TUpdate<Schema::TablePartitionStats::Memory>(stats.Memory),
-        NIceDb::TUpdate<Schema::TablePartitionStats::Network>(stats.Network),
-        NIceDb::TUpdate<Schema::TablePartitionStats::Storage>(stats.Storage),
-        NIceDb::TUpdate<Schema::TablePartitionStats::ReadThroughput>(stats.ReadThroughput),
-        NIceDb::TUpdate<Schema::TablePartitionStats::WriteThroughput>(stats.WriteThroughput),
-        NIceDb::TUpdate<Schema::TablePartitionStats::ReadIops>(stats.ReadIops),
-        NIceDb::TUpdate<Schema::TablePartitionStats::WriteIops>(stats.WriteIops),
+// Both Schema::TablePartitionStats and Schema::TablePartitionStatsByShardIdx
+// expose identically-named columns; templating on the table type lets us write
+// the field block once.
+template <typename T, typename TRow>
+void WritePartitionStatsRow(TRow& row, const TPartitionStats& stats) {
+    row.Update(
+        NIceDb::TUpdate<typename T::SeqNoGeneration>(stats.SeqNo.Generation),
+        NIceDb::TUpdate<typename T::SeqNoRound>(stats.SeqNo.Round),
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::SearchHeight>(stats.SearchHeight),
-        NIceDb::TUpdate<Schema::TablePartitionStats::FullCompactionTs>(stats.FullCompactionTs),
-        NIceDb::TUpdate<Schema::TablePartitionStats::MemDataSize>(stats.MemDataSize),
+        NIceDb::TUpdate<typename T::RowCount>(stats.RowCount),
+        NIceDb::TUpdate<typename T::DataSize>(stats.DataSize),
+        NIceDb::TUpdate<typename T::IndexSize>(stats.IndexSize),
+        NIceDb::TUpdate<typename T::ByKeyFilterSize>(stats.ByKeyFilterSize),
 
-        NIceDb::TUpdate<Schema::TablePartitionStats::LocksAcquired>(stats.LocksAcquired),
-        NIceDb::TUpdate<Schema::TablePartitionStats::LocksWholeShard>(stats.LocksWholeShard),
-        NIceDb::TUpdate<Schema::TablePartitionStats::LocksBroken>(stats.LocksBroken)
+        NIceDb::TUpdate<typename T::LastAccessTime>(stats.LastAccessTime.GetValue()),
+        NIceDb::TUpdate<typename T::LastUpdateTime>(stats.LastUpdateTime.GetValue()),
+
+        NIceDb::TUpdate<typename T::ImmediateTxCompleted>(stats.ImmediateTxCompleted),
+        NIceDb::TUpdate<typename T::PlannedTxCompleted>(stats.PlannedTxCompleted),
+        NIceDb::TUpdate<typename T::TxRejectedByOverload>(stats.TxRejectedByOverload),
+        NIceDb::TUpdate<typename T::TxRejectedBySpace>(stats.TxRejectedBySpace),
+        NIceDb::TUpdate<typename T::TxCompleteLag>(stats.TxCompleteLag.GetValue()),
+        NIceDb::TUpdate<typename T::InFlightTxCount>(stats.InFlightTxCount),
+
+        NIceDb::TUpdate<typename T::RowUpdates>(stats.RowUpdates),
+        NIceDb::TUpdate<typename T::RowDeletes>(stats.RowDeletes),
+        NIceDb::TUpdate<typename T::RowReads>(stats.RowReads),
+        NIceDb::TUpdate<typename T::RangeReads>(stats.RangeReads),
+        NIceDb::TUpdate<typename T::RangeReadRows>(stats.RangeReadRows),
+
+        NIceDb::TUpdate<typename T::CPU>(stats.GetCurrentRawCpuUsage()),
+        NIceDb::TUpdate<typename T::Memory>(stats.Memory),
+        NIceDb::TUpdate<typename T::Network>(stats.Network),
+        NIceDb::TUpdate<typename T::Storage>(stats.Storage),
+        NIceDb::TUpdate<typename T::ReadThroughput>(stats.ReadThroughput),
+        NIceDb::TUpdate<typename T::WriteThroughput>(stats.WriteThroughput),
+        NIceDb::TUpdate<typename T::ReadIops>(stats.ReadIops),
+        NIceDb::TUpdate<typename T::WriteIops>(stats.WriteIops),
+
+        NIceDb::TUpdate<typename T::SearchHeight>(stats.SearchHeight),
+        NIceDb::TUpdate<typename T::FullCompactionTs>(stats.FullCompactionTs),
+        NIceDb::TUpdate<typename T::MemDataSize>(stats.MemDataSize),
+
+        NIceDb::TUpdate<typename T::LocksAcquired>(stats.LocksAcquired),
+        NIceDb::TUpdate<typename T::LocksWholeShard>(stats.LocksWholeShard),
+        NIceDb::TUpdate<typename T::LocksBroken>(stats.LocksBroken)
     );
 
     if (!stats.StoragePoolsStats.empty()) {
-        NKikimrTableStats::TStoragePoolsStats protobufRepresentation;
-        for (const auto& [poolKind, storagePoolStats] : stats.StoragePoolsStats) {
-            auto* poolUsage = protobufRepresentation.MutablePoolsUsage()->Add();
+        NKikimrTableStats::TStoragePoolsStats proto;
+        for (const auto& [poolKind, poolStats] : stats.StoragePoolsStats) {
+            auto* poolUsage = proto.MutablePoolsUsage()->Add();
             poolUsage->SetPoolKind(poolKind);
-            poolUsage->SetDataSize(storagePoolStats.DataSize);
-            poolUsage->SetIndexSize(storagePoolStats.IndexSize);
+            poolUsage->SetDataSize(poolStats.DataSize);
+            poolUsage->SetIndexSize(poolStats.IndexSize);
         }
-        TString serializedStoragePoolsStats;
-        Y_ABORT_UNLESS(protobufRepresentation.SerializeToString(&serializedStoragePoolsStats));
-        persistedStats.Update(NIceDb::TUpdate<Schema::TablePartitionStats::StoragePoolsStats>(serializedStoragePoolsStats));
+        TString serialized;
+        Y_ABORT_UNLESS(proto.SerializeToString(&serialized));
+        row.Update(NIceDb::TUpdate<typename T::StoragePoolsStats>(serialized));
     } else {
-        persistedStats.Update(NIceDb::TNull<Schema::TablePartitionStats::StoragePoolsStats>());
+        row.Update(NIceDb::TNull<typename T::StoragePoolsStats>());
     }
+}
+
+} // namespace
+
+void TSchemeShard::PersistTablePartitionStatsByPosition(NIceDb::TNiceDb& db, const TPathId& tableId, ui64 partitionId, const TPartitionStats& stats) {
+    using T = Schema::TablePartitionStats;
+    auto row = db.Table<T>().Key(tableId.OwnerId, tableId.LocalPathId, partitionId);
+    WritePartitionStatsRow<T>(row, stats);
+}
+
+void TSchemeShard::PersistTablePartitionStatsByShardIdx(NIceDb::TNiceDb& db, const TPathId& tableId, const TShardIdx& shardIdx, const TPartitionStats& stats) {
+    using T = Schema::TablePartitionStatsByShardIdx;
+    auto row = db.Table<T>().Key(tableId.OwnerId, tableId.LocalPathId, shardIdx.GetOwnerId(), shardIdx.GetLocalId());
+    WritePartitionStatsRow<T>(row, stats);
 }
 
 void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TShardIdx& shardIdx, const TTableInfo::TPtr tableInfo) {
@@ -2926,24 +3095,33 @@ void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId
         return;
     }
 
-    PersistTablePartitionStats(db, tableId, p->Position, *statsPtr);
+    if (tableInfo->PartitionsInShardIdxFormat) {
+        PersistTablePartitionStatsByShardIdx(db, tableId, shardIdx, *statsPtr);
+    } else {
+        PersistTablePartitionStatsByPosition(db, tableId, p->Position, *statsPtr);
+    }
 }
 
-void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
+void TSchemeShard::PersistAllTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx) {
     if (!AppData()->FeatureFlags.GetEnablePersistentPartitionStats()) {
         return;
     }
 
     const auto& tableStats = tableInfo->GetStats();
     const auto& partitions = tableInfo->GetPartitions();
+    const bool byShardIdx = tableInfo->PartitionsInShardIdxFormat;
 
     for (ui64 pi = startIdx; pi < partitions.size(); ++pi) {
         const TShardIdx shardIdx = partitions[pi]->ShardIdx;
-        if (!tableStats.PartitionStats.contains(shardIdx)) {
+        const auto* statsPtr = tableStats.PartitionStats.FindPtr(shardIdx);
+        if (!statsPtr) {
             continue;
         }
-        const auto& stats = tableStats.PartitionStats.at(shardIdx);
-        PersistTablePartitionStats(db, tableId, pi, stats);
+        if (byShardIdx) {
+            PersistTablePartitionStatsByShardIdx(db, tableId, shardIdx, *statsPtr);
+        } else {
+            PersistTablePartitionStatsByPosition(db, tableId, pi, *statsPtr);
+        }
     }
 }
 
@@ -4507,13 +4685,25 @@ void TSchemeShard::PersistRemoveTable(NIceDb::TNiceDb& db, TPathId pathId, const
     }
 
     for (ui32 pNo = 0; pNo < tableInfo->GetPartitions().size(); ++pNo) {
-        if (pathId.OwnerId == TabletID()) {
-            db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pNo).Delete();
+        const auto* shardInfo = tableInfo->GetPartitions().at(pNo);
+
+        if (tableInfo->PartitionsInShardIdxFormat) {
+            db.Table<Schema::TablePartitionsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId,
+                     shardInfo->ShardIdx.GetOwnerId(), shardInfo->ShardIdx.GetLocalId())
+                .Delete();
+            db.Table<Schema::TablePartitionStatsByShardIdx>()
+                .Key(pathId.OwnerId, pathId.LocalPathId,
+                     shardInfo->ShardIdx.GetOwnerId(), shardInfo->ShardIdx.GetLocalId())
+                .Delete();
+        } else {
+            if (pathId.OwnerId == TabletID()) {
+                db.Table<Schema::TablePartitions>().Key(pathId.LocalPathId, pNo).Delete();
+            }
+            db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pNo).Delete();
         }
-        db.Table<Schema::MigratedTablePartitions>().Key(pathId.OwnerId, pathId.LocalPathId, pNo).Delete();
         db.Table<Schema::TablePartitionStats>().Key(pathId.OwnerId, pathId.LocalPathId, pNo).Delete();
 
-        const auto* shardInfo = tableInfo->GetPartitions().at(pNo);
         if (auto& lag = shardInfo->LastCondEraseLag) {
             TabletCounters->Percentile()[COUNTER_NUM_SHARDS_BY_TTL_LAG].DecrementFor(lag->Seconds());
             lag.Clear();
@@ -4539,6 +4729,12 @@ void TSchemeShard::PersistRemoveTable(NIceDb::TNiceDb& db, TPathId pathId, const
         TabletCounters->Simple()[COUNTER_TTL_ENABLED_TABLE_COUNT].Sub(1);
     }
 
+    if (tableInfo->PartitionsInShardIdxFormat) {
+        TabletCounters->Simple()[COUNTER_FORMAT_SHARDIDX_TABLE_COUNT].Sub(1);
+    } else {
+        TabletCounters->Simple()[COUNTER_FORMAT_POSITION_TABLE_COUNT].Sub(1);
+    }
+
     if (TablesWithSnapshots.contains(pathId)) {
         const TTxId snapshotId = TablesWithSnapshots.at(pathId);
         PersistDropSnapshot(db, snapshotId, pathId);
@@ -4556,7 +4752,7 @@ void TSchemeShard::PersistRemoveTable(NIceDb::TNiceDb& db, TPathId pathId, const
     }
 
     // sanity check: by this time compaction queue and metrics must be updated already
-    for (const auto& [shardIdx, p] : tableInfo->GetPartitionStore()) {
+    for (const auto& shardIdx : tableInfo->GetPartitionStore() | std::views::keys) {
         OnShardRemoved(shardIdx);
     }
 
@@ -5416,6 +5612,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvDataShard::TEvConditionalEraseRowsResponse, Handle);
 
         HFuncTraced(TEvPrivate::TEvServerlessStorageBilling, Handle);
+        HFuncTraced(TEvPrivate::TEvProgressTablePartitionsFormatSweep, Handle);
 
         HFuncTraced(NSysView::TEvSysView::TEvGetPartitionStats, Handle);
 
@@ -7935,7 +8132,7 @@ void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, 
     Send(SysPartitionStatsCollector, ev.Release());
 
     if (!tableInfo->IsBackup) {
-        for (const auto& [shardIdx, p] : tableInfo->GetPartitionStore()) {
+        for (const auto& shardIdx : tableInfo->GetPartitionStore() | std::views::keys) {
             OnShardRemoved(shardIdx); // note that queues might not contain the shard
         }
         // No EnqueueBackgroundCompaction — new shards have no stats yet.

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -8087,6 +8087,9 @@ void TSchemeShard::SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, T
     Send(SysPartitionStatsCollector, ev.Release());
 
     tableInfo->SetPartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
@@ -8116,6 +8119,9 @@ void TSchemeShard::MovePartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, 
     }
 
     tableInfo->MovePartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, TVector<TTableShardInfo>&& newPartitioning) {
@@ -8139,6 +8145,9 @@ void TSchemeShard::CopyPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, 
     }
 
     tableInfo->CopyPartitioning(std::move(newPartitioning));
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 }
 
 void TSchemeShard::ApplySplitMerge(
@@ -8165,6 +8174,9 @@ void TSchemeShard::ApplySplitMerge(
     }
 
     tableInfo->ApplySplitMerge(std::move(dstPartitions), removedShards, splitStartIdx, now);
+
+    // report TTableInfo::VerifyConsistency() time
+    TabletCounters->Cumulative()[COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS].Increment(tableInfo->LastVerifyConsistencyTime);
 
     TVector<std::pair<ui64, ui64>> shardIndices;
     shardIndices.reserve(tableInfo->GetPartitions().size());

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -467,6 +467,20 @@ public:
 
     NExternalSource::IExternalSourceFactory::TPtr ExternalSourceFactory{NExternalSource::CreateExternalSourceFactory({})};
 
+    struct TTablePartitionsFormatSweepState {
+        enum class EStatus : ui8 {
+            Idle = 0,
+            Running,
+            Paused,
+        };
+        EStatus Status = EStatus::Idle;
+        bool TargetIsShardIdx = false;
+        TDeque<TPathId> Queue;
+        ui64 Done = 0;
+        ui64 Skipped = 0;
+    };
+    TTablePartitionsFormatSweepState TablePartitionsFormatSweep;
+
     THolder<TProposeResponse> IgniteOperation(TProposeRequest& request, TOperationContext& context);
     bool ProcessOperationParts(
         const TVector<ISubOperation::TPtr>& parts,
@@ -815,11 +829,22 @@ public:
     void PersistTable(NIceDb::TNiceDb &db, const TPathId pathId);
     void PersistChannelsBinding(NIceDb::TNiceDb& db, const TShardIdx shardId, const TChannelsBindings& bindedChannels);
     void PersistTablePartitioning(NIceDb::TNiceDb &db, const TPathId pathId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    void PersistTablePartitioningVersion(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo);
     void PersistTablePartitioningDeletion(NIceDb::TNiceDb& db, const TPathId tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    // O(k) helpers for the ByShardIdx-format fast path; called before/after ApplySplitMerge.
+    void PersistTablePartitioningByShardIdxDelete(NIceDb::TNiceDb& db, const TPathId tableId, const TTableInfo::TPtr tableInfo, const TVector<TShardIdx>& srcShardIdxs);
+    void PersistTablePartitioningByShardIdxInsert(NIceDb::TNiceDb& db, const TPathId tableId, const TTableInfo::TPtr tableInfo, ui64 srcFirstIdx, ui64 kAdded);
     void PersistTablePartitionCondErase(NIceDb::TNiceDb& db, const TPathId& pathId, const TTableShardInfo* partition, const TTableInfo::TPtr tableInfo);
-    void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, ui64 partitionId, const TPartitionStats& stats);
+    // Two row writers, one per backing schema table. PartitionsInShardIdxFormat
+    // selects which one is used; the dispatchers below hide that choice.
+    void PersistTablePartitionStatsByPosition(NIceDb::TNiceDb& db, const TPathId& tableId, ui64 partitionId, const TPartitionStats& stats);
+    void PersistTablePartitionStatsByShardIdx(NIceDb::TNiceDb& db, const TPathId& tableId, const TShardIdx& shardIdx, const TPartitionStats& stats);
+    // One partition (looks up stats in tableInfo).
     void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TShardIdx& shardIdx, const TTableInfo::TPtr tableInfo);
-    void PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    // All partitions starting at startIdx.
+    void PersistAllTablePartitionStats(NIceDb::TNiceDb& db, const TPathId& tableId, const TTableInfo::TPtr tableInfo, ui64 startIdx = 0);
+    // Rewrite all partition rows in the format selected by `shardIdxFormat`, deleting the alternative-format rows in the same tx.
+    void PersistTablePartitioningInFormat(NIceDb::TNiceDb& db, const TPathId pathId, const TTableInfo::TPtr tableInfo, bool shardIdxFormat);
     void PersistTableCreated(NIceDb::TNiceDb& db, const TPathId tableId);
     void PersistTableAlterVersion(NIceDb::TNiceDb &db, const TPathId pathId, const TTableInfo::TPtr tableInfo);
     void PersistClearAlterTableFull(NIceDb::TNiceDb& db, const TPathId& pathId);
@@ -1183,6 +1208,33 @@ public:
     struct TTxMakeAccessDatabaseNoInheritable;
     NTabletFlatExecutor::ITransaction* CreateTxMakeAccessDatabaseNoInheritable(const TActorId& answerTo, bool isDryRun, std::function< NActors::IEventBase* (const TMap<TPathId, TSet<TString>>&) >);
 
+    // Per-table conversion table partitions storage format (include partition stats).
+    // Atomic: eligibility check + DB row moves across localdb tables + live table flag flip in one go.
+    enum class EFormatSwitchStatus {
+        Ok,
+        AlreadyDone,
+        Busy,
+        NotATable,
+    };
+    EFormatSwitchStatus SwitchTablePartitionsFormat(NIceDb::TNiceDb& db, TPathId pathId, bool shardIdxFormat);
+
+    struct TTxTablePartitionsFormatSwitch;
+    NTabletFlatExecutor::ITransaction* CreateTxTablePartitionsFormatSwitch(NMon::TEvRemoteHttpInfo::TPtr ev, TPathId pathId, bool shardIdxFormat);
+
+    struct TTxTablePartitionsFormatSweepStep;
+    NTabletFlatExecutor::ITransaction* CreateTxTablePartitionsFormatSweepStep();
+
+    struct TTxTablePartitionsFormatSweepAutoStart;
+    NTabletFlatExecutor::ITransaction* CreateTxTablePartitionsFormatSweepAutoStart();
+
+    void InitializeTablePartitionsFormatSweep();
+    void ContinueTablePartitionsFormatSweep();
+    void StartTablePartitionsFormatSweep(NIceDb::TNiceDb& db, bool targetIsShardIdx);
+    void PauseTablePartitionsFormatSweep(NIceDb::TNiceDb& db);
+    void ResumeTablePartitionsFormatSweep(NIceDb::TNiceDb& db);
+    void CancelTablePartitionsFormatSweep(NIceDb::TNiceDb& db);
+    void ClearTablePartitionsFormatSweep(NIceDb::TNiceDb& db);
+
     struct TTxServerlessStorageBilling;
     NTabletFlatExecutor::ITransaction* CreateTxServerlessStorageBilling();
 
@@ -1510,6 +1562,8 @@ public:
     void Handle(TEvSchemeShard::TEvLogin::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvLoginFinalize::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvListUsers::TPtr& ev, const TActorContext& ctx);
+
+    void Handle(TEvPrivate::TEvProgressTablePartitionsFormatSweep::TPtr& ev, const TActorContext& ctx);
 
     void RestartPipeTx(TTabletId tabletId, const TActorContext& ctx);
 

--- a/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_incremental_restore_scan.cpp
@@ -82,7 +82,7 @@ public:
               << ", CompletedOperations.size()=" << state.CompletedOperations.size()
               << ", CurrentIncrementalIdx=" << state.CurrentIncrementalIdx
               << ", IncrementalBackups.size()=" << state.IncrementalBackups.size());
-              
+
         if (!state.AreAllCurrentOperationsComplete()) {
             const TInstant now = ctx.Now();
             const i64 overall = Self->IncrementalRestoreSettings.MaxIncrementalRestoreOverallDurationSeconds;
@@ -141,11 +141,11 @@ public:
 private:
     ui64 OperationId;
     bool CompletedOperationsChanged = false;
-    
+
     void SetCompletedOperationsChanged(bool changed) {
         CompletedOperationsChanged = changed;
     }
-    
+
     TString SerializeOperationIds(const THashSet<TOperationId>& operations) {
         NKikimrSchemeOp::TIncrementalRestoreOperationsList protoList;
         for (const auto& opId : operations) {
@@ -156,28 +156,28 @@ private:
         }
         return protoList.SerializeAsString();
     }
-    
+
     THashSet<TOperationId> DeserializeOperationIds(const TString& serializedData, const TActorContext& ctx) {
         THashSet<TOperationId> operations;
         if (serializedData.empty()) {
             return operations;
         }
-        
+
         NKikimrSchemeOp::TIncrementalRestoreOperationsList protoList;
         if (!protoList.ParseFromString(serializedData)) {
             LOG_E("Failed to parse serialized operation IDs data");
             return operations;
         }
-        
+
         for (const auto& protoOp : protoList.GetSubOps()) {
             TTxId txId(protoOp.GetId().GetTxId());
             TSubTxId subTxId = protoOp.GetId().GetSubTxId();
             operations.insert(TOperationId(txId, subTxId));
         }
-        
+
         return operations;
     }
-    
+
     bool HandleRetryPath(TIncrementalRestoreState& state, NIceDb::TNiceDb& db, const TActorContext& ctx) {
         const TInstant now = ctx.Now();
         const i64 overall = Self->IncrementalRestoreSettings.MaxIncrementalRestoreOverallDurationSeconds;
@@ -504,7 +504,7 @@ private:
         auto progressEvent = MakeHolder<TEvPrivate::TEvProgressIncrementalRestore>(OperationId);
         Self->Schedule(TDuration::Seconds(1), progressEvent.Release());
     }
-    
+
     void FinalizeIncrementalRestoreOperation(NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx, TIncrementalRestoreState& state) {
         LOG_I("Enqueuing finalization of incremental restore operation: " << OperationId);
 
@@ -533,7 +533,7 @@ private:
             ctx);
     }
 
-    void CollectTargetTablePaths(TIncrementalRestoreState& state, 
+    void CollectTargetTablePaths(TIncrementalRestoreState& state,
                                NKikimrSchemeOp::TIncrementalRestoreFinalize& finalize) {
         Y_UNUSED(state);
         auto opIt = Self->LongIncrementalRestoreOps.find(TOperationId(OperationId, 0));
@@ -542,7 +542,7 @@ private:
             for (const auto& tablePath : op.GetTablePathList()) {
                 finalize.AddTargetTablePaths(tablePath);
             }
-            
+
             for (auto& [pathId, pathInfo] : Self->PathsById) {
                 if (pathInfo->PathState == NKikimrSchemeOp::EPathState::EPathStateIncomingIncrementalRestore) {
                     TString pathString = TPath::Init(pathId, Self).PathString();
@@ -570,9 +570,9 @@ private:
         auto opIt = Self->LongIncrementalRestoreOps.find(TOperationId(OperationId, 0));
         if (opIt != Self->LongIncrementalRestoreOps.end()) {
             const auto& op = opIt->second;
-            
+
             TString bcPathString = TPath::Init(state.BackupCollectionPathId, Self).PathString();
-            
+
             TString fullBackupPath = JoinPath({bcPathString, op.GetFullBackupTrimmedName()});
             for (const auto& tablePath : op.GetTablePathList()) {
                 TPath fullPath = TPath::Resolve(tablePath, Self);
@@ -580,7 +580,7 @@ private:
                 TString sourceTablePath = JoinPath({fullBackupPath, tableName});
                 finalize.AddBackupTablePaths(sourceTablePath);
             }
-            
+
             for (const auto& incrBackupName : op.GetIncrementalBackupTrimmedNames()) {
                 TString incrBackupPath = JoinPath({bcPathString, incrBackupName});
                 for (const auto& tablePath : op.GetTablePathList()) {
@@ -637,8 +637,8 @@ void TSchemeShard::Handle(TEvPrivate::TEvRunIncrementalRestore::TPtr& ev, const 
     const auto& backupCollectionPathId = msg->BackupCollectionPathId;
     const auto& operationId = msg->OperationId;
     const auto& incrementalBackupNames = msg->IncrementalBackupNames;
-    
-    LOG_I("Handle(TEvRunIncrementalRestore) starting sequential processing for " 
+
+    LOG_I("Handle(TEvRunIncrementalRestore) starting sequential processing for "
           << incrementalBackupNames.size() << " incremental backups"
           << " backupCollectionPathId: " << backupCollectionPathId
           << " operationId: " << operationId
@@ -673,7 +673,7 @@ void TSchemeShard::Handle(TEvPrivate::TEvRunIncrementalRestore::TPtr& ev, const 
 
 void TSchemeShard::Handle(TEvPrivate::TEvProgressIncrementalRestore::TPtr& ev, const TActorContext& ctx) {
     ui64 operationId = ev->Get()->OperationId;
-    
+
     LOG_I("Handle(TEvProgressIncrementalRestore)"
         << " operationId: " << operationId
         << " tablet: " << TabletID());
@@ -808,7 +808,7 @@ void TSchemeShard::TrackIncrementalRestoreSubOpAndExpectedShards(
 
     auto tableInfoPtr = Tables.FindPtr(tablePathId);
     if (tableInfoPtr) {
-        for (const auto& [shardIdx, _] : (*tableInfoPtr)->GetPartitionStore()) {
+        for (const auto& shardIdx : (*tableInfoPtr)->GetPartitionStore() | std::views::keys) {
             tableOpState.ExpectedShards.insert(shardIdx);
         }
     }
@@ -844,12 +844,12 @@ void TSchemeShard::DispatchIncrementalRestoreShardRequests(
     auto opIt = state.TableOperations.find(subOpId);
     if (opIt != state.TableOperations.end()) {
         opIt->second.ExpectedShards.clear();
-        for (const auto& [shardIdx, _] : (*srcTableInfoPtr)->GetPartitionStore()) {
+        for (const auto& shardIdx : (*srcTableInfoPtr)->GetPartitionStore() | std::views::keys) {
             opIt->second.ExpectedShards.insert(shardIdx);
         }
     }
 
-    for (const auto& [shardIdx, _] : (*srcTableInfoPtr)->GetPartitionStore()) {
+    for (const auto& shardIdx : (*srcTableInfoPtr)->GetPartitionStore() | std::views::keys) {
         auto shardInfoIt = ShardInfos.find(shardIdx);
         if (shardInfoIt == ShardInfos.end()) {
             LOG_W("DispatchIncrementalRestoreShardRequests: ShardInfo missing for shardIdx=" << shardIdx);
@@ -1541,7 +1541,7 @@ NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxProgressIncrementalRest
 NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxProgressIncrementalRestore(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev, const TActorContext& ctx) {
     auto* msg = ev->Get();
     TTxId txId(msg->Record.GetTxId());
-    
+
     auto txToIncrRestoreIt = TxIdToIncrementalRestore.find(txId);
     if (txToIncrRestoreIt != TxIdToIncrementalRestore.end()) {
         return new TTxProgressIncrementalRestore(this, txToIncrRestoreIt->second);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1962,6 +1962,14 @@ void TTableInfo::ApplySplitMerge(
 }
 
 void TTableInfo::VerifyConsistency() const {
+    // AppData is absent in lowlevel unit tests
+    if (HasAppData() && !AppData()->FeatureFlags.GetEnableTablePartitionsConsistencyCheck()) {
+        LastVerifyConsistencyTime = 0;
+        return;
+    }
+
+    THPTimer cpuTimer;
+
     Y_ABORT_UNLESS(PartitionStore.size() == Partitions.size());
     Y_ABORT_UNLESS(Stats.PartitionStats.size() == Partitions.size());
     Y_ABORT_UNLESS(Stats.Aggregated.PartCount == Partitions.size());
@@ -1992,6 +2000,8 @@ void TTableInfo::VerifyConsistency() const {
         Y_ABORT_UNLESS(CondEraseSchedule.Empty());
         Y_ABORT_UNLESS(InFlightCondErase.empty());
     }
+
+    LastVerifyConsistencyTime = ui64(1e9 * cpuTimer.PassedReset());
 }
 
 void TTableAggregatedStats::RemoveShardStats(const TVector<TShardIdx>& keys, TInstant now) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -848,6 +848,8 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
 
     bool IsExternalBlobsEnabled = false;
 
+    mutable ui64 LastVerifyConsistencyTime = 0;
+
     const NKikimrSchemeOp::TPartitionConfig& PartitionConfig() const { return TableDescription.GetPartitionConfig(); }
     NKikimrSchemeOp::TPartitionConfig& MutablePartitionConfig() { return *TableDescription.MutablePartitionConfig(); }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -819,6 +819,12 @@ struct TTableInfo : public TSimpleRefCount<TTableInfo> {
     TMap<ui32, TColumn> Columns;
     TVector<ui32> KeyColumnIds;
     bool IsBackup = false;
+    // True when partition rows are stored in TablePartitionsByShardIdx (keyed by ShardIdx).
+    // False (default) when stored in TablePartitions/MigratedTablePartitions (keyed by position);
+    // both legacy tables are scheduled for removal once migration is complete, after which this
+    // flag and its branches can be deleted.
+    // Toggled during the first split/merge after EnableTablePartitionsFormatShardIdx changes.
+    bool PartitionsInShardIdxFormat = false;
     bool IsRestore = false;
     bool IsTemporary = false;
     TActorId OwnerActorId;

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -54,6 +54,7 @@ namespace TEvPrivate {
         EvTestNotifySubdomainCleanup,
         EvFlushConditionalEraseBatch,
         EvRunForcedCompaction,
+        EvProgressTablePartitionsFormatSweep,
         EvFullBackupItemDone,
         EvEnd
     };
@@ -382,6 +383,10 @@ namespace TEvPrivate {
         const bool Success = false;
         const TString Error;
     };
+
+    struct TEvProgressTablePartitionsFormatSweep
+        : public TEventLocal<TEvProgressTablePartitionsFormatSweep, EvProgressTablePartitionsFormatSweep>
+    {};
 
     // Sent self->self post-commit when a CopyTable sub-op of a tracked full backup finishes.
     struct TEvFullBackupItemDone : public NActors::TEventLocal<TEvFullBackupItemDone, EvFullBackupItemDone> {

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -334,6 +334,8 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<OwnerShardId, LocalShardId, ChannelId, PoolName, Binding>;
     };
 
+    // Deprecated: superseded by TablePartitionsByShardIdx. Scheduled for removal
+    // once the migration to the ShardIdx-keyed format is complete.
     struct TablePartitions : Table<8> {
         struct TabId :          Column<1, NScheme::NTypeIds::Uint64> {};
         struct Id :             Column<2, NScheme::NTypeIds::Uint64> {};
@@ -346,6 +348,8 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<TabId, Id, RangeEnd, DatashardIdx, LastCondErase, NextCondErase>;
     };
 
+    // Deprecated: superseded by TablePartitionStatsByShardIdx. Scheduled for removal
+    // once the migration to the ShardIdx-keyed format is complete.
     struct TablePartitionStats : Table<101> { // HACK: Force to use policy with multiple levels
         // key
         struct TableOwnerId : Column<1, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
@@ -443,6 +447,12 @@ struct Schema : NIceDb::Schema {
         >;
     };
 
+    // Deprecated: cross-tablet-migrated counterpart of TablePartitions, superseded
+    // by TablePartitionsByShardIdx (whose key shape covers both local and migrated
+    // tables). Scheduled for removal once the migration is complete; see also the
+    // un-ported write site in schemeshard__init_root.cpp that still targets this
+    // table during cross-schemeshard subdomain migration and will need to be
+    // redirected to TablePartitionsByShardIdx as part of retirement.
     struct MigratedTablePartitions : Table<56> {
         struct OwnerPathId :    Column<1, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
         struct LocalPathId :    Column<2, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
@@ -2384,6 +2394,126 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<OriginalOpId, ItemSeq, ItemKind, TablePathId, WaitTxId, SrcTablePathId>;
     };
 
+    // Alternative to TablePartitions/MigratedTablePartitions: keyed by path+shard identity so
+    // that split/merge writes only O(k) rows (src+dst shards) instead of O(N) positional rows.
+    // Guarded by EnableTablePartitionsFormatShardIdx feature flag.
+    // Rows are not ordered by key range; schemeshard sorts them by RangeEnd on load.
+    struct TablePartitionsByShardIdx : Table<134> {
+        struct OwnerPathId :    Column<1, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct LocalPathId :    Column<2, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct OwnerShardIdx :  Column<3, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct LocalShardIdx :  Column<4, NScheme::NTypeIds::Uint64> { using Type = TLocalShardIdx; };
+        struct RangeEnd :       Column<5, NScheme::NTypeIds::String> { using Type = TString; };
+        struct LastCondErase :  Column<6, NScheme::NTypeIds::Uint64> {};
+        struct NextCondErase :  Column<7, NScheme::NTypeIds::Uint64> {};
+
+        using TKey = TableKey<OwnerPathId, LocalPathId, OwnerShardIdx, LocalShardIdx>;
+        using TColumns = TableColumns<
+            OwnerPathId,
+            LocalPathId,
+            OwnerShardIdx,
+            LocalShardIdx,
+            RangeEnd,
+            LastCondErase,
+            NextCondErase
+        >;
+    };
+
+    // Guarded by EnableTablePartitionsFormatShardIdx feature flag.
+    // ShardIdx-keyed counterpart of TablePartitionStats; eliminates O(N) position lookup.
+    struct TablePartitionStatsByShardIdx : Table<135> {
+        struct OwnerPathId :  Column<1, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct LocalPathId :  Column<2, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct OwnerShardIdx : Column<3, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
+        struct LocalShardIdx : Column<4, NScheme::NTypeIds::Uint64> { using Type = TLocalShardIdx; };
+
+        struct SeqNoGeneration : Column<5, NScheme::NTypeIds::Uint64> {};
+        struct SeqNoRound :      Column<6, NScheme::NTypeIds::Uint64> {};
+
+        struct RowCount :  Column<7,  NScheme::NTypeIds::Uint64> {};
+        struct DataSize :  Column<8,  NScheme::NTypeIds::Uint64> {};
+        struct IndexSize : Column<9,  NScheme::NTypeIds::Uint64> {};
+
+        struct LastAccessTime : Column<10, NScheme::NTypeIds::Uint64> { using Type = TInstant::TValue; };
+        struct LastUpdateTime : Column<11, NScheme::NTypeIds::Uint64> { using Type = TInstant::TValue; };
+
+        struct ImmediateTxCompleted : Column<12, NScheme::NTypeIds::Uint64> {};
+        struct PlannedTxCompleted :   Column<13, NScheme::NTypeIds::Uint64> {};
+        struct TxRejectedByOverload : Column<14, NScheme::NTypeIds::Uint64> {};
+        struct TxRejectedBySpace :    Column<15, NScheme::NTypeIds::Uint64> {};
+        struct TxCompleteLag :        Column<16, NScheme::NTypeIds::Uint64> { using Type = TInstant::TValue; };
+        struct InFlightTxCount :      Column<17, NScheme::NTypeIds::Uint64> {};
+
+        struct RowUpdates :    Column<18, NScheme::NTypeIds::Uint64> {};
+        struct RowDeletes :    Column<19, NScheme::NTypeIds::Uint64> {};
+        struct RowReads :      Column<20, NScheme::NTypeIds::Uint64> {};
+        struct RangeReads :    Column<21, NScheme::NTypeIds::Uint64> {};
+        struct RangeReadRows : Column<22, NScheme::NTypeIds::Uint64> {};
+
+        struct CPU :            Column<23, NScheme::NTypeIds::Uint64> {};
+        struct Memory :         Column<24, NScheme::NTypeIds::Uint64> {};
+        struct Network :        Column<25, NScheme::NTypeIds::Uint64> {};
+        struct Storage :        Column<26, NScheme::NTypeIds::Uint64> {};
+        struct ReadThroughput : Column<27, NScheme::NTypeIds::Uint64> {};
+        struct WriteThroughput : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct ReadIops :       Column<29, NScheme::NTypeIds::Uint64> {};
+        struct WriteIops :      Column<30, NScheme::NTypeIds::Uint64> {};
+
+        struct SearchHeight :   Column<31, NScheme::NTypeIds::Uint64> { static constexpr ui64 Default = 0; };
+        struct FullCompactionTs : Column<32, NScheme::NTypeIds::Uint64> { static constexpr ui64 Default = 0; };
+        struct MemDataSize :    Column<33, NScheme::NTypeIds::Uint64> { static constexpr ui64 Default = 0; };
+
+        struct StoragePoolsStats : Column<34, NScheme::NTypeIds::String> { using Type = TString; };
+
+        struct ByKeyFilterSize : Column<35, NScheme::NTypeIds::Uint64> {};
+
+        struct LocksAcquired :  Column<36, NScheme::NTypeIds::Uint64> {};
+        struct LocksWholeShard : Column<37, NScheme::NTypeIds::Uint64> {};
+        struct LocksBroken :    Column<38, NScheme::NTypeIds::Uint64> {};
+
+        using TKey = TableKey<OwnerPathId, LocalPathId, OwnerShardIdx, LocalShardIdx>;
+        using TColumns = TableColumns<
+            OwnerPathId,
+            LocalPathId,
+            OwnerShardIdx,
+            LocalShardIdx,
+            SeqNoGeneration,
+            SeqNoRound,
+            RowCount,
+            DataSize,
+            IndexSize,
+            LastAccessTime,
+            LastUpdateTime,
+            ImmediateTxCompleted,
+            PlannedTxCompleted,
+            TxRejectedByOverload,
+            TxRejectedBySpace,
+            TxCompleteLag,
+            InFlightTxCount,
+            RowUpdates,
+            RowDeletes,
+            RowReads,
+            RangeReads,
+            RangeReadRows,
+            CPU,
+            Memory,
+            Network,
+            Storage,
+            ReadThroughput,
+            WriteThroughput,
+            ReadIops,
+            WriteIops,
+            SearchHeight,
+            FullCompactionTs,
+            MemDataSize,
+            StoragePoolsStats,
+            ByKeyFilterSize,
+            LocksAcquired,
+            LocksWholeShard,
+            LocksBroken
+        >;
+    };
+
     // Control op row for a trackable full backup. BackupCollectionPathId pair
     // lets reboot rebuild BCPathToFullBackup from non-terminal rows.
     struct FullBackups : Table<136> {
@@ -2570,6 +2700,8 @@ struct Schema : NIceDb::Schema {
         WaitingForcedCompactionShards,
         SharedShards,
         IncrementalRestoreItem,
+        TablePartitionsByShardIdx,
+        TablePartitionStatsByShardIdx,
         FullBackups,
         FullBackupItems
     >;
@@ -2586,6 +2718,8 @@ struct Schema : NIceDb::Schema {
     static constexpr ui64 SysParam_ServerlessStorageLastBillTime = 10;
     static constexpr ui64 SysParam_MaxIncompatibleChange = 11;
     static constexpr ui64 SysParam_IsOldArgonHashFormatMigrationCompleted = 12;
+    static constexpr ui64 SysParam_TablePartitionsFormatSweepStatus = 13;
+    static constexpr ui64 SysParam_TablePartitionsFormatSweepTarget = 14;
 
     // List of incompatible changes:
     // * Change 1: store migrated shards of local tables (e.g. after a rename) as a migrated record

--- a/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
@@ -361,6 +361,7 @@ Y_UNIT_TEST(DeepCopy_PointersAreIndependent) {
     dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 0);
     info->ApplySplitMerge(std::move(dst), {TShardIdx(1, 1)}, /*splitFirstIdx=*/1, TInstant::Zero());
     UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 4u);
+    info->VerifyConsistency();
 
     // Copy must be unaffected — its pointers still reach its own PartitionStore.
     UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 3u);
@@ -399,6 +400,30 @@ Y_UNIT_TEST(DeepCopy_WithTTL) {
     UNIT_ASSERT_VALUES_EQUAL(copy->GetInFlightCondErase().size(), 1u);
     UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 4u);
     copy->VerifyConsistency();
+}
+
+Y_UNIT_TEST(DeepCopy_PreservesPartitionsFormat) {
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(3));
+
+    // test default and explicit values
+    {
+        auto copy = TTableInfo::DeepCopy(*info);
+        UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 3u);
+        UNIT_ASSERT_VALUES_EQUAL(copy->PartitionsInShardIdxFormat, info->PartitionsInShardIdxFormat);
+    }
+    info->PartitionsInShardIdxFormat = false;
+    {
+        auto copy = TTableInfo::DeepCopy(*info);
+        UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 3u);
+        UNIT_ASSERT_VALUES_EQUAL(copy->PartitionsInShardIdxFormat, info->PartitionsInShardIdxFormat);
+    }
+    info->PartitionsInShardIdxFormat = true;
+    {
+        auto copy = TTableInfo::DeepCopy(*info);
+        UNIT_ASSERT_VALUES_EQUAL(copy->GetPartitions().size(), 3u);
+        UNIT_ASSERT_VALUES_EQUAL(copy->PartitionsInShardIdxFormat, info->PartitionsInShardIdxFormat);
+    }
 }
 
 // --- TTL state machine ---

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -1,0 +1,91 @@
+#include "schemeshard_counters.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <ydb/core/base/tablet.h>  // for TEvTablet
+#include <ydb/core/tx/tx.h>  // for TTestTxConfig
+#include <ydb/core/testlib/basics/runtime.h>  // for TTestBasicRuntime
+#include <ydb/core/protos/tablet.pb.h>  // for NKikimrTabletBase::TEvGetCountersResponse
+#include <ydb/core/protos/tablet_counters.pb.h>  // for NKikimrTabletBase::TTabletCounters
+
+
+
+using namespace NActors;
+using namespace NKikimr;
+
+namespace {
+
+NKikimrTabletBase::TEvGetCountersResponse GetCounters(TTestBasicRuntime& runtime) {
+    const auto sender = runtime.AllocateEdgeActor();
+    runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, new TEvTablet::TEvGetCounters);
+    auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>(sender);
+
+    UNIT_ASSERT(ev);
+    return ev->Get()->Record;
+}
+
+auto GetPercentileCounters(TTestBasicRuntime& runtime, const TString& name) {
+    const auto counters = GetCounters(runtime);
+    for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetPercentileCounters()) {
+        if (name != counter.GetName()) {
+            continue;
+        }
+
+        return counter;
+    }
+
+    Y_FAIL("Counter not found: %s", name.c_str());
+}
+
+}  // anonymous namespace
+
+namespace NSchemeShardUT_Private {
+
+ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name) {
+    const auto counters = GetCounters(runtime);
+    for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetSimpleCounters()) {
+        if (name != counter.GetName()) {
+            continue;
+        }
+
+        return counter.GetValue();
+    }
+
+    UNIT_ASSERT_C(false, "Counter not found: " << name);
+    return 0; // unreachable
+}
+
+void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value) {
+    UNIT_ASSERT_VALUES_EQUAL(value, GetSimpleCounter(runtime, name));
+}
+
+ui64 GetPercentileCounter(const auto& counters, const TString& range) {
+    for (ui32 i = 0; i < counters.RangesSize(); ++i) {
+        if (range != counters.GetRanges(i)) {
+            continue;
+        }
+
+        UNIT_ASSERT(i < counters.ValuesSize());
+        return counters.GetValues(i);
+    }
+
+    Y_FAIL("Range not found: %s", range.c_str());
+}
+
+ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range) {
+    auto counters = GetPercentileCounters(runtime, name);
+    return GetPercentileCounter(counters, range);
+}
+
+void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues) {
+    auto counters = GetPercentileCounters(runtime, name);
+    Cerr << counters.DebugString();
+    for (const auto& [range, value] : rangeValues) {
+        const auto v = GetPercentileCounter(counters, range);
+        UNIT_ASSERT_VALUES_EQUAL_C(v, value, "Unexpected value in range"
+            << ": range# " << range
+            << ", expected# " << value
+            << ", got# " << v);
+    }
+}
+
+}  // namespace NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.cpp
@@ -58,6 +58,20 @@ void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 va
     UNIT_ASSERT_VALUES_EQUAL(value, GetSimpleCounter(runtime, name));
 }
 
+ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name) {
+    const auto counters = GetCounters(runtime);
+    for (const auto& counter : counters.GetTabletCounters().GetAppCounters().GetCumulativeCounters()) {
+        if (name != counter.GetName()) {
+            continue;
+        }
+
+        return counter.GetValue();
+    }
+
+    UNIT_ASSERT_C(false, "Cumulative counter not found: " << name);
+    return 0; // unreachable
+}
+
 ui64 GetPercentileCounter(const auto& counters, const TString& range) {
     for (ui32 i = 0; i < counters.RangesSize(); ++i) {
         if (range != counters.GetRanges(i)) {

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -14,6 +14,7 @@ using namespace NActors;
 
 ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
 void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
+ui64 GetCumulativeCounter(TTestBasicRuntime& runtime, const TString& name);
 ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
 void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NActors {
+
+class TTestBasicRuntime;
+
+}
+
+namespace NSchemeShardUT_Private {
+
+using namespace NActors;
+
+ui64 GetSimpleCounter(TTestBasicRuntime& runtime, const TString& name);
+void CheckSimpleCounter(TTestBasicRuntime& runtime, const TString& name, ui64 value);
+ui64 GetPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const TString& range);
+void CheckPercentileCounter(TTestBasicRuntime& runtime, const TString& name, const THashMap<TString, ui64>& rangeValues);
+
+}  // namespace NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/ya.make
+++ b/ydb/core/tx/schemeshard/ut_helpers/ya.make
@@ -34,6 +34,8 @@ SRCS(
     helpers_flags_n.h
     ls_checks.cpp
     ls_checks.h
+    schemeshard_counters.cpp
+    schemeshard_counters.h
     shred_helpers.cpp
     test_env.cpp
     test_env.h

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/public/lib/value/value.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>  // for Y_UNIT_TEST_FLAGS_N
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
 
@@ -11,6 +12,10 @@ using namespace NKikimr;
 using namespace NKikimr::NMiniKQL;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
+
+// defined in ut_table_partitions_format.cpp
+TString PostSwitchAction(TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format);
+TPathId GetPathId(TTestActorRuntime& runtime, const TString& path);
 
 namespace {
 
@@ -829,6 +834,328 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitBySizeTest) {
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
                            {NLs::PartitionCount(20)});
+    }
+
+    Y_UNIT_TEST(SplitRestartRoundTrip) {
+        // Split a table into 3 partitions, restart schemeshard, then verify
+        // that the partition count, shard identities, and boundaries survive
+        // TTxInit loading from TablePartitionsByShardIdx (ShardIdx format).
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    SizeToSplit: 100500
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Split into 2.
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            const ui64 shard0 = describe.GetPathDescription().GetTablePartitions(0).GetDatashardId();
+            TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "M" } } } }
+            )", shard0));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // Split into 3.
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            const ui64 shard1 = describe.GetPathDescription().GetTablePartitions(1).GetDatashardId();
+            TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "T" } } } }
+            )", shard1));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"M", "T", ""})});
+
+        // Record shard IDs before restart.
+        TVector<ui64> preShardIds;
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            for (const auto& p : describe.GetPathDescription().GetTablePartitions()) {
+                preShardIds.push_back(p.GetDatashardId());
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(preShardIds.size(), 3u);
+
+        // Restart schemeshard — forces TTxInit to re-load from persistent tables.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"M", "T", ""})});
+
+        TVector<ui64> postShardIds;
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            for (const auto& p : describe.GetPathDescription().GetTablePartitions()) {
+                postShardIds.push_back(p.GetDatashardId());
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(preShardIds, postShardIds);
+    }
+
+    Y_UNIT_TEST(ShardIdxFormatMigration) {
+        // Start in positional format, do one split, enable ShardIdx format,
+        // do another split (triggers migration to ShardIdx format), then restart
+        // schemeshard and verify the partition state survives the round-trip.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(false);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    SizeToSplit: 100500
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // First split in positional format.
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            const ui64 shard0 = describe.GetPathDescription().GetTablePartitions(0).GetDatashardId();
+            TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "M" } } } }
+            )", shard0));
+            env.TestWaitNotification(runtime, txId);
+        }
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"M", ""})});
+
+        // Enable ShardIdx format.  The next split migrates from positional rows
+        // to ShardIdx rows and sets PartitionsInShardIdxFormat.
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            const ui64 shard1 = describe.GetPathDescription().GetTablePartitions(1).GetDatashardId();
+            TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "T" } } } }
+            )", shard1));
+            env.TestWaitNotification(runtime, txId);
+        }
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"M", "T", ""})});
+
+        // Record shard IDs before restart.
+        TVector<ui64> preShardIds;
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            for (const auto& p : describe.GetPathDescription().GetTablePartitions()) {
+                preShardIds.push_back(p.GetDatashardId());
+            }
+        }
+
+        // Restart schemeshard: forces TTxInit to load from ShardIdx rows.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Verify boundaries and shard identities survived the round-trip.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+                           {NLs::PartitionKeys({"M", "T", ""})});
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/Table", true);
+            TVector<ui64> postShardIds;
+            for (const auto& p : describe.GetPathDescription().GetTablePartitions()) {
+                postShardIds.push_back(p.GetDatashardId());
+            }
+            UNIT_ASSERT_VALUES_EQUAL(preShardIds, postShardIds);
+        }
+    }
+
+    Y_UNIT_TEST(DropTableShardIdxFormatNoOrphanRows) {
+        // PersistRemoveTable should delete from TablePartitionsByShardIdx.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "M" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "T" } } } }
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 3
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathId = GetPathId(runtime, "/MyRoot/Table");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"M", "T", ""})}
+        );
+
+        // Switch table to shardidx format
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+
+        // Counts all rows in TablePartitionsByShardIdx via a full composite-key range scan.
+        // ReadLocalTableRecords() only works for single-column keys, so we issue the
+        // MiniKQL query directly, specifying all four key columns in the range.
+        auto countShardIdxRows = [&]() -> ui64 {
+            const auto result = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, R"(
+                (
+                    (let range '(
+                        '('OwnerPathId  (Null) (Void))
+                        '('LocalPathId  (Null) (Void))
+                        '('OwnerShardIdx (Null) (Void))
+                        '('LocalShardIdx (Null) (Void))
+                    ))
+                    (let fields '('OwnerPathId))
+                    (return (AsList
+                        (SetResult 'Result (SelectRange 'TablePartitionsByShardIdx range fields '()))
+                    ))
+                )
+            )");
+            return NKikimr::NClient::TValue::Create(result)[0]["List"].Size();
+        };
+
+        // After switching to shardidx format, TablePartitionStatsByShardIdx should have exactly 3 rows
+        UNIT_ASSERT_VALUES_EQUAL(countShardIdxRows(), 3u);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"M", "T", ""})}
+        );
+
+        // Drop the table — PersistRemoveTable must delete those rows.
+        TestDropTable(runtime, ++txId, "/MyRoot", "Table");
+        env.TestWaitNotification(runtime, txId);
+
+        // TablePartitionsByShardIdx must now be empty.
+        UNIT_ASSERT_VALUES_EQUAL(countShardIdxRows(), 0u);
+
+        // Restart schemeshard — before the fix, TTxInit crashed here because
+        // orphaned TablePartitionsByShardIdx rows referenced the dropped pathId.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"),
+            {NLs::PathNotExist}
+        );
+    }
+
+    Y_UNIT_TEST(FormatDowngradeNoOrphanStatsRows) {
+        // PersistTablePartitioningDeletion should delete from
+        // TablePartitionStatsByShardIdx when PartitionsInShardIdxFormat=true.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnablePersistentPartitionStats(true);
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "M" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "T" } } } }
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 3
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto pathId = GetPathId(runtime, "/MyRoot/Table");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"M", "T", ""})}
+        );
+
+        // Switch table to shardidx format
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+
+        auto countStatsShardIdxRows = [&]() -> ui64 {
+            const auto result = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, R"(
+                (
+                    (let range '(
+                        '('OwnerPathId  (Null) (Void))
+                        '('LocalPathId  (Null) (Void))
+                        '('OwnerShardIdx (Null) (Void))
+                        '('LocalShardIdx (Null) (Void))
+                    ))
+                    (let fields '('OwnerPathId))
+                    (return (AsList
+                        (SetResult 'Result (SelectRange 'TablePartitionStatsByShardIdx range fields '()))
+                    ))
+                )
+            )");
+            return NKikimr::NClient::TValue::Create(result)[0]["List"].Size();
+        };
+
+        // After switching to shardidx format, TablePartitionStatsByShardIdx should have exactly 3 rows
+        UNIT_ASSERT_VALUES_EQUAL(countStatsShardIdxRows(), 3u);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"M", "T", ""})}
+        );
+
+        // Switch table back to position format
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+
+        // After switching to position format, TablePartitionStatsByShardIdx must be empty, no orphaned rows
+        UNIT_ASSERT_VALUES_EQUAL(countStatsShardIdxRows(), 0u);
+
+        // Restart to verify no crash loading orphaned rows
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"M", "T", ""})}
+        );
     }
 
 }

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
 #include <ydb/public/lib/value/value.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>  // for Y_UNIT_TEST_FLAGS_N
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
@@ -2891,5 +2892,113 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitMergeValidation) {
             SourceTabletId: 72075186233409546
             SourceTabletId: 72075186233409546
         )", {{NKikimrScheme::StatusInvalidParameter, "Duplicate SourceTabletId"}});
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardConsistencyCheckCounter) {
+    // COUNTER_TABLE_PARTITIONS_CONSISTENCY_CHECK_TIME_NS accumulates the wall-clock
+    // nanoseconds spent in TTableInfo::VerifyConsistency(), gated by the
+    // EnableTablePartitionsConsistencyCheck feature flag (default on).
+    static constexpr const char* CounterName = "SchemeShard/TablePartitionsConsistencyCheckTimeNs";
+
+    Y_UNIT_TEST(ZeroWhenFlagOff) {
+        // With the check disabled, VerifyConsistency() returns early and resets
+        // LastVerifyConsistencyTime to 0, so every report site increments by 0
+        // and the cumulative counter stays exactly 0.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsConsistencyCheck(false);
+
+        // Many partitions: a verify here would be measurable if it ran at all.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 200
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Exercise ApplySplitMerge as well (the first shard of a uniform table).
+        TestSplitTable(runtime, ++txId, "/MyRoot/Table", Sprintf(R"(
+            SourceTabletId: %lu
+            SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 1 } } } }
+        )", TTestTxConfig::FakeHiveTablets + 0));
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCumulativeCounter(runtime, CounterName), 0u);
+    }
+
+    Y_UNIT_TEST(ReportedWhenFlagOn) {
+        // With the check enabled (default), the cumulative counter accumulates a
+        // non-zero time across the partitioning report sites. A 200-partition
+        // verify reliably exceeds 1us, so create/copy/move alone guarantee > 0;
+        // split and merge additionally cover the ApplySplitMerge report sites and
+        // assert the verification invariants hold on real operation results.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsConsistencyCheck(true);
+
+        // Small table with explicit, predictable shard ids for split/merge.
+        // Partitions: (-inf,"A") -> F+0, ["A","B") -> F+1, ["B",+inf) -> F+2.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "SplitMe"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "A" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "B" } } } }
+            PartitionConfig {
+                PartitioningPolicy { MinPartitionsCount: 1 SizeToSplit: 100500 }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Split the first partition -> ApplySplitMerge (split).
+        TestSplitTable(runtime, ++txId, "/MyRoot/SplitMe", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Text: "0" } } } }
+            )",
+            TTestTxConfig::FakeHiveTablets + 0
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        // Merge the two non-first partitions F+1, F+2 -> ApplySplitMerge (merge).
+        TestSplitTable(runtime, ++txId, "/MyRoot/SplitMe", Sprintf(R"(
+                SourceTabletId: %lu
+                SourceTabletId: %lu
+            )",
+            TTestTxConfig::FakeHiveTablets + 1,
+            TTestTxConfig::FakeHiveTablets + 2
+        ));
+        env.TestWaitNotification(runtime, txId);
+
+        // Big table to force a measurable verify time.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "BigTable"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 200
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Copy -> SetPartitioning on the new table.
+        TestCopyTable(runtime, ++txId, "/MyRoot", "BigCopy", "/MyRoot/BigTable");
+        env.TestWaitNotification(runtime, txId);
+
+        // Move -> MovePartitioning + the move_table report site.
+        TestMoveTable(runtime, ++txId, "/MyRoot/BigTable", "/MyRoot/BigMoved");
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_GT(GetCumulativeCounter(runtime, CounterName), 0u);
     }
 }

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
@@ -1,0 +1,733 @@
+#include <ydb/core/protos/counters_schemeshard.pb.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
+#include <ydb/library/actors/core/mon.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+// Also used in ut_split_merge.cpp
+TString PostSwitchAction(TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format) {
+    auto sender = runtime.AllocateEdgeActor();
+    const TString query = TStringBuilder()
+    << "/app?Action=TablePartitionsFormatSwitch"
+    << "&OwnerPathId=" << pathId.OwnerId
+    << "&LocalPathId=" << pathId.LocalPathId
+    << "&format=" << format
+    ;
+    auto req = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(query, HTTP_METHOD_POST);
+    runtime.SendToPipe(schemeShard, sender, req.release(), 0, {});
+    auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteBinaryInfoRes>(sender);
+    return r->Get()->Blob;
+}
+
+TPathId GetPathId(TTestActorRuntime& runtime, const TString& path) {
+    auto desc = DescribePath(runtime, path);
+    const auto& self = desc.GetPathDescription().GetSelf();
+    return TPathId(self.GetSchemeshardId(), self.GetPathId());
+}
+
+namespace {
+
+TString PostSweepAction(TTestActorRuntime& runtime, ui64 schemeShard, const TString& params) {
+    auto sender = runtime.AllocateEdgeActor();
+    const TString query = TStringBuilder()
+        << "/app?TabletID=" << schemeShard
+        << "&Action=TablePartitionsFormatSweep"
+        << params
+    ;
+    auto req = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(query, HTTP_METHOD_POST);
+    runtime.SendToPipe(schemeShard, sender, req.release(), 0, {});
+    auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
+    return r->Get()->Html;
+}
+
+// Get table partitions format counters by parsing AdminRequest mon page.
+// Sensitive to page markup changes.
+TString GetTableFormatCounters(const TString& r) {
+    TStringBuf text = r;
+    TStringBuf _;
+    text.Split("<h4>Status</h4>\n", _, text);
+    text.Split("</div>", text, _);
+    // skip "Currently:...", return "Tables:..."
+    text.NextTok('\n');
+    return TString(text.NextTok("<br>"));
+}
+
+ui64 GetTablePartitionVersion(TTestActorRuntime& runtime, const TString& path) {
+    auto desc = DescribePath(runtime, path);
+    return desc.GetPathDescription().GetSelf().GetPathVersion();
+}
+
+TPathId CreateFourPartTable(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId, const TString& name) {
+    TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            Name: "%s"
+            Columns { Name: "key"   Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "C" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "M" } } } }
+            SplitBoundary { KeyPrefix { Tuple { Optional { Text: "T" } } } }
+            PartitionConfig {
+                PartitioningPolicy { MinPartitionsCount: 4 }
+            }
+        )",
+        name.c_str()
+    ));
+    env.TestWaitNotification(runtime, txId);
+
+    return GetPathId(runtime, "/MyRoot/" + name);
+}
+
+}  // namespace
+
+Y_UNIT_TEST_SUITE(TTablePartitionsFormat) {
+
+    Y_UNIT_TEST(FormatSwitchingDisabled) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching is not enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(false);
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        CreateFourPartTable(runtime, env, txId, "table");
+
+        {
+            const TPathId pathId = GetPathId(runtime, "/MyRoot/dir");
+            auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+            UNIT_ASSERT_C(r.Contains("Format switching is disabled"), r);
+            r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+            UNIT_ASSERT_C(r.Contains("Format switching is disabled"), r);
+        }
+        {
+            const TPathId pathId = GetPathId(runtime, "/MyRoot/table");
+            auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+            UNIT_ASSERT_C(r.Contains("Format switching is disabled"), r);
+            r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+            UNIT_ASSERT_C(r.Contains("Format switching is disabled"), r);
+        }
+        {
+            auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+            UNIT_ASSERT_C(r.Contains("ERROR: format switching is disabled"), r);
+            r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Pause=1");
+            UNIT_ASSERT_C(r.Contains("ERROR: format switching is disabled"), r);
+            r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Resume=1");
+            UNIT_ASSERT_C(r.Contains("ERROR: format switching is disabled"), r);
+            r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Cancel=1");
+            UNIT_ASSERT_C(r.Contains("ERROR: format switching is disabled"), r);
+        }
+    }
+
+    // Switch tests
+
+    Y_UNIT_TEST(SwitchForward) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId pathId = CreateFourPartTable(runtime, env, txId, "Table");
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 0);
+
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"C", "M", "T", ""})}
+        );
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"C", "M", "T", ""})}
+        );
+    }
+
+    Y_UNIT_TEST(SwitchForwardThenBack) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId pathId = CreateFourPartTable(runtime, env, txId, "Table");
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 0);
+
+        // Forward: position -> shardidx.
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 1);
+
+        // Reverse: shardidx -> position.
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 0);
+
+        // Describe still shows 4 partitions, schema intact.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"C", "M", "T", ""})}
+        );
+
+        // Survive reboot in position format.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true),
+            {NLs::PartitionKeys({"C", "M", "T", ""})}
+        );
+    }
+
+    Y_UNIT_TEST(SwitchIdempotentNoop) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId pathId = CreateFourPartTable(runtime, env, txId, "Table");
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 0);
+
+        // Already in position format: action returns ALREADY_DONE.
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+        UNIT_ASSERT_C(r.Contains("ALREADY_DONE\n"), r);
+
+        // Switch to shardidx.
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), 1);
+
+        // Now ALREADY_DONE on shardidx.
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("ALREADY_DONE\n"), r);
+    }
+
+    Y_UNIT_TEST(SwitchDescribeVersionStable) {
+        // PartitioningVersion / TablePartitionVersion must NOT bump across a format switch.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId pathId = CreateFourPartTable(runtime, env, txId, "Table");
+        const ui64 vBefore = GetTablePartitionVersion(runtime, "/MyRoot/Table");
+
+        auto r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+        UNIT_ASSERT_VALUES_EQUAL(GetTablePartitionVersion(runtime, "/MyRoot/Table"), vBefore);
+
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "position");
+        UNIT_ASSERT_C(r.Contains("OK\n"), r);
+        UNIT_ASSERT_VALUES_EQUAL(GetTablePartitionVersion(runtime, "/MyRoot/Table"), vBefore);
+    }
+
+    // Sweep tests
+
+    Y_UNIT_TEST(SweepOnZeroTables) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+        UNIT_ASSERT_C(r.Contains("Tables: 0 in <code>position</code>, 0 in <code>shardidx</code>, total 0"), r);
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        UNIT_ASSERT_C(r.Contains("Start: OK"), r);
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+    }
+
+    Y_UNIT_TEST(SweepOnAllDone) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 0 in <code>shardidx</code>, total 0", GetTableFormatCounters(r));
+
+        const TPathId p1 = CreateFourPartTable(runtime, env, txId, "T1");
+
+        // Switch format manually
+        r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p1, "shardidx");
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
+
+        // Try to run sweep when all tables already converted
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        UNIT_ASSERT_C(r.Contains("Start: OK"), r);
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
+        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
+    }
+
+    Y_UNIT_TEST(SweepSkipsConverted) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId p1 = CreateFourPartTable(runtime, env, txId, "T1");
+        const TPathId p2 = CreateFourPartTable(runtime, env, txId, "T2");
+        const TPathId p3 = CreateFourPartTable(runtime, env, txId, "T3");
+
+        // Pre-convert T1 and T2 to ShardIdx.
+        PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p1, "shardidx");
+        PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p2, "shardidx");
+
+        // Start sweep targeting ShardIdx.
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        // All 3 tables in ShardIdx — 2 skipped (pre-converted), 1 done.
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+        UNIT_ASSERT_C(
+            PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p3, "shardidx").Contains("ALREADY_DONE\n"),
+            "T3 not in ShardIdx after sweep"
+        );
+    }
+
+    Y_UNIT_TEST(SweepConvergesAllTables) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        const TPathId p1 = CreateFourPartTable(runtime, env, txId, "T1");
+        const TPathId p2 = CreateFourPartTable(runtime, env, txId, "T2");
+        const TPathId p3 = CreateFourPartTable(runtime, env, txId, "T3");
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        UNIT_ASSERT_C(r.Contains("Start: OK"), r);
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
+
+        // Let sweep steps fire (100ms adaptive delay, simulated time).
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        // All 3 tables should now be in shardidx format.
+        UNIT_ASSERT_C(
+            PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p1, "shardidx").Contains("ALREADY_DONE\n"),
+            "T1 not in ShardIdx after sweep"
+        );
+        UNIT_ASSERT_C(
+            PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p2, "shardidx").Contains("ALREADY_DONE\n"),
+            "T2 not in ShardIdx after sweep"
+        );
+        UNIT_ASSERT_C(
+            PostSwitchAction(runtime, TTestTxConfig::SchemeShard, p3, "shardidx").Contains("ALREADY_DONE\n"),
+            "T3 not in ShardIdx after sweep"
+        );
+
+        // Status must be IDLE.
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+    }
+
+    Y_UNIT_TEST(SweepPauseResume) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+        CreateFourPartTable(runtime, env, txId, "T3");
+
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Pause=1");
+        UNIT_ASSERT_C(r.Contains("Pause: OK"), r);
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Paused</code>"), r);
+
+        // Advance time — no progress expected while paused.
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Paused</code>"), r);
+
+        // Resume and let finish.
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Resume=1");
+        UNIT_ASSERT_C(r.Contains("Resume: OK"), r);
+
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+    }
+
+    Y_UNIT_TEST(SweepCancel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Cancel=1");
+        UNIT_ASSERT_C(r.Contains("Cancel: OK"), r);
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+        // Advance time — no further progress expected.
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+    }
+
+    Y_UNIT_TEST(SweepRestartResume) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+        CreateFourPartTable(runtime, env, txId, "T3");
+
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        // Let one step fire.
+        runtime.SimulateSleep(TDuration::MilliSeconds(200));
+
+        // Reboot mid-sweep — sweep should resume automatically.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // Let the resumed sweep finish.
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+        // All tables must be in ShardIdx format.
+        for (const TString& name : {"T1", "T2", "T3"}) {
+            const TPathId pathId = GetPathId(runtime, "/MyRoot/" + name);
+            r = PostSwitchAction(runtime, TTestTxConfig::SchemeShard, pathId, "shardidx");
+            UNIT_ASSERT_C(r.Contains("ALREADY_DONE\n"), name << " not in ShardIdx format after restart-resume");
+        }
+    }
+
+    Y_UNIT_TEST(SweepSweepVersionStable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+
+        const ui64 v1Before = GetTablePartitionVersion(runtime, "/MyRoot/T1");
+        const ui64 v2Before = GetTablePartitionVersion(runtime, "/MyRoot/T2");
+
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        UNIT_ASSERT_VALUES_EQUAL(GetTablePartitionVersion(runtime, "/MyRoot/T1"), v1Before);
+        UNIT_ASSERT_VALUES_EQUAL(GetTablePartitionVersion(runtime, "/MyRoot/T2"), v2Before);
+    }
+
+    Y_UNIT_TEST(SweepAutoCancelOnFlagChange) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // To be independent from current flag defaults
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(false);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+        CreateFourPartTable(runtime, env, txId, "T3");
+
+        // Start sweep targeting ShardIdx.
+        PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
+        // Let one step fire.
+        runtime.SimulateSleep(TDuration::MilliSeconds(200));
+
+        // Flip the feature flag to opposite — sweep should self-cancel at next step.
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(false);
+        // Wait for the self-cancel step to fire.
+        runtime.SimulateSleep(TDuration::Seconds(2));
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+    }
+
+    Y_UNIT_TEST(SweepAutoOnBoot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Format switching disabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(false);
+        // Auto sweep disabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Table creates in position format
+        CreateFourPartTable(runtime, env, txId, "T1");
+        CreateFourPartTable(runtime, env, txId, "T2");
+        CreateFourPartTable(runtime, env, txId, "T3");
+
+        // Format switching enabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(true);
+
+        // Reboot without autosweep should do nothing
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+        UNIT_ASSERT_C(r.Contains("Tables: 3 in <code>position</code>, 0 in <code>shardidx</code>, total 3"), r);
+
+        // Flip the autosweep feature flag on — sweep should self-start at next reboot
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(true);
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
+        UNIT_ASSERT_C(r.Contains("Tables: 2 in <code>position</code>, 1 in <code>shardidx</code>, total 3"), r);
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+        UNIT_ASSERT_C(r.Contains("Tables: 0 in <code>position</code>, 3 in <code>shardidx</code>, total 3"), r);
+    }
+
+    // Format counters tests
+
+    // Table partition format upon creation depends on both
+    // EnableTablePartitionsFormatShardIdx and EnableTablePartitionsFormatShardIdxByDefault enabled
+    Y_UNIT_TEST_FLAGS(CreateTable, FormatShardIdx, FormatShardIdxByDefault) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Auto sweep disabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(FormatShardIdx);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(FormatShardIdxByDefault);
+
+        // New table must be in shardidx if EnableTablePartitionsFormatShardIdx{,ByDefault} are both set
+        const ui32 expectedShardIdxTables = ((FormatShardIdx && FormatShardIdxByDefault) ? 1 : 0);
+
+        // Test body
+        CreateFourPartTable(runtime, env, ++txId, "T1");
+
+        // Tablet counters
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatPosition"), 1 - expectedShardIdxTables);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, "SchemeShard/TablesInFormatShardidx"), expectedShardIdxTables);
+
+        // Admin page counters
+        auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+        UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+        TString expectedCounts = Sprintf("Tables: %d in <code>position</code>, %d in <code>shardidx</code>, total 1",
+            1 - expectedShardIdxTables,
+            expectedShardIdxTables
+        );
+        UNIT_ASSERT_VALUES_EQUAL(expectedCounts, GetTableFormatCounters(r));
+    }
+
+    // CopyTable retains format of the original regardless of flags
+    Y_UNIT_TEST_FLAGS_N(CopyTable, bool OriginalInShardIdx, bool FormatShardIdx, bool FormatShardIdxByDefault) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Auto sweep disabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Set format for the original table
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(OriginalInShardIdx);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(OriginalInShardIdx);
+
+        // Create original table
+        CreateFourPartTable(runtime, env, ++txId, "T1");
+
+        // Check original table format
+        {
+            auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+            UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+            ui32 expectedShardIdxTables = (OriginalInShardIdx ? 1 : 0);
+
+            TString expectedCounts = Sprintf("Tables: %d in <code>position</code>, %d in <code>shardidx</code>, total 1",
+                1 - expectedShardIdxTables,
+                expectedShardIdxTables
+            );
+            UNIT_ASSERT_VALUES_EQUAL(expectedCounts, GetTableFormatCounters(r));
+        }
+
+        // Test body
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(FormatShardIdx);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(FormatShardIdxByDefault);
+
+        TestCopyTable(runtime, ++txId, "/MyRoot", "T1-copy", "/MyRoot/T1");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+            UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+            ui32 expectedShardIdxTables = (OriginalInShardIdx ? 2 : 0);
+
+            TString expectedCounts = Sprintf("Tables: %d in <code>position</code>, %d in <code>shardidx</code>, total 2",
+                2 - expectedShardIdxTables,
+                expectedShardIdxTables
+            );
+            UNIT_ASSERT_VALUES_EQUAL(expectedCounts, GetTableFormatCounters(r));
+        }
+    }
+
+    // MoveTable retains format of the original regardless of flags
+    Y_UNIT_TEST_FLAGS_N(MoveTable, bool OriginalInShardIdx, bool FormatShardIdx, bool FormatShardIdxByDefault) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Auto sweep disabled
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatAutoConvert(false);
+
+        // Set format for the original table
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(OriginalInShardIdx);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(OriginalInShardIdx);
+
+        // Create original table
+        CreateFourPartTable(runtime, env, ++txId, "T1");
+
+        // Check original table format
+        {
+            auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+            UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+            ui32 expectedShardIdxTables = (OriginalInShardIdx ? 1 : 0);
+
+            TString expectedCounts = Sprintf("Tables: %d in <code>position</code>, %d in <code>shardidx</code>, total 1",
+                1 - expectedShardIdxTables,
+                expectedShardIdxTables
+            );
+            UNIT_ASSERT_VALUES_EQUAL(expectedCounts, GetTableFormatCounters(r));
+        }
+
+        // Test body
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdx(FormatShardIdx);
+        runtime.GetAppData().FeatureFlags.SetEnableTablePartitionsFormatShardIdxByDefault(FormatShardIdxByDefault);
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/T1", "/MyRoot/T1-moved");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            auto r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
+            UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
+
+            ui32 expectedShardIdxTables = (OriginalInShardIdx ? 1 : 0);
+
+            TString expectedCounts = Sprintf("Tables: %d in <code>position</code>, %d in <code>shardidx</code>, total 1",
+                1 - expectedShardIdxTables,
+                expectedShardIdxTables
+            );
+            UNIT_ASSERT_VALUES_EQUAL(expectedCounts, GetTableFormatCounters(r));
+        }
+    }
+
+}

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
 #include <ydb/library/actors/core/mon.h>
+#include <ydb/library/actors/http/http.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -33,15 +34,22 @@ namespace {
 
 TString PostSweepAction(TTestActorRuntime& runtime, ui64 schemeShard, const TString& params) {
     auto sender = runtime.AllocateEdgeActor();
-    const TString query = TStringBuilder()
-        << "/app?TabletID=" << schemeShard
-        << "&Action=TablePartitionsFormatSweep"
-        << params
-    ;
-    auto req = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(query, HTTP_METHOD_POST);
-    runtime.SendToPipe(schemeShard, sender, req.release(), 0, {});
-    auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
-    return r->Get()->Html;
+    TString redirectLocation;
+    {
+        const TString query = TStringBuilder() << "/app?TabletID=" << schemeShard << "&Action=TablePartitionsFormatSweep" << params;
+        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_POST), 0, {});
+        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteBinaryInfoRes>(sender);
+        NHttp::THttpParser<NHttp::THttpResponse> parser(r->Get()->Blob);
+        NHttp::THeaders headers(parser.Headers);
+        redirectLocation = headers.Get("Location");
+    }
+    // `Location` is relative to the original query base, needs adding `/` prefix.
+    {
+        const TString query = TStringBuilder() << "/" << redirectLocation;
+        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_GET), 0, {});
+        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
+        return r->Get()->Html;
+    }
 }
 
 // Get table partitions format counters by parsing AdminRequest mon page.
@@ -274,11 +282,9 @@ Y_UNIT_TEST_SUITE(TTablePartitionsFormat) {
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
         UNIT_ASSERT_C(r.Contains("Tables: 0 in <code>position</code>, 0 in <code>shardidx</code>, total 0"), r);
 
+        // Nothing will be run on zero tables
         r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
         UNIT_ASSERT_C(r.Contains("Start: OK"), r);
-        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
-
-        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
     }
 
@@ -309,10 +315,6 @@ Y_UNIT_TEST_SUITE(TTablePartitionsFormat) {
         // Try to run sweep when all tables already converted
         r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "&Start=1&format=shardidx");
         UNIT_ASSERT_C(r.Contains("Start: OK"), r);
-        UNIT_ASSERT_C(r.Contains("Currently: <code>Running</code>"), r);
-        UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
-
-        r = PostSweepAction(runtime, TTestTxConfig::SchemeShard, "");
         UNIT_ASSERT_C(r.Contains("Currently: <code>Idle</code>"), r);
         UNIT_ASSERT_VALUES_EQUAL("Tables: 0 in <code>position</code>, 1 in <code>shardidx</code>, total 1", GetTableFormatCounters(r));
     }

--- a/ydb/core/tx/schemeshard/ut_split_merge/ya.make
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ya.make
@@ -12,22 +12,24 @@ IF (NOT WITH_VALGRIND)
         SIZE(MEDIUM)
     ENDIF()
 
-    PEERDIR(
-        library/cpp/getopt
-        library/cpp/regex/pcre
-        library/cpp/svnversion
-        ydb/core/testlib/pg
-        ydb/core/tx
-        ydb/core/tx/schemeshard/ut_helpers
-        yql/essentials/public/udf/service/exception_policy
-    )
+PEERDIR(
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/testlib/pg
+    ydb/core/tx
+    ydb/core/tx/schemeshard/ut_helpers
+    ydb/public/lib/value
+    yql/essentials/public/udf/service/exception_policy
+)
 
     YQL_LAST_ABI_VERSION()
 
-    SRCS(
-        ut_split_merge.cpp
-        ut_find_split_key.cpp
-    )
+SRCS(
+    ut_split_merge.cpp
+    ut_find_split_key.cpp
+    ut_table_partitions_format.cpp
+)
 
     END()
 ENDIF()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -238,6 +238,7 @@ SRCS(
     schemeshard__serverless_storage_billing.cpp
     schemeshard__state_changed_reply.cpp
     schemeshard__sync_update_tenants.cpp
+    schemeshard__table_partitions_format.cpp
     schemeshard__table_stats.cpp
     schemeshard__table_stats_histogram.cpp
     schemeshard__tenant_shred_manager.cpp
@@ -358,6 +359,8 @@ GENERATE_ENUM_SERIALIZATION(schemeshard_info_types.h)
 GENERATE_ENUM_SERIALIZATION(schemeshard_index_build_info.h)
 
 GENERATE_ENUM_SERIALIZATION(schemeshard_types.h)
+
+GENERATE_ENUM_SERIALIZATION(schemeshard_impl.h)
 
 GENERATE_ENUM_SERIALIZATION(operation_queue_timer.h)
 

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -108,6 +108,7 @@ SRCS(
     schemeshard__login_finalize.cpp
     schemeshard__make_access_database_no_inheritable.cpp
     schemeshard__monitoring.cpp
+    schemeshard__monitoring.h
     schemeshard__notify.cpp
     schemeshard__op_traits.h
     schemeshard__operation.cpp
@@ -363,6 +364,8 @@ GENERATE_ENUM_SERIALIZATION(schemeshard_types.h)
 GENERATE_ENUM_SERIALIZATION(schemeshard_impl.h)
 
 GENERATE_ENUM_SERIALIZATION(operation_queue_timer.h)
+
+GENERATE_ENUM_SERIALIZATION_WITH_HEADER(schemeshard__monitoring.h)  # for ESweepAlert
 
 PEERDIR(
     contrib/libs/protobuf

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -9692,6 +9692,346 @@
         }
     },
     {
+        "TableId": 134,
+        "TableName": "TablePartitionsByShardIdx",
+        "TableKey": [
+            1,
+            2,
+            3,
+            4
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 7,
+                "ColumnName": "NextCondErase",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 1,
+                "ColumnName": "OwnerPathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "LocalPathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "OwnerShardIdx",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "LocalShardIdx",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "RangeEnd",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "LastCondErase",
+                "ColumnType": "Uint64"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    7,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 135,
+        "TableName": "TablePartitionStatsByShardIdx",
+        "TableKey": [
+            1,
+            2,
+            3,
+            4
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "OwnerPathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "LocalPathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "OwnerShardIdx",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "LocalShardIdx",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "SeqNoGeneration",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "SeqNoRound",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 7,
+                "ColumnName": "RowCount",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 8,
+                "ColumnName": "DataSize",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 9,
+                "ColumnName": "IndexSize",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 10,
+                "ColumnName": "LastAccessTime",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 11,
+                "ColumnName": "LastUpdateTime",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "ImmediateTxCompleted",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 13,
+                "ColumnName": "PlannedTxCompleted",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 14,
+                "ColumnName": "TxRejectedByOverload",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "TxRejectedBySpace",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 16,
+                "ColumnName": "TxCompleteLag",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "InFlightTxCount",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "RowUpdates",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 19,
+                "ColumnName": "RowDeletes",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 20,
+                "ColumnName": "RowReads",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 21,
+                "ColumnName": "RangeReads",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 22,
+                "ColumnName": "RangeReadRows",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 23,
+                "ColumnName": "CPU",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 24,
+                "ColumnName": "Memory",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 25,
+                "ColumnName": "Network",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 26,
+                "ColumnName": "Storage",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 27,
+                "ColumnName": "ReadThroughput",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 28,
+                "ColumnName": "WriteThroughput",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 29,
+                "ColumnName": "ReadIops",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 30,
+                "ColumnName": "WriteIops",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 31,
+                "ColumnName": "SearchHeight",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 32,
+                "ColumnName": "FullCompactionTs",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 33,
+                "ColumnName": "MemDataSize",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 34,
+                "ColumnName": "StoragePoolsStats",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 35,
+                "ColumnName": "ByKeyFilterSize",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 36,
+                "ColumnName": "LocksAcquired",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 37,
+                "ColumnName": "LocksWholeShard",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 38,
+                "ColumnName": "LocksBroken",
+                "ColumnType": "Uint64"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30,
+                    31,
+                    32,
+                    33,
+                    34,
+                    35,
+                    36,
+                    37,
+                    38
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
         "TableId": 136,
         "TableName": "FullBackups",
         "TableKey": [


### PR DESCRIPTION
Cherry-pick from `main`:
- c5b0c81, https://github.com/ydb-platform/ydb/pull/38804
- 0c61e1b, https://github.com/ydb-platform/ydb/pull/41916
- a4d28c9, https://github.com/ydb-platform/ydb/pull/42253
- 7a8d955, https://github.com/ydb-platform/ydb/pull/42201

Complements:
- https://github.com/ydb-platform/ydb/pull/40590

Introduce ShardIdx-keyed partition tables so that split/merge writes only O(k) rows to the local db instead of O(N).

This is an INCOMPATIBLE CHANGE that changes DB schema, old binaries would see empty partitions for any table that has migrated to the new format.

### New feature flags

- `enable_table_partitions_format_shard_idx` -- gate for all format operations
- `enable_table_partitions_format_shard_idx_by_default` -- new tables use `shardidx`
- `enable_table_partitions_format_auto_convert` -- auto-sweep on boot
- `enable_table_partitions_consistency_check` -- disable consistency check

### New mon page admin actions

- `TablePartitionsFormatSwitch` -- single table format switch
- `TablePartitionsFormatSweep` -- background sweep for all tables

Issues: #37069.

