### PR TITLE
LOGBROKER-10354 Added option to specify last offset to read from partition

### DIFF
--- a/ydb/core/local_proxy/local_pq_client/local_topic_read_session.cpp
+++ b/ydb/core/local_proxy/local_pq_client/local_topic_read_session.cpp
@@ -60,15 +60,17 @@ class TLocalTopicReadSessionActor final
         };
 
         struct TEvConfirmCreate : public TEventLocal<TEvConfirmCreate, EvConfirmCreate> {
-            TEvConfirmCreate(i64 partitionSessionId, std::optional<ui64> readOffset, std::optional<ui64> commitOffset)
+            TEvConfirmCreate(i64 partitionSessionId, std::optional<ui64> readOffset, std::optional<ui64> commitOffset, std::optional<ui64> maxOffset)
                 : PartitionSessionId(partitionSessionId)
                 , ReadOffset(readOffset)
                 , CommitOffset(commitOffset)
+                , MaxOffset(maxOffset)
             {}
 
             const i64 PartitionSessionId;
             const std::optional<ui64> ReadOffset;
             const std::optional<ui64> CommitOffset;
+            const std::optional<ui64> MaxOffset;
         };
 
         struct TEvConfirmDestroy : public TEventLocal<TEvConfirmDestroy, EvConfirmDestroy> {
@@ -114,8 +116,8 @@ class TLocalTopicReadSessionActor final
             ActorSystem->Send(SelfId, new TEvPartition::TEvOffsetsCommitRequest(PartitionSessionId, startOffset, endOffset));
         }
 
-        void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) final {
-            ActorSystem->Send(SelfId, new TEvPartition::TEvConfirmCreate(PartitionSessionId, readOffset, commitOffset));
+        void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) final {
+            ActorSystem->Send(SelfId, new TEvPartition::TEvConfirmCreate(PartitionSessionId, readOffset, commitOffset, maxOffset));
         }
 
         void ConfirmDestroy() final {
@@ -304,9 +306,11 @@ private:
         const auto partitionSessionId = ev->Get()->PartitionSessionId;
         const auto readOffset = ev->Get()->ReadOffset;
         const auto commitOffset = ev->Get()->CommitOffset;
+        const auto maxOffset = ev->Get()->MaxOffset;
         LOG_D("Partition session #" << partitionSessionId << " confirmed"
             << ", read offset: " << (readOffset ? ToString(*readOffset) : "null")
-            << ", commit offset: " << (commitOffset ? ToString(*commitOffset) : "null"));
+            << ", commit offset: " << (commitOffset ? ToString(*commitOffset) : "null")
+            << ", max offset: " << (maxOffset ? ToString(*maxOffset) : "null"));
 
         TRpcIn message;
 
@@ -317,6 +321,9 @@ private:
         }
         if (commitOffset) {
             startResponse.set_commit_offset(*commitOffset);
+        }
+        if (maxOffset) {
+            startResponse.set_max_offset(*maxOffset);
         }
 
         AddSessionEvent(std::move(message));

