### PR TITLE
Pass Telegram credentials via scoped env vars in test_ya

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -448,14 +448,14 @@ runs:
           .github/scripts/tests/report_analyzer.py --report_file "$CURRENT_REPORT" --summary_file $CURRENT_PUBLIC_DIR/summary_report.txt || true
 
           set +x
-          GH_ALERTS_TG_LOGINS='${{ inputs.telegram_alert_logins }}' \
+          TELEGRAM_BOT_TOKEN="${{ inputs.telegram_ydbot_token }}" \
+          TELEGRAM_CHAT_ID="${{ inputs.telegram_alert_chat }}" \
+          GH_ALERTS_TG_LOGINS="${{ inputs.telegram_alert_logins }}" \
           .github/scripts/report_ram_analyzer.py \
             --report-file "$CURRENT_REPORT" \
             --output-file $CURRENT_PUBLIC_DIR/ram_report.html \
             --output-file-url $CURRENT_PUBLIC_DIR_URL/ram_report.html \
             --ram-usage-file ram_usage.txt \
-            --bot-token '${{ inputs.telegram_ydbot_token }}' \
-            --chat-id '${{ inputs.telegram_alert_chat }}' \
             --memory-threshold 97 || true
           set -x
 


### PR DESCRIPTION
## Summary
- Follow-up to #42676: pass `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` as scoped env vars to `report_ram_analyzer.py` instead of `--bot-token` / `--chat-id` CLI args.
- Keeps credentials out of the `ya make` step environment and avoids exposing the token in `/proc/<pid>/cmdline` while the analyzer runs.
- Uses double-quoted GHA expressions for env assignment (safe for secrets with special characters).

## Problem
#42676 stopped leaking the token into yatest logs, but CLI args still put the bot token in the process command line (`ps`, `/proc/.../cmdline`) for the lifetime of `report_ram_analyzer.py`.

## Test plan
- [ ] Verify RAM OOM Telegram alerts still work when memory threshold is exceeded
- [ ] Confirm `TELEGRAM_BOT_TOKEN` is not visible in `testing_out_stuff/stdout` for `ya make`
- [ ] Confirm token does not appear in `ps` / `/proc/.../cmdline` during `report_ram_analyzer.py` execution


Made with [Cursor](https://cursor.com)