### PR TITLE
Clear prefix bloom filter when the last prefix is dropped

### DIFF
--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -636,44 +636,31 @@ void TUserTable::ApplyAlter(
         }
     }
 
-    if (configDelta.HasEnableFilterByKey() || configDelta.ByKeyFilterPrefixesSize() > 0) {
+    // Rebuild the prefix bloom set from the full authoritative config the schemeshard sends. The
+    // last disjunct also fires when the table had prefixes but the delta clears them all (DROP of
+    // the last prefix bloom, or KEY_BLOOM_FILTER = DISABLED), which carries no explicit bloom field.
+    if (configDelta.HasEnableFilterByKey() || configDelta.ByKeyFilterPrefixesSize() > 0 || config.ByKeyFilterPrefixesSize() > 0) {
         using TPrefix = NTable::TScheme::TTableInfo::TByKeyFilterPrefix;
-        // Rebuild unified prefix list from current config + delta
-        // Use a map to track FPP per prefix length
+        const ui32 keyCount = KeyColumnIds.size();
+
+        // Full-key filter is governed by EnableFilterByKey; the delta may toggle it or leave it.
+        bool enableFullKey = config.GetEnableFilterByKey();
+        if (configDelta.HasEnableFilterByKey()) {
+            enableFullKey = configDelta.GetEnableFilterByKey();
+            config.SetEnableFilterByKey(enableFullKey);
+        }
+
         TMap<ui32, double> prefixMap;
-        // Start with existing prefixes from current config
-        for (const auto& p : config.GetByKeyFilterPrefixes()) {
+        for (const auto& p : configDelta.GetByKeyFilterPrefixes()) {
             if (p.GetPrefixLength() > 0) {
                 double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
                 Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
                 prefixMap[p.GetPrefixLength()] = fpp;
             }
         }
-        ui32 keyCount = KeyColumnIds.size();
-
-        if (configDelta.HasEnableFilterByKey()) {
-            config.SetEnableFilterByKey(configDelta.GetEnableFilterByKey());
-            if (configDelta.GetEnableFilterByKey()) {
-                prefixMap.emplace(keyCount, NTable::DefaultBloomFilterFpp);
-            } else {
-                prefixMap.erase(keyCount);
-            }
-        }
-
-        if (configDelta.ByKeyFilterPrefixesSize() > 0) {
-            // Delta replaces the explicit prefix list
-            prefixMap.clear();
-            for (const auto& p : configDelta.GetByKeyFilterPrefixes()) {
-                if (p.GetPrefixLength() > 0) {
-                    double fpp = p.HasFalsePositiveProbability() ? p.GetFalsePositiveProbability() : NTable::DefaultBloomFilterFpp;
-                    Y_ENSURE(fpp > 0.0 && fpp < 1.0, "Bloom filter FalsePositiveProbability " << fpp << " out of range (0, 1)");
-                    prefixMap[p.GetPrefixLength()] = fpp;
-                }
-            }
-            // Re-add full-key entry if EnableFilterByKey is enabled
-            if (config.GetEnableFilterByKey()) {
-                prefixMap.emplace(keyCount, NTable::DefaultBloomFilterFpp);
-            }
+        // Re-add full-key entry if EnableFilterByKey is enabled.
+        if (enableFullKey) {
+            prefixMap.emplace(keyCount, NTable::DefaultBloomFilterFpp);
         }
 
         config.ClearByKeyFilterPrefixes();
@@ -684,6 +671,7 @@ void TUserTable::ApplyAlter(
             entry->SetFalsePositiveProbability(fpp);
             prefixes.push_back(TPrefix{len, fpp});
         }
+        // An empty list emits a clear sentinel, so the engine drops any previously-set filter.
         for (ui32 tid : tids) {
             alter.SetByKeyFilterPrefixes(tid, prefixes);
         }

--- a/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
@@ -1,0 +1,150 @@
+#include <ydb/core/tablet_flat/bloom_filter_defaults.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+
+#include "datashard_ut_common_kqp.h"
+
+namespace NKikimr {
+
+using namespace NKikimr::NDataShard;
+using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace Tests;
+
+// Datashard-level coverage for the bloom filter logic
+Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
+
+    std::tuple<TTestActorRuntime&, Tests::TServer::TPtr, TActorId> CreateServer() {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        return {runtime, server, sender};
+    }
+
+    // The shard's own bloom prefix lengths -> FPP map, from its persisted schema.
+    TMap<ui32, double> ShardBloomPrefixes(TTestActorRuntime& runtime, ui64 shard) {
+        auto edge = runtime.AllocateEdgeActor();
+        runtime.SendToPipe(shard, edge, new TEvDataShard::TEvGetInfoRequest(),
+            0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto* resp = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvGetInfoResponse>(handle);
+        UNIT_ASSERT(resp);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Record.UserTablesSize(), 1u);
+        const auto& pc = resp->Record.GetUserTables(0).GetDescription().GetPartitionConfig();
+        TMap<ui32, double> result;
+        for (const auto& p : pc.GetByKeyFilterPrefixes()) {
+            result[p.GetPrefixLength()] = p.GetFalsePositiveProbability();
+        }
+        return result;
+    }
+
+    TVector<ui32> ShardBloomPrefixLengths(TTestActorRuntime& runtime, ui64 shard) {
+        TVector<ui32> out;
+        for (const auto& [len, fpp] : ShardBloomPrefixes(runtime, shard)) {
+            out.push_back(len);
+        }
+        return out;
+    }
+
+    // The engine ByKeyFilterPrefixes the shard persists must track CREATE / ALTER ADD INDEX, and
+    // must be cleared when KEY_BLOOM_FILTER=DISABLED wipes the whole config. The clear case is the
+    // important one: the shard had prefixes and ApplyAlter must drop them from the engine, not keep
+    // a stale filter.
+    Y_UNIT_TEST(PrefixesUpdatedOnAlter) {
+        auto [runtime, server, sender] = CreateServer();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/T` (
+                    Key1 Uint64, Key2 Uint64, Value String,
+                    PRIMARY KEY (Key1, Key2),
+                    INDEX idx1 LOCAL USING bloom_filter ON (Key1)
+                );
+            )"), "SUCCESS");
+
+        auto shards = GetTableShards(server, sender, "/Root/T");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+        const ui64 shard = shards.at(0);
+
+        // ApplyConfig carried the prefix to the datashard.
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1}));
+
+        // ALTER ADD INDEX -> ApplyAlter adds the second prefix alongside the first.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                ALTER TABLE `/Root/T` ADD INDEX idx2 LOCAL USING bloom_filter ON (Key1, Key2);
+            )"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
+
+        // KEY_BLOOM_FILTER = DISABLED clears the whole bloom config -> ApplyAlter must drop every
+        // prefix from the engine.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{}));
+    }
+
+    // The EnableFilterByKey (whole-key KEY_BLOOM_FILTER) branch: the whole-key filter is unified
+    // into the engine prefix list as an entry of length == number of key columns, must coexist with
+    // shorter prefix blooms, and be cleared by KEY_BLOOM_FILTER=DISABLED.
+    Y_UNIT_TEST(FullKeyCoexistsWithPrefix) {
+        auto [runtime, server, sender] = CreateServer();
+
+        // (Key1, Key2) primary key => whole-key bloom has prefix length 2.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/T` (
+                    Key1 Uint64, Key2 Uint64, Value String,
+                    PRIMARY KEY (Key1, Key2),
+                    INDEX idx1 LOCAL USING bloom_filter ON (Key1)
+                );
+            )"), "SUCCESS");
+        auto shards = GetTableShards(server, sender, "/Root/T");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+        const ui64 shard = shards.at(0);
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1}));
+
+        // Enable the whole-key filter -> length-2 entry added alongside the length-1 prefix.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = ENABLED);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
+
+        // Disabling KEY_BLOOM_FILTER clears all bloom state on the shard.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{}));
+    }
+
+    // The per-prefix false-positive probability resolved by ApplyConfig
+    // (explicit value, or NTable::DefaultBloomFilterFpp when unspecified) must reach the shard.
+    Y_UNIT_TEST(FppPropagatedToShard) {
+        auto [runtime, server, sender] = CreateServer();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/T` (
+                    Key1 Uint64, Key2 Uint64, Value String,
+                    PRIMARY KEY (Key1, Key2),
+                    INDEX idx1 LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability = 0.02),
+                    INDEX idx2 LOCAL USING bloom_filter ON (Key1, Key2)
+                );
+            )"), "SUCCESS");
+        auto shards = GetTableShards(server, sender, "/Root/T");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        auto prefixes = ShardBloomPrefixes(runtime, shards.at(0));
+        UNIT_ASSERT_VALUES_EQUAL(prefixes.size(), 2u);
+        // Explicit FPP is preserved; the unspecified one falls back to the engine default.
+        UNIT_ASSERT_DOUBLES_EQUAL(prefixes.at(1), 0.02, 1e-9);
+        UNIT_ASSERT_DOUBLES_EQUAL(prefixes.at(2), NTable::DefaultBloomFilterFpp, 1e-9);
+    }
+
+} // Y_UNIT_TEST_SUITE(DataShardBloomFilter)
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
@@ -88,6 +88,11 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{}));
+
+        // Re-adding a bloom index after disable should correctly re-establish bloom state.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` ADD INDEX idx3 LOCAL USING bloom_filter ON (Key1);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1}));
     }
 
     // The EnableFilterByKey (whole-key KEY_BLOOM_FILTER) branch: the whole-key filter is unified
