### PR TITLE
Reduce hash correlations when partitioning keys for aggregation

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
@@ -59,15 +59,14 @@ size_t CalcMaxBlockLenForOutput(std::vector<TType*> wideComponents) {
     return CalcBlockLen(maxBlockItemSize);
 }
 
-using TEqualsPtr = bool(*)(const NUdf::TUnboxedValuePod*, const NUdf::TUnboxedValuePod*);
-using THashPtr = NUdf::THashType(*)(const NUdf::TUnboxedValuePod*);
-
-using TEqualsFunc = std::function<bool(const NUdf::TUnboxedValuePod*, const NUdf::TUnboxedValuePod*)>;
-using THashFunc = std::function<NUdf::THashType(const NUdf::TUnboxedValuePod*)>;
-
 static ui64 GetInstanceSeed(void* self) {
-    // Used to return CityHash64(self) but looks like that's unnecessary: we put the seed through regular and then Fibonacci hashing anyway
-    return reinterpret_cast<ui64>(self);
+    char buf[sizeof(void*)];
+    WriteUnaligned<void*>(buf, self);
+    return CityHash64(buf, sizeof(buf));
+}
+
+static Y_FORCE_INLINE ui32 GlobalHashToRhItemHash(ui64 hash) {
+    return static_cast<ui32>(hash >> 32);
 }
 
 struct TSegmentedArena
@@ -577,10 +576,13 @@ struct TDqHashCombineTestParams
     TTestStateCallback StateCallback;
 };
 
