### PR TITLE
Added the aggregator of all detailed metrics on a single node

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -317,4 +317,5 @@ message TFeatureFlags {
     optional bool EnableTopicWriteOffsetDeltaInKeys = 275 [default = false];
     optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];
     optional bool EnableKqpConstraintsTransformer = 277 [default = true];
+    optional bool EnableDetailedMetrics = 278 [default = false];
 }

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -1,0 +1,368 @@
+#include "node_database_metrics_aggregator.h"
+
+namespace NKikimr {
+
+void TNodeDatabaseMetricsAggregator::HandleDatabaseSchemaVersionChange(std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+    TEvTabletCounters::TEvTabletAddCounters* message)
+{
+    if (message->TableMetricsConfig->TenantDbSchemaVersion == tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion) {
+        return;
+    }
+
+    auto messageTail = [&] () -> TString { return TStringBuilder() << " (update received from the tablet ID " << message->TabletID
+                << ", follower ID " << message->FollowerId << " (type " << TTabletTypes::TypeToStr(message->TabletType)
+                << "), tenant database schema version " << message->TableMetricsConfig->TenantDbSchemaVersion
+                << ") for the table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+                << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId << "), tenant database " << TenantPathId; };
+
+    if (message->TableMetricsConfig->TenantDbSchemaVersion < tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion) {
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Ignoring outdated detailed metrics configuration, current schema version "
+            << tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion << messageTail());
+
+        return;
+    }
+
+    if (message->TableMetricsConfig->MonitoringProjectId != tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId) {
+        if (!tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId) {
+            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+                "Adding the monitoring project ID " << (*message->TableMetricsConfig->MonitoringProjectId) << messageTail());
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup = DatabaseCounterGroup->GetSubgroup("monitoring_project_id",
+                *message->TableMetricsConfig->MonitoringProjectId);
+
+            DatabaseCounterGroup->RemoveSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath);
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RegisterSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup);
+        } else if (!message->TableMetricsConfig->MonitoringProjectId) {
+            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+                "Removing the monitoring project ID " << (*tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId) << messageTail());
+
+            DatabaseCounterGroup->RegisterSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup);
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath);
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup.Reset();
+        } else {
+            LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+                "Changing the monitoring project ID from " << (*tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId)
+                << " to " << (*message->TableMetricsConfig->MonitoringProjectId) << messageTail());
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath);
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup = DatabaseCounterGroup->GetSubgroup("monitoring_project_id",
+                *message->TableMetricsConfig->MonitoringProjectId);
+
+            tableMetricsIt->second.MonitoringProjectCounterGroup->RegisterSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath,
+                tableMetricsIt->second.TableCounterGroup);
+        }
+    } else {
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Not changing the monitoring project ID " << tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId.value_or("NOT_SPECIFIED")
+            << messageTail());
+    }
+
+    tableMetricsIt->second.TableMetricsConfig.TenantDbSchemaVersion = message->TableMetricsConfig->TenantDbSchemaVersion;
+    tableMetricsIt->second.TableMetricsConfig.MonitoringProjectId = message->TableMetricsConfig->MonitoringProjectId;
+}
+
+
+void TNodeDatabaseMetricsAggregator::HandleTableSchemaVersionChange(std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+    TEvTabletCounters::TEvTabletAddCounters* message)
+{
+    if (message->TableMetricsConfig->TableSchemaVersion == tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion) {
+        return;
+    }
+
+    if (message->TableMetricsConfig->TableSchemaVersion < tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion) {
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Ignoring the detailed metrics configuration (received table schema version " << message->TableMetricsConfig->TableSchemaVersion
+            << ", the current known table schema version " << tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion
+            << ") received from the tablet ID " << message->TabletID << " (type " << TTabletTypes::TypeToStr(message->TabletType)
+            << "), table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId << "), tenant database " << TenantPathId);
+
+        return;
+    }
+
+    Y_ABORT_UNLESS(message->TableMetricsConfig->TablePath == tableMetricsIt->second.TableMetricsConfig.TablePath,
+        "The table path for the table ID %" PRIu64 " changed from %s to %s when the table schema version changed from %" PRIu64 " to %" PRIu64,
+        tableMetricsIt->second.TableMetricsConfig.TableId, tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        message->TableMetricsConfig->TablePath.c_str(), tableMetricsIt->second.TableMetricsConfig.TableSchemaVersion,
+        message->TableMetricsConfig->TableSchemaVersion);
+}
+
+void TNodeDatabaseMetricsAggregator::ProcessTabletCounters(TEvTabletCounters::TEvTabletAddCounters* message) {
+    if (!message->TableMetricsConfig) {
+        return;
+    }
+
+    switch (message->TabletType) {
+    case TTabletTypes::DataShard:
+        break;
+    default: // Process detailed metrics only from known types
+        return;
+    }
+
+    auto tableMetricsIt = PerTableMetrics.find(message->TableMetricsConfig->TableId);
+    if (tableMetricsIt == PerTableMetrics.end()) {
+        // This is a new entry for a new table, process detailed metrics only if the metrics level is above DATABASE
+        switch (message->TableMetricsConfig->MetricsLevel) {
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+        case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
+            break;
+        default:
+            return;
+        }
+
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the table " << message->TableMetricsConfig->TablePath
+            << " (table ID " << message->TableMetricsConfig->TableId
+            << "), metrics level " << NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(message->TableMetricsConfig->MetricsLevel)
+            << ", tenant database " << TenantPathId
+            << ", monitoring project ID " << message->TableMetricsConfig->MonitoringProjectId.value_or("NOT_SPECIFIED"));
+
+        // Place all table metrics into a subgroup with the "monitoring_project_id" label, if the monitoring project ID is known
+        auto parentCounterGroup = DatabaseCounterGroup;
+        NMonitoring::TDynamicCounterPtr monitoringProjectCounterGroup;
+
+        if (message->TableMetricsConfig->MonitoringProjectId) {
+            monitoringProjectCounterGroup = DatabaseCounterGroup->GetSubgroup("monitoring_project_id",
+                *message->TableMetricsConfig->MonitoringProjectId);
+            parentCounterGroup = monitoringProjectCounterGroup;
+        }
+
+        auto tableCounterGroup = parentCounterGroup->GetSubgroup("table",
+            message->TableMetricsConfig->TablePath);
+
+        // Allocate a new entry for this new table
+        tableMetricsIt = PerTableMetrics.emplace(std::piecewise_construct,
+            std::forward_as_tuple(message->TableMetricsConfig->TableId),
+            std::forward_as_tuple(TTableMetricsInfo{
+                .TableMetricsConfig = *message->TableMetricsConfig,
+                .PartitionReplicaTabletType = message->TabletType,
+                .TableCounterGroup = tableCounterGroup,
+                .MonitoringProjectCounterGroup = monitoringProjectCounterGroup,
+                .PerPartitionCounterGroup = tableCounterGroup->GetSubgroup("detailed_metrics", "per_partition"),
+                .PerPartitionTableYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(message->TabletType, tableCounterGroup),
+            })
+        ).first;
+    } else {
+        // This is an existing table, make sure all tablets have the same type
+        Y_ABORT_UNLESS(message->TabletType == tableMetricsIt->second.PartitionReplicaTabletType,
+            "The tablet ID %" PRIu64 " (type %s) of the table %s (table ID %" PRIu64 ") uses an inconsistent type (expected %s)",
+            message->TabletID, TTabletTypes::TypeToStr(message->TabletType), tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+            tableMetricsIt->second.TableMetricsConfig.TableId, TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType));
+
+        /**
+         * @todo Once per-table metrics are added (from Scheme Shard), the code here should be changed to verify that the tablet type for per-partition
+         *       metrics (should be Data Shard or Column Shard) is different from the tablet type for per-table metrics (should be Scheme Shard).
+         *       If the same tablet type is used for reporting both per-partition and per-table metrics, the code in this class as it is written now
+         *       will get confused and will lose metrics values - the counters at the table level will get overwritten by per-table and per-partition
+         *       metrics.
+         */
+
+        HandleDatabaseSchemaVersionChange(tableMetricsIt, message);
+        HandleTableSchemaVersionChange(tableMetricsIt, message);
+    }
+
+    // Add a new partition entry, if this partition has never been seen before
+    auto partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.find(message->TabletID);
+    if (partitionMetricsIt == tableMetricsIt->second.PerPartitionMetrics.end()) {
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the tablet ID " << message->TabletID
+            << " (type " << TTabletTypes::TypeToStr(message->TabletType)
+            << "), table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId
+            << "), tenant database " << TenantPathId);
+
+        auto partitionCounterGroup = tableMetricsIt->second.PerPartitionCounterGroup->GetSubgroup("tablet_id",
+            ToString(message->TabletID));
+
+        auto allFollowersCounterGroup = partitionCounterGroup->GetSubgroup("follower_id",
+            "replicas_only");
+
+        // Allocate a new entry for this new partition
+        partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.emplace(std::piecewise_construct,
+            std::forward_as_tuple(message->TabletID),
+            std::forward_as_tuple(TPartitionMetricsInfo{
+                .PartitionCounterGroup = partitionCounterGroup,
+                .PartitionYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(message->TabletType, partitionCounterGroup),
+                .AllFollowersCounterGroup = allFollowersCounterGroup,
+                .AllFollowersYdbMetricsAggregator = CreateYdbMetricsAggregatorByTabletType(message->TabletType, allFollowersCounterGroup),
+            })
+        ).first;
+
+        // Connect the metrics aggregators for this partition to the corresponding parents
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->AddSourceCountersGroup("replicas_only",
+            allFollowersCounterGroup);
+
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->AddSourceCountersGroup(ToString(message->TabletID),
+            partitionCounterGroup
+        );
+    }
+
+    // Add a new replica entry, if this follower/leader has never been seen before
+    auto replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.find(message->FollowerId);
+    if (replicaMetricsIt == partitionMetricsIt->second.PerReplicaMetrics.end()) {
+        LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Creating a new entry for detailed metrics for the follower ID " << message->FollowerId
+            << ", tablet ID " << message->TabletID
+            << " (type " << TTabletTypes::TypeToStr(message->TabletType)
+            << "), table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+            << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId
+            << "), tenant database " << TenantPathId);
+
+        auto inserted = TabletIdFollowerIdToTableIdMap.emplace(std::make_pair(message->TabletID, message->FollowerId),
+            tableMetricsIt->second.TableMetricsConfig.TableId);
+
+        Y_ABORT_UNLESS(inserted.second,
+            "The combination of the tablet ID %" PRIu64 " (type %s) and the follower ID %" PRIu32 " is already present for the table ID %" PRIu64
+            " when adding a new entry for detailed metrics for the table %s (table ID %" PRIu64 ")",
+            message->TabletID, TTabletTypes::TypeToStr(message->TabletType), message->FollowerId, inserted.first->second,
+            tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(), tableMetricsIt->second.TableMetricsConfig.TableId);
+
+        auto replicaCounterGroup = partitionMetricsIt->second.PartitionCounterGroup->GetSubgroup("follower_id",
+            ToString(message->FollowerId));
+
+        replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.emplace(std::piecewise_construct,
+            std::forward_as_tuple(message->FollowerId),
+            std::forward_as_tuple(TPartitionReplicaMetricsInfo{
+                .ReplicaCounterGroup = replicaCounterGroup,
+                .TabletCountersProcessor = CreateTabletCountersProcessor(replicaCounterGroup, message->TabletType),
+                .TabletYdbMetricsMapper = CreateYdbMetricsMapperByTabletType(message->TabletType,
+                    replicaCounterGroup, replicaCounterGroup),
+            })
+        ).first;
+
+        // Connect the metrics aggregators for this partition to the corresponding parents
+        if (message->FollowerId == 0) {
+            // The leader goes directly to the partition metrics
+            partitionMetricsIt->second.PartitionYdbMetricsAggregator->AddSourceCountersGroup(ToString(message->FollowerId),
+                replicaCounterGroup);
+        } else {
+            // All followers go to the "replicas_only" group and then (indirectly) to the partition metrics
+            partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->AddSourceCountersGroup(ToString(message->FollowerId),
+                replicaCounterGroup);
+        }
+    }
+
+    // Update the received metrics and all aggregates. The TTabletCountersForTabletType class (the one, which really implements
+    // the ITabletCountersProcessor interface) is written in such a way, that the ProcessTabletCounters() function updates only the values
+    // of direct counters, which derive their values directly from the tablet counters. Any aggregate values (e.g. "SUM(DbUniqueRowsTotal)"
+    // or "HIST(ConsumedCPU)") are not updated. To see the updated values, the RecalculateAggregatedValues() function must be called explicitly.
+    replicaMetricsIt->second.TabletCountersProcessor->ProcessTabletCounters(message->TabletID,
+        message->ExecutorCounters.Get(),
+        message->AppCounters.Get(),
+        message->TabletType);
+
+    replicaMetricsIt->second.TabletCountersProcessor->RecalculateAggregatedValues();
+    replicaMetricsIt->second.TabletYdbMetricsMapper->TransferCounterValues();
+
+    if (message->FollowerId != 0) {
+        partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RecalculateAllTargetCounters();
+    }
+
+    partitionMetricsIt->second.PartitionYdbMetricsAggregator->RecalculateAllTargetCounters();
+    tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+}
+
+void TNodeDatabaseMetricsAggregator::ForgetTablet(ui64 tabletId, ui32 followerId) {
+    auto lookupIt = TabletIdFollowerIdToTableIdMap.find(std::make_pair(tabletId, followerId));
+
+    if (lookupIt == TabletIdFollowerIdToTableIdMap.end()) {
+        LOG_WARN_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+            "Not deleting the entry for detailed metrics for an unknown tablet ID " << tabletId
+            << " (requested follower ID " << followerId
+            << "), tenant database " << TenantPathId);
+        return;
+    }
+
+    auto tableMetricsIt = PerTableMetrics.find(lookupIt->second);
+
+    Y_ABORT_UNLESS(tableMetricsIt != PerTableMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %" PRIu64 " and the follower ID %" PRIu32 " is missing for the table ID %" PRIu64
+        " in the tables map", tabletId, followerId, lookupIt->second);
+
+    TabletIdFollowerIdToTableIdMap.erase(lookupIt);
+
+    auto partitionMetricsIt = tableMetricsIt->second.PerPartitionMetrics.find(tabletId);
+
+    Y_ABORT_UNLESS(partitionMetricsIt != tableMetricsIt->second.PerPartitionMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %" PRIu64 " and the follower ID %" PRIu32 " is missing for the table %s "
+        "(table ID %" PRIu64 ") in the partitions map", tabletId, followerId, tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        tableMetricsIt->second.TableMetricsConfig.TableId);
+
+    auto replicaMetricsIt = partitionMetricsIt->second.PerReplicaMetrics.find(followerId);
+
+    Y_ABORT_UNLESS(replicaMetricsIt != partitionMetricsIt->second.PerReplicaMetrics.end(),
+        "The entry for the detailed metrics for the tablet ID %" PRIu64 " and the follower ID %" PRIu32 " is missing for the table %s "
+        "(table ID %" PRIu64 ") in the replicas map", tabletId, followerId, tableMetricsIt->second.TableMetricsConfig.TablePath.c_str(),
+        tableMetricsIt->second.TableMetricsConfig.TableId);
+
+    // Remove the entry for this follower ID and update the parent partition
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the follower ID " << followerId
+        << ", tablet ID " << tabletId
+        << " (type " << TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType)
+        << "), table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+        << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId
+        << "), tenant database " << TenantPathId);
+
+    partitionMetricsIt->second.PartitionCounterGroup->RemoveSubgroup("follower_id", ToString(followerId));
+
+    if (followerId == 0) {
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->RemoveSourceCountersGroup(ToString(followerId));
+    } else {
+        partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RemoveSourceCountersGroup(ToString(followerId));
+    }
+
+    partitionMetricsIt->second.PerReplicaMetrics.erase(replicaMetricsIt);
+
+    if (!partitionMetricsIt->second.PerReplicaMetrics.empty()) {
+        // The parent partition still contains some replicas, just update the counters
+        if (followerId != 0) {
+            partitionMetricsIt->second.AllFollowersYdbMetricsAggregator->RecalculateAllTargetCounters();
+        }
+        partitionMetricsIt->second.PartitionYdbMetricsAggregator->RecalculateAllTargetCounters();
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+
+        return;
+    }
+
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the tablet ID " << tabletId
+        << " (type " << TTabletTypes::TypeToStr(tableMetricsIt->second.PartitionReplicaTabletType)
+        << "), table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+        << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId
+        << "), tenant database " << TenantPathId);
+
+    tableMetricsIt->second.PerPartitionCounterGroup->RemoveSubgroup("tablet_id", ToString(tabletId));
+    tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RemoveSourceCountersGroup(ToString(tabletId));
+    tableMetricsIt->second.PerPartitionMetrics.erase(partitionMetricsIt);
+
+    if (!tableMetricsIt->second.PerPartitionMetrics.empty()) {
+        // The parent table still contains some partitions, just update the counters
+        tableMetricsIt->second.PerPartitionTableYdbMetricsAggregator->RecalculateAllTargetCounters();
+        return;
+    }
+
+    // The parent table does not contain any partitions, delete the entry
+    LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+        "Deleting the entry for detailed metrics for the table " << tableMetricsIt->second.TableMetricsConfig.TablePath
+        << " (table ID " << tableMetricsIt->second.TableMetricsConfig.TableId
+        << "), tenant database " << TenantPathId
+    );
+
+    if (tableMetricsIt->second.MonitoringProjectCounterGroup) {
+        tableMetricsIt->second.MonitoringProjectCounterGroup->RemoveSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath);
+    } else {
+        DatabaseCounterGroup->RemoveSubgroup("table", tableMetricsIt->second.TableMetricsConfig.TablePath);
+    }
+
+    PerTableMetrics.erase(tableMetricsIt);
+}
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "ydb_metrics_aggregator.h"
+#include "ydb_metrics_mapper.h"
+
+#include <ydb/core/base/tablet_types.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <util/generic/ptr.h>
+
+namespace NKikimr {
+
+// Aggregator for all database metrics on a single node.
+class TNodeDatabaseMetricsAggregator : public TThrRefBase {
+    static TString FakeDatabasePath(const TPathId& tenantPathId) {
+        // There is no easy way to get a real database path. Use a fake path constructed from the tenant path ID.
+        return TStringBuilder() << tenantPathId.OwnerId << "-" << tenantPathId.LocalPathId;
+    }
+public:
+
+    TNodeDatabaseMetricsAggregator(const TPathId& tenantPathId, // Tenant path ID for the database
+        NMonitoring::TDynamicCounterPtr parentCounterGroup)     // The parent group to store counters for all databases to
+        : TenantPathId(tenantPathId)
+        , DatabasePath(FakeDatabasePath(tenantPathId))
+        , ParentCounterGroup(parentCounterGroup)
+        , DatabaseCounterGroup(parentCounterGroup->GetSubgroup("database", DatabasePath))
+    {
+    }
+
+    // Delete all counters for the database.
+    void DeleteAllDatabaseCounters() {
+        ParentCounterGroup->RemoveSubgroup("database", DatabasePath);
+    }
+
+    // Process tablet counters and apply them to the corresponding metrics counters.
+    void ProcessTabletCounters(TEvTabletCounters::TEvTabletAddCounters* message);
+
+    // Remove the values supplied by the specified tablet from all counters.
+    void ForgetTablet(ui64 tabletId, ui32 followerId);
+
+private:
+
+    // A partition replica detailed metrics.
+    struct TPartitionReplicaMetricsInfo {
+        // Counter group for this follower or leader. Public YDB metrics (table.datashard.*) are created directly in this counter group.
+        // Low level metrics for each tablet type are created in child subgroups, e.g. "type"="DataShard" for a DataShard tablets.
+        NMonitoring::TDynamicCounterPtr ReplicaCounterGroup;
+
+        // Low-level counters processor. Translates counter values from tablet to the actual metrics counters for the ReplicaCounterGroup.
+        ITabletCountersProcessorPtr TabletCountersProcessor;
+
+        // Mapper to translate tablet type dependant counters from corresponding type subgroup to the ReplicaCounterGroup counters.
+        TYdbMetricsMapperPtr TabletYdbMetricsMapper;
+    };
+
+    // Detailed metrics for a partition, e.g. all partition replicas.
+    struct TPartitionMetricsInfo {
+        // High-level counter group for a partition. Contains aggregated values across all replicas, has "tablet_id" = "<table_id>" label.
+        NMonitoring::TDynamicCounterPtr PartitionCounterGroup;
+
+        // High-level metrics aggregator for a partition.
+        TYdbMetricsAggregatorPtr PartitionYdbMetricsAggregator;
+
+        // High-level counter group for followers. Corresponds to the "follower_id" = "replicas_only" label.
+        NMonitoring::TDynamicCounterPtr AllFollowersCounterGroup;
+
+        // High-level metrics aggregator for followers.
+        TYdbMetricsAggregatorPtr AllFollowersYdbMetricsAggregator;
+
+        // Detailed metrics for each of replicas.
+        std::unordered_map<ui32, TPartitionReplicaMetricsInfo> PerReplicaMetrics;
+    };
+
+    // Detailed metrics for a table.
+    struct TTableMetricsInfo {
+        // Most recent detailed metrics configuration for the table, e.g. with highest TTableMetricsConfig::TableSchemaVersion field.
+        TEvTabletCounters::TTableMetricsConfig TableMetricsConfig;
+
+        // Tablet type of all partition replicas.
+        TTabletTypes::EType PartitionReplicaTabletType;
+
+        // Counter group for all high-level counters for the table, e.g. labeled "table" = "<table_path>".
+        NMonitoring::TDynamicCounterPtr TableCounterGroup;
+
+        // Group with "monitoring_project_id" = "<project_id>" label used as a parent for TableCounterGroup if TTableMetricsConfig::MonitoringProjectId
+        // field is set. DatabaseCounterGroup used otherwise.
+        NMonitoring::TDynamicCounterPtr MonitoringProjectCounterGroup;
+
+        // The counter group, which contains all high-level counters grouped by the partition ID.
+        NMonitoring::TDynamicCounterPtr PerPartitionCounterGroup;
+
+        // The aggregator for the high-level table metrics. Aggregates metrics from all replicas of all table partitions (from PerPartitionMetrics).
+        TYdbMetricsAggregatorPtr PerPartitionTableYdbMetricsAggregator;
+
+        // Table partion metrics indexed by tablet ID.
+        std::unordered_map<ui64, TPartitionMetricsInfo> PerPartitionMetrics;
+    };
+
+    // Track schema version changes for a table.
+    void HandleTableSchemaVersionChange(std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+        TEvTabletCounters::TEvTabletAddCounters* message);
+
+    // Track schema version changes for a tenant database.
+    void HandleDatabaseSchemaVersionChange(std::unordered_map<ui64, TTableMetricsInfo>::iterator tableMetricsIt,
+        TEvTabletCounters::TEvTabletAddCounters* message);
+
+    const TPathId TenantPathId;                             // Tenant path ID for the database
+    TString DatabasePath;                                   // Database path, see FakeDatabasePath
+    NMonitoring::TDynamicCounterPtr ParentCounterGroup;     // Parent group for counters for all databases
+    NMonitoring::TDynamicCounterPtr DatabaseCounterGroup;   // Group for aggregated database counters, labeled "database" = "<database_path>".
+    std::unordered_map<ui64, TTableMetricsInfo> PerTableMetrics;    // Metrics for each table in the database.
+
+    struct TabletIdFollowerIdPairHash {
+        std::size_t operator()(const std::pair<ui64, ui32>& p) const {
+            return std::hash<ui64>{}(p.first) ^ std::hash<ui32>{}(p.second);
+        }
+    };
+
+    std::unordered_map<std::pair<ui64, ui32>, ui64, TabletIdFollowerIdPairHash> TabletIdFollowerIdToTableIdMap; // {tablet ID + follower ID} -> table ID
+};
+
+using TNodeDatabaseMetricsAggregatorPtr = TIntrusivePtr<TNodeDatabaseMetricsAggregator>;
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -1,0 +1,1710 @@
+#include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
+
+#include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+#include <ydb/core/tablet/tablet_counters_app.h>
+#include <ydb/core/tablet_flat/flat_executor_counters.h>
+#include <ydb/core/testlib/basics/appdata.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <library/cpp/monlib/dynamic_counters/encode.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NDetailedMetricsTests;
+using namespace NKikimr::NTabletFlatExecutor;
+
+namespace {
+
+// Retrieve the private counters as a JSON string.
+TString GetPrivateJsonForCounters(const NMonitoring::TDynamicCounters& counters) {
+    TStringStream stream;
+
+    counters.Accept(
+        TString{},
+        TString{},
+        *(NMonitoring::CreateEncoder(
+            &stream,
+            NMonitoring::EFormat::JSON,
+            "sensor",
+            NMonitoring::TCountableBase::EVisibility::Private
+        ).Get())
+    );
+
+    return stream.Str();
+}
+
+} // namespace <anonymous>
+
+/**
+ * Unit tests for the per-node per-database metrics aggregator class (TNodeDatabaseMetricsAggregator).
+ */
+Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) exposes no detailed metrics,
+     * if there are no tablets reporting detailed metrics.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsLeaders) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (followers) does not try to expose
+     * detailed metrics at all.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        InitializeTabletCountersAggregator(runtime, true /* forFollowers */);
+
+        // The "ydb_detailed_raw" counter group should not exist
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(!detailedCounters);
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) does not process
+     * any detailed metrics, if the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(NoDetailedMetricsFeatureFlagDisabled) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(
+            runtime,
+            false /* forFollowers */,
+            false /* enableDetailedMetrics */
+        );
+
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Send an update for detailed metrics, but it should not be processed
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 101, 0, &tableMetricsConfig);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with the given low metrics level.
+     *
+     * @param[in] metricsLevel The metrics level to test with
+     */
+    void VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel metricsLevel
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Send detailed metrics with the given metrics level (too low)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = metricsLevel,
+        };
+
+        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 0, 20, &tableMetricsConfig);
+
+        // The "ydb_detailed_raw" counter group should contain no metrics
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with low metrics level (UNSPECIFIED).
+     */
+    Y_UNIT_TEST(NoDetailedMetricsNewTableForLowMetricsLevelUnspecified) {
+        VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator ignores detailed metrics
+     * for new tables with low metrics level (DISABLED).
+     */
+    Y_UNIT_TEST(NoDetailedMetricsNewTableForLowMetricsLevelDisabled) {
+        VerifyNoDetailedMetricsNewTableForLowMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) correctly handles
+     * the case when the TEvTabletCountersForgetTablet message is received
+     * for an unknown follower ID or for an unknown tablet ID.
+     */
+    Y_UNIT_TEST(ForgetUnknownFollowerOrTablet) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 1 table with 1 partition and only leaders for each of them
+        // and try to delete an unknown follower
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        auto expectedMetrics = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 101, 0, &tableMetricsConfig);
+
+        // Try deleting unknown tablet/follower
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 1, 123456789); // Unknown follower
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 987654321, 101); // Unknown tablet
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for this tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id")
+                        .StartNested("table", "/Root/fake-db/fake-table")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .StartNested("tablet_id", "1")
+                                    .AddNestedGroup("follower_id", "101", expectedMetrics)
+                                    .AddNestedGroup("follower_id", "replicas_only", expectedMetrics)
+                                    .AddGroup(expectedMetrics)
+                                .EndNested()
+                            .EndNested()
+                            .AddGroup(expectedMetrics)
+                        .EndNested()
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include only leaders
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardLeaders) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions and only leaders for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        auto expected0x01 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x01, 0, 20, &tableMetricsConfig1);
+        auto expected0x02 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x02, 0, 40, &tableMetricsConfig1);
+        auto expected0x04 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x04, 0, 60, &tableMetricsConfig1);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        auto expected0x10 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x10, 0, 10, &tableMetricsConfig2);
+        auto expected0x20 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x20, 0, 30, &tableMetricsConfig2);
+        auto expected0x40 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x40, 0, 50, &tableMetricsConfig2);
+
+        auto emptyMetrics = EmptyDataShardMetrics();
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        auto makeExpectedJson = [&] () -> TString {
+
+#undef AddExpected
+#define AddExpected(tabletId, expectedMetrics) \
+    AddNestedIf("tablet_id", tabletId, [&] () { return !expectedMetrics.empty(); }, [&] (auto json) { return json \
+        .AddNestedGroup("follower_id", "0", expectedMetrics) \
+        .AddNestedGroup("follower_id", "replicas_only", emptyMetrics) \
+        .AddGroup(expectedMetrics); \
+    })
+
+        auto expectedTable1 = expected0x01 | expected0x02 | expected0x04;
+            auto expectedTable2 = expected0x10 | expected0x20 | expected0x40;
+            return NormalizeJson(TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .AddNestedIf("monitoring_project_id", "fake-monitoring-project-id",
+                            [&] () { return !expectedTable2.empty(); }, [&] (auto json) { return json
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .AddExpected("16", expected0x10)
+                                .AddExpected("32", expected0x20)
+                                .AddExpected("64", expected0x40)
+                            .EndNested()
+                            .AddGroup(expectedTable2)
+                        .EndNested();
+                    })
+                    .AddNestedIf("table", "/Root/fake-db/fake-table1",
+                            [&] () { return !expectedTable1.empty(); }, [&] (auto json) { return json
+                        .StartNested("detailed_metrics", "per_partition")
+                            .AddExpected("1", expected0x01)
+                            .AddExpected("2", expected0x02)
+                            .AddExpected("4", expected0x04)
+                        .EndNested()
+                        .AddGroup(expectedTable1);
+                    })
+                .EndNested()
+                .BuildJson()
+            );
+        };
+
+        TString expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second partition for each table
+        expected0x02 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x02, 0, 80, &tableMetricsConfig1, 0x08);
+        expected0x20 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 0x20, 0, 60, &tableMetricsConfig2, 0x80);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second partition for each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x02, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x20, 0);
+
+        expected0x02.clear();
+        expected0x20.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting leaders):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x01, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x04, 0);
+
+        expected0x01.clear();
+        expected0x04.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x10, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 0x40, 0);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include only followers
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions and only followers for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        auto expected10101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 10101, 10, &tableMetricsConfig1, 0x0001);
+        auto expected20101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 20, &tableMetricsConfig1, 0x0002);
+        auto expected30101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 30101, 30, &tableMetricsConfig1, 0x0004);
+
+        auto expected10201 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 10201, 40, &tableMetricsConfig1, 0x0010);
+        auto expected20201 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 50, &tableMetricsConfig1, 0x0020);
+        auto expected30201 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 30201, 60, &tableMetricsConfig1, 0x0040);
+
+        auto expected10301 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 10301, 70, &tableMetricsConfig1, 0x0100);
+        auto expected20301 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 80, &tableMetricsConfig1, 0x0200);
+        auto expected30301 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 30301, 90, &tableMetricsConfig1, 0x0400);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        auto expected10102 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 10102, 10, &tableMetricsConfig2, 0x0002);
+        auto expected20102 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 20, &tableMetricsConfig2, 0x0004);
+        auto expected30102 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 30102, 30, &tableMetricsConfig2, 0x0008);
+
+        auto expected10202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 10202, 40, &tableMetricsConfig2, 0x0020);
+        auto expected20202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 50, &tableMetricsConfig2, 0x0040);
+        auto expected30202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 30202, 60, &tableMetricsConfig2, 0x0080);
+
+        auto expected10302 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 10302, 70, &tableMetricsConfig2, 0x0200);
+        auto expected20302 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 80, &tableMetricsConfig2, 0x0400);
+        auto expected30302 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 30302, 90, &tableMetricsConfig2, 0x0800);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        auto makeExpectedJson = [&] () -> TString {
+
+#undef AddExpected
+#define AddExpected(tabletId) \
+    AddNestedIf("tablet_id", #tabletId, [&] () { return !expectedTablet##tabletId.empty(); }, [&] (auto json) { return json \
+        .AddNestedGroup("follower_id", "10" #tabletId, expected10##tabletId) \
+        .AddNestedGroup("follower_id", "20" #tabletId, expected20##tabletId) \
+        .AddNestedGroup("follower_id", "30" #tabletId, expected30##tabletId) \
+        .AddNestedGroup("follower_id", "replicas_only", expectedTablet##tabletId) \
+        .AddGroup(expectedTablet##tabletId); \
+    })
+
+            auto expectedTablet101 = expected10101 | expected20101 | expected30101;
+            auto expectedTablet201 = expected10201 | expected20201 | expected30201;
+            auto expectedTablet301 = expected10301 | expected20301 | expected30301;
+            auto expectedTable1 = expectedTablet101 | expectedTablet201 | expectedTablet301 ;
+            auto expectedTablet102 = expected10102 | expected20102 | expected30102;
+            auto expectedTablet202 = expected10202 | expected20202 | expected30202;
+            auto expectedTablet302 = expected10302 | expected20302 | expected30302;
+            auto expectedTable2 = expectedTablet102 | expectedTablet202 | expectedTablet302;
+            return NormalizeJson(TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .AddNestedIf("monitoring_project_id", "fake-monitoring-project-id",
+                            [&] () { return !expectedTable2.empty(); }, [&] (auto json) { return json
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .AddExpected(102)
+                                .AddExpected(202)
+                                .AddExpected(302)
+                            .EndNested()
+                            .AddGroup(expectedTable2)
+                        .EndNested();
+                    })
+                    .AddNestedIf("table", "/Root/fake-db/fake-table1",
+                            [&] () { return !expectedTable1.empty(); }, [&] (auto json) { return json
+                        .StartNested("detailed_metrics", "per_partition")
+                            .AddExpected(101)
+                            .AddExpected(201)
+                            .AddExpected(301)
+                        .EndNested()
+                        .AddGroup(expectedTable1);
+                    })
+                .EndNested()
+                .BuildJson()
+            );
+        };
+
+        TString expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second follower for each partition for each table
+        expected20101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 0, &tableMetricsConfig1, 0x0008);
+        expected20201 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 0, &tableMetricsConfig1, 0x0080);
+        expected20301 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 0, &tableMetricsConfig1, 0x0800);
+
+        expected20102 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 0, &tableMetricsConfig2, 0x0001);
+        expected20202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 0, &tableMetricsConfig2, 0x0010);
+        expected20302 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 0, &tableMetricsConfig2, 0x0100);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second follower for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 20101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 20201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 20301);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 20102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 20202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 20302);
+
+        expected20101.clear();
+        expected20201.clear();
+        expected20301.clear();
+    
+        expected20102.clear();
+        expected20202.clear();
+        expected20302.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting followers):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for the second partition in each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 10201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 30201);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 10202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 30202);
+
+        expected10201.clear();
+        expected30201.clear();
+
+        expected10202.clear();
+        expected30202.clear();
+        
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting partitions):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 10101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 30101);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 10301);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 30301);
+
+        expected10101.clear();
+        expected30101.clear();
+
+        expected10301.clear();
+        expected30301.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 6: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 10102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 30102);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 10302);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 30302);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the Tablet Counters Aggregator (leaders) handles detailed metrics
+     * for Data Shard tables, which include both leaders and followers
+     * (including adding, updating and removing tablets).
+     */
+    Y_UNIT_TEST(DataShardLeadersAndsFollowers) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // TEST 1: Simulate 2 tables with 3 partitions with the leader + 2 followers for each of them
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 1234,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        auto expected101Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101,     0,  10, &tableMetricsConfig1, 0x0001);
+        auto expected10101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 10101,  20, &tableMetricsConfig1, 0x0002);
+        auto expected20101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101,  30, &tableMetricsConfig1, 0x0004);
+
+        auto expected201Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201,     0,  40, &tableMetricsConfig1, 0x0010);
+        auto expected10201 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 10201,  50, &tableMetricsConfig1, 0x0020);
+        auto expected20201 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201,  60, &tableMetricsConfig1, 0x0040);
+
+        auto expected301Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301,     0,  70, &tableMetricsConfig1, 0x0100);
+        auto expected10301 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 10301,  80, &tableMetricsConfig1, 0x0200);
+        auto expected20301 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301,  90, &tableMetricsConfig1, 0x0400);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 4321,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable,
+            .MonitoringProjectId = "fake-monitoring-project-id"
+        };
+
+        auto expected102Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102,     0,  10, &tableMetricsConfig2, 0x0001);
+        auto expected10102 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 10102,  20, &tableMetricsConfig2, 0x0002);
+        auto expected20102 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102,  30, &tableMetricsConfig2, 0x0004);
+
+        auto expected202Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202,     0,  40, &tableMetricsConfig2, 0x0010);
+        auto expected10202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 10202,  50, &tableMetricsConfig2, 0x0020);
+        auto expected20202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202,  60, &tableMetricsConfig2, 0x0040);
+
+        auto expected302Leader = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302,     0,  70, &tableMetricsConfig2, 0x0100);
+        auto expected10302 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 10302,  80, &tableMetricsConfig2, 0x0200);
+        auto expected20302 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302,  90, &tableMetricsConfig2, 0x0400);
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        auto makeExpectedJson = [&] () -> TString {
+
+#undef AddExpected
+#define AddExpected(tabletId) \
+    AddNestedIf("tablet_id", #tabletId, [&] () { return !expectedTablet##tabletId.empty(); }, [&] (auto json) { return json \
+        .AddNestedGroup("follower_id", "0", expected##tabletId##Leader) \
+        .AddNestedGroup("follower_id", "10" #tabletId, expected10##tabletId) \
+        .AddNestedGroup("follower_id", "20" #tabletId, expected20##tabletId) \
+        .AddNestedGroup("follower_id", "replicas_only", expected10##tabletId | expected20##tabletId) \
+        .AddGroup(expectedTablet##tabletId); \
+    })
+
+            auto expectedTablet101 = expected101Leader | expected10101 | expected20101;
+            auto expectedTablet201 = expected201Leader | expected10201 | expected20201;
+            auto expectedTablet301 = expected301Leader | expected10301 | expected20301;
+            auto expectedTable1 = expectedTablet101 | expectedTablet201 | expectedTablet301;
+            auto expectedTablet102 = expected102Leader | expected10102 | expected20102;
+            auto expectedTablet202 = expected202Leader | expected10202 | expected20202;
+            auto expectedTablet302 = expected302Leader | expected10302 | expected20302;
+            auto expectedTable2 = expectedTablet102 | expectedTablet202 | expectedTablet302;
+            return NormalizeJson(TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .AddNestedIf("monitoring_project_id", "fake-monitoring-project-id",
+                            [&] () { return !expectedTable2.empty(); }, [&] (auto json) { return json
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .StartNested("detailed_metrics", "per_partition")
+                                .AddExpected(102)
+                                .AddExpected(202)
+                                .AddExpected(302)
+                            .EndNested()
+                            .AddGroup(expectedTable2)
+                        .EndNested();
+                    })
+                    .AddNestedIf("table", "/Root/fake-db/fake-table1",
+                            [&] () { return !expectedTable1.empty(); }, [&] (auto json) { return json
+                        .StartNested("detailed_metrics", "per_partition")
+                            .AddExpected(101)
+                            .AddExpected(201)
+                            .AddExpected(301)
+                        .EndNested()
+                        .AddGroup(expectedTable1);
+                    })
+                .EndNested()
+                .BuildJson()
+            );
+        };
+
+        TString expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 2: Update metrics for the second follower for each partition for each table
+        expected20101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 20101, 0, &tableMetricsConfig1, 0x0008);
+        expected20201 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 201, 20201, 0, &tableMetricsConfig1, 0x0080);
+        expected20301 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 301, 20301, 0, &tableMetricsConfig1, 0x0800);
+
+        expected20102 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 102, 20102, 0, &tableMetricsConfig2, 0x0008);
+        expected20202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 20202, 0, &tableMetricsConfig2, 0x0080);
+        expected20302 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 302, 20302, 0, &tableMetricsConfig2, 0x0800);
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 3: Remove metrics for the second follower for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 20101);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 20201);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 20301);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 20102);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 20202);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 20302);
+
+        expected20101.clear();
+        expected20201.clear();
+        expected20301.clear();
+
+        expected20102.clear();
+        expected20202.clear();
+        expected20302.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting followers):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 4: Remove metrics for the leader for each partition of each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 0);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 0);
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 0);
+
+        expected101Leader.clear();
+        expected201Leader.clear();
+        expected301Leader.clear();
+
+        expected102Leader.clear();
+        expected202Leader.clear();
+        expected302Leader.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting leaders):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 5: Remove metrics for the second partition in each table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 201, 10201);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 202, 10202);
+
+        expected10201.clear();
+
+        expected10202.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting partitions):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 6: Remove metrics for all remaining partitions in the first table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 101, 10101);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 301, 10301);
+
+        expected10101.clear();
+
+        expected10301.clear();
+
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after deleting table 1):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // TEST 7: Remove metrics for all remaining partitions in the second table
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 102, 10102);
+
+        SendForgetDataShardTablet(runtime, aggregatorId, edgeActorId, 302, 10302);
+
+        countersJson = NormalizeJson(GetPrivateJsonForCounters(*detailedCounters));
+        Cerr << "TEST Current counters (after deleting table 2):" << Endl << countersJson << Endl;
+
+        expectedJson = NormalizeJson(
+R"json(
+{
+}
+)json"
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+#undef AddExpected
+#define AddExpected(tabletId) \
+    StartNested("detailed_metrics", "per_partition") \
+        .StartNested("tablet_id", #tabletId) \
+            .AddNestedGroup("follower_id", "0", expectedTablet##tabletId) \
+            .AddNestedGroup("follower_id", "replicas_only", emptyMetrics) \
+            .AddGroup(expectedTablet##tabletId) \
+        .EndNested() \
+    .EndNested() \
+    .AddGroup(expectedTablet##tabletId)
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @param[in] hasOldMonitoringProjectId Indicates if the current monitoring
+     *                                      project ID (to change from) is set
+     * @param[in] newMonitoringProjectId The new monitoring project ID (to change to)
+     */
+    void VerifyChangeMonitoringProjectIdOldSchemaVersion(
+        bool hasOldMonitoringProjectId,
+        const std::optional<TString>& newMonitoringProjectId
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 3 tables, one without a monitoring project ID and two with different
+        // monitoring project IDs set (all three with a single partition and a leader)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 12340001,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        auto expectedTablet101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 10, &tableMetricsConfig1, 0x01);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 12340002,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-2"
+        };
+
+        auto expectedTablet202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 20, &tableMetricsConfig2, 0x02);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig3 = {
+            .TableId = 12340003,
+            .TablePath = "/Root/fake-db/fake-table3",
+            .TableSchemaVersion = 1000333,
+            .TenantDbSchemaVersion = 2000333,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-3"
+        };
+
+        auto expectedTablet303 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 30, &tableMetricsConfig3, 0x04);
+
+        auto emptyMetrics = EmptyDataShardMetrics();
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        auto makeExpectedJson = [&] () -> TString {
+            return NormalizeJson(TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .AddExpected(202)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                        .StartNested("table", "/Root/fake-db/fake-table3")
+                            .AddExpected(303)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .AddExpected(101)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+            );
+        };
+
+        TString expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // Try changing the monitoring project ID with an old schema version
+        if (hasOldMonitoringProjectId) {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig2 = tableMetricsConfig2;
+
+            invalidTableMetricsConfig2.TenantDbSchemaVersion = 2000221;
+            invalidTableMetricsConfig2.MonitoringProjectId = newMonitoringProjectId;
+
+            expectedTablet202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &invalidTableMetricsConfig2, 0x08);
+
+            // Update the other two tables to make sure the regular updates work
+            expectedTablet101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &tableMetricsConfig1, 0x10);
+            expectedTablet303 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        } else {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig1 = tableMetricsConfig1;
+
+            invalidTableMetricsConfig1.TenantDbSchemaVersion = 2000110;
+            invalidTableMetricsConfig1.MonitoringProjectId = newMonitoringProjectId;
+
+            expectedTablet101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &invalidTableMetricsConfig1, 0x10);
+
+            // Update the other two tables to make sure the regular updates work
+            expectedTablet202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &tableMetricsConfig2, 0x08);
+            expectedTablet303 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        }
+
+        // Verify all counters in the "ydb_detailed_raw" group - the counters should change,
+        // but the monitoring project IDs should not
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        expectedJson = makeExpectedJson();
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being removed.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdRemoved) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            {} // Empty std::optional == remove the monitoring project ID
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdAddedNew) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1" // Does not match any table
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdAddedExisting) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3" // Matches table 3
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdChangedToNew) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1" // Does not match any table
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is ignored, if the tenant database schema version is older than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdOldVersionIgnoredIdChangedToExisting) {
+        VerifyChangeMonitoringProjectIdOldSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3" // Matches table 3
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed, if the tenant database schema version is newer than the current one.
+     *
+     * @param[in] hasOldMonitoringProjectId Indicates if the current monitoring
+     *                                      project ID (to change from) is set
+     * @param[in] newMonitoringProjectId The new monitoring project ID (to change to)
+     * @param[in] finalExectedJson The final expected JSON for all counters (after all updates)
+     */
+    void VerifyChangeMonitoringProjectIdNewSchemaVersion(
+        bool hasOldMonitoringProjectId,
+        const std::optional<TString>& newMonitoringProjectId,
+        std::function<TString(const TExpectedSensorGroup&, const TExpectedSensorGroup&, const TExpectedSensorGroup&)> makeFinalExpectedJson
+    ) {
+        TTestBasicRuntime runtime(1);
+
+        runtime.Initialize(TAppPrepare().Unwrap());
+        runtime.SetLogPriority(NKikimrServices::TABLET_AGGREGATOR, NActors::NLog::PRI_TRACE);
+
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
+        TActorId edgeActorId = runtime.AllocateEdgeActor();
+
+        // Simulate 3 tables, one without a monitoring project ID and two with different
+        // monitoring project IDs set (all three with a single partition and a leader)
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig1 = {
+            .TableId = 12340001,
+            .TablePath = "/Root/fake-db/fake-table1",
+            .TableSchemaVersion = 1000111,
+            .TenantDbSchemaVersion = 2000111,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            // .MonitoringProjectId = ... - no monitoring project ID for this table
+        };
+
+        auto expectedTablet101 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 10, &tableMetricsConfig1, 0x01);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig2 = {
+            .TableId = 12340002,
+            .TablePath = "/Root/fake-db/fake-table2",
+            .TableSchemaVersion = 1000222,
+            .TenantDbSchemaVersion = 2000222,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-2"
+        };
+
+        auto expectedTablet202 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 20, &tableMetricsConfig2, 0x02);
+
+        TEvTabletCounters::TTableMetricsConfig tableMetricsConfig3 = {
+            .TableId = 12340003,
+            .TablePath = "/Root/fake-db/fake-table3",
+            .TableSchemaVersion = 1000333,
+            .TenantDbSchemaVersion = 2000333,
+            .MetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition,
+            .MonitoringProjectId = "fake-monitoring-project-id-3"
+        };
+
+        auto expectedTablet303 = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 30, &tableMetricsConfig3, 0x04);
+
+        auto emptyMetrics = EmptyDataShardMetrics();
+
+        // The "ydb_detailed_raw" counter group should contain detailed metrics for all tables
+        auto detailedCounters = runtime.GetAppData(0).Counters->FindSubgroup(
+            "counters",
+            "ydb_detailed_raw"
+        );
+
+        UNIT_ASSERT(detailedCounters);
+
+        TString countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (initial):" << Endl << countersJson << Endl;
+
+        TString expectedJson = NormalizeJson(
+            TSensorsJsonBuilder::Start()
+                .StartNested("database", "1113-1001")
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .AddExpected(202)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                        .StartNested("table", "/Root/fake-db/fake-table3")
+                            .AddExpected(303)
+                        .EndNested()
+                    .EndNested()
+                    .StartNested("table", "/Root/fake-db/fake-table1")
+                        .AddExpected(101)
+                    .EndNested()
+                .EndNested()
+                .BuildJson()
+        );
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            expectedJson,
+            "Expected JSON:" << Endl << expectedJson
+        );
+
+        // Try changing the monitoring project ID with a new schema version
+        if (hasOldMonitoringProjectId) {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig2 = tableMetricsConfig2;
+
+            invalidTableMetricsConfig2.TenantDbSchemaVersion = 2000223;
+            invalidTableMetricsConfig2.MonitoringProjectId = newMonitoringProjectId;
+
+            expectedTablet202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &invalidTableMetricsConfig2, 0x08);
+
+            // Update the other two tables to make sure the regular updates work
+            expectedTablet101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &tableMetricsConfig1, 0x10);
+            expectedTablet303 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        } else {
+            TEvTabletCounters::TTableMetricsConfig invalidTableMetricsConfig1 = tableMetricsConfig1;
+
+            invalidTableMetricsConfig1.TenantDbSchemaVersion = 2000112;
+            invalidTableMetricsConfig1.MonitoringProjectId = newMonitoringProjectId;
+
+            expectedTablet101 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 101, 0, 70, &invalidTableMetricsConfig1, 0x10);
+
+            // Update the other two tables to make sure the regular updates work
+            expectedTablet202 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 202, 0, 80, &tableMetricsConfig2, 0x08);
+            expectedTablet303 += SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 303, 0, 90, &tableMetricsConfig3, 0x20);
+        }
+
+        // Verify all counters in the "ydb_detailed_raw" group - the counters should change,
+        // but the monitoring project IDs should not
+        countersJson = NormalizeJson(
+            GetPrivateJsonForCounters(*detailedCounters),
+            {
+                // Drop all low-level sensors to make asserts easier
+                {"type", {"DataShard"}},
+            }
+        );
+
+        Cerr << "TEST Current counters (after the update):" << Endl << countersJson << Endl;
+
+        auto finalExpectedJson = makeFinalExpectedJson(expectedTablet101, expectedTablet202, expectedTablet303);
+
+        UNIT_ASSERT_EQUAL_C(
+            countersJson,
+            finalExpectedJson,
+            "Expected JSON:" << Endl << finalExpectedJson
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being removed.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdRemoved) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            {}, // Empty std::optional == remove the monitoring project ID
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .AddExpected(101)
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table2")
+                            .AddExpected(202)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+                }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdAddedNew) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1", // Does not match any table
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-1")
+                            .StartNested("table", "/Root/fake-db/fake-table1")
+                                .AddExpected(101)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being added
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdAddedExisting) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3", // Matches table 3
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table1")
+                                .AddExpected(101)
+                            .EndNested()
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it does not match any of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdChangedToNew) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-1", // Does not match any table
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-1")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .AddExpected(101)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is being changed
+     *       and it matches one of the existing monitoring project IDs.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdChangedToExisting) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-3", // Matches table 3
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .AddExpected(101)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is not changed
+     *       at all (was not set before) even though the tenant database schema version
+     *       is increased.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdNotChangedUnset) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            false /* hasOldMonitoringProjectId */,
+            {}, // Empty std::optional == unset monitoring project ID (the current value)
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .AddExpected(101)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+
+    /**
+     * Verify that the message to change the monitoring project ID for a table
+     * is processed correctly, if the tenant database schema version is newer
+     * than the current one.
+     *
+     * @note This test is for the variation, when the monitoring project ID is not changed
+     *       at all (was set before) even though the tenant database schema version
+     *       is increased.
+     */
+    Y_UNIT_TEST(ChangeMonitoringProjectIdNewVersionProcessedIdNotChangedSet) {
+        VerifyChangeMonitoringProjectIdNewSchemaVersion(
+            true /* hasOldMonitoringProjectId */,
+            "fake-monitoring-project-id-2", // Matches table 2 (the current value)
+            [] (const TExpectedSensorGroup& expectedTablet101, const TExpectedSensorGroup& expectedTablet202, const TExpectedSensorGroup& expectedTablet303) {
+                auto emptyMetrics = EmptyDataShardMetrics();
+                return NormalizeJson(TSensorsJsonBuilder::Start()
+                    .StartNested("database", "1113-1001")
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-2")
+                            .StartNested("table", "/Root/fake-db/fake-table2")
+                                .AddExpected(202)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("monitoring_project_id", "fake-monitoring-project-id-3")
+                            .StartNested("table", "/Root/fake-db/fake-table3")
+                                .AddExpected(303)
+                            .EndNested()
+                        .EndNested()
+                        .StartNested("table", "/Root/fake-db/fake-table1")
+                            .AddExpected(101)
+                        .EndNested()
+                    .EndNested()
+                    .BuildJson());
+            }
+        );
+    }
+}

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.cpp
@@ -1,18 +1,42 @@
 #include "ut_helpers.h"
 
