### PR TITLE
Filter Grafana support links by live signals

### DIFF
--- a/ydb/mvp/meta/support_links/grafana_dashboard_probe.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_probe.h
@@ -1,0 +1,914 @@
+#pragma once
+
+#include "grafana_dashboard_common.h"
+
+#include <library/cpp/json/json_reader.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/map.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+#include <util/string/strip.h>
+
+#include <limits>
+
+namespace NMVP::NSupportLinks {
+
+struct TGrafanaDashboardCandidate {
+    TString Title;
+    TString ResolvedUrl;
+    TString DashboardApiUrl;
+    TCgiParameters QueryParameters;
+};
+
+struct TGrafanaProbeGroup {
+    TString DatasourceUid;
+    TString Query;
+    TVector<TString> Buckets;
+};
+
+namespace NGrafanaDashboardProbeDetails {
+
+enum class EExpressionOrigin {
+    VariableQuery,
+    PanelExpr,
+};
+
+struct TExpressionCandidate {
+    TString Expression;
+    TString DatasourceRef;
+    EExpressionOrigin Origin = EExpressionOrigin::VariableQuery;
+};
+
+struct TLabelMatcher {
+    TString Name;
+    TString Op;
+    TString Value;
+};
+
+struct TPromSelector {
+    TString Metric;
+    TVector<TLabelMatcher> Matchers;
+};
+
+struct TBucketProbe {
+    TString Selector;
+    int Score = std::numeric_limits<int>::min();
+};
+
+inline bool IsIdentifierChar(char ch) {
+    return (ch >= 'a' && ch <= 'z')
+        || (ch >= 'A' && ch <= 'Z')
+        || (ch >= '0' && ch <= '9')
+        || ch == '_'
+        || ch == ':';
+}
+
+inline bool IsSpace(char ch) {
+    return ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t';
+}
+
+inline void SkipSpaces(TStringBuf text, size_t& pos) {
+    while (pos < text.size() && IsSpace(text[pos])) {
+        ++pos;
+    }
+}
+
+inline TString GetJsonStringField(const NJson::TJsonValue& value, TStringBuf key) {
+    if (!value.Has(TString(key))) {
+        return {};
+    }
+    const auto& field = value[TString(key)];
+    return field.GetType() == NJson::JSON_STRING
+        ? field.GetString()
+        : TString();
+}
+
+inline TString GetDatasourceReference(const NJson::TJsonValue& value) {
+    if (value.GetType() == NJson::JSON_STRING) {
+        return value.GetString();
+    }
+    if (value.GetType() != NJson::JSON_MAP) {
+        return {};
+    }
+    TString uid = GetJsonStringField(value, "uid");
+    if (!uid.empty()) {
+        return uid;
+    }
+    return GetJsonStringField(value, "name");
+}
+
+inline TString GetVariableQueryText(const NJson::TJsonValue& value) {
+    if (value.GetType() == NJson::JSON_STRING) {
+        return value.GetString();
+    }
+    if (value.GetType() == NJson::JSON_MAP) {
+        TString query = GetJsonStringField(value, "query");
+        if (!query.empty()) {
+            return query;
+        }
+    }
+    return {};
+}
+
+inline TString EscapePromLabelValue(TStringBuf value) {
+    TStringBuilder builder;
+    for (char ch : value) {
+        if (ch == '\\' || ch == '"') {
+            builder << '\\';
+        }
+        builder << ch;
+    }
+    return builder;
+}
+
+inline TString BuildSelectorText(const TPromSelector& selector) {
+    TStringBuilder builder;
+    builder << selector.Metric << '{';
+    bool first = true;
+    for (const auto& matcher : selector.Matchers) {
+        if (!first) {
+            builder << ',';
+        }
+        first = false;
+        builder
+            << matcher.Name
+            << matcher.Op
+            << '"'
+            << EscapePromLabelValue(matcher.Value)
+            << '"';
+    }
+    builder << '}';
+    return builder;
+}
+
+inline TString BuildSignalProbeQuery(TStringBuf selector) {
+    return TStringBuilder()
+        << "count(count_over_time(" << selector << "[1m])) or on() vector(0)";
+}
+
+inline bool TryGetGrafanaVariableValue(
+    const TCgiParameters& queryParameters,
+    TStringBuf variableName,
+    TString& value)
+{
+    const TString key = TStringBuilder() << "var-" << variableName;
+    if (!queryParameters.Has(key)) {
+        return false;
+    }
+    value = queryParameters.Get(key);
+    return true;
+}
+
+inline bool ResolveTemplateString(
+    TStringBuf rawValue,
+    const TCgiParameters& queryParameters,
+    TString& resolvedValue,
+    bool& hasAllValue)
+{
+    resolvedValue.clear();
+    hasAllValue = false;
+
+    for (size_t pos = 0; pos < rawValue.size();) {
+        if (rawValue[pos] != '$') {
+            resolvedValue.push_back(rawValue[pos]);
+            ++pos;
+            continue;
+        }
+
+        TString variableName;
+        size_t nextPos = pos;
+        if (pos + 1 < rawValue.size() && rawValue[pos + 1] == '{') {
+            const size_t endPos = rawValue.find('}', pos + 2);
+            if (endPos == TStringBuf::npos) {
+                return false;
+            }
+            TStringBuf variableSpec = rawValue.SubStr(pos + 2, endPos - pos - 2);
+            variableName = TString(variableSpec.Before(':'));
+            nextPos = endPos + 1;
+        } else {
+            size_t endPos = pos + 1;
+            while (endPos < rawValue.size() && (IsIdentifierChar(rawValue[endPos]) || rawValue[endPos] == '-')) {
+                ++endPos;
+            }
+            if (endPos == pos + 1) {
+                resolvedValue.push_back(rawValue[pos]);
+                ++pos;
+                continue;
+            }
+            variableName = TString(rawValue.SubStr(pos + 1, endPos - pos - 1));
+            nextPos = endPos;
+        }
+
+        TString variableValue;
+        if (!TryGetGrafanaVariableValue(queryParameters, variableName, variableValue)) {
+            return false;
+        }
+        if (variableValue == "$__all" || variableValue == "__all") {
+            hasAllValue = true;
+        }
+        resolvedValue += variableValue;
+        pos = nextPos;
+    }
+
+    return true;
+}
+
+inline bool ParseQuotedValue(TStringBuf text, size_t& pos, TString& value) {
+    if (pos >= text.size() || text[pos] != '"') {
+        return false;
+    }
+
+    ++pos;
+    value.clear();
+    bool escaped = false;
+    while (pos < text.size()) {
+        const char ch = text[pos++];
+        if (escaped) {
+            value.push_back(ch);
+            escaped = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (ch == '"') {
+            return true;
+        }
+        value.push_back(ch);
+    }
+
+    return false;
+}
+
+inline bool TryParseSelector(TStringBuf selectorText, TPromSelector& selector) {
+    const size_t openBracePos = selectorText.find('{');
+    const size_t closeBracePos = selectorText.rfind('}');
+    if (openBracePos == TStringBuf::npos || closeBracePos == TStringBuf::npos || closeBracePos < openBracePos) {
+        return false;
+    }
+
+    selector.Metric = StripString(TString(selectorText.SubStr(0, openBracePos)));
+    selector.Matchers.clear();
+
+    const TStringBuf matchersText = selectorText.SubStr(openBracePos + 1, closeBracePos - openBracePos - 1);
+    size_t pos = 0;
+    while (pos < matchersText.size()) {
+        SkipSpaces(matchersText, pos);
+        if (pos == matchersText.size()) {
+            break;
+        }
+        if (matchersText[pos] == ',') {
+            ++pos;
+            continue;
+        }
+
+        const size_t nameStart = pos;
+        while (pos < matchersText.size() && IsIdentifierChar(matchersText[pos])) {
+            ++pos;
+        }
+        if (pos == nameStart) {
+            return false;
+        }
+
+        TLabelMatcher matcher;
+        matcher.Name = TString(matchersText.SubStr(nameStart, pos - nameStart));
+        SkipSpaces(matchersText, pos);
+        if (pos >= matchersText.size()) {
+            return false;
+        }
+
+        if (matchersText[pos] == '=' && pos + 1 < matchersText.size() && matchersText[pos + 1] == '~') {
+            matcher.Op = "=~";
+            pos += 2;
+        } else if (matchersText[pos] == '!' && pos + 1 < matchersText.size() && matchersText[pos + 1] == '=') {
+            matcher.Op = "!=";
+            pos += 2;
+        } else if (matchersText[pos] == '!' && pos + 1 < matchersText.size() && matchersText[pos + 1] == '~') {
+            matcher.Op = "!~";
+            pos += 2;
+        } else if (matchersText[pos] == '=') {
+            matcher.Op = "=";
+            ++pos;
+        } else {
+            return false;
+        }
+
+        SkipSpaces(matchersText, pos);
+        if (!ParseQuotedValue(matchersText, pos, matcher.Value)) {
+            return false;
+        }
+
+        selector.Matchers.push_back(std::move(matcher));
+        SkipSpaces(matchersText, pos);
+        if (pos < matchersText.size() && matchersText[pos] == ',') {
+            ++pos;
+        }
+    }
+
+    return true;
+}
+
+inline size_t FindSelectorEnd(TStringBuf expression, size_t openBracePos) {
+    bool insideString = false;
+    bool escaped = false;
+
+    for (size_t pos = openBracePos + 1; pos < expression.size(); ++pos) {
+        const char ch = expression[pos];
+        if (insideString) {
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (ch == '"') {
+                insideString = false;
+            }
+            continue;
+        }
+        if (ch == '"') {
+            insideString = true;
+            continue;
+        }
+        if (ch == '}') {
+            return pos;
+        }
+    }
+
+    return TStringBuf::npos;
+}
+
+inline TVector<TString> ExtractSelectors(TStringBuf expression) {
+    TVector<TString> selectors;
+    bool insideString = false;
+    bool escaped = false;
+
+    for (size_t pos = 0; pos < expression.size(); ++pos) {
+        const char ch = expression[pos];
+        if (insideString) {
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (ch == '"') {
+                insideString = false;
+            }
+            continue;
+        }
+        if (ch == '"') {
+            insideString = true;
+            continue;
+        }
+        if (ch != '{') {
+            continue;
+        }
+
+        const size_t selectorEnd = FindSelectorEnd(expression, pos);
+        if (selectorEnd == TStringBuf::npos) {
+            break;
+        }
+
+        size_t selectorStart = pos;
+        while (selectorStart > 0 && IsIdentifierChar(expression[selectorStart - 1])) {
+            --selectorStart;
+        }
+
+        TString selector(expression.SubStr(selectorStart, selectorEnd - selectorStart + 1));
+        if (selector.Contains("__bucket__")) {
+            selectors.push_back(std::move(selector));
+        }
+        pos = selectorEnd;
+    }
+
+    return selectors;
+}
+
+inline bool HasNonTenantMatcher(const TPromSelector& selector) {
+    for (const auto& matcher : selector.Matchers) {
+        if (matcher.Name != "__workspace__" && matcher.Name != "__bucket__") {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool ContainsRegexMeta(TStringBuf value) {
+    for (char ch : value) {
+        if (ch == '\\'
+            || ch == '.'
+            || ch == '*'
+            || ch == '+'
+            || ch == '?'
+            || ch == '['
+            || ch == ']'
+            || ch == '('
+            || ch == ')'
+            || ch == '{'
+            || ch == '}')
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool TrySplitAlternatives(TStringBuf value, TVector<TString>& values) {
+    values.clear();
+    if (value.empty() || ContainsRegexMeta(value)) {
+        return false;
+    }
+
+    for (TStringBuf token = value.NextTok('|'); !token.empty(); token = value.NextTok('|')) {
+        values.push_back(TString(token));
+    }
+
+    return !values.empty();
+}
+
+inline bool TryResolveTenantValues(
+    TStringBuf op,
+    TStringBuf value,
+    TVector<TString>& values)
+{
+    values.clear();
+    if (value.empty() || value == ".*") {
+        return false;
+    }
+
+    if (op == "=") {
+        values.push_back(TString(value));
+        return true;
+    }
+
+    if (op == "=~") {
+        return TrySplitAlternatives(value, values);
+    }
+
+    return false;
+}
+
+inline int ScoreSelector(const TPromSelector& selector, EExpressionOrigin origin) {
+    int score = origin == EExpressionOrigin::PanelExpr ? 20 : 10;
+    if (!selector.Metric.empty()) {
+        score += 10;
+    }
+    for (const auto& matcher : selector.Matchers) {
+        if (matcher.Name == "__workspace__" || matcher.Name == "__bucket__") {
+            continue;
+        }
+        if (matcher.Op == "=") {
+            score += 10;
+        } else if (matcher.Op == "=~") {
+            score += 2;
+        }
+        if ((matcher.Name == "database"
+                || matcher.Name == "host"
+                || matcher.Name == "node"
+                || matcher.Name == "cluster"
+                || matcher.Name == "storagePool")
+            && matcher.Op == "=")
+        {
+            score += 10;
+        }
+    }
+    return score;
+}
+
+inline TString ResolveDatasourceUid(TStringBuf datasourceRef, const TCgiParameters& queryParameters) {
+    TString datasourceUid;
+    if (!datasourceRef.empty()) {
+        bool hasAllValue = false;
+        if (ResolveTemplateString(datasourceRef, queryParameters, datasourceUid, hasAllValue) && !datasourceUid.empty()) {
+            if (datasourceUid != "$__all" && datasourceUid != "__all") {
+                return datasourceUid;
+            }
+        } else if (!datasourceRef.Contains('$')) {
+            return TString(datasourceRef);
+        }
+    }
+
+    if (queryParameters.Has("var-ds")) {
+        return queryParameters.Get("var-ds");
+    }
+
+    return {};
+}
+
+inline bool BuildConcreteSelectors(
+    const TPromSelector& selector,
+    const TCgiParameters& queryParameters,
+    TVector<TPromSelector>& concreteSelectors)
+{
+    concreteSelectors.clear();
+
+    if (selector.Metric.empty() && !HasNonTenantMatcher(selector)) {
+        return false;
+    }
+
+    TVector<TString> bucketValues;
+    TVector<TString> workspaceValues;
+    bool hasWorkspaceMatcher = false;
+
+    TPromSelector resolvedSelector;
+    resolvedSelector.Metric = selector.Metric;
+
+    for (const auto& rawMatcher : selector.Matchers) {
+        bool hasAllValue = false;
+        TString resolvedValue;
+        if (!ResolveTemplateString(rawMatcher.Value, queryParameters, resolvedValue, hasAllValue)) {
+            return false;
+        }
+
+        TLabelMatcher resolvedMatcher = rawMatcher;
+        if (hasAllValue) {
+            if (resolvedMatcher.Op == "=~" || resolvedMatcher.Op == "!~") {
+                resolvedValue = ".*";
+            } else {
+                return false;
+            }
+        }
+        if (resolvedValue.empty()) {
+            return false;
+        }
+
+        if (resolvedMatcher.Name == "__bucket__") {
+            if (!TryResolveTenantValues(resolvedMatcher.Op, resolvedValue, bucketValues)) {
+                return false;
+            }
+            resolvedMatcher.Op = "=";
+            resolvedMatcher.Value = resolvedValue;
+        } else if (resolvedMatcher.Name == "__workspace__") {
+            hasWorkspaceMatcher = true;
+            if (!TryResolveTenantValues(resolvedMatcher.Op, resolvedValue, workspaceValues)) {
+                return false;
+            }
+            resolvedMatcher.Op = "=";
+            resolvedMatcher.Value = resolvedValue;
+        } else {
+            resolvedMatcher.Value = resolvedValue;
+        }
+
+        resolvedSelector.Matchers.push_back(std::move(resolvedMatcher));
+    }
+
+    if (bucketValues.empty()) {
+        return false;
+    }
+    if (!hasWorkspaceMatcher) {
+        workspaceValues.push_back({});
+    }
+
+    for (const auto& bucketValue : bucketValues) {
+        for (const auto& workspaceValue : workspaceValues) {
+            TPromSelector concreteSelector = resolvedSelector;
+            for (auto& matcher : concreteSelector.Matchers) {
+                if (matcher.Name == "__bucket__") {
+                    matcher.Op = "=";
+                    matcher.Value = bucketValue;
+                } else if (matcher.Name == "__workspace__" && hasWorkspaceMatcher) {
+                    matcher.Op = "=";
+                    matcher.Value = workspaceValue;
+                }
+            }
+            concreteSelectors.push_back(std::move(concreteSelector));
+        }
+    }
+
+    return !concreteSelectors.empty();
+}
+
+inline TString FindBucketValue(const TPromSelector& selector) {
+    for (const auto& matcher : selector.Matchers) {
+        if (matcher.Name == "__bucket__") {
+            return matcher.Value;
+        }
+    }
+    return {};
+}
+
+inline void CollectTemplatingExpressions(
+    const NJson::TJsonValue& dashboard,
+    TVector<TExpressionCandidate>& expressions)
+{
+    if (!dashboard.Has("templating") || dashboard["templating"].GetType() != NJson::JSON_MAP) {
+        return;
+    }
+    const auto& templating = dashboard["templating"];
+    if (!templating.Has("list") || templating["list"].GetType() != NJson::JSON_ARRAY) {
+        return;
+    }
+
+    for (const auto& item : templating["list"].GetArray()) {
+        if (item.GetType() != NJson::JSON_MAP) {
+            continue;
+        }
+
+        TString queryText;
+        if (item.Has("query")) {
+            queryText = GetVariableQueryText(item["query"]);
+        }
+        if (queryText.empty()) {
+            queryText = GetJsonStringField(item, "definition");
+        }
+        if (queryText.empty() || !queryText.Contains("__bucket__")) {
+            continue;
+        }
+
+        expressions.push_back(TExpressionCandidate{
+            .Expression = std::move(queryText),
+            .DatasourceRef = item.Has("datasource") ? GetDatasourceReference(item["datasource"]) : TString(),
+            .Origin = EExpressionOrigin::VariableQuery,
+        });
+    }
+}
+
+inline void CollectPanelExpressions(
+    const NJson::TJsonValue& panel,
+    TStringBuf inheritedDatasource,
+    TVector<TExpressionCandidate>& expressions)
+{
+    if (panel.GetType() != NJson::JSON_MAP) {
+        return;
+    }
+
+    TString panelDatasource(inheritedDatasource);
+    if (panel.Has("datasource")) {
+        const TString datasourceRef = GetDatasourceReference(panel["datasource"]);
+        if (!datasourceRef.empty()) {
+            panelDatasource = datasourceRef;
+        }
+    }
+
+    if (panel.Has("targets") && panel["targets"].GetType() == NJson::JSON_ARRAY) {
+        for (const auto& target : panel["targets"].GetArray()) {
+            if (target.GetType() != NJson::JSON_MAP || !target.Has("expr") || target["expr"].GetType() != NJson::JSON_STRING) {
+                continue;
+            }
+            const TString expression = target["expr"].GetString();
+            if (!expression.Contains("__bucket__")) {
+                continue;
+            }
+
+            TString datasourceRef = panelDatasource;
+            if (target.Has("datasource")) {
+                const TString targetDatasource = GetDatasourceReference(target["datasource"]);
+                if (!targetDatasource.empty()) {
+                    datasourceRef = targetDatasource;
+                }
+            }
+
+            expressions.push_back(TExpressionCandidate{
+                .Expression = expression,
+                .DatasourceRef = std::move(datasourceRef),
+                .Origin = EExpressionOrigin::PanelExpr,
+            });
+        }
+    }
+
+    if (panel.Has("panels") && panel["panels"].GetType() == NJson::JSON_ARRAY) {
+        for (const auto& nestedPanel : panel["panels"].GetArray()) {
+            CollectPanelExpressions(nestedPanel, panelDatasource, expressions);
+        }
+    }
+}
+
+inline void CollectDashboardExpressions(
+    const NJson::TJsonValue& dashboard,
+    TVector<TExpressionCandidate>& expressions)
+{
+    expressions.clear();
+    CollectTemplatingExpressions(dashboard, expressions);
+
+    if (!dashboard.Has("panels") || dashboard["panels"].GetType() != NJson::JSON_ARRAY) {
+        return;
+    }
+
+    for (const auto& panel : dashboard["panels"].GetArray()) {
+        CollectPanelExpressions(panel, TStringBuf(), expressions);
+    }
+}
+
+inline TString BuildDashboardApiUrl(TStringBuf grafanaEndpoint, const NJson::TJsonValue& item) {
+    TString uid = GetJsonStringField(item, "uid");
+    if (!uid.empty()) {
+        return JoinUrl(grafanaEndpoint, TStringBuilder() << "/api/dashboards/uid/" << uid);
+    }
+
+    TString dashboardUrl = GetJsonStringField(item, "url");
+    if (dashboardUrl.empty()) {
+        dashboardUrl = GetJsonStringField(item, "uri");
+    }
+    if (dashboardUrl.empty()) {
+        return {};
+    }
+
+    const auto pathAndQuery = BuildGrafanaDashboardUrlParts(grafanaEndpoint, dashboardUrl);
+    TStringBuf path = pathAndQuery.first;
+    if (IsAbsoluteUrl(path)) {
+        const size_t schemePos = path.find("://");
+        if (schemePos != TStringBuf::npos) {
+            const size_t pathPos = path.find('/', schemePos + 3);
+            path = pathPos == TStringBuf::npos
+                ? TStringBuf("/")
+                : path.SubStr(pathPos);
+        }
+    }
+
+    TVector<TString> pathParts;
+    TStringBuf pathRemainder(path);
+    while (!pathRemainder.empty() && pathRemainder[0] == '/') {
+        pathRemainder = pathRemainder.SubStr(1);
+    }
+    for (TStringBuf token = pathRemainder.NextTok('/'); !token.empty(); token = pathRemainder.NextTok('/')) {
+        pathParts.push_back(TString(token));
+    }
+
+    if (pathParts.size() >= 2 && pathParts[0] == "d") {
+        return JoinUrl(grafanaEndpoint, TStringBuilder() << "/api/dashboards/uid/" << pathParts[1]);
+    }
+    if (pathParts.size() >= 2 && pathParts[0] == "db") {
+        return JoinUrl(grafanaEndpoint, TStringBuilder() << "/api/dashboards/db/" << pathParts[1]);
+    }
+
+    return {};
+}
+
+inline bool TryBuildCandidate(
+    const NJson::TJsonValue& item,
+    TStringBuf grafanaEndpoint,
+    const THashMap<TString, TString>& clusterInfo,
+    const TCgiParameters& requestQueryParameters,
+    TGrafanaDashboardCandidate& candidate)
+{
+    TString dashboardUrl = GetJsonStringField(item, "url");
+    if (dashboardUrl.empty()) {
+        dashboardUrl = GetJsonStringField(item, "uri");
+    }
+    if (dashboardUrl.empty()) {
+        return false;
+    }
+
+    candidate = {};
+    candidate.Title = GetJsonStringField(item, "title");
+    candidate.ResolvedUrl = BuildGrafanaDashboardUrl(grafanaEndpoint, dashboardUrl, clusterInfo, requestQueryParameters);
+    candidate.DashboardApiUrl = BuildDashboardApiUrl(grafanaEndpoint, item);
+    const auto resolvedUrlParts = BuildGrafanaDashboardUrlParts(grafanaEndpoint, candidate.ResolvedUrl);
+    candidate.QueryParameters = resolvedUrlParts.second;
+
+    return !candidate.ResolvedUrl.empty() && !candidate.DashboardApiUrl.empty();
+}
+
+inline TVector<TGrafanaProbeGroup> BuildProbeGroups(
+    const NJson::TJsonValue& dashboard,
+    const TCgiParameters& queryParameters)
+{
+    TVector<TExpressionCandidate> expressions;
+    CollectDashboardExpressions(dashboard, expressions);
+
+    TMap<TString, TMap<TString, TBucketProbe>> bestProbes;
+    for (const auto& expression : expressions) {
+        const TString datasourceUid = ResolveDatasourceUid(expression.DatasourceRef, queryParameters);
+        if (datasourceUid.empty()) {
+            continue;
+        }
+
+        const auto selectorTexts = ExtractSelectors(expression.Expression);
+        for (const auto& selectorText : selectorTexts) {
+            TPromSelector rawSelector;
+            if (!TryParseSelector(selectorText, rawSelector)) {
+                continue;
+            }
+
+            TVector<TPromSelector> concreteSelectors;
+            if (!BuildConcreteSelectors(rawSelector, queryParameters, concreteSelectors)) {
+                continue;
+            }
+
+            for (const auto& concreteSelector : concreteSelectors) {
+                const TString bucketValue = FindBucketValue(concreteSelector);
+                if (bucketValue.empty()) {
+                    continue;
+                }
+
+                const int score = ScoreSelector(concreteSelector, expression.Origin);
+                auto& probe = bestProbes[datasourceUid][bucketValue];
+                if (probe.Selector.empty() || score > probe.Score) {
+                    probe.Selector = BuildSelectorText(concreteSelector);
+                    probe.Score = score;
+                }
+            }
+        }
+    }
+
+    TVector<TGrafanaProbeGroup> probeGroups;
+    for (const auto& [datasourceUid, probesByBucket] : bestProbes) {
+        TGrafanaProbeGroup probeGroup;
+        probeGroup.DatasourceUid = datasourceUid;
+        for (const auto& [bucket, probe] : probesByBucket) {
+            if (probe.Selector.empty()) {
+                continue;
+            }
+            if (!probeGroup.Query.empty()) {
+                probeGroup.Query += " + ";
+            }
+            probeGroup.Query += TStringBuilder() << '(' << BuildSignalProbeQuery(probe.Selector) << ')';
+            probeGroup.Buckets.push_back(bucket);
+        }
+        if (!probeGroup.Query.empty()) {
+            probeGroups.push_back(std::move(probeGroup));
+        }
+    }
+
+    return probeGroups;
+}
+
+inline bool TryExtractNumericValue(const NJson::TJsonValue& value, double& number) {
+    if (value.GetType() == NJson::JSON_DOUBLE) {
+        number = value.GetDouble();
+        return true;
+    }
+    if (value.GetType() == NJson::JSON_INTEGER) {
+        number = value.GetInteger();
+        return true;
+    }
+    if (value.GetType() == NJson::JSON_STRING) {
+        return TryFromString(value.GetString(), number);
+    }
+    return false;
+}
+
+inline bool HasSignalInProbeResponse(TStringBuf body) {
+    NJson::TJsonValue responseJson;
+    NJson::TJsonReaderConfig jsonReaderConfig;
+    if (!NJson::ReadJsonTree(body, &jsonReaderConfig, &responseJson) || responseJson.GetType() != NJson::JSON_MAP) {
+        return false;
+    }
+    if (!responseJson.Has("data") || responseJson["data"].GetType() != NJson::JSON_MAP) {
+        return false;
+    }
+
+    const auto& data = responseJson["data"];
+    if (data.Has("result") && data["result"].GetType() == NJson::JSON_ARRAY) {
+        const auto& result = data["result"].GetArray();
+        if (!result.empty() && result[0].GetType() == NJson::JSON_MAP) {
+            for (const auto& item : result) {
+                if (!item.Has("value") || item["value"].GetType() != NJson::JSON_ARRAY) {
+                    continue;
+                }
+                const auto& value = item["value"].GetArray();
+                if (value.size() < 2) {
+                    continue;
+                }
+                double numericValue = 0;
+                if (TryExtractNumericValue(value[1], numericValue) && numericValue > 0) {
+                    return true;
+                }
+            }
+        } else if (result.size() >= 2) {
+            double numericValue = 0;
+            return TryExtractNumericValue(result[1], numericValue) && numericValue > 0;
+        }
+    }
+
+    return false;
+}
+
+} // namespace NGrafanaDashboardProbeDetails
+
+inline TVector<TGrafanaProbeGroup> BuildGrafanaDashboardProbeGroups(
+    const NJson::TJsonValue& dashboard,
+    const TCgiParameters& queryParameters)
+{
+    return NGrafanaDashboardProbeDetails::BuildProbeGroups(dashboard, queryParameters);
+}
+
+inline bool TryBuildGrafanaDashboardCandidate(
+    const NJson::TJsonValue& item,
+    TStringBuf grafanaEndpoint,
+    const THashMap<TString, TString>& clusterInfo,
+    const TCgiParameters& requestQueryParameters,
+    TGrafanaDashboardCandidate& candidate)
+{
+    return NGrafanaDashboardProbeDetails::TryBuildCandidate(
+        item,
+        grafanaEndpoint,
+        clusterInfo,
+        requestQueryParameters,
+        candidate);
+}
+
+inline bool HasGrafanaDashboardProbeSignal(TStringBuf body) {
+    return NGrafanaDashboardProbeDetails::HasSignalInProbeResponse(body);
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -25,6 +25,8 @@
 
 namespace NMVP::NSupportLinks {
 
+inline constexpr TDuration GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT = TDuration::Seconds(5);
+
 class TGrafanaDashboardSearchActor : public NActors::TActorBootstrapped<TGrafanaDashboardSearchActor> {
 public:
     TGrafanaDashboardSearchActor(
@@ -53,6 +55,7 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
+            cFunc(NActors::TEvents::TSystem::Wakeup, HandleFilteringTimeout);
             cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
@@ -113,7 +116,7 @@ private:
             request->Set("Authorization", AuthorizationHeaderValue);
         }
 
-        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
+        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request, GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT);
         Send(HttpProxyId, event.Release());
     }
 
@@ -168,6 +171,7 @@ private:
             return;
         }
 
+        Schedule(GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT, new NActors::TEvents::TEvWakeup());
         CurrentDashboardIndex = 0;
         RequestDashboardModel();
     }
@@ -219,6 +223,14 @@ private:
 
     void HandleDashboardModelResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
         const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        if (!event->Get()->Error.empty()) {
+            BLOG_W("Support links Grafana dashboard model timeout/error, returning dashboard without filtering: title=" << candidate.Title
+                << " url=" << candidate.DashboardApiUrl
+                << " error=" << event->Get()->Error);
+            AddCurrentDashboardAsLink();
+            AdvanceToNextDashboard();
+            return;
+        }
         if (!IsSuccessfulResponse(*event->Get())) {
             BLOG_W("Support links Grafana dashboard model fetch failed: title=" << candidate.Title
                 << " url=" << candidate.DashboardApiUrl
@@ -272,6 +284,14 @@ private:
     void HandleProbeResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
         const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
         const auto& probeGroup = CurrentProbeGroups[CurrentProbeGroupIndex];
+        if (!event->Get()->Error.empty()) {
+            BLOG_W("Support links Grafana probe timeout/error, returning dashboard without filtering: title=" << candidate.Title
+                << " datasource=" << probeGroup.DatasourceUid
+                << " error=" << event->Get()->Error);
+            AddCurrentDashboardAsLink();
+            AdvanceToNextDashboard();
+            return;
+        }
         if (!IsSuccessfulResponse(*event->Get())) {
             BLOG_W("Support links Grafana probe request failed: title=" << candidate.Title
                 << " datasource=" << probeGroup.DatasourceUid
@@ -297,11 +317,41 @@ private:
         RequestProbe();
     }
 
+    void AddCurrentDashboardAsLink() {
+        if (CurrentDashboardIndex >= DashboardCandidates.size()) {
+            return;
+        }
+
+        const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        Links.emplace_back(TResolvedLink{
+            .Title = candidate.Title,
+            .Url = candidate.ResolvedUrl,
+        });
+    }
+
+    void AddRemainingDashboardsAsLinks() {
+        for (size_t index = CurrentDashboardIndex; index < DashboardCandidates.size(); ++index) {
+            const auto& candidate = DashboardCandidates[index];
+            Links.emplace_back(TResolvedLink{
+                .Title = candidate.Title,
+                .Url = candidate.ResolvedUrl,
+            });
+        }
+    }
+
     void AdvanceToNextDashboard() {
         CurrentProbeGroups.clear();
         CurrentProbeGroupIndex = 0;
         ++CurrentDashboardIndex;
         RequestDashboardModel();
+    }
+
+    void HandleFilteringTimeout() {
+        if (CurrentDashboardIndex < DashboardCandidates.size()) {
+            BLOG_W("Support links Grafana filtering timed out, returning unresolved dashboards without filtering");
+            AddRemainingDashboardsAsLinks();
+        }
+        ReplyAndDie();
     }
 
     static bool IsDashboardItem(const NJson::TJsonValue& item) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -2,9 +2,11 @@
 
 #include "events.h"
 #include "grafana_dashboard_common.h"
+#include "grafana_dashboard_probe.h"
 #include "source_common.h"
 
 #include <ydb/mvp/core/appdata.h>
+#include <ydb/mvp/core/mvp_log.h>
 #include <ydb/mvp/meta/mvp.h>
 #include <ydb/mvp/meta/support_links/source.h>
 
@@ -16,6 +18,7 @@
 
 #include <library/cpp/json/json_reader.h>
 
+#include <util/generic/vector.h>
 #include <util/generic/yexception.h>
 #include <util/string/cast.h>
 #include <util/string/strip.h>
@@ -42,12 +45,8 @@ public:
     {}
 
     void Bootstrap() {
-        const TString authHeaderValue = GetAuthorizationHeaderValue();
-        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet(BuildSearchUrl());
-        request->Set("Authorization", authHeaderValue);
-
-        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
-        Send(HttpProxyId, event.Release());
+        AuthorizationHeaderValue = GetAuthorizationHeaderValue();
+        SendGrafanaGetRequest(BuildSearchUrl(), "search dashboards");
         Become(&TGrafanaDashboardSearchActor::StateWork);
     }
 
@@ -68,8 +67,21 @@ private:
     size_t Place = 0;
     TVector<TResolvedLink> Links;
     TVector<TSupportError> Errors;
+    TString AuthorizationHeaderValue;
+    TVector<TGrafanaDashboardCandidate> DashboardCandidates;
+    size_t CurrentDashboardIndex = 0;
+    TVector<TGrafanaProbeGroup> CurrentProbeGroups;
+    size_t CurrentProbeGroupIndex = 0;
 
-    TString GetAuthorizationHeaderValue() {
+    enum class ERequestKind {
+        Search,
+        DashboardModel,
+        Probe,
+    };
+
+    ERequestKind RequestKind = ERequestKind::Search;
+
+    TString GetAuthorizationHeaderValue() const {
         auto* appData = MVPAppData();
         if (!appData || !appData->Tokenator) {
             return {};
@@ -93,21 +105,57 @@ private:
         return url;
     }
 
+    void SendGrafanaGetRequest(TString url, TStringBuf purpose) {
+        BLOG_D("Support links Grafana request: purpose=" << purpose << " method=GET url=" << url);
+
+        NHttp::THttpOutgoingRequestPtr request = NHttp::THttpOutgoingRequest::CreateRequestGet(url);
+        if (!AuthorizationHeaderValue.empty()) {
+            request->Set("Authorization", AuthorizationHeaderValue);
+        }
+
+        auto event = MakeHolder<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(request);
+        Send(HttpProxyId, event.Release());
+    }
+
+    static TString DescribeHttpFailure(const NHttp::TEvHttpProxy::TEvHttpIncomingResponse& response) {
+        if (!response.Error.empty()) {
+            return response.Error;
+        }
+        if (response.Response) {
+            return TStringBuilder() << response.Response->Status << ' ' << response.Response->Message;
+        }
+        return "Unknown Grafana request error";
+    }
+
+    static bool IsSuccessfulResponse(const NHttp::TEvHttpProxy::TEvHttpIncomingResponse& response) {
+        return response.Error.empty() && response.Response && response.Response->Status == "200";
+    }
+
     void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
-        if (!event->Get()->Error.empty() || !event->Get()->Response || event->Get()->Response->Status != "200") {
+        switch (RequestKind) {
+            case ERequestKind::Search:
+                HandleSearchResponse(event);
+                return;
+            case ERequestKind::DashboardModel:
+                HandleDashboardModelResponse(event);
+                return;
+            case ERequestKind::Probe:
+                HandleProbeResponse(event);
+                return;
+        }
+    }
+
+    void HandleSearchResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
+        if (!IsSuccessfulResponse(*event->Get())) {
             TSupportError error;
             error.Source = Config.GetSource();
-            if (!event->Get()->Error.empty()) {
-                error.Message = event->Get()->Error;
-            } else if (event->Get()->Response) {
+            error.Message = DescribeHttpFailure(*event->Get());
+            if (event->Get()->Response) {
                 ui32 status = 0;
                 if (TryFromString<ui32>(event->Get()->Response->Status, status)) {
                     error.Status = status;
                 }
                 error.Reason = TString(event->Get()->Response->Message);
-                error.Message = TStringBuilder() << event->Get()->Response->Status << " " << event->Get()->Response->Message;
-            } else {
-                error.Message = "Unknown Grafana request error";
             }
             Errors.push_back(std::move(error));
             ReplyAndDie();
@@ -115,7 +163,13 @@ private:
         }
 
         ParseSearchResponse(event->Get()->Response->Body);
-        ReplyAndDie();
+        if (!Errors.empty() || DashboardCandidates.empty()) {
+            ReplyAndDie();
+            return;
+        }
+
+        CurrentDashboardIndex = 0;
+        RequestDashboardModel();
     }
 
     void ParseSearchResponse(TStringBuf body) {
@@ -137,33 +191,117 @@ private:
                 continue;
             }
 
-            TString title;
-            TString dashboardUrl;
-            if (item.Has("title") && item["title"].GetType() == NJson::JSON_STRING) {
-                title = item["title"].GetString();
-            }
-            if (item.Has("url") && item["url"].GetType() == NJson::JSON_STRING) {
-                dashboardUrl = item["url"].GetString();
-            } else if (item.Has("uri") && item["uri"].GetType() == NJson::JSON_STRING) {
-                dashboardUrl = item["uri"].GetString();
-            }
-
-            if (dashboardUrl.empty()) {
-                continue;
-            }
-
-            const TString resolvedUrl = BuildGrafanaDashboardUrl(
-                GrafanaEndpoint,
-                dashboardUrl,
-                ClusterInfo,
-                RequestQueryParameters);
-            if (!resolvedUrl.empty()) {
-                Links.emplace_back(TResolvedLink{
-                    .Title = std::move(title),
-                    .Url = resolvedUrl,
-                });
+            TGrafanaDashboardCandidate candidate;
+            if (TryBuildGrafanaDashboardCandidate(
+                    item,
+                    GrafanaEndpoint,
+                    ClusterInfo,
+                    RequestQueryParameters,
+                    candidate))
+            {
+                DashboardCandidates.push_back(std::move(candidate));
+            } else {
+                BLOG_D("Support links Grafana skip dashboard without resolvable probe metadata");
             }
         }
+    }
+
+    void RequestDashboardModel() {
+        if (CurrentDashboardIndex >= DashboardCandidates.size()) {
+            ReplyAndDie();
+            return;
+        }
+
+        RequestKind = ERequestKind::DashboardModel;
+        const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        SendGrafanaGetRequest(candidate.DashboardApiUrl, "fetch dashboard model");
+    }
+
+    void HandleDashboardModelResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
+        const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        if (!IsSuccessfulResponse(*event->Get())) {
+            BLOG_W("Support links Grafana dashboard model fetch failed: title=" << candidate.Title
+                << " url=" << candidate.DashboardApiUrl
+                << " error=" << DescribeHttpFailure(*event->Get()));
+            AdvanceToNextDashboard();
+            return;
+        }
+
+        NJson::TJsonValue responseJson;
+        NJson::TJsonReaderConfig jsonReaderConfig;
+        if (!NJson::ReadJsonTree(event->Get()->Response->Body, &jsonReaderConfig, &responseJson) || responseJson.GetType() != NJson::JSON_MAP) {
+            BLOG_W("Support links Grafana dashboard model has invalid JSON: title=" << candidate.Title
+                << " url=" << candidate.DashboardApiUrl);
+            AdvanceToNextDashboard();
+            return;
+        }
+
+        const NJson::TJsonValue* dashboard = &responseJson;
+        if (responseJson.Has("dashboard") && responseJson["dashboard"].GetType() == NJson::JSON_MAP) {
+            dashboard = &responseJson["dashboard"];
+        }
+
+        CurrentProbeGroups = BuildGrafanaDashboardProbeGroups(*dashboard, candidate.QueryParameters);
+        CurrentProbeGroupIndex = 0;
+        if (CurrentProbeGroups.empty()) {
+            BLOG_D("Support links Grafana dashboard has no probeable buckets: title=" << candidate.Title
+                << " url=" << candidate.ResolvedUrl);
+            AdvanceToNextDashboard();
+            return;
+        }
+
+        RequestProbe();
+    }
+
+    void RequestProbe() {
+        if (CurrentProbeGroupIndex >= CurrentProbeGroups.size()) {
+            AdvanceToNextDashboard();
+            return;
+        }
+
+        const auto& probeGroup = CurrentProbeGroups[CurrentProbeGroupIndex];
+        TString url = JoinUrl(
+            GrafanaEndpoint,
+            TStringBuilder() << "/api/datasources/proxy/uid/" << probeGroup.DatasourceUid << "/api/v1/query");
+        url = AppendQueryParam(url, "query", probeGroup.Query);
+
+        RequestKind = ERequestKind::Probe;
+        SendGrafanaGetRequest(url, "probe dashboard signal");
+    }
+
+    void HandleProbeResponse(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
+        const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        const auto& probeGroup = CurrentProbeGroups[CurrentProbeGroupIndex];
+        if (!IsSuccessfulResponse(*event->Get())) {
+            BLOG_W("Support links Grafana probe request failed: title=" << candidate.Title
+                << " datasource=" << probeGroup.DatasourceUid
+                << " error=" << DescribeHttpFailure(*event->Get()));
+            AdvanceToNextProbeGroup();
+            return;
+        }
+
+        if (HasGrafanaDashboardProbeSignal(event->Get()->Response->Body)) {
+            Links.emplace_back(TResolvedLink{
+                .Title = candidate.Title,
+                .Url = candidate.ResolvedUrl,
+            });
+            AdvanceToNextDashboard();
+            return;
+        }
+
+        AdvanceToNextProbeGroup();
+    }
+
+    void AdvanceToNextProbeGroup() {
+        ++CurrentProbeGroupIndex;
+        RequestProbe();
+    }
+
+    void AdvanceToNextDashboard() {
+        CurrentProbeGroups.clear();
+        CurrentProbeGroupIndex = 0;
+        ++CurrentDashboardIndex;
+        RequestDashboardModel();
     }
 
     static bool IsDashboardItem(const NJson::TJsonValue& item) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -18,7 +18,10 @@
 
 #include <library/cpp/json/json_reader.h>
 
+#include <util/datetime/base.h>
+#include <util/generic/hash.h>
 #include <util/generic/vector.h>
+#include <util/system/mutex.h>
 #include <util/generic/yexception.h>
 #include <util/string/cast.h>
 #include <util/string/strip.h>
@@ -26,6 +29,59 @@
 namespace NMVP::NSupportLinks {
 
 inline constexpr TDuration GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT = TDuration::Seconds(5);
+inline constexpr TDuration GRAFANA_DASHBOARD_MODEL_CACHE_TTL = TDuration::Minutes(5);
+
+class TGrafanaDashboardModelCache {
+public:
+    static bool TryGet(TStringBuf dashboardApiUrl, TString& body) {
+        TGuard<TMutex> guard(Mutex());
+        auto& entries = Entries();
+        const auto it = entries.find(TString(dashboardApiUrl));
+        if (it == entries.end()) {
+            return false;
+        }
+        if (it->second.ExpireAt <= TInstant::Now()) {
+            entries.erase(it);
+            return false;
+        }
+        body = it->second.Body;
+        return true;
+    }
+
+    static void Put(TString dashboardApiUrl, TString body) {
+        TGuard<TMutex> guard(Mutex());
+        Entries()[std::move(dashboardApiUrl)] = TEntry{
+            .Body = std::move(body),
+            .ExpireAt = TInstant::Now() + GRAFANA_DASHBOARD_MODEL_CACHE_TTL,
+        };
+    }
+
+    static void Erase(TStringBuf dashboardApiUrl) {
+        TGuard<TMutex> guard(Mutex());
+        Entries().erase(TString(dashboardApiUrl));
+    }
+
+    static void ResetForTests() {
+        TGuard<TMutex> guard(Mutex());
+        Entries().clear();
+    }
+
+private:
+    struct TEntry {
+        TString Body;
+        TInstant ExpireAt;
+    };
+
+    static TMutex& Mutex() {
+        static TMutex mutex;
+        return mutex;
+    }
+
+    static THashMap<TString, TEntry>& Entries() {
+        static THashMap<TString, TEntry> entries;
+        return entries;
+    }
+};
 
 class TGrafanaDashboardSearchActor : public NActors::TActorBootstrapped<TGrafanaDashboardSearchActor> {
 public:
@@ -216,8 +272,18 @@ private:
             return;
         }
 
-        RequestKind = ERequestKind::DashboardModel;
         const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
+        TString cachedBody;
+        if (TGrafanaDashboardModelCache::TryGet(candidate.DashboardApiUrl, cachedBody)) {
+            BLOG_D("Support links Grafana dashboard model cache hit: title=" << candidate.Title
+                << " url=" << candidate.DashboardApiUrl);
+            if (TryHandleDashboardModelBody(cachedBody, false)) {
+                return;
+            }
+            TGrafanaDashboardModelCache::Erase(candidate.DashboardApiUrl);
+        }
+
+        RequestKind = ERequestKind::DashboardModel;
         SendGrafanaGetRequest(candidate.DashboardApiUrl, "fetch dashboard model");
     }
 
@@ -239,13 +305,22 @@ private:
             return;
         }
 
+        if (TryHandleDashboardModelBody(event->Get()->Response->Body, true)) {
+            TGrafanaDashboardModelCache::Put(candidate.DashboardApiUrl, TString(event->Get()->Response->Body));
+        }
+    }
+
+    bool TryHandleDashboardModelBody(TStringBuf body, bool advanceOnInvalidJson) {
+        const auto& candidate = DashboardCandidates[CurrentDashboardIndex];
         NJson::TJsonValue responseJson;
         NJson::TJsonReaderConfig jsonReaderConfig;
-        if (!NJson::ReadJsonTree(event->Get()->Response->Body, &jsonReaderConfig, &responseJson) || responseJson.GetType() != NJson::JSON_MAP) {
+        if (!NJson::ReadJsonTree(body, &jsonReaderConfig, &responseJson) || responseJson.GetType() != NJson::JSON_MAP) {
             BLOG_W("Support links Grafana dashboard model has invalid JSON: title=" << candidate.Title
                 << " url=" << candidate.DashboardApiUrl);
-            AdvanceToNextDashboard();
-            return;
+            if (advanceOnInvalidJson) {
+                AdvanceToNextDashboard();
+            }
+            return false;
         }
 
         const NJson::TJsonValue* dashboard = &responseJson;
@@ -259,10 +334,11 @@ private:
             BLOG_D("Support links Grafana dashboard has no probeable buckets: title=" << candidate.Title
                 << " url=" << candidate.ResolvedUrl);
             AdvanceToNextDashboard();
-            return;
+            return true;
         }
 
         RequestProbe();
+        return true;
     }
 
     void RequestProbe() {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
@@ -11,11 +11,13 @@
 
 #include <library/cpp/cgiparam/cgiparam.h>
 #include <library/cpp/json/json_writer.h>
+#include <library/cpp/testing/common/env.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/generic/algorithm.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/vector.h>
+#include <util/stream/file.h>
 
 #include <utility>
 
@@ -80,6 +82,57 @@ NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
         builder.Set(name, param);
     }
     return builder;
+}
+
+TString MakeDashboardModelBody(TStringBuf query, TStringBuf datasource = "${ds}") {
+    NJson::TJsonValue root(NJson::JSON_MAP);
+    NJson::TJsonValue dashboard(NJson::JSON_MAP);
+    NJson::TJsonValue templating(NJson::JSON_MAP);
+    NJson::TJsonValue list(NJson::JSON_ARRAY);
+    NJson::TJsonValue item(NJson::JSON_MAP);
+    NJson::TJsonValue datasourceJson(NJson::JSON_MAP);
+
+    datasourceJson["uid"] = TString(datasource);
+    item["name"] = "probe";
+    item["datasource"] = std::move(datasourceJson);
+    item["query"] = TString(query);
+    list.AppendValue(std::move(item));
+    templating["list"] = std::move(list);
+    dashboard["templating"] = std::move(templating);
+    root["dashboard"] = std::move(dashboard);
+
+    return NJson::WriteJson(root, false);
+}
+
+TString MakeProbeResponseBody(TStringBuf value) {
+    NJson::TJsonValue root(NJson::JSON_MAP);
+    NJson::TJsonValue data(NJson::JSON_MAP);
+    NJson::TJsonValue result(NJson::JSON_ARRAY);
+    NJson::TJsonValue item(NJson::JSON_MAP);
+    NJson::TJsonValue sample(NJson::JSON_ARRAY);
+    NJson::TJsonValue metric(NJson::JSON_MAP);
+
+    sample.AppendValue(1717500000);
+    sample.AppendValue(TString(value));
+    item["metric"] = std::move(metric);
+    item["value"] = std::move(sample);
+    result.AppendValue(std::move(item));
+    data["resultType"] = "vector";
+    data["result"] = std::move(result);
+    root["status"] = "success";
+    root["data"] = std::move(data);
+
+    return NJson::WriteJson(root, false);
+}
+
+NJson::TJsonValue ReadFixtureJson(TStringBuf relativePath) {
+    const TString path = ArcadiaFromCurrentLocation(__SOURCE_FILE__, relativePath);
+    const TString body = TUnbufferedFileInput(path).ReadAll();
+
+    NJson::TJsonValue value;
+    NJson::TJsonReaderConfig jsonReaderConfig;
+    UNIT_ASSERT_C(NJson::ReadJsonTree(body, &jsonReaderConfig, &value), "failed to parse json fixture");
+    return value;
 }
 
 class TResolveRunnerActor : public NActors::TActorBootstrapped<TResolveRunnerActor> {
@@ -169,6 +222,7 @@ public:
         struct TDashboardCandidate {
             TString Title;
             TString Url;
+            TString Uid;
             THashSet<TString> Tags;
             TString FolderUid;
         };
@@ -177,25 +231,28 @@ public:
             {
                 .Title = "YDB Cluster Overview",
                 .Url = "/d/matched/dashboard",
+                .Uid = "matched",
                 .Tags = {"ydb-common", "ydb-storage"},
                 .FolderUid = "ops-folder",
             },
             {
                 .Title = "YDB Database Overview",
                 .Url = "/d/missing-tag/dashboard",
+                .Uid = "missing-tag",
                 .Tags = {"ydb-common"},
                 .FolderUid = "ops-folder",
             },
             {
                 .Title = "YDB Storage Overview",
                 .Url = "/d/wrong-folder/dashboard",
+                .Uid = "wrong-folder",
                 .Tags = {"ydb-common", "ydb-storage"},
                 .FolderUid = "other-folder",
             },
         };
 
-        NJson::TJsonValue responseJson(NJson::JSON_ARRAY);
         if (targetsSearchApi) {
+            NJson::TJsonValue responseJson(NJson::JSON_ARRAY);
             for (const auto& dashboard : dashboards) {
                 bool matchesTags = true;
                 for (const TString& tag : requestTags) {
@@ -214,15 +271,38 @@ public:
                 item["type"] = "dash-db";
                 item["title"] = dashboard.Title;
                 item["url"] = dashboard.Url;
+                item["uid"] = dashboard.Uid;
                 responseJson.AppendValue(std::move(item));
             }
+
+            ReplyJson(event, "HTTP/1.1 200 OK", NJson::WriteJson(responseJson, false));
+            return;
         }
 
-        TString body = NJson::WriteJson(responseJson, false);
-        const TString statusLine = targetsSearchApi
-            ? "HTTP/1.1 200 OK"
-            : "HTTP/1.1 400 Bad Request";
+        if (url.Contains("/api/dashboards/uid/matched")) {
+            ReplyJson(
+                event,
+                "HTTP/1.1 200 OK",
+                MakeDashboardModelBody("label_values(ElapsedMicrosec{__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"},database)"));
+            return;
+        }
 
+        if (url.Contains("/api/datasources/proxy/uid/")) {
+            UNIT_ASSERT(url.Contains("__bucket__%3D%22utils%22"));
+            UNIT_ASSERT(url.Contains("database%3D%22/root/test%22"));
+            ReplyJson(event, "HTTP/1.1 200 OK", MakeProbeResponseBody("1"));
+            return;
+        }
+
+        ReplyJson(event, "HTTP/1.1 400 Bad Request", R"({"message":"bad request"})");
+    }
+
+    void ReplyJson(
+        NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event,
+        TStringBuf statusLine,
+        TStringBuf body)
+    {
+        const auto request = event->Get()->Request;
         NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
         EatWholeString(
             response,
@@ -243,27 +323,51 @@ public:
     }
 };
 
-class TGrafanaSearchReplyActor : public NActors::TActor<TGrafanaSearchReplyActor> {
+class TGrafanaApiReplyActor : public NActors::TActor<TGrafanaApiReplyActor> {
 public:
-    using TBase = NActors::TActor<TGrafanaSearchReplyActor>;
+    using TBase = NActors::TActor<TGrafanaApiReplyActor>;
 
-    explicit TGrafanaSearchReplyActor(TString body)
-        : TBase(&TGrafanaSearchReplyActor::StateWork)
-        , Body(std::move(body))
+    struct TRule {
+        TString UrlContains;
+        TString StatusLine;
+        TString Body;
+    };
+
+    explicit TGrafanaApiReplyActor(TVector<TRule> rules)
+        : TBase(&TGrafanaApiReplyActor::StateWork)
+        , Rules(std::move(rules))
     {}
 
     void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event) {
+        const auto request = event->Get()->Request;
+        const TString url(request->URL);
+        for (const auto& rule : Rules) {
+            if (!url.Contains(rule.UrlContains)) {
+                continue;
+            }
+            Reply(event, rule.StatusLine, rule.Body);
+            return;
+        }
+
+        Reply(event, "HTTP/1.1 404 Not Found", R"({"message":"not found"})");
+    }
+
+    void Reply(
+        NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event,
+        TStringBuf statusLine,
+        TStringBuf body)
+    {
         const auto request = event->Get()->Request;
         NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
         EatWholeString(
             response,
             TStringBuilder()
-                << "HTTP/1.1 200 OK\r\n"
+                << statusLine << "\r\n"
                 << "Connection: close\r\n"
                 << "Content-Type: application/json; charset=utf-8\r\n"
-                << "Content-Length: " << Body.size() << "\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
                 << "\r\n"
-                << Body);
+                << body);
         Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
     }
 
@@ -274,7 +378,7 @@ public:
     }
 
 private:
-    TString Body;
+    TVector<TRule> Rules;
 };
 
 class TForbiddenReplyActor : public NActors::TActor<TForbiddenReplyActor> {
@@ -374,12 +478,18 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
             MakeMetaSettings());
         auto httpProxyId = runtime.Register(new TSearchApiRequestCheckActor());
 
+        THashMap<TString, TString> clusterInfo;
+        clusterInfo["k8s_namespace"] = "ydb-workspace";
+        clusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+
         TAutoPtr<NActors::IEventHandle> handle;
-        auto* response = ResolveSource(runtime, source, {}, MakeUrlParameters(""), httpProxyId, handle);
+        auto* response = ResolveSource(runtime, source, clusterInfo, MakeUrlParameters("database=%2Froot%2Ftest"), httpProxyId, handle);
         UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
         UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Title, "YDB Cluster Overview");
-        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Url, "https://grafana.example.net/d/matched/dashboard");
+        AssertUrlQuery(
+            response->Links[0].Url,
+            "https://grafana.example.net/d/matched/dashboard?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-database=/root/test");
     }
 
     Y_UNIT_TEST(ResolveBuildsDashboardLinksFromSearchResponse) {
@@ -387,12 +497,18 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
         TTestActorRuntime runtime;
 
         const TString body = R"json([
-            {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu"},
+            {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu","uid":"ydb_cpu"},
             {"type":"dashboard","title":"DB overview","uri":"db/db-overview"},
             {"type":"dash-folder","title":"Folder","url":"/dashboards/f/team-folder"},
             {"title":"Skip me"}
         ])json";
-        auto httpProxyId = runtime.Register(new TGrafanaSearchReplyActor(body));
+        TVector<TGrafanaApiReplyActor::TRule> rules = {
+            {.UrlContains = "/api/search", .StatusLine = "HTTP/1.1 200 OK", .Body = body},
+            {.UrlContains = "/api/dashboards/uid/ydb_cpu", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(ElapsedMicrosec{__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"},database)")},
+            {.UrlContains = "/api/dashboards/db/db-overview", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(requestBytes{__workspace__=\"$workspace\",__bucket__=\"dsproxynode\",database=\"$database\"},storagePool)")},
+            {.UrlContains = "/api/datasources/proxy/uid/3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63/api/v1/query", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeProbeResponseBody("1")},
+        };
+        auto httpProxyId = runtime.Register(new TGrafanaApiReplyActor(std::move(rules)));
         auto source = NMVP::MakeGrafanaDashboardSearchSource(
             MakeConfig("/api/search", TVector<TString>{"ydb-common"}),
             MakeMetaSettings());
@@ -420,6 +536,103 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
         AssertUrlQuery(
             response->Links[1].Url,
             "https://grafana.example.net/db/db-overview?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global&var-database=/root/test");
+    }
+
+    Y_UNIT_TEST(ResolveFiltersDashboardsWithoutSignal) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        const TString body = R"json([
+            {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu","uid":"ydb_cpu"},
+            {"type":"dash-db","title":"Storage","url":"/d/storage/storage","uid":"storage"}
+        ])json";
+        TVector<TGrafanaApiReplyActor::TRule> rules = {
+            {.UrlContains = "/api/search", .StatusLine = "HTTP/1.1 200 OK", .Body = body},
+            {.UrlContains = "/api/dashboards/uid/ydb_cpu", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(ElapsedMicrosec{__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"},database)")},
+            {.UrlContains = "/api/dashboards/uid/storage", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(requestBytes{__workspace__=\"$workspace\",__bucket__=\"dsproxynode\",database=\"$database\"},storagePool)")},
+            {.UrlContains = "__bucket__%3D%22utils%22", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeProbeResponseBody("1")},
+            {.UrlContains = "__bucket__%3D%22dsproxynode%22", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeProbeResponseBody("0")},
+        };
+        auto httpProxyId = runtime.Register(new TGrafanaApiReplyActor(std::move(rules)));
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(
+            MakeConfig("/api/search", TVector<TString>{"ydb-common"}),
+            MakeMetaSettings());
+
+        THashMap<TString, TString> clusterInfo;
+        clusterInfo["k8s_namespace"] = "ydb-workspace";
+        clusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* response = ResolveSource(
+            runtime,
+            source,
+            clusterInfo,
+            MakeUrlParameters("database=%2Froot%2Ftest"),
+            httpProxyId,
+            handle);
+
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Title, "CPU");
+    }
+
+    Y_UNIT_TEST(BuildsProbeQueryFromFixture) {
+        const NJson::TJsonValue fixture = ReadFixtureJson("ut/grafana_dashboard_probe_fixture.json");
+        UNIT_ASSERT(fixture.Has("dashboard"));
+
+        TCgiParameters queryParameters;
+        queryParameters.InsertUnescaped("var-ds", "fc872d93-d988-491c-83cd-19249cb962b0");
+        queryParameters.InsertUnescaped("var-workspace", "ydb-disks-ext");
+        queryParameters.InsertUnescaped("var-database", "/testing-disks-ext/NBS");
+        queryParameters.InsertUnescaped("var-storagePool", "pool-1");
+
+        const auto probeGroups = NMVP::NSupportLinks::BuildGrafanaDashboardProbeGroups(
+            fixture["dashboard"],
+            queryParameters);
+
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].DatasourceUid, "fc872d93-d988-491c-83cd-19249cb962b0");
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].Buckets.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].Buckets[0], "dsproxynode");
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].Buckets[1], "pdisks");
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].Buckets[2], "utils");
+
+        const TString expectedQuery =
+            "(count(count_over_time(requestBytes{__workspace__=\"ydb-disks-ext\",__bucket__=\"dsproxynode\",database=\"/testing-disks-ext/NBS\",storagePool=\"pool-1\"}[1m])) or on() vector(0)) + "
+            "(count(count_over_time(CompletionThreadCPU{__workspace__=\"ydb-disks-ext\",__bucket__=\"pdisks\"}[1m])) or on() vector(0)) + "
+            "(count(count_over_time(ElapsedMicrosec{container=\"ydb-dynamic\",__workspace__=\"ydb-disks-ext\",__bucket__=\"utils\",database=\"/testing-disks-ext/NBS\"}[1m])) or on() vector(0))";
+        UNIT_ASSERT_VALUES_EQUAL(probeGroups[0].Query, expectedQuery);
+    }
+
+    Y_UNIT_TEST(IgnoresUnusedHeaderVariablesWhenBuildingProbeQuery) {
+        const NJson::TJsonValue fixture = ReadFixtureJson("ut/grafana_dashboard_probe_fixture.json");
+        UNIT_ASSERT(fixture.Has("dashboard"));
+
+        TCgiParameters baseQueryParameters;
+        baseQueryParameters.InsertUnescaped("var-ds", "fc872d93-d988-491c-83cd-19249cb962b0");
+        baseQueryParameters.InsertUnescaped("var-workspace", "ydb-disks-ext");
+        baseQueryParameters.InsertUnescaped("var-database", "/testing-disks-ext/NBS");
+        baseQueryParameters.InsertUnescaped("var-storagePool", "pool-1");
+
+        TCgiParameters extendedQueryParameters = baseQueryParameters;
+        extendedQueryParameters.InsertUnescaped("var-handleclass", "GetFast");
+        extendedQueryParameters.InsertUnescaped("var-aggregation", "not_selected");
+        extendedQueryParameters.InsertUnescaped("var-query1", "");
+        extendedQueryParameters.InsertUnescaped("var-env", "[PROD] MAN");
+        extendedQueryParameters.InsertUnescaped("var-unused", "42");
+
+        const auto baseProbeGroups = NMVP::NSupportLinks::BuildGrafanaDashboardProbeGroups(
+            fixture["dashboard"],
+            baseQueryParameters);
+        const auto extendedProbeGroups = NMVP::NSupportLinks::BuildGrafanaDashboardProbeGroups(
+            fixture["dashboard"],
+            extendedQueryParameters);
+
+        UNIT_ASSERT_VALUES_EQUAL(baseProbeGroups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].DatasourceUid, baseProbeGroups[0].DatasourceUid);
+        UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].Buckets, baseProbeGroups[0].Buckets);
+        UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].Query, baseProbeGroups[0].Query);
     }
 
     Y_UNIT_TEST(ResolveReturnsHttpError) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
