### PR TITLE
SchemeShard: Don't make progress on start/timeout forced compaction, just schedule it.

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -6428,11 +6428,6 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         });
 
         Self->ScheduleForcedCompactionProgress(ctx);
-        if (Self->ForcedCompactionsDoneShardsToPersist || Self->CancellingForcedCompactions) {
-            // for cleanup and to progress cancelling forced compactions after restart
-            Self->ForcedCompactionProgressStartTime = ctx.Now();
-            Self->Execute(Self->CreateTxProgressForcedCompaction(), ctx);
-        }
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -6427,9 +6427,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             .FullBackupIds = std::move(FullBackupsToResume),
         });
 
-        Self->ProcessForcedCompactionQueues();
+        Self->ScheduleForcedCompactionProgress(ctx);
         if (Self->ForcedCompactionsDoneShardsToPersist || Self->CancellingForcedCompactions) {
             // for cleanup and to progress cancelling forced compactions after restart
+            Self->ForcedCompactionProgressStartTime = ctx.Now();
             Self->Execute(Self->CreateTxProgressForcedCompaction(), ctx);
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -2,8 +2,6 @@
 
 #include "schemeshard_impl.h"
 
-#include <util/generic/scope.h>
-
 namespace NKikimr::NSchemeShard {
 
 void TSchemeShard::AddForcedCompaction(
@@ -38,7 +36,7 @@ void TSchemeShard::ForgetForcedCompactionShard(
     const TShardIdx& shardId,
     const TForcedCompactionInfo::TPtr& forcedCompactionInfo) // info may be null
 {
-    ForcedCompactionsDoneShardsToPersist.emplace_back(shardId, forcedCompactionInfo);
+    ForcedCompactionsDoneShardsToPersist[shardId] = forcedCompactionInfo;
     if (forcedCompactionInfo && forcedCompactionInfo->State == TForcedCompactionInfo::EState::InProgress) {
         InProgressForcedCompactionsByShard[shardId] = forcedCompactionInfo; // for counting
     }
@@ -146,18 +144,14 @@ void TSchemeShard::CompleteForcedCompactionForShard(const TShardIdx& shardIdx, c
     auto compaction = *compactionPtr;
 
     if (compaction->ShardsInFlight.erase(shardIdx)) {
-        ForcedCompactionsDoneShardsToPersist.emplace_back(shardIdx, compaction);
+        ForcedCompactionsDoneShardsToPersist[shardIdx] = compaction;
     }
 
-    const auto now = ctx.Now();
-    if (IsForcedCompactionCompleted(*compaction)
-        || ForcedCompactionsDoneShardsToPersist.size() >= ForcedCompactionPersistBatchSize
-        || now - ForcedCompactionProgressStartTime > ForcedCompactionPersistBatchMaxTime)
-    {
-        ForcedCompactionProgressStartTime = now;
-        Execute(CreateTxProgressForcedCompaction());
+    if (IsForcedCompactionCompleted(*compaction)) {
+        HasUnpersistedCompletedForcedCompactions = true;
     }
-    ProcessForcedCompactionQueues();
+
+    ScheduleForcedCompactionProgress(ctx);
 }
 
 bool TSchemeShard::IsForcedCompactionCompleted(const TForcedCompactionInfo& info) const {
@@ -170,7 +164,7 @@ bool TSchemeShard::IsForcedCompactionCompleted(const TForcedCompactionInfo& info
     return info.ShardsInFlight.empty();
 }
 
-void TSchemeShard::RetryForcedCompactionForShard(const TShardIdx& shardIdx, const TPathId& tablePathId) {
+void TSchemeShard::RetryForcedCompactionForShard(const TShardIdx& shardIdx, const TPathId& tablePathId, const TActorContext &ctx) {
     auto compactionPtr = InProgressForcedCompactionsByShard.FindPtr(shardIdx);
     if (!compactionPtr) {
         return;
@@ -181,66 +175,36 @@ void TSchemeShard::RetryForcedCompactionForShard(const TShardIdx& shardIdx, cons
         ++ForcedCompactionTotalInQueues;
     }
     ForcedCompactionTablesQueue.Enqueue(tablePathId);
-    ProcessForcedCompactionQueues();
+    ScheduleForcedCompactionProgress(ctx);
 }
 
 void TSchemeShard::ProcessForcedCompactionQueues() {
-    // Skip the nested call: the outer loop will continue with consistent state.
-    if (InProcessForcedCompactionQueues) {
-        return;
-    }
-    InProcessForcedCompactionQueues = true;
-    Y_DEFER { InProcessForcedCompactionQueues = false; };
-
     // try enqueue shards from multiple tables fairly
     auto initialQueueSize = ForcedCompactionTablesQueue.Size();
     THashSet<TPathId> tablesWithoutCandidates;
     while (!ForcedCompactionTablesQueue.Empty() && tablesWithoutCandidates.size() < initialQueueSize) {
         auto tablePathId = ForcedCompactionTablesQueue.Front();
         auto& compaction = InProgressForcedCompactionsByTable.at(tablePathId);
-        TryEnqueueOneShard(tablePathId, *compaction, &tablesWithoutCandidates);
+        auto* shards = ForcedCompactionShardsByTable.FindPtr(tablePathId);
+        if (shards && !shards->Empty() && compaction->MaxShardsInFlight > compaction->ShardsInFlight.size()) {
+            const auto shardIdx = shards->Front();
+            shards->PopFront();
+            --ForcedCompactionTotalInQueues;
+            compaction->ShardsInFlight.insert(shardIdx);
+            EnqueueForcedCompaction(shardIdx);
+        }
+        if (!shards || shards->Empty()) {
+            tablesWithoutCandidates.insert(tablePathId);
+            ForcedCompactionShardsByTable.erase(tablePathId);
+            ForcedCompactionTablesQueue.PopFront();
+        } else {
+            if (compaction->MaxShardsInFlight <= compaction->ShardsInFlight.size()) {
+                tablesWithoutCandidates.insert(tablePathId);
+            }
+            ForcedCompactionTablesQueue.PopFrontToBack();
+        }
     }
     UpdateForcedCompactionQueueMetrics();
-}
-
-void TSchemeShard::ProcessForcedCompactionQueuesForTable(const TPathId& tablePathId, TForcedCompactionInfo& compaction) {
-    // Skip the nested call of ProcessForcedCompactionQueues()
-    if (InProcessForcedCompactionQueues) {
-        return;
-    }
-    InProcessForcedCompactionQueues = true;
-    Y_DEFER { InProcessForcedCompactionQueues = false; };
-
-    TryEnqueueOneShard(tablePathId, compaction, nullptr);
-}
-
-void TSchemeShard::TryEnqueueOneShard(
-    const TPathId& tablePathId,
-    TForcedCompactionInfo& compaction,
-    THashSet<TPathId>* tablesWithoutCandidates)
-{
-    auto* shards = ForcedCompactionShardsByTable.FindPtr(tablePathId);
-    if (shards && !shards->Empty() && compaction.MaxShardsInFlight > compaction.ShardsInFlight.size()) {
-        const auto shardIdx = shards->Front();
-        shards->PopFront();
-        --ForcedCompactionTotalInQueues;
-        compaction.ShardsInFlight.insert(shardIdx);
-        EnqueueForcedCompaction(shardIdx);
-    }
-    if (!shards || shards->Empty()) {
-        if (tablesWithoutCandidates) {
-            tablesWithoutCandidates->insert(tablePathId);
-        }
-        ForcedCompactionShardsByTable.erase(tablePathId);
-        ForcedCompactionTablesQueue.PopFront();
-    } else {
-        if (tablesWithoutCandidates) {
-            if (compaction.MaxShardsInFlight <= compaction.ShardsInFlight.size()) {
-                tablesWithoutCandidates->insert(tablePathId);
-            }
-        }
-        ForcedCompactionTablesQueue.PopFrontToBack();
-    }
 }
 
 void TSchemeShard::Handle(TEvForcedCompaction::TEvCreateRequest::TPtr& ev, const TActorContext& ctx) {
@@ -261,6 +225,27 @@ void TSchemeShard::Handle(TEvForcedCompaction::TEvForgetRequest::TPtr& ev, const
 
 void TSchemeShard::Handle(TEvForcedCompaction::TEvListRequest::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxListForcedCompaction(ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr&, const TActorContext& ctx) {
+    ForcedCompactionProgressScheduled = false;
+
+    const auto now = ctx.Now();
+    if (HasUnpersistedCompletedForcedCompactions
+        || ForcedCompactionsDoneShardsToPersist.size() >= ForcedCompactionPersistBatchSize
+        || now - ForcedCompactionProgressStartTime > ForcedCompactionPersistBatchMaxTime)
+    {
+        ForcedCompactionProgressStartTime = now;
+        Execute(CreateTxProgressForcedCompaction());
+    }
+    ProcessForcedCompactionQueues();
+}
+
+void TSchemeShard::ScheduleForcedCompactionProgress(const TActorContext& ctx) {
+    if (!ForcedCompactionProgressScheduled) {
+        ForcedCompactionProgressScheduled = true;
+        ctx.Schedule(TDuration::MilliSeconds(100), new TEvPrivate::TEvProgressForcedCompaction());
+    }
 }
 
 NOperationQueue::EStartStatus TSchemeShard::StartForcedCompaction(const TShardIdx& shardIdx) {
@@ -378,7 +363,7 @@ void TSchemeShard::ProcessForcedCompactionOnSplitMerge(
     size_t removedSrcShardCount = 0;
     for (const auto& srcShardIdx : srcShardIdxs) {
         auto* shardCompactionPtr = InProgressForcedCompactionsByShard.FindPtr(srcShardIdx);
-        if (!shardCompactionPtr) {
+        if (!shardCompactionPtr || ForcedCompactionsDoneShardsToPersist.contains(srcShardIdx)) {
             continue;
         }
         Y_ENSURE(shardCompactionPtr->Get()->Id == compaction->Id);
@@ -428,8 +413,7 @@ void TSchemeShard::ProcessForcedCompactionOnSplitMerge(
             << ", new TotalShardCount# " << compaction->TotalShardCount
             << " at schemeshard " << TabletID());
 
-        // we need to enqueue at least one shard instead of the deleted one in order to make progress
-        ProcessForcedCompactionQueuesForTable(tablePathId, *compaction);
+        ScheduleForcedCompactionProgress(ctx);
     }
 }
 
@@ -468,7 +452,7 @@ void TSchemeShard::OnForcedCompactionTimeout(const TShardIdx& shardIdx) {
         << ", running# " << ForcedCompactionQueue->RunningSize() << " shards"
         << " at schemeshard " << TabletID());
 
-    RetryForcedCompactionForShard(shardIdx, pathId);
+    RetryForcedCompactionForShard(shardIdx, pathId, ctx);
 }
 
 void TSchemeShard::UpdateForcedCompactionQueueMetrics() {

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -36,7 +36,7 @@ void TSchemeShard::ForgetForcedCompactionShard(
     const TShardIdx& shardId,
     const TForcedCompactionInfo::TPtr& forcedCompactionInfo) // info may be null
 {
-    ForcedCompactionsDoneShardsToPersist[shardId] = forcedCompactionInfo;
+    ForcedCompactionsDoneShardsToPersist.emplace(shardId, forcedCompactionInfo);
     if (forcedCompactionInfo && forcedCompactionInfo->State == TForcedCompactionInfo::EState::InProgress) {
         InProgressForcedCompactionsByShard[shardId] = forcedCompactionInfo; // for counting
     }
@@ -144,9 +144,9 @@ void TSchemeShard::CompleteForcedCompactionForShard(const TShardIdx& shardIdx, c
     auto compaction = *compactionPtr;
 
     if (compaction->ShardsInFlight.erase(shardIdx)) {
-        ForcedCompactionsDoneShardsToPersist[shardIdx] = compaction;
+        ForcedCompactionsDoneShardsToPersist.emplace(shardIdx, compaction);
         if (IsForcedCompactionCompleted(*compaction)) {
-            HasUnpersistedCompletedForcedCompactions = true;
+            ForcedCompactionNeedsImmediatePersist = true;
         }
     }
 
@@ -233,7 +233,7 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr&, const 
     const bool hasAnythingToPersist = !ForcedCompactionsDoneShardsToPersist.empty()
          || !CancellingForcedCompactions.empty();
     if (hasAnythingToPersist) {
-        if (HasUnpersistedCompletedForcedCompactions
+        if (ForcedCompactionNeedsImmediatePersist
             || ForcedCompactionsDoneShardsToPersist.size() >= ForcedCompactionPersistBatchSize
             || now - ForcedCompactionProgressStartTime >= ForcedCompactionPersistBatchMaxTime)
         {
@@ -247,7 +247,7 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr&, const 
 void TSchemeShard::ScheduleForcedCompactionProgress(const TActorContext& ctx) {
     if (!ForcedCompactionProgressScheduled) {
         ForcedCompactionProgressScheduled = true;
-        ctx.Schedule(TDuration::Zero(), new TEvPrivate::TEvProgressForcedCompaction());
+        ctx.Send(SelfId(), new TEvPrivate::TEvProgressForcedCompaction());
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction.cpp
@@ -145,10 +145,9 @@ void TSchemeShard::CompleteForcedCompactionForShard(const TShardIdx& shardIdx, c
 
     if (compaction->ShardsInFlight.erase(shardIdx)) {
         ForcedCompactionsDoneShardsToPersist[shardIdx] = compaction;
-    }
-
-    if (IsForcedCompactionCompleted(*compaction)) {
-        HasUnpersistedCompletedForcedCompactions = true;
+        if (IsForcedCompactionCompleted(*compaction)) {
+            HasUnpersistedCompletedForcedCompactions = true;
+        }
     }
 
     ScheduleForcedCompactionProgress(ctx);
@@ -231,12 +230,16 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr&, const 
     ForcedCompactionProgressScheduled = false;
 
     const auto now = ctx.Now();
-    if (HasUnpersistedCompletedForcedCompactions
-        || ForcedCompactionsDoneShardsToPersist.size() >= ForcedCompactionPersistBatchSize
-        || now - ForcedCompactionProgressStartTime > ForcedCompactionPersistBatchMaxTime)
-    {
-        ForcedCompactionProgressStartTime = now;
-        Execute(CreateTxProgressForcedCompaction());
+    const bool hasAnythingToPersist = !ForcedCompactionsDoneShardsToPersist.empty()
+         || !CancellingForcedCompactions.empty();
+    if (hasAnythingToPersist) {
+        if (HasUnpersistedCompletedForcedCompactions
+            || ForcedCompactionsDoneShardsToPersist.size() >= ForcedCompactionPersistBatchSize
+            || now - ForcedCompactionProgressStartTime >= ForcedCompactionPersistBatchMaxTime)
+        {
+            ForcedCompactionProgressStartTime = now;
+            Execute(CreateTxProgressForcedCompaction());
+        }
     }
     ProcessForcedCompactionQueues();
 }
@@ -244,7 +247,7 @@ void TSchemeShard::Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr&, const 
 void TSchemeShard::ScheduleForcedCompactionProgress(const TActorContext& ctx) {
     if (!ForcedCompactionProgressScheduled) {
         ForcedCompactionProgressScheduled = true;
-        ctx.Schedule(TDuration::MilliSeconds(100), new TEvPrivate::TEvProgressForcedCompaction());
+        ctx.Schedule(TDuration::Zero(), new TEvPrivate::TEvProgressForcedCompaction());
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
@@ -99,8 +99,7 @@ struct TSchemeShard::TForcedCompaction::TTxCancel: public TRwTxBase {
     void DoComplete(const TActorContext &ctx) override {
         LOG_N("TForcedCompaction::TTxCancel DoComplete " << Request->Get()->Record.ShortDebugString());
         SideEffects.ApplyOnComplete(Self, ctx);
-        Self->ForcedCompactionProgressStartTime = ctx.Now();
-        Self->Execute(Self->CreateTxProgressForcedCompaction());
+        Self->ScheduleForcedCompactionProgress(ctx);
     }
 
 private:

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
@@ -92,6 +92,7 @@ struct TSchemeShard::TForcedCompaction::TTxCancel: public TRwTxBase {
         forcedCompactionInfo.ShardsInFlight.clear();
 
         Self->CancellingForcedCompactions.emplace_back(*forcedCompactionInfoPtr, Request->Sender, request.GetTxId(), Request->Cookie);
+        Self->HasUnpersistedCompletedForcedCompactions = true;
 
         SideEffects.ApplyOnExecute(Self, txc, ctx);
     }

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__cancel.cpp
@@ -92,15 +92,15 @@ struct TSchemeShard::TForcedCompaction::TTxCancel: public TRwTxBase {
         forcedCompactionInfo.ShardsInFlight.clear();
 
         Self->CancellingForcedCompactions.emplace_back(*forcedCompactionInfoPtr, Request->Sender, request.GetTxId(), Request->Cookie);
-        Self->HasUnpersistedCompletedForcedCompactions = true;
+        Self->ForcedCompactionNeedsImmediatePersist = true;
 
         SideEffects.ApplyOnExecute(Self, txc, ctx);
     }
 
     void DoComplete(const TActorContext &ctx) override {
         LOG_N("TForcedCompaction::TTxCancel DoComplete " << Request->Get()->Record.ShortDebugString());
-        SideEffects.ApplyOnComplete(Self, ctx);
         Self->ScheduleForcedCompactionProgress(ctx);
+        SideEffects.ApplyOnComplete(Self, ctx);
     }
 
 private:
@@ -115,7 +115,6 @@ private:
             auto& issue = *record.MutableIssues()->Add();
             issue.set_severity(NYql::TSeverityIds::S_ERROR);
             issue.set_message(errorMessage);
-
         }
 
         SideEffects.Send(Request->Sender, std::move(response), 0, Request->Cookie);

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
@@ -76,6 +76,10 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
             }
         }
 
+        if (settings.max_shards_in_flight() == 0) {
+            return Reply(std::move(response), Ydb::StatusIds::BAD_REQUEST, "max_shards_in_flight must be greater than 0");
+        }
+
         auto info = MakeIntrusive<TForcedCompactionInfo>();
         info->Id = id;
         info->State = TForcedCompactionInfo::EState::InProgress;
@@ -182,7 +186,6 @@ private:
             auto& issue = *record.MutableIssues()->Add();
             issue.set_severity(NYql::TSeverityIds::S_ERROR);
             issue.set_message(errorMessage);
-
         }
 
         SideEffects.Send(Request->Sender, std::move(response), 0, Request->Cookie);

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__create.cpp
@@ -166,7 +166,7 @@ struct TSchemeShard::TForcedCompaction::TTxCreate: public TRwTxBase {
 
     void DoComplete(const TActorContext &ctx) override {
         LOG_N("TForcedCompaction::TTxCreate DoComplete " << Request->Get()->Record.ShortDebugString());
-        Self->ProcessForcedCompactionQueues();
+        Self->ScheduleForcedCompactionProgress(ctx);
         SideEffects.ApplyOnComplete(Self, ctx);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
@@ -63,7 +63,7 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
         }
         Self->ForcedCompactionsDoneShardsToPersist.clear();
         Self->CancellingForcedCompactions.clear();
-        Self->HasUnpersistedCompletedForcedCompactions = false;
+        Self->ForcedCompactionNeedsImmediatePersist = false;
         SideEffects.ApplyOnExecute(Self, txc, ctx);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_forced_compaction__progress.cpp
@@ -63,6 +63,7 @@ struct TSchemeShard::TForcedCompaction::TTxProgress: public TRwTxBase {
         }
         Self->ForcedCompactionsDoneShardsToPersist.clear();
         Self->CancellingForcedCompactions.clear();
+        Self->HasUnpersistedCompletedForcedCompactions = false;
         SideEffects.ApplyOnExecute(Self, txc, ctx);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5853,6 +5853,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvForcedCompaction::TEvCancelRequest, Handle);
         HFuncTraced(TEvForcedCompaction::TEvForgetRequest, Handle);
         HFuncTraced(TEvForcedCompaction::TEvListRequest, Handle);
+        HFuncTraced(TEvPrivate::TEvProgressForcedCompaction, Handle);
         // } // NForcedCompaction
 
         //namespace NCdcStreamScan {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -2016,12 +2016,13 @@ public:
     TFifoQueue<TPathId> ForcedCompactionTablesQueue;
     THashMap<TPathId, TFifoQueue<TShardIdx>> ForcedCompactionShardsByTable;
     ui64 ForcedCompactionTotalInQueues = 0;
-    bool InProcessForcedCompactionQueues = false;
+    bool ForcedCompactionProgressScheduled = false;
 
-    TVector<std::pair<TShardIdx, TForcedCompactionInfo::TPtr>> ForcedCompactionsDoneShardsToPersist; // info may be null
+    THashMap<TShardIdx, TForcedCompactionInfo::TPtr> ForcedCompactionsDoneShardsToPersist; // info may be null
     ui32 ForcedCompactionPersistBatchSize = 100;
     TInstant ForcedCompactionProgressStartTime;
     TDuration ForcedCompactionPersistBatchMaxTime = TDuration::MilliSeconds(100);
+    bool HasUnpersistedCompletedForcedCompactions = false;
 
     struct TCancellingForcedCompaction {
         struct TWaiter {
@@ -2068,16 +2069,15 @@ public:
 
     void CompleteForcedCompactionForShard(const TShardIdx& shardIdx, const TActorContext &ctx);
     bool IsForcedCompactionCompleted(const TForcedCompactionInfo& forcedCompactionInfo) const;
-    void RetryForcedCompactionForShard(const TShardIdx& shardIdx, const TPathId& tablePathId);
+    void RetryForcedCompactionForShard(const TShardIdx& shardIdx, const TPathId& tablePathId, const TActorContext &ctx);
     void ProcessForcedCompactionQueues();
-    void ProcessForcedCompactionQueuesForTable(const TPathId& tablePathId, TForcedCompactionInfo& compaction);
-    void TryEnqueueOneShard(const TPathId& tablePathId, TForcedCompactionInfo& forcedCompactionInfo, THashSet<TPathId>* tablesWithoutCandidates);
     void UpdateForcedCompactionQueueMetrics();
 
     void EnqueueForcedCompaction(const TShardIdx& shardIdx);
     NOperationQueue::EStartStatus StartForcedCompaction(const TShardIdx& shardIdx);
     void OnForcedCompactionTimeout(const TShardIdx& shardIdx);
     void HandleForcedCompactionResult(TEvDataShard::TEvCompactTableResult::TPtr &ev, const TActorContext &ctx);
+    void ScheduleForcedCompactionProgress(const TActorContext& ctx);
 
     void ProcessForcedCompactionOnSplitMerge(
         NIceDb::TNiceDb& db,
@@ -2097,6 +2097,7 @@ public:
     void Handle(TEvForcedCompaction::TEvCancelRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvForcedCompaction::TEvForgetRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvForcedCompaction::TEvListRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvProgressForcedCompaction::TPtr& ev, const TActorContext& ctx);
     // } // NForcedCompaction
 
     // namespace NCdcStreamScan {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -2022,7 +2022,7 @@ public:
     ui32 ForcedCompactionPersistBatchSize = 100;
     TInstant ForcedCompactionProgressStartTime;
     TDuration ForcedCompactionPersistBatchMaxTime = TDuration::MilliSeconds(100);
-    bool HasUnpersistedCompletedForcedCompactions = false;
+    bool ForcedCompactionNeedsImmediatePersist = false;
 
     struct TCancellingForcedCompaction {
         struct TWaiter {

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -56,6 +56,7 @@ namespace TEvPrivate {
         EvRunForcedCompaction,
         EvProgressTablePartitionsFormatSweep,
         EvFullBackupItemDone,
+        EvProgressForcedCompaction,
         EvEnd
     };
 
@@ -399,6 +400,11 @@ namespace TEvPrivate {
         const ui64 FullBackupId;
         const TPathId DstPathId;
         const bool Success;
+    };
+
+    struct TEvProgressForcedCompaction : TEventLocal<TEvProgressForcedCompaction, EvProgressForcedCompaction> {
+        TEvProgressForcedCompaction()
+        {}
     };
 
 }; // TEvPrivate

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -1867,6 +1867,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1895,6 +1896,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple/ValueIndex/indexImplTable");
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardNotBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1963,6 +1965,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TActorId sender = runtime.AllocateEdgeActor();
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1996,6 +1999,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         ui64 compactionId1 = txId;
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple2");
         ui64 compactionId2 = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info1.Shards) {
             CheckShardBackgroundCompacted(runtime, info1.UserTable, shard, info1.OwnerId);
@@ -2028,6 +2032,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId1 = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             auto count = GetCompactionStats(
@@ -2041,6 +2046,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId2 = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             auto count = GetCompactionStats(
@@ -2076,6 +2082,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId1 = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId2 = txId;
 
@@ -2100,6 +2108,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true);
         ui64 compactionId1 = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple/ValueIndex/indexImplTable", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId2 = txId;
 
@@ -2123,6 +2133,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, schemeshardId, ++txId, "/MyRoot/User", "Simple", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestGetCompaction(runtime, compactionId, "/MyRoot", Ydb::StatusIds::NOT_FOUND);
     }
 
@@ -2151,7 +2162,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(15));
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 1; });
+        env.SimulateSleep(runtime, TDuration::Seconds(16));
 
         UNIT_ASSERT_VALUES_EQUAL(
             TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2182,7 +2194,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(15));
+        env.SimulateSleep(runtime, TDuration::Seconds(16));
 
         UNIT_ASSERT_VALUES_EQUAL(
             TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2193,7 +2205,10 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
     Y_UNIT_TEST(CheckGetOperationSuccess) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.GetAppData().CompactionConfig.MutableForcedCompactionConfig()->SetPersistBatchSize(1);
         Setup(runtime, env);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender); // apply PersistBatchSize
 
         ui64 txId = 1000;
 
@@ -2202,8 +2217,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2302,8 +2318,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         // wrong db
         TestGetCompaction(runtime, compactionId, "/UnknownDb", Ydb::StatusIds::NOT_FOUND);
@@ -2328,8 +2344,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
 
@@ -2367,8 +2384,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true, 5);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
 
@@ -2407,8 +2425,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         block.Stop().Unblock(1); // complete one shard
         env.SimulateSleep(runtime, TDuration::Seconds(1));
@@ -2450,8 +2469,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true, 4);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         block.Stop().Unblock(2); // complete two shards
         env.SimulateSleep(runtime, TDuration::Seconds(1));
@@ -2491,8 +2511,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2518,8 +2538,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId, Ydb::StatusIds::PRECONDITION_FAILED);
@@ -2535,6 +2556,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         ui64 compactionId = txId;
 
@@ -2564,8 +2586,9 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TBlockEvents<TEvDataShard::TEvCompactTableResult> block(runtime);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2599,8 +2622,8 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2700,6 +2723,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true);
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -2733,6 +2757,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false);
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -2790,6 +2815,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TActorId sender = runtime.AllocateEdgeActor();
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -2826,6 +2852,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
             TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple1");
             ui64 compactionId = txId;
+            runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
 
             UNIT_ASSERT_VALUES_EQUAL(
                 TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2858,6 +2885,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
             TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple2");
             ui64 compactionId = txId;
+            runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
 
             UNIT_ASSERT_VALUES_EQUAL(
                 TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2909,6 +2937,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 1; });
         env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
@@ -2985,6 +3014,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
         env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
@@ -3030,7 +3060,10 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
     Y_UNIT_TEST(ShouldOnlyAddNewShardsFromUncompactedOnSplit) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.GetAppData().CompactionConfig.MutableForcedCompactionConfig()->SetPersistBatchSize(1);
         Setup(runtime, env);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender); // apply PersistBatchSize
 
         ui64 txId = 1000;
 
@@ -3062,6 +3095,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 2);
         ui64 compactionId = txId;
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 1; });
         env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
@@ -3126,6 +3160,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -3156,7 +3191,10 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
     Y_UNIT_TEST(ShouldNotAddNewShardsForCompactedShard) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.GetAppData().CompactionConfig.MutableForcedCompactionConfig()->SetPersistBatchSize(1);
         Setup(runtime, env);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender); // apply PersistBatchSize
 
         ui64 txId = 1000;
 
@@ -3188,6 +3226,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
             });
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 2);
+        runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 1; });
         ui64 compactionId = txId;
         env.SimulateSleep(runtime, TDuration::Seconds(1));
 

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -2083,7 +2083,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId1 = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId2 = txId;
 
@@ -2109,7 +2108,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true);
         ui64 compactionId1 = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple/ValueIndex/indexImplTable", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId2 = txId;
 
@@ -2133,7 +2131,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, schemeshardId, ++txId, "/MyRoot/User", "Simple", false, 1, Ydb::StatusIds::PRECONDITION_FAILED);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
         TestGetCompaction(runtime, compactionId, "/MyRoot", Ydb::StatusIds::NOT_FOUND);
     }
 
@@ -2163,7 +2160,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 1; });
-        env.SimulateSleep(runtime, TDuration::Seconds(16));
+        env.SimulateSleep(runtime, TDuration::Seconds(15));
 
         UNIT_ASSERT_VALUES_EQUAL(
             TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2219,7 +2216,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2319,7 +2315,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         // wrong db
         TestGetCompaction(runtime, compactionId, "/UnknownDb", Ydb::StatusIds::NOT_FOUND);
@@ -2346,7 +2341,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
 
@@ -2386,7 +2380,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true, 5);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
 
@@ -2427,7 +2420,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         block.Stop().Unblock(1); // complete one shard
         env.SimulateSleep(runtime, TDuration::Seconds(1));
@@ -2540,7 +2532,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId);
         TestCancelCompaction(runtime, ++txId, "/MyRoot", compactionId, Ydb::StatusIds::PRECONDITION_FAILED);
@@ -2588,7 +2579,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2815,7 +2805,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TActorId sender = runtime.AllocateEdgeActor();
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -2852,7 +2841,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
             TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple1");
             ui64 compactionId = txId;
-            runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
+            runtime.WaitFor("TEvCompactTable", [&]{ return block.size() >= 2; });
 
             UNIT_ASSERT_VALUES_EQUAL(
                 TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -1867,7 +1867,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1896,7 +1895,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple/ValueIndex/indexImplTable");
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardNotBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1965,7 +1963,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TActorId sender = runtime.AllocateEdgeActor();
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -1999,7 +1996,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         ui64 compactionId1 = txId;
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple2");
         ui64 compactionId2 = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info1.Shards) {
             CheckShardBackgroundCompacted(runtime, info1.UserTable, shard, info1.OwnerId);
@@ -2032,7 +2028,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId1 = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             auto count = GetCompactionStats(
@@ -2046,7 +2041,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId2 = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             auto count = GetCompactionStats(
@@ -2134,6 +2128,23 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestGetCompaction(runtime, compactionId, "/MyRoot", Ydb::StatusIds::NOT_FOUND);
     }
 
+    Y_UNIT_TEST(SchemeshardShouldNotCompactWithZeroMaxShardsInFlight) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        Setup(runtime, env);
+
+        ui64 txId = 1000;
+
+        CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
+        auto info = GetPathInfo(runtime, "/MyRoot/Simple");
+
+        CheckNoBackgroundCompactionsInPeriod(runtime, env, "/MyRoot/Simple");
+
+        TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 0, Ydb::StatusIds::BAD_REQUEST);
+        ui64 compactionId = txId;
+        TestGetCompaction(runtime, compactionId, "/MyRoot", Ydb::StatusIds::NOT_FOUND);
+    }
+
     Y_UNIT_TEST(ShouldRetryOnTimeout) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -2191,7 +2202,7 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple");
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(16));
+        env.SimulateSleep(runtime, TDuration::Seconds(15));
 
         UNIT_ASSERT_VALUES_EQUAL(
             TestGetCompaction(runtime, compactionId, "/MyRoot").GetForcedCompaction().GetState(),
@@ -2463,7 +2474,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true, 4);
         ui64 compactionId = txId;
         runtime.WaitFor("EvCompactTableResult", [&]{ return block.size() >= 2; });
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         block.Stop().Unblock(2); // complete two shards
         env.SimulateSleep(runtime, TDuration::Seconds(1));
@@ -2504,7 +2514,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2547,7 +2556,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
         CreateTableWithData(runtime, env, "/MyRoot", "Simple", 2, ++txId);
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         ui64 compactionId = txId;
 
@@ -2613,7 +2621,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false, 3);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         {
             auto response = TestGetCompaction(runtime, compactionId, "/MyRoot");
@@ -2713,7 +2720,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", true);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);
@@ -2747,7 +2753,6 @@ Y_UNIT_TEST_SUITE(TSchemeshardForcedCompactionTest) {
 
         TestCompact(runtime, ++txId, "/MyRoot", "/MyRoot/Simple", false);
         ui64 compactionId = txId;
-        env.SimulateSleep(runtime, TDuration::Seconds(1));
 
         for (auto shard: info.Shards) {
             CheckShardBackgroundCompacted(runtime, info.UserTable, shard, info.OwnerId);


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Избавился от потенциально рекурсивных вызовов внутри EnqueueForcedCompaction(): теперь вызов EnqueueForcedCompaction только планирует отправку EvProgressForcedCompaction и не трогает очереди внутри себя. Позволит исключить проблемы типа https://github.com/ydb-platform/ydb/issues/42189 и https://github.com/ydb-platform/ydb/pull/42501  