+#include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/tablet/tablet_counters_app.h>
+#include <ydb/core/tablet_flat/flat_executor_counters.h>
+#include <ydb/core/testlib/basics/appdata.h>
+
 #include <library/cpp/json/json_prettifier.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
-
 #include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+using namespace NKikimr::NTabletFlatExecutor;
 
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {
 
-TString NormalizeJson(const TString& jsonString) {
+TString NormalizeJson(const TString& jsonString,
+    const std::unordered_map<TString, std::unordered_set<TString>>& removeSensorsByLabels)
+{
     NJson::TJsonValue parsedJson;
     UNIT_ASSERT(NJson::ReadJsonTree(TStringBuf(jsonString), &parsedJson));
+
+    if (!removeSensorsByLabels.empty()) {
+        auto& sensorsArray = parsedJson["sensors"];
+
+        for (size_t i = 0; i < sensorsArray.GetArraySafe().size(); ++i) {
+            for (const auto& [labelName, labelValue] : sensorsArray[i]["labels"].GetMapSafe()) {
+                auto labelIt = removeSensorsByLabels.find(labelName);
+                if (labelIt != removeSensorsByLabels.end() && labelIt->second.contains(labelValue.GetStringSafe())) {
+                    sensorsArray.EraseValue(i);
+                    --i; // Don't step over the next element.
+                    break;
+                }
+            }
+        }
+    }
 
     // NOTE: The prettifier is needed here to make sure all brackets (both [] and {})
     //       are aligned "Python style" with the opening bracket placed on the starting line.
@@ -28,6 +52,148 @@ TString NormalizeJson(const TString& jsonString) {
         false /* unquote */,
         2 /* padding */
     );
+}
+
+TActorId InitializeTabletCountersAggregator(TTestBasicRuntime& runtime,
+    bool forFollowers,
+    bool enableDetailedMetrics)
+{
+    // To use detailed metrics per-database counters in the Tablet Counters Aggregator should be enabled
+    runtime.GetAppData().FeatureFlags.SetEnableDbCounters(true);
+    runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
+
+    // Register the Tablet Counters Aggregator actor
+    TActorId aggregatorId = runtime.Register(CreateTabletCountersAggregator(forFollowers));
+    runtime.EnableScheduleForActor(aggregatorId);
+
+    // Wait for the TEvBootstrap event to be processed, after this the actor is ready
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
+
+    runtime.DispatchEvents(options);
+    return aggregatorId;
+}
+
+TExpectedSensorGroup SendDataShardMetrics(TTestBasicRuntime& runtime,
+    const TActorId& aggregatorId,
+    const TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId,
+    ui32 cpuLoadPercentage,
+    TEvTabletCounters::TTableMetricsConfig* tableMetricsConfig,
+    std::optional<ui64> metricsOffset)
+{
+    if (!metricsOffset) {
+        metricsOffset = tabletId; // Use the tablet ID as the default metrics offset
+    }
+
+    TExpectedSensorGroup result;
+
+    // Populate executor counters with some fake values
+    auto executorCounters = MakeHolder<TExecutorCounters>();
+    auto executorCountersBaseline = MakeHolder<TExecutorCounters>();
+
+    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
+
+    result.Add("table.datashard.row_count", executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_ROWS_TOTAL] = 10000 + (*metricsOffset));
+    result.Add("table.datashard.size_bytes", executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_DATA_BYTES] = 20000 + (*metricsOffset));
+
+    result.Add("table.datashard.cache_hit.bytes", executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(30000 + (*metricsOffset)));
+    result.Add("table.datashard.cache_miss.bytes", executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(40000 + (*metricsOffset)));
+
+    // Populate DataShard counters with some fake values
+    auto tabletCounters = CreateAppCountersByTabletType(TTabletTypes::DataShard);
+    auto tabletCountersBaseline = CreateAppCountersByTabletType(TTabletTypes::DataShard);
+
+    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
+
+    result.Add("table.datashard.write.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW].Increment(50000 + (*metricsOffset)));
+    result.Add("table.datashard.write.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW_BYTES].Increment(60000 + (*metricsOffset)));
+    result.Add("table.datashard.read.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW].Increment(10070000 + (*metricsOffset)));
+    result.Add("table.datashard.read.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_ROWS].Increment(20080000 + (*metricsOffset)));
+    result.Add("table.datashard.read.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW_BYTES].Increment(30090000 + (*metricsOffset)));
+    result.Add("table.datashard.read.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_BYTES].Increment(40100000 + (*metricsOffset)));
+    result.Add("table.datashard.erase.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW].Increment(110000 + (*metricsOffset)));
+    result.Add("table.datashard.erase.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW_BYTES].Increment(120000 + (*metricsOffset)));
+    result.Add("table.datashard.bulk_upsert.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS].Increment(130000 + (*metricsOffset)));
+    result.Add("table.datashard.bulk_upsert.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS_BYTES].Increment(140000 + (*metricsOffset)));
+    result.Add("table.datashard.scan.rows", tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_ROWS].Increment(150000 + (*metricsOffset)));
+    result.Add("table.datashard.scan.bytes", tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_BYTES].Increment(160000 + (*metricsOffset)));
+
+    // Send these counters to the Tablet Counters Aggregator
+    runtime.Send(new IEventHandle(aggregatorId,
+        edgeActorId,
+        new TEvTabletCounters::TEvTabletAddCounters(new TEvTabletCounters::TInFlightCookie(),
+            tabletId,
+            followerId,
+            TTabletTypes::DataShard,
+            TPathId(1113, 1001),
+            executorCounters->MakeDiffForAggr(*executorCountersBaseline),
+            tabletCounters->MakeDiffForAggr(*tabletCountersBaseline),
+            tableMetricsConfig)));
+
+    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
+    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
+
+    result.Add("table.datashard.consumed_cpu_us", executorCounters->Cumulative()[TExecutorCounters::CONSUMED_CPU].Increment(
+        cpuLoadPercentage * 10000 + (*metricsOffset)
+    ));
+
+    // Send cpu consumption to the Tablet Counters Aggregator as cumulative counter for a simulated one-second interval.
+    // The aggregator will update corresponding CPU consumption histogram automatically.
+    runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+    runtime.Send(new IEventHandle(aggregatorId,
+        edgeActorId,
+        new TEvTabletCounters::TEvTabletAddCounters(new TEvTabletCounters::TInFlightCookie(),
+            tabletId,
+            followerId,
+            TTabletTypes::DataShard,
+            TPathId(1113, 1001),
+            executorCounters->MakeDiffForAggr(*executorCountersBaseline),
+            tabletCounters->MakeDiffForAggr(*tabletCountersBaseline),
+            tableMetricsConfig)));
+
+    ui64 bucket = (cpuLoadPercentage * 10000 + (*metricsOffset) + 99999) / 100000 * 10;
+    result.AddHist("table.datashard.used_core_percents", {{bucket, 1}});
+
+    return result;
+}
+
+TExpectedSensorGroup EmptyDataShardMetrics() {
+    TExpectedSensorGroup result;
+
+    result.Add("table.datashard.row_count", TTabletSimpleCounter{});
+    result.Add("table.datashard.size_bytes", TTabletSimpleCounter{});
+    result.Add("table.datashard.cache_hit.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.cache_miss.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.write.rows", TTabletCumulativeCounter{});
+    result.Add("table.datashard.write.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.read.rows", TTabletCumulativeCounter{});
+    result.Add("table.datashard.read.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.erase.rows", TTabletCumulativeCounter{});
+    result.Add("table.datashard.erase.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.bulk_upsert.rows", TTabletCumulativeCounter{});
+    result.Add("table.datashard.bulk_upsert.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.scan.rows", TTabletCumulativeCounter{});
+    result.Add("table.datashard.scan.bytes", TTabletCumulativeCounter{});
+    result.Add("table.datashard.consumed_cpu_us", TTabletCumulativeCounter{});
+    result.AddHist("table.datashard.used_core_percents", {});
+
+    return result;
+}
+
+void SendForgetDataShardTablet(NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId)
+{
+    runtime.Send(new IEventHandle(aggregatorId,
+        edgeActorId,
+        new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId,
+            followerId,
+            TTabletTypes::DataShard,
+            TPathId(1113, 1001))));
 }
 
 } // namespace NDetailedMetricsTests

--- a/ydb/core/tablet/detailed_metrics/ut_helpers.h
+++ b/ydb/core/tablet/detailed_metrics/ut_helpers.h
@@ -1,25 +1,124 @@
 #pragma once
 
+#include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/string.h>
+
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
+#include <ydb/core/testlib/basics/runtime.h>
+
+#include <optional>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace NKikimr {
 
 namespace NDetailedMetricsTests {
 
-/**
- * Normalizes the given JSON to be well formatted with all keys sorted.
- *
- * @warning This function sorts only maps by the key value. It does not sort
- *          items in arrays at all. Luckily, all counters and groups in TDynamicCounters
- *          are stored in SORTED maps, which means that the array of sensors
- *          is always inherently sorted in a stable order. This makes it safe
- *          to compare sensor arrays directly without sorting them.
- *
- * @param[in] jsonString The JSON to normalize (as a string)
- *
- * @return The corresponding normalized JSON
- */
-TString NormalizeJson(const TString& jsonString);
+// Expected sensor value
+struct TExpectedSensorValue {
+    enum Type {
+        Undefined,
+        Gauge,
+        Rate,
+        Hist,
+    };
+    Type Type = Undefined;
+    ui64 Value = 0;
+    std::unordered_map<ui64, ui64> Buckets;
+    ui64 InfValue;
+
+    // Merge sensor with a new value, isDelta true for value updates and false for aggregations.
+    void Merge(const TExpectedSensorValue& other, bool isDelta) {
+        UNIT_ASSERT(Type == other.Type || Type == Undefined);
+        if (isDelta && Type == Gauge) {
+            Value = other.Value;
+        } else {
+            Value += other.Value;
+        }
+        Type = other.Type;
+        if (isDelta) {
+            Buckets.clear();
+            InfValue = 0;
+        }
+        for (const auto& [key, value] : other.Buckets) {
+            Buckets[key] += value;
+        }
+        InfValue += other.InfValue;
+    }
+};
+
+// A group of named sensors with expected values.
+struct TExpectedSensorGroup : public std::map<TString, TExpectedSensorValue> {
+    void Add(const TString& name, const TTabletSimpleCounter& counter) {
+        (*this)[name].Merge({.Type = TExpectedSensorValue::Gauge, .Value = counter.Get()}, true);
+    }
+
+    void Add(const TString& name, const TTabletCumulativeCounter& counter) {
+        (*this)[name].Merge({.Type = TExpectedSensorValue::Rate, .Value = counter.Get()}, true);
+    }
+
+    void AddHist(const TString& name, const std::unordered_map<ui64, ui64>& buckets, ui64 infValue = 0) {
+        (*this)[name].Merge({.Type = TExpectedSensorValue::Hist, .Buckets = buckets, .InfValue = infValue}, true);
+    }
+
+    // Apply new sensor values.
+    TExpectedSensorGroup& operator+=(const TExpectedSensorGroup& other) {
+        for (const auto& [name, value] : other) {
+            (*this)[name].Merge(value, true);
+        }
+        return *this;
+    }
+
+    TExpectedSensorGroup operator+(const TExpectedSensorGroup& other) const {
+        TExpectedSensorGroup result(*this);
+        result += other;
+        return result;
+    }
+
+    // Aggregate sensor values from underlying levels.
+    TExpectedSensorGroup& operator|=(const TExpectedSensorGroup& other) {
+        for (const auto& [name, value] : other) {
+            (*this)[name].Merge(value, false);
+        }
+        return *this;
+    }
+
+    TExpectedSensorGroup operator|(const TExpectedSensorGroup& other) const {
+        TExpectedSensorGroup result(*this);
+        result |= other;
+        return result;
+    }
+};
+
+// Normalize JSON to be well formatted with all keys sorted. Removes sensors with labels matching pairs from removeSensorsByLabels.
+TString NormalizeJson(const TString& jsonString,
+    const std::unordered_map<TString, std::unordered_set<TString>>& removeSensorsByLabels = {});
+
+// Create and initialize the Tablet Counters Aggregator actor.
+NActors::TActorId InitializeTabletCountersAggregator(NActors::TTestBasicRuntime& runtime,
+    bool forFollowers,
+    bool enableDetailedMetrics = true); // The value of EnableDetailedMetrics feature flag
+
+// Send low level metrics to the Tablet Counters Aggregator for the specified DataShard tablet.
+TExpectedSensorGroup SendDataShardMetrics(NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId,
+    ui32 cpuLoadPercentage,
+    TEvTabletCounters::TTableMetricsConfig* tableMetricsConfig = nullptr,
+    std::optional<ui64> metricsOffset = {});
+
+// Create a group of DataShard sensors with default values.
+TExpectedSensorGroup EmptyDataShardMetrics();
+
+// Send a message to the Tablet Counters Aggregator to forget the specified Data Shard tablet.
+void SendForgetDataShardTablet(NActors::TTestBasicRuntime& runtime,
+    const NActors::TActorId& aggregatorId,
+    const NActors::TActorId& edgeActorId,
+    ui64 tabletId,
+    ui32 followerId);
 
 } // namespace NDetailedMetricsTests
 

--- a/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
+++ b/ydb/core/tablet/detailed_metrics/ut_sensors_json_builder.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "ut_helpers.h"
+
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <unordered_map>
+
+namespace NKikimr {
+
+namespace NDetailedMetricsTests {
+
+// JSON sensors array builder.
+class TSensorsJsonBuilder {
+public:
+    static TSensorsJsonBuilder Start() {
+        return TSensorsJsonBuilder();
+    }
+
+    // Finalize the building process and create the final JSON of sensors.
+    TString BuildJson() {
+        Y_ABORT_UNLESS(ParentBuilder == nullptr, "The sensors JSON should be created at the root level");
+        return NJson::WriteJson(RootJson);
+    }
+
+    // Start a new nested level of sensors with the given label.
+    TSensorsJsonBuilder StartNested(const TString& labelKey, const TString& labelValue) {
+        return TSensorsJsonBuilder(*this, labelKey, labelValue);
+    }
+
+    // Finish the current level of sensors and return back to the parent level.
+    TSensorsJsonBuilder& EndNested() {
+        Y_ABORT_UNLESS(ParentBuilder != nullptr, "Unable to finish the root level of sensors");
+        return *ParentBuilder;
+    }
+
+    // Add a new GAUGE sensor at the current level of sensors.
+    TSensorsJsonBuilder& AddGauge(const TString& name, ui64 value) {
+        AddSimpleSensor(TSensorKind::GAUGE, name, value);
+        return *this;
+    }
+
+    // Add a new RATE sensor at the current level of sensors.
+    TSensorsJsonBuilder& AddRate(const TString& name, ui64 value) {
+        AddSimpleSensor(TSensorKind::RATE, name, value);
+        return *this;
+    }
+
+    // Add a new HIST sensor for the CPU usage at the current level of sensors.
+    TSensorsJsonBuilder& AddCpuHistogram(
+        const TString& name,
+        const std::unordered_map<ui64, ui64>& buckets,
+        ui64 infValue = 0
+    ) {
+        auto &record = SensorsJson.AppendValue(NJson::JSON_MAP);
+        record["kind"] = TSensorKind::HIST;
+
+        auto& histRecord = record.InsertValue("hist", NJson::JSON_MAP);
+        histRecord["inf"] = infValue;
+
+        auto& boundsRecord = histRecord.InsertValue("bounds", NJson::JSON_ARRAY);
+        auto& bucketsRecord = histRecord.InsertValue("buckets", NJson::JSON_ARRAY);
+
+        // First, copy the values into the full list of buckets to assign defaults
+        // and verify all bucket keys
+        std::unordered_map<ui64, ui64> fullBuckets = {
+            {0, 0},
+            {10, 0},
+            {20, 0},
+            {30, 0},
+            {40, 0},
+            {50, 0},
+            {60, 0},
+            {70, 0},
+            {80, 0},
+            {90, 0},
+            {100, 0},
+        };
+
+        for (auto [key, value] : buckets) {
+            Y_ABORT_UNLESS(fullBuckets.contains(key), "Invalid bucket key %" PRIu64, key);
+            fullBuckets[key] = value;
+        }
+
+        // Second, copy the bucket boundaries and values into the JSON values
+        for (ui64 i = 0; i <= 100; i += 10) {
+            boundsRecord.AppendValue(i);
+            bucketsRecord.AppendValue(fullBuckets.at(i));
+        }
+
+        auto& labelsRecord = record.InsertValue("labels", NJson::JSON_MAP);
+        labelsRecord["name"] = name;
+
+        for (const auto& [key, value] : Labels ) {
+            labelsRecord[key] = value;
+        }
+
+        return *this;
+    }
+
+    // Add a group of sensors at the current level.
+    TSensorsJsonBuilder& AddGroup(const TExpectedSensorGroup& group) {
+        for (const auto& [name, item] : group) {
+            switch (item.Type) {
+                case TExpectedSensorValue::Undefined:
+                    Y_ABORT("Undefined sensor type");
+                case TExpectedSensorValue::Gauge:
+                    AddGauge(name, item.Value);
+                    break;
+                case TExpectedSensorValue::Rate:
+                    AddRate(name, item.Value);
+                    break;
+                case TExpectedSensorValue::Hist:
+                    AddCpuHistogram(name, item.Buckets, item.InfValue);
+                    break;
+                }
+        }
+        return *this;
+    }
+
+    // Add a nested group of sensors.
+    TSensorsJsonBuilder& AddNestedGroup(const TString &labelKey, const TString &labelValue, const TExpectedSensorGroup& group) {
+        if (group.empty()) {
+            return *this;
+        }
+        return StartNested(labelKey, labelValue).AddGroup(group).EndNested();
+    }
+
+    // Add a nested group of sensors using generator functor.
+    template<typename Pred, typename Gen>
+    TSensorsJsonBuilder& AddNestedIf(const TString &labelKey, const TString &labelValue, Pred pred, Gen gen) {
+        if (pred()) {
+            return gen(StartNested(labelKey, labelValue)).EndNested();
+        }
+        return *this;
+    }
+
+private:
+    TSensorsJsonBuilder()
+        : ParentBuilder(nullptr)
+        , RootJson(NJson::JSON_MAP)
+        , SensorsJson(RootJson.InsertValue("sensors", NJson::JSON_ARRAY)) {
+    }
+
+    // Constructor for the nested level builder.
+    TSensorsJsonBuilder(
+        TSensorsJsonBuilder& parentBuilder,
+        const TString& nestedLabelKey,
+        const TString& nestedLabelValue
+    ) : ParentBuilder(&parentBuilder)
+      , SensorsJson(parentBuilder.SensorsJson)
+      , Labels(parentBuilder.Labels) {
+        // Also include the nested label for all nested sensors
+        Labels[nestedLabelKey] = nestedLabelValue;
+    }
+
+    // Add a new simple sensor (RATE or GAUGE) at the current level of sensors.
+    void AddSimpleSensor(const char* kind, const TString& name, ui64 value) {
+        auto& record = SensorsJson.AppendValue(NJson::JSON_MAP);
+
+        record["kind"] = kind;
+        record["value"] = value;
+
+        auto& labelsRecord = record.InsertValue("labels", NJson::JSON_MAP);
+        labelsRecord["name"] = name;
+
+        for (const auto& [key, value] : Labels ) {
+            labelsRecord[key] = value;
+        }
+    }
+
+    class TSensorKind {
+    public:
+        static constexpr const char* RATE = "RATE";
+        static constexpr const char* GAUGE = "GAUGE";
+        static constexpr const char* HIST = "HIST";
+    };
+
+    TSensorsJsonBuilder* ParentBuilder;             // Parent JSON builder (used for nested arrays of sensors).
+    NJson::TJsonValue RootJson;                     // Holder for the root level JSON value (populated only for the root builder).
+    NJson::TJsonValue& SensorsJson;                 // The JSON value, which accumulates sensors for all levels.
+    std::unordered_map<TString, TString> Labels;    // Labels for sensors at this level and below.
+};
+
+} // namespace NDetailedMetricsTests
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.cpp
@@ -348,4 +348,4 @@ TYdbMetricsAggregatorPtr CreateYdbMetricsAggregatorByTabletType(
     }
 }
 
-}
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator.h
@@ -95,7 +95,8 @@ using TYdbMetricsAggregatorPtr = TIntrusivePtr<TYdbMetricsAggregator>;
  */
 TYdbMetricsAggregatorPtr CreateYdbMetricsAggregatorByTabletType(
     TTabletTypes::EType tabletType,
-    NMonitoring::TDynamicCounterPtr targetCounterGroup);
+    NMonitoring::TDynamicCounterPtr targetCounterGroup
+);
 
 
 } // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_aggregator_ut.cpp
@@ -1,5 +1,6 @@
 #include "ydb_metrics_aggregator.h"
 #include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
 
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
@@ -21,11 +22,13 @@ namespace {
  *
  * @return The counters group created for these public counters
  */
-NMonitoring::TDynamicCounterPtr PopulateDataShardPublicCounters(
+std::pair<NMonitoring::TDynamicCounterPtr, TExpectedSensorGroup> PopulateDataShardPublicCounters(
     TTestBasicRuntime& runtime,
     const TString& sourceGroupName,
     ui32 offset
 ) {
+    TExpectedSensorGroup expectedMetrics;
+
     auto sourceCountersGroup = runtime.GetAppData(0).Counters->GetSubgroup(
         "counters",
         sourceGroupName
@@ -33,11 +36,13 @@ NMonitoring::TDynamicCounterPtr PopulateDataShardPublicCounters(
 
     // Simple counters
     const auto setSimpleCounterValue = [&](const char* name, ui64 value) {
+        auto v = offset * 1000 + value;
+        expectedMetrics.Add(name, TTabletSimpleCounter().Set(v));
         sourceCountersGroup->GetNamedCounter(
             "name",
             name,
             false /* derivative */
-        )->Set(offset * 1000 + value);
+        )->Set(v);
     };
 
     setSimpleCounterValue("table.datashard.row_count",  1);
@@ -45,11 +50,13 @@ NMonitoring::TDynamicCounterPtr PopulateDataShardPublicCounters(
 
     // Cumulative counters
     const auto setCumulativeCounterValue = [&](const char* name, ui64 value) {
+        auto v = offset * 1000 + value;
+        expectedMetrics.Add(name, TTabletCumulativeCounter().Increment(v));
         sourceCountersGroup->GetNamedCounter(
             "name",
             name,
             true /* derivative */
-        )->Set(offset * 1000 + value);
+        )->Set(v);
     };
 
     setCumulativeCounterValue("table.datashard.write.rows",         3);
@@ -103,7 +110,11 @@ NMonitoring::TDynamicCounterPtr PopulateDataShardPublicCounters(
     cpuHistogram->Collect(static_cast<i64>(100), offset * 1000 + 11);
     cpuHistogram->Collect(static_cast<i64>(101), offset * 1000 + 12);
 
-    return sourceCountersGroup;
+    std::unordered_map<ui64, ui64> cpuBuckets;
+    for (ui64 i = 0; i < 11; i++) { cpuBuckets[i * 10] = offset * 1000 + i + 1; }
+    expectedMetrics.AddHist("table.datashard.used_core_percents", cpuBuckets, offset * 1000 + 12);
+
+    return std::make_pair(sourceCountersGroup, expectedMetrics);
 }
 
 } // namespace <anonymous>
@@ -124,9 +135,9 @@ Y_UNIT_TEST_SUITE(TYdbMetricsAggregatorTest) {
         runtime.Initialize(TAppPrepare().Unwrap());
 
         // Create 3 sets of source counters
-        auto sourceCountersGroup1 = PopulateDataShardPublicCounters(runtime, "source-group-1", 1);
-        auto sourceCountersGroup2 = PopulateDataShardPublicCounters(runtime, "source-group-2", 20);
-        auto sourceCountersGroup3 = PopulateDataShardPublicCounters(runtime, "source-group-3", 300);
+        auto [sourceCountersGroup1, expectedMetrics1] = PopulateDataShardPublicCounters(runtime, "source-group-1", 1);
+        auto [sourceCountersGroup2, expectedMetrics2] = PopulateDataShardPublicCounters(runtime, "source-group-2", 20);
+        auto [sourceCountersGroup3, expectedMetrics3] = PopulateDataShardPublicCounters(runtime, "source-group-3", 300);
 
         // TEST 1: Create the public metrics aggregator without any source groups:
         //         at this point the target values should be all zeros
@@ -144,152 +155,9 @@ Y_UNIT_TEST_SUITE(TYdbMetricsAggregatorTest) {
         Cerr << "TEST Target counters (initial):" << Endl << countersJson << Endl;
 
         TString expectedJsonAllZeros = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 0
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 0
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(EmptyDataShardMetrics())
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -307,152 +175,9 @@ R"json(
         Cerr << "TEST Target counters (2 source groups added):" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 21020
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 21018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 21026
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 21028
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 21030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 21016
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 21014
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 21012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 21010
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 21002
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 21024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 21022
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 21004
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          21002,
-          21004,
-          21006,
-          21008,
-          21010,
-          21012,
-          21014,
-          21016,
-          21018,
-          21020,
-          21022
-        ],
-        "inf": 21024
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 21008
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 21006
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(expectedMetrics1 | expectedMetrics2)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -469,152 +194,9 @@ R"json(
         Cerr << "TEST Target counters (all source groups added):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 321030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 321027
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 321039
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 321042
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 321045
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 321024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 321021
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 321018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 321015
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 321003
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 321036
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 321033
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 321006
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          321003,
-          321006,
-          321009,
-          321012,
-          321015,
-          321018,
-          321021,
-          321024,
-          321027,
-          321030,
-          321033
-        ],
-        "inf": 321036
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 321012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 321009
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(expectedMetrics1 | expectedMetrics2 | expectedMetrics3)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -623,160 +205,18 @@ R"json(
             "Expected JSON (all source groups added):" << Endl << expectedJson
         );
 
-        // TEST 4: Update the first source groups and make sure the target counters are updated
-        PopulateDataShardPublicCounters(runtime, "source-group-1", 1000);
+        // TEST 4: Update the first source group and make sure the target counters are updated
+        std::tie(sourceCountersGroup1, expectedMetrics1) = PopulateDataShardPublicCounters(runtime, "source-group-1", 1000);
+        
         aggregator->RecalculateAllTargetCounters();
 
         countersJson = NormalizeJson(NMonitoring::ToJson(*targetCountersGroup));
         Cerr << "TEST Target counters (the first group updated):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 1320030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 1320027
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 1320039
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 1320042
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 1320045
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 1320024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 1320021
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 1320018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 1320015
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 1320003
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 1320036
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 1320033
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 1320006
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          1320003,
-          1320006,
-          1320009,
-          1320012,
-          1320015,
-          1320018,
-          1320021,
-          1320024,
-          1320027,
-          1320030,
-          1320033
-        ],
-        "inf": 1320036
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 1320012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 1320009
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(expectedMetrics1 | expectedMetrics2 | expectedMetrics3)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -793,152 +233,9 @@ R"json(
         Cerr << "TEST Target counters (the first source group removed):" << Endl << countersJson << Endl;
 
         expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 320020
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 320018
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 320026
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 320028
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 320030
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 320016
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 320014
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 320012
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 320010
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 320002
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 320024
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 320022
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 320004
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          320002,
-          320004,
-          320006,
-          320008,
-          320010,
-          320012,
-          320014,
-          320016,
-          320018,
-          320020,
-          320022
-        ],
-        "inf": 320024
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 320008
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 320006
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(expectedMetrics2 | expectedMetrics3)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_target_counters_base.h
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_target_counters_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "ydb_metrics_aggregator.h"
-
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>

--- a/ydb/core/tablet/detailed_metrics/ydb_metrics_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/ydb_metrics_ut.cpp
@@ -1,11 +1,7 @@
 #include "ut_helpers.h"
+#include "ut_sensors_json_builder.h"
 
-#include <ydb/core/protos/counters_datashard.pb.h>
-#include <ydb/core/tablet/tablet_counters_aggregator.h>
-#include <ydb/core/tablet/tablet_counters_app.h>
-#include <ydb/core/tablet_flat/flat_executor_counters.h>
 #include <ydb/core/testlib/basics/appdata.h>
-#include <ydb/core/testlib/basics/runtime.h>
 
 #include <library/cpp/monlib/dynamic_counters/encode.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -13,29 +9,8 @@
 using namespace NActors;
 using namespace NKikimr;
 using namespace NKikimr::NDetailedMetricsTests;
-using namespace NKikimr::NTabletFlatExecutor;
 
 namespace {
-
-/**
- * Create and initialize the Tablet Counters Aggregator actor.
- *
- * @param[in] runtime The test runtime
- *
- * @return The ID of the Tablet Counters Aggregator actor
- */
-TActorId InitializeTabletCountersAggregator(TTestBasicRuntime& runtime) {
-    // Register the Tablet Counters Aggregator actor
-    TActorId aggregatorId = runtime.Register(CreateTabletCountersAggregator(false /* follower */));
-    runtime.EnableScheduleForActor(aggregatorId);
-
-    // Wait for the TEvBootstrap event to be processed, after this the actor is ready
-    TDispatchOptions options;
-    options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
-
-    runtime.DispatchEvents(options);
-    return aggregatorId;
-}
 
 /**
  * Force the Tablet Counters Aggregator actor to recalculate and update all YDB metrics.
@@ -61,103 +36,37 @@ void ForceCounterRecalculation(
     );
 }
 
-/**
- * Send low level metrics to the Tablet Counters Aggregator for the given DataShard tablet.
- *
- * @param[in] runtime The test runtime
- * @param[in] aggregatorId The ID of the Tablet Counters Aggregator actor
- * @param[in] edgeActorId The ID of the edge actor used for sending all messages
- * @param[in] tabletId The ID of the DataShard tablet
- * @param[in] cpuLoadPercentage The CPU load percentage to report for this tablet
- */
-void SendDataShardMetrics(
-    TTestBasicRuntime& runtime,
-    const TActorId& aggregatorId,
-    const TActorId& edgeActorId,
-    ui64 tabletId,
-    ui32 cpuLoadPercentage
-) {
-    // Populate executor counters with some fake values
-    auto executorCounters = MakeHolder<TExecutorCounters>();
-    auto executorCountersBaseline = MakeHolder<TExecutorCounters>();
-
-    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
-
-    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_ROWS_TOTAL] = 1000 + tabletId;
-    executorCounters->Simple()[TExecutorCounters::DB_UNIQUE_DATA_BYTES] = 2000 + tabletId;
-
-    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(3000 + tabletId);
-    executorCounters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(4000 + tabletId);
-
-    // Populate DataShard counters with some fake values
-    auto tabletCounters = CreateAppCountersByTabletType(TTabletTypes::DataShard);
-    auto tabletCountersBaseline = CreateAppCountersByTabletType(TTabletTypes::DataShard);
-
-    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
-
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW].Increment(5000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_UPDATE_ROW_BYTES].Increment(6000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW].Increment(10007000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_ROWS].Increment(20008000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_ROW_BYTES].Increment(30009000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_SELECT_RANGE_BYTES].Increment(40010000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW].Increment(11000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_ENGINE_HOST_ERASE_ROW_BYTES].Increment(12000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS].Increment(13000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_UPLOAD_ROWS_BYTES].Increment(14000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_ROWS].Increment(15000 + tabletId);
-    tabletCounters->Cumulative()[NDataShard::COUNTER_SCANNED_BYTES].Increment(16000 + tabletId);
-
-    // Send these counters to the Tablet Counters Aggregator
-    runtime.Send(
-        new IEventHandle(
-            aggregatorId,
-            edgeActorId,
-            new TEvTabletCounters::TEvTabletAddCounters(
-                new TEvTabletCounters::TInFlightCookie(),
-                tabletId,
-                TTabletTypes::DataShard,
-                TPathId(1113, 1001),
-                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
-                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline)
-            )
-        )
-    );
-
-    // NOTE: Tablet Counters Aggregator automatically differentiates cumulative
-    //       counters and uses the differential to update the associated histograms
-    //       (if present). It uses the time between consecutive TEvTabletAddCounters
-    //       messages (per tablet ID) to calculate the differential.
-    //
-    //       The code here sends the main update with all counters as needed,
-    //       but the CPU consumption value is set to zero. Then the time is moved
-    //       forward by exactly 1 second and a new update is sent with only
-    //       the CPU consumption value.
-    executorCounters->RememberCurrentStateAsBaseline(*executorCountersBaseline);
-    tabletCounters->RememberCurrentStateAsBaseline(*tabletCountersBaseline);
-
-    executorCounters->Cumulative()[TExecutorCounters::CONSUMED_CPU].Increment(
-        cpuLoadPercentage * 10000 + tabletId
-    );
-
-    runtime.AdvanceCurrentTime(TDuration::Seconds(1));
-    runtime.Send(
-        new IEventHandle(
-            aggregatorId,
-            edgeActorId,
-            new TEvTabletCounters::TEvTabletAddCounters(
-                new TEvTabletCounters::TInFlightCookie(),
-                tabletId,
-                TTabletTypes::DataShard,
-                TPathId(1113, 1001),
-                executorCounters->MakeDiffForAggr(*executorCountersBaseline),
-                tabletCounters->MakeDiffForAggr(*tabletCountersBaseline)
-            )
-        )
-    );
-}
-
 } // namespace <anonymous>
