### PR TITLE
schemeshard: enable EnableTablePartitionsFormat* flags

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -310,9 +310,9 @@ message TFeatureFlags {
     // Use TablePartitionsByShardIdx (keyed by ShardIdx) instead of TablePartitions
     // (keyed by positional index) for local tables.  When ON, split/merge writes only
     // O(k) rows (src+dst shards) instead of O(N) rows (all partitions after srcFirstIdx).
-    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = false];
-    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = false];
-    optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = false];
+    optional bool EnableTablePartitionsFormatShardIdx = 271 [default = true];
+    optional bool EnableTablePartitionsFormatShardIdxByDefault = 272 [default = true];
+    optional bool EnableTablePartitionsFormatAutoConvert = 273 [default = true];
     optional bool EnableTopicMessagesBatching = 274 [default = false];
     optional bool EnableTopicWriteOffsetDeltaInKeys = 275 [default = false];
     optional bool EnableTablePartitionsConsistencyCheck = 276 [default = true];


### PR DESCRIPTION
Related to:
- https://github.com/ydb-platform/ydb/issues/37069
- https://github.com/ydb-platform/ydb/pull/42253

Feature flags:
- `EnableTablePartitionsFormatShardIdx`
- `EnableTablePartitionsFormatShardIdxByDefault`
- `EnableTablePartitionsFormatAutoConvert`

Enable them back on by default in `main` to broaden the use of covered functionality.