### PR TITLE
Add log message priorities to the DQ tasks runner and channels

### DIFF
--- a/ydb/core/fq/libs/init/init.cpp
+++ b/ydb/core/fq/libs/init/init.cpp
@@ -128,11 +128,11 @@ void Init(
     }
 
     if (protoConfig.GetCompute().GetYdb().GetEnable() && protoConfig.GetCompute().GetYdb().GetControlPlane().GetEnable()) {
-        auto computeDatabaseService = NFq::CreateComputeDatabaseControlPlaneServiceActor(protoConfig.GetCompute(), 
-                                                                                         NKikimr::CreateYdbCredentialsProviderFactory, 
-                                                                                         commonConfig, 
-                                                                                         signer, 
-                                                                                         yqSharedResources, 
+        auto computeDatabaseService = NFq::CreateComputeDatabaseControlPlaneServiceActor(protoConfig.GetCompute(),
+                                                                                         NKikimr::CreateYdbCredentialsProviderFactory,
+                                                                                         commonConfig,
+                                                                                         signer,
+                                                                                         yqSharedResources,
                                                                                          yqCounters->GetSubgroup("subsystem", "DatabaseControlPlane"));
         actorRegistrator(NFq::ComputeDatabaseControlPlaneServiceActorId(), computeDatabaseService.release());
     }
@@ -259,7 +259,7 @@ void Init(
             commonTopicClientSettings
         );
         auto pqGateway = pqGatewayFactory ? pqGatewayFactory->CreatePqGateway() : NYql::CreatePqNativeGateway(std::move(pqServices));
-        RegisterDqPqReadActorFactory(*asyncIoFactory, yqSharedResources->UserSpaceYdbDriver, credentialsFactory, pqGateway, 
+        RegisterDqPqReadActorFactory(*asyncIoFactory, yqSharedResources->UserSpaceYdbDriver, credentialsFactory, pqGateway,
             yqCounters->GetSubgroup("subsystem", "DqSourceTracker"), commonConfig.GetPqReconnectPeriod(), true);
 
         s3ActorsFactory->RegisterS3ReadActorFactory(*asyncIoFactory, credentialsFactory, httpGateway, s3HttpRetryPolicy, readActorFactoryCfg,

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -8,11 +8,6 @@
 namespace NKikimr {
 namespace NKqp {
 
-bool TKqpComputeActor::IsDebugLogEnabled(const TActorSystem* actorSystem) {
-    auto* settings = actorSystem->LoggerSettings();
-    return settings && settings->Satisfies(NActors::NLog::EPriority::PRI_DEBUG, NKikimrServices::KQP_TASKS_RUNNER);
-}
-
 TKqpComputeActor::TKqpComputeActor(
     const TActorId& executerId, ui64 txId, NDqProto::TDqTask* task, IDqAsyncIoFactory::TPtr asyncIoFactory,
     const TComputeRuntimeSettings& settings, const TComputeMemoryLimits& memoryLimits,

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -44,13 +44,10 @@ TKqpComputeActor::TKqpComputeActor(
 void TKqpComputeActor::DoBootstrap() {
     const TActorSystem* actorSystem = TlsActivationContext->ActorSystem();
 
-    TLogFunc logger;
-    if (IsDebugLogEnabled(actorSystem)) {
-        logger = [actorSystem, txId = this->GetTxId(), taskId = GetTask().GetId()] (const TString& message) {
-            LOG_DEBUG_S(*actorSystem, NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId
-                << ", task: " << taskId << ": " << message);
-        };
-    }
+    TLogFunc logger = [actorSystem, txId = this->GetTxId(), taskId = GetTask().GetId()] (NActors::NLog::EPrio priority, const TString& message) {
+        LOG_LOG_S(*actorSystem, static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId
+            << ", task: " << taskId << ": " << message);
+    };
 
     TDqTaskRunnerContext execCtx;
 

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.h
@@ -62,8 +62,6 @@ private:
 
     void HandleExecute(TEvKqpCompute::TEvScanError::TPtr& ev);
 
-    bool IsDebugLogEnabled(const TActorSystem* actorSystem);
-
     ui64 CalculateFreeSpace() const;
 
 private:

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -280,13 +280,10 @@ void TKqpScanComputeActor::DoBootstrap() {
         settings.ReadRanges.push_back(readRange);
     }
 
-    NDq::TLogFunc logger;
-    if (IsDebugLogEnabled(actorSystem, NKikimrServices::KQP_TASKS_RUNNER)) {
-        logger = [actorSystem, txId = TxId, taskId = GetTask().GetId()](const TString& message) {
-            LOG_DEBUG_S(*actorSystem, NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId
-                << ", task: " << taskId << ": " << message);
-        };
-    }
+    NDq::TLogFunc logger = [actorSystem, txId = TxId, taskId = GetTask().GetId()](NActors::NLog::EPrio priority, const TString& message) {
+        LOG_LOG_S(*actorSystem, static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId
+            << ", task: " << taskId << ": " << message);
+    };
 
     auto taskRunner = MakeDqTaskRunner(GetAllocatorPtr(), execCtx, settings, logger);
     TBase::SetTaskRunner(taskRunner);

--- a/ydb/core/kqp/executer_actor/kqp_literal_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_literal_executer.cpp
@@ -204,8 +204,8 @@ public:
             YQL_ENSURE(resultChannel.DstTask == 0);
         }
 
-        auto log = [as = TlsActivationContext->ActorSystem(), txId = TxId, taskId = task.Id](const TString& message) {
-            LOG_DEBUG_S(*as, NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId << ", task: " << taskId << ". "
+        TLogFunc log = [as = TlsActivationContext->ActorSystem(), txId = TxId, taskId = task.Id](NActors::NLog::EPrio priority, const TString& message) {
+            LOG_LOG_S(*as, static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_TASKS_RUNNER, "TxId: " << txId << ", task: " << taskId << ". "
                 << message);
         };
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.cpp
@@ -10,12 +10,8 @@ namespace NDq {
 using namespace NActors;
 
 namespace {
-TDqExecutionSettings ExecutionSettings;
 
-bool IsDebugLogEnabled(const TActorSystem* actorSystem) {
-    auto* settings = actorSystem->LoggerSettings();
-    return settings && settings->Satisfies(NActors::NLog::EPriority::PRI_DEBUG, NKikimrServices::KQP_COMPUTE);
-}
+TDqExecutionSettings ExecutionSettings;
 
 } // anonymous namespace
 
@@ -50,13 +46,10 @@ public:
 
         MemoryQuota = InitMemoryQuota();
 
-        TLogFunc logger;
-        if (IsDebugLogEnabled(actorSystem)) {
-            logger = [actorSystem, txId = this->GetTxId(), taskId = GetTask().GetId()] (const TString& message) {
-                LOG_DEBUG_S(*actorSystem, NKikimrServices::KQP_COMPUTE, "TxId: " << txId
-                    << ", task: " << taskId << ": " << message);
-            };
-        }
+        TLogFunc logger = [actorSystem, txId = this->GetTxId(), taskId = GetTask().GetId()] (NActors::NLog::EPrio priority, const TString& message) {
+            LOG_LOG_S(*actorSystem, static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_COMPUTE, "TxId: " << txId
+                << ", task: " << taskId << ": " << message);
+        };
 
         auto taskRunner = TaskRunnerFactory(GetAllocatorPtr(), Task, RuntimeSettings.StatsMode, logger);
         SetTaskRunner(taskRunner);

--- a/ydb/library/yql/dq/actors/compute/ut/dq_async_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_async_compute_actor_ut.cpp
@@ -40,8 +40,12 @@ namespace NYql::NDq {
 namespace {
 static const bool TESTS_VERBOSE = getenv("TESTS_VERBOSE") != nullptr;
 static const bool TESTS_LARGE = getenv("TESTS_LARGE") != nullptr;
-#define LOG_D(stream) LOG_DEBUG_S(*ActorSystem.SingleSys(), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
-#define LOG_E(stream) LOG_ERROR_S(*ActorSystem.SingleSys(), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
+
+#define LOG(priority, stream) LOG_LOG_S(*ActorSystem.SingleSys(), static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
+
+#define LOG_D(stream) LOG(NActors::NLog::EPrio::Debug, stream)
+#define LOG_E(stream) LOG(NActors::NLog::EPrio::Error, stream)
+
 struct TMockHttpRequest : NMonitoring::IMonHttpRequest {
     TStringStream Out;
     TCgiParameters Params;
@@ -414,8 +418,8 @@ struct TAsyncCATestFixture: public NUnitTest::TBaseFixture {
         // DstEndpoint
         // IsPersistent
         // EnableSpilling
-        TLogFunc logFunc = [this](const TString& msg) {
-            LOG_D(msg);
+        TLogFunc logFunc = [this](NActors::NLog::EPrio priority, const TString& msg) {
+            LOG(priority, msg);
         };
         // DqOutputChannel is used for simulating input on CA under the test
         TDqChannelSettings settings = {

--- a/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_sync_compute_actor_ut.cpp
@@ -41,8 +41,10 @@ namespace {
 static const bool TESTS_VERBOSE = getenv("TESTS_VERBOSE") != nullptr;
 static const bool TESTS_LARGE = getenv("TESTS_LARGE") != nullptr;
 
-#define LOG_D(stream) LOG_DEBUG_S(*ActorSystem.SingleSys(), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
-#define LOG_E(stream) LOG_ERROR_S(*ActorSystem.SingleSys(), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
+#define LOG(priority, stream) LOG_LOG_S(*ActorSystem.SingleSys(), static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::KQP_COMPUTE, LogPrefix << stream)
+
+#define LOG_D(stream) LOG(NActors::NLog::EPrio::Debug, stream)
+#define LOG_E(stream) LOG(NActors::NLog::EPrio::Error, stream)
 
 void SegmentationFaultHandler(int) {
     Cerr << "segmentation fault call stack:" << Endl;
@@ -420,8 +422,8 @@ struct TSyncComputeActorTestFixture: public NUnitTest::TBaseFixture {
         // DstEndpoint
         // IsPersistent
         // EnableSpilling
-        TLogFunc logFunc = [this](const TString& msg) {
-            LOG_D(msg);
+        TLogFunc logFunc = [this](NActors::NLog::EPrio priority, const TString& msg) {
+            LOG(priority, msg);
         };
         // DqOutputChannel is used for simulating input on CA under the test
         TDqChannelSettings settings = {

--- a/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
+++ b/ydb/library/yql/dq/actors/task_runner/task_runner_actor_local.cpp
@@ -22,11 +22,12 @@
 #include <ydb/library/yql/dq/actors/spilling/spiller_factory.h>
 #include <yql/essentials/minikql/mkql_watermark.h>
 
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
-#define LOG_W(stream) LOG_WARN_S (*TlsActivationContext, NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
-#define LOG_I(stream) LOG_INFO_S (*TlsActivationContext, NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
+#define LOG(priority, stream) LOG_LOG_S(*TlsActivationContext, static_cast<NActors::NLog::EPriority>(priority), NKikimrServices::DQ_TASK_RUNNER, "SelfId: " << SelfId() << ", TxId: " << TxId << ", task: " << TaskId << ". " << stream)
+#define LOG_E(stream) LOG(NActors::NLog::EPrio::Error, stream)
+#define LOG_W(stream) LOG(NActors::NLog::EPrio::Warn, stream)
+#define LOG_I(stream) LOG(NActors::NLog::EPrio::Info, stream)
+#define LOG_D(stream) LOG(NActors::NLog::EPrio::Debug, stream)
+#define LOG_T(stream) LOG(NActors::NLog::EPrio::Trace, stream)
 
 using namespace NActors;
 
@@ -519,8 +520,8 @@ private:
     void OnDqTask(TEvTaskRunnerCreate::TPtr& ev) {
         ParentId = ev->Sender;
         auto settings = NDq::TDqTaskSettings(&ev->Get()->Task);
-        TaskRunner = Factory(Alloc, settings, ev->Get()->StatsMode, [this](const TString& message) {
-            LOG_D(message);
+        TaskRunner = Factory(Alloc, settings, ev->Get()->StatsMode, [this](NActors::NLog::EPrio priority, const TString& message) {
+            LOG(priority, message);
         });
 
         auto& inputs = settings.GetInputs();

--- a/ydb/library/yql/dq/common/dq_common.h
+++ b/ydb/library/yql/dq/common/dq_common.h
@@ -2,6 +2,7 @@
 
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/log_iface.h>
 
 #include <util/generic/variant.h>
 
@@ -9,7 +10,7 @@ namespace NYql::NDq {
 
 using TTxId = std::variant<ui64, TString>;
 
-using TLogFunc = std::function<void(const TString& message)>;
+using TLogFunc = std::function<void(NActors::NLog::EPrio priority, const TString& message)>;
 
 using TWakeUpCallback = std::function<void()>;
 using TErrorCallback = std::function<void(const TString& error)>;

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -12,7 +12,7 @@
 
 namespace NYql::NDq {
 
-#define LOG(s) do { if (Y_UNLIKELY(LogFunc)) { LogFunc(TStringBuilder() << "channelId: " << PopStats.ChannelId << ". " << s); } } while (0)
+#define LOG(s) do { if (LogFunc) { LogFunc(NActors::NLog::EPrio::Debug, TStringBuilder() << "channelId: " << PopStats.ChannelId << ". " << s); } } while (0)
 
 #ifndef NDEBUG
 #define DLOG(s) LOG(s)

--- a/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
@@ -25,7 +25,7 @@ namespace {
 
 // #define DEBUG_LOGS
 
-void Log(TStringBuf msg) {
+void Log(NLog::EPrio, TStringBuf msg) {
 #ifdef DEBUG_LOGS
     Cerr << msg << Endl;
 #else

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -1,4 +1,3 @@
-#include "dq_channel_service.h"
 #include "dq_tasks_counters.h"
 #include "dq_tasks_runner.h"
 
@@ -37,6 +36,7 @@
 using namespace NKikimr;
 using namespace NKikimr::NMiniKQL;
 using namespace NYql::NDqProto;
+using NActors::NLog::EPrio;
 
 namespace NYql::NDq {
 
@@ -153,7 +153,7 @@ void ValidateParamValue(std::string_view paramName, const TType* type, const NUd
 
 } // namespace
 
-#define LOG(...) do { if (Y_UNLIKELY(LogFunc)) { LogFunc(__VA_ARGS__); } } while (0)
+#define LOG(...) do { if (LogFunc) { LogFunc(__VA_ARGS__); } } while (0)
 
 NUdf::TUnboxedValue DqBuildInputValue(
     const NDqProto::TTaskInput& inputDesc,
@@ -299,7 +299,7 @@ public:
                     }
                 }
                 if (log) {
-                    log(logMessage);
+                    log(NActors::NLog::EPrio::Debug, logMessage);
                 }
             };
             ComputationLogProvider = NUdf::MakeLogProvider(std::move(logProviderFunc), NUdf::ELogLevel::Debug);
@@ -371,7 +371,7 @@ public:
         }
 
         auto runtimeSettings = NYql::DeserializeRuntimeSettingsFromProto(task.GetProgram().GetRuntimeSettings());
-    
+
         TComputationPatternOpts opts(alloc.Ref(), typeEnv, taskRunnerFactory,
             Context.FuncRegistry, NUdf::EValidateMode::None, validatePolicy, optLLVM, EGraphPerProcess::Multi,
             AllocatedHolder->ProgramParsed.StatsRegistry.Get(), CollectFull() ? &CountersProvider : nullptr, nullptr,
@@ -481,7 +481,7 @@ public:
         programExplorer.Walk(programRoot.GetNode(), patternEnv);
         auto programSize = programExplorer.GetNodes().size();
 
-        LOG(TStringBuilder() << "task: " << TaskId << ", program size: " << programSize
+        LOG(EPrio::Debug, TStringBuilder() << "task: " << TaskId << ", program size: " << programSize
             << ", llvm: `" << Settings.OptLLVM << "`.");
 
         auto opts = CreatePatternOpts(task, patternAlloc, patternEnv);
@@ -495,7 +495,7 @@ public:
     }
 
     std::shared_ptr<TPatternCacheEntry> BuildTask(const TDqTaskSettings& task) {
-        LOG(TStringBuilder() << "Build task: " << TaskId);
+        LOG(EPrio::Debug, TStringBuilder() << "Build task: " << TaskId);
         auto startTime = TInstant::Now();
 
         const NDqProto::TProgram& program = task.GetProgram();
@@ -573,7 +573,7 @@ public:
         if (Stats) {
             Stats->BuildCpuTime = buildTime;
         }
-        LOG(TStringBuilder() << "Build task: " << TaskId << " takes " << buildTime.MicroSeconds() << " us");
+        LOG(EPrio::Debug, TStringBuilder() << "Build task: " << TaskId << " takes " << buildTime.MicroSeconds() << " us");
         return entry;
     }
 
@@ -587,7 +587,7 @@ public:
         LangVer = task.GetProgram().GetLangVer();
         auto entry = BuildTask(task);
 
-        LOG(TStringBuilder() << "Prepare task: " << TaskId);
+        LOG(EPrio::Debug, TStringBuilder() << "Prepare task: " << TaskId);
         auto startTime = TInstant::Now();
 
         auto& holderFactory = AllocatedHolder->ProgramParsed.CompGraph->GetHolderFactory();
@@ -630,13 +630,13 @@ public:
                 auto typeCheckLog = [&] () {
                     TStringStream out;
                     out << *outputType << " != " << *entry->InputItemTypes[i];
-                    LOG(TStringBuilder() << "Task: " << TaskId << " types is not the same: " << out.Str() << " has NOT been transformed by "
+                    LOG(EPrio::Debug, TStringBuilder() << "Task: " << TaskId << " types is not the same: " << out.Str() << " has NOT been transformed by "
                         << transformDesc.GetType() << " with input type: " << *transform->TransformInputType
                         << " , output type: " << *outputType);
                     return out.Str();
                 };
                 YQL_ENSURE(outputTypeNodeRaw == entry->InputItemTypesRaw[i], "" << typeCheckLog());
-                LOG(TStringBuilder() << "Task: " << TaskId << " has transform by "
+                LOG(EPrio::Debug, TStringBuilder() << "Task: " << TaskId << " has transform by "
                     << transformDesc.GetType() << " with input type: " << *transform->TransformInputType
                     << " , output type: " << *outputType);
 
@@ -796,13 +796,13 @@ public:
                     auto typeCheckLog = [&] () {
                         TStringStream out;
                         out << *inputType << " != " << *entry->OutputItemTypes[i];
-                        LOG(TStringBuilder() << "Task: " << TaskId << " types is not the same: " << out.Str() << " has NOT been transformed by "
+                        LOG(EPrio::Debug, TStringBuilder() << "Task: " << TaskId << " types is not the same: " << out.Str() << " has NOT been transformed by "
                             << transformDesc.GetType() << " with output type: " << *transform->TransformOutputType
                             << " , input type: " << *inputType);
                         return out.Str();
                     };
                     YQL_ENSURE(inputType->IsSameType(*localOutputType),  "" << typeCheckLog());
-                    LOG(TStringBuilder() << "Task: " << TaskId << " has transform by "
+                    LOG(EPrio::Debug, TStringBuilder() << "Task: " << TaskId << " has transform by "
                         << transformDesc.GetType() << " with input type: " << *inputType
                         << " , output type: " << *transform->TransformOutputType);
                 }
@@ -891,7 +891,7 @@ public:
 
         auto prepareTime = TInstant::Now() - startTime;
 
-        LOG(TStringBuilder() << "Prepare task: " << TaskId << ", takes " << prepareTime.MicroSeconds() << " us");
+        LOG(EPrio::Debug, TStringBuilder() << "Prepare task: " << TaskId << ", takes " << prepareTime.MicroSeconds() << " us");
         if (Stats) {
             Stats->BuildCpuTime += prepareTime;
             for (auto& [channelId, inputChannel] : AllocatedHolder->InputChannels) {
@@ -905,7 +905,7 @@ public:
     }
 
     ERunStatus Run() final {
-        LOG(TStringBuilder() << "Run task: " << TaskId);
+        LOG(EPrio::Trace, TStringBuilder() << "Run task: " << TaskId);
         if (!AllocatedHolder->ResultStream && !AllocatedHolder->ResultStreamFinished) {
             auto guard = BindAllocator();
             TBindTerminator term(AllocatedHolder->ProgramParsed.CompGraph->GetTerminator());
@@ -1109,7 +1109,7 @@ private:
 
     ERunStatus FetchAndDispatch() {
         if (!AllocatedHolder->Output) {
-            LOG("no consumers, Finish execution");
+            LOG(EPrio::Debug, "no consumers, Finish execution");
             return ERunStatus::Finished;
         }
 
@@ -1166,7 +1166,7 @@ private:
                         AllocatedHolder->CheckForNotConsumedLinear();
                     }
 
-                    LOG(TStringBuilder() << "task " << TaskId << ", execution finished, finish consumers");
+                    LOG(EPrio::Debug, TStringBuilder() << "task " << TaskId << ", execution finished, finish consumers");
                     AllocatedHolder->Output->Finish();
                     return ERunStatus::Finished;
                 }

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
@@ -262,7 +262,9 @@ public:
         auto ctx = ExecutionContext;
         TLogFunc logger;
         if (YQL_CLOG_ACTIVE(DEBUG, ProviderDq)) {
-            logger = [taskId = ToString(task.GetId()), traceId = traceId](const TString& message) {
+            // Legacy behavior: IDqTaskRunner can now emit actor system-specific message priorities but these are ignored here,
+            // everything from the task runner is emitted at YQL DEBUG level instead
+            logger = [taskId = ToString(task.GetId()), traceId = traceId](NActors::NLog::EPrio, const TString& message) {
                 YQL_LOG_CTX_ROOT_SESSION_SCOPE(traceId, taskId);
                 YQL_CLOG(DEBUG, ProviderDq) << message;
             };


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The DQ task runner and DQ channels used to be able to only emit Debug-level messages which is terribly inconvenient in practice. E.g. TDqTaskRunner::Run should only log its invocation at the Trace level, not even at Debug, otherwise the amount of log spam is unmanageable.

The IsDebugLogEnabled gate is removed though. This will result in some additional log level checks and message formatting but we only have a reasonably bounded number of LOG(...) invocations each Run(), so this shouldn't affect performance noticeably; e.g. a short log message at the start of Run() should cost us about 100ns on our typical Xeons, and each Run() processes large batches typically. By the way, it looks like the IsDebugLogEnabled gate was slightly broken anyway - it was lowering the sample rate. The log message had to pass the sampling rate check twice with two independent random trials.

This also might enable us to log messages that weren't there before (e.g. if the component log level is configured to Warn and we start emitting Warn-level messages). But that's the point: we also want to be able to emit higher priority levels than Debug.

Note: TaskRunners created via the TLocalFactory in the ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp use YQL logging and thus coerce all actor system log priorities to the YQL Debug priority, just as before. I can try and add actor log priorities -> YQL levels mapping but we'll need to get rid of `if (YQL_CLOG_ACTIVE(DEBUG, ProviderDq))` in this case.

Note: `static_cast<NActors::NLog::EPriority>(priority)` is still required because LOG_LOG_S only does this cast in the arguments of the `IsLogPriorityEnabled` function but not in the call to `:NActors::MemLogAdapter`. Maybe needs to be fixed, but in a separate PR.