### PR TITLE
[IC] Add interconnect direct send predictor

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -318,6 +318,10 @@ namespace {
             NumEventsInQueueHistogram->Collect(value);
         }
 
+        void UpdateSendPathHistogram(ui64 value) override {
+            SendPathHistogram->Collect(value);
+        }
+
         void UpdateRdmaReadTimeHistogram(ui64 value) override {
             RdmaReadTimeHistogram->Collect(value);
         }
@@ -404,8 +408,10 @@ namespace {
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram = AdaptiveCounters->GetHistogram(
                     "NumEventsInQueue", NMonitoring::ExplicitHistogram({0, 1, 2, 6, 24, 120}));
+                SendPathHistogram = AdaptiveCounters->GetHistogram(
+                    "SendPath", NMonitoring::ExplicitHistogram({0, 1, 2}));
                 RdmaReadTimeHistogram = AdaptiveCounters->GetHistogram(
-+                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents = AdaptiveCounters->GetCounter("RdmaMultipartEvents", true);
             }
 
@@ -504,6 +510,7 @@ namespace {
         NMonitoring::THistogramPtr PingTimeHistogram;
         NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
         NMonitoring::THistogramPtr NumEventsInQueueHistogram;
+        NMonitoring::THistogramPtr SendPathHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
         NMonitoring::TDynamicCounters::TCounterPtr RdmaMultipartEvents;
 
@@ -768,6 +775,10 @@ namespace {
             NumEventsInQueueHistogram_->Record(value);
         }
 
+        void UpdateSendPathHistogram(ui64 value) override {
+            SendPathHistogram_->Record(value);
+        }
+
         void UpdateRdmaReadTimeHistogram(ui64 value) override {
             RdmaReadTimeHistogram_->Record(value);
         }
@@ -872,6 +883,8 @@ namespace {
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.num_events_in_queue"}}), NMonitoring::ExplicitHistogram({0, 1, 2, 6, 24, 120}));
+                SendPathHistogram_ = AdaptiveMetrics_->HistogramRate(
+                        NMonitoring::MakeLabels({{"sensor", "interconnect.send_path"}}), NMonitoring::ExplicitHistogram({0, 1, 2}));
                 RdmaReadTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.rdma_read_time_us"}}), NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents_ = createRate(AdaptiveMetrics_, "interconnect.rdma_multipart_events");
@@ -1004,6 +1017,7 @@ namespace {
         NMonitoring::IHistogram* PingTimeHistogram_;
         NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
         NMonitoring::IHistogram* NumEventsInQueueHistogram_;
+        NMonitoring::IHistogram* SendPathHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;
         NMonitoring::IRate* RdmaMultipartEvents_;
 

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -47,6 +47,7 @@ public:
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;
     virtual void UpdateIcQueueTimeHistogram(ui64 value) = 0;
     virtual void UpdateNumEventsInQueueHistogram(ui64 value) = 0;
+    virtual void UpdateSendPathHistogram(ui64 value) = 0;
     virtual void UpdateRdmaReadTimeHistogram(ui64 value) = 0;
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -38,6 +38,12 @@ namespace NActors {
         return eventTypeName.empty() ? TStringBuf("manual") : TStringBuf(eventTypeName);
     }
 
+    enum class ESendPath : ui64 {
+        DirectSend = 0,
+        BatchPredicted = 1,
+        YieldByTime = 2,
+    };
+
     TInterconnectSessionTCP::TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy, TSessionParams params)
         : TActor(&TInterconnectSessionTCP::StateFunc)
         , Created(TInstant::Now())
@@ -227,7 +233,7 @@ namespace NActors {
             }
         }
 
-        IssueRam(true);
+        IssueRam();
     }
 
     void TInterconnectSessionTCP::Forward(STATEFN_SIG) {
@@ -499,17 +505,53 @@ namespace NActors {
         }
     }
 
-    void TInterconnectSessionTCP::IssueRam(bool batching) {
+    void TInterconnectSessionTCP::IssueRam() {
         const auto& batchPeriod = Proxy->Common->Settings.BatchPeriod;
-        if (!RamInQueue || (!batching && RamInQueue->Batching && batchPeriod != TDuration())) {
-            auto ev = std::make_unique<TEvRam>(batching);
+        if (!RamInQueue) {
+            auto startRam = [&] {
+                LWPROBE(StartRam, Proxy->PeerNodeId);
+                RamStartedCycles = GetCycleCountFast();
+            };
+
+            if (batchPeriod != TDuration()) {
+                auto ev = std::make_unique<TEvRam>(true);
+                RamInQueue = ev.get();
+                auto handle = std::make_unique<IEventHandle>(SelfId(), SelfId(), ev.release());
+                TActivationContext::Schedule(batchPeriod, handle.release());
+                startRam();
+            } else {
+                GenerateTraffic();
+                if (!RamInQueue || RamInQueue->Batching) {
+                    auto recordSendPath = [&](ESendPath sendPath) {
+                        Proxy->Metrics->UpdateSendPathHistogram(static_cast<ui64>(sendPath));
+                    };
+                    DirectPredictor.Predict(
+                        [&]() {
+                            recordSendPath(ESendPath::DirectSend);
+                            RamInQueue = nullptr;
+                        },
+                        [&]() {
+                            recordSendPath(ESendPath::BatchPredicted);
+                            auto ev = std::make_unique<TEvRam>(true);
+                            RamInQueue = ev.get();
+                            auto handle = std::make_unique<IEventHandle>(SelfId(), SelfId(), ev.release());
+                            TActivationContext::Send(handle.release());
+                            startRam();
+                        });
+                }
+            }
+        }
+    }
+
+    void TInterconnectSessionTCP::IssueRamCpuStarvation() {
+        const auto& batchPeriod = Proxy->Common->Settings.BatchPeriod;
+        if (!RamInQueue || RamInQueue->Batching && batchPeriod != TDuration()) {
+            Proxy->Metrics->UpdateSendPathHistogram(static_cast<ui64>(ESendPath::YieldByTime));
+            auto ev = std::make_unique<TEvRam>(false);
             RamInQueue = ev.get();
             auto handle = std::make_unique<IEventHandle>(SelfId(), SelfId(), ev.release());
-            if (batching && batchPeriod != TDuration()) {
-                TActivationContext::Schedule(batchPeriod, handle.release());
-            } else {
-                TActivationContext::Send(handle.release());
-            }
+            TActivationContext::Send(handle.release());
+
             LWPROBE(StartRam, Proxy->PeerNodeId);
             RamStartedCycles = GetCycleCountFast();
         }
@@ -518,6 +560,9 @@ namespace NActors {
     void TInterconnectSessionTCP::HandleRam(TEvRam::TPtr& ev) {
         if (ev->Get() == RamInQueue) {
             LWPROBE(FinishRam, Proxy->PeerNodeId, NHPTimer::GetSeconds(GetCycleCountFast() - ev->SendTime) * 1000.0);
+            if (RamInQueue->Batching) {
+                DirectPredictor.Train(!NumEventsInQueue);
+            }
             RamInQueue = nullptr;
             GenerateTraffic();
         }
@@ -563,7 +608,7 @@ namespace NActors {
                 break;
             } else if (TimeLimit->CheckExceeded()) {
                 SetEnoughCpu(++StarvingInRow < StarvingInRowForNotEnoughCpu);
-                IssueRam(false);
+                IssueRamCpuStarvation();
                 notEnoughCpu = true;
                 break;
             }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <tuple>
+#include <utility>
 
 namespace NInterconnect {
     class TInterconnectZcProcessor;
@@ -412,6 +413,68 @@ namespace NActors {
         void GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr ev);
     };
 
+    // Predicts when the caller may bypass the regular TEvRam path that collects a batch of events
+    // and use the direct path instead.
+    //
+    // Predict() calls the direct callback while the current direct-send budget is non-zero; otherwise it
+    // calls the training callback. The training callback only starts the safe/checking path. It does not
+    // have to call Train() immediately: delayed/asynchronous confirmation may report the result later via
+    // Train(bool). If the result is never reported, the predictor stays conservative and keeps choosing the
+    // training callback.
+    //
+    // Successful training reports raise a saturating confidence counter. Once confidence reaches the
+    // threshold, the predictor grants DIRECT_SEND_UNTIL_RETRAIN direct calls, then asks for one more
+    // training pass. Failed training reports cancel an active direct burst and decrement confidence. This
+    // gives branch-predictor-like hysteresis: noisy misses do not reset all accumulated confidence.
+    class TDirectSendPredictor {
+        static constexpr ui32 CONFIDENCE_TO_SWITCH = 4;
+        static constexpr ui32 MAX_CONFIDENCE = 7;
+        static constexpr ui32 DIRECT_SEND_UNTIL_RETRAIN = 64;
+    public:
+        template <typename TDirectCallback, typename TDirectArgsTuple, typename TTrainCallback, typename TTrainArgsTuple>
+        void Predict(
+                TDirectCallback&& directCallback,
+                TDirectArgsTuple&& directArgs,
+                TTrainCallback&& trainCallback,
+                TTrainArgsTuple&& trainArgs) {
+            if (DirectSendCnt) {
+                DirectSendCnt--;
+                std::apply(std::forward<TDirectCallback>(directCallback), std::forward<TDirectArgsTuple>(directArgs));
+            } else {
+                std::apply(std::forward<TTrainCallback>(trainCallback), std::forward<TTrainArgsTuple>(trainArgs));
+            }
+        }
+
+        template <typename TDirectCallback, typename TTrainCallback>
+        void Predict(TDirectCallback&& directCallback, TTrainCallback&& trainCallback) {
+            Predict(
+                std::forward<TDirectCallback>(directCallback),
+                std::tuple<>(),
+                std::forward<TTrainCallback>(trainCallback),
+                std::tuple<>());
+        }
+
+        void Train(bool ok) noexcept {
+            if (ok) {
+                if (Confidence < MAX_CONFIDENCE) {
+                    ++Confidence;
+                }
+                if (Confidence >= CONFIDENCE_TO_SWITCH) {
+                    DirectSendCnt = DIRECT_SEND_UNTIL_RETRAIN;
+                }
+            } else {
+                DirectSendCnt = 0;
+                if (Confidence) {
+                    Confidence--;
+                }
+            }
+        }
+
+    private:
+        ui32 DirectSendCnt = 0;
+        ui32 Confidence = 0;
+    };
+
     class TInterconnectSessionTCP
        : public TActor<TInterconnectSessionTCP>
        , public TInterconnectLoggingBase
@@ -552,7 +615,9 @@ namespace NActors {
 
         TEvRam* RamInQueue = nullptr;
         ui64 RamStartedCycles = 0;
-        void IssueRam(bool batching);
+        TDirectSendPredictor DirectPredictor;
+        void IssueRam();
+        void IssueRamCpuStarvation();
         void HandleRam(TEvRam::TPtr& ev);
         void GenerateTraffic();
         void ProducePackets();

--- a/ydb/library/actors/interconnect/ut/direct_send_predictor_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/direct_send_predictor_ut.cpp
@@ -1,0 +1,233 @@
+#include <ydb/library/actors/interconnect/interconnect_tcp_session.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/yexception.h>
+
+using namespace NActors;
+
+namespace {
+
+constexpr ui32 MaxPassToSwitch = 4;
+constexpr ui32 MaxConfidence = 7;
+constexpr ui32 DirectSendUntilRetrain = 64;
+
+struct TPredictorCounters {
+    ui32 Direct = 0;
+    ui32 Train = 0;
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(DirectSendPredictor) {
+    Y_UNIT_TEST(SwitchesToDirectAfterConsecutiveSuccessfulTraining) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+
+        auto direct = [&] {
+            ++counters.Direct;
+        };
+        auto train = [&] {
+            ++counters.Train;
+            predictor.Train(true);
+        };
+
+        for (ui32 i = 0; i < MaxPassToSwitch; ++i) {
+            predictor.Predict(direct, train);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Train, i + 1);
+        }
+
+        for (ui32 i = 0; i < DirectSendUntilRetrain; ++i) {
+            predictor.Predict(direct, train);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Direct, i + 1);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch);
+        }
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, DirectSendUntilRetrain);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch + 1);
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, DirectSendUntilRetrain + 1);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch + 1);
+    }
+
+    Y_UNIT_TEST(FailedTrainingDecrementsConfidence) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+        bool trainResult = true;
+
+        auto direct = [&] {
+            ++counters.Direct;
+        };
+        auto train = [&] {
+            ++counters.Train;
+            predictor.Train(trainResult);
+        };
+
+        for (ui32 i = 0; i < MaxPassToSwitch - 1; ++i) {
+            predictor.Predict(direct, train);
+        }
+
+        trainResult = false;
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch);
+
+        trainResult = true;
+        for (ui32 i = 0; i < 2; ++i) {
+            predictor.Predict(direct, train);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+        }
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch + 2);
+    }
+
+    Y_UNIT_TEST(ForwardsArgumentsToSelectedCallback) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+        ui32 directSum = 0;
+        TString directTrace;
+        ui32 trainSum = 0;
+
+        auto direct = [&](ui32 value, TStringBuf marker) {
+            ++counters.Direct;
+            directSum += value;
+            directTrace += marker;
+        };
+        auto train = [&](bool ok, ui32 value) {
+            ++counters.Train;
+            trainSum += value;
+            predictor.Train(ok);
+        };
+
+        for (ui32 i = 0; i < MaxPassToSwitch; ++i) {
+            predictor.Predict(
+                direct,
+                std::forward_as_tuple(10u, TStringBuf("direct")),
+                train,
+                std::forward_as_tuple(true, i + 1));
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch);
+        UNIT_ASSERT_VALUES_EQUAL(trainSum, 10);
+
+        predictor.Predict(
+            direct,
+            std::forward_as_tuple(7u, TStringBuf("D")),
+            train,
+            std::forward_as_tuple(true, 100u));
+
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch);
+        UNIT_ASSERT_VALUES_EQUAL(directSum, 7);
+        UNIT_ASSERT_VALUES_EQUAL(directTrace, "D");
+        UNIT_ASSERT_VALUES_EQUAL(trainSum, 10);
+    }
+
+    Y_UNIT_TEST(TrainingMayArriveAfterCallback) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+        bool trainingRequested = false;
+
+        auto direct = [&] {
+            ++counters.Direct;
+        };
+        auto train = [&] {
+            ++counters.Train;
+            trainingRequested = true;
+        };
+
+        for (ui32 i = 0; i < MaxPassToSwitch; ++i) {
+            predictor.Predict(direct, train);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Train, i + 1);
+            UNIT_ASSERT(trainingRequested);
+            trainingRequested = false;
+            predictor.Train(true);
+        }
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 1);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, MaxPassToSwitch);
+    }
+
+    Y_UNIT_TEST(MissingTrainingReportKeepsTrainingPath) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+
+        auto direct = [&] {
+            ++counters.Direct;
+        };
+        auto train = [&] {
+            ++counters.Train;
+        };
+
+        for (ui32 i = 0; i < MaxPassToSwitch + 1; ++i) {
+            predictor.Predict(direct, train);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Direct, 0);
+            UNIT_ASSERT_VALUES_EQUAL(counters.Train, i + 1);
+        }
+    }
+
+    Y_UNIT_TEST(SingleMissAtHighConfidenceKeepsHysteresis) {
+        TDirectSendPredictor predictor;
+        TPredictorCounters counters;
+        bool trainResult = false;
+
+        auto direct = [&] {
+            ++counters.Direct;
+        };
+        auto train = [&] {
+            ++counters.Train;
+            predictor.Train(trainResult);
+        };
+
+        for (ui32 i = 0; i < MaxConfidence; ++i) {
+            predictor.Train(true);
+        }
+
+        for (ui32 i = 0; i < DirectSendUntilRetrain; ++i) {
+            predictor.Predict(direct, train);
+        }
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, DirectSendUntilRetrain);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, 1);
+
+        trainResult = true;
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, DirectSendUntilRetrain);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, 2);
+
+        predictor.Predict(direct, train);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Direct, DirectSendUntilRetrain + 1);
+        UNIT_ASSERT_VALUES_EQUAL(counters.Train, 2);
+    }
+
+    Y_UNIT_TEST(PropagatesCallbackExceptions) {
+        TDirectSendPredictor predictor;
+
+        auto direct = [] {
+            ythrow yexception() << "direct callback";
+        };
+        auto train = [] {
+            ythrow yexception() << "train callback";
+        };
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(predictor.Predict(direct, train), yexception, "train callback");
+
+        auto successfulTrain = [&] {
+            predictor.Train(true);
+        };
+        for (ui32 i = 0; i < MaxPassToSwitch; ++i) {
+            predictor.Predict([] {}, successfulTrain);
+        }
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(predictor.Predict(direct, train), yexception, "direct callback");
+    }
+}

--- a/ydb/library/actors/interconnect/ut/ya.make
+++ b/ydb/library/actors/interconnect/ut/ya.make
@@ -11,6 +11,7 @@ ENDIF()
 SRCS(
     channel_scheduler_ut.cpp
     connection_checker_ut.cpp
+    direct_send_predictor_ut.cpp
     event_holder_pool_ut.cpp
     interconnect_ut.cpp
     large.cpp


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In most cases event rate for particular actor is not enouth to collect significant events in mailbox during the time of local send even loop. It cause just extra 2 allocations per each event without batching profit.

The new approach process IC queue just after enquing event from proxy, and allows batching only in case of prediction.


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