+
+TExpectedSensorGroup EmptyYdbMetrics() {
+    TExpectedSensorGroup result;
+
+    result.Add("resources.storage.limit_bytes", TTabletSimpleCounter{});
+    result.Add("resources.storage.limit_bytes.hdd", TTabletSimpleCounter{});
+    result.Add("resources.storage.limit_bytes.ssd", TTabletSimpleCounter{});
+    result.Add("resources.storage.table.used_bytes", TTabletSimpleCounter{});
+    result.Add("resources.storage.table.used_bytes.hdd", TTabletSimpleCounter{});
+    result.Add("resources.storage.table.used_bytes.ssd", TTabletSimpleCounter{});
+    result.Add("resources.storage.topic.used_bytes", TTabletSimpleCounter{});
+    result.Add("resources.storage.used_bytes", TTabletSimpleCounter{});
+    result.Add("resources.storage.used_bytes.hdd", TTabletSimpleCounter{});
+    result.Add("resources.storage.used_bytes.ssd", TTabletSimpleCounter{});
+    result.Add("resources.stream.limit_shards", TTabletSimpleCounter{});
+    result.Add("resources.stream.storage.limit_bytes", TTabletSimpleCounter{});
+    result.Add("resources.stream.storage.reserved_bytes", TTabletSimpleCounter{});
+    result.Add("resources.stream.throughput.limit_bytes_per_second", TTabletSimpleCounter{});
+    result.Add("resources.stream.used_shards", TTabletSimpleCounter{});
+    result.Add("table.columnshard.bulk_upsert.bytes", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.bulk_upsert.rows", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.erase.bytes", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.erase.rows", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.scan.bytes", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.scan.rows", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.write.bytes", TTabletCumulativeCounter{});
+    result.Add("table.columnshard.write.rows", TTabletCumulativeCounter{});
+
+    return result;
+}
 
 /**
  * Unit tests for the public YDB metrics logic in the Tablet Counters Aggregator.
@@ -171,7 +80,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorYdbMetricsTest) {
         TTestBasicRuntime runtime(1);
         runtime.Initialize(TAppPrepare().Unwrap());
 
-        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime);
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
         TActorId edgeActorId = runtime.AllocateEdgeActor();
 
         // Do not send any tablet metrics, just force the YDB metrics to be recalculated
@@ -185,313 +94,10 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregatorYdbMetricsTest) {
         Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.topic.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.limit_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.reserved_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.throughput.limit_bytes_per_second"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.used_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 0
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 0
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(EmptyYdbMetrics())
+                .AddGroup(EmptyDataShardMetrics())
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(
@@ -509,13 +115,13 @@ R"json(
         TTestBasicRuntime runtime(1);
         runtime.Initialize(TAppPrepare().Unwrap());
 
-        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime);
+        TActorId aggregatorId = InitializeTabletCountersAggregator(runtime, false /* forFollowers */);
         TActorId edgeActorId = runtime.AllocateEdgeActor();
 
         // Send some fake DataShard metrics and force the YDB metrics to be recalculated
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 20);
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 20, 40);
-        SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 300, 60);
+        auto expectedMetrics = SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 1, 0, 20);
+        expectedMetrics |= SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 20, 0, 40);
+        expectedMetrics |= SendDataShardMetrics(runtime, aggregatorId, edgeActorId, 300, 0, 60);
 
         ForceCounterRecalculation(runtime, aggregatorId, edgeActorId);
 
