### PR TITLE
query_replay_yt: reuse compile actor across queries

### DIFF
--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -83,6 +83,7 @@ class TQueryReplayMapper
     TIntrusivePtr<NKikimr::NKqp::TModuleResolverState> ModuleResolverState;
 
     NYql::IHTTPGateway::TPtr HttpGateway;
+    TActorId CompileActorId;
     TVector<TString> UdfFiles;
     ui32 ActorSystemThreadsCount = 5;
     NActors::NLog::EPriority YqlLogPriority = NActors::NLog::EPriority::PRI_ERROR;
@@ -168,6 +169,8 @@ public:
         ModuleResolverState = MakeIntrusive<NKikimr::NKqp::TModuleResolverState>();
         HttpGateway = NYql::IHTTPGateway::Make();
         Y_ABORT_UNLESS(GetYqlDefaultModuleResolver(ModuleResolverState->ExprCtx, ModuleResolverState->ModuleResolver));
+        CompileActorId = ActorSystem->Register(CreateQueryCompiler(
+            ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
     }
 
     THolder<TQueryReplayEvents::TEvCompileResponse> RunReplay(NJson::TJsonValue&& json) {
@@ -184,12 +187,9 @@ public:
 
         THolder<TQueryReplayEvents::TEvCompileResponse> replayResult;
         {
-            NJson::TJsonValue firstCompileReplayJson = replayJson;
-            auto compileActorId = ActorSystem->Register(CreateQueryCompiler(ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
-
             auto future = ActorSystem->Ask<TQueryReplayEvents::TEvCompileResponse>(
-                compileActorId,
-                THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(firstCompileReplayJson))),
+                CompileActorId,
+                THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(replayJson))),
                 TDuration::Seconds(600));
 
             replayResult.Reset(future.ExtractValueSync().Release());

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -201,9 +201,9 @@ class TReplayCompileActor: public TActorBootstrapped<TReplayCompileActor> {
 public:
     TReplayCompileActor(TIntrusivePtr<TModuleResolverState> moduleResolverState, const NMiniKQL::IFunctionRegistry* functionRegistry,
         NYql::IHTTPGateway::TPtr httpGateway, bool antlr4ParserIsAmbiguityError)
-        : ModuleResolverState(moduleResolverState)
+        : Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
+        , ModuleResolverState(moduleResolverState)
         , KqpSettings()
-        , Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
         , FunctionRegistry(functionRegistry)
         , HttpGateway(std::move(httpGateway))
     {

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -215,6 +215,7 @@ public:
     }
 
     void PassAway() override {
+        ReleaseCompileHost();
         TActor::PassAway();
     }
 
@@ -491,10 +492,13 @@ private:
         Reply(status, {issue});
     }
 
-    void ResetForNextRequest() {
-        Gateway.Reset();
-        KqpHost.Reset();
+    void ReleaseCompileHost() {
         AsyncCompileResult.Reset();
+        KqpHost.Reset();
+        Gateway.Reset();
+    }
+
+    void ResetForNextRequest() {
         Query.reset();
         MetadataLoader.reset();
         GUCSettings = std::make_shared<TGUCSettings>();
@@ -533,6 +537,8 @@ private:
 
     void Handle(TQueryReplayEvents::TEvCompileRequest::TPtr& ev) {
         Owner = ev->Sender;
+
+        ReleaseCompileHost();
 
         ReplayDetails = std::move(ev->Get()->ReplayDetails);
 

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -224,6 +224,8 @@ private:
         try {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TQueryReplayEvents::TEvCompileRequest, Handle);
+                hFunc(TEvKqp::TEvContinueProcess, IgnoreStaleEvent);
+                hFunc(TEvents::TEvWakeup, IgnoreStaleEvent);
                 default:
                     Reply(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected event in StateInit");
             }
@@ -287,13 +289,22 @@ private:
     void Continue() {
         TActorSystem* actorSystem = TActivationContext::ActorSystem();
         TActorId selfId = SelfId();
-        auto callback = [actorSystem, selfId](const TFuture<bool>& future) {
+        const ui32 generation = static_cast<ui32>(WakeupTag);
+        auto callback = [actorSystem, selfId, generation](const TFuture<bool>& future) {
             bool finished = future.GetValue();
-            auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(0, finished);
+            auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(generation, finished);
             actorSystem->Send(selfId, processEv.Release());
         };
 
         AsyncCompileResult->Continue().Apply(callback);
+    }
+
+    void IgnoreStaleEvent(TEvKqp::TEvContinueProcess::TPtr& ev) {
+        Y_UNUSED(ev);
+    }
+
+    void IgnoreStaleEvent(TEvents::TEvWakeup::TPtr& ev) {
+        Y_UNUSED(ev);
     }
 
     NJson::TJsonValue ExtractQueryPlan(const TString& plan) {
@@ -587,16 +598,18 @@ private:
         KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,
             federatedQuerySetup, nullptr, GUCSettings, NKikimrConfig::TQueryServiceConfig(), Nothing(), FunctionRegistry, false);
 
+        ++WakeupTag;
         StartCompilation();
         Continue();
 
-        ++WakeupTag;
         Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup(WakeupTag));
         Become(&TThis::StateCompile);
     }
 
     void Handle(TEvKqp::TEvContinueProcess::TPtr& ev) {
-        Y_ENSURE(!ev->Get()->QueryId);
+        if (ev->Get()->QueryId != static_cast<ui32>(WakeupTag)) {
+            return;
+        }
 
         if (!ev->Get()->Finished) {
             Continue();

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -203,12 +203,11 @@ public:
         NYql::IHTTPGateway::TPtr httpGateway, bool antlr4ParserIsAmbiguityError)
         : ModuleResolverState(moduleResolverState)
         , KqpSettings()
-        , Config(MakeIntrusive<TKikimrConfiguration>())
+        , Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
         , FunctionRegistry(functionRegistry)
         , HttpGateway(std::move(httpGateway))
     {
-        Config->SetAntlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError);
-        Config->SetEnableBatchUpdates(true);
+        InitConfig();
     }
 
     void Bootstrap() {
@@ -286,10 +285,16 @@ private:
                 YQL_ENSURE(false, "Unexpected query type: " << Query->Settings.QueryType);
         }
     }
+    void InitConfig() {
+        Config = MakeIntrusive<TKikimrConfiguration>();
+        Config->SetAntlr4ParserIsAmbiguityError(Antlr4ParserIsAmbiguityError);
+        Config->SetEnableBatchUpdates(true);
+    }
+
     void Continue() {
         TActorSystem* actorSystem = TActivationContext::ActorSystem();
         TActorId selfId = SelfId();
-        const ui32 generation = static_cast<ui32>(WakeupTag);
+        const ui32 generation = WakeupTag;
         auto callback = [actorSystem, selfId, generation](const TFuture<bool>& future) {
             bool finished = future.GetValue();
             auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(generation, finished);
@@ -493,6 +498,10 @@ private:
         Query.reset();
         MetadataLoader.reset();
         GUCSettings = std::make_shared<TGUCSettings>();
+        InitConfig();
+        ReplayDetails = NJson::TJsonValue();
+        TableMetadata.reset();
+        QueryId.clear();
         Become(&TThis::StateInit);
     }
 
@@ -573,9 +582,7 @@ private:
         GUCSettings->ImportFromJson(ReplayDetails);
 
         Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), ReplayDetails["query_cluster"].GetStringSafe(), KqpSettings.Settings, false);
-        if (!Query->Database.empty()) {
-            Config->_KqpTablePathPrefix = ReplayDetails["query_database"].GetStringSafe();
-        }
+        Config->_KqpTablePathPrefix = database;
 
         ui32 syntax = (ReplayDetails["query_syntax"].GetStringSafe() == "1") ? 1 : 0;
         if (queryType == NKikimrKqp::QUERY_TYPE_SQL_SCAN) {
@@ -607,7 +614,7 @@ private:
     }
 
     void Handle(TEvKqp::TEvContinueProcess::TPtr& ev) {
-        if (ev->Get()->QueryId != static_cast<ui32>(WakeupTag)) {
+        if (ev->Get()->QueryId != WakeupTag) {
             return;
         }
 
@@ -637,7 +644,8 @@ private:
 
 private:
     TActorId Owner;
-    ui64 WakeupTag = 0;
+    ui32 WakeupTag = 0;
+    bool Antlr4ParserIsAmbiguityError = false;
     TIntrusivePtr<TModuleResolverState> ModuleResolverState;
     TString QueryId;
     std::unique_ptr<TKqpQueryId> Query;

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -235,7 +235,7 @@ private:
         try {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TEvKqp::TEvContinueProcess, Handle);
-                cFunc(TEvents::TEvWakeup::EventType, HandleTimeout);
+                hFunc(TEvents::TEvWakeup, HandleTimeout);
                 default:
                     Reply(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected event in CompileState");
             }
@@ -475,9 +475,18 @@ private:
         Reply(status, {issue});
     }
 
+    void ResetForNextRequest() {
+        Gateway.Reset();
+        KqpHost.Reset();
+        AsyncCompileResult.Reset();
+        Query.reset();
+        MetadataLoader.reset();
+        GUCSettings = std::make_shared<TGUCSettings>();
+        Become(&TThis::StateInit);
+    }
+
     void Reply(const Ydb::StatusIds::StatusCode& status, const TIssues& issues, const std::optional<TString>& queryPlan = std::nullopt) {
         std::unique_ptr<TQueryReplayEvents::TEvCompileResponse> ev = std::make_unique<TQueryReplayEvents::TEvCompileResponse>(true);
-        Y_UNUSED(queryPlan);
         if (status != Ydb::StatusIds::SUCCESS) {
             ev->Success = false;
             if (!MetadataLoader) {
@@ -499,7 +508,7 @@ private:
         }
 
         Send(Owner, ev.release());
-        PassAway();
+        ResetForNextRequest();
     }
 
     void Handle(TQueryReplayEvents::TEvCompileRequest::TPtr& ev) {
@@ -581,7 +590,8 @@ private:
         StartCompilation();
         Continue();
 
-        Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup());
+        ++WakeupTag;
+        Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup(WakeupTag));
         Become(&TThis::StateCompile);
     }
 
@@ -605,12 +615,16 @@ private:
         Reply(status, kqpResult.Issues(), queryPlan);
     }
 