@@ -119,6 +124,16 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{}));
+
+        // Re-enabling KEY_BLOOM_FILTER should correctly re-establish the whole-key filter.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = ENABLED);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{2}));
+
+        // Adding a new prefix bloom index after disable should also work correctly.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` ADD INDEX idx3 LOCAL USING bloom_filter ON (Key1);"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
     }
 
     // The per-prefix false-positive probability resolved by ApplyConfig

--- a/ydb/core/tx/datashard/ut_bloom_filter/ya.make
+++ b/ydb/core/tx/datashard/ut_bloom_filter/ya.make
@@ -1,0 +1,31 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+FORK_SUBTESTS()
+
+IF (SANITIZER_TYPE == "thread")
+    SIZE(LARGE)
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    yql/essentials/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/src/client/result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_bloom_filter.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -316,6 +316,7 @@ END()
 
 RECURSE_FOR_TESTS(
     build_index/ut
+    ut_bloom_filter
     ut_borrowed_compaction
     ut_change_collector
     ut_change_exchange


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

ApplyAlter only updated the bloom filter when the delta carried a bloom field.
Dropping the last prefix (DROP INDEX or KEY_BLOOM_FILTER = DISABLED) carries
none, so the shard kept a stale filter until restart. Rebuild it from the full
config the schemeshard sends instead.

Add ut_bloom_filter, a datashard-level suite covering prefix add/drop, the
drop-to-empty case, whole-key filter, and FPP propagation.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
