### PR TITLE
query_replay_yt: cache KqpHost/Gateway per database

### DIFF
--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -83,6 +83,7 @@ class TQueryReplayMapper
     TIntrusivePtr<NKikimr::NKqp::TModuleResolverState> ModuleResolverState;
 
     NYql::IHTTPGateway::TPtr HttpGateway;
+    TActorId CompileActorId;
     TVector<TString> UdfFiles;
     ui32 ActorSystemThreadsCount = 5;
     NActors::NLog::EPriority YqlLogPriority = NActors::NLog::EPriority::PRI_ERROR;
@@ -168,6 +169,8 @@ public:
         ModuleResolverState = MakeIntrusive<NKikimr::NKqp::TModuleResolverState>();
         HttpGateway = NYql::IHTTPGateway::Make();
         Y_ABORT_UNLESS(GetYqlDefaultModuleResolver(ModuleResolverState->ExprCtx, ModuleResolverState->ModuleResolver));
+        CompileActorId = ActorSystem->Register(CreateQueryCompiler(
+            ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
     }
 
     THolder<TQueryReplayEvents::TEvCompileResponse> RunReplay(NJson::TJsonValue&& json) {
@@ -184,12 +187,9 @@ public:
 
         THolder<TQueryReplayEvents::TEvCompileResponse> replayResult;
         {
-            NJson::TJsonValue firstCompileReplayJson = replayJson;
-            auto compileActorId = ActorSystem->Register(CreateQueryCompiler(ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
-
             auto future = ActorSystem->Ask<TQueryReplayEvents::TEvCompileResponse>(
-                compileActorId,
-                THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(firstCompileReplayJson))),
+                CompileActorId,
+                THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(replayJson))),
                 TDuration::Seconds(600));
 
             replayResult.Reset(future.ExtractValueSync().Release());

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -258,6 +258,8 @@ private:
         try {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TQueryReplayEvents::TEvCompileRequest, Handle);
+                hFunc(TEvKqp::TEvContinueProcess, IgnoreStaleEvent);
+                hFunc(TEvents::TEvWakeup, IgnoreStaleEvent);
                 default:
                     Reply(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected event in StateInit");
             }
@@ -321,13 +323,22 @@ private:
     void Continue() {
         TActorSystem* actorSystem = TActivationContext::ActorSystem();
         TActorId selfId = SelfId();
-        auto callback = [actorSystem, selfId](const TFuture<bool>& future) {
+        const ui32 generation = static_cast<ui32>(WakeupTag);
+        auto callback = [actorSystem, selfId, generation](const TFuture<bool>& future) {
             bool finished = future.GetValue();
-            auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(0, finished);
+            auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(generation, finished);
             actorSystem->Send(selfId, processEv.Release());
         };
 
         AsyncCompileResult->Continue().Apply(callback);
+    }
+
+    void IgnoreStaleEvent(TEvKqp::TEvContinueProcess::TPtr& ev) {
+        Y_UNUSED(ev);
+    }
+
+    void IgnoreStaleEvent(TEvents::TEvWakeup::TPtr& ev) {
+        Y_UNUSED(ev);
     }
 
     NJson::TJsonValue ExtractQueryPlan(const TString& plan) {
@@ -681,16 +692,18 @@ private:
         Config->SetSqlVersion(syntax);
         Config->FreezeDefaults();
 
+        ++WakeupTag;
         StartCompilation();
         Continue();
 
-        ++WakeupTag;
         Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup(WakeupTag));
         Become(&TThis::StateCompile);
     }
 
     void Handle(TEvKqp::TEvContinueProcess::TPtr& ev) {
-        Y_ENSURE(!ev->Get()->QueryId);
+        if (ev->Get()->QueryId != static_cast<ui32>(WakeupTag)) {
+            return;
+        }
 
         if (!ev->Get()->Finished) {
             Continue();

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -694,7 +694,9 @@ private:
         GUCSettings->ImportFromJson(ReplayDetails);
 
         Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), cluster, KqpSettings.Settings, false);
-        Config->_KqpTablePathPrefix = database;
+        if (!database.empty()) {
+            Config->_KqpTablePathPrefix = database;
+        }
 
         Config->SetSqlVersion(syntax);
         Config->FreezeDefaults();

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -235,9 +235,9 @@ class TReplayCompileActor: public TActorBootstrapped<TReplayCompileActor> {
 public:
     TReplayCompileActor(TIntrusivePtr<TModuleResolverState> moduleResolverState, const NMiniKQL::IFunctionRegistry* functionRegistry,
         NYql::IHTTPGateway::TPtr httpGateway, bool antlr4ParserIsAmbiguityError)
-        : ModuleResolverState(moduleResolverState)
+        : Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
+        , ModuleResolverState(moduleResolverState)
         , KqpSettings()
-        , Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
         , FunctionRegistry(functionRegistry)
         , HttpGateway(std::move(httpGateway))
     {

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -237,12 +237,11 @@ public:
         NYql::IHTTPGateway::TPtr httpGateway, bool antlr4ParserIsAmbiguityError)
         : ModuleResolverState(moduleResolverState)
         , KqpSettings()
-        , Config(MakeIntrusive<TKikimrConfiguration>())
+        , Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
         , FunctionRegistry(functionRegistry)
         , HttpGateway(std::move(httpGateway))
     {
-        Config->SetAntlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError);
-        Config->SetEnableBatchUpdates(true);
+        InitConfig();
     }
 
     void Bootstrap() {
@@ -320,10 +319,16 @@ private:
                 YQL_ENSURE(false, "Unexpected query type: " << Query->Settings.QueryType);
         }
     }