@@ -527,313 +133,10 @@ R"json(
         Cerr << "TEST Current counters:" << Endl << countersJson << Endl;
 
         TString expectedJson = NormalizeJson(
-R"json(
-{
-  "sensors": [
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.limit_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.table.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.topic.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.hdd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.storage.used_bytes.ssd"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.limit_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.limit_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.storage.reserved_bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.throughput.limit_bytes_per_second"
-      },
-      "value": 0
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "resources.stream.used_shards"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.bulk_upsert.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.erase.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.scan.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.bytes"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.columnshard.write.rows"
-      },
-      "value": 0
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.bytes"
-      },
-      "value": 42321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.bulk_upsert.rows"
-      },
-      "value": 39321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_hit.bytes"
-      },
-      "value": 9321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.cache_miss.bytes"
-      },
-      "value": 12321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.consumed_cpu_us"
-      },
-      "value": 1200321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.bytes"
-      },
-      "value": 36321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.erase.rows"
-      },
-      "value": 33321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.bytes"
-      },
-      "value": 210057642
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.read.rows"
-      },
-      "value": 90045642
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.row_count"
-      },
-      "value": 3321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.bytes"
-      },
-      "value": 48321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.scan.rows"
-      },
-      "value": 45321
-    },
-    {
-      "kind": "GAUGE",
-      "labels": {
-        "name": "table.datashard.size_bytes"
-      },
-      "value": 6321
-    },
-    {
-      "hist": {
-        "bounds": [
-          0,
-          10,
-          20,
-          30,
-          40,
-          50,
-          60,
-          70,
-          80,
-          90,
-          100
-        ],
-        "buckets": [
-          0,
-          0,
-          0,
-          1,
-          0,
-          1,
-          0,
-          1,
-          0,
-          0,
-          0
-        ],
-        "inf": 0
-      },
-      "kind": "HIST",
-      "labels": {
-        "name": "table.datashard.used_core_percents"
-      }
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.bytes"
-      },
-      "value": 18321
-    },
-    {
-      "kind": "RATE",
-      "labels": {
-        "name": "table.datashard.write.rows"
-      },
-      "value": 15321
-    }
-  ]
-}
-)json"
+            TSensorsJsonBuilder::Start()
+                .AddGroup(EmptyYdbMetrics())
+                .AddGroup(expectedMetrics)
+                .BuildJson()
         );
 
         UNIT_ASSERT_EQUAL_C(

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -2,6 +2,7 @@
 #include "tablet_counters_app.h"
 #include "labeled_counters_merger.h"
 #include "labeled_db_counters.h"
+#include "detailed_metrics/node_database_metrics_aggregator.h"
 #include "detailed_metrics/ydb_metrics_mapper.h"
 #include "private/aggregated_counters.h"
 #include "private/labeled_db_counters.h"
@@ -92,40 +93,49 @@ public:
         if (!IsFollower) {
             YdbCounters = MakeIntrusive<TYdbTabletCounters>(GetServiceCounters(counters, "ydb"), Counters);
         }
-    }
 
