### PR TITLE
Add viewer query fire-and-forget action

### DIFF
--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -265,7 +265,7 @@ void InitViewerWhoAmIJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerQueryJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/query", new THttpHandler<TJsonQuery>(TJsonQuery::GetSwagger()), 11);
+    handlers.AddHandler("/viewer/query", new THttpHandler<TJsonQuery>(TJsonQuery::GetSwagger()), 12);
 }
 
 void InitViewerNetInfoJsonHandler(TJsonHandlers& handlers) {

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -78,7 +78,7 @@ protected:
 
     template<typename T>
     struct TRequestResponse {
-        std::variant<std::monostate, std::shared_ptr<T>, TString, std::nullptr_t> Response;
+        std::variant<std::monostate, std::shared_ptr<T>, TString> Response;
         NWilson::TSpan Span;
 
         TRequestResponse() = default;
@@ -128,17 +128,6 @@ protected:
             if (!IsDone()) {
                 Span.EndError(error);
                 Response = error;
-                return true;
-            }
-            return false;
-        }
-
-        bool FinishOk() {
-            if (!IsDone()) {
-                if (Span) {
-                    Span.EndOk();
-                }
-                Response = nullptr;
                 return true;
             }
             return false;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -78,7 +78,7 @@ protected:
 
     template<typename T>
     struct TRequestResponse {
-        std::variant<std::monostate, std::shared_ptr<T>, TString> Response;
+        std::variant<std::monostate, std::shared_ptr<T>, TString, std::nullptr_t> Response;
         NWilson::TSpan Span;
 
         TRequestResponse() = default;
@@ -128,6 +128,15 @@ protected:
             if (!IsDone()) {
                 Span.EndError(error);
                 Response = error;
+                return true;
+            }
+            return false;
+        }
+
+        bool FinishOk() {
+            if (!IsDone()) {
+                Span.EndOk();
+                Response = nullptr;
                 return true;
             }
             return false;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -135,7 +135,9 @@ protected:
 
         bool FinishOk() {
             if (!IsDone()) {
-                Span.EndOk();
+                if (Span) {
+                    Span.EndOk();
+                }
                 Response = nullptr;
                 return true;
             }

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1376,6 +1376,7 @@
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTA=",
                     "Offset": 11,
                     "OriginalSize": 20,
@@ -1383,12 +1384,12 @@
                     "SeqNo": 12,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTE=",
                     "Offset": 12,
                     "OriginalSize": 20,
@@ -1396,12 +1397,12 @@
                     "SeqNo": 13,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTI=",
                     "Offset": 13,
                     "OriginalSize": 20,
@@ -1409,12 +1410,12 @@
                     "SeqNo": 14,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTM=",
                     "Offset": 14,
                     "OriginalSize": 20,
@@ -1422,12 +1423,12 @@
                     "SeqNo": 15,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTQ=",
                     "Offset": 15,
                     "OriginalSize": 20,
@@ -1435,8 +1436,7 @@
                     "SeqNo": 16,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1448,6 +1448,7 @@
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0w",
                     "Offset": 0,
                     "OriginalSize": 9,
@@ -1455,12 +1456,12 @@
                     "SeqNo": 1,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0x",
                     "Offset": 1,
                     "OriginalSize": 9,
@@ -1468,12 +1469,12 @@
                     "SeqNo": 2,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0y",
                     "Offset": 2,
                     "OriginalSize": 9,
@@ -1481,8 +1482,7 @@
                     "SeqNo": 3,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1494,6 +1494,7 @@
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZV93aXRoX21ldGE=",
                     "MessageMetadata": [
                         {
@@ -1511,8 +1512,7 @@
                     "SeqNo": 11,
                     "StorageSize": 37,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1524,6 +1524,7 @@
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTk=",
                     "Offset": 20,
                     "OriginalSize": 20,
@@ -1531,8 +1532,7 @@
                     "SeqNo": 21,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1544,6 +1544,7 @@
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0w",
                     "Offset": 0,
                     "OriginalSize": 9,
@@ -1551,12 +1552,12 @@
                     "SeqNo": 1,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0x",
                     "Offset": 1,
                     "OriginalSize": 9,
@@ -1564,12 +1565,12 @@
                     "SeqNo": 2,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0y",
                     "Offset": 2,
                     "OriginalSize": 9,
@@ -1577,12 +1578,12 @@
                     "SeqNo": 3,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS0z",
                     "Offset": 3,
                     "OriginalSize": 9,
@@ -1590,12 +1591,12 @@
                     "SeqNo": 4,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "bWVzc2FnZS00",
                     "Offset": 4,
                     "OriginalSize": 9,
@@ -1603,8 +1604,7 @@
                     "SeqNo": 5,
                     "StorageSize": 9,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1616,6 +1616,7 @@
                 {
                     "Codec": 1,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "text",
                     "Message": "Y29tcHI=",
                     "Offset": 20,
                     "OriginalSize": 20,
@@ -1623,8 +1624,7 @@
                     "SeqNo": 21,
                     "StorageSize": 38,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": "text"
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -1639,6 +1639,7 @@
                 {
                     "Codec": 0,
                     "CreateTimestamp": "not-zero-number",
+                    "Ip": "",
                     "Message": "eyJ1cGRhdGUiOnsibmFtZSI6ImVsbGV2ZW4ifSwia2V5IjpbMTFdfQ==",
                     "Offset": 0,
                     "OriginalSize": 40,
@@ -1646,8 +1647,7 @@
                     "SeqNo": 1,
                     "StorageSize": 40,
                     "TimestampDiff": "number",
-                    "WriteTimestamp": "not-zero-number",
-                    "Ip": ""
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -4556,18 +4556,6 @@
             "Status": "StatusSuccess"
         }
     },
-    "test.TestViewer.test_viewer_domain_peers": {
-        "FieldsAvailable": "0000011110111010000000000110101000011",
-        "FieldsRequired": "0000000000010000000000000000001000001",
-        "FoundNodes": "1",
-        "Nodes": [
-            {
-                "ConnectStatus": "Grey",
-                "NodeId": 1
-            }
-        ],
-        "TotalNodes": "1"
-    },
     "test.TestViewer.test_viewer_describe_column_table_local_index": {
         "root_child_names": [
             ".metadata",
@@ -4583,6 +4571,18 @@
             }
         ],
         "table_children_exist": true
+    },
+    "test.TestViewer.test_viewer_domain_peers": {
+        "FieldsAvailable": "0000011110111010000000000110101000011",
+        "FieldsRequired": "0000000000010000000000000000001000001",
+        "FoundNodes": "1",
+        "Nodes": [
+            {
+                "ConnectStatus": "Grey",
+                "NodeId": 1
+            }
+        ],
+        "TotalNodes": "1"
     },
     "test.TestViewer.test_viewer_external_http_access_controls": {
         "administration_bscontrollerinfo_database": {
@@ -5540,14 +5540,14 @@
                 "EnableAlterDatabaseCreateHiveFirst": true,
                 "EnableDrainOnShutdown": false,
                 "EnableExtraSidsControlForHttpViewer": true,
+                "EnableLocalBloomFilterIndex": true,
+                "EnableLocalIndexAsSchemeObject": true,
                 "EnableMvccSnapshotReads": true,
                 "EnablePersistentQueryStats": true,
                 "EnablePublicApiExternalBlobs": false,
                 "EnableSchemeTransactionsAtSchemeShard": true,
                 "EnableScriptExecutionOperations": true,
-                "EnableTopicTransfer": true,
-                "EnableLocalBloomFilterIndex": true,
-                "EnableLocalIndexAsSchemeObject": true
+                "EnableTopicTransfer": true
             },
             "FederatedQueryConfig": {
                 "Audit": {
@@ -6589,14 +6589,14 @@
                 "EnableAlterDatabaseCreateHiveFirst": true,
                 "EnableDrainOnShutdown": false,
                 "EnableExtraSidsControlForHttpViewer": true,
+                "EnableLocalBloomFilterIndex": true,
+                "EnableLocalIndexAsSchemeObject": true,
                 "EnableMvccSnapshotReads": true,
                 "EnablePersistentQueryStats": true,
                 "EnablePublicApiExternalBlobs": false,
                 "EnableSchemeTransactionsAtSchemeShard": true,
                 "EnableScriptExecutionOperations": true,
-                "EnableTopicTransfer": true,
-                "EnableLocalBloomFilterIndex": true,
-                "EnableLocalIndexAsSchemeObject": true
+                "EnableTopicTransfer": true
             },
             "FederatedQueryConfig": {
                 "Audit": {
@@ -7638,14 +7638,14 @@
                 "EnableAlterDatabaseCreateHiveFirst": true,
                 "EnableDrainOnShutdown": false,
                 "EnableExtraSidsControlForHttpViewer": true,
+                "EnableLocalBloomFilterIndex": true,
+                "EnableLocalIndexAsSchemeObject": true,
                 "EnableMvccSnapshotReads": true,
                 "EnablePersistentQueryStats": true,
                 "EnablePublicApiExternalBlobs": false,
                 "EnableSchemeTransactionsAtSchemeShard": true,
                 "EnableScriptExecutionOperations": true,
-                "EnableTopicTransfer": true,
-                "EnableLocalBloomFilterIndex": true,
-                "EnableLocalIndexAsSchemeObject": true
+                "EnableTopicTransfer": true
             },
             "FederatedQueryConfig": {
                 "Audit": {
@@ -11374,6 +11374,28 @@
             }
         ],
         "status_code": 200
+    },
+    "test.TestViewer.test_viewer_query_forget_delayed": {
+        "message": "Query is running in background",
+        "status": "SUCCESS"
+    },
+    "test.TestViewer.test_viewer_query_forget_immediate": {
+        "result": [
+            {
+                "columns": [
+                    {
+                        "name": "column0",
+                        "type": "Int32"
+                    }
+                ],
+                "rows": [
+                    [
+                        42
+                    ]
+                ]
+            }
+        ],
+        "status": "SUCCESS"
     },
     "test.TestViewer.test_viewer_query_from_table": {
         "/Root/dedicated_db": {

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -1643,6 +1643,34 @@ class TestViewer(object):
         return result
 
     @classmethod
+    def test_viewer_query_forget_immediate(cls):
+        """Test execute-query-and-forget immediate return when query finishes quickly"""
+        # Run query that executes and completes before forget_after (10 seconds)
+        result = cls.call_viewer("/viewer/query", {
+            'database': cls.dedicated_db,
+            'action': 'execute-query-and-forget',
+            'query': 'SELECT 7*6;',
+            'schema': 'multi',
+            'forget_after': 10000
+        })
+        cls.delete_keys_recursively(result, {'Version', 'version'})
+        return result
+
+    @classmethod
+    def test_viewer_query_forget_delayed(cls):
+        """Test execute-query-and-forget when query takes longer than forget_after"""
+        # Run query with very small forget_after (1ms) so it will be forgotten and run in background
+        result = cls.call_viewer("/viewer/query", {
+            'database': cls.dedicated_db,
+            'action': 'execute-query-and-forget',
+            'query': 'SELECT * FROM table1 LIMIT 3;',
+            'schema': 'multi',
+            'forget_after': 1
+        })
+        cls.delete_keys_recursively(result, {'Version', 'version'})
+        return result
+
+    @classmethod
     def test_viewer_external_http_access_controls(cls):
         result = {}
 

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -411,6 +411,9 @@ public:
         if (Timeout) {
             Deadline = TActivationContext::Now() + Timeout;
         }
+        if (Forget) {
+            QueryRequestStartTime = TActivationContext::Now();
+        }
         SendKpqProxyRequest();
         Become(&TThis::StateWork);
         if (Timeout || KeepAlive || Long || Action == "fetch-long-query" || Forget) {
@@ -650,7 +653,7 @@ public:
         }
         request.SetIsInternalCall(InternalCall);
         ActorIdToProto(SelfId(), event->Record.MutableRequestActorId());
-        if (Forget) {
+        if (Forget && !QueryRequestStartTime) {
             QueryRequestStartTime = TActivationContext::Now();
         }
         return MakeRequest<TResponseType>(NKqp::MakeKqpProxyID(SelfId().NodeId()), event.Release());

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -367,8 +367,8 @@ public:
         if (params.Has("stats_period")) {
             StatsPeriod = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("stats_period"), StatsPeriod.MilliSeconds()), 1000, 600000));
         }
-        if (params.Has("forget-after")) {
-            ForgetAfter = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("forget-after"), ForgetAfter.MilliSeconds()), 1, MaxForgetAfter.MilliSeconds()));
+        if (params.Has("forget_after")) {
+            ForgetAfter = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("forget_after"), ForgetAfter.MilliSeconds()), 1, MaxForgetAfter.MilliSeconds()));
         }
         if (Streaming == EStreamingType::None || params.Has("timeout")) {
             Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), 60000)); // override default timeout to 60 seconds
@@ -1591,9 +1591,9 @@ public:
                 description: timeout in ms, for synchronous queries it's 60s by default, for streaming queries it's off by default
                 type: integer
                 required: false
-              - name: forget-after
+              - name: forget_after
                 in: query
-                description: wait timeout in ms for execute-query-and-forget before returning success and leaving query running in background, clamped to 1..60000 ms
+                description: underscore alias for forget-after
                 type: integer
                 required: false
                 default: 1000

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -1253,7 +1253,7 @@ private:
 
     void ForgetQuery() {
         QueryForgotten = true;
-        if (QueryResponse && !QueryResponse.IsDone()) {
+        if (!QueryResponse.IsDone()) {
             QueryResponse.FinishOk();
         }
     }
@@ -1269,10 +1269,10 @@ private:
         if (Forget && QueryRequestStartTime && (now - QueryRequestStartTime >= ForgetAfter)) {
             return ReplyAndForgetQuery();
         }
-        if (Timeout && (now - QueryStartTime > Timeout)) {
+        if (!Forget && Timeout && (now - QueryStartTime > Timeout)) {
             return ReplyWithTimeoutError();
         }
-        if (KeepAlive && (now - LastSendTime > KeepAlive)) {
+        if (!Forget && KeepAlive && (now - LastSendTime > KeepAlive)) {
             SendKeepAlive();
         }
         if (OperationId && (!GetOperationResponse.has_value() || GetOperationResponse->IsDone())) {

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -411,12 +411,9 @@ public:
         if (Timeout) {
             Deadline = TActivationContext::Now() + Timeout;
         }
-        if (Forget) {
-            QueryRequestStartTime = TActivationContext::Now();
-        }
         SendKpqProxyRequest();
         Become(&TThis::StateWork);
-        if (Timeout || KeepAlive || Long || Action == "fetch-long-query" || Forget) {
+        if (Timeout || KeepAlive || Long || Action == "fetch-long-query") {
             Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
         }
         QueryStartTime = TActivationContext::Now();
@@ -1272,7 +1269,7 @@ private:
         if (Forget && QueryRequestStartTime && (now - QueryRequestStartTime >= ForgetAfter)) {
             return ReplyAndForgetQuery();
         }
-        if (!Forget && Timeout && (now - QueryStartTime > Timeout)) {
+        if (Timeout && (!Forget || !QueryRequestStartTime) && (now - QueryStartTime > Timeout)) {
             return ReplyWithTimeoutError();
         }
         if (!Forget && KeepAlive && (now - LastSendTime > KeepAlive)) {

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -570,7 +570,8 @@ public:
     void PingSession() {
         auto event = std::make_unique<NKqp::TEvKqp::TEvPingSessionRequest>();
         event->Record.MutableRequest()->SetSessionId(SessionId);
-        ActorIdToProto(SelfId(), event->Record.MutableRequest()->MutableExtSessionCtrlActorId());
+        TActorId ctrlActor = Forget ? MakeViewerID(SelfId().NodeId()) : SelfId();
+        ActorIdToProto(ctrlActor, event->Record.MutableRequest()->MutableExtSessionCtrlActorId());
         Send(NKqp::MakeKqpProxyID(SelfId().NodeId()), event.release());
     }
 
@@ -682,9 +683,7 @@ public:
         }
 
         SessionId = CreateSessionResponse->Record.GetResponse().GetSessionId();
-        if (!Forget) {
-            PingSession();
-        }
+        PingSession();
 
         if (Streaming != EStreamingType::None) {
             NJson::TJsonValue json;

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -436,7 +436,7 @@ public:
             auto event = std::make_unique<NKqp::TEvKqp::TEvCancelQueryRequest>();
             event->Record.MutableRequest()->SetSessionId(SessionId);
             Send(NKqp::MakeKqpProxyID(SelfId().NodeId()), event.release());
-            if (QueryResponse && !QueryResponse.IsDone()) {
+            if (!QueryResponse.IsDone()) {
                 QueryResponse.Error("QueryCancelled");
             }
         }
@@ -444,7 +444,7 @@ public:
 
     void CloseSession() {
         if (SessionId && !QueryForgotten) {
-            if (QueryResponse && !QueryResponse.IsDone()) {
+            if (!QueryResponse.IsDone()) {
                 CancelQuery();
             }
             auto event = std::make_unique<NKqp::TEvKqp::TEvCloseSessionRequest>();
@@ -1264,9 +1264,6 @@ private:
 
     void ForgetQuery() {
         QueryForgotten = true;
-        if (!QueryResponse.IsDone()) {
-            QueryResponse.Error("Cancelled");
-        }
     }
 
     void CheckOperationStatus() {

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -93,9 +93,10 @@ private:
         }
     }
 
-    TDuration GetWakeupPeriod() const {
+    TDuration GetWakeupPeriod(TInstant now = TInstant()) const {
         if (Forget && QueryRequestStartTime) {
-            return Min(WakeupPeriod, ForgetAfter);
+            now = now ? now : TActivationContext::Now();
+            return Min(WakeupPeriod, ForgetAfter - Min(now - QueryRequestStartTime, ForgetAfter));
         }
         return WakeupPeriod;
     }
@@ -356,7 +357,7 @@ public:
             StatsPeriod = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("stats_period"), StatsPeriod.MilliSeconds()), 1000, 600000));
         }
         if (params.Has("forget-after")) {
-            ForgetAfter = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("forget-after"), ForgetAfter.MilliSeconds()));
+            ForgetAfter = TDuration::MilliSeconds(Max<ui64>(FromStringWithDefault<ui64>(params.Get("forget-after"), ForgetAfter.MilliSeconds()), 1));
         }
         if (Streaming == EStreamingType::None || params.Has("timeout")) {
             Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), 60000)); // override default timeout to 60 seconds
@@ -442,6 +443,10 @@ public:
     }
 
     void Cancelled() {
+        if (Forget) {
+            ForgetQuery();
+            return TBase::Cancelled();
+        }
         CancelQuery();
         TBase::Cancelled();
     }
@@ -1237,16 +1242,20 @@ private:
     }
 
     void ReplyAndForgetQuery() {
-        QueryForgotten = true;
-        if (QueryResponse && !QueryResponse.IsDone()) {
-            QueryResponse.Error("QueryForgotten");
-        }
+        ForgetQuery();
 
         NJson::TJsonValue json;
         InitJsonResponse(json);
         json["status"] = Ydb::StatusIds_StatusCode_Name(Ydb::StatusIds::SUCCESS);
         json["message"] = "Query is running in background";
         ReplyWithJsonAndPassAway("QueryForgotten", std::move(json));
+    }
+
+    void ForgetQuery() {
+        QueryForgotten = true;
+        if (QueryResponse && !QueryResponse.IsDone()) {
+            QueryResponse.FinishOk();
+        }
     }
 
     void CheckOperationStatus() {
@@ -1269,7 +1278,7 @@ private:
         if (OperationId && (!GetOperationResponse.has_value() || GetOperationResponse->IsDone())) {
             CheckOperationStatus();
         }
-        Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
+        Schedule(GetWakeupPeriod(now), new TEvents::TEvWakeup());
     }
 
 private:

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -1257,7 +1257,7 @@ private:
     void ForgetQuery() {
         QueryForgotten = true;
         if (!QueryResponse.IsDone()) {
-            QueryResponse.FinishOk();
+            QueryResponse.Error("Cancelled");
         }
     }
 

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -30,10 +30,14 @@ class TJsonQuery : public TViewerPipeClient {
     int TotalRows = 0;
     bool CollectDiagnostics = true;
     bool Long = false;
+    bool Forget = false;
+    bool QueryForgotten = false;
     TDuration StatsPeriod;
     TDuration KeepAlive = TDuration::MilliSeconds(10000);
+    TDuration ForgetAfter = TDuration::Seconds(1);
     TInstant LastSendTime;
     TInstant QueryStartTime;
+    TInstant QueryRequestStartTime;
     TInstant Deadline;
     static constexpr TDuration WakeupPeriod = TDuration::Seconds(1);
 
@@ -87,6 +91,13 @@ private:
         if (!ExecutionId.empty()) {
             jsonResponse["execution_id"] = ExecutionId;
         }
+    }
+
+    TDuration GetWakeupPeriod() const {
+        if (Forget && QueryRequestStartTime) {
+            return Min(WakeupPeriod, ForgetAfter);
+        }
+        return WakeupPeriod;
     }
 
     void CreateStandardErrorResponse(NJson::TJsonValue& jsonResponse, const TString& message) {
@@ -294,6 +305,7 @@ public:
             Action = params.Get("action");
         }
         Long = Action == "execute-long-query";
+        Forget = Action == "execute-query-and-forget";
         if (params.Has("schema")) {
             Schema = StringToSchemaType(params.Get("schema"));
             if (Params.Get("schema") == "multipart") {
@@ -342,6 +354,9 @@ public:
         InternalCall = FromStringWithDefault<bool>(params.Get("internal_call"), InternalCall);
         if (params.Has("stats_period")) {
             StatsPeriod = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("stats_period"), StatsPeriod.MilliSeconds()), 1000, 600000));
+        }
+        if (params.Has("forget-after")) {
+            ForgetAfter = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("forget-after"), ForgetAfter.MilliSeconds()));
         }
         if (Streaming == EStreamingType::None || params.Has("timeout")) {
             Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), 60000)); // override default timeout to 60 seconds
@@ -397,15 +412,15 @@ public:
         }
         SendKpqProxyRequest();
         Become(&TThis::StateWork);
-        if (Timeout || KeepAlive || Long || Action == "fetch-long-query") {
-            Schedule(WakeupPeriod, new TEvents::TEvWakeup());
+        if (Timeout || KeepAlive || Long || Action == "fetch-long-query" || Forget) {
+            Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
         }
         QueryStartTime = TActivationContext::Now();
         LastSendTime = TActivationContext::Now();
     }
 
     void CancelQuery() {
-        if (SessionId) {
+        if (SessionId && !QueryForgotten) {
             auto event = std::make_unique<NKqp::TEvKqp::TEvCancelQueryRequest>();
             event->Record.MutableRequest()->SetSessionId(SessionId);
             Send(NKqp::MakeKqpProxyID(SelfId().NodeId()), event.release());
@@ -416,7 +431,7 @@ public:
     }
 
     void CloseSession() {
-        if (SessionId) {
+        if (SessionId && !QueryForgotten) {
             if (QueryResponse && !QueryResponse.IsDone()) {
                 CancelQuery();
             }
@@ -563,7 +578,7 @@ public:
             request.SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
             request.SetType(NKikimrKqp::QUERY_TYPE_SQL_SCRIPT);
             request.SetKeepSession(false);
-        } else if (Action.empty() || Action == "execute-query" || Action == "execute") {
+        } else if (Action.empty() || Action == "execute-query" || Action == "execute" || Forget) {
             request.SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
             request.SetType(ConcurrentResults ? NKikimrKqp::QUERY_TYPE_SQL_GENERIC_CONCURRENT_QUERY : NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY);
             request.SetKeepSession(false);
@@ -630,6 +645,9 @@ public:
         }
         request.SetIsInternalCall(InternalCall);
         ActorIdToProto(SelfId(), event->Record.MutableRequestActorId());
+        if (Forget) {
+            QueryRequestStartTime = TActivationContext::Now();
+        }
         return MakeRequest<TResponseType>(NKqp::MakeKqpProxyID(SelfId().NodeId()), event.Release());
     }
 
@@ -648,7 +666,9 @@ public:
         }
 
         SessionId = CreateSessionResponse->Record.GetResponse().GetSessionId();
-        PingSession();
+        if (!Forget) {
+            PingSession();
+        }
 
         if (Streaming != EStreamingType::None) {
             NJson::TJsonValue json;
@@ -660,6 +680,9 @@ public:
             StreamJsonResponse("SessionCreated", std::move(json));
         }
         QueryResponse = MakeQueryRequest<NKqp::TEvKqp::TEvQueryRequest, NKqp::TEvKqp::TEvQueryResponse>();
+        if (Forget) {
+            Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
+        }
     }
 
 private:
@@ -1213,6 +1236,19 @@ private:
         ReplyWithJsonAndPassAway("Error", std::move(json), error);
     }
 
+    void ReplyAndForgetQuery() {
+        QueryForgotten = true;
+        if (QueryResponse && !QueryResponse.IsDone()) {
+            QueryResponse.Error("QueryForgotten");
+        }
+
+        NJson::TJsonValue json;
+        InitJsonResponse(json);
+        json["status"] = Ydb::StatusIds_StatusCode_Name(Ydb::StatusIds::SUCCESS);
+        json["message"] = "Query is running in background";
+        ReplyWithJsonAndPassAway("QueryForgotten", std::move(json));
+    }
+
     void CheckOperationStatus() {
         if (!GetOperationResponse.has_value() || GetOperationResponse->IsDone()) {
             GetOperationResponse = MakeRequest<NKqp::TEvGetScriptExecutionOperationResponse>(NKqp::MakeKqpProxyID(SelfId().NodeId()), new NKqp::TEvGetScriptExecutionOperation(Database, *OperationId, GetUserSID()));
@@ -1221,6 +1257,9 @@ private:
 
     void HandleWakeup() {
         auto now = TActivationContext::Now();
+        if (Forget && QueryRequestStartTime && (now - QueryRequestStartTime >= ForgetAfter)) {
+            return ReplyAndForgetQuery();
+        }
         if (Timeout && (now - QueryStartTime > Timeout)) {
             return ReplyWithTimeoutError();
         }
@@ -1230,7 +1269,7 @@ private:
         if (OperationId && (!GetOperationResponse.has_value() || GetOperationResponse->IsDone())) {
             CheckOperationStatus();
         }
-        Schedule(WakeupPeriod, new TEvents::TEvWakeup());
+        Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
     }
 
 private:
@@ -1421,11 +1460,12 @@ public:
               - name: action
                 in: query
                 type: string
-                enum: [execute-scan, execute-script, execute-query, execute-data, execute-long-query, fetch-long-query, explain-ast, explain-scan, explain-script, explain-query, explain-data, cancel-query]
+                enum: [execute-scan, execute-script, execute-query, execute-query-and-forget, execute-data, execute-long-query, fetch-long-query, explain-ast, explain-scan, explain-script, explain-query, explain-data, cancel-query]
                 required: true
                 description: >
                     execute method:
                       * `execute-query` - execute query (QueryService)
+                      * `execute-query-and-forget` - execute query (QueryService), wait up to forget-after for an immediate response, then leave it running in background
                       * `execute-data` - execute data query (DataQuery)
                       * `execute-scan` - execute scan query (ScanQuery)
                       * `execute-script` - execute script query (ScriptingService)
@@ -1533,6 +1573,12 @@ public:
                 description: timeout in ms, for synchronous queries it's 60s by default, for streaming queries it's off by default
                 type: integer
                 required: false
+              - name: forget-after
+                in: query
+                description: wait timeout in ms for execute-query-and-forget before returning success and leaving query running in background
+                type: integer
+                required: false
+                default: 1000
               - name: ui64
                 in: query
                 description: return ui64 as number to avoid 56-bit js rounding

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -1482,7 +1482,7 @@ public:
                 description: >
                     execute method:
                       * `execute-query` - execute query (QueryService)
-                      * `execute-query-and-forget` - execute query (QueryService), wait up to forget-after for an immediate response, then leave it running in background; after the query is forgotten, it cannot be cancelled using query_id
+                      * `execute-query-and-forget` - execute query (QueryService), wait up to forget_after for an immediate response, then leave it running in background; after the query is forgotten, it cannot be cancelled using query_id
                       * `execute-data` - execute data query (DataQuery)
                       * `execute-scan` - execute scan query (ScanQuery)
                       * `execute-script` - execute script query (ScriptingService)
@@ -1592,7 +1592,7 @@ public:
                 required: false
               - name: forget_after
                 in: query
-                description: underscore alias for forget-after
+                description: maximum time in ms to wait for an execute-query-and-forget result before leaving the query running in background
                 type: integer
                 required: false
                 default: 1000

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -39,7 +39,9 @@ class TJsonQuery : public TViewerPipeClient {
     TInstant QueryStartTime;
     TInstant QueryRequestStartTime;
     TInstant Deadline;
+    TInstant WakeupScheduledAt;
     static constexpr TDuration WakeupPeriod = TDuration::Seconds(1);
+    static constexpr TDuration MaxForgetAfter = TDuration::Seconds(60);
 
     enum ESchemaType {
         Classic,
@@ -99,6 +101,15 @@ private:
             return Min(WakeupPeriod, ForgetAfter - Min(now - QueryRequestStartTime, ForgetAfter));
         }
         return WakeupPeriod;
+    }
+
+    void ScheduleWakeup(TDuration period, TInstant now = TInstant()) {
+        now = now ? now : TActivationContext::Now();
+        TInstant wakeupAt = now + period;
+        if (!WakeupScheduledAt || wakeupAt < WakeupScheduledAt) {
+            WakeupScheduledAt = wakeupAt;
+            Schedule(period, new TEvents::TEvWakeup());
+        }
     }
 
     void CreateStandardErrorResponse(NJson::TJsonValue& jsonResponse, const TString& message) {
@@ -357,7 +368,7 @@ public:
             StatsPeriod = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("stats_period"), StatsPeriod.MilliSeconds()), 1000, 600000));
         }
         if (params.Has("forget-after")) {
-            ForgetAfter = TDuration::MilliSeconds(Max<ui64>(FromStringWithDefault<ui64>(params.Get("forget-after"), ForgetAfter.MilliSeconds()), 1));
+            ForgetAfter = TDuration::MilliSeconds(std::clamp<ui64>(FromStringWithDefault<ui64>(params.Get("forget-after"), ForgetAfter.MilliSeconds()), 1, MaxForgetAfter.MilliSeconds()));
         }
         if (Streaming == EStreamingType::None || params.Has("timeout")) {
             Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), 60000)); // override default timeout to 60 seconds
@@ -414,7 +425,7 @@ public:
         SendKpqProxyRequest();
         Become(&TThis::StateWork);
         if (Timeout || KeepAlive || Long || Action == "fetch-long-query") {
-            Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
+            ScheduleWakeup(GetWakeupPeriod());
         }
         QueryStartTime = TActivationContext::Now();
         LastSendTime = TActivationContext::Now();
@@ -686,7 +697,7 @@ public:
         }
         QueryResponse = MakeQueryRequest<NKqp::TEvKqp::TEvQueryRequest, NKqp::TEvKqp::TEvQueryResponse>();
         if (Forget) {
-            Schedule(GetWakeupPeriod(), new TEvents::TEvWakeup());
+            ScheduleWakeup(GetWakeupPeriod());
         }
     }
 
@@ -1266,6 +1277,7 @@ private:
 
     void HandleWakeup() {
         auto now = TActivationContext::Now();
+        WakeupScheduledAt = TInstant();
         if (Forget && QueryRequestStartTime && (now - QueryRequestStartTime >= ForgetAfter)) {
             return ReplyAndForgetQuery();
         }
@@ -1278,7 +1290,7 @@ private:
         if (OperationId && (!GetOperationResponse.has_value() || GetOperationResponse->IsDone())) {
             CheckOperationStatus();
         }
-        Schedule(GetWakeupPeriod(now), new TEvents::TEvWakeup());
+        ScheduleWakeup(GetWakeupPeriod(now), now);
     }
 
 private:
@@ -1474,7 +1486,7 @@ public:
                 description: >
                     execute method:
                       * `execute-query` - execute query (QueryService)
-                      * `execute-query-and-forget` - execute query (QueryService), wait up to forget-after for an immediate response, then leave it running in background
+                      * `execute-query-and-forget` - execute query (QueryService), wait up to forget-after for an immediate response, then leave it running in background; after the query is forgotten, it cannot be cancelled using query_id
                       * `execute-data` - execute data query (DataQuery)
                       * `execute-scan` - execute scan query (ScanQuery)
                       * `execute-script` - execute script query (ScriptingService)
@@ -1584,10 +1596,11 @@ public:
                 required: false
               - name: forget-after
                 in: query
-                description: wait timeout in ms for execute-query-and-forget before returning success and leaving query running in background
+                description: wait timeout in ms for execute-query-and-forget before returning success and leaving query running in background, clamped to 1..60000 ms
                 type: integer
                 required: false
                 default: 1000
+                maximum: 60000
               - name: ui64
                 in: query
                 description: return ui64 as number to avoid 56-bit js rounding


### PR DESCRIPTION
Add a new `/viewer/query` action, `execute-query-and-forget`, for queries that should continue running after the HTTP request returns.

Summary:
- add `execute-query-and-forget` handling for QueryService execution
- add `forget_after` query parameter with a 1 second default wait
- return normal query errors if they arrive before `forget_after`
- return success after `forget_after` and leave the query running in the background
- avoid cancelling, closing, or ping-attaching the KQP session after the query is forgotten
- document the new action and parameter in swagger

Frontend usage:
- https://gist.github.com/adameat/166b27d3b5cd5885412c3f486e5d4d1f

Validation:
- `./ya make --build relwithdebinfo -T ydb/core/viewer`