+    void InitConfig() {
+        Config = MakeIntrusive<TKikimrConfiguration>();
+        Config->SetAntlr4ParserIsAmbiguityError(Antlr4ParserIsAmbiguityError);
+        Config->SetEnableBatchUpdates(true);
+    }
+
     void Continue() {
         TActorSystem* actorSystem = TActivationContext::ActorSystem();
         TActorId selfId = SelfId();
-        const ui32 generation = static_cast<ui32>(WakeupTag);
+        const ui32 generation = WakeupTag;
         auto callback = [actorSystem, selfId, generation](const TFuture<bool>& future) {
             bool finished = future.GetValue();
             auto processEv = MakeHolder<TEvKqp::TEvContinueProcess>(generation, finished);
@@ -526,6 +531,10 @@ private:
         MetadataLoader.reset();
         Gateway.Reset();
         KqpHost.Reset();
+        InitConfig();
+        ReplayDetails = NJson::TJsonValue();
+        TableMetadata.reset();
+        QueryId.clear();
         Become(&TThis::StateInit);
     }
 
@@ -685,9 +694,7 @@ private:
         GUCSettings->ImportFromJson(ReplayDetails);
 
         Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), cluster, KqpSettings.Settings, false);
-        if (!Query->Database.empty()) {
-            Config->_KqpTablePathPrefix = database;
-        }
+        Config->_KqpTablePathPrefix = database;
 
         Config->SetSqlVersion(syntax);
         Config->FreezeDefaults();