-    void Apply(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId,
-        const TTabletCountersBase* executorCounters, const TTabletCountersBase* appCounters,
-        const TActorContext& ctx)
-    {
-        AllTypes->Apply(tabletId, executorCounters, nullptr, tabletType);
-        //
-        auto typeCounters = GetOrAddCountersByTabletType(tabletType, CountersByTabletType, Counters);
-        if (typeCounters) {
-            typeCounters->Apply(tabletId, executorCounters, appCounters, tabletType);
-        }
-        //
-        if (!IsFollower && DbWatcherActorId && tenantPathId) {
-            auto dbCounters = GetDbCounters(tenantPathId, ctx);
-            if (dbCounters) {
-                auto* limitedAppCounters = GetOrAddLimitedAppCounters(tabletType);
-                dbCounters->Apply(tabletId, executorCounters, appCounters, tabletType, limitedAppCounters);
+        // The detailed metrics are processed only by the leader instance of the Tablet Counters Aggregator
+        if (!IsFollower) {
+            // Create detailed metrics subgroup if it does not exist yet
+            DetailedMetricsRoot = counters->FindSubgroup("counters", "ydb_detailed_raw");
+
+            if (DetailedMetricsRoot == nullptr) {
+                // Specify private visibility to hide detailed metrics from HTTP interface. They still could be retrieved using @private HTTP parameter.
+                DetailedMetricsRoot = MakeIntrusive<NMonitoring::TDynamicCounters>(
+                    NMonitoring::TCountableBase::EVisibility::Private
+                );
+
+                counters->RegisterSubgroup("counters", "ydb_detailed_raw", DetailedMetricsRoot);
+                LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_AGGREGATOR,
+                    "Successfully created the 'ydb_detailed_raw' counter group" );
             }
         }
+    }
 
-        //
-        auto& quietStats = QuietTabletCounters[tabletId];
+    void Apply(TEvTabletCounters::TEvTabletAddCounters* message, const TActorContext& ctx) {
+        AllTypes->Apply(message->TabletID, message->ExecutorCounters.Get(), nullptr, message->TabletType);
 
-        if (executorCounters) {
-            if (quietStats.first == nullptr)
-                quietStats.first = new TTabletCountersBase();
-            quietStats.first->Populate(*executorCounters);
+        if (auto typeCounters = GetOrAddCountersByTabletType(message->TabletType, CountersByTabletType, Counters)) {
+            typeCounters->Apply(message->TabletID, message->ExecutorCounters.Get(), message->AppCounters.Get(), message->TabletType);
         }
 
-        if (appCounters) {
+        if (DbWatcherActorId && message->TenantPathId) {
+            auto dbCounters = GetDbCounters(message->TenantPathId, ctx);
+            dbCounters->Apply(message, GetOrAddLimitedAppCounters(message->TabletType));
+        }
+
+        auto& quietStats = QuietTabletCounters[message->TabletID];
+
+        if (message->ExecutorCounters.Get()) {
+            if (quietStats.first == nullptr)
+                quietStats.first = new TTabletCountersBase();
+            quietStats.first->Populate(*message->ExecutorCounters.Get());
+        }
+
+        if (message->AppCounters.Get()) {
             if (quietStats.second == nullptr)
                 quietStats.second = new TTabletCountersBase();
-            quietStats.second->Populate(*appCounters);
+            quietStats.second->Populate(*message->AppCounters.Get());
         }
     }
 
@@ -176,7 +186,7 @@ public:
         iterDbLabeled->Apply(tabletId, labeledCounters);
     }
 
-    void ForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId) {
+    void ForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId) {
         AllTypes->Forget(tabletId);
         // and now erase from every other path
         auto iterTabletType = CountersByTabletType.find(tabletType);
@@ -185,7 +195,7 @@ public:
         }
         // from db counters
         if (auto itPath = CountersByPathId.find(tenantPathId); itPath != CountersByPathId.end()) {
-            itPath->second->Forget(tabletId, tabletType);
+            itPath->second->Forget(tabletId, followerId, tabletType);
         }
 
         for (auto iter = LabeledDbCounters.begin(); iter != LabeledDbCounters.end(); ++iter) {
@@ -205,9 +215,6 @@ public:
         }
 
         QuietTabletCounters.erase(tabletId);
-
-        TString tabletIdStr = Sprintf("%" PRIu64, tabletId);
-        Counters->RemoveSubgroup("tabletid", tabletIdStr.data());
     }
 
     void Query(const NKikimrTabletCountersAggregator::TEvTabletCountersRequest& request, NKikimrTabletCountersAggregator::TEvTabletCountersResponse& response) {
@@ -327,7 +334,12 @@ public:
     }
 
     void RemoveTabletsByPathId(TPathId pathId) {
-        CountersByPathId.erase(pathId);
+        auto dbCountersIt = CountersByPathId.find(pathId);
+
+        if (dbCountersIt != CountersByPathId.end()) {
+            dbCountersIt->second->DeleteAllDatabaseCounters();
+            CountersByPathId.erase(dbCountersIt);
+        }
     }
 
     void RemoveTabletsByDbPath(const TString& dbPath) {
@@ -344,9 +356,9 @@ public:
         return {};
     }
 
