### PR TITLE
Stop leaking Telegram bot token into public test logs

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -448,14 +448,14 @@ runs:
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
           set +x
-          GH_ALERTS_TG_LOGINS="${{ inputs.telegram_alert_logins }}" \
+          TELEGRAM_BOT_TOKEN='${{ inputs.telegram_ydbot_token }}' \
+          TELEGRAM_CHAT_ID='${{ inputs.telegram_alert_chat }}' \
+          GH_ALERTS_TG_LOGINS='${{ inputs.telegram_alert_logins }}' \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
-            --bot-token '${{ inputs.telegram_ydbot_token }}' \
-            --chat-id '${{ inputs.telegram_alert_chat }}' \
             --memory-threshold 97 || true
           set -x
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -154,9 +154,6 @@ runs:
       shell: bash
       env:
         COLLECT_COREDUMPS: ${{ inputs.collect_coredumps }}
-        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_ydbot_token }}
-        GH_ALERTS_TG_LOGINS: ${{ inputs.telegram_alert_logins }}
-        GH_ALERTS_TG_CHAT: ${{ inputs.telegram_alert_chat }}
         PR_NUMBER: ${{ inputs.pull_number }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
         GITHUB_BASE_REF: ${{ github.base_ref }}
@@ -450,12 +447,16 @@ runs:
 
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
+          # Telegram credentials are passed only to this script (not step env) so they
+          # are not inherited by ya make / yatest and dumped into public test logs.
+          GH_ALERTS_TG_LOGINS="${{ inputs.telegram_alert_logins }}" \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
-            --chat-id "$GH_ALERTS_TG_CHAT" \
+            --bot-token "${{ inputs.telegram_ydbot_token }}" \
+            --chat-id "${{ inputs.telegram_alert_chat }}" \
             --memory-threshold 97 || true
 
           # convert to chromium trace

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -448,14 +448,14 @@ runs:
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
           set +x
-          TELEGRAM_BOT_TOKEN='${{ inputs.telegram_ydbot_token }}' \
-          TELEGRAM_CHAT_ID='${{ inputs.telegram_alert_chat }}' \
           GH_ALERTS_TG_LOGINS='${{ inputs.telegram_alert_logins }}' \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
+            --bot-token '${{ inputs.telegram_ydbot_token }}' \
+            --chat-id '${{ inputs.telegram_alert_chat }}' \
             --memory-threshold 97 || true
           set -x
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -447,17 +447,17 @@ runs:
 
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
-          # Telegram credentials are passed only to this script (not step env) so they
-          # are not inherited by ya make / yatest and dumped into public test logs.
+          set +x
           GH_ALERTS_TG_LOGINS="${{ inputs.telegram_alert_logins }}" \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
-            --bot-token "${{ inputs.telegram_ydbot_token }}" \
-            --chat-id "${{ inputs.telegram_alert_chat }}" \
+            --bot-token '${{ inputs.telegram_ydbot_token }}' \
+            --chat-id '${{ inputs.telegram_alert_chat }}' \
             --memory-threshold 97 || true
+          set -x
 
           # convert to chromium trace
           # seems analyze-make don't have simple "output" parameter, so change cwd


### PR DESCRIPTION
## Summary
- Remove `TELEGRAM_BOT_TOKEN`, `GH_ALERTS_TG_LOGINS`, and `GH_ALERTS_TG_CHAT` from the `ya build and test` step environment in `test_ya`.
- Pass Telegram credentials only to `report_ram_analyzer.py` via `--bot-token` / `--chat-id` and a scoped `GH_ALERTS_TG_LOGINS` env var.

## Problem
The bot token was exported on the entire `ya build and test` step and inherited by `ya make` via `sudo -E`. yatest logs the full process environment at DEBUG level into `testing_out_stuff/stdout`. Failed-suite artifacts are zipped and synced to public S3 (`--acl-public`), which exposed the token.

## Test plan
- [ ] Merge and verify RAM OOM alerts still work when memory threshold is exceeded
- [ ] Confirm `TELEGRAM_BOT_TOKEN` no longer appears in `testing_out_stuff/stdout` for CI test runs
- [ ] Revoke and rotate the leaked bot token in BotFather / GitHub secrets (if not done already)


Made with [Cursor](https://cursor.com)