### PR TITLE
EnableDataShardDetailedMetrics feature flag and its handling in scheme shard

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -318,4 +318,5 @@ message TFeatureFlags {
     optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];
     optional bool EnableKqpConstraintsTransformer = 277 [default = true];
     optional bool EnableLocalIndexAsSchemeObject = 278 [default = true];
+    optional bool EnableDetailedMetrics = 279 [default = false];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -318,5 +318,5 @@ message TFeatureFlags {
     optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];
     optional bool EnableKqpConstraintsTransformer = 277 [default = true];
     optional bool EnableLocalIndexAsSchemeObject = 278 [default = true];
-    optional bool EnableDetailedMetrics = 279 [default = false];
+    optional bool EnableDataShardDetailedMetrics = 279 [default = false];
 }

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,6 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardSplitKeySelection)
     FEATURE_FLAG_SETTER(EnableDataShardSplitHistogramOmission)
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
+    FEATURE_FLAG_SETTER(EnableDetailedMetrics)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -88,7 +88,7 @@ public:
     FEATURE_FLAG_SETTER(EnableDataShardSplitKeySelection)
     FEATURE_FLAG_SETTER(EnableDataShardSplitHistogramOmission)
     FEATURE_FLAG_SETTER(EnableCsDictionaryEncoding)