-private:
+public:
     // subgroups
-    class TTabletCountersForTabletType : public TThrRefBase {
+    class TTabletCountersForTabletType : public ITabletCountersProcessor {
     public:
         //
         TTabletCountersForTabletType(::NMonitoring::TDynamicCounters* owner, const char* category, const char* name)
@@ -354,8 +366,24 @@ private:
             , TabletExecutorCountersSection(TabletCountersSection->GetSubgroup("category", "executor"))
             , TabletAppCountersSection(TabletCountersSection->GetSubgroup("category", "app"))
             , TabletExecutorCounters(TabletExecutorCountersSection)
-            , TabletAppCounters(TabletAppCountersSection)
-        {}
+            , TabletAppCounters(TabletAppCountersSection) {
+        }
+
+        void ProcessTabletCounters(ui64 tabletId,
+            const TTabletCountersBase* executorCounters,
+            const TTabletCountersBase* applicationCounters,
+            TTabletTypes::EType tabletType) override
+        {
+            Apply(tabletId, executorCounters, applicationCounters, tabletType);
+        }
+
+        void RecalculateAggregatedValues() override {
+            RecalcAll();
+        }
+
+        void ForgetTablet(ui64 tabletId) override {
+            Forget(tabletId);
+        }
 
         void Apply(ui64 tabletId,
             const TTabletCountersBase* executorCounters,
@@ -740,6 +768,7 @@ private:
         TSolomonCounters TabletAppCounters;
     };
 
+private:
     using TTabletCountersForTabletTypePtr = TIntrusivePtr<TTabletCountersForTabletType>;
     typedef TMap<TTabletTypes::EType, TTabletCountersForTabletTypePtr> TCountersByTabletType;
 
@@ -995,9 +1024,18 @@ private:
 public:
     class TTabletCountersForDb : public NSysView::IDbCounters {
     public:
-        TTabletCountersForDb()
-            : SolomonCounters(new ::NMonitoring::TDynamicCounters)
-        {}
+        TTabletCountersForDb(
+            NMonitoring::TDynamicCounterPtr detailedMetricsRoot,
+            const TPathId& tenantPathId
+        ) : SolomonCounters(new ::NMonitoring::TDynamicCounters)
+        {
+            if (AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+                NodeDatabaseMetricsAggregator = MakeIntrusive<TNodeDatabaseMetricsAggregator>(
+                    tenantPathId,
+                    detailedMetricsRoot
+                );
+            }
+        }
 
         TTabletCountersForDb(::NMonitoring::TDynamicCounterPtr externalGroup,
             ::NMonitoring::TDynamicCounterPtr internalGroup,
@@ -1039,32 +1077,42 @@ public:
             }
         }
 
-        void Apply(ui64 tabletId, const TTabletCountersBase* executorCounters,
-            const TTabletCountersBase* appCounters, TTabletTypes::EType type,
-            const TTabletCountersBase* limitedAppCounters)
-        {
+        void Apply(TEvTabletCounters::TEvTabletAddCounters* message, const TTabletCountersBase* limitedAppCounters) {
+            // Aggregate all detailed metrics (both for leaders and followers)
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->ProcessTabletCounters(message);
+            }
+
+            // Process counters only from leaders
+            if (message->FollowerId) {
+                return;
+            }
+
             auto allTypes = GetOrAddCounters(TTabletTypes::Unknown);
             {
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(TTabletTypes::Unknown).GetLock());
-                allTypes->Apply(tabletId, executorCounters, nullptr, type);
+                allTypes->Apply(message->TabletID, message->ExecutorCounters.Get(), nullptr, message->TabletType);
             }
-            auto typeCounters = GetOrAddCounters(type);
+            auto typeCounters = GetOrAddCounters(message->TabletType);
             {
-                TWriteGuard guard(CountersByTabletType.GetBucketForKey(type).GetLock());
-                typeCounters->Apply(tabletId, executorCounters, appCounters, type, limitedAppCounters);
+                TWriteGuard guard(CountersByTabletType.GetBucketForKey(message->TabletType).GetLock());
+                typeCounters->Apply(message->TabletID, message->ExecutorCounters.Get(), message->AppCounters.Get(), message->TabletType, limitedAppCounters);
             }
         }
 
-        void Forget(ui64 tabletId, TTabletTypes::EType type) {
-            auto allTypes = GetCounters(TTabletTypes::Unknown);
-            if (allTypes) {
+        void Forget(ui64 tabletId, ui32 followerId, TTabletTypes::EType type) {
+            if (auto allTypes = GetCounters(TTabletTypes::Unknown)) {
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(TTabletTypes::Unknown).GetLock());
                 allTypes->Forget(tabletId);
             }
-            auto typeCounters = GetCounters(type);
-            if (typeCounters) {
+            if (auto typeCounters = GetCounters(type)) {
                 TWriteGuard guard(CountersByTabletType.GetBucketForKey(type).GetLock());
                 typeCounters->Forget(tabletId);
+            }
+
+            // Remove this tablet from the detailed metrics also.
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->ForgetTablet(tabletId, followerId);
             }
         }
 
@@ -1077,6 +1125,13 @@ public:
             }
         }
 
