### PR TITLE
SchemeShard: fix UAF in TryEnqueueOneShard after reentrant compaction

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -226,6 +226,7 @@ void TSchemeShard::TryEnqueueOneShard(
         --ForcedCompactionTotalInQueues;
         compaction.ShardsInFlight.insert(shardIdx);
         EnqueueForcedCompaction(shardIdx);
+        shards = ForcedCompactionShardsByTable.FindPtr(tablePathId);
     }
     if (!shards || shards->Empty()) {
         if (tablesWithoutCandidates) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Re-fetch ForcedCompactionShardsByTable entry after EnqueueForcedCompaction.
That call can synchronously complete a dropped-table shard and erase the queue in TTxProgress, leaving a stale FindPtr from before the enqueue.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TSchemeshardForcedCompactionTest.SchemeshardShouldHandleTableDropDuringCompaction.err:

```
==324536==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c5e3f98a960 at pc 0x00002c9e7552 bp 0x7ffc745b4d80 sp 0x7ffc745b4d78
READ of size 8 at 0x7c5e3f98a960 thread T0
    #0 0x00002c9e7551 in size /-S/util/generic/hash_table.h:614:16
    #1 0x00002c9e7551 in empty /-S/util/generic/hash_table.h:621:16
    #2 0x00002c9e7551 in empty /-S/util/generic/hash_set.h:129:20
    #3 0x00002c9e7551 in Empty /-S/ydb/core/util/circular_queue.h:127:22
    #4 0x00002c9e7551 in NKikimr::NSchemeShard::TSchemeShard::TryEnqueueOneShard(NKikimr::TPathId const&, NKikimr::NSchemeShard::TForcedCompactionInfo&, THashSet<NKikimr::TPathId, THash<NKikimr::TPathId>, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>*) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:230:28
    #5 0x00002c9e651b in NKikimr::NSchemeShard::TSchemeShard::ProcessForcedCompactionQueues() /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:201:9
    #6 0x00002c9e5e48 in NKikimr::NSchemeShard::TSchemeShard::CompleteForcedCompactionForShard(NKikimr::NSchemeShard::TShardIdx const&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:160:5
    #7 0x00002c9ee235 in NKikimr::NSchemeShard::TSchemeShard::OnForcedCompactionTimeout(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:457:9
    #8 0x00002b8abdad in NKikimr::NOperationQueue::TOperationQueue<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>::CheckTimeoutOperations() /-S/ydb/core/util/operation_queue.h:570:21
    #9 0x00002b8aade3 in NKikimr::NOperationQueue::TOperationQueue<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>::StartOperations() /-S/ydb/core/util/operation_queue.h:597:5
    #10 0x00002b8b1a09 in Wakeup /-S/ydb/core/util/operation_queue.h:536:5
    #11 0x00002b8b1a09 in NKikimr::NOperationQueue::TOperationQueueWithTimer<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>, 2146435109, 296, 681u>::HandleWakeup(NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/operation_queue_timer.h:95:16
    #12 0x00002b8b039e in NKikimr::NOperationQueue::TOperationQueueWithTimer<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>, 2146435109, 296, 681u>::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tx/schemeshard/operation_queue_timer.h:100:13
    #13 0x000019328e87 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:350:17
    #14 0x0000369acc37 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #15 0x0000369a5252 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #16 0x0000369af853 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #17 0x0000369d3163 in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NActors::TEvents::TEvWakeup>(TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, std::__y1::function<bool (NActors::TEvents::TEvWakeup::TPtr const&)> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:506:13
    #18 0x0000369d24df in GrabEdgeEvent<NActors::TEvents::TEvWakeup> /-S/ydb/library/actors/testlib/test_runtime.h:555:20
    #19 0x0000369d24df in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEvent<NActors::TEvents::TEvWakeup>(NActors::TActorId const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:561:20
    #20 0x0000369b6062 in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEventRethrow<NActors::TEvents::TEvWakeup>(NActors::TActorId const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:606:24
    #21 0x00003b525c4d in NSchemeShardUT_Private::TTestEnv::SimulateSleep(NActors::TTestActorRuntime&, TDuration) /-S/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp:1042:13
    #22 0x000017a3e2ad in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseSchemeshardShouldHandleTableDropDuringCompaction::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2841:17
    #23 0x000017aa21c7 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #24 0x000017aa21c7 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #25 0x000017aa21c7 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #26 0x000017aa21c7 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #27 0x000017aa21c7 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:167:12
    #28 0x000017aa21c7 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:319:10
    #29 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:436:12
    #30 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:995:10
    #31 0x00001837da29 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #32 0x000018356517 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #33 0x000017aa14dc in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #34 0x000018357ccf in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #35 0x000018377b3c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:895:44
    #36 0x7fee40636d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #37 0x7fee40636e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #38 0x000015724028 in _start (/home/runner/.ya/build/build_root/iydy/00539b/ydb/core/tx/schemeshard/ut_compaction/ydb-core-tx-schemeshard-ut_compaction+0x15724028) (BuildId: 6c16de6dd8922805f04fc4d28fbada701863a6d9)
0x7c5e3f98a960 is located 64 bytes inside of 72-byte region [0x7c5e3f98a920,0x7c5e3f98a968)
freed by thread T0 here:
    #0 0x000017b952a2 in operator delete(void*, unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x00002c9f4b0c in __libcpp_operator_delete<__yhashtable_node<std::__y1::pair<const NKikimr::TPathId, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx> > > *, unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:46:3
    #2 0x00002c9f4b0c in __libcpp_deallocate<__yhashtable_node<std::__y1::pair<const NKikimr::TPathId, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx> > > > /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:86:12
    #3 0x00002c9f4b0c in deallocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:120:7
    #4 0x00002c9f4b0c in put_node /-S/util/generic/hash_table.h:502:28
    #5 0x00002c9f4b0c in delete_node /-S/util/generic/hash_table.h:961:9
    #6 0x00002c9f4b0c in erase_one<NKikimr::TPathId> /-S/util/generic/hash_table.h
    #7 0x00002c9f4b0c in erase<NKikimr::TPathId> /-S/util/generic/hash.h:294:20
    #8 0x00002c9f4b0c in NKikimr::NSchemeShard::TSchemeShard::TForcedCompaction::TTxProgress::DoExecute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp:53:57
    #9 0x00002b6f5c58 in NKikimr::NSchemeShard::TSchemeShard::TRwTxBase::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_impl.cpp:1880:9
    #10 0x00001dd242b0 in NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(NKikimr::NTabletFlatExecutor::TSeat*) /-S/ydb/core/tablet_flat/flat_executor.cpp:2041:35
    #11 0x00001dd1e60a in NKikimr::NTabletFlatExecutor::TExecutor::DoExecute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NKikimr::NTabletFlatExecutor::TExecutor::ETxMode) /-S/ydb/core/tablet_flat/flat_executor.cpp:1955:13
    #12 0x00001dd26fb5 in Execute /-S/ydb/core/tablet_flat/flat_executor.cpp:1969:5
    #13 0x00001dd26fb5 in non-virtual thunk to NKikimr::NTabletFlatExecutor::TExecutor::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/flat_executor.cpp
    #14 0x00001dcb86bb in NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>) /-S/ydb/core/tablet_flat/tablet_flat_executed.cpp:62:21
    #15 0x00002c9e5e06 in NKikimr::NSchemeShard::TSchemeShard::CompleteForcedCompactionForShard(NKikimr::NSchemeShard::TShardIdx const&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:158:9
    #16 0x00002c9e915c in NKikimr::NSchemeShard::TSchemeShard::StartForcedCompaction(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:275:9
    #17 0x00002b8ab2c7 in NKikimr::NOperationQueue::TOperationQueue<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>::StartOperations() /-S/ydb/core/util/operation_queue.h:613:31
    #18 0x00002c9e7a91 in Enqueue /-S/ydb/core/util/operation_queue.h:455:9
    #19 0x00002c9e7a91 in NKikimr::NSchemeShard::TSchemeShard::EnqueueForcedCompaction(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:442:32
    #20 0x00002c9e7286 in NKikimr::NSchemeShard::TSchemeShard::TryEnqueueOneShard(NKikimr::TPathId const&, NKikimr::NSchemeShard::TForcedCompactionInfo&, THashSet<NKikimr::TPathId, THash<NKikimr::TPathId>, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>*) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:228:9
    #21 0x00002c9e651b in NKikimr::NSchemeShard::TSchemeShard::ProcessForcedCompactionQueues() /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:201:9
    #22 0x00002c9e5e48 in NKikimr::NSchemeShard::TSchemeShard::CompleteForcedCompactionForShard(NKikimr::NSchemeShard::TShardIdx const&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:160:5
    #23 0x00002c9ee235 in NKikimr::NSchemeShard::TSchemeShard::OnForcedCompactionTimeout(NKikimr::NSchemeShard::TShardIdx const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:457:9
    #24 0x00002b8abdad in NKikimr::NOperationQueue::TOperationQueue<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>::CheckTimeoutOperations() /-S/ydb/core/util/operation_queue.h:570:21
    #25 0x00002b8aade3 in NKikimr::NOperationQueue::TOperationQueue<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>::StartOperations() /-S/ydb/core/util/operation_queue.h:597:5
    #26 0x00002b8b1a09 in Wakeup /-S/ydb/core/util/operation_queue.h:536:5
    #27 0x00002b8b1a09 in NKikimr::NOperationQueue::TOperationQueueWithTimer<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>, 2146435109, 296, 681u>::HandleWakeup(NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/operation_queue_timer.h:95:16
    #28 0x00002b8b039e in NKikimr::NOperationQueue::TOperationQueueWithTimer<NKikimr::NSchemeShard::TShardIdx, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>, 2146435109, 296, 681u>::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tx/schemeshard/operation_queue_timer.h:100:13
    #29 0x000019328e87 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:350:17
    #30 0x0000369acc37 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #31 0x0000369a5252 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #32 0x0000369af853 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #33 0x0000369d3163 in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NActors::TEvents::TEvWakeup>(TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, std::__y1::function<bool (NActors::TEvents::TEvWakeup::TPtr const&)> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:506:13
    #34 0x0000369d24df in GrabEdgeEvent<NActors::TEvents::TEvWakeup> /-S/ydb/library/actors/testlib/test_runtime.h:555:20
    #35 0x0000369d24df in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEvent<NActors::TEvents::TEvWakeup>(NActors::TActorId const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:561:20
    #36 0x0000369b6062 in NActors::TEvents::TEvWakeup::TPtr NActors::TTestActorRuntimeBase::GrabEdgeEventRethrow<NActors::TEvents::TEvWakeup>(NActors::TActorId const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:606:24
    #37 0x00003b525c4d in NSchemeShardUT_Private::TTestEnv::SimulateSleep(NActors::TTestActorRuntime&, TDuration) /-S/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp:1042:13
    #38 0x000017a3e2ad in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseSchemeshardShouldHandleTableDropDuringCompaction::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2841:17
    #39 0x000017aa21c7 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #40 0x000017aa21c7 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #41 0x000017aa21c7 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #42 0x000017aa21c7 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #43 0x000017aa21c7 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:167:12
    #44 0x000017aa21c7 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:319:10
    #45 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:436:12
    #46 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:995:10
    #47 0x00001837da29 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
previously allocated by thread T0 here:
    #0 0x000017b9463d in operator new(unsigned long) /-S/contrib/libs/clang20-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x00002c9f076e in __libcpp_operator_new<unsigned long> /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:37:10
    #2 0x00002c9f076e in __libcpp_allocate<__yhashtable_node<std::__y1::pair<const NKikimr::TPathId, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx> > > > /-S/contrib/libs/cxxsupp/libcxx/include/__new/allocate.h:64:28
    #3 0x00002c9f076e in allocate /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:105:14
    #4 0x00002c9f076e in get_node /-S/util/generic/hash_table.h:497:43
    #5 0x00002c9f076e in new_node<const std::__y1::piecewise_construct_t &, std::__y1::tuple<const NKikimr::TPathId &>, std::__y1::tuple<> > /-S/util/generic/hash_table.h:947:19
    #6 0x00002c9f076e in __yhashtable_iterator<std::__y1::pair<NKikimr::TPathId const, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>> THashTable<std::__y1::pair<NKikimr::TPathId const, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>, NKikimr::TPathId, THash<NKikimr::TPathId>, TSelect1st, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>::emplace_direct<std::__y1::piecewise_construct_t const&, std::__y1::tuple<NKikimr::TPathId const&>, std::__y1::tuple<>>(__yhashtable_node<std::__y1::pair<NKikimr::TPathId const, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>>>**, std::__y1::piecewise_construct_t const&, std::__y1::tuple<NKikimr::TPathId const&>&&, std::__y1::tuple<>&&) /-S/util/generic/hash_table.h:697:21
    #7 0x00002c9e29ef in NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>& THashMap<NKikimr::TPathId, NKikimr::TFifoQueue<NKikimr::NSchemeShard::TShardIdx>, THash<NKikimr::TPathId>, TEqualTo<NKikimr::TPathId>, std::__y1::allocator<NKikimr::TPathId>>::operator[]<NKikimr::TPathId>(NKikimr::TPathId const&) /-S/util/generic/hash.h:250:20
    #8 0x00002c9e2781 in NKikimr::NSchemeShard::TSchemeShard::AddForcedCompactionShard(NKikimr::NSchemeShard::TShardIdx const&, NKikimr::TPathId const&, TIntrusivePtr<NKikimr::NSchemeShard::TForcedCompactionInfo, TDefaultIntrusivePtrOps<NKikimr::NSchemeShard::TForcedCompactionInfo>> const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:29:9
    #9 0x00002c9fc1f7 in NKikimr::NSchemeShard::TSchemeShard::TForcedCompaction::TTxCreate::DoExecute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp:158:19
    #10 0x00002b6f5c58 in NKikimr::NSchemeShard::TSchemeShard::TRwTxBase::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_impl.cpp:1880:9
    #11 0x00001dd242b0 in NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(NKikimr::NTabletFlatExecutor::TSeat*) /-S/ydb/core/tablet_flat/flat_executor.cpp:2041:35
    #12 0x00001dd1e60a in NKikimr::NTabletFlatExecutor::TExecutor::DoExecute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NKikimr::NTabletFlatExecutor::TExecutor::ETxMode) /-S/ydb/core/tablet_flat/flat_executor.cpp:1955:13
    #13 0x00001dd26fb5 in Execute /-S/ydb/core/tablet_flat/flat_executor.cpp:1969:5
    #14 0x00001dd26fb5 in non-virtual thunk to NKikimr::NTabletFlatExecutor::TExecutor::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/flat_executor.cpp
    #15 0x00001dcb8331 in Execute /-S/ydb/core/tablet_flat/tablet_flat_executed.cpp:62:21
    #16 0x00001dcb8331 in NKikimr::NTabletFlatExecutor::TTabletExecutedFlat::Execute(TAutoPtr<NKikimr::NTabletFlatExecutor::ITransaction, TDelete>, NActors::TActorContext const&) /-S/ydb/core/tablet_flat/tablet_flat_executed.cpp:57:5
    #17 0x00002c9e80f7 in NKikimr::NSchemeShard::TSchemeShard::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateRequest>, TDelete>&, NActors::TActorContext const&) /-S/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp:247:5
    #18 0x00002b6c406c in NKikimr::NSchemeShard::TSchemeShard::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/tx/schemeshard/schemeshard_impl.cpp:5495:9
    #19 0x000019328e87 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/library/actors/core/actor.cpp:350:17
    #20 0x0000369acc37 in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/ydb/library/actors/testlib/test_runtime.cpp:1723:33
    #21 0x0000369a5252 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/ydb/library/actors/testlib/test_runtime.cpp:1312:45
    #22 0x0000369af853 in NActors::TTestActorRuntimeBase::WaitForEdgeEvents(std::__y1::function<bool (NActors::TTestActorRuntimeBase&, TAutoPtr<NActors::IEventHandle, TDelete>&)>, TSet<NActors::TActorId, TLess<NActors::TActorId>, std::__y1::allocator<NActors::TActorId>> const&, TDuration) /-S/ydb/library/actors/testlib/test_runtime.cpp:1571:22
    #23 0x00003b339afc in NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse* NActors::TTestActorRuntimeBase::GrabEdgeEventIf<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse>(TAutoPtr<NActors::IEventHandle, TDelete>&, std::__y1::function<bool (NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse const&)>, TDuration) /-S/ydb/library/actors/testlib/test_runtime.h:475:13
    #24 0x00003b2bf09b in GrabEdgeEvent<NKikimr::NSchemeShard::TEvForcedCompaction::TEvCreateResponse> /-S/ydb/library/actors/testlib/test_runtime.h:539:20
    #25 0x00003b2bf09b in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2335:27
    #26 0x00003b2c03f8 in NSchemeShardUT_Private::TestCompact(NActors::TTestActorRuntime&, unsigned long, TBasicString<char, std::__y1::char_traits<char>> const&, TBasicString<char, std::__y1::char_traits<char>> const&, bool, unsigned int, Ydb::StatusIds_StatusCode) /-S/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp:2340:9
    #27 0x000017a3ccbc in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TTestCaseSchemeshardShouldHandleTableDropDuringCompaction::Execute_(NUnitTest::TTestContext&) /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:2827:13
    #28 0x000017aa21c7 in operator() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #29 0x000017aa21c7 in __invoke<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:179:25
    #30 0x000017aa21c7 in __call<(lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:251:5
    #31 0x000017aa21c7 in __invoke_r<void, (lambda at /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:273:10
    #32 0x000017aa21c7 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:167:12
    #33 0x000017aa21c7 in std::__y1::__function::__func<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:319:10
    #34 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:436:12
    #35 0x00001837da29 in operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:995:10
    #36 0x00001837da29 in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:527:20
    #37 0x000018356517 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:378:18
    #38 0x000017aa14dc in NKikimr::NSchemeShard::NTestSuiteTSchemeshardForcedCompactionTest::TCurrentTest::Execute() /-S/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp:1846:1
    #39 0x000018357ccf in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:499:19
    #40 0x000018377b3c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:895:44
    #41 0x7fee40636d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
SUMMARY: AddressSanitizer: heap-use-after-free /-S/util/generic/hash_table.h:614:16 in size
Shadow bytes around the buggy address:
  0x7c5e3f98a680: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fd fd
  0x7c5e3f98a700: fd fd fd fd fd fd fd fa fa fa fa fa fd fd fd fd
  0x7c5e3f98a780: fd fd fd fd fd fd fa fa fa fa 00 00 00 00 00 00
  0x7c5e3f98a800: 00 00 00 fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c5e3f98a880: fd fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
=>0x7c5e3f98a900: fa fa fa fa fd fd fd fd fd fd fd fd[fd]fa fa fa
  0x7c5e3f98a980: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x7c5e3f98aa00: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
  0x7c5e3f98aa80: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x7c5e3f98ab00: fd fd fd fd fd fd fa fa fa fa fd fd fd fd fd fd
  0x7c5e3f98ab80: fd fd fd fa fa fa fa fa 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==324536==ABORTING
```