--- a/ydb/core/testlib/test_pq_client.h
+++ b/ydb/core/testlib/test_pq_client.h
@@ -297,13 +297,15 @@ struct TRequestWritePQ {
     TString SourceId;
     ui64 SeqNo;
 
-    THolder<NMsgBusProxy::TBusPersQueue> GetRequest(const TString& data, const TString& cookie) const {
+    THolder<NMsgBusProxy::TBusPersQueue> GetRequest(const TString& data, const TString& cookie, TMaybe<i64> cmdWriteOffset = {}) const {
         THolder<NMsgBusProxy::TBusPersQueue> request(new NMsgBusProxy::TBusPersQueue);
         auto req = request->Record.MutablePartitionRequest();
         req->SetTopic(Topic);
         req->SetPartition(Partition);
         req->SetMessageNo(0);
         req->SetOwnerCookie(cookie);
+        if (cmdWriteOffset.Defined())
+            req->SetCmdWriteOffset(*cmdWriteOffset);
         auto write = req->AddCmdWrite();
         write->SetSourceId(SourceId);
         write->SetSeqNo(SeqNo);
@@ -1157,12 +1159,13 @@ public:
             const TRequestWritePQ& writeRequest, const TString& data,
             const TString& ticket = "",
             NMsgBusProxy::EResponseStatus expectedStatus = NMsgBusProxy::MSTATUS_OK,
-            NMsgBusProxy::EResponseStatus expectedOwnerStatus = NMsgBusProxy::MSTATUS_OK
+            NMsgBusProxy::EResponseStatus expectedOwnerStatus = NMsgBusProxy::MSTATUS_OK,
+            const TMaybe<i64> cmdWriteOffset = {}
     ) {
 
         TString cookie = GetOwnership({writeRequest.Topic, writeRequest.Partition}, expectedOwnerStatus);
 
-        THolder<NMsgBusProxy::TBusPersQueue> request = writeRequest.GetRequest(data, cookie);
+        THolder<NMsgBusProxy::TBusPersQueue> request = writeRequest.GetRequest(data, cookie, cmdWriteOffset);
         if (!ticket.empty())
             request.Get()->Record.SetTicket(ticket);
 

--- a/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
+++ b/ydb/library/testlib/pq_helpers/mock_pq_gateway.cpp
@@ -62,7 +62,7 @@ class TMockPqReadSession final : private TMockSessionBase, public IMockPqReadSes
         void Commit(uint64_t /*startOffset*/, uint64_t /*endOffset*/) override final {
         }
 
-        void ConfirmCreate(std::optional<uint64_t> /*readOffset*/, std::optional<uint64_t> /*commitOffset*/) override final {
+        void ConfirmCreate(std::optional<uint64_t> /*readOffset*/, std::optional<uint64_t> /*commitOffset*/, std::optional<uint64_t> /*maxOffset*/) override final {
         }
 
         void ConfirmDestroy() override final {

--- a/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
+++ b/ydb/library/yql/providers/pq/gateway/clients/file/yql_pq_file_topic_client.cpp
@@ -342,7 +342,7 @@ struct TDummyPartitionSession final : public TPartitionSessionControl {
     void Commit(uint64_t /*startOffset*/, uint64_t /*endOffset*/) override {
     }
 
-    void ConfirmCreate(std::optional<uint64_t> /*readOffset*/, std::optional<uint64_t> /*commitOffset*/) override {
+    void ConfirmCreate(std::optional<uint64_t> /*readOffset*/, std::optional<uint64_t> /*commitOffset*/, std::optional<uint64_t> /*maxOffset*/) override {
         // TODO seek to offset
     }
 

--- a/ydb/public/api/protos/ydb_persqueue_v1.proto
+++ b/ydb/public/api/protos/ydb_persqueue_v1.proto
@@ -376,8 +376,6 @@ message StreamingReadClientMessage {
         // If client is not setting read_offset, sanity check will fail so do not set verify_read_offset if you not setting correct read_offset.
         bool verify_read_offset = 4;
 
-        // If set to non-zero server will return messages up to this offset (inclusive).
-        int64 max_offset = 5;
     }
 
     // Signal for server that client finished working with this partition. Must be sent only after corresponding Release request from server.

--- a/ydb/public/api/protos/ydb_persqueue_v1.proto
+++ b/ydb/public/api/protos/ydb_persqueue_v1.proto
@@ -358,7 +358,7 @@ message StreamingReadClientMessage {
         int64 request_uncompressed_size = 1;
     }
 
-    // Signal for server that cient is ready to recive data for partition.
+    // Signal for server that cient is ready to recieve data for partition.
     message StartPartitionSessionResponse {
         // Partition session identifier of partition to start read.
         int64 partition_session_id = 1;
@@ -376,6 +376,8 @@ message StreamingReadClientMessage {
         // If client is not setting read_offset, sanity check will fail so do not set verify_read_offset if you not setting correct read_offset.
         bool verify_read_offset = 4;
 
+        // If set to non-zero server will return messages up to this offset (inclusive).
+        int64 max_offset = 5;
     }
 
     // Signal for server that client finished working with this partition. Must be sent only after corresponding Release request from server.

--- a/ydb/public/api/protos/ydb_topic.proto
+++ b/ydb/public/api/protos/ydb_topic.proto
@@ -516,7 +516,7 @@ message StreamReadMessage {
         // Server will commit this position if this is not done yet.
         optional int64 commit_offset = 3;
 
-        // If max_ofset is set, server will return data only up to max_offset (exclusive)
+        // If max_ofset is set, server will return data only up to max_offset (inclusive)
         // If set and is less than read_offset, commit_offset or actual committed offset then server will send an error message (status != SUCCESS) and close stream.
         optional int64 max_offset = 4;
     }

--- a/ydb/public/api/protos/ydb_topic.proto
+++ b/ydb/public/api/protos/ydb_topic.proto
@@ -515,6 +515,10 @@ message StreamReadMessage {
         // All messages with offset less than commit_offset are processed by client.
         // Server will commit this position if this is not done yet.
         optional int64 commit_offset = 3;
+
+        // If max_ofset is set, server will return data only up to max_offset (exclusive)
+        // If set and is less than read_offset, commit_offset or actual committed offset then server will send an error message (status != SUCCESS) and close stream.
+        optional int64 max_offset = 4;
     }
 
     // Command from server to stop and destroy concrete partition session.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -63,7 +63,7 @@ struct TPartitionSessionControl: public TPartitionSession {
     virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
 
     //! Confirm partition session creation from TStartPartitionSessionEvent.
-    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) = 0;
+    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset = std::nullopt) = 0;
 
     //! Confirm partition session destruction from TStopPartitionSessionEvent.
     virtual void ConfirmDestroy() = 0;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -63,7 +63,7 @@ struct TPartitionSessionControl: public TPartitionSession {
     virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
 
     //! Confirm partition session creation from TStartPartitionSessionEvent.
-    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) = 0;
+    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) = 0;
 
     //! Confirm partition session destruction from TStopPartitionSessionEvent.
     virtual void ConfirmDestroy() = 0;
@@ -291,7 +291,7 @@ struct TReadSessionEvent {
         //! Confirm partition session creation.
         //! This signals that user is ready to receive data from this partition session.
         //! If maybe is empty then no rewinding
-        void Confirm(std::optional<uint64_t> readOffset = std::nullopt, std::optional<uint64_t> commitOffset = std::nullopt);
+        void Confirm(std::optional<uint64_t> readOffset = std::nullopt, std::optional<uint64_t> commitOffset = std::nullopt, std::optional<uint64_t> maxOffset = std::nullopt);
 
     private:
         uint64_t CommittedOffset;

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -557,7 +557,7 @@ TReadSessionEvent::TCreatePartitionStreamEvent::TCreatePartitionStreamEvent(TPar
 
 void TReadSessionEvent::TCreatePartitionStreamEvent::Confirm(std::optional<ui64> readOffset, std::optional<ui64> commitOffset) {
     if (PartitionStream) {
-        static_cast<TPartitionStreamImpl*>(PartitionStream.Get())->ConfirmCreate(readOffset, commitOffset);
+        static_cast<TPartitionStreamImpl*>(PartitionStream.Get())->ConfirmCreate(readOffset, commitOffset, {});
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
@@ -315,10 +315,10 @@ TStartPartitionSessionEvent::TStartPartitionSessionEvent(TPartitionSession::TPtr
     , EndOffset(endOffset) {
 }
 
-void TStartPartitionSessionEvent::Confirm(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) {
+void TStartPartitionSessionEvent::Confirm(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) {
     if (PartitionSession) {
         static_cast<TPartitionSessionControl*>(PartitionSession.Get())
-            ->ConfirmCreate(readOffset, commitOffset);
+            ->ConfirmCreate(readOffset, commitOffset, maxOffset);
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -72,7 +72,7 @@ using TASessionClosedEvent = std::conditional_t<UseMigrationProtocol,
 
 struct TMigrationPartitionStream: public NYdb::NPersQueue::TPartitionStream {
     virtual void Commit(uint64_t startOffset, uint64_t endOffset) = 0;
-    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) = 0;
+    virtual void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) = 0;
     virtual void ConfirmDestroy() = 0;
     virtual void ConfirmEnd(std::span<const uint32_t> childIds) = 0;
 };
@@ -729,7 +729,7 @@ public:
     void Commit(uint64_t startOffset, uint64_t endOffset) override;
     void RequestStatus() override;
 
-    void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) override;
+    void ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) override;
     void ConfirmDestroy() override;
     void ConfirmEnd(std::span<const uint32_t> childIds) override;
 
@@ -1218,7 +1218,7 @@ public:
     ~TSingleClusterReadSessionImpl();
 
     void Start();
-    void ConfirmPartitionStreamCreate(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::optional<ui64> readOffset, std::optional<ui64> commitOffset);
+    void ConfirmPartitionStreamCreate(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::optional<ui64> readOffset, std::optional<ui64> commitOffset, std::optional<ui64> maxOffset);
     void ConfirmPartitionStreamDestroy(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream);
     void ConfirmPartitionStreamEnd(TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::span<const ui32> childIds);
     void RequestPartitionStreamStatus(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream);

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -78,12 +78,12 @@ void TPartitionStreamImpl<UseMigrationProtocol>::RequestStatus() {
 }
 
 template<bool UseMigrationProtocol>
-void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset) {
+void TPartitionStreamImpl<UseMigrationProtocol>::ConfirmCreate(std::optional<uint64_t> readOffset, std::optional<uint64_t> commitOffset, std::optional<uint64_t> maxOffset) {
     if (auto sessionShared = CbContext->LockShared()) {
         if (commitOffset.has_value()) {
             SetFirstNotReadOffset(commitOffset.value());
         }
-        sessionShared->ConfirmPartitionStreamCreate(this, readOffset, commitOffset);
+        sessionShared->ConfirmPartitionStreamCreate(this, readOffset, commitOffset, maxOffset);
     }
 }
 
@@ -647,17 +647,21 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::IsActualPartitionStrea
 }
 
 template<bool UseMigrationProtocol>
-void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStreamCreate(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, std::optional<ui64> readOffset, std::optional<ui64> commitOffset) {
-    TStringBuilder commitOffsetLogStr;
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStreamCreate(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream,
+    std::optional<ui64> readOffset, std::optional<ui64> commitOffset, std::optional<ui64> maxOffset) {
+    TStringBuilder offsetLogStr;
     if (commitOffset) {
-        commitOffsetLogStr << ". Commit offset: " << *commitOffset;
+        offsetLogStr << ". Commit offset: " << *commitOffset;
+    }
+    if (maxOffset) {
+        offsetLogStr << ". Max offset: " << *maxOffset;
     }
     LOG_LAZY(Log,
         TLOG_INFO,
         GetLogPrefix() << "Confirm partition stream create. Partition stream id: " << GetPartitionStreamId(partitionStream)
             << ". Cluster: \"" << GetCluster(partitionStream) << "\". Topic: \"" << partitionStream->GetTopicPath()
             << "\". Partition: " << partitionStream->GetPartitionId()
-            << ". Read offset: " << readOffset << commitOffsetLogStr
+            << ". Read offset: " << readOffset << offsetLogStr
     );
 
     std::lock_guard guard(Lock);
@@ -694,6 +698,9 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ConfirmPartitionStream
         }
         if (commitOffset) {
             startRead.set_commit_offset(*commitOffset);
+        }
+        if (maxOffset) {
+            startRead.set_max_offset(*maxOffset);
         }
 
         WriteToProcessorImpl(std::move(req));

--- a/ydb/services/persqueue_v1/actors/events.h
+++ b/ydb/services/persqueue_v1/actors/events.h
@@ -337,17 +337,19 @@ struct TEvPQProxy {
     };
 
     struct TEvStartRead : public NActors::TEventLocal<TEvStartRead, EvStartRead> {
-        TEvStartRead(ui64 id, ui64 readOffset, const TMaybe<ui64>& commitOffset, bool verifyReadOffset)
+        TEvStartRead(ui64 id, ui64 readOffset, const TMaybe<ui64>& commitOffset, bool verifyReadOffset, const TMaybe<ui64>& maxOffset)
             : AssignId(id)
             , ReadOffset(readOffset)
             , CommitOffset(commitOffset)
             , VerifyReadOffset(verifyReadOffset)
+            , MaxOffset(maxOffset)
         { }
 
         const ui64 AssignId;
         ui64 ReadOffset;
         TMaybe<ui64> CommitOffset;
         bool VerifyReadOffset;
+        TMaybe<ui64> MaxOffset;
     };
 
     struct TEvReleased : public NActors::TEventLocal<TEvReleased, EvReleased> {
@@ -410,17 +412,19 @@ struct TEvPQProxy {
 
     struct TEvLockPartition : public NActors::TEventLocal<TEvLockPartition, EvLockPartition> {
         explicit TEvLockPartition(const ui64 readOffset, const TMaybe<ui64>& commitOffset, bool verifyReadOffset,
-                                   bool startReading)
+                                   bool startReading, const TMaybe<ui64>& maxOffset)
             : ReadOffset(readOffset)
             , CommitOffset(commitOffset)
             , VerifyReadOffset(verifyReadOffset)
             , StartReading(startReading)
+            , MaxOffset(maxOffset)
         { }
 
         ui64 ReadOffset;
         TMaybe<ui64> CommitOffset;
         bool VerifyReadOffset;
         bool StartReading;
+        TMaybe<ui64> MaxOffset;
     };
 
 

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -1184,7 +1184,7 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
 
     if (!MaxTimeLagMs && !ReadTimestampMs && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
-    } else if (IsNeedMorePartitionData()) {
+    } else {
         WaitForData = true;
         if (PipeClient) //pipe will be recreated soon
             WaitDataInPartition(ctx);

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -429,7 +429,9 @@ void TPartitionActor::ResendRecentRequests() {
         MakeCommit(ctx);
         if (WaitForData) { //resend wait-for-data requests
             WaitDataInfly.clear();
-            WaitDataInPartition(ctx);
+            if (IsNeedMorePartitionData()) {
+                WaitDataInPartition(ctx);
+            }
         }
     }
 }
@@ -637,6 +639,7 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
     ClientHasAnyCommits = resp.GetClientHasAnyCommits();
 
     ClientCommitOffset = ReadOffset = CommittedOffset = resp.HasOffset() ? resp.GetOffset() : 0;
+    ClientMaxOffset.Clear();
     AFL_ENSURE(EndOffset >= CommittedOffset);
 
     if (resp.HasWriteTimestampMS())
@@ -778,9 +781,9 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
 
     AFL_ENSURE(!RequestInfly);
 
-    if (EndOffset > ReadOffset && isInFlightMemoryOk) {
+    if (isInFlightMemoryOk && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
-    } else if (EndOffset == ReadOffset) {
+    } else if (IsNeedMorePartitionData()) {
         WaitForData = true;
         if (PipeClient) //pipe will be recreated soon
             WaitDataInPartition(ctx);
@@ -829,11 +832,11 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
 
     auto isMemoryLimitReached = PartitionInFlightMemoryController.IsMemoryLimitReached();
     LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " " << Partition
-                        << " isMemoryLimitReached " << isMemoryLimitReached << " EndOffset " << EndOffset << " ReadOffset " << ReadOffset
+                        << " isMemoryLimitReached " << isMemoryLimitReached << " EndOffset " << EndOffset << " ReadOffset " << ReadOffset << " MaxOffset " << ClientMaxOffset
                         << " read result size " << res.ResultSize());
-    if (EndOffset > ReadOffset && !isMemoryLimitReached) {
+    if (!isMemoryLimitReached && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
-    } else if (EndOffset == ReadOffset) {
+    } else if (IsNeedMorePartitionData()) {
         WaitForData = true;
         if (PipeClient) //pipe will be recreated soon
             WaitDataInPartition(ctx);
@@ -1000,10 +1003,10 @@ void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
     }
 
     CommittedOffset = CommitsInfly.front().second.Offset;
-    
+
     bool wasMemoryLimitReached = PartitionInFlightMemoryController.IsMemoryLimitReached();
     bool isMemoryOkNow = PartitionInFlightMemoryController.Remove(CommittedOffset);
-    if (wasMemoryLimitReached && isMemoryOkNow && EndOffset > ReadOffset) {
+    if (wasMemoryLimitReached && isMemoryOkNow && IsPartitionDataReady()) {
         LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " " << Partition
                         << " ready for read after commit with readOffset " << ReadOffset << " endOffset " << EndOffset);
         SendPartitionReady(ctx);
@@ -1079,6 +1082,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvLockPartition::TPtr& ev, const TActo
     ClientReadOffset = ev->Get()->ReadOffset;
     ClientCommitOffset = ev->Get()->CommitOffset;
     ClientVerifyReadOffset = ev->Get()->VerifyReadOffset;
+    ClientMaxOffset = ev->Get()->MaxOffset;
 
     if (StartReading) {
         AFL_ENSURE(ev->Get()->StartReading); //otherwise it is signal from actor, this could not be done
@@ -1096,7 +1100,8 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
     AFL_ENSURE(!WaitForData);
     LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " Start reading " << Partition
                         << " EndOffset " << EndOffset << " readOffset " << ReadOffset << " committedOffset " << CommittedOffset
-                        << " clientCommitOffset " << ClientCommitOffset << " clientReadOffset " << ClientReadOffset);
+                        << " clientCommitOffset " << ClientCommitOffset
+                        << " clientReadOffset " << ClientReadOffset << " clientMaxOffset " << ClientMaxOffset);
 
     Counters.PartitionsToBeLocked.Dec();
     LockCounted = false;
@@ -1131,6 +1136,26 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
         }
     }
 
+    if (ClientMaxOffset.Defined()) {
+        if (*ClientMaxOffset < ReadOffset) {
+            ctx.Send(ParentId,
+                        new TEvPQProxy::TEvCloseSession(TStringBuilder()
+                                << "trying to read from position that is larger than provided to max: read " << ReadOffset
+                                << " max " << ClientMaxOffset,
+                            PersQueue::ErrorCode::BAD_REQUEST));
+            return;
+        }
+
+        if (*ClientMaxOffset < ClientCommitOffset.GetOrElse(0)) {
+            ctx.Send(ParentId,
+                        new TEvPQProxy::TEvCloseSession(TStringBuilder()
+                                << "trying to commit to position that is larger than provided to max: commit " << ClientCommitOffset
+                                << " max " << ClientMaxOffset,
+                            PersQueue::ErrorCode::BAD_REQUEST));
+            return;
+        }
+    }
+
     if (ClientCommitOffset.GetOrElse(0) > CommittedOffset) {
         if (ClientCommitOffset > ReadOffset) {
             ctx.Send(ParentId,
@@ -1157,9 +1182,9 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
         ClientCommitOffset = CommittedOffset;
     }
 
-    if (EndOffset > ReadOffset && !MaxTimeLagMs && !ReadTimestampMs) {
+    if (!MaxTimeLagMs && !ReadTimestampMs && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
-    } else {
+    } else if (IsNeedMorePartitionData()) {
         WaitForData = true;
         if (PipeClient) //pipe will be recreated soon
             WaitDataInPartition(ctx);
@@ -1333,7 +1358,7 @@ void TPartitionActor::WaitDataInPartition(const TActorContext& ctx) {
 
     AFL_ENSURE(InitDone);
     AFL_ENSURE(PipeClient);
-    AFL_ENSURE(ReadOffset >= EndOffset || MaxTimeLagMs || ReadTimestampMs);
+    AFL_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData());
 
     TAutoPtr<TEvPersQueue::TEvHasDataInfo> event(new TEvPersQueue::TEvHasDataInfo());
     event->Record.SetPartition(Partition.Partition);
@@ -1381,24 +1406,24 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
 
     AFL_ENSURE(record.HasEndOffset());
     AFL_ENSURE(EndOffset <= record.GetEndOffset()); //end offset could not be changed if no data arrived, but signal will be sended anyway after timeout
-    AFL_ENSURE(ReadOffset >= EndOffset || MaxTimeLagMs || ReadTimestampMs); //otherwise no WaitData were needed
+    AFL_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData()); //otherwise no WaitData were needed
 
     LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " " << Partition
                     << " wait for data done: " << " readOffset " << ReadOffset << " EndOffset " << EndOffset << " newEndOffset "
-                    << record.GetEndOffset() << " commitOffset " << CommittedOffset << " clientCommitOffset " << ClientCommitOffset
+                    << record.GetEndOffset() << " commitOffset " << CommittedOffset << " clientCommitOffset " << ClientCommitOffset << " clientMaxOffset " << ClientMaxOffset
                     << " cookie " << ev->Get()->Record.GetCookie() << " readingFinished " << record.GetReadingFinished() << " firstRead " << FirstRead);
 
     EndOffset = record.GetEndOffset();
     SizeLag = record.GetSizeLag();
 
     if (!record.GetReadingFinished()) {
-        if (ReadOffset < EndOffset) {
+        if (IsPartitionDataReady()) {
             WaitForData = false;
             WaitDataInfly.clear();
             if (!PartitionInFlightMemoryController.IsMemoryLimitReached()) {
                 SendPartitionReady(ctx);
             }
-        } else if (PipeClient) {
+        } else if (PipeClient && IsNeedMorePartitionData()) {
             WaitDataInPartition(ctx);
         }
     }
@@ -1471,7 +1496,8 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
                     << " maxCount " << ev->Get()->MaxCount << " maxSize " << ev->Get()->MaxSize << " maxTimeLagMs "
                     << ev->Get()->MaxTimeLagMs << " readTimestampMs " << ev->Get()->ReadTimestampMs
                     << " readOffset " << ReadOffset << " EndOffset " << EndOffset << " ClientCommitOffset "
-                    << ClientCommitOffset << " committedOffset " << CommittedOffset << " Guid " << ev->Get()->Guid);
+                    << ClientCommitOffset << " committedOffset " << CommittedOffset << " ClientMaxOffset " << ClientMaxOffset
+                    << " Guid " << ev->Get()->Guid);
 
     AFL_ENSURE(ReadGuid.empty());
     AFL_ENSURE(!RequestInfly);
@@ -1480,7 +1506,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
 
     const auto req = ev->Get();
 
-    auto request = MakeReadRequest(ReadOffset, 0, req->MaxCount, req->MaxSize, req->MaxTimeLagMs, req->ReadTimestampMs, DirectReadId);
+    auto request = MakeReadRequest(ReadOffset, ClientMaxOffset.GetOrElse(0), req->MaxCount, req->MaxSize, req->MaxTimeLagMs, req->ReadTimestampMs, DirectReadId);
     RequestInfly = true;
     CurrentRequest = request;
 
@@ -1594,9 +1620,17 @@ void TPartitionActor::HandleWakeup(const TActorContext& ctx) {
 }
 
 void TPartitionActor::DoWakeup(const TActorContext& ctx) {
-    if (WaitForData && ReadOffset >= EndOffset && WaitDataInfly.size() <= 1 && PipeClient) { //send one more
+    if (PipeClient && WaitForData && WaitDataInfly.size() <= 1 && IsNeedMorePartitionData()) { //send one more
         WaitDataInPartition(ctx);
     }
+}
+
+bool TPartitionActor::IsPartitionDataReady() const {
+    return ReadOffset < EndOffset && (!ClientMaxOffset.Defined() || ReadOffset < *ClientMaxOffset);
+}
+
+bool TPartitionActor::IsNeedMorePartitionData() const {
+    return ReadOffset >= EndOffset && (!ClientMaxOffset.Defined() || ReadOffset < *ClientMaxOffset);
 }
 
 }

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -1184,7 +1184,7 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
 
     if (!MaxTimeLagMs && !ReadTimestampMs && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
-    } else {
+    } else if (MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData()) {
         WaitForData = true;
         if (PipeClient) //pipe will be recreated soon
             WaitDataInPartition(ctx);

--- a/ydb/services/persqueue_v1/actors/partition_actor.h
+++ b/ydb/services/persqueue_v1/actors/partition_actor.h
@@ -200,6 +200,7 @@ private:
     bool ClientVerifyReadOffset;
     ui64 CommittedOffset;
     ui64 WriteTimestampEstimateMs;
+    TMaybe<ui64> ClientMaxOffset;
 
     ui64 ReadIdToResponse;
     ui64 ReadIdCommitted;
@@ -280,6 +281,9 @@ private:
     bool ReadingFinishedSent;
 
     std::unordered_set<ui64> NotCommitedToFinishParents;
+
+    inline bool IsPartitionDataReady() const;
+    inline bool IsNeedMorePartitionData() const;
 };
 
 

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -230,7 +230,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(typename IContext::TEvReadF
 
                 const ui64 readOffset = req.read_offset();
                 TMaybe<ui64> commitOffset = req.has_commit_offset() ? req.commit_offset() : TMaybe<ui64>{};
-                TMaybe<ui64> maxOffset =  req.has_max_offset() ? req.max_offset() : TMaybe<ui64>{};
+                TMaybe<ui64> maxOffset =  req.has_max_offset() ? req.max_offset() + 1 : TMaybe<ui64>{}; // input max_offset is inclusive, maxOffset is exclusive
                 if (ReadWithoutConsumer && req.has_commit_offset()) {
                     return CloseSession(PersQueue::ErrorCode::BAD_REQUEST, "can't commit when reading without a consumer", ctx);
                 }

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -159,7 +159,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(typename IContext::TEvReadF
                 const bool verifyReadOffset = req.verify_read_offset();
 
                 ctx.Send(ctx.SelfID, new TEvPQProxy::TEvStartRead(
-                        getAssignId(request.start_read()), readOffset, req.commit_offset(), verifyReadOffset
+                        getAssignId(request.start_read()), readOffset, req.commit_offset(), verifyReadOffset, TMaybe<ui64>{}
                 ));
                 return (void)ReadFromStreamOrDie(ctx);
             }
@@ -229,14 +229,15 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(typename IContext::TEvReadF
                 const auto& req = request.start_partition_session_response();
 
                 const ui64 readOffset = req.read_offset();
-                const ui64 commitOffset = req.commit_offset();
+                TMaybe<ui64> commitOffset = req.has_commit_offset() ? req.commit_offset() : TMaybe<ui64>{};
+                TMaybe<ui64> maxOffset =  req.has_max_offset() ? req.max_offset() : TMaybe<ui64>{};
                 if (ReadWithoutConsumer && req.has_commit_offset()) {
                     return CloseSession(PersQueue::ErrorCode::BAD_REQUEST, "can't commit when reading without a consumer", ctx);
                 }
 
                 ctx.Send(ctx.SelfID, new TEvPQProxy::TEvStartRead(
-                        getAssignId(req), readOffset, req.has_commit_offset() ? commitOffset : TMaybe<ui64>{},
-                        req.has_read_offset()
+                        getAssignId(req), readOffset, commitOffset,
+                        req.has_read_offset(), maxOffset
                 ));
                 return (void)ReadFromStreamOrDie(ctx);
             }
@@ -537,12 +538,13 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPQProxy::TEvStartRead::T
     LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " got StartRead from client"
         << ": partition# " << it->second.Partition
         << ", readOffset# " << ev->Get()->ReadOffset
-        << ", commitOffset# " << ev->Get()->CommitOffset);
+        << ", commitOffset# " << ev->Get()->CommitOffset
+        << ", maxOffset# " << ev->Get()->MaxOffset);
 
     // proxy request to partition - allow initing
     // TODO: add here VerifyReadOffset too and check it againts Committed position
     ctx.Send(it->second.Actor, new TEvPQProxy::TEvLockPartition(
-        ev->Get()->ReadOffset, ev->Get()->CommitOffset, ev->Get()->VerifyReadOffset, true
+        ev->Get()->ReadOffset, ev->Get()->CommitOffset, ev->Get()->VerifyReadOffset, true, ev->Get()->MaxOffset
     ));
 }
 
@@ -1339,7 +1341,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
         << " topic=" << converter->GetPrintableString()
         << " assign: record# " << record);
 
-    ctx.Send(actorId, new TEvPQProxy::TEvLockPartition(0, {}, false, false));
+    ctx.Send(actorId, new TEvPQProxy::TEvLockPartition(0, {}, false, false, {}));
 }
 
 template <bool UseMigrationProtocol>

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -1014,7 +1014,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             ui64 PartitionId;
         };
 
-        TAssignInfo GetNextAssign(const TString& topic, ui64 prevGeneration=0) {
+        TAssignInfo GetNextAssign(const TString& topic, ui64 prevGeneration=0, ui64 readOffset=0, ui64 commitOffset=0, ui64 maxOffset=0) {
             // Get StartPartitionSessionRequest, send StartPartitionSessionResponse.
 
             Cerr << "Get next assign id\n";
@@ -1035,6 +1035,12 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
 
                 Topic::StreamReadMessage::FromClient req;
                 req.mutable_start_partition_session_response()->set_partition_session_id(result.AssignId);
+                if (readOffset)
+                    req.mutable_start_partition_session_response()->set_read_offset(readOffset);
+                if (commitOffset)
+                    req.mutable_start_partition_session_response()->set_commit_offset(commitOffset);
+                if (maxOffset)
+                    req.mutable_start_partition_session_response()->set_max_offset(maxOffset);
                 if (!ControlStream->Write(req)) {
                     ythrow yexception() << "write fail";
                 }
@@ -1228,6 +1234,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             req.mutable_init_request()->add_topics_read_settings()->set_path(topic);
             req.mutable_init_request()->set_consumer(consumer);
             req.mutable_init_request()->set_session_id(SessionId);
+            Cerr << "Send direct read init request: " << req.ShortDebugString() << Endl;
             if (!DirectStream->Write(req)) {
                 ythrow yexception() << "write fail";
             }
@@ -1574,6 +1581,99 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
                                   << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
         UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.first);
         UNIT_ASSERT_VALUES_EQUAL(resp.Range.second, 2);
+    }
+
+    Y_UNIT_TEST(DirectReadCorrectMaxOffsetOnRestart) {
+        TPersQueueV1TestServer server{{.CheckACL=true, .NodeCount=1}};
+        SET_LOCALS;
+        TString topicPath{"acc/topic1"};
+        TString oldPath{"/Root/PQ/rt3.dc1--acc--topic1"};
+        TDirectReadTestSetup setup{server};
+
+        {
+            // 1. Write 20 messages.
+            Cerr << (TStringBuilder() << "XXXXX Write 20 messages" << Endl);
+            setup.DoWrite(pqClient->GetDriver(), topicPath, 10_KB, 20);
+        }
+
+        Cerr << (TStringBuilder() << "XXXXX InitControlSession" << Endl);
+        setup.InitControlSession(topicPath, 100_KB);
+
+        Cerr << "XXXXX GetNextAssign\n";
+        auto assignRes = setup.GetNextAssign(topicPath, 0, /*read_offset*/5, /*commit_offset*/2, /*max_offset*/25);
+        UNIT_ASSERT_VALUES_EQUAL(assignRes.PartitionId, 0);
+        auto assignId = assignRes.AssignId;
+
+        Cerr << (TStringBuilder() << "XXXXX InitDirectSession" << Endl);
+        setup.InitDirectSession(topicPath);
+
+        // Send StartDirectReadPartitionSessionRequest, get StartDirectReadPartitionSessionResponse
+        setup.SendReadSessionAssign(assignId, assignRes.Generation);
+
+        // 2. Read the message back. It should contain only one offset.
+        Cerr << "XXXXX ReadDataNoAck\n";
+        auto resp = setup.ReadDataNoAck(assignId, 1);
+        auto startOffset = resp.Range.first;
+        auto endOffset = resp.Range.second;
+        Cerr << (TStringBuilder() << "XXXXX startOffset = " << startOffset << " endOffset = " << endOffset << Endl);
+
+        Cerr << "XXXXX Write 20 more messages\n";
+        setup.DoWrite(pqClient->GetDriver(), topicPath, 10_KB, 20);
+
+        Cerr << "XXXXX Kill tablet\n";
+        auto pathDescr = server.Server->AnnoyingClient->Ls(oldPath)->Record.GetPathDescription().GetPersQueueGroup();
+        auto tabletId = pathDescr.GetPartitions(0).GetTabletId();
+        server.Server->AnnoyingClient->KillTablet(*(server.Server->CleverServer), tabletId);
+        Cerr << "XXXXX ExpectDestroyPartitionSession\n";
+        setup.ExpectDestroyPartitionSession(assignId);
+
+        Cerr << "XXXXX Sleep 1 seconds\n";
+        Sleep(TDuration::Seconds(1));
+
+        Cerr << "XXXXX GetNextAssign\n";
+        auto nextAssignRes = setup.GetNextAssign(topicPath, assignRes.Generation);
+        assignId = nextAssignRes.AssignId;
+
+        Cerr << "XXXXX Sleep 2 seconds\n";
+        Sleep(TDuration::Seconds(2));
+
+        Cerr << "XXXXX SendReadSessionAssign\n";
+        setup.SendReadSessionAssign(assignId, nextAssignRes.Generation);
+
+        Cerr << "XXXXX Sleep 3 seconds\n";
+        Sleep(TDuration::Seconds(3));
+
+        Cerr << "XXXXX ReadDataNoAck direct_read_id = 1\n";
+        resp = setup.ReadDataNoAck(assignId, 1);
+        Cerr << (TStringBuilder() << "XXXXX grpcByteSize = " << resp.Response.ByteSize() << " bytes_size = " << resp.Response.direct_read_response().bytes_size()
+                                  << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
+        UNIT_ASSERT_VALUES_EQUAL(startOffset, resp.Range.first);
+        UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.second);
+
+        startOffset = resp.Range.first;
+        endOffset = resp.Range.second;
+
+        setup.SendReadRequest(2_MB);
+
+        Cerr << "XXXXX Sleep 3 seconds\n";
+        Sleep(TDuration::Seconds(3));
+
+        Cerr << "XXXXX ReadDataNoAck direct_read_id = 2\n";
+        resp = setup.ReadDataNoAck(assignId, 2);
+        Cerr << (TStringBuilder() << "XXXXX grpcByteSize = " << resp.Response.ByteSize() << " bytes_size = " << resp.Response.direct_read_response().bytes_size()
+                                  << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
+        UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.first);
+        // UNIT_ASSERT_VALUES_EQUAL(resp.Range.second, 20); // don't check since it's non-deterministic
+        endOffset = resp.Range.second;
+
+        Cerr << "XXXXX ReadDataNoAck direct_read_id = 3\n";
+        resp = setup.ReadDataNoAck(assignId, 3);
+        Cerr << (TStringBuilder() << "XXXXX grpcByteSize = " << resp.Response.ByteSize() << " bytes_size = " << resp.Response.direct_read_response().bytes_size()
+                                  << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
+        UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.first);
+        UNIT_ASSERT_VALUES_EQUAL(resp.Range.second, 25);
+
+
     }
 
     Y_UNIT_TEST(DirectReadBadCases) {
@@ -8711,6 +8811,49 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     Y_UNIT_TEST(ConsumerAvailabilityPeriod) {
         TestConsumerAvailabilityPeriod(true);
         TestConsumerAvailabilityPeriod(false);
+    }
+
+    Y_UNIT_TEST(ReadCommitMaxOffset) {
+        NPersQueue::TTestServer server;
+        TString topicFullName = "rt3.dc1--topic1";
+        auto driver = SetupTestAndGetDriver(server, topicFullName);
+
+        auto topicClient = NYdb::NTopic::TTopicClient(*driver);
+
+        NYdb::NTopic::TWriteSessionSettings wSettings {topicFullName, "srcId", "srcId"};
+        wSettings.DirectWriteToPartition(false);
+        auto writer = topicClient.CreateSimpleBlockingWriteSession(wSettings);
+        for (int i = 1; i <= 10; ++i) {
+            auto res = writer->Write("Message_" + ToString(i), i);
+            UNIT_ASSERT(res);
+        }
+        auto res = writer->Close();
+        UNIT_ASSERT(res);
+
+        {
+            std::optional<ui64> readOffset = 4;
+            std::optional<ui64> commitOffset = 3;
+            std::optional<ui64> maxOffset = 6;
+            NYdb::NTopic::TReadSessionSettings rSettings;
+            rSettings.ConsumerName("debug").AppendTopics({topicFullName});
+            auto readSession = topicClient.CreateReadSession(rSettings);
+
+            auto ev = readSession->GetEvent(true);
+            UNIT_ASSERT(ev.has_value());
+            auto spsEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*ev);
+            UNIT_ASSERT(spsEv);
+            spsEv->Confirm(readOffset, commitOffset, maxOffset);
+            ev = readSession->GetEvent(true);
+            auto dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev);
+            UNIT_ASSERT(dataEv);
+            const auto& messages = dataEv->GetMessages();
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0].GetData(), "Message_5");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1].GetData(), "Message_6");
+
+            UNIT_ASSERT(!readSession->WaitEvent().Wait(TDuration::Seconds(3))); // no more events
+        }
+
     }
 }
 }

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -1591,16 +1591,16 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         TDirectReadTestSetup setup{server};
 
         {
-            // 1. Write 20 messages.
-            Cerr << (TStringBuilder() << "XXXXX Write 20 messages" << Endl);
-            setup.DoWrite(pqClient->GetDriver(), topicPath, 10_KB, 20);
+            // 1. Write 10 messages.
+            Cerr << (TStringBuilder() << "XXXXX Write 10 messages" << Endl);
+            setup.DoWrite(pqClient->GetDriver(), topicPath, 10_KB, 10);
         }
 
         Cerr << (TStringBuilder() << "XXXXX InitControlSession" << Endl);