+        // Delete all counters for the database.
+        void DeleteAllDatabaseCounters() {
+            if (NodeDatabaseMetricsAggregator) {
+                NodeDatabaseMetricsAggregator->DeleteAllDatabaseCounters();
+            }
+        }
+
     private:
         TTabletCountersForTabletTypePtr GetCounters(TTabletTypes::EType tabletType) {
             TTabletCountersForTabletTypePtr res;
@@ -1086,15 +1141,12 @@ public:
 
         TTabletCountersForTabletTypePtr GetOrAddCounters(TTabletTypes::EType tabletType) {
             auto res = GetCounters(tabletType);
-            if (res) {
-                return res;
+            if (!res) {
+                res = CountersByTabletType.InsertIfAbsentWithInit(tabletType, [this, tabletType] {
+                    TString type = (tabletType == TTabletTypes::Unknown) ? "all" : TTabletTypes::TypeToStr(tabletType);
+                    return MakeIntrusive<TTabletCountersForTabletType>(SolomonCounters.Get(), "type", type.data());
+                });
             }
-            res = CountersByTabletType.InsertIfAbsentWithInit(tabletType, [this, tabletType] {
-                TString type = (tabletType == TTabletTypes::Unknown) ?
-                    "all" : TTabletTypes::TypeToStr(tabletType);
-                return MakeIntrusive<TTabletCountersForTabletType>(
-                    SolomonCounters.Get(), "type", type.data());
-            });
             return res;
         }
 
@@ -1105,6 +1157,8 @@ public:
         TConcurrentRWHashMap<TTabletTypes::EType, TTabletCountersForTabletTypePtr, 16> CountersByTabletType;
 
         TYdbTabletCountersPtr YdbCounters;
+
+        TNodeDatabaseMetricsAggregatorPtr NodeDatabaseMetricsAggregator; // Aggregator for all detailed database metrics on this node.
     };
 
     class TTabletsDbWatcherCallback : public NKikimr::NSysView::TDbWatcherCallback {
@@ -1129,12 +1183,14 @@ private:
             return it->second;
         }
 
-        auto dbCounters = MakeIntrusive<TTabletMon::TTabletCountersForDb>();
+        auto dbCounters = MakeIntrusive<TTabletMon::TTabletCountersForDb>(DetailedMetricsRoot, pathId);
         CountersByPathId[pathId] = dbCounters;
 
-        auto evRegister = MakeHolder<NSysView::TEvSysView::TEvRegisterDbCounters>(
-            NKikimrSysView::TABLETS, pathId, dbCounters);
-        ctx.Send(NSysView::MakeSysViewServiceID(ctx.SelfID.NodeId()), evRegister.Release());
+        // SysView service and processor handle counters only from leaders.
+        if (!IsFollower) {
+            auto evRegister = MakeHolder<NSysView::TEvSysView::TEvRegisterDbCounters>(NKikimrSysView::TABLETS, pathId, dbCounters);
+            ctx.Send(NSysView::MakeSysViewServiceID(ctx.SelfID.NodeId()), evRegister.Release());
+        }
 
         if (DbWatcherActorId) {
             auto evWatch = MakeHolder<NSysView::TEvSysView::TEvWatchDatabase>(pathId);
@@ -1184,6 +1240,7 @@ private:
     TLabeledCountersByDbPath LabeledDbCounters;
     TLabeledCountersByTabletTypeAndGroup LabeledCountersByTabletTypeAndGroup;
     TQuietTabletCounters QuietTabletCounters;
+    NMonitoring::TDynamicCounterPtr DetailedMetricsRoot; // Counter group for detailed metrics on this node, it has "counters" = "ydb_detailed_raw" label.
 };
 
 
@@ -1194,6 +1251,15 @@ TIntrusivePtr<NSysView::IDbCounters> CreateTabletDbCounters(
 {
     return MakeIntrusive<TTabletMon::TTabletCountersForDb>(
         externalGroup, internalGroup, std::move(executorCounters));
+}
+
+ITabletCountersProcessorPtr CreateTabletCountersProcessor(
+    NMonitoring::TDynamicCounterPtr parentCounterGroup,
+    TTabletTypes::EType tabletType)
+{
+    return MakeIntrusive<TTabletMon::TTabletCountersForTabletType>(
+        parentCounterGroup.Get(), "type", TTabletTypes::TypeToStr(tabletType)
+    );
 }
 
 ////////////////////////////////////////////
@@ -1282,9 +1348,7 @@ TTabletCountersAggregatorActor::Bootstrap(const TActorContext &ctx) {
 ////////////////////////////////////////////
 void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletAddCounters::TPtr &ev, const TActorContext &ctx) {
-    Y_UNUSED(ctx);
-    TEvTabletCounters::TEvTabletAddCounters* msg = ev->Get();
-    TabletMon->Apply(msg->TabletID, msg->TabletType, msg->TenantPathId, msg->ExecutorCounters.Get(), msg->AppCounters.Get(), ctx);
+    TabletMon->Apply(ev->Get(), ctx);
 }
 
 ////////////////////////////////////////////
@@ -1320,7 +1384,7 @@ void
 TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletCountersForgetTablet::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ctx);
     TEvTabletCounters::TEvTabletCountersForgetTablet* msg = ev->Get();
-    TabletMon->ForgetTablet(msg->TabletID, msg->TabletType, msg->TenantPathId);
+    TabletMon->ForgetTablet(msg->TabletID, msg->FollowerId, msg->TabletType, msg->TenantPathId);
 }
 
 ////////////////////////////////////////////
