### PR TITLE
Add retries for pipe sends in SET NOT NULL

### DIFF
--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -880,7 +880,7 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
     TTxId ValidationSnapshotTxId = TTxId();
     TStepId ValidationSnapshotStep = TStepId();
 
-    ui32 MaxInProgressValidationShards = 10;
+    constexpr static ui32 MaxInProgressValidationShards = 10;
 
     bool ValidationFailed = false;  // true if any shard found NULL values
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -6607,7 +6607,10 @@ void TSchemeShard::Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TAc
         return;
     }
 
-    // TODO(flown4qqqq): add retry SetColumnConstraintPipes
+    if (SetColumnConstraintPipes.Has(clientId)) {
+        Execute(CreatePipeRetrySetColumnConstraint(SetColumnConstraintPipes.GetOwnerId(clientId), SetColumnConstraintPipes.GetTabletId(clientId)), ctx);
+        return;
+    }
 
     if (IncrementalRestorePipes.Has(clientId)) {
         RetryIncrementalRestorePipe(IncrementalRestorePipes.GetOwnerId(clientId),
@@ -6674,7 +6677,10 @@ void TSchemeShard::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TAc
         return;
     }
 
-    // TODO(flown4qqqq): SetColumnConstraintPipes
+    if (SetColumnConstraintPipes.Has(clientId)) {
+        Execute(CreatePipeRetrySetColumnConstraint(SetColumnConstraintPipes.GetOwnerId(clientId), SetColumnConstraintPipes.GetTabletId(clientId)), ctx);
+        return;
+    }
 
     if (IncrementalRestorePipes.Has(clientId)) {
         RetryIncrementalRestorePipe(IncrementalRestorePipes.GetOwnerId(clientId),

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1919,7 +1919,6 @@ public:
 
         class TTxCreateSetColumnConstraint;
         struct TTxProgressSetColumnConstraint;
-        struct TTxReplyRetrySetColumnConstraint;
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1919,6 +1919,7 @@ public:
 
         class TTxCreateSetColumnConstraint;
         struct TTxProgressSetColumnConstraint;
+        struct TTxReplyRetrySetColumnConstraint;
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);
@@ -1977,6 +1978,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxReplyModifySetColumnConstraint(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxReplyCompletedSetColumnConstraint(TTxId completedTxId);
     NTabletFlatExecutor::ITransaction* CreateTxReplyValidateRowCondition(TIndexBuildId operationId, TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreatePipeRetrySetColumnConstraint(TIndexBuildId operationId, TTabletId tabletId);
 
     THashMap<TIndexBuildId, std::shared_ptr<TSetColumnConstraintOperationInfo>> SetColumnConstraintOperations;
     THashMap<TString, std::shared_ptr<TSetColumnConstraintOperationInfo>> SetColumnConstraintOperationsByUid;

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -361,7 +361,6 @@ public:
             return true;
         }
 
-
         // There is a scenario where, even when using a pipe,
         // we may send a TEvValidateRowConditionRequest to a DataShard twice.
         // As a result, we may receive two responses.

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -656,6 +656,74 @@ ITransaction* TSchemeShard::CreateTxSetColumnConstraintProgress(TIndexBuildId op
     return new TIndexBuilder::TTxProgressSetColumnConstraint(this, operationId);
 }
 
+struct TSchemeShard::TIndexBuilder::TTxReplyRetrySetColumnConstraint
+    : public TSchemeShard::TIndexBuilder::TTxBase
+{
+private:
+    TTabletId ShardId;
+
+public:
+    explicit TTxReplyRetrySetColumnConstraint(TSelf* self, TIndexBuildId operationId, TTabletId shardId)
+        : TTxBase(self, operationId, TXTYPE_CREATE_SET_COLUMN_CONSTRAINT)
+        , ShardId(shardId)
+    {}
+
+    bool DoExecute([[maybe_unused]] TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto& shardIdx = Self->GetShardIdx(ShardId);
+
+        LOG_N("TTxReplyRetrySetColumnConstraint: PipeRetry"
+            << ", id# " << BuildId
+            << ", shardId# " << ShardId
+            << ", shardIdx# " << shardIdx);
+
+        auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(BuildId);
+        if (!operationInfoPtr) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: operation not found, id# " << BuildId);
+            return true;
+        }
+
+        auto& operationInfo = *operationInfoPtr->get();
+
+        if (operationInfo.OperationState != TSetColumnConstraintOperationInfo::EOperationState::Validate) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: superfluous event, id# " << BuildId
+                << ", state# " << ToString(operationInfo.OperationState));
+            return true;
+        }
+
+        if (!operationInfo.ValidationShards.contains(shardIdx)) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: shard not found in ValidationShards"
+                << ", id# " << BuildId
+                << ", shardIdx# " << shardIdx);
+            return true;
+        }
+
+        // Reschedule shard for re-validation
+        if (operationInfo.InProgressValidationShards.erase(shardIdx)) {
+            operationInfo.ToValidateShards.emplace_front(shardIdx);
+
+            Self->SetColumnConstraintPipes.Close(BuildId, ShardId, ctx);
+
+            // Re-send the validate request
+            Progress(BuildId);
+        }
+
+        return true;
+    }
+
+    void DoComplete(const TActorContext& /*ctx*/) override {}
+
+    void OnUnhandledException(TTransactionContext& /*txc*/, const TActorContext& /*ctx*/,
+        TIndexBuildInfo* /*operationInfo*/, const std::exception& exc) override
+    {
+        LOG_E("TTxReplyRetrySetColumnConstraint: OnUnhandledException"
+            ", id# " << BuildId << ", exception: " << exc.what());
+    }
+};
+
+ITransaction* TSchemeShard::CreatePipeRetrySetColumnConstraint(TIndexBuildId operationId, TTabletId tabletId) {
+    return new TIndexBuilder::TTxReplyRetrySetColumnConstraint(this, operationId, tabletId);
+}
+
 ITransaction* TSchemeShard::CreateTxReplyAllocateSetColumnConstraint(
     TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev)
 {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -656,8 +656,7 @@ ITransaction* TSchemeShard::CreateTxSetColumnConstraintProgress(TIndexBuildId op
     return new TIndexBuilder::TTxProgressSetColumnConstraint(this, operationId);
 }
 
-struct TSchemeShard::TIndexBuilder::TTxReplyRetrySetColumnConstraint
-    : public TSchemeShard::TIndexBuilder::TTxBase
+struct TTxReplyRetrySetColumnConstraint : public TSchemeShard::TIndexBuilder::TTxBase
 {
 private:
     TTabletId ShardId;
@@ -697,13 +696,11 @@ public:
             return true;
         }
 
-        // Reschedule shard for re-validation
         if (operationInfo.InProgressValidationShards.erase(shardIdx)) {
             operationInfo.ToValidateShards.emplace_front(shardIdx);
 
             Self->SetColumnConstraintPipes.Close(BuildId, ShardId, ctx);
 
-            // Re-send the validate request
             Progress(BuildId);
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -361,6 +361,18 @@ public:
             return true;
         }
 
+
+        // There is a scenario where, even when using a pipe,
+        // we may send a TEvValidateRowConditionRequest to a DataShard twice.
+        // As a result, we may receive two responses.
+        // Therefore, we should ignore extra responses so that
+        // `DoneValidationShards` does not end up containing duplicates.
+        if (!operationInfo.InProgressValidationShards.contains(shardIdx)) {
+            LOG_N("TTxReplyValidateRowCondition: superfluous shard event, id# " << BuildId
+                << ", shardIdx# " << shardIdx);
+            return true;
+        }
+
         auto& shardStatus = operationInfo.ValidationShards.at(shardIdx);
 
         if (record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::DONE) {
@@ -431,7 +443,68 @@ public:
     }
 };
 
-}
+struct TTxReplyRetrySetColumnConstraint : public TSchemeShard::TIndexBuilder::TTxBase
+{
+private:
+    TTabletId ShardId;
+
+public:
+    explicit TTxReplyRetrySetColumnConstraint(TSelf* self, TIndexBuildId operationId, TTabletId shardId)
+        : TTxBase(self, operationId, TXTYPE_CREATE_SET_COLUMN_CONSTRAINT)
+        , ShardId(shardId)
+    {}
+
+    bool DoExecute([[maybe_unused]] TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto& shardIdx = Self->GetShardIdx(ShardId);
+
+        LOG_N("TTxReplyRetrySetColumnConstraint: PipeRetry"
+            << ", id# " << BuildId
+            << ", shardId# " << ShardId
+            << ", shardIdx# " << shardIdx);
+
+        auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(BuildId);
+        if (!operationInfoPtr) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: operation not found, id# " << BuildId);
+            return true;
+        }
+
+        auto& operationInfo = *operationInfoPtr->get();
+
+        if (operationInfo.OperationState != TSetColumnConstraintOperationInfo::EOperationState::Validate) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: superfluous event, id# " << BuildId
+                << ", state# " << ToString(operationInfo.OperationState));
+            return true;
+        }
+
+        if (!operationInfo.ValidationShards.contains(shardIdx)) {
+            LOG_I("TTxReplyRetrySetColumnConstraint: shard not found in ValidationShards"
+                << ", id# " << BuildId
+                << ", shardIdx# " << shardIdx);
+            return true;
+        }
+
+        if (operationInfo.InProgressValidationShards.erase(shardIdx)) {
+            operationInfo.ToValidateShards.emplace_front(shardIdx);
+
+            Self->SetColumnConstraintPipes.Close(BuildId, ShardId, ctx);
+
+            Progress(BuildId);
+        }
+
+        return true;
+    }
+
+    void DoComplete(const TActorContext& /*ctx*/) override {}
+
+    void OnUnhandledException(TTransactionContext& /*txc*/, const TActorContext& /*ctx*/,
+        TIndexBuildInfo* /*operationInfo*/, const std::exception& exc) override
+    {
+        LOG_E("TTxReplyRetrySetColumnConstraint: OnUnhandledException"
+            ", id# " << BuildId << ", exception: " << exc.what());
+    }
+};
+
+} // NSetColumnConstraint
 
 using namespace NTabletFlatExecutor;
 
@@ -656,69 +729,8 @@ ITransaction* TSchemeShard::CreateTxSetColumnConstraintProgress(TIndexBuildId op
     return new TIndexBuilder::TTxProgressSetColumnConstraint(this, operationId);
 }
 
-struct TTxReplyRetrySetColumnConstraint : public TSchemeShard::TIndexBuilder::TTxBase
-{
-private:
-    TTabletId ShardId;
-
-public:
-    explicit TTxReplyRetrySetColumnConstraint(TSelf* self, TIndexBuildId operationId, TTabletId shardId)
-        : TTxBase(self, operationId, TXTYPE_CREATE_SET_COLUMN_CONSTRAINT)
-        , ShardId(shardId)
-    {}
-
-    bool DoExecute([[maybe_unused]] TTransactionContext& txc, const TActorContext& ctx) override {
-        const auto& shardIdx = Self->GetShardIdx(ShardId);
-
-        LOG_N("TTxReplyRetrySetColumnConstraint: PipeRetry"
-            << ", id# " << BuildId
-            << ", shardId# " << ShardId
-            << ", shardIdx# " << shardIdx);
-
-        auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(BuildId);
-        if (!operationInfoPtr) {
-            LOG_I("TTxReplyRetrySetColumnConstraint: operation not found, id# " << BuildId);
-            return true;
-        }
-
-        auto& operationInfo = *operationInfoPtr->get();
-
-        if (operationInfo.OperationState != TSetColumnConstraintOperationInfo::EOperationState::Validate) {
-            LOG_I("TTxReplyRetrySetColumnConstraint: superfluous event, id# " << BuildId
-                << ", state# " << ToString(operationInfo.OperationState));
-            return true;
-        }
-
-        if (!operationInfo.ValidationShards.contains(shardIdx)) {
-            LOG_I("TTxReplyRetrySetColumnConstraint: shard not found in ValidationShards"
-                << ", id# " << BuildId
-                << ", shardIdx# " << shardIdx);
-            return true;
-        }
-
-        if (operationInfo.InProgressValidationShards.erase(shardIdx)) {
-            operationInfo.ToValidateShards.emplace_front(shardIdx);
-
-            Self->SetColumnConstraintPipes.Close(BuildId, ShardId, ctx);
-
-            Progress(BuildId);
-        }
-
-        return true;
-    }
-
-    void DoComplete(const TActorContext& /*ctx*/) override {}
-
-    void OnUnhandledException(TTransactionContext& /*txc*/, const TActorContext& /*ctx*/,
-        TIndexBuildInfo* /*operationInfo*/, const std::exception& exc) override
-    {
-        LOG_E("TTxReplyRetrySetColumnConstraint: OnUnhandledException"
-            ", id# " << BuildId << ", exception: " << exc.what());
-    }
-};
-
 ITransaction* TSchemeShard::CreatePipeRetrySetColumnConstraint(TIndexBuildId operationId, TTabletId tabletId) {
-    return new TIndexBuilder::TTxReplyRetrySetColumnConstraint(this, operationId, tabletId);
+    return new NSetColumnConstraint::TTxReplyRetrySetColumnConstraint(this, operationId, tabletId);
 }
 
 ITransaction* TSchemeShard::CreateTxReplyAllocateSetColumnConstraint(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

As part of the SET NOT NULL implementation, a basic pull request was created (https://github.com/ydb-platform/ydb/pull/36152). It left a large number of gaps. This pull request addresses one of them.

This PR adds code that makes `SET NOT NULL` use retries when sending messages from SchemeShard to DataShards.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Please note that, in a sense, this is a preparatory pull request for implementing fault-tolerant execution of the `SET NOT NULL` operation. The code added here cannot be tested directly right now — this will only be possible as part of reboot tests. This PR is being made somewhat independently in order to make the future pull request that adds reboot tests a bit easier for human code review.
