### PR TITLE
Add logs for support links

### DIFF
--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -37,6 +37,9 @@ meta:
       - source: grafana/dashboard
         title: Database Overview
         url: /d/ydb_database/overview
+      - source: grafana/logging
+        title: Database Logs
+        bucket: ydb
       - source: grafana/dashboard/search
         tag:
           - ui-database

--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -39,7 +39,6 @@ meta:
         url: /d/ydb_database/overview
       - source: grafana/logging
         title: Database Logs
-        bucket: ydb
       - source: grafana/dashboard/search
         tag:
           - ui-database

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,8 +22,6 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
-            // Bucket override for source=grafana/logging.
-            optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,7 +22,7 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
-            // Loki bucket override for source=grafana/logging.
+            // Bucket override for source=grafana/logging.
             optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,6 +22,8 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
+            // Loki bucket override for source=grafana/logging.
+            optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;

--- a/ydb/mvp/meta/support_links/grafana_logging_source.h
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "grafana_dashboard_common.h"
+#include "source_common.h"
+
+#include <ydb/mvp/meta/support_links/source.h>
+
+#include <library/cpp/cgiparam/cgiparam.h>
+#include <library/cpp/json/json_writer.h>
+
+#include <util/generic/yexception.h>
+#include <util/string/escape.h>
+
+#include <utility>
+
+namespace NMVP::NSupportLinks {
+
+inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_URL = "/explore";
+
+inline TVector<std::pair<TString, TString>> BuildGrafanaLoggingBindings(const NHttp::TUrlParameters& requestQueryParameters) {
+    TVector<std::pair<TString, TString>> bindings;
+
+    const TString database = requestQueryParameters["database"];
+    if (!database.empty()) {
+        bindings.emplace_back("database", database);
+    }
+
+    return bindings;
+}
+
+inline TString BuildGrafanaLoggingExpr(const TVector<std::pair<TString, TString>>& bindings) {
+    TString expr = "{";
+    bool first = true;
+    for (const auto& [name, value] : bindings) {
+        if (!first) {
+            expr += ", ";
+        }
+        first = false;
+        expr += TStringBuilder() << name << "=\"" << EscapeC(value) << '"';
+    }
+    expr += "}";
+    return expr;
+}
+
+inline NJson::TJsonValue BuildGrafanaLoggingPanesJson(const TString& datasource, const TVector<std::pair<TString, TString>>& bindings) {
+    NJson::TJsonValue panesJson(NJson::JSON_MAP);
+    NJson::TJsonValue paneJson(NJson::JSON_MAP);
+    NJson::TJsonValue queryJson(NJson::JSON_MAP);
+
+    queryJson["refId"] = "A";
+    queryJson["expr"] = BuildGrafanaLoggingExpr(bindings);
+    queryJson["queryType"] = "range";
+    queryJson["direction"] = "backward";
+    queryJson["datasource"]["type"] = "loki";
+    queryJson["datasource"]["uid"] = datasource;
+
+    paneJson["datasource"] = datasource;
+    paneJson["queries"].AppendValue(std::move(queryJson));
+    paneJson["range"]["from"] = "now-1h";
+    paneJson["range"]["to"] = "now";
+
+    panesJson["x"] = std::move(paneJson);
+    return panesJson;
+}
+
+inline bool TryBuildGrafanaLoggingUrl(
+    TStringBuf grafanaEndpoint,
+    TStringBuf url,
+    TStringBuf bucket,
+    const THashMap<TString, TString>& clusterInfo,
+    const NHttp::TUrlParameters& requestQueryParameters,
+    TString& resolvedUrl,
+    TString& errorMessage)
+{
+    const TStringBuf path = url.empty() ? GRAFANA_LOGGING_DEFAULT_URL : url;
+    resolvedUrl = IsAbsoluteUrl(path) ? TString(path) : JoinUrl(grafanaEndpoint, path);
+
+    if (resolvedUrl.Contains('?')) {
+        errorMessage = "query parameters are not supported in url for source=grafana/logging";
+        return false;
+    }
+
+    const auto workspaceIt = clusterInfo.find(TString(NSupportLinks::GRAFANA_WORKSPACE_KEY));
+    if (workspaceIt == clusterInfo.end() || workspaceIt->second.empty()) {
+        errorMessage = "k8s_namespace is required in cluster info for source=grafana/logging";
+        return false;
+    }
+
+    const auto datasourceIt = clusterInfo.find("datasource_logging");
+    if (datasourceIt == clusterInfo.end() || datasourceIt->second.empty()) {
+        errorMessage = "datasource_logging is required in cluster info for source=grafana/logging";
+        return false;
+    }
+
+    TVector<std::pair<TString, TString>> bindings = BuildGrafanaLoggingBindings(requestQueryParameters);
+    bindings.emplace_back("__workspace__", workspaceIt->second);
+    bindings.emplace_back("__bucket__", bucket);
+
+    TCgiParameters queryParameters;
+    queryParameters.InsertUnescaped("schemaVersion", "1");
+    queryParameters.InsertUnescaped("panes", NJson::WriteJson(
+        BuildGrafanaLoggingPanesJson(datasourceIt->second, bindings),
+        false));
+    queryParameters.InsertUnescaped("orgId", "1");
+
+    resolvedUrl += TStringBuilder() << '?' << queryParameters.Print();
+    return true;
+}
+
+} // namespace NMVP::NSupportLinks
+
+namespace NMVP {
+
+class TGrafanaLoggingSource : public ILinkSource {
+public:
+    TGrafanaLoggingSource(TString sourceName, TString title, TString url, TString bucket, TString grafanaEndpoint)
+        : SourceName(std::move(sourceName))
+        , Title(std::move(title))
+        , Url(std::move(url))
+        , Bucket(std::move(bucket))
+        , GrafanaEndpoint(std::move(grafanaEndpoint))
+    {}
+
+    TResolveOutput Resolve(const TLinkResolveInput& input, const TResolveContext&) const override {
+        TResolveOutput result{
+            .Name = SourceName,
+        };
+
+        TString resolvedUrl;
+        TString errorMessage;
+        if (!NSupportLinks::TryBuildGrafanaLoggingUrl(
+                GrafanaEndpoint,
+                Url,
+                Bucket,
+                input.ClusterInfo,
+                input.UrlParameters,
+                resolvedUrl,
+                errorMessage))
+        {
+            result.Errors.emplace_back(NSupportLinks::TSupportError{
+                .Source = SourceName,
+                .Message = std::move(errorMessage),
+            });
+            return result;
+        }
+
+        result.Links.emplace_back(NSupportLinks::TResolvedLink{
+            .Title = Title,
+            .Url = std::move(resolvedUrl),
+        });
+        return result;
+    }
+
+private:
+    TString SourceName;
+    TString Title;
+    TString Url;
+    TString Bucket;
+    TString GrafanaEndpoint;
+};
+
+inline void ValidateGrafanaLoggingSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
+    const TStringBuf url = config.GetUrl().empty()
+        ? NSupportLinks::GRAFANA_LOGGING_DEFAULT_URL
+        : TStringBuf(config.GetUrl());
+    if (url.Contains('?')) {
+        ythrow yexception() << "query parameters are not supported in url for source=" << config.GetSource();
+    }
+    if (!NSupportLinks::IsAbsoluteUrl(url) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
+        ythrow yexception() << "grafana.endpoint is required for relative url";
+    }
+}
+
+inline std::shared_ptr<ILinkSource> MakeGrafanaLoggingSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
+    ValidateGrafanaLoggingSourceConfig(config, metaSettings);
+    return std::make_shared<TGrafanaLoggingSource>(
+        config.GetSource(),
+        config.GetTitle(),
+        config.GetUrl(),
+        config.GetBucket(),
+        metaSettings.SupportLinks.GrafanaEndpoint
+    );
+}
+
+} // namespace NMVP