@@ -701,7 +708,7 @@ private:
     }
 
     void Handle(TEvKqp::TEvContinueProcess::TPtr& ev) {
-        if (ev->Get()->QueryId != static_cast<ui32>(WakeupTag)) {
+        if (ev->Get()->QueryId != WakeupTag) {
             return;
         }
 
@@ -731,7 +738,8 @@ private:
 
 private:
     TActorId Owner;
-    ui64 WakeupTag = 0;
+    ui32 WakeupTag = 0;
+    bool Antlr4ParserIsAmbiguityError = false;
     TIntrusivePtr<TModuleResolverState> ModuleResolverState;
     TString QueryId;
     std::unique_ptr<TKqpQueryId> Query;

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -22,6 +22,7 @@
 
 #include <ydb/core/client/scheme_cache_lib/yql_db_scheme_resolver.h>
 
+#include <algorithm>
 #include <memory>
 
 using namespace NKikimrConfig;
@@ -183,6 +184,11 @@ public:
         return IsMissingTableMetadata;
     }
 
+    void ResetMetadata(std::shared_ptr<TMetadataInfoHolder> tableMetadata) {
+        TableMetadata = std::move(tableMetadata);
+        IsMissingTableMetadata = false;
+    }
+
     virtual NThreading::TFuture<TTableResults> ResolveTables(const TVector<TTable>& tables) override {
         return NThreading::MakeFuture(Resolve(tables));
     }
@@ -195,6 +201,34 @@ public:
     TVector<NKikimrKqp::TKqpTableMetadataProto> GetCollectedSchemeData() override {
         return {};
     }
+};
+
+struct THostCacheKey {
+    TString Cluster;
+    TString Database;
+    NKikimrKqp::EQueryType QueryType = NKikimrKqp::QUERY_TYPE_SQL_DML;
+    ui32 SqlVersion = 0;
+
+    bool operator==(const THostCacheKey& other) const {
+        return Cluster == other.Cluster
+            && Database == other.Database
+            && QueryType == other.QueryType
+            && SqlVersion == other.SqlVersion;
+    }
+};
+
+template <>
+struct THash<THostCacheKey> {
+    size_t operator()(const THostCacheKey& key) const {
+        return MultiHash(key.Cluster, key.Database, key.QueryType, key.SqlVersion);
+    }
+};
+
+struct THostCacheEntry {
+    std::shared_ptr<TStaticTableMetadataLoader> MetadataLoader;
+    TIntrusivePtr<IKqpGateway> Gateway;
+    TIntrusivePtr<IKqpHost> KqpHost;
+    TGUCSettings::TPtr GucSettings;
 };
 
 class TReplayCompileActor: public TActorBootstrapped<TReplayCompileActor> {
@@ -476,13 +510,78 @@ private:
     }
 
     void ResetForNextRequest() {
-        Gateway.Reset();
-        KqpHost.Reset();
         AsyncCompileResult.Reset();
         Query.reset();
         MetadataLoader.reset();
-        GUCSettings = std::make_shared<TGUCSettings>();
+        Gateway.Reset();
+        KqpHost.Reset();
         Become(&TThis::StateInit);
+    }
+
+    THostCacheEntry CreateHostCacheEntry(
+        std::shared_ptr<TMetadataInfoHolder> tableMetadata,
+        NKikimrKqp::EQueryType queryType,
+        const TString& cluster,
+        const TString& database)
+    {
+        auto metadataLoader = std::make_shared<TStaticTableMetadataLoader>(
+            TlsActivationContext->ActorSystem(), tableMetadata);
+
+        auto c = MakeIntrusive<NMonitoring::TDynamicCounters>();
+        auto counters = MakeIntrusive<TKqpRequestCounters>();
+        counters->Counters = new TKqpCounters(c);
+        counters->TxProxyMon = new NTxProxy::TTxProxyMon(c);
+
+        std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader = metadataLoader;
+        auto gateway = CreateKikimrIcGateway(
+            cluster, queryType, database, database, std::move(loader),
+            TActivationContext::ActorSystem(), SelfId().NodeId(), counters);
+
+        auto gucSettings = std::make_shared<TGUCSettings>();
+        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>(
+            {nullptr, HttpGateway, nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, {}, nullptr, {}, nullptr, nullptr});
+        auto kqpHost = CreateKqpHost(
+            gateway, cluster, database, Config, ModuleResolverState->ModuleResolver,
+            federatedQuerySetup, nullptr, gucSettings, NKikimrConfig::TQueryServiceConfig(), Nothing(), FunctionRegistry, false);
+
+        return {
+            std::move(metadataLoader),
+            std::move(gateway),
+            std::move(kqpHost),
+            std::move(gucSettings),
+        };
+    }
+
+    void TouchHostCacheLru(const THostCacheKey& key) {
+        const auto it = std::find(HostCacheLru.begin(), HostCacheLru.end(), key);
+        if (it != HostCacheLru.end()) {
+            HostCacheLru.erase(it);
+        }
+        HostCacheLru.push_back(key);
+    }
+
+    void EvictHostCacheIfNeeded() {
+        while (HostCache.size() >= MaxHostCacheSize && !HostCacheLru.empty()) {
+            const auto key = HostCacheLru.front();
+            HostCacheLru.pop_front();
+            HostCache.erase(key);
+        }
+    }
+
+    THostCacheEntry& GetOrCreateHostCacheEntry(
+        const THostCacheKey& cacheKey,
+        std::shared_ptr<TMetadataInfoHolder> tableMetadata)
+    {
+        if (auto* entry = HostCache.FindPtr(cacheKey)) {
+            TouchHostCacheLru(cacheKey);
+            entry->MetadataLoader->ResetMetadata(tableMetadata);
+            return *entry;
+        }
+
+        EvictHostCacheIfNeeded();
+        HostCache.emplace(cacheKey, CreateHostCacheEntry(tableMetadata, cacheKey.QueryType, cacheKey.Cluster, cacheKey.Database));
+        HostCacheLru.push_back(cacheKey);
+        return HostCache.at(cacheKey);
     }
 
     void Reply(const Ydb::StatusIds::StatusCode& status, const TIssues& issues, const std::optional<TString>& queryPlan = std::nullopt) {
@@ -546,10 +645,23 @@ private:
 
         QueryId = ReplayDetails["query_id"].GetStringSafe();
 
-        TKqpQuerySettings settings(queryType);
+        ui32 syntax = (ReplayDetails["query_syntax"].GetStringSafe() == "1") ? 1 : 0;
+        if (queryType == NKikimrKqp::QUERY_TYPE_SQL_SCAN) {
+            syntax = 1;
+        }
+
+        const auto& cluster = ReplayDetails["query_cluster"].GetStringSafe();
         const auto& database = ReplayDetails["query_database"].GetStringSafe();
+        const THostCacheKey cacheKey{cluster, database, queryType, syntax};
+        auto& hostEntry = GetOrCreateHostCacheEntry(cacheKey, TableMetadata);
+        MetadataLoader = hostEntry.MetadataLoader;
+        Gateway = hostEntry.Gateway;
+        KqpHost = hostEntry.KqpHost;
+        GUCSettings = hostEntry.GucSettings;
+
+        TKqpQuerySettings settings(queryType);
         Query = std::make_unique<NKikimr::NKqp::TKqpQueryId>(
-            ReplayDetails["query_cluster"].GetStringSafe(),
+            cluster,
             database,
             database,
             queryText,
@@ -561,31 +673,13 @@ private:
 
         GUCSettings->ImportFromJson(ReplayDetails);
 
-        Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), ReplayDetails["query_cluster"].GetStringSafe(), KqpSettings.Settings, false);
+        Config->Init(KqpSettings.DefaultSettings.GetDefaultSettings(), cluster, KqpSettings.Settings, false);
         if (!Query->Database.empty()) {
-            Config->_KqpTablePathPrefix = ReplayDetails["query_database"].GetStringSafe();
+            Config->_KqpTablePathPrefix = database;
         }
 