@@ -28,6 +28,7 @@ public:
     TTestActorRuntime()
         : TMvpTestRuntime(1, false)
     {
+        NMVP::NSupportLinks::TGrafanaDashboardModelCache::ResetForTests();
         Initialize();
     }
 };
@@ -428,6 +429,68 @@ public:
     }
 };
 
+class TDashboardModelCacheCheckActor : public NActors::TActor<TDashboardModelCacheCheckActor> {
+public:
+    using TBase = NActors::TActor<TDashboardModelCacheCheckActor>;
+
+    explicit TDashboardModelCacheCheckActor(size_t* dashboardModelRequests)
+        : TBase(&TDashboardModelCacheCheckActor::StateWork)
+        , DashboardModelRequests(dashboardModelRequests)
+    {}
+
+    void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event) {
+        const TString url(event->Get()->Request->URL);
+        if (url.Contains("/api/search")) {
+            Reply(event, "HTTP/1.1 200 OK", R"json([
+                {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu","uid":"ydb_cpu"}
+            ])json");
+            return;
+        }
+        if (url.Contains("/api/dashboards/uid/ydb_cpu")) {
+            ++(*DashboardModelRequests);
+            Reply(
+                event,
+                "HTTP/1.1 200 OK",
+                MakeDashboardModelBody("label_values(ElapsedMicrosec{__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"},database)"));
+            return;
+        }
+        if (url.Contains("/api/datasources/proxy/uid/")) {
+            Reply(event, "HTTP/1.1 200 OK", MakeProbeResponseBody("1"));
+            return;
+        }
+
+        Reply(event, "HTTP/1.1 404 Not Found", R"({"message":"not found"})");
+    }
+
+    void Reply(
+        NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event,
+        TStringBuf statusLine,
+        TStringBuf body)
+    {
+        const auto request = event->Get()->Request;
+        NHttp::THttpIncomingResponsePtr response = new NHttp::THttpIncomingResponse(request);
+        EatWholeString(
+            response,
+            TStringBuilder()
+                << statusLine << "\r\n"
+                << "Connection: close\r\n"
+                << "Content-Type: application/json; charset=utf-8\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "\r\n"
+                << body);
+        Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingRequest, Handle);
+        }
+    }
+
+private:
+    size_t* DashboardModelRequests;
+};
+
 NMVP::NSupportLinks::TEvPrivate::TEvSourceResponse* ResolveSource(
     TTestActorRuntime& runtime,
     std::shared_ptr<NMVP::ILinkSource> source,
@@ -684,6 +747,43 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
         UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].DatasourceUid, baseProbeGroups[0].DatasourceUid);
         UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].Buckets, baseProbeGroups[0].Buckets);
         UNIT_ASSERT_VALUES_EQUAL(extendedProbeGroups[0].Query, baseProbeGroups[0].Query);