--- a/ydb/mvp/meta/support_links/grafana_logging_source.h
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.h
@@ -16,6 +16,7 @@
 namespace NMVP::NSupportLinks {
 
 inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_URL = "/explore";
+inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_BUCKET = "ydb";
 
 inline TVector<std::pair<TString, TString>> BuildGrafanaLoggingBindings(const NHttp::TUrlParameters& requestQueryParameters) {
     TVector<std::pair<TString, TString>> bindings;
@@ -66,7 +67,6 @@ inline NJson::TJsonValue BuildGrafanaLoggingPanesJson(const TString& datasource,
 inline bool TryBuildGrafanaLoggingUrl(
     TStringBuf grafanaEndpoint,
     TStringBuf url,
-    TStringBuf bucket,
     const THashMap<TString, TString>& clusterInfo,
     const NHttp::TUrlParameters& requestQueryParameters,
     TString& resolvedUrl,
@@ -94,7 +94,7 @@ inline bool TryBuildGrafanaLoggingUrl(
 
     TVector<std::pair<TString, TString>> bindings = BuildGrafanaLoggingBindings(requestQueryParameters);
     bindings.emplace_back("__workspace__", workspaceIt->second);
-    bindings.emplace_back("__bucket__", bucket);
+    bindings.emplace_back("__bucket__", TString(GRAFANA_LOGGING_DEFAULT_BUCKET));
 
     TCgiParameters queryParameters;
     queryParameters.InsertUnescaped("schemaVersion", "1");
@@ -113,11 +113,10 @@ namespace NMVP {
 
 class TGrafanaLoggingSource : public ILinkSource {
 public:
-    TGrafanaLoggingSource(TString sourceName, TString title, TString url, TString bucket, TString grafanaEndpoint)
+    TGrafanaLoggingSource(TString sourceName, TString title, TString url, TString grafanaEndpoint)
         : SourceName(std::move(sourceName))
         , Title(std::move(title))
         , Url(std::move(url))
-        , Bucket(std::move(bucket))
         , GrafanaEndpoint(std::move(grafanaEndpoint))
     {}
 
@@ -131,7 +130,6 @@ public:
         if (!NSupportLinks::TryBuildGrafanaLoggingUrl(
                 GrafanaEndpoint,
                 Url,
-                Bucket,
                 input.ClusterInfo,
                 input.UrlParameters,
                 resolvedUrl,
@@ -155,7 +153,6 @@ private:
     TString SourceName;
     TString Title;
     TString Url;
-    TString Bucket;
     TString GrafanaEndpoint;
 };
 
@@ -177,7 +174,6 @@ inline std::shared_ptr<ILinkSource> MakeGrafanaLoggingSource(TSupportLinkEntryCo
         config.GetSource(),
         config.GetTitle(),
         config.GetUrl(),
-        config.GetBucket(),
         metaSettings.SupportLinks.GrafanaEndpoint
     );
 }

--- a/ydb/mvp/meta/support_links/grafana_logging_source.h
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "grafana_dashboard_common.h"
 #include "source_common.h"
 
 #include <ydb/mvp/meta/support_links/source.h>
@@ -16,7 +15,6 @@
 namespace NMVP::NSupportLinks {
 
 inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_URL = "/explore";
-inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_BUCKET = "ydb";
 
 inline TVector<std::pair<TString, TString>> BuildGrafanaLoggingBindings(const NHttp::TUrlParameters& requestQueryParameters) {
     TVector<std::pair<TString, TString>> bindings;
@@ -80,12 +78,6 @@ inline bool TryBuildGrafanaLoggingUrl(
         return false;
     }
 
-    const auto workspaceIt = clusterInfo.find(TString(NSupportLinks::GRAFANA_WORKSPACE_KEY));
-    if (workspaceIt == clusterInfo.end() || workspaceIt->second.empty()) {
-        errorMessage = "k8s_namespace is required in cluster info for source=grafana/logging";
-        return false;
-    }
-
     const auto datasourceIt = clusterInfo.find("datasource_logging");
     if (datasourceIt == clusterInfo.end() || datasourceIt->second.empty()) {
         errorMessage = "datasource_logging is required in cluster info for source=grafana/logging";
@@ -93,8 +85,6 @@ inline bool TryBuildGrafanaLoggingUrl(
     }
 
     TVector<std::pair<TString, TString>> bindings = BuildGrafanaLoggingBindings(requestQueryParameters);
-    bindings.emplace_back("__workspace__", workspaceIt->second);
-    bindings.emplace_back("__bucket__", TString(GRAFANA_LOGGING_DEFAULT_BUCKET));
 
     TCgiParameters queryParameters;
     queryParameters.InsertUnescaped("schemaVersion", "1");

--- a/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
@@ -1,0 +1,246 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/cgiparam/cgiparam.h>
+#include <library/cpp/json/json_reader.h>
+
+#include <ydb/library/actors/http/http.h>
+#include <ydb/mvp/meta/support_links/grafana_logging_source.h>
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+namespace {
+
+NMVP::TMetaSettings MakeMetaSettings(TStringBuf grafanaEndpoint) {
+    NMVP::TMetaSettings settings;
+    settings.SupportLinks.GrafanaEndpoint = TString(grafanaEndpoint);
+    return settings;
+}
+
+NMVP::TSupportLinkEntryConfig MakeConfig(TStringBuf url = TStringBuf()) {
+    NMVP::TSupportLinkEntryConfig config;
+    config.SetSource("grafana/logging");
+    config.SetTitle("Logs");
+    if (!url.empty()) {
+        config.SetUrl(TString(url));
+    }
+    return config;
+}
+
+NMVP::TSupportLinkEntryConfig MakeConfigWithBucket(TStringBuf bucket, TStringBuf url = TStringBuf()) {
+    NMVP::TSupportLinkEntryConfig config = MakeConfig(url);
+    config.SetBucket(TString(bucket));
+    return config;
+}
+
+NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
+    NHttp::TUrlParametersBuilder builder;
+    for (TStringBuf param = query.NextTok('&'); !param.empty(); param = query.NextTok('&')) {
+        TStringBuf name = param.NextTok('=');
+        builder.Set(name, param);
+    }
+    return builder;
+}
+
+NJson::TJsonValue ParseJson(TStringBuf body) {
+    NJson::TJsonReaderConfig jsonReaderConfig;
+    NJson::TJsonValue json;
+    UNIT_ASSERT(NJson::ReadJsonTree(body, &jsonReaderConfig, &json));
+    return json;
+}
+
+struct TGrafanaLoggingTestContext {
+    NMVP::TSupportLinkEntryConfig Config;
+    NMVP::TMetaSettings Settings;
+    THashMap<TString, TString> ClusterInfo;
+    NHttp::TUrlParametersBuilder UrlParameters;
+    NMVP::ILinkSource::TLinkResolveInput Input;
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+    NMVP::ILinkSource::TResolveContext Context;
+
+    explicit TGrafanaLoggingTestContext(TStringBuf url = TStringBuf())
+        : Config(MakeConfig(url))
+        , Settings(MakeMetaSettings("https://grafana.example.net"))
+        , UrlParameters("")
+        , Input{
+            .ClusterInfo = ClusterInfo,
+            .UrlParameters = UrlParameters,
+        }
+        , Owner(1, "ow")
+        , HttpProxyId(2, "hp")
+        , Context{
+            .Place = 0,
+            .Owner = Owner,
+            .HttpProxyId = HttpProxyId,
+        }
+    {}
+
+    std::shared_ptr<NMVP::ILinkSource> CreateSource() const {
+        return NMVP::MakeGrafanaLoggingSource(Config, Settings);
+    }
+
+    NMVP::TResolveOutput Resolve() const {
+        return CreateSource()->Resolve(Input, Context);
+    }
+};
+
+void AssertPanesQuery(
+    const TString& url,
+    TStringBuf expectedBaseUrl,
+    TStringBuf expectedExpr,
+    TStringBuf expectedDatasource)
+{
+    const TStringBuf actualUrl = url;
+    UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedBaseUrl);
+
+    TCgiParameters query;
+    query.Scan(actualUrl.After('?'));
+    UNIT_ASSERT_VALUES_EQUAL(query.Get("schemaVersion"), "1");
+    UNIT_ASSERT_VALUES_EQUAL(query.Get("orgId"), "1");
+
+    const NJson::TJsonValue panesJson = ParseJson(query.Get("panes"));
+    UNIT_ASSERT_VALUES_EQUAL(panesJson.GetMapSafe().size(), 1u);
+    const NJson::TJsonValue& pane = panesJson["x"];
+    UNIT_ASSERT_VALUES_EQUAL(pane["datasource"].GetString(), expectedDatasource);
+    UNIT_ASSERT_VALUES_EQUAL(pane["range"]["from"].GetString(), "now-1h");
+    UNIT_ASSERT_VALUES_EQUAL(pane["range"]["to"].GetString(), "now");
+    UNIT_ASSERT(!pane.Has("panelsState"));
+    UNIT_ASSERT(!pane.Has("compact"));
+    UNIT_ASSERT_VALUES_EQUAL(pane["queries"][0]["expr"].GetString(), expectedExpr);
+    UNIT_ASSERT_VALUES_EQUAL(pane["queries"][0]["queryType"].GetString(), "range");
+    UNIT_ASSERT(!pane["queries"][0].Has("editorMode"));
+    UNIT_ASSERT_VALUES_EQUAL(pane["queries"][0]["direction"].GetString(), "backward");
+    UNIT_ASSERT_VALUES_EQUAL(pane["queries"][0]["datasource"]["type"].GetString(), "loki");
+    UNIT_ASSERT_VALUES_EQUAL(pane["queries"][0]["datasource"]["uid"].GetString(), expectedDatasource);
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
+    Y_UNIT_TEST(ValidationRejectsDefaultRelativeUrlWithoutGrafanaEndpoint) {
+        TGrafanaLoggingTestContext context;
+        context.Settings = MakeMetaSettings("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "grafana.endpoint is required for relative url"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveBuildsDefaultExploreUrlFromScratch) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        context.ClusterInfo["datasource_logging"] = "cd868168-09d4-4ece-82db-e646130697e5";
+        context.UrlParameters = MakeUrlParameters("database=%2Froot%2Ftenant");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{database=\"/root/tenant\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "cd868168-09d4-4ece-82db-e646130697e5"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveBuildsAbsoluteExploreUrlFromScratch) {
+        TGrafanaLoggingTestContext context("https://external.example.net/explore");
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        context.UrlParameters = MakeUrlParameters("database=%2Fnew%2Fdb");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://external.example.net/explore",
+            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "ds-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesDatabaseRequestParameter) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        context.UrlParameters = MakeUrlParameters("custom_label=new-value&database=%2Fnew%2Fdb");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "ds-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveSkipsRequestParametersOtherThanDatabase) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        context.UrlParameters = MakeUrlParameters("cluster=ignored-cluster&custom_label=ignored&database=%2Fnew%2Fdb");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "ds-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesBucketOverrideFromConfig) {
+        TGrafanaLoggingTestContext context;
+        context.Config = MakeConfigWithBucket("custom-bucket");
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        context.UrlParameters = MakeUrlParameters("database=%2Fnew%2Fdb");
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"custom-bucket\"}",
+            "ds-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveReturnsErrorWhenWorkspaceMissing) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 0u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Source, "grafana/logging");
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Message, "k8s_namespace is required in cluster info for source=grafana/logging");
+    }
+
+    Y_UNIT_TEST(ResolveReturnsErrorWhenDatasourceMissing) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["k8s_namespace"] = "ydb-common";
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 0u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Source, "grafana/logging");
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Message, "datasource_logging is required in cluster info for source=grafana/logging");
+    }
+
+    Y_UNIT_TEST(ValidationRejectsUrlWithQueryParameters) {
+        TGrafanaLoggingTestContext context("/explore?panes=template");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "query parameters are not supported in url for source=grafana/logging"
+        );
+    }
+}

--- a/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
@@ -123,7 +123,6 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
 
     Y_UNIT_TEST(ResolveBuildsDefaultExploreUrlFromScratch) {
         TGrafanaLoggingTestContext context;
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
         context.ClusterInfo["datasource_logging"] = "cd868168-09d4-4ece-82db-e646130697e5";
         context.UrlParameters = MakeUrlParameters("database=%2Froot%2Ftenant");
         auto result = context.Resolve();
@@ -133,14 +132,13 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/root/tenant\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "{database=\"/root/tenant\"}",
             "cd868168-09d4-4ece-82db-e646130697e5"
         );
     }
 
     Y_UNIT_TEST(ResolveBuildsAbsoluteExploreUrlFromScratch) {
         TGrafanaLoggingTestContext context("https://external.example.net/explore");
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
         context.ClusterInfo["datasource_logging"] = "ds-42";
         context.UrlParameters = MakeUrlParameters("database=%2Fnew%2Fdb");
         auto result = context.Resolve();
@@ -150,14 +148,13 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://external.example.net/explore",
-            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "{database=\"/new/db\"}",
             "ds-42"
         );
     }
 
     Y_UNIT_TEST(ResolveUsesDatabaseRequestParameter) {
         TGrafanaLoggingTestContext context;
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
         context.ClusterInfo["datasource_logging"] = "ds-42";
         context.UrlParameters = MakeUrlParameters("custom_label=new-value&database=%2Fnew%2Fdb");
         auto result = context.Resolve();
@@ -167,14 +164,13 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "{database=\"/new/db\"}",
             "ds-42"
         );
     }
 
     Y_UNIT_TEST(ResolveSkipsRequestParametersOtherThanDatabase) {
         TGrafanaLoggingTestContext context;
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
         context.ClusterInfo["datasource_logging"] = "ds-42";
         context.UrlParameters = MakeUrlParameters("cluster=ignored-cluster&custom_label=ignored&database=%2Fnew%2Fdb");
         auto result = context.Resolve();
@@ -184,25 +180,29 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
+            "{database=\"/new/db\"}",
             "ds-42"
         );
     }
 
-    Y_UNIT_TEST(ResolveReturnsErrorWhenWorkspaceMissing) {
+    Y_UNIT_TEST(ResolveDoesNotRequireWorkspace) {
         TGrafanaLoggingTestContext context;
         context.ClusterInfo["datasource_logging"] = "ds-42";
+        context.UrlParameters = MakeUrlParameters("database=%2Fnew%2Fdb");
         auto result = context.Resolve();
 
-        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 0u);
-        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Source, "grafana/logging");
-        UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Message, "k8s_namespace is required in cluster info for source=grafana/logging");
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{database=\"/new/db\"}",
+            "ds-42"
+        );
     }
 
     Y_UNIT_TEST(ResolveReturnsErrorWhenDatasourceMissing) {
         TGrafanaLoggingTestContext context;
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
         auto result = context.Resolve();
 
         UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 0u);