-        ui32 syntax = (ReplayDetails["query_syntax"].GetStringSafe() == "1") ? 1 : 0;
-        if (queryType == NKikimrKqp::QUERY_TYPE_SQL_SCAN) {
-            syntax = 1;
-        }
-	    Config->SetSqlVersion(syntax);
+        Config->SetSqlVersion(syntax);
         Config->FreezeDefaults();
-
-        MetadataLoader = make_shared<TStaticTableMetadataLoader>(TlsActivationContext->ActorSystem(), TableMetadata);
-        std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader = MetadataLoader;
-
-        auto c = MakeIntrusive<NMonitoring::TDynamicCounters>();
-        auto counters = MakeIntrusive<TKqpRequestCounters>();
-        counters->Counters = new TKqpCounters(c);
-        counters->TxProxyMon = new NTxProxy::TTxProxyMon(c);
-
-        Gateway = CreateKikimrIcGateway(Query->Cluster, queryType, Query->Database, Query->DatabaseId, std::move(loader),
-            TActivationContext::ActorSystem(), SelfId().NodeId(), counters);
-        auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({nullptr, HttpGateway, nullptr, nullptr, nullptr, {}, {}, {}, nullptr, {}, nullptr, {}, nullptr, {}, nullptr, nullptr});
-        KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,
-            federatedQuerySetup, nullptr, GUCSettings, NKikimrConfig::TQueryServiceConfig(), Nothing(), FunctionRegistry, false);
 
         StartCompilation();
         Continue();