+using TEqualsFunc = TWideUnboxedEqual;
+using THashFunc = TWideUnboxedHasherFib<true>;
+
 class TBaseAggregationState: public TComputationValue<TBaseAggregationState>
 {
 protected:
-    using TMap = TDqRobinHoodHashSet<NUdf::TUnboxedValuePod*, TEqualsFunc, THashFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
+    using TMap = TDqRobinHoodHashSet<NUdf::TUnboxedValuePod*, TEqualsFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
 
     static size_t GetStaticMaxRowCount(size_t entryPayloadSizeBytes, size_t memoryLimit) {
         size_t memoryPerRow = entryPayloadSizeBytes + static_cast<size_t>(TMap::GetCellSize() * ExtraMapCapacity);
@@ -870,7 +872,7 @@ protected:
 
                 // TODO: Checkpoint: ensure RefCounts are valid
                 bool isNew = false;
-                Map->Insert(keyAndStateBuf, isNew);
+                Map->Insert(keyAndStateBuf, GlobalHashToRhItemHash(Hasher(keyAndStateBuf)), isNew);
 
                 MKQL_ENSURE(isNew, "Every key in the spilled state must be unique");
             }
@@ -913,7 +915,7 @@ protected:
                 // TODO: extract into a method (this is mostly a copy from ProcessFetchedRow)
                 TUnboxedValuePod* keyBuffer = nullptr;
                 bool isNew = false;
-                char* mapIt = Map->Insert(TempKeyBuffer.data(), isNew);
+                char* mapIt = Map->Insert(TempKeyBuffer.data(), GlobalHashToRhItemHash(Hasher(TempKeyBuffer.data())), isNew);
                 char* statePtr = nullptr;
 
                 if (isNew) {
@@ -1036,9 +1038,11 @@ protected:
         ui64 bucketId = 0;
         ui64 hash = Hasher(keyBuf.data());
         if (EnableSpilling) {
-            // Lower 16 bits are used by the hash shuffle connection to distribute keys among tasks, so we can't use these (even with the hash seed)
-            // Another solution would be to rehash using a different function but shifted bits are uniform enough
-            bucketId = ((hash * 11400714819323198485llu) >> 16) & ((1ull << BucketBits) - 1ull);
+            // Lower 16 bits of the same hash value are used by the hash shuffle connection to distribute keys among tasks,
+            // so we can't use these (even with the hash seed).
+            // Another solution would be to rehash using a different function but shifted bits are uniform enough.
+            // Actual hashmap items are using the upper 32 bits.
+            bucketId = (hash >> 16) & ((1ull << BucketBits) - 1ull);
         }
 
         if (!SpillingStack.empty()) {
@@ -1076,20 +1080,20 @@ protected:
             return EFillState::ContinueFilling;
         }
 
-        TUnboxedValuePod* keyBuffer = nullptr;
+        TUnboxedValuePod* persistentKeyBuffer = nullptr;
         bool isNew = false;
-        auto mapIt = Map->Insert(keyBuf.data(), hash, isNew);
+        auto mapIt = Map->Insert(keyBuf.data(), GlobalHashToRhItemHash(hash), isNew);
         char* statePtr = nullptr;
         if (isNew) {
             // Copy the value to the specified arena page
-            keyBuffer = static_cast<TUnboxedValuePod*>(Store->Alloc(bucketId));
-            memcpy(keyBuffer, keyBuf.data(), keyBuf.size_bytes());
-            // std::copy(TempKeyBuffer.begin(), TempKeyBuffer.end(), keyBuffer);
-            *static_cast<TUnboxedValuePod**>(Map->GetKeyPtr(mapIt)) = keyBuffer;
+            persistentKeyBuffer = static_cast<TUnboxedValuePod*>(Store->Alloc(bucketId));
+            memcpy(persistentKeyBuffer, keyBuf.data(), keyBuf.size_bytes());
+            // std::copy(TempKeyBuffer.begin(), TempKeyBuffer.end(), persistentKeyBuffer);
+            *static_cast<TUnboxedValuePod**>(Map->GetKeyPtr(mapIt)) = persistentKeyBuffer;
         } else {
-            keyBuffer = Map->GetKeyValue(mapIt);
+            persistentKeyBuffer = Map->GetKeyValue(mapIt);
         }
-        statePtr = reinterpret_cast<char *>(keyBuffer) + StatesOffset;
+        statePtr = reinterpret_cast<char *>(persistentKeyBuffer) + StatesOffset;
 
         // TODO: loop over Aggs, but for now we always have one and only GenericAggregation
         if (isNew) {
@@ -1180,8 +1184,8 @@ public:
         , Nodes(nodes)
         , WideFieldsIndex(wideFieldsIndex)
         , KeyTypes(keyTypes)
-        , Hasher(THashFunc(TWideUnboxedHasher(KeyTypes, GetInstanceSeed(this))))
-        , Equals(TWideUnboxedEqual(KeyTypes))
+        , Hasher(THashFunc(KeyTypes, GetInstanceSeed(this)))
+        , Equals(TEqualsFunc(KeyTypes))
         , Draining(false)
         , SourceEmpty(false)
         , CanBypass(!isAggregator && supportsBypass)
@@ -1303,7 +1307,7 @@ protected:
         auto tryAlloc = [this](size_t rows) -> bool {
             size_t newCapacity = GetMapCapacity(rows);
             try {
-                Map.Reset(new TMap(Hasher, Equals, newCapacity));
+                Map.Reset(new TMap(Equals, newCapacity));
                 if (!HasMemoryForProcessing()) {
                     Map.Reset(nullptr);
                     return false;
@@ -1324,7 +1328,7 @@ protected:
 
         // This can emit uncaught TMemoryLimitExceededException if we can't afford even a tiny map
         size_t smallCapacity = GetMapCapacity(LowerFixedRowCount);
-        Map.Reset(new TMap(Hasher, Equals, smallCapacity));
+        Map.Reset(new TMap(Equals, smallCapacity));
         return LowerFixedRowCount;
     }
 

--- a/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
@@ -36,8 +36,12 @@ struct TDqRobinHoodBatchRequestItem {
 
 
 // TODO: only POD key & payloads are now supported
-// This modification doesn't mix per-instance random SelfHash into the hash value; please do it in your Hasher instead
-template <typename TKey, typename TEqual, typename THash, typename TAllocator>
+//
+// This modification always uses the user-supplied hash and doesn't call any external hash functions.
+// Also it doesn't mix a per-instance seed into the supplied hash value
+// and doesn't perform Fibonacci hash value optimization.
+// Users should do their own seeding/Fibonacci optimization.
+template <typename TKey, typename TEqual, typename TAllocator>
 class TDqRobinHoodHashSet {
 public:
     static constexpr const ui32 PrefetchBatchSize = 64;
@@ -49,7 +53,6 @@ public:
     using const_iterator = const char*;
 
 protected:
-    THash HashLocal_;
     TEqual EqualLocal_;
 
 public:
@@ -68,11 +71,10 @@ public:
         }
     };
 
-    explicit TDqRobinHoodHashSet(THash hash, TEqual equal, const ui64 initialCapacity)
-        : HashLocal_(std::move(hash))
-        , EqualLocal_(std::move(equal))
+    explicit TDqRobinHoodHashSet(TEqual equal, const ui64 initialCapacity)
+        : EqualLocal_(std::move(equal))
         , Capacity_(initialCapacity)
-        , CapacityShift_(32 - MostSignificantBit(initialCapacity))
+        , CapacityShift_(64 - MostSignificantBit(initialCapacity))
         , Allocator_()
     {
         Y_ENSURE((Capacity_ & (Capacity_ - 1)) == 0);
@@ -91,17 +93,12 @@ public:
     void operator=(TDqRobinHoodHashSet&&) = delete;
 
     // returns iterator
-    Y_FORCE_INLINE char* Insert(TKey key, const ui64 hash, bool& isNew) {
-        auto shortHash = static_cast<ui32>(hash);
-        auto ptr = MakeIterator(shortHash, Data_, CapacityShift_);
-        auto ret = InsertImpl(key, shortHash, isNew, Data_, DataEnd_, ptr);
+    // "bring your own hash" version; hash must be equal to Hasher(key) if you want to mix both versions of Insert in the same hashmap instance
+    Y_FORCE_INLINE char* Insert(TKey key, const ui32 hash, bool& isNew) {
+        auto ptr = MakeIterator(hash, Data_, CapacityShift_);
+        auto ret = InsertImpl(key, hash, isNew, Data_, DataEnd_, ptr);
         Size_ += isNew ? 1 : 0;
         return ret;
-    }
-
-    // returns iterator
-    Y_FORCE_INLINE char* Insert(TKey key, bool& isNew) {
-        return Insert(key, HashLocal_(key), isNew);
     }
 
     // should be called after Insert if isNew is true
@@ -194,8 +191,8 @@ private:
     };
 
     Y_FORCE_INLINE char* MakeIterator(const ui32 hash, char* data, ui32 capacityShift) {
-        // https://web.archive.org/web/20180620004325/https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
-        ui32 bucket = static_cast<ui32>((static_cast<ui64>(hash) * 11400714819323198485ull)) >> capacityShift;
+        // Use most significant bits; only top 32 bits of (hash << 32) can be non-zero, lower bits of the bucket will be zeroes when growing beyond 32-bit capacities
+        ui64 bucket = (static_cast<ui64>(hash) << 32) >> capacityShift;
         char* ptr = data + GetCellSize() * bucket;
         return ptr;
     }
@@ -271,7 +268,7 @@ private:
 
     Y_NO_INLINE void Grow() {
         auto newCapacity = Capacity_ * CalculateRHHashTableGrowFactor(Capacity_);
-        ui32 newCapacityShift = 32 - MostSignificantBit(newCapacity);
+        ui32 newCapacityShift = 64 - MostSignificantBit(newCapacity);
         char *newData, *newDataEnd;
         Allocate(newCapacity, newData, newDataEnd);
         Y_DEFER {

--- a/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
@@ -93,7 +93,6 @@ public:
     void operator=(TDqRobinHoodHashSet&&) = delete;
 
     // returns iterator
-    // "bring your own hash" version; hash must be equal to Hasher(key) if you want to mix both versions of Insert in the same hashmap instance
     Y_FORCE_INLINE char* Insert(TKey key, const ui32 hash, bool& isNew) {
         auto ptr = MakeIterator(hash, Data_, CapacityShift_);
         auto ret = InsertImpl(key, hash, isNew, Data_, DataEnd_, ptr);
@@ -191,7 +190,8 @@ private:
     };
 
     Y_FORCE_INLINE char* MakeIterator(const ui32 hash, char* data, ui32 capacityShift) {
-        // Use most significant bits; only top 32 bits of (hash << 32) can be non-zero, lower bits of the bucket will be zeroes when growing beyond 32-bit capacities
+        // Use most significant bits; only top 32 bits of (hash << 32) can be non-zero, lower bits of the bucket will be zeroes when growing beyond 32-bit capacities.
+        // Affects performance somewhat but at least you can have humongous hash maps
         ui64 bucket = (static_cast<ui64>(hash) << 32) >> capacityShift;
         char* ptr = data + GetCellSize() * bucket;
         return ptr;

--- a/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_rh_hash.h
@@ -30,7 +30,7 @@ struct TDqRobinHoodBatchRequestItem {
     }
 
     // intermediate data
-    ui64 Hash;
+    ui32 Hash;
     char* InitialIterator;
 };
 

--- a/ydb/library/yql/dq/comp_nodes/type_utils.h
+++ b/ydb/library/yql/dq/comp_nodes/type_utils.h
@@ -27,36 +27,48 @@ struct TWideUnboxedEqual {
     const TKeyTypes& Types;
 };
 
-struct TWideUnboxedHasher {
-    TWideUnboxedHasher(const TKeyTypes& types, const ui64 seed = 0ULL)
+template<bool FibonacciOptimization>
+struct TWideUnboxedHasherFib {
+    TWideUnboxedHasherFib(const TKeyTypes& types, const ui64 seed = 0ULL)
         : Seed(seed)
         , Types(types)
     {}
 
     NUdf::THashType operator()(const NUdf::TUnboxedValuePod* values) const {
+        NUdf::THashType hash;
+
         if (Types.size() == 1U) {
             if (const auto v = *values) {
-                return CombineHashes(Seed, NUdf::GetValueHash(Types.front().first, v));
+                hash = CombineHashes(Seed, NUdf::GetValueHash(Types.front().first, v));
             } else {
-                return HashOfNull;
+                hash = HashOfNull;
+            }
+        } else {
+            hash = Seed;
+
+            for (const auto& type : Types) {
+                if (const auto v = *values++) {
+                    hash = CombineHashes(hash, NUdf::GetValueHash(type.first, v));
+                } else {
+                    hash = CombineHashes(hash, HashOfNull);
+                }
             }
         }
 
-        NUdf::THashType hash = Seed;
-        for (const auto& type : Types) {
-            if (const auto v = *values++) {
-                hash = CombineHashes(hash, NUdf::GetValueHash(type.first, v));
-            } else {
-                hash = CombineHashes(hash, HashOfNull);
-            }
+        // https://web.archive.org/web/20180620004325/https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+        if constexpr (FibonacciOptimization) {
+            return hash * 11400714819323198485ull;
+        } else {
+            return hash;
         }
-        return hash;
     }
 
 private:
     const ui64 Seed;
     const TKeyTypes& Types;
 };
+
+using TWideUnboxedHasher = TWideUnboxedHasherFib<false>;
 
 bool UnwrapBlockTypes(const TArrayRef<TType* const>& typeComponents, std::vector<TType*>& result);
 

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_rh_hash_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_rh_hash_ut.cpp
@@ -91,7 +91,7 @@ void GenerateSamples(TKeyTypes& types, ui64 key, TArrayRef<TUnboxedValue> result
             next = TUnboxedValuePod(static_cast<double>(key));
             break;
         case EDataSlot::String:
-            next = TUnboxedValuePod(NYql::NUdf::TStringValue(Sprintf("%08d.%08d.%08d", key, key, key)));
+            next = TUnboxedValuePod(NYql::NUdf::TStringValue(Sprintf("%08" PRIu64 ".%08" PRIu64, key, key)));
             break;
         default:
             UNIT_FAIL(TStringBuilder() << "can't generate values of type " << type.first);

--- a/ydb/library/yql/dq/comp_nodes/ut/dq_rh_hash_ut.cpp
+++ b/ydb/library/yql/dq/comp_nodes/ut/dq_rh_hash_ut.cpp
@@ -1,0 +1,269 @@
+#include <ydb/library/yql/dq/comp_nodes/dq_rh_hash.h>
+#include <ydb/library/yql/dq/comp_nodes/type_utils.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/size_literals.h>
+
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
+
+#include <limits>
+
+using NYql::NUdf::TUnboxedValue;
+using NYql::NUdf::TUnboxedValuePod;
+using NYql::NUdf::EDataSlot;
+using NKikimr::NMiniKQL::TDqRobinHoodHashSet;
+using NKikimr::NMiniKQL::TWideUnboxedHasherFib;
+using NKikimr::NMiniKQL::TWideUnboxedEqual;
+using NKikimr::NMiniKQL::TKeyTypes;
+using NKikimr::NMiniKQL::TScopedAlloc;
+
+// Generate a bunch of distinct integral values for key in [0..2^16)
+template<typename T>
+TUnboxedValue EncodeUint(ui64 key, bool largeValues) {
+    if (largeValues && sizeof(T) > 2) {
+        key <<= (sizeof(T) * 8 / 2);
+    }
+    if (key > std::numeric_limits<T>::max()) {
+        key = key % std::numeric_limits<T>::max();
+    }
+    return TUnboxedValuePod(static_cast<T>(key));
+}
+
+template<typename T>
+TUnboxedValue EncodeInt(ui64 key, bool largeValues) {
+    if (largeValues && sizeof(T) > 2) {
+        key <<= (sizeof(T) * 8 / 2);
+    }
+    if constexpr (sizeof(T) < sizeof(ui64)) {
+        if (key / 2 > static_cast<ui64>(std::numeric_limits<T>::max())) {
+            key = key % (static_cast<ui64>(std::numeric_limits<T>::max()) * 2u + 2u);
+        }
+    }
+
+    T signedKey;
+    if (key == 0) {
+        signedKey = 0;
+    } else {
+        signedKey = (key % 2 == 0) ? static_cast<T>((key) >> 1) : static_cast<T>(-((key + 1) >> 1));
+    }
+
+    return TUnboxedValuePod(signedKey);
+}
+
+void GenerateSamples(TKeyTypes& types, ui64 key, TArrayRef<TUnboxedValue> result, bool largeValues)
+{
+    TUnboxedValue* it = result.begin();
+
+    for (auto type : types) {
+        UNIT_ASSERT(it < result.end());
+        TUnboxedValue& next = *it;
+
+        key = (key + 1) % (1 << 16);
+
+        switch (type.first) {
+        case EDataSlot::Bool:
+            next = TUnboxedValuePod(static_cast<bool>((key % 2) == 0));
+            break;
+        case EDataSlot::Uint16:
+            next = EncodeUint<ui16>(key, largeValues);
+            break;
+        case EDataSlot::Uint32:
+            next = EncodeUint<ui32>(key, largeValues);
+            break;
+        case EDataSlot::Uint64:
+            next = EncodeUint<ui64>(key, largeValues);
+            break;
+        case EDataSlot::Int16:
+            next = EncodeInt<i16>(key, largeValues);
+            break;
+        case EDataSlot::Int32:
+            next = EncodeInt<i32>(key, largeValues);
+            break;
+        case EDataSlot::Int64:
+            next = EncodeInt<i64>(key, largeValues);
+            break;
+        case EDataSlot::Float:
+            next = TUnboxedValuePod(static_cast<float>(key));
+            break;
+        case EDataSlot::Double:
+            next = TUnboxedValuePod(static_cast<double>(key));
+            break;
+        case EDataSlot::String:
+            next = TUnboxedValuePod(NYql::NUdf::TStringValue(Sprintf("%08d.%08d.%08d", key, key, key)));
+            break;
+        default:
+            UNIT_FAIL(TStringBuilder() << "can't generate values of type " << type.first);
+        }
+
+        ++it;
+    }
+}
+
+using TRHMap = TDqRobinHoodHashSet<TUnboxedValue*, NKikimr::NMiniKQL::TWideUnboxedEqual, std::allocator<char>>;
+
+// Number of buckets used to estimate how evenly the entries are spread across the table.
+static constexpr ui32 NumBuckets = 256;
+
+// Runs the generate/insert/measure loop for a single set of input types.
+void TestDistributionScenario(TKeyTypes types, ui64 samples, bool largeValues) {
+    size_t nullableCount = 0;
+    for (const auto& type : types) {
+        nullableCount += type.second ? 1 : 0;
+    }
+
+    // Also add all the combinations with null values (use key == 0 for non-null values).
+    // The mask == 0 combination (all zeroes, no nulls) is skipped because it duplicates
+    // the key == 0 sample, so we add (2^nullableCount - 1) extra entries, all containing at least one null.
+    size_t nullCombos = nullableCount ? ((size_t(1) << nullableCount) - 1) : 0;
+
+    size_t samplesWithNulls = samples + nullCombos;
+
+    std::vector<TUnboxedValue> store;
+    store.resize(types.size() * samplesWithNulls);
+
+    TWideUnboxedHasherFib<true> hasher(types);
+
+    TRHMap map(TWideUnboxedEqual(types), samples * 2);
+
+    for (ui64 i = 0; i < samples; ++i) {
+        TUnboxedValue* valuesPtr = store.data() + types.size() * i;
+        GenerateSamples(types, i, TArrayRef<TUnboxedValue>(valuesPtr, types.size()), largeValues);
+    }
+
+    for (size_t mask = 1; mask <= nullCombos; ++mask) {
+        size_t i = mask - 1 + samples;
+
+        TUnboxedValue* valuesPtr = store.data() + (types.size() * i);
+        GenerateSamples(types, 0, TArrayRef<TUnboxedValue>(valuesPtr, types.size()), largeValues);
+
+        size_t nullableBit = 0;
+        for (ui32 j = 0; j < types.size(); ++j) {
+            if (types[j].second) {
+                if (mask & (size_t(1) << nullableBit)) {
+                    valuesPtr[j] = TUnboxedValuePod();
+                }
+                ++nullableBit;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < store.size(); i += types.size()) {
+        bool isNew = false;
+        TUnboxedValue* valuesPtr = store.data() + i;
+        // Hasher params & the bit shift follow the real-world usage pattern of this map
+        // (not extracted into a function yet)
+        map.Insert(valuesPtr, hasher(valuesPtr) >> 32, isNew);
+        UNIT_ASSERT(isNew);
+    }
+
+    UNIT_ASSERT(map.GetSize() == samplesWithNulls);
+
+    // Collect hash distribution stats into a set of buckets
+    // Also collect the max PSL over the entire map
+    std::vector<size_t> bucketSizes(NumBuckets, 0);
+    char* iter = map.Begin();
+    char* end = map.End();
+    size_t capacity = map.GetCapacity();
+
+    i32 maxPsl = 0;
+    size_t idx = 0;
+    while (iter != end) {
+        if (map.IsValid(iter)) {
+            size_t bucket = idx * NumBuckets / capacity;
+            ++bucketSizes[bucket];
+
+            TRHMap::TPSLStorage psl = ReadUnaligned<TRHMap::TPSLStorage>(iter);
+            // collect the max of psl.Distance
+            maxPsl = std::max(maxPsl, psl.Distance);
+        }
+
+        map.Advance(iter);
+        idx++;
+    }
+
+    size_t maxBucket = 0;
+    size_t minBucket = std::numeric_limits<size_t>::max();
+    for (size_t b : bucketSizes) {
+        maxBucket = std::max(maxBucket, b);
+        minBucket = std::min(minBucket, b);
+    }
+
+    /*
+    for (const auto& type : types) {
+        Cerr << type.first << ", " << type.second << Endl;
+    }
+
+    Cerr << "bucket spread (max - min): " << (maxBucket - minBucket)
+         << " (max=" << maxBucket << ", min=" << minBucket << ", buckets=" << NumBuckets << ")" << Endl;
+    Cerr << maxPsl << Endl;
+    */
+
+    UNIT_ASSERT_C(maxBucket - minBucket < 150, "Hash distribution is unbalanced");
+    UNIT_ASSERT_C(maxPsl < 15, "Hash table max PSL is too large");
+}
+
+Y_UNIT_TEST_SUITE(TDqRhHashTest) {
+    Y_UNIT_TEST_TWIN(TestDistribution, LargeValues) {
+        // The test should run the initialization/verification loop for every single-value case
+        // (nullable and non-nullable types - 9 types each currently excluding bool which has too few values to compute any distributions)
+        // and for every two-value case (with types.size() == 2) with either both types being non-nullable
+        // and both types being nullable (99 type combinations for non-nullable types, 99 type combinations with nullable types - except <bool, bool>)
+        // Should be fast enough for 64ki samples
+
+        // String values are allocated via the MiniKQL allocator, so a scope must be bound.
+        // It must outlive the per-scenario stores holding the TUnboxedValues.
+        TScopedAlloc alloc(__LOCATION__);
+
+        ui64 samples = 1 << 16;
+
+        // Single-value types
+        static const EDataSlot singleValueTypes[] = {
+            EDataSlot::Uint16,
+            EDataSlot::Uint32,
+            EDataSlot::Uint64,
+            EDataSlot::Int16,
+            EDataSlot::Int32,
+            EDataSlot::Int64,
+            EDataSlot::Float,
+            EDataSlot::Double,
+            EDataSlot::String,
+        };
+
+        // Two-value types: bool is included
+        static const EDataSlot tupleValueTypes[] = {
+            EDataSlot::Bool,
+            EDataSlot::Uint16,
+            EDataSlot::Uint32,
+            EDataSlot::Uint64,
+            EDataSlot::Int16,
+            EDataSlot::Int32,
+            EDataSlot::Int64,
+            EDataSlot::Float,
+            EDataSlot::Double,
+            EDataSlot::String,
+        };
+
+        // Skip {Bool} and {Bool, Bool} cases because we need at least 2^16 distinct values
+
+        // Single-value cases: non-nullable and nullable variants of every type
+        for (bool nullable : {false, true}) {
+            for (EDataSlot slot : singleValueTypes) {
+                TestDistributionScenario(TKeyTypes{{slot, nullable}}, samples, LargeValues);
+            }
+        }
+
+        // Two-value cases: every ordered pair of types, both non-nullable or both nullable
+        for (bool nullable : {false, true}) {
+            for (EDataSlot first : tupleValueTypes) {
+                for (EDataSlot second : tupleValueTypes) {
+                    if (first == EDataSlot::Bool && second == EDataSlot::Bool) {
+                        continue;
+                    }
+                    TestDistributionScenario(TKeyTypes{{first, nullable}, {second, nullable}}, samples, LargeValues);
+                }
+            }
+        }
+    }
+}

--- a/ydb/library/yql/dq/comp_nodes/ut/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ut/ya.make
@@ -28,6 +28,7 @@ YQL_LAST_ABI_VERSION()
 SRCS(
     dq_hash_combine_ut.cpp
     dq_hash_join_ut.cpp
+    dq_rh_hash_ut.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Untangle hash calculation from the hash map. Also allocate distinct bit ranges for different use cases (upper 32 bits: hash map cell; next 16 bits: spilling bucket; lower 16 bits: hash shuffle). Fix the ui32 multiplication overflow. Add the hashing quality test.