-    void HandleTimeout() {
+    void HandleTimeout(TEvents::TEvWakeup::TPtr& ev) {
+        if (ev->Get()->Tag != WakeupTag) {
+            return;
+        }
         return Reply(Ydb::StatusIds::TIMEOUT, "Query compilation timed out.");
     }
 
 private:
     TActorId Owner;
+    ui64 WakeupTag = 0;
     TIntrusivePtr<TModuleResolverState> ModuleResolverState;
     TString QueryId;
     std::unique_ptr<TKqpQueryId> Query;

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -582,7 +582,9 @@ private:
         GUCSettings->ImportFromJson(ReplayDetails);
 
         Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), ReplayDetails["query_cluster"].GetStringSafe(), KqpSettings.Settings, false);
-        Config->_KqpTablePathPrefix = database;
+        if (!database.empty()) {
+            Config->_KqpTablePathPrefix = database;
+        }
 
         ui32 syntax = (ReplayDetails["query_syntax"].GetStringSafe() == "1") ? 1 : 0;
         if (queryType == NKikimrKqp::QUERY_TYPE_SQL_SCAN) {


### PR DESCRIPTION
## Summary
- Register a single `TReplayCompileActor` per YT mapper job in `Start()` instead of creating one per row
- Return the actor to `StateInit` after each compile response instead of calling `PassAway()`
- Ignore stale compile timeout wakeups via `WakeupTag`

## Motivation
Each YT map job processes thousands of queries sequentially. Creating and destroying a compile actor per query adds avoidable overhead on top of KQP compilation.

## Test plan
- [ ] CI build of `ydb/tools/query_replay_yt`
- [ ] Compare YT map job avg duration before/after on a query replay run


Made with [Cursor](https://cursor.com)