-        setup.InitControlSession(topicPath, 100_KB);
+        setup.InitControlSession(topicPath, 1_MB);
 
         Cerr << "XXXXX GetNextAssign\n";
-        auto assignRes = setup.GetNextAssign(topicPath, 0, /*read_offset*/5, /*commit_offset*/2, /*max_offset*/25);
+        auto assignRes = setup.GetNextAssign(topicPath, 0, /*read_offset*/5, /*commit_offset*/2, /*max_offset*/8);
         UNIT_ASSERT_VALUES_EQUAL(assignRes.PartitionId, 0);
         auto assignId = assignRes.AssignId;
 
@@ -1610,15 +1610,14 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         // Send StartDirectReadPartitionSessionRequest, get StartDirectReadPartitionSessionResponse
         setup.SendReadSessionAssign(assignId, assignRes.Generation);
 
-        // 2. Read the message back. It should contain only one offset.
+        // 2. Read the message back. It should contain 4 messages from 5 to 8 (inclusive).
         Cerr << "XXXXX ReadDataNoAck\n";
         auto resp = setup.ReadDataNoAck(assignId, 1);
         auto startOffset = resp.Range.first;
         auto endOffset = resp.Range.second;
         Cerr << (TStringBuilder() << "XXXXX startOffset = " << startOffset << " endOffset = " << endOffset << Endl);
