### PR TITLE
docs: include yql/reference/toc_p.yaml from yql/toc_p.yaml

### DIFF
--- a/ydb/docs/en/core/yql/toc_p.yaml
+++ b/ydb/docs/en/core/yql/toc_p.yaml
@@ -1,2 +1,3 @@
 items:
 - include: { mode: link, path: toc_i.yaml }
+- include: { mode: link, path: reference/toc_p.yaml }

--- a/ydb/docs/ru/core/yql/toc_p.yaml
+++ b/ydb/docs/ru/core/yql/toc_p.yaml
@@ -1,2 +1,3 @@
 items:
 - include: { mode: link, path: toc_i.yaml }
+- include: { mode: link, path: reference/toc_p.yaml }


### PR DESCRIPTION
## Summary
- Add `include` of `reference/toc_p.yaml` into `yql/toc_p.yaml` for both `ru` and `en` locales, so the YQL reference TOC is plugged into the parent YQL section.

## Test plan
- [ ] Docs build succeeds for ru and en
- [ ] YQL reference appears in the navigation