--- a/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
@@ -26,12 +26,6 @@ NMVP::TSupportLinkEntryConfig MakeConfig(TStringBuf url = TStringBuf()) {
     return config;
 }
 
-NMVP::TSupportLinkEntryConfig MakeConfigWithBucket(TStringBuf bucket, TStringBuf url = TStringBuf()) {
-    NMVP::TSupportLinkEntryConfig config = MakeConfig(url);
-    config.SetBucket(TString(bucket));
-    return config;
-}
-
 NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
     NHttp::TUrlParametersBuilder builder;
     for (TStringBuf param = query.NextTok('&'); !param.empty(); param = query.NextTok('&')) {
@@ -191,24 +185,6 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
             result.Links[0].Url,
             "https://grafana.example.net/explore",
             "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"ydb\"}",
-            "ds-42"
-        );
-    }
-
-    Y_UNIT_TEST(ResolveUsesBucketOverrideFromConfig) {
-        TGrafanaLoggingTestContext context;
-        context.Config = MakeConfigWithBucket("custom-bucket");
-        context.ClusterInfo["k8s_namespace"] = "ydb-common";
-        context.ClusterInfo["datasource_logging"] = "ds-42";
-        context.UrlParameters = MakeUrlParameters("database=%2Fnew%2Fdb");
-        auto result = context.Resolve();
-
-        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
-        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
-        AssertPanesQuery(
-            result.Links[0].Url,
-            "https://grafana.example.net/explore",
-            "{database=\"/new/db\", __workspace__=\"ydb-common\", __bucket__=\"custom-bucket\"}",
             "ds-42"
         );
     }

--- a/ydb/mvp/meta/support_links/source.cpp
+++ b/ydb/mvp/meta/support_links/source.cpp
@@ -1,6 +1,7 @@
 #include "source.h"
 #include "grafana_dashboard_source.h"
 #include "grafana_dashboard_search_source.h"
+#include "grafana_logging_source.h"
 
 #include <util/generic/yexception.h>
 
@@ -28,6 +29,10 @@ void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMeta
         ValidateGrafanaDashboardSearchSourceConfig(config, metaSettings);
         return;
     }
+    if (config.GetSource() == "grafana/logging") {
+        ValidateGrafanaLoggingSourceConfig(config, metaSettings);
+        return;
+    }
 
     ythrow yexception() << "unsupported support_links source: " << config.GetSource();
 }
@@ -40,6 +45,9 @@ std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config, cons
     }
     if (config.GetSource() == "grafana/dashboard/search") {
         return MakeGrafanaDashboardSearchSource(std::move(config), metaSettings);
+    }
+    if (config.GetSource() == "grafana/logging") {
+        return MakeGrafanaLoggingSource(std::move(config), metaSettings);
     }
 
     ythrow yexception() << "unsupported support_links source: " << config.GetSource();

--- a/ydb/mvp/meta/support_links/ut/ya.make
+++ b/ydb/mvp/meta/support_links/ut/ya.make
@@ -5,6 +5,7 @@ SIZE(SMALL)
 SRCS(
     grafana_dashboard_source_ut.cpp
     grafana_dashboard_search_source_ut.cpp
+    grafana_logging_source_ut.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds a new support_links source (grafana/logging) to generate Grafana Explore URLs for viewing database logs, integrated into the existing support-links resolver/factory and configuration schema.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Implement grafana/logging link source that builds an /explore URL with a Loki query derived from request parameters and cluster info (workspace/datasource), with optional bucket override.
- Register the new source in validation/factory routing and extend config schema + example YAML.
- Add unit tests and wire them into the support_links unittest build.