-
-        Cerr << "XXXXX Write 20 more messages\n";
-        setup.DoWrite(pqClient->GetDriver(), topicPath, 10_KB, 20);
+        UNIT_ASSERT_VALUES_EQUAL(5, startOffset);
+        UNIT_ASSERT_VALUES_EQUAL(8 + 1, endOffset);
 
         Cerr << "XXXXX Kill tablet\n";
         auto pathDescr = server.Server->AnnoyingClient->Ls(oldPath)->Record.GetPathDescription().GetPersQueueGroup();
@@ -1649,29 +1648,6 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
                                   << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
         UNIT_ASSERT_VALUES_EQUAL(startOffset, resp.Range.first);
         UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.second);
-
-        startOffset = resp.Range.first;
-        endOffset = resp.Range.second;
-
-        setup.SendReadRequest(2_MB);
-
-        Cerr << "XXXXX Sleep 3 seconds\n";
-        Sleep(TDuration::Seconds(3));
-
-        Cerr << "XXXXX ReadDataNoAck direct_read_id = 2\n";
-        resp = setup.ReadDataNoAck(assignId, 2);
-        Cerr << (TStringBuilder() << "XXXXX grpcByteSize = " << resp.Response.ByteSize() << " bytes_size = " << resp.Response.direct_read_response().bytes_size()
-                                  << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
-        UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.first);
-        // UNIT_ASSERT_VALUES_EQUAL(resp.Range.second, 20); // don't check since it's non-deterministic
-        endOffset = resp.Range.second;
-
-        Cerr << "XXXXX ReadDataNoAck direct_read_id = 3\n";
-        resp = setup.ReadDataNoAck(assignId, 3);
-        Cerr << (TStringBuilder() << "XXXXX grpcByteSize = " << resp.Response.ByteSize() << " bytes_size = " << resp.Response.direct_read_response().bytes_size()
-                                  << " startOffset = " << resp.Range.first << " endOffset = " << resp.Range.second << Endl);
-        UNIT_ASSERT_VALUES_EQUAL(endOffset, resp.Range.first);
-        UNIT_ASSERT_VALUES_EQUAL(resp.Range.second, 25);
 
 
     }