+    }
+
+    Y_UNIT_TEST(UsesDashboardModelCacheForRepeatedResolve) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        size_t dashboardModelRequests = 0;
+        auto httpProxyId = runtime.Register(new TDashboardModelCacheCheckActor(&dashboardModelRequests));
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(
+            MakeConfig("/api/search", TVector<TString>{"ydb-common"}),
+            MakeMetaSettings());
+
+        THashMap<TString, TString> clusterInfo;
+        clusterInfo["k8s_namespace"] = "ydb-workspace";
+        clusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* firstResponse = ResolveSource(
+            runtime,
+            source,
+            clusterInfo,
+            MakeUrlParameters("database=%2Froot%2Ftest"),
+            httpProxyId,
+            handle);
+        UNIT_ASSERT_VALUES_EQUAL(firstResponse->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(firstResponse->Links.size(), 1);
+
+        auto* secondResponse = ResolveSource(
+            runtime,
+            source,
+            clusterInfo,
+            MakeUrlParameters("database=%2Froot%2Ftest"),
+            httpProxyId,
+            handle);
+        UNIT_ASSERT_VALUES_EQUAL(secondResponse->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(secondResponse->Links.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(dashboardModelRequests, 1);
     }
 
     Y_UNIT_TEST(ResolveReturnsHttpError) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source_ut.cpp
@@ -252,6 +252,7 @@ public:
         };
 
         if (targetsSearchApi) {
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Timeout, NMVP::NSupportLinks::GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT);
             NJson::TJsonValue responseJson(NJson::JSON_ARRAY);
             for (const auto& dashboard : dashboards) {
                 bool matchesTags = true;
@@ -280,6 +281,7 @@ public:
         }
 
         if (url.Contains("/api/dashboards/uid/matched")) {
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Timeout, NMVP::NSupportLinks::GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT);
             ReplyJson(
                 event,
                 "HTTP/1.1 200 OK",
@@ -288,6 +290,7 @@ public:
         }
 
         if (url.Contains("/api/datasources/proxy/uid/")) {
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Timeout, NMVP::NSupportLinks::GRAFANA_SUPPORT_LINKS_REQUEST_TIMEOUT);
             UNIT_ASSERT(url.Contains("__bucket__%3D%22utils%22"));
             UNIT_ASSERT(url.Contains("database%3D%22/root/test%22"));
             ReplyJson(event, "HTTP/1.1 200 OK", MakeProbeResponseBody("1"));
@@ -331,6 +334,7 @@ public:
         TString UrlContains;
         TString StatusLine;
         TString Body;
+        TString Error;
     };
 
     explicit TGrafanaApiReplyActor(TVector<TRule> rules)