@@ -1600,9 +1664,9 @@ CreateTabletCountersAggregator(bool follower) {
     return new TTabletCountersAggregatorActor(follower);
 }
 
-void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity) {
+void TabletCountersForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity) {
     const TActorId countersAggregator = MakeTabletCountersAggregatorID(identity.NodeId(), follower);
-    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, tabletType, tenantPathId));
+    identity.Send(countersAggregator, new TEvTabletCounters::TEvTabletCountersForgetTablet(tabletId, followerId, tabletType, tenantPathId));
 }
 
 ///////////////////////////////////////////

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -9,6 +9,7 @@
 #include <ydb/library/actors/core/event.h>
 
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/labeled_counters.pb.h>
 #include <ydb/core/protos/tablet_counters_aggregator.pb.h>
 #include <ydb/core/sys_view/common/events.h>
@@ -40,6 +41,16 @@ struct TEvTabletCounters {
 
     static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_TABLET_COUNTERS_AGGREGATOR), "expect EvEnd < EventSpaceEnd(TKikimrEvents::ES_TABLET_COUNTERS)");
 
+    // The metrics configuration for the given table.
+    struct TTableMetricsConfig {
+        ui64 TableId;                                   // ID of the given table (as PathId)
+        TString TablePath;                              // Full path for the given table (as /Root/TenantDb/TableName).
+        ui64 TableSchemaVersion;                        // Current schema version for the given table.
+        ui64 TenantDbSchemaVersion;                     // Current schema version for the parent tenant database.
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel MetricsLevel; // The metrics level for the given table.
+        std::optional<TString> MonitoringProjectId;     // Monitoring system ID of the project to send detailed metrics to.
+    };
+
     // Used just as an atomic counter
     struct TInFlightCookie : TThrRefBase {};
 
@@ -51,15 +62,19 @@ struct TEvTabletCounters {
         TAutoPtr<TTabletCountersBase> ExecutorCounters;
         TAutoPtr<TTabletCountersBase> AppCounters;
         TIntrusivePtr<TInFlightCookie> InFlightCounter;     // Used to detect when previous event has been consumed by the aggregator
+        const ui32 FollowerId; // The follower ID, which produced the given set of counters.
+        std::optional<TTableMetricsConfig> TableMetricsConfig; // The metrics configuration for the table, which corresponds to the given tablet (if known).
 
-        TEvTabletAddCounters(TIntrusivePtr<TInFlightCookie> inFlightCounter, ui64 tabletID, TTabletTypes::EType tabletType, TPathId tenantPathId,
-            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters)
+        TEvTabletAddCounters(TIntrusivePtr<TInFlightCookie> inFlightCounter, ui64 tabletID, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId,
+            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters, TTableMetricsConfig* tableMetricsConfig = nullptr)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
             , ExecutorCounters(executorCounters)
             , AppCounters(appCounters)
             , InFlightCounter(inFlightCounter)
+            , FollowerId(followerId)
+            , TableMetricsConfig(tableMetricsConfig ? std::optional<TTableMetricsConfig>(*tableMetricsConfig) : std::nullopt)
         {}
     };
 
@@ -82,11 +97,13 @@ struct TEvTabletCounters {
         const ui64 TabletID;
         const TTabletTypes::EType TabletType;
         const TPathId TenantPathId;
+        const ui32 FollowerId; // The follower ID to forget all counters for.
 
-        TEvTabletCountersForgetTablet(ui64 tabletID, TTabletTypes::EType tabletType, TPathId tenantPathId)
+        TEvTabletCountersForgetTablet(ui64 tabletID, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
+            , FollowerId(followerId)
         {}
     };
 
@@ -125,8 +142,31 @@ struct TTabletLabeledCountersResponseContext {
     ui32 GetNameId(TStringBuf name);
 };
 
+// Translate low level metric values to the corresponding metrics counters.
+class ITabletCountersProcessor : public virtual TThrRefBase {
+public:
+    // Apply tablet counters deltas to the corresponding metrics counters. Only direct counters are updated.
+    // To update aggregates use RecalculateAggregatedValues() function.
+    virtual void ProcessTabletCounters(ui64 tabletId, const TTabletCountersBase* executorCounters,
+        const TTabletCountersBase* applicationCounters, TTabletTypes::EType tabletType ) = 0;
+
+    // Remove counters for a specified tablet.
+    virtual void ForgetTablet(ui64 tabletId) = 0;
+
+    // Recalculate the values of all aggregate counters.
+    virtual void RecalculateAggregatedValues() = 0;
+};
+
+using ITabletCountersProcessorPtr = TIntrusivePtr<ITabletCountersProcessor>;
+
+// Create tablet counters processor for the given tablet type. Creates a subgroup with the label "type"="tabletType".
+ITabletCountersProcessorPtr CreateTabletCountersProcessor(
+    NMonitoring::TDynamicCounterPtr parentCounterGroup, // The parent counter group to create subgroup in
+    TTabletTypes::EType tabletType
+);
+
 ////////////////////////////////////////////
-void TabletCountersForgetTablet(ui64 tabletId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity);
+void TabletCountersForgetTablet(ui64 tabletId, ui32 followerId, TTabletTypes::EType tabletType, TPathId tenantPathId, bool follower, TActorIdentity identity);
 
 TStringBuf GetHistogramAggregateSimpleName(TStringBuf name);
 bool IsHistogramAggregateSimpleName(TStringBuf name);

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -134,7 +134,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregator) {
             AppCounters->RememberCurrentStateAsBaseline(*AppCountersBaseline);
 
             runtime.Send(new IEventHandle(aggregatorId, sender, new TEvTabletCounters::TEvTabletAddCounters(
-                CounterEventsInFlight, TabletId, TabletType, TenantPathId, executorCounters, appCounters)));
+                CounterEventsInFlight, TabletId, 0, TabletType, TenantPathId, executorCounters, appCounters)));
 
             // force recalc
             runtime.Send(new IEventHandle(aggregatorId, sender, new NActors::TEvents::TEvWakeup()));
@@ -144,7 +144,7 @@ Y_UNIT_TEST_SUITE(TTabletCountersAggregator) {
             runtime.Send(new IEventHandle(
                 aggregatorId,
                 sender,
-                new TEvTabletCounters::TEvTabletCountersForgetTablet(TabletId, TabletType, TenantPathId)));
+                new TEvTabletCounters::TEvTabletCountersForgetTablet(TabletId, 0, TabletType, TenantPathId)));
 
             // force recalc
             runtime.Send(new IEventHandle(aggregatorId, sender, new NActors::TEvents::TEvWakeup()));

--- a/ydb/core/tablet/ut/ya.make
+++ b/ydb/core/tablet/ut/ya.make
@@ -27,8 +27,10 @@ SRCS(
     tablet_req_blockbs_ut.cpp
     tablet_resolver_ut.cpp
     tablet_state_ut.cpp
+    detailed_metrics/node_database_metrics_aggregator_ut.cpp
     detailed_metrics/ut_helpers.cpp
     detailed_metrics/ut_helpers.h
+    detailed_metrics/ut_sensors_json_builder.h
     detailed_metrics/ydb_metrics_aggregator_ut.cpp
     detailed_metrics/ydb_metrics_ut.cpp
 )

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -56,6 +56,8 @@ SRCS(
     tablet_tracing_signals.h
     detailed_metrics/metric_value_aggregator.cpp
     detailed_metrics/metric_value_aggregator.h
+    detailed_metrics/node_database_metrics_aggregator.cpp
+    detailed_metrics/node_database_metrics_aggregator.h
     detailed_metrics/ydb_metrics_aggregator.cpp
     detailed_metrics/ydb_metrics_aggregator.h
     detailed_metrics/ydb_metrics_mapper.cpp

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -251,7 +251,7 @@ void TExecutor::Broken(EBrokenReason reason) {
 
     if (Owner) {
         ForceSendCounters();
-        TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+        TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
             Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
         Owner->Detach(OwnerCtx());
     }
@@ -866,7 +866,7 @@ TExecutorCaches TExecutor::CleanupState() {
 void TExecutor::Boot(TEvTablet::TEvBoot::TPtr &ev, const TActorContext &ctx) {
     if (Stats->IsFollower()) {
         ForceSendCounters();
-        TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+        TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
             Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
     }
 
@@ -957,7 +957,7 @@ void TExecutor::Restored(TEvTablet::TEvRestored::TPtr &ev, const TActorContext &
 
 void TExecutor::DetachTablet() {
     ForceSendCounters();
-    TabletCountersForgetTablet(Owner->TabletID(), Owner->TabletType(),
+    TabletCountersForgetTablet(Owner->TabletID(), FollowerId, Owner->TabletType(),
         Owner->Info()->TenantPathId, Stats->IsFollower(), SelfId());
     return PassAway();
 }
@@ -4065,7 +4065,7 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, FollowerId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
 
         if (ResourceMetrics) {
             ResourceMetrics->TryUpdate(ctx);
@@ -4094,7 +4094,7 @@ void TExecutor::ForceSendCounters() {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, FollowerId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
     }
 }
 

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,6 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardSplitKeySelection)
     FEATURE_FLAG_SETTER(EnableDataShardSplitHistogramOmission)
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
+    FEATURE_FLAG_SETTER(EnableDetailedMetrics)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -114,6 +114,17 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
     }
 
     if (copyAlter.HasDetailedMetricsSettings()) {
+        // Do not allow changing detailed metrics settings without the feature flag
+        if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+            errStr =
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)";
+
+            status = NKikimrScheme::StatusInvalidParameter;
+            return nullptr;
+        }
+
         // New detailed metrics settings are specified in the request,
         // make sure the detailed metrics settings are valid (correct metrics level etc)
         if (!ValidateTableDetailedMetricsSettings(
@@ -176,6 +187,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
         .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
         .EnableSetColumnConstraint = AppData()->FeatureFlags.GetEnableSetColumnConstraint(),
+        .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
     };
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -757,6 +757,7 @@ public:
             .EnableTablePgTypes = true,
             .EnableTableDatetime64 = true,
             .EnableParameterizedDecimal = true,
+            .EnableDetailedMetrics = true,
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(nullptr, schema, *typeRegistry,
             limits, *domainInfo, featureFlags, errStr, LocalSequences);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -553,6 +553,18 @@ public:
         }
 
         if (schema.HasDetailedMetricsSettings()) {
+            // Do not allow changing detailed metrics settings without the feature flag
+            if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+                result->SetError(
+                    NKikimrScheme::StatusInvalidParameter,
+                    "The detailed metrics settings are specified in the request, "
+                    "but the detailed metrics feature is disabled by the corresponding "
+                    "feature flag (EnableDetailedMetrics)"
+                );
+
+                return result;
+            }
+
             TString errorString;
 
             // Make sure the detailed metrics settings are valid (correct metrics level etc)
@@ -623,6 +635,7 @@ public:
             .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
             .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
             .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
+            .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(
             nullptr,

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -676,7 +676,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->MutableTTLSettings()->CopyFrom(ttl);
     }
 
-    if (op.HasDetailedMetricsSettings()) {
+    if (featureFlags.EnableDetailedMetrics && op.HasDetailedMetricsSettings()) {
         switch (op.GetDetailedMetricsSettings().GetStatusCase()) {
         case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
             if (op.GetDetailedMetricsSettings().HasConfigured()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -997,6 +997,7 @@ public:
         bool EnableTableDatetime64;
         bool EnableParameterizedDecimal;
         bool EnableSetColumnConstraint = false; // This flag is used in alter table operation only
+        bool EnableDetailedMetrics;
     };
 
     static TAlterDataPtr CreateAlterData(

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -56,12 +56,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
      *
-     * @note This test also verifies that the detailed metrics settings are preserved
+     * @note This function also verifies that the detailed metrics settings are preserved
      *       across SchemeShard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevel) {
+    void VerifyCreateTableNoDetailedMetricsLevel(bool enableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         TestCreateTable(
             runtime,
@@ -93,12 +97,38 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(false /* enableDetailedMetrics */);
+    }
+
+    /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(true /* enableDetailedMetrics */);
+    }
+
+    /**
      * Verify that CREATE TABLE with the detailed metrics settings explicitly dropped
      * is not allowed and fails with an error.
      */
     Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowed) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -129,6 +159,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         TestCreateTable(
             runtime,
             100,
@@ -152,6 +184,109 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE fails correctly, when the given detailed metrics
+     * level (or an explicit "drop") is specified in the request and
+     * the EnableDetailedMetrics feature flag is disabled.
+     *
+     * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
+     */
+    void VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        std::optional<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel> metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            (!metricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    DetailedMetricsSettings {
+                        NotConfigured {
+                        }
+                    }
+                )"
+                : Sprintf(
+                    R"(
+                        Name: "TestTable"
+                        Columns { Name: "key"   Type: "Uint64" }
+                        Columns { Name: "value" Type: "String" }
+                        KeyColumnNames: ["key"]
+                        DetailedMetricsSettings {
+                            Configured {
+                                MetricsLevel: %s
+                            }
+                        }
+                    )",
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(*metricsLevel).c_str()
+                ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when dropping detailed metrics level
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            {}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level UNSPECIFIED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelUnspecifiedNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level DISABLED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelDisabledNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level TABLE
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelTableNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level PARTITION
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelPartitionNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
      * Verify that CREATE TABLE works correctly, when the given valid
      * detailed metrics level is specified in the request.
      *
@@ -165,6 +300,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -261,10 +398,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
      *
      * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
+    void VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+        bool enableDetailedMetrics
+    ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -310,6 +453,36 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            false /* enableDetailedMetrics */
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            true /* enableDetailedMetrics */
+        );
+    }
+
+    /**
      * Verify that ALTER TABLE with the detailed metrics level explicitly removed
      * works correctly.
      *
@@ -322,6 +495,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     void VerifyAlterTableRemoveDetailedMetricsLevel(bool sourceHasMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -401,6 +576,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         // First, create a table without any detailed metrics settings
         TestCreateTable(
             runtime,
@@ -453,6 +630,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -591,6 +770,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with some detailed metrics settings configured
         TestCreateTable(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added an aggregator for detailed per-table/per-partition metrics on a single node.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Added the TNodeDatabaseMetricsAggregator class
* Added an instance of TNodeDatabaseMetricsAggregator to TTabletCountersForDb
* Changed TEvTabletAddCounters to add the information about detailed metrics
* Changed TEvTabletAddCounters to add the follower ID
* Changed TEvTabletCountersForgetTablet to add the follower ID
* Added a helper class to verify sensors JSONs for unit tests