-    FEATURE_FLAG_SETTER(EnableDetailedMetrics)
+    FEATURE_FLAG_SETTER(EnableDataShardDetailedMetrics)
     #undef FEATURE_FLAG_SETTER
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -115,11 +115,11 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
 
     if (copyAlter.HasDetailedMetricsSettings()) {
         // Do not allow changing detailed metrics settings without the feature flag
-        if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+        if (!AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics()) {
             errStr =
                 "The detailed metrics settings are specified in the request, "
                 "but the detailed metrics feature is disabled by the corresponding "
-                "feature flag (EnableDetailedMetrics)";
+                "feature flag (EnableDataShardDetailedMetrics)";
 
             status = NKikimrScheme::StatusInvalidParameter;
             return nullptr;
@@ -193,7 +193,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
         .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
         .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
-        .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
+        .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics(),
     };
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -114,6 +114,17 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
     }
 
     if (copyAlter.HasDetailedMetricsSettings()) {
+        // Do not allow changing detailed metrics settings without the feature flag
+        if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+            errStr =
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)";
+
+            status = NKikimrScheme::StatusInvalidParameter;
+            return nullptr;
+        }
+
         // New detailed metrics settings are specified in the request,
         // make sure the detailed metrics settings are valid (correct metrics level etc)
         if (!ValidateTableDetailedMetricsSettings(
@@ -182,6 +193,7 @@ TTableInfo::TAlterDataPtr ParseParams(const TPath& path, TTableInfo::TPtr table,
         .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
         .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
         .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
+        .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
     };
 
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -756,6 +756,7 @@ public:
             .EnableTablePgTypes = true,
             .EnableTableDatetime64 = true,
             .EnableParameterizedDecimal = true,
+            .EnableDetailedMetrics = true,
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(nullptr, schema, *typeRegistry,
             limits, *domainInfo, featureFlags, errStr, LocalSequences);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -554,12 +554,12 @@ public:
 
         if (schema.HasDetailedMetricsSettings()) {
             // Do not allow changing detailed metrics settings without the feature flag
-            if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+            if (!AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics()) {
                 result->SetError(
                     NKikimrScheme::StatusInvalidParameter,
                     "The detailed metrics settings are specified in the request, "
                     "but the detailed metrics feature is disabled by the corresponding "
-                    "feature flag (EnableDetailedMetrics)"
+                    "feature flag (EnableDataShardDetailedMetrics)"
                 );
 
                 return result;
@@ -635,7 +635,7 @@ public:
             .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
             .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
             .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
-            .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
+            .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics(),
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(
             nullptr,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -553,6 +553,18 @@ public:
         }
 
         if (schema.HasDetailedMetricsSettings()) {
+            // Do not allow changing detailed metrics settings without the feature flag
+            if (!AppData()->FeatureFlags.GetEnableDetailedMetrics()) {
+                result->SetError(
+                    NKikimrScheme::StatusInvalidParameter,
+                    "The detailed metrics settings are specified in the request, "
+                    "but the detailed metrics feature is disabled by the corresponding "
+                    "feature flag (EnableDetailedMetrics)"
+                );
+
+                return result;
+            }
+
             TString errorString;
 
             // Make sure the detailed metrics settings are valid (correct metrics level etc)
@@ -623,6 +635,7 @@ public:
             .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
             .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
             .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),
+            .EnableDetailedMetrics = AppData()->FeatureFlags.GetEnableDetailedMetrics(),
         };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(
             nullptr,

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -673,7 +673,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->MutableTTLSettings()->CopyFrom(ttl);
     }
 
-    if (op.HasDetailedMetricsSettings()) {
+    if (featureFlags.EnableDetailedMetrics && op.HasDetailedMetricsSettings()) {
         switch (op.GetDetailedMetricsSettings().GetStatusCase()) {
         case NKikimrSchemeOp::TTableDetailedMetricsSettings::kConfigured:
             if (op.GetDetailedMetricsSettings().HasConfigured()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1001,6 +1001,7 @@ public:
         bool EnableTablePgTypes;
         bool EnableTableDatetime64;
         bool EnableParameterizedDecimal;
+        bool EnableDetailedMetrics;
     };
 
     static TAlterDataPtr CreateAlterData(

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -56,12 +56,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
      *
-     * @note This test also verifies that the detailed metrics settings are preserved
+     * @note This function also verifies that the detailed metrics settings are preserved
      *       across SchemeShard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevel) {
+    void VerifyCreateTableNoDetailedMetricsLevel(bool enableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         TestCreateTable(
             runtime,
@@ -93,12 +97,38 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(false /* enableDetailedMetrics */);
+    }
+
+    /**
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across SchemeShard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyCreateTableNoDetailedMetricsLevel(true /* enableDetailedMetrics */);
+    }
+
+    /**
      * Verify that CREATE TABLE with the detailed metrics settings explicitly dropped
      * is not allowed and fails with an error.
      */
     Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowed) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -129,6 +159,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         TestCreateTable(
             runtime,
             100,
@@ -152,6 +184,109 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that CREATE TABLE fails correctly, when the given detailed metrics
+     * level (or an explicit "drop") is specified in the request and
+     * the EnableDetailedMetrics feature flag is disabled.
+     *
+     * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
+     */
+    void VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        std::optional<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel> metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            (!metricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "String" }
+                    KeyColumnNames: ["key"]
+                    DetailedMetricsSettings {
+                        NotConfigured {
+                        }
+                    }
+                )"
+                : Sprintf(
+                    R"(
+                        Name: "TestTable"
+                        Columns { Name: "key"   Type: "Uint64" }
+                        Columns { Name: "value" Type: "String" }
+                        KeyColumnNames: ["key"]
+                        DetailedMetricsSettings {
+                            Configured {
+                                MetricsLevel: %s
+                            }
+                        }
+                    )",
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(*metricsLevel).c_str()
+                ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when dropping detailed metrics level
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            {}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level UNSPECIFIED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelUnspecifiedNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level DISABLED
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelDisabledNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level TABLE
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelTableNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, when the detailed metrics level PARTITION
+     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(CreateTableDetailedMetricsLevelPartitionNotAllowedFeatureFlagDisabled) {
+        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
      * Verify that CREATE TABLE works correctly, when the given valid
      * detailed metrics level is specified in the request.
      *
@@ -165,6 +300,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -261,10 +398,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
      *
      * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
+     *
+     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
+    void VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+        bool enableDetailedMetrics
+    ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -310,6 +453,36 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagDisabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            false /* enableDetailedMetrics */
+        );
+    }
+
+    /**
+     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
+     * when applied to a table, which does not have any detailed metrics settings configured.
+     *
+     * @note This test also verifies that the detailed metrics settings are preserved
+     *       across Scheme Shard restarts.
+     *
+     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
+     */
+    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagEnabled) {
+        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
+            true /* enableDetailedMetrics */
+        );
+    }
+
+    /**
      * Verify that ALTER TABLE with the detailed metrics level explicitly removed
      * works correctly.
      *
@@ -322,6 +495,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     void VerifyAlterTableRemoveDetailedMetricsLevel(bool sourceHasMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -401,6 +576,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+
         // First, create a table without any detailed metrics settings
         TestCreateTable(
             runtime,
@@ -453,6 +630,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     ) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -591,6 +770,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     Y_UNIT_TEST(AlterTableSourceWithDetailedMetricsLevelTargetNoDetailedMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
 
         // First, create a table with some detailed metrics settings configured
         TestCreateTable(

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_env.h>
+#include <ydb/library/testlib/helpers.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -54,18 +55,14 @@ void VerifyTableDescriptionAndRestartSchemeShard(
  */
 Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
-     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
-     *
-     * @note This function also verifies that the detailed metrics settings are preserved
-     *       across SchemeShard restarts.
-     *
-     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
+     * Verify that CREATE TABLE without the detailed metrics level specified works correctly
+     * regardless of EnableDetailedMetrics feature flag state.
      */
-    void VerifyCreateTableNoDetailedMetricsLevel(bool enableDetailedMetrics) {
+    Y_UNIT_TEST_TWIN(CreateTableNoDetailedMetricsLevel, EnableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(EnableDetailedMetrics);
 
         TestCreateTable(
             runtime,
@@ -94,30 +91,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
                 },
             }
         );
-    }
-
-    /**
-     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
-     *
-     * @note This test also verifies that the detailed metrics settings are preserved
-     *       across SchemeShard restarts.
-     *
-     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
-     */
-    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagDisabled) {
-        VerifyCreateTableNoDetailedMetricsLevel(false /* enableDetailedMetrics */);
-    }
-
-    /**
-     * Verify that CREATE TABLE without the detailed metrics level specified works correctly.
-     *
-     * @note This test also verifies that the detailed metrics settings are preserved
-     *       across SchemeShard restarts.
-     *
-     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
-     */
-    Y_UNIT_TEST(CreateTableNoDetailedMetricsLevelFeatureFlagEnabled) {
-        VerifyCreateTableNoDetailedMetricsLevel(true /* enableDetailedMetrics */);
     }
 
     /**
@@ -190,7 +163,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
      *
      * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
      */