@@ -8833,7 +8809,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         {
             std::optional<ui64> readOffset = 4;
             std::optional<ui64> commitOffset = 3;
-            std::optional<ui64> maxOffset = 6;
+            std::optional<ui64> maxOffset = 6; //inclusive
             NYdb::NTopic::TReadSessionSettings rSettings;
             rSettings.ConsumerName("debug").AppendTopics({topicFullName});
             auto readSession = topicClient.CreateReadSession(rSettings);
@@ -8847,9 +8823,10 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             auto dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev);
             UNIT_ASSERT(dataEv);
             const auto& messages = dataEv->GetMessages();
-            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 3);
             UNIT_ASSERT_VALUES_EQUAL(messages[0].GetData(), "Message_5");
             UNIT_ASSERT_VALUES_EQUAL(messages[1].GetData(), "Message_6");
+            UNIT_ASSERT_VALUES_EQUAL(messages[2].GetData(), "Message_7");
 
             UNIT_ASSERT(!readSession->WaitEvent().Wait(TDuration::Seconds(3))); // no more events
         }

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -8832,5 +8832,101 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         }
 
     }
+
+    Y_UNIT_TEST(ReadCommitMaxOffsetWithGaps) {
+        NPersQueue::TTestServer server;
+        TString topicFullName = "rt3.dc1--topic1";
+        auto driver = SetupTestAndGetDriver(server, topicFullName);
+
+        auto topicClient = NYdb::NTopic::TTopicClient(*driver);
+
+        /*NYdb::NTopic::TWriteSessionSettings wSettings {topicFullName, "srcId", "srcId"};
+        wSettings.DirectWriteToPartition(false);
+        auto writer = topicClient.CreateSimpleBlockingWriteSession(wSettings);
+        for (int i = 1; i <= 10; ++i) {
+            auto res = writer->Write("Message_" + ToString(i), i);
+            UNIT_ASSERT(res);
+        }
+        auto res = writer->Close();
+        UNIT_ASSERT(res);
+        */
+
+        auto write = [&](TRequestWritePQ& writeRequest, const TString& data, const TMaybe<i64>& writeOffset = {}) {
+            NKikimrPQClient::TDataChunk dataChunk;
+            dataChunk.SetCreateTime(42);
+            dataChunk.SetSeqNo(++writeRequest.SeqNo);
+            dataChunk.SetData(data);
+
+            TString serialized;
+            UNIT_ASSERT(dataChunk.SerializeToString(&serialized));
+            server.AnnoyingClient->WriteToPQ(writeRequest, serialized, "", NMsgBusProxy::MSTATUS_OK, NMsgBusProxy::MSTATUS_OK, writeOffset);
+        };
+
+        TRequestWritePQ writeRequest = {topicFullName, 0, NPQ::NSourceIdEncoding::Decode("srcId"), 0};
+        // write 10 messages
+        for (ui64 i = 1; i <= 10; ++i) {
+            write(writeRequest, "Message_" + ToString(i));
+        }
+
+        // write one message with offset gap - offset = 20
+        write(writeRequest, "Message_21", 20);
+        //  write the rest
+        for (ui64 i = 22; i <= 30; ++i) {
+            write(writeRequest, "Message_" + ToString(i));
+        }
+
+        {
+            // set max offset in the gap - should get back messages 8, 9, 10
+            std::optional<ui64> readOffset = 7;
+            std::optional<ui64> commitOffset = 3;
+            std::optional<ui64> maxOffset = 12; //inclusive
+            NYdb::NTopic::TReadSessionSettings rSettings;
+            rSettings.ConsumerName("debug").AppendTopics({topicFullName});
+            auto readSession = topicClient.CreateReadSession(rSettings);
+
+            auto ev = readSession->GetEvent(true);
+            UNIT_ASSERT(ev.has_value());
+            auto spsEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*ev);
+            UNIT_ASSERT(spsEv);
+            spsEv->Confirm(readOffset, commitOffset, maxOffset);
+            ev = readSession->GetEvent(true);
+            auto dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev);
+            UNIT_ASSERT(dataEv);
+            const auto& messages = dataEv->GetMessages();
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0].GetData(), "Message_8");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1].GetData(), "Message_9");
+            UNIT_ASSERT_VALUES_EQUAL(messages[2].GetData(), "Message_10");
+
+            UNIT_ASSERT(!readSession->WaitEvent().Wait(TDuration::Seconds(3))); // no more events
+        }
+
+        {
+            // set read offset before the gap, max offset after the gap - should get back messages 10, 21, 22
+            std::optional<ui64> readOffset = 9;
+            std::optional<ui64> commitOffset = 3;
+            std::optional<ui64> maxOffset = 21; //inclusive
+            NYdb::NTopic::TReadSessionSettings rSettings;
+            rSettings.ConsumerName("debug").AppendTopics({topicFullName});
+            auto readSession = topicClient.CreateReadSession(rSettings);
+
+            auto ev = readSession->GetEvent(true);
+            UNIT_ASSERT(ev.has_value());
+            auto spsEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*ev);
+            UNIT_ASSERT(spsEv);
+            spsEv->Confirm(readOffset, commitOffset, maxOffset);
+            ev = readSession->GetEvent(true);
+            auto dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev);
+            UNIT_ASSERT(dataEv);
+            const auto& messages = dataEv->GetMessages();
+            UNIT_ASSERT_VALUES_EQUAL(messages.size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(messages[0].GetData(), "Message_10");
+            UNIT_ASSERT_VALUES_EQUAL(messages[1].GetData(), "Message_21");
+            UNIT_ASSERT_VALUES_EQUAL(messages[2].GetData(), "Message_22");
+
+            UNIT_ASSERT(!readSession->WaitEvent().Wait(TDuration::Seconds(3))); // no more events
+        }
+
+    }
 }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added option max_offset to limit reading from partition up to specified offset (inclusive). If set to 0 or not set then reading is not limited.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->


