### PR TITLE
Update ydbdoc-review.yml

### DIFF
--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write 
 
 jobs:
   ydbdoc-review:
@@ -46,14 +47,13 @@ jobs:
           YDBDOC_MODEL_CHECK: ${{ vars.YDBDOC_MODEL_CHECK }}
           YDBDOC_MODEL_TRANSLATE: ${{ vars.YDBDOC_MODEL_TRANSLATE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PUSH_TOKEN: ${{ secrets.YDBDOC_PUSH_PAT }}  # секрет YDBDOC_PUSH_PAT → env для приложения
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
       - name: Trigger docs rebuild for translation PR
         if: ${{ !cancelled() }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.YDBDOC_PUSH_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

заменил токен
secrets.YDBDOC_PUSH_PAT на secrets.GITHUB_TOKEN. Нужно было потому, что у PAT нет прав вешать лейбл. А мы в конце rebuild_docs хотим повесить


### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