@@ -344,6 +348,10 @@ public:
         for (const auto& rule : Rules) {
             if (!url.Contains(rule.UrlContains)) {
                 continue;
+            }
+            if (!rule.Error.empty()) {
+                ReplyError(event, rule.Error);
+                return;
             }
             Reply(event, rule.StatusLine, rule.Body);
             return;
@@ -369,6 +377,14 @@ public:
                 << "\r\n"
                 << body);
         Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, response));
+    }
+
+    void ReplyError(
+        NHttp::TEvHttpProxy::TEvHttpOutgoingRequest::TPtr event,
+        TStringBuf error)
+    {
+        const auto request = event->Get()->Request;
+        Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(request, nullptr, TString(error)));
     }
 
     STFUNC(StateWork) {
@@ -552,6 +568,41 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSearchSource) {
             {.UrlContains = "/api/dashboards/uid/storage", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(requestBytes{__workspace__=\"$workspace\",__bucket__=\"dsproxynode\",database=\"$database\"},storagePool)")},
             {.UrlContains = "__bucket__%3D%22utils%22", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeProbeResponseBody("1")},
             {.UrlContains = "__bucket__%3D%22dsproxynode%22", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeProbeResponseBody("0")},
+        };
+        auto httpProxyId = runtime.Register(new TGrafanaApiReplyActor(std::move(rules)));
+        auto source = NMVP::MakeGrafanaDashboardSearchSource(
+            MakeConfig("/api/search", TVector<TString>{"ydb-common"}),
+            MakeMetaSettings());
+
+        THashMap<TString, TString> clusterInfo;
+        clusterInfo["k8s_namespace"] = "ydb-workspace";
+        clusterInfo["datasource"] = "3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63";
+
+        TAutoPtr<NActors::IEventHandle> handle;
+        auto* response = ResolveSource(
+            runtime,
+            source,
+            clusterInfo,
+            MakeUrlParameters("database=%2Froot%2Ftest"),
+            httpProxyId,
+            handle);
+
+        UNIT_ASSERT_VALUES_EQUAL(response->Errors.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(response->Links[0].Title, "CPU");
+    }
+
+    Y_UNIT_TEST(ResolveReturnsDashboardWhenProbeTimesOut) {
+        TMetaDatabaseTokenNameGuard tokenNameGuard("meta-token");
+        TTestActorRuntime runtime;
+
+        const TString body = R"json([
+            {"type":"dash-db","title":"CPU","url":"/d/ydb_cpu/cpu","uid":"ydb_cpu"}
+        ])json";
+        TVector<TGrafanaApiReplyActor::TRule> rules = {
+            {.UrlContains = "/api/search", .StatusLine = "HTTP/1.1 200 OK", .Body = body},
+            {.UrlContains = "/api/dashboards/uid/ydb_cpu", .StatusLine = "HTTP/1.1 200 OK", .Body = MakeDashboardModelBody("label_values(ElapsedMicrosec{__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"},database)")},
+            {.UrlContains = "/api/datasources/proxy/uid/3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63/api/v1/query", .Error = "Connection timed out"},
         };
         auto httpProxyId = runtime.Register(new TGrafanaApiReplyActor(std::move(rules)));
         auto source = NMVP::MakeGrafanaDashboardSearchSource(

--- a/ydb/mvp/meta/support_links/ut/grafana_dashboard_probe_fixture.json
+++ b/ydb/mvp/meta/support_links/ut/grafana_dashboard_probe_fixture.json
@@ -1,0 +1,83 @@
+{
+    "dashboard": {
+        "uid": "probe-fixture",
+        "title": "Support Links Probe Fixture",
+        "templating": {
+            "list": [
+                {
+                    "name": "ds",
+                    "type": "datasource",
+                    "query": "victoriametrics-datasource"
+                },
+                {
+                    "name": "workspace",
+                    "type": "custom",
+                    "current": {
+                        "value": "ydb-disks-ext"
+                    }
+                },
+                {
+                    "name": "database",
+                    "type": "query",
+                    "datasource": {
+                        "uid": "${ds}"
+                    },
+                    "query": {
+                        "query": "label_values(version{__workspace__=\"$workspace\",__bucket__=\"utils\"},database)"
+                    }
+                },
+                {
+                    "name": "storagePool",
+                    "type": "query",
+                    "datasource": {
+                        "uid": "${ds}"
+                    },
+                    "query": {
+                        "query": "label_values(requestBytes{__workspace__=\"$workspace\",__bucket__=\"dsproxynode\",database=\"$database\"},storagePool)"
+                    }
+                }
+            ]
+        },
+        "panels": [
+            {
+                "id": 1,
+                "title": "Database CPU",
+                "datasource": {
+                    "uid": "${ds}"
+                },
+                "targets": [
+                    {
+                        "refId": "A",
+                        "expr": "topk(20, rate(ElapsedMicrosec{container=\"ydb-dynamic\",__workspace__=\"$workspace\",__bucket__=\"utils\",database=\"$database\"}[5m]))"
+                    }
+                ]
+            },
+            {
+                "id": 2,
+                "title": "DSProxy Load",
+                "datasource": {
+                    "uid": "${ds}"
+                },
+                "targets": [
+                    {
+                        "refId": "A",
+                        "expr": "sum(rate(requestBytes{__workspace__=\"$workspace\",__bucket__=\"dsproxynode\",database=\"$database\",storagePool=\"$storagePool\"}[5m]))"
+                    }
+                ]
+            },
+            {
+                "id": 3,
+                "title": "PDisk CPU",
+                "datasource": {
+                    "uid": "${ds}"
+                },
+                "targets": [
+                    {
+                        "refId": "A",
+                        "expr": "sum(rate(CompletionThreadCPU{__workspace__=\"$workspace\",__bucket__=\"pdisks\"}[5m]))"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/ydb/mvp/meta/support_links/ut/ya.make
+++ b/ydb/mvp/meta/support_links/ut/ya.make
@@ -13,4 +13,8 @@ PEERDIR(
     ydb/core/testlib/actors
 )
 
+DATA(
+    arcadia/ydb/mvp/meta/support_links/ut/grafana_dashboard_probe_fixture.json
+)
+
 END()


### PR DESCRIPTION
## Summary
- fetch each Grafana dashboard JSON model after search results
- build per-dashboard probe queries from bucket selectors and filter out dashboards without live signals
- add fixtures and unit tests for probe query generation, dashboard filtering, and ignoring unused header variables

## Testing
- ./ya make --build relwithdebinfo -tA ydb/mvp/meta/support_links/ut
- ./ya make --build relwithdebinfo -tA ydb/mvp/meta/ut