@@ -640,6 +734,10 @@ private:
     NJson::TJsonValue ReplayDetails;
     std::shared_ptr<TStaticTableMetadataLoader> MetadataLoader;
     NYql::IHTTPGateway::TPtr HttpGateway;
+
+    static constexpr size_t MaxHostCacheSize = 64;
+    THashMap<THostCacheKey, THostCacheEntry> HostCache;
+    TDeque<THostCacheKey> HostCacheLru;
 };
 
 IActor* CreateQueryCompiler(TIntrusivePtr<TModuleResolverState> moduleResolverState,

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -235,7 +235,7 @@ private:
         try {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TEvKqp::TEvContinueProcess, Handle);
-                cFunc(TEvents::TEvWakeup::EventType, HandleTimeout);
+                hFunc(TEvents::TEvWakeup, HandleTimeout);
                 default:
                     Reply(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected event in CompileState");
             }
@@ -475,9 +475,18 @@ private:
         Reply(status, {issue});
     }
 
+    void ResetForNextRequest() {
+        Gateway.Reset();
+        KqpHost.Reset();
+        AsyncCompileResult.Reset();
+        Query.reset();
+        MetadataLoader.reset();
+        GUCSettings = std::make_shared<TGUCSettings>();
+        Become(&TThis::StateInit);
+    }
+
     void Reply(const Ydb::StatusIds::StatusCode& status, const TIssues& issues, const std::optional<TString>& queryPlan = std::nullopt) {
         std::unique_ptr<TQueryReplayEvents::TEvCompileResponse> ev = std::make_unique<TQueryReplayEvents::TEvCompileResponse>(true);
-        Y_UNUSED(queryPlan);
         if (status != Ydb::StatusIds::SUCCESS) {
             ev->Success = false;
             if (!MetadataLoader) {
@@ -499,7 +508,7 @@ private:
         }
 
         Send(Owner, ev.release());
-        PassAway();
+        ResetForNextRequest();
     }
 
     void Handle(TQueryReplayEvents::TEvCompileRequest::TPtr& ev) {
@@ -581,7 +590,8 @@ private:
         StartCompilation();
         Continue();
 
-        Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup());
+        ++WakeupTag;
+        Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup(WakeupTag));
         Become(&TThis::StateCompile);
     }
 
@@ -605,12 +615,16 @@ private:
         Reply(status, kqpResult.Issues(), queryPlan);
     }
 
-    void HandleTimeout() {
+    void HandleTimeout(TEvents::TEvWakeup::TPtr& ev) {
+        if (ev->Get()->Tag != WakeupTag) {
+            return;
+        }
         return Reply(Ydb::StatusIds::TIMEOUT, "Query compilation timed out.");
     }
 
 private:
     TActorId Owner;
+    ui64 WakeupTag = 0;
     TIntrusivePtr<TModuleResolverState> ModuleResolverState;
     TString QueryId;
     std::unique_ptr<TKqpQueryId> Query;


### PR DESCRIPTION
## Summary
- Cache `KqpHost`, `Gateway`, and metadata loader per `(cluster, database, query_type, sql_version)` inside the reused compile actor
- Refresh table metadata in place via `TStaticTableMetadataLoader::ResetMetadata()` on cache hits
- LRU eviction with a limit of 64 entries per mapper job

## Depends on
- #42378 (compile actor reuse)

## Motivation
Creating `CreateKikimrIcGateway` + `CreateKqpHost` for every query is a noticeable per-row cost in YT map jobs. Queries from the same database can reuse the host while only metadata changes.

## Test plan
- [ ] CI build of `ydb/tools/query_replay_yt`
- [ ] Compare YT map job avg duration vs #42378 on a query replay run


Made with [Cursor](https://cursor.com)