### PR TITLE
schemeshard: extend StatsBatchLatency beyond 1 second

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -592,6 +592,15 @@ enum EPercentileCounters {
         Ranges: { Value: 200000      Name: "200 ms"       }
         Ranges: { Value: 500000      Name: "500 ms"       }
         Ranges: { Value: 1000000     Name: "1000 ms"      }
+        Ranges: { Value: 5000000     Name: "5000 ms"      }
+        Ranges: { Value: 10000000    Name: "10000 ms"     }
+        Ranges: { Value: 30000000    Name: "30000 ms"     }
+        Ranges: { Value: 50000000    Name: "50000 ms"     }
+        Ranges: { Value: 60000000    Name: "60000 ms"     }
+        Ranges: { Value: 70000000    Name: "70000 ms"     }
+        Ranges: { Value: 300000000   Name: "300000 ms"    }
+        Ranges: { Value: 600000000   Name: "600000 ms"    }
+        Ranges: { Value: 900000000   Name: "900000 ms"    }
     }];
 
     COUNTER_PQ_STATS_BATCH_LATENCY = 6 [(CounterOpts) = {


### PR DESCRIPTION
Extend `SchemeShard/StatsBatchLatency` histogram sensor bins to provide better coverage for delays beyond 1 second.

Close #42595.