### PR TITLE
schemeshard: extend NumShardsByTtlLag below 15 minutes

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -522,6 +522,11 @@ enum EPercentileCounters {
         Name: "NumShardsByTtlLag"
         Integral: true
         Ranges: { Value: 0        Name: "0"     }
+        Ranges: { Value: 30       Name: "30"    }
+        Ranges: { Value: 60       Name: "60"    }
+        Ranges: { Value: 120      Name: "120"   }
+        Ranges: { Value: 300      Name: "300"   }
+        Ranges: { Value: 600      Name: "600"   }
         Ranges: { Value: 900      Name: "900"   }
         Ranges: { Value: 1800     Name: "1800"  }
         Ranges: { Value: 3600     Name: "3600"  }

--- a/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
+++ b/ydb/core/tx/schemeshard/ut_ttl/ut_ttl.cpp
@@ -1383,7 +1383,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
             // Sometimes stats arrive too quickly?
             WaitForStats(runtime, 1);
         }
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 1}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 3" << Endl;
 
@@ -1410,7 +1410,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         runtime.AdvanceCurrentTime(TDuration::Hours(1));
         WaitForCondErase(runtime);
         WaitForStats(runtime, 2);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 2}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 7" << Endl;
 
@@ -1426,7 +1426,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
         // just after alter
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 1}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 8" << Endl;
 
@@ -1453,7 +1453,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
         // just after alter
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 1}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 1}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 10" << Endl;
 
@@ -1479,7 +1479,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         runtime.AdvanceCurrentTime(TDuration::Hours(1));
         WaitForCondErase(runtime, TEvCondEraseResp::ProtoRecordType::OK, 2);
         WaitForStats(runtime, 2);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 2}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 12" << Endl;
 
@@ -1489,7 +1489,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
 
         // just after move
         CheckSimpleCounter(runtime, "SchemeShard/TTLEnabledTables", 1);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"30", 2}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         // after a while
         runtime.AdvanceCurrentTime(TDuration::Minutes(20));
@@ -1512,7 +1512,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTTLTests) {
         // after a while
         runtime.AdvanceCurrentTime(TDuration::Minutes(10));
         WaitForStats(runtime, 2);
-        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"900", 2}, {"1800", 0}, {"inf", 0}});
+        CheckPercentileCounter(runtime, "SchemeShard/NumShardsByTtlLag", {{"600", 2}, {"900", 0}, {"1800", 0}, {"inf", 0}});
 
         Cerr << "TEST 15" << Endl;
 


### PR DESCRIPTION
Extend `SchemeShard/NumShardsByTtlLag` histogram sensor bins to provide better coverage for delays below 15 minutes.
Most important is to be able to distinguish zero lag (ttl didn't run, just initialized) from other low values.