### PR TITLE
[Backport stable-26-1-1-9-hotfix] Stop leaking Telegram bot token into public test logs (#42676)

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -154,9 +154,6 @@ runs:
       shell: bash
       env:
         COLLECT_COREDUMPS: ${{ inputs.collect_coredumps }}
-        TELEGRAM_BOT_TOKEN: ${{ inputs.telegram_ydbot_token }}
-        GH_ALERTS_TG_LOGINS: ${{ inputs.telegram_alert_logins }}
-        GH_ALERTS_TG_CHAT: ${{ inputs.telegram_alert_chat }}
         PR_NUMBER: ${{ inputs.pull_number }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
         GITHUB_BASE_REF: ${{ github.base_ref }}
@@ -416,13 +413,17 @@ runs:
 
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
+          set +x
+          GH_ALERTS_TG_LOGINS='${{ inputs.telegram_alert_logins }}' \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
-            --chat-id "$GH_ALERTS_TG_CHAT" \
+            --bot-token '${{ inputs.telegram_ydbot_token }}' \
+            --chat-id '${{ inputs.telegram_alert_chat }}' \
             --memory-threshold 97 || true
+          set -x
 
           # convert to chromium trace
           # seems analyze-make don't have simple "output" parameter, so change cwd


### PR DESCRIPTION
## Summary
- Backport of #42676 to stop leaking `TELEGRAM_BOT_TOKEN` into public CI test artifacts.
- Pass Telegram credentials only to `report_ram_analyzer.py` (not `ya make` step env).
- Wrap the Telegram invocation with `set +x` / `set -x`.

## Test plan
- [ ] CI pre-commit on this branch passes

Made with [Cursor](https://cursor.com)