-    void VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+    void VerifyCreateTableWithDetailedMetricsFlagDisabled(
         std::optional<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel> metricsLevel
     ) {
         TTestBasicRuntime runtime;
@@ -237,51 +210,33 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
-     * Verify that CREATE TABLE fails correctly, when dropping detailed metrics level
-     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
+     * Verify that CREATE TABLE fails correctly, with different detailed metrics levels
+     * and the EnableDetailedMetrics feature flag disabled.
      */
     Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
-        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
-            {}
-        );
+        VerifyCreateTableWithDetailedMetricsFlagDisabled({});
     }
 
-    /**
-     * Verify that CREATE TABLE fails correctly, when the detailed metrics level UNSPECIFIED
-     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
-     */
     Y_UNIT_TEST(CreateTableDetailedMetricsLevelUnspecifiedNotAllowedFeatureFlagDisabled) {
-        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        VerifyCreateTableWithDetailedMetricsFlagDisabled(
             NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
         );
     }
 
-    /**
-     * Verify that CREATE TABLE fails correctly, when the detailed metrics level DISABLED
-     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
-     */
     Y_UNIT_TEST(CreateTableDetailedMetricsLevelDisabledNotAllowedFeatureFlagDisabled) {
-        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        VerifyCreateTableWithDetailedMetricsFlagDisabled(
             NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
         );
     }
 
-    /**
-     * Verify that CREATE TABLE fails correctly, when the detailed metrics level TABLE
-     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
-     */
     Y_UNIT_TEST(CreateTableDetailedMetricsLevelTableNotAllowedFeatureFlagDisabled) {
-        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        VerifyCreateTableWithDetailedMetricsFlagDisabled(
             NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
         );
     }
 
-    /**
-     * Verify that CREATE TABLE fails correctly, when the detailed metrics level PARTITION
-     * is specified in the request and the EnableDetailedMetrics feature flag is disabled.
-     */
     Y_UNIT_TEST(CreateTableDetailedMetricsLevelPartitionNotAllowedFeatureFlagDisabled) {
-        VerifyCreateTableWithDetailedMetricsLevelWithFeatureFlagDisabled(
+        VerifyCreateTableWithDetailedMetricsFlagDisabled(
             NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
         );
     }
@@ -398,16 +353,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
      *
      * @note This test also verifies that the detailed metrics settings are preserved
      *       across Scheme Shard restarts.
-     *
-     * @param[in] enableDetailedMetrics Indicates if the corresponding feature flag is enabled
      */
-    void VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
-        bool enableDetailedMetrics
-    ) {
+    Y_UNIT_TEST_TWIN(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel, EnableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(enableDetailedMetrics);
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(EnableDetailedMetrics);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -449,36 +400,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
                     UNIT_ASSERT(!tableDescription.HasDetailedMetricsSettings());
                 },
             }
-        );
-    }
-
-    /**
-     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
-     * when applied to a table, which does not have any detailed metrics settings configured.
-     *
-     * @note This test also verifies that the detailed metrics settings are preserved
-     *       across Scheme Shard restarts.
-     *
-     * @note This test is for the variation when the EnableDetailedMetrics feature flag is disabled.
-     */
-    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagDisabled) {
-        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
-            false /* enableDetailedMetrics */
-        );
-    }
-
-    /**
-     * Verify that ALTER TABLE without the detailed metrics level specified works correctly,
-     * when applied to a table, which does not have any detailed metrics settings configured.
-     *
-     * @note This test also verifies that the detailed metrics settings are preserved
-     *       across Scheme Shard restarts.
-     *
-     * @note This test is for the variation when the EnableDetailedMetrics feature flag is enabled.
-     */
-    Y_UNIT_TEST(AlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevelFeatureFlagEnabled) {
-        VerifyAlterTableSourceNoDetailedMetricsLevelTargetNoDetailedMetricsLevel(
-            true /* enableDetailedMetrics */
         );
     }
 

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -242,6 +242,101 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     }
 
     /**
+     * Verify that ALTER TABLE fails correctly, when the given detailed metrics
+     * level (or an explicit "drop") is specified in the request and
+     * the EnableDetailedMetrics feature flag is disabled.
+     *
+     * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
+     */
+    void VerifyAlterTableWithDetailedMetricsFlagDisabled(
+        std::optional<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel> metricsLevel
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+
+        // First, create a table without any detailed metrics settings
+        TestCreateTable(
+            runtime,
+            100,
+            "/MyRoot",
+            R"(
+                Name: "TestTable"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "String" }
+                KeyColumnNames: ["key"]
+            )"
+        );
+
+        env.TestWaitNotification(runtime, 100);
+
+        // Second, execute ALTER TABLE with the detailed metrics settings explicitly specified
+        TestAlterTable(
+            runtime,
+            101,
+            "/MyRoot",
+            (!metricsLevel)
+                ? R"(
+                    Name: "TestTable"
+                    DetailedMetricsSettings {
+                        NotConfigured {
+                        }
+                    }
+                )"
+                : Sprintf(
+                    R"(
+                        Name: "TestTable"
+                        DetailedMetricsSettings {
+                            Configured {
+                                MetricsLevel: %s
+                            }
+                        }
+                    )",
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(*metricsLevel).c_str()
+                ),
+            {{
+                NKikimrScheme::StatusInvalidParameter,
+                "The detailed metrics settings are specified in the request, "
+                "but the detailed metrics feature is disabled by the corresponding "
+                "feature flag (EnableDetailedMetrics)",
+            }}
+        );
+    }
+
+    /**
+     * Verify that CREATE TABLE fails correctly, with different detailed metrics levels
+     * and the EnableDetailedMetrics feature flag disabled.
+     */
+    Y_UNIT_TEST(AlterTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
+        VerifyAlterTableWithDetailedMetricsFlagDisabled({});
+    }
+
+    Y_UNIT_TEST(AlterTableDetailedMetricsLevelUnspecifiedNotAllowedFeatureFlagDisabled) {
+        VerifyAlterTableWithDetailedMetricsFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    Y_UNIT_TEST(AlterTableDetailedMetricsLevelDisabledNotAllowedFeatureFlagDisabled) {
+        VerifyAlterTableWithDetailedMetricsFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    Y_UNIT_TEST(AlterTableDetailedMetricsLevelTableNotAllowedFeatureFlagDisabled) {
+        VerifyAlterTableWithDetailedMetricsFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    Y_UNIT_TEST(AlterTableDetailedMetricsLevelPartitionNotAllowedFeatureFlagDisabled) {
+        VerifyAlterTableWithDetailedMetricsFlagDisabled(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    /**
      * Verify that CREATE TABLE works correctly, when the given valid
      * detailed metrics level is specified in the request.
      *

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -56,13 +56,13 @@ void VerifyTableDescriptionAndRestartSchemeShard(
 Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that CREATE TABLE without the detailed metrics level specified works correctly
-     * regardless of EnableDetailedMetrics feature flag state.
+     * regardless of EnableDataShardDetailedMetrics feature flag state.
      */
     Y_UNIT_TEST_TWIN(CreateTableNoDetailedMetricsLevel, EnableDetailedMetrics) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(EnableDetailedMetrics);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(EnableDetailedMetrics);
 
         TestCreateTable(
             runtime,
@@ -101,7 +101,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -159,7 +159,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that CREATE TABLE fails correctly, when the given detailed metrics
      * level (or an explicit "drop") is specified in the request and
-     * the EnableDetailedMetrics feature flag is disabled.
+     * the EnableDataShardDetailedMetrics feature flag is disabled.
      *
      * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
      */
@@ -169,7 +169,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(false);
 
         TestCreateTable(
             runtime,
@@ -204,14 +204,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
                 NKikimrScheme::StatusInvalidParameter,
                 "The detailed metrics settings are specified in the request, "
                 "but the detailed metrics feature is disabled by the corresponding "
-                "feature flag (EnableDetailedMetrics)",
+                "feature flag (EnableDataShardDetailedMetrics)",
             }}
         );
     }
 
     /**
      * Verify that CREATE TABLE fails correctly, with different detailed metrics levels
-     * and the EnableDetailedMetrics feature flag disabled.
+     * and the EnableDataShardDetailedMetrics feature flag disabled.
      */
     Y_UNIT_TEST(CreateTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
         VerifyCreateTableWithDetailedMetricsFlagDisabled({});
@@ -244,7 +244,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
     /**
      * Verify that ALTER TABLE fails correctly, when the given detailed metrics
      * level (or an explicit "drop") is specified in the request and
-     * the EnableDetailedMetrics feature flag is disabled.
+     * the EnableDataShardDetailedMetrics feature flag is disabled.
      *
      * @param[in] metricsLevel The detailed metrics level to verify (unset == use drop)
      */
@@ -254,7 +254,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(false);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(false);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -299,14 +299,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
                 NKikimrScheme::StatusInvalidParameter,
                 "The detailed metrics settings are specified in the request, "
                 "but the detailed metrics feature is disabled by the corresponding "
-                "feature flag (EnableDetailedMetrics)",
+                "feature flag (EnableDataShardDetailedMetrics)",
             }}
         );
     }
 
     /**
      * Verify that CREATE TABLE fails correctly, with different detailed metrics levels
-     * and the EnableDetailedMetrics feature flag disabled.
+     * and the EnableDataShardDetailedMetrics feature flag disabled.
      */
     Y_UNIT_TEST(AlterTableDroppingDetailedMetricsSettingsNotAllowedFeatureFlagDisabled) {
         VerifyAlterTableWithDetailedMetricsFlagDisabled({});
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         TestCreateTable(
             runtime,
@@ -453,7 +453,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(EnableDetailedMetrics);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(EnableDetailedMetrics);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -512,7 +512,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -592,7 +592,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         // First, create a table without any detailed metrics settings
         TestCreateTable(
@@ -647,7 +647,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         // First, create a table with or without detailed metrics settings configured
         TestCreateTable(
@@ -787,7 +787,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
 
-        runtime.GetAppData().FeatureFlags.SetEnableDetailedMetrics(true);
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
 
         // First, create a table with some detailed metrics settings configured
         TestCreateTable(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

EnableDataShardDetailedMetrics feature flag and its basic handling in scheme shard.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

* Introducing EnableDataShardDetailedMetrics feature flag;
* Additional Scheme shard checks for a EnableDataShardDetailedMetrics feature flag if detailed metrics related setting are present in create/alter table requests;
* Unit test for scheme shard EnableDataShardDetailedMetrics flag handling. 

This is a part of https://github.com/ydb-platform/ydb/pull/38596 regarding introduction of EnableDataShardDetailedMetrics feature flag and related scheme shard handling.
Posted as a separate PR to reduce original PR size, reduce possibility of merge conflicts and cut off review dependency on schemeshard, since main feature of node detailed metrics aggregator is not scheme shard dependent.