### PR TITLE
Compact fulltext indexes - index build support

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -90,6 +90,9 @@ bool IsSecondaryIndex(NKikimrSchemeOp::EIndexType indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             return false;
         default:
             Y_ENSURE(false, InvalidIndexType(indexType));
@@ -108,7 +111,10 @@ TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType indexType, co
         Y_ASSERT(indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance
-            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson);
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact);
         takeKeyColumns--;
     }
 
@@ -270,7 +276,10 @@ bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType indexType, const TTableColumn
         Y_ASSERT(indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain
             || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance
-            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson);
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJson
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance
+            || indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact);
     }
     if (const auto* broken = IsContains(index.DataColumns, tmp, true)) {
         explain = TStringBuilder()
@@ -290,6 +299,9 @@ bool DoesIndexSupportTTL(NKikimrSchemeOp::EIndexType indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             return false;
         default:
             Y_DEBUG_ABORT_S(InvalidIndexType(indexType));
@@ -313,10 +325,13 @@ std::span<const std::string_view> GetImplTables(
                 return PrefixedGlobalKMeansTreeImplTables;
             }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
             return GlobalFulltextPlainImplTables;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             return GlobalFulltextWithRelevanceImplTables;
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             return GlobalFulltextPlainImplTables;
         default:
             Y_ENSURE(false, InvalidIndexType(indexType));

--- a/ydb/core/kqp/common/kqp_batch_operations.cpp
+++ b/ydb/core/kqp/common/kqp_batch_operations.cpp
@@ -13,6 +13,9 @@ bool IsIndexSupported(NYql::TIndexDescription::EType type, bool enabledIndexStre
         case NYql::TIndexDescription::EType::GlobalFulltextPlain:
         case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
         case NYql::TIndexDescription::EType::GlobalJson:
+        case NYql::TIndexDescription::EType::GlobalFulltextCompact:
+        case NYql::TIndexDescription::EType::GlobalFulltextCompactRelevance:
+        case NYql::TIndexDescription::EType::GlobalJsonCompact:
         case NYql::TIndexDescription::EType::LocalBloomFilter:
         case NYql::TIndexDescription::EType::LocalBloomNgramFilter:
         case NYql::TIndexDescription::EType::LocalMinMax:

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1095,6 +1095,7 @@ public:
                             case TIndexDescription::EType::GlobalAsync:
                             case TIndexDescription::EType::GlobalSyncUnique:
                             case TIndexDescription::EType::GlobalJson:
+                            case TIndexDescription::EType::GlobalJsonCompact:
                                 // no specialized index description
                                 Y_ASSERT(std::holds_alternative<std::monostate>(index.SpecializedIndexDescription));
                                 break;
@@ -1103,6 +1104,8 @@ public:
                                 break;
                             case TIndexDescription::EType::GlobalFulltextPlain:
                             case TIndexDescription::EType::GlobalFulltextRelevance:
+                            case TIndexDescription::EType::GlobalFulltextCompact:
+                            case TIndexDescription::EType::GlobalFulltextCompactRelevance:
                                 *indexDesc->MutableFulltextIndexDescription()->MutableSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(index.SpecializedIndexDescription).GetSettings();
                                 break;
                             default:

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -153,10 +153,13 @@ TString IndexTypeToName(NYql::TIndexDescription::EType type) {
         case NYql::TIndexDescription::EType::GlobalSyncVectorKMeansTree:
             return "global sync vector_kmeans_tree";
         case NYql::TIndexDescription::EType::GlobalFulltextPlain:
+        case NYql::TIndexDescription::EType::GlobalFulltextCompact:
             return "global sync fulltext_plain";
         case NYql::TIndexDescription::EType::GlobalFulltextRelevance:
+        case NYql::TIndexDescription::EType::GlobalFulltextCompactRelevance:
             return "global sync fulltext_relevance";
         case NYql::TIndexDescription::EType::GlobalJson:
+        case NYql::TIndexDescription::EType::GlobalJsonCompact:
             return "global sync json";
         case NYql::TIndexDescription::EType::LocalBloomFilter:
             return "local bloom_filter";
@@ -424,7 +427,10 @@ TExprBase BuildUpsertTableWithIndex(const TKiWriteTable& write, const TCoAtomLis
             return index.second->Type != TIndexDescription::EType::GlobalSyncVectorKMeansTree
                 && index.second->Type != TIndexDescription::EType::GlobalFulltextPlain
                 && index.second->Type != TIndexDescription::EType::GlobalFulltextRelevance
-                && index.second->Type != TIndexDescription::EType::GlobalJson;
+                && index.second->Type != TIndexDescription::EType::GlobalJson
+                && index.second->Type != TIndexDescription::EType::GlobalFulltextCompact
+                && index.second->Type != TIndexDescription::EType::GlobalFulltextCompactRelevance
+                && index.second->Type != TIndexDescription::EType::GlobalJsonCompact;
         });
 
         if (onlyStreamIndexes) {
@@ -994,6 +1000,9 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
             case TIndexDescription::EType::GlobalFulltextPlain:
             case TIndexDescription::EType::GlobalFulltextRelevance:
             case TIndexDescription::EType::GlobalJson:
+            case TIndexDescription::EType::GlobalFulltextCompact:
+            case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+            case TIndexDescription::EType::GlobalJsonCompact:
             case TIndexDescription::EType::LocalBloomFilter:
             case TIndexDescription::EType::LocalBloomNgramFilter:
             case TIndexDescription::EType::LocalMinMax:

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -803,7 +803,9 @@ private:
                 auto literal = TString(query.Cast<TCoDataCtor>().Literal());
                 YQL_ENSURE(indexDesc);
                 YQL_ENSURE(indexDesc->Type == TIndexDescription::EType::GlobalFulltextPlain
-                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance);
+                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance
+                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompact
+                    || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompactRelevance);
 
                 auto& desc = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexDesc->SpecializedIndexDescription);
                 for(const auto& column: readColumns) {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -272,7 +272,10 @@ struct TReadMatch {
             auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Cast().Index().Value());
             if (indexDesc->Type == TIndexDescription::EType::GlobalFulltextPlain
                 || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                || indexDesc->Type == TIndexDescription::EType::GlobalJson) {
+                || indexDesc->Type == TIndexDescription::EType::GlobalJson
+                || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompact
+                || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompactRelevance
+                || indexDesc->Type == TIndexDescription::EType::GlobalJsonCompact) {
                 return {};
             }
 
@@ -289,7 +292,10 @@ struct TReadMatch {
             auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Cast().Index().Value());
             if (indexDesc->Type == TIndexDescription::EType::GlobalFulltextPlain
                 || indexDesc->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                || indexDesc->Type == TIndexDescription::EType::GlobalJson) {
+                || indexDesc->Type == TIndexDescription::EType::GlobalJson
+                || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompact
+                || indexDesc->Type == TIndexDescription::EType::GlobalFulltextCompactRelevance
+                || indexDesc->Type == TIndexDescription::EType::GlobalJsonCompact) {
                 return {};
             }
 
@@ -328,7 +334,9 @@ struct TReadMatch {
         YQL_ENSURE(tableDesc.Metadata);
         auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
         if (indexDesc->Type != TIndexDescription::EType::GlobalFulltextPlain
-            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance) {
+            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance
+            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextCompact
+            && indexDesc->Type != TIndexDescription::EType::GlobalFulltextCompactRelevance) {
             return {};
         }
 
@@ -1879,7 +1887,9 @@ TMaybeNode<TExprBase> KqpRewriteFlatMapOverFullTextMatch(const NYql::NNodes::TEx
     YQL_ENSURE(tableDesc.Metadata);
     auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(read.Index().Value());
     if (indexDesc->Type != TIndexDescription::EType::GlobalFulltextPlain
-        && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance) {
+        && indexDesc->Type != TIndexDescription::EType::GlobalFulltextRelevance
+        && indexDesc->Type != TIndexDescription::EType::GlobalFulltextCompact
+        && indexDesc->Type != TIndexDescription::EType::GlobalFulltextCompactRelevance) {
         return {};
     }
 

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_delete_index.cpp
@@ -86,6 +86,9 @@ TExprBase BuildDeleteIndexStagesImpl(const TKikimrTableDescription& table,
 
         switch (indexDesc->Type) {
             case TIndexDescription::EType::GlobalAsync:
+            case TIndexDescription::EType::GlobalFulltextCompact:
+            case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+            case TIndexDescription::EType::GlobalJsonCompact:
                 AFL_ENSURE(false);
             case TIndexDescription::EType::GlobalSync:
             case TIndexDescription::EType::GlobalSyncUnique: {
@@ -177,6 +180,9 @@ TExprBase KqpBuildDeleteIndexStages(TExprBase node, TExprContext& ctx, const TKq
             case TIndexDescription::EType::GlobalSync:
             case TIndexDescription::EType::GlobalAsync:
             case TIndexDescription::EType::GlobalSyncUnique:
+            case TIndexDescription::EType::GlobalFulltextCompact:
+            case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+            case TIndexDescription::EType::GlobalJsonCompact:
                 return false;
             case TIndexDescription::EType::GlobalSyncVectorKMeansTree:
             case TIndexDescription::EType::GlobalFulltextPlain:

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
@@ -136,6 +136,10 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildAffectedIndex
                     result.emplace_back(indexTable, &index);
                     break;
                 }
+                case TIndexDescription::EType::GlobalFulltextCompact:
+                case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+                case TIndexDescription::EType::GlobalJsonCompact:
+                    Y_ENSURE(false, "Not implemented");
                 case TIndexDescription::EType::GlobalSyncVectorKMeansTree: {
                     if (index.KeyColumns.size() == 1) {
                         YQL_ENSURE(implTable->Next && !implTable->Next->Next);

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
@@ -212,6 +212,9 @@ TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKq
         std::optional<TExprBase> upsertIndexRows;
         switch (indexDesc->Type) {
             case TIndexDescription::EType::GlobalAsync:
+            case TIndexDescription::EType::GlobalFulltextCompact:
+            case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+            case TIndexDescription::EType::GlobalJsonCompact:
                 AFL_ENSURE(false);
             case TIndexDescription::EType::GlobalSync:
             case TIndexDescription::EType::GlobalSyncUnique: {

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_upsert_index.cpp
@@ -1024,6 +1024,10 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                     }
                     break;
                 }
+                case TIndexDescription::EType::GlobalFulltextCompact:
+                case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+                case TIndexDescription::EType::GlobalJsonCompact:
+                    Y_ENSURE(false, "Not implemented");
                 case TIndexDescription::EType::LocalBloomFilter:
                 case TIndexDescription::EType::LocalBloomNgramFilter:
                 case TIndexDescription::EType::LocalMinMax:
@@ -1100,6 +1104,10 @@ TMaybeNode<TExprList> KqpPhyUpsertIndexEffectsImpl(TKqpPhyUpsertIndexMode mode, 
                     }
                     break;
                 }
+                case TIndexDescription::EType::GlobalFulltextCompact:
+                case TIndexDescription::EType::GlobalFulltextCompactRelevance:
+                case TIndexDescription::EType::GlobalJsonCompact:
+                    Y_ENSURE(false, "Not implemented");
                 case TIndexDescription::EType::LocalBloomFilter:
                 case TIndexDescription::EType::LocalBloomNgramFilter:
                 case TIndexDescription::EType::LocalMinMax:

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -119,6 +119,9 @@ public:
         LocalBloomNgramFilter = 7,
         GlobalJson = 8,
         LocalMinMax = 9,
+        GlobalFulltextCompact = 10,
+        GlobalFulltextCompactRelevance = 11,
+        GlobalJsonCompact = 12,
     };
 
     // Index states here must be in sync with NKikimrSchemeOp::EIndexState protobuf
@@ -176,6 +179,7 @@ public:
             case EType::GlobalSyncUnique:
             case EType::GlobalJson:
             case EType::LocalMinMax:
+            case EType::GlobalJsonCompact:
                 // no specialized index description
                 YQL_ENSURE(index.GetSpecializedIndexDescriptionCase() == NKikimrSchemeOp::TIndexDescription::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
                 break;
@@ -186,7 +190,9 @@ public:
                 break;
             }
             case EType::GlobalFulltextPlain:
-            case EType::GlobalFulltextRelevance: {
+            case EType::GlobalFulltextRelevance:
+            case EType::GlobalFulltextCompact:
+            case EType::GlobalFulltextCompactRelevance: {
                 NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
                 *fulltextIndexDescription.MutableSettings() = index.GetFulltextIndexDescription().GetSettings();
                 SpecializedIndexDescription = std::move(fulltextIndexDescription);
@@ -227,6 +233,7 @@ public:
             case EType::GlobalSyncUnique:
             case EType::GlobalJson:
             case EType::LocalMinMax:
+            case EType::GlobalJsonCompact:
                 // no specialized index description
                 YQL_ENSURE(message->GetSpecializedIndexDescriptionCase() == NKikimrKqp::TIndexDescriptionProto::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
                 break;
@@ -235,6 +242,8 @@ public:
                 break;
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
+            case EType::GlobalFulltextCompact:
+            case EType::GlobalFulltextCompactRelevance:
                 SpecializedIndexDescription = message->GetFulltextIndexDescription();
                 break;
             case EType::LocalBloomFilter:
@@ -278,6 +287,12 @@ public:
                 return TIndexDescription::EType::LocalBloomNgramFilter;
             case NKikimrSchemeOp::EIndexType::EIndexTypeLocalMinMax:
                 return TIndexDescription::EType::LocalMinMax;
+            case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompact:
+                return TIndexDescription::EType::GlobalFulltextCompact;
+            case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance:
+                return TIndexDescription::EType::GlobalFulltextCompactRelevance;
+            case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact:
+                return TIndexDescription::EType::GlobalJsonCompact;
             default:
                 YQL_ENSURE(false, << NKikimr::NTableIndex::InvalidIndexType(indexType));
         }
@@ -299,6 +314,12 @@ public:
                 return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance;
             case NYql::TIndexDescription::EType::GlobalJson:
                 return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson;
+            case NYql::TIndexDescription::EType::GlobalFulltextCompact:
+                return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompact;
+            case NYql::TIndexDescription::EType::GlobalFulltextCompactRelevance:
+                return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance;
+            case NYql::TIndexDescription::EType::GlobalJsonCompact:
+                return NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact;
             case NYql::TIndexDescription::EType::LocalBloomFilter:
                 return NKikimrSchemeOp::EIndexType::EIndexTypeLocalBloomFilter;
             case NYql::TIndexDescription::EType::LocalBloomNgramFilter:
@@ -336,6 +357,7 @@ public:
             case EType::GlobalSyncUnique:
             case EType::GlobalJson:
             case EType::LocalMinMax:
+            case EType::GlobalJsonCompact:
                 // no specialized index description
                 Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
                 break;
@@ -344,6 +366,8 @@ public:
                 break;
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
+            case EType::GlobalFulltextCompact:
+            case EType::GlobalFulltextCompactRelevance:
                 *message->MutableFulltextIndexDescription() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(SpecializedIndexDescription);
                 break;
             case EType::LocalBloomFilter:
@@ -380,6 +404,9 @@ public:
             case EType::GlobalFulltextRelevance:
             case EType::GlobalJson:
                 return true;
+            case EType::GlobalFulltextCompact:
+            case EType::GlobalFulltextCompactRelevance:
+            case EType::GlobalJsonCompact:
             case EType::LocalBloomFilter:
             case EType::LocalBloomNgramFilter:
             case EType::LocalMinMax:
@@ -396,6 +423,9 @@ public:
             case EType::GlobalFulltextPlain:
             case EType::GlobalFulltextRelevance:
             case EType::GlobalJson:
+            case EType::GlobalFulltextCompact:
+            case EType::GlobalFulltextCompactRelevance:
+            case EType::GlobalJsonCompact:
                 return NKikimr::NTableIndex::GetImplTables(NYql::TIndexDescription::ConvertIndexType(Type), KeyColumns);
             case EType::LocalBloomFilter:
             case EType::LocalBloomNgramFilter:

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -209,11 +209,13 @@ struct TKiExploreTxResults {
                 YQL_ENSURE(indexTables.size() >= 2, "K-means tree index should have at least 2 tables");
                 dataTable = indexTable = indexTables[1];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::NKMeans::PostingTable));
-            } else if (index.Type == TIndexDescription::EType::GlobalFulltextPlain) {
+            } else if (index.Type == TIndexDescription::EType::GlobalFulltextPlain ||
+                index.Type == TIndexDescription::EType::GlobalFulltextCompact) {
                 YQL_ENSURE(indexTables.size() == 1, "Global fulltext plain index should have 1 table");
                 dataTable = indexTable = indexTables[0];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::ImplTable));
-            } else if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance) {
+            } else if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
+                index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
                 YQL_ENSURE(indexTables.size() == 4, "Global fulltext relevance index should have 4 tables");
                 indexTable = indexTables[3];
                 YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::ImplTable));
@@ -228,7 +230,8 @@ struct TKiExploreTxResults {
 
             if (!isUpdate) {
                 ops[indexTable] = TPrimitiveYdbOperation::Write;
-                if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance) {
+                if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
+                    index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
                     ops[dictTable] |= TPrimitiveYdbOperation::Read|TPrimitiveYdbOperation::Write;
                 }
             } else {
@@ -236,7 +239,8 @@ struct TKiExploreTxResults {
                     if (updateColumns.contains(column)) {
                         // delete old index values and upsert rows into index table
                         ops[indexTable] = TPrimitiveYdbOperation::Write;
-                        if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance) {
+                        if (index.Type == TIndexDescription::EType::GlobalFulltextRelevance ||
+                            index.Type == TIndexDescription::EType::GlobalFulltextCompactRelevance) {
                             ops[dictTable] |= TPrimitiveYdbOperation::Read|TPrimitiveYdbOperation::Write;
                         }
                         break;

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -1234,13 +1234,21 @@ private:
                     ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), "Fulltext index support is disabled"));
                     return TStatus::Error;
                 }
-                indexType = TIndexDescription::EType::GlobalFulltextPlain;
+                if (SessionCtx->Config().FeatureFlags.GetEnableCompactFulltextIndex()) {
+                    indexType = TIndexDescription::EType::GlobalFulltextCompact;
+                } else {
+                    indexType = TIndexDescription::EType::GlobalFulltextPlain;
+                }
             } else if (type == "globalFulltextRelevance") {
                 if (!SessionCtx->Config().FeatureFlags.GetEnableFulltextIndex()) {
                     ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), "Fulltext index support is disabled"));
                     return TStatus::Error;
                 }
-                indexType = TIndexDescription::EType::GlobalFulltextRelevance;
+                if (SessionCtx->Config().FeatureFlags.GetEnableCompactFulltextIndex()) {
+                    indexType = TIndexDescription::EType::GlobalFulltextCompactRelevance;
+                } else {
+                    indexType = TIndexDescription::EType::GlobalFulltextRelevance;
+                }
             } else if (type == "globalJson") {
                 if (!SessionCtx->Config().FeatureFlags.GetEnableJsonIndex()) {
                     ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), "JSON index support is disabled"));
@@ -1250,7 +1258,11 @@ private:
                     ctx.AddError(TIssue(ctx.GetPosition(index.Pos()), "JSON index is not supported on column tables"));
                     return TStatus::Error;
                 }
-                indexType = TIndexDescription::EType::GlobalJson;
+                if (SessionCtx->Config().FeatureFlags.GetEnableCompactFulltextIndex()) {
+                    indexType = TIndexDescription::EType::GlobalJsonCompact;
+                } else {
+                    indexType = TIndexDescription::EType::GlobalJson;
+                }
             } else if (type == "localBloomFilter") {
                 if (meta->StoreType == EStoreType::Column &&
                     !SessionCtx->Config().FeatureFlags.GetEnableLocalBloomFilterIndex()) {
@@ -1334,7 +1346,9 @@ private:
                         break;
                     }
                     case TIndexDescription::EType::GlobalFulltextPlain:
-                    case TIndexDescription::EType::GlobalFulltextRelevance: {
+                    case TIndexDescription::EType::GlobalFulltextRelevance:
+                    case TIndexDescription::EType::GlobalFulltextCompact:
+                    case TIndexDescription::EType::GlobalFulltextCompactRelevance: {
                         NKikimr::NFulltext::FillSetting(
                             *fulltextIndexDescription.MutableSettings(),
                             nameLower, value.StringValue(), error);
@@ -1372,6 +1386,7 @@ private:
                 case TIndexDescription::EType::GlobalAsync:
                 case TIndexDescription::EType::GlobalSyncUnique:
                 case TIndexDescription::EType::GlobalJson:
+                case TIndexDescription::EType::GlobalJsonCompact:
                     // no specialized index description
                     // no settings validation
                     break;
@@ -1384,16 +1399,10 @@ private:
                     specializedIndexDescription = std::move(vectorIndexKmeansTreeDescription);
                     break;
                 }
-                case TIndexDescription::EType::GlobalFulltextPlain: {
-                    TString error;
-                    if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), error)) {
-                        ctx.AddError(TIssue(ctx.GetPosition(index.IndexSettings().Pos()), error));
-                        return IGraphTransformer::TStatus::Error;
-                    }
-                    specializedIndexDescription = std::move(fulltextIndexDescription);
-                    break;
-                }
-                case TIndexDescription::EType::GlobalFulltextRelevance: {
+                case TIndexDescription::EType::GlobalFulltextPlain:
+                case TIndexDescription::EType::GlobalFulltextRelevance:
+                case TIndexDescription::EType::GlobalFulltextCompact:
+                case TIndexDescription::EType::GlobalFulltextCompactRelevance: {
                     TString error;
                     if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), error)) {
                         ctx.AddError(TIssue(ctx.GetPosition(index.IndexSettings().Pos()), error));

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1412,18 +1412,28 @@ private:
 
             auto [indexMeta, index] = tableMeta->GetIndex(indexName);
 
-            YQL_ENSURE(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                || index->Type == TIndexDescription::EType::GlobalFulltextPlain
-                || index->Type == TIndexDescription::EType::GlobalJson);
-            if (index->Type == TIndexDescription::EType::GlobalJson) {
-                fullTextProto.SetIndexType(NKqpProto::EKqpFullTextIndexType::EKqpFullTextJson);
-            } else {
+            NKqpProto::EKqpFullTextIndexType kqpType;
+            bool hasDesc = false;
+            switch (index->Type) {
+            case TIndexDescription::EType::GlobalFulltextRelevance:
+                kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance;
+                hasDesc = true;
+                break;
+            case TIndexDescription::EType::GlobalFulltextPlain:
+                kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain;
+                hasDesc = true;
+                break;
+            case TIndexDescription::EType::GlobalJson:
+                kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextJson;
+                break;
+            default:
+                YQL_ENSURE(false, "Index type " << index->Type << " is not supported");
+            }
+            fullTextProto.SetIndexType(kqpType);
+            if (hasDesc) {
                 auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
                 YQL_ENSURE(desc, "unexpected index description type");
                 fullTextProto.MutableIndexDescription()->MutableSettings()->CopyFrom(desc->GetSettings());
-                fullTextProto.SetIndexType(index->Type == TIndexDescription::EType::GlobalFulltextRelevance
-                    ? NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance
-                    : NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain);
             }
 
             auto fillCol = [&](const NYql::TKikimrColumnMetadata* columnMeta, NKikimrKqp::TKqpColumnMetadataProto* columnProto) {

--- a/ydb/core/kqp/ut/indexes/compact/kqp_fulltext_compact_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/compact/kqp_fulltext_compact_ut.cpp
@@ -1,0 +1,168 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
+#include <library/cpp/json/json_reader.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
+
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/tx/datashard/datashard.h>
+
+#include <ydb/core/tx/schemeshard/index/build_index.h>
+#include <ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_ut_common.h>
+
+namespace NKikimr::NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+namespace {
+
+void ExecuteQuery(NQuery::TQueryClient& db, const TString& query) {
+    auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+}
+
+TResultSet ReadIndex(NQuery::TQueryClient& db, const char* table = "indexImplTable") {
+    TString query = Sprintf(R"sql(
+        SELECT * FROM `/Root/Texts/fulltext_idx/%s`;
+    )sql", table);
+    auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    return result.GetResultSet(0);
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(KqpFulltextCompact) {
+
+Y_UNIT_TEST(AddIndexCompact) {
+    auto kikimr = KikimrWithCompact();
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+    auto db = kikimr.GetQueryClient();
+
+    CreateTexts(db);
+    UpsertTexts(db);
+    AddIndex(db, "fulltext_plain");
+
+    auto index = ReadIndex(db);
+    CompareYson(R"([
+        [%true;4294967295u;100u;"d";"animals"];
+        [%true;4294967295u;300u;"ddd";"cats"];
+        [%true;4294967295u;200u;"dd";"chase"];
+        [%true;4294967295u;400u;"\xC8\1\xC8\1";"dogs"];
+        [%true;4294967295u;400u;"\x90\3";"foxes"];
+        [%true;4294967295u;400u;"\xAC\2d";"love"];
+        [%true;4294967295u;200u;"dd";"small"]
+    ])", NYdb::FormatResultSetYson(index));
+}
+
+Y_UNIT_TEST_TWIN(AddIndexCompactRelevance, Covered) {
+    auto kikimr = KikimrWithCompact();
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+    auto db = kikimr.GetQueryClient();
+
+    CreateTexts(db);
+    UpsertTexts(db);
+    if (Covered) {
+        AddIndexCovered(db, "fulltext_relevance");
+    } else {
+        AddIndex(db, "fulltext_relevance");
+    }
+
+    auto index = ReadIndex(db);
+    CompareYson(R"([
+        [%true;4294967295u;100u;"\xA4\1";"animals"];
+        [%true;4294967295u;300u;"\xA4\1\xA4\1\xE4\1\2";"cats"];
+        [%true;4294967295u;200u;"\xA4\1\xA4\1";"chase"];
+        [%true;4294967295u;400u;"\x88\3\x88\3";"dogs"];
+        [%true;4294967295u;400u;"\x90\6";"foxes"];
+        [%true;4294967295u;400u;"\xAC\4\xA4\1";"love"];
+        [%true;4294967295u;200u;"\xA4\1\xA4\1";"small"]
+    ])", NYdb::FormatResultSetYson(index));
+
+    index = ReadIndex(db, NTableIndex::NFulltext::DocsTable);
+    if (Covered) {
+        CompareYson(R"([
+            [["cats data"];[100u];4u];
+            [["dogs data"];[200u];4u];
+            [["cats cats data"];[300u];3u];
+            [["foxes data"];[400u];3u]
+        ])", NYdb::FormatResultSetYson(index));
+    } else {
+        CompareYson(R"([
+            [[100u];4u];
+            [[200u];4u];
+            [[300u];3u];
+            [[400u];3u]
+        ])", NYdb::FormatResultSetYson(index));
+    }
+
+    index = ReadIndex(db, NTableIndex::NFulltext::DictTable);
+    CompareYson(R"([
+        [1u;"animals"];
+        [3u;"cats"];
+        [2u;"chase"];
+        [2u;"dogs"];
+        [1u;"foxes"];
+        [2u;"love"];
+        [2u;"small"]
+    ])", NYdb::FormatResultSetYson(index));
+
+    index = ReadIndex(db, NTableIndex::NFulltext::StatsTable);
+    CompareYson(R"([
+        [4u;0u;14u]
+    ])", NYdb::FormatResultSetYson(index));
+}
+
+} // Y_UNIT_TEST_SUITE(KqpFulltextCompact)
+
+Y_UNIT_TEST_SUITE(KqpJsonCompact) {
+
+TResultSet ReadIndex(NQuery::TQueryClient& db, const char* table = "indexImplTable") {
+    TString query = Sprintf(R"sql(
+        SELECT * FROM `/Root/Texts/json_idx/%s`;
+    )sql", table);
+    auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    return result.GetResultSet(0);
+}
+
+Y_UNIT_TEST(AddJsonCompactIndex) {
+    auto kikimr = KikimrWithCompact();
+    auto db = kikimr.GetQueryClient();
+
+    ExecuteQuery(db, R"sql(
+        CREATE TABLE `/Root/Texts` (
+            Key Uint64,
+            Text Json,
+            Data String,
+            PRIMARY KEY (Key)
+        );
+    )sql");
+
+    ExecuteQuery(db, R"sql(
+        UPSERT INTO `/Root/Texts` (Key, Text, Data) VALUES
+            (100, '"hello world"', "data1"),
+            (200, '42', "data2"),
+            (300, 'true', "data3"),
+            (400, '{"name":"test","value":123}', "data4")
+    )sql");
+
+    ExecuteQuery(db, R"sql(
+        ALTER TABLE `/Root/Texts` ADD INDEX json_idx
+            GLOBAL USING json ON (Text)
+    )sql");
+
+    auto index = ReadIndex(db);
+    auto indexStr = NYdb::FormatResultSetYson(index);
+    Cerr << "json index: " << indexStr << Endl;
+
+    NYdb::TResultSetParser parser(index);
+    UNIT_ASSERT(parser.RowsCount() > 0);
+}
+
+} // Y_UNIT_TEST_SUITE(KqpJsonCompact)
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/indexes/compact/ya.make
+++ b/ydb/core/kqp/ut/indexes/compact/ya.make
@@ -7,9 +7,8 @@ REQUIREMENTS(cpu:2)
 SIZE(MEDIUM)
 
 SRCS(
-    kqp_indexes_multishard_ut.cpp
-    kqp_indexes_ut.cpp
-    kqp_stream_indexes_ut.cpp
+    kqp_fulltext_compact_ut.cpp
+    ../fulltext/kqp_fulltext_ut_common.cpp
 )
 
 PEERDIR(
@@ -25,12 +24,3 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 END()
-
-RECURSE_FOR_TESTS(
-    common
-    compact
-    fulltext
-    json
-    prefixed_vector
-    vector
-)

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_ut_common.cpp
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_ut_common.cpp
@@ -7,6 +7,7 @@ using namespace NYdb;
 TKikimrRunner Kikimr(NKikimrConfig::TFeatureFlags&& featureFlags) {
     auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
     settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
     return TKikimrRunner(settings);
 }
 
@@ -24,6 +25,18 @@ TKikimrRunner Kikimr() {
     featureFlags.SetEnableFulltextIndex(true);
     auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
     settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
+    return TKikimrRunner(settings);
+}
+
+TKikimrRunner KikimrWithCompact() {
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableFulltextIndex(true);
+    featureFlags.SetEnableCompactFulltextIndex(true);
+    featureFlags.SetEnableJsonIndex(true);
+    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    settings.AppConfig.MutableTableServiceConfig()->SetEnableIndexStreamWrite(true);
     return TKikimrRunner(settings);
 }
 
@@ -107,10 +120,10 @@ void AddIndexCovered(NQuery::TQueryClient& db, const TString& indexName) {
     UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 }
 
-void AddIndexSnowball(NQuery::TQueryClient& db, const TString& language) {
+void AddIndexSnowball(NQuery::TQueryClient& db, const TString& language, const TString& type) {
     TString query = Sprintf(R"sql(
         ALTER TABLE `/Root/Texts` ADD INDEX fulltext_idx
-            GLOBAL USING fulltext_plain
+            GLOBAL USING %s
             ON (Text)
             WITH (
                 tokenizer=standard,
@@ -118,7 +131,7 @@ void AddIndexSnowball(NQuery::TQueryClient& db, const TString& language) {
                 use_filter_snowball=true,
                 language=%s
             )
-    )sql", language.c_str());
+    )sql", type.c_str(), language.c_str());
     auto result = db.ExecuteQuery(query, NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
     UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 }

--- a/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_ut_common.h
+++ b/ydb/core/kqp/ut/indexes/fulltext/kqp_fulltext_ut_common.h
@@ -9,12 +9,13 @@ using namespace NYdb;
 TKikimrRunner Kikimr(NKikimrConfig::TFeatureFlags&& featureFlags);
 TKikimrRunner Kikimr();
 TKikimrRunner Kikimr(bool enableIndexStreamWrite);
+TKikimrRunner KikimrWithCompact();
 void CreateTexts(NQuery::TQueryClient& db, const bool utf8 = false);
 void UpsertSomeTexts(NQuery::TQueryClient& db);
 void UpsertTexts(NQuery::TQueryClient& db);
 void AddIndex(NQuery::TQueryClient& db, const TString& indexName = "fulltext_plain");
 void AddIndexCovered(NQuery::TQueryClient& db, const TString& indexName = "fulltext_plain");
-void AddIndexSnowball(NQuery::TQueryClient& db, const TString& language);
+void AddIndexSnowball(NQuery::TQueryClient& db, const TString& language, const TString& type = "fulltext_plain");
 void AddIndexNGram(NQuery::TQueryClient& db, const size_t nGramMinLength = 3, const size_t nGramMaxLength = 3,
     const bool relevance = false, const bool edgeNGram = false, const bool covered = false);
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -319,4 +319,5 @@ message TFeatureFlags {
     optional bool EnableKqpConstraintsTransformer = 277 [default = true];
     optional bool EnableLocalIndexAsSchemeObject = 278 [default = true];
     optional bool EnableDataShardDetailedMetrics = 279 [default = false];
+    optional bool EnableCompactFulltextIndex = 280 [default = false];
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -458,6 +458,9 @@ message TTableDescription {
      *       regardless of the detailed metrics settings at the database level.
      */
     optional TTableDetailedMetricsSettings DetailedMetricsSettings = 51;
+
+    // For fulltext indexes - to determine if the table is an impl table of an index
+    optional EIndexType IndexImplType = 52;
 }
 
 message TCompressionOptions {
@@ -1333,6 +1336,9 @@ enum EIndexType {
     EIndexTypeLocalBloomFilter = 8;
     EIndexTypeLocalBloomNgramFilter = 9;
     EIndexTypeLocalMinMax = 10;
+    EIndexTypeGlobalFulltextCompact = 11;
+    EIndexTypeGlobalFulltextCompactRelevance = 12;
+    EIndexTypeGlobalJsonCompact = 13;
 }
 
 enum EIndexState {

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -359,6 +359,25 @@ public:
             for (const auto& pi : Self->SysTablesPartOwners) {
                 Result->Record.AddSysTablesPartOwners(pi);
             }
+
+            if (tableInfo.IndexImplType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompact ||
+                tableInfo.IndexImplType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance ||
+                tableInfo.IndexImplType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact) {
+                // For now, only allow to split compact fulltext index table by __ydb_token
+                auto pb = Result->Record.MutableTableStats();
+                if (pb->GetSplitBySizeSuggestedKey().size()) {
+                    TSerializedCellVec key(pb->GetSplitBySizeSuggestedKey());
+                    if (key.GetCells().size() > 1) {
+                        pb->SetSplitBySizeSuggestedKey(TSerializedCellVec::Serialize({key.GetCells()[0]}));
+                    }
+                }
+                if (pb->GetSplitByLoadSuggestedKey().size()) {
+                    TSerializedCellVec key(pb->GetSplitByLoadSuggestedKey());
+                    if (key.GetCells().size() > 1) {
+                        pb->SetSplitByLoadSuggestedKey(TSerializedCellVec::Serialize({key.GetCells()[0]}));
+                    }
+                }
+            }
         }
 
         // Also return back the CPU usage data

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -327,6 +327,9 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
     ReplicationConfig = TReplicationConfig(descr.GetReplicationConfig());
     IncrementalBackupConfig = TIncrementalBackupConfig(descr.GetIncrementalBackupConfig());
     UniqueIndexKeySize = descr.GetUniqueIndexKeySize();
+    if (descr.HasIndexImplType()) {
+        IndexImplType = descr.GetIndexImplType();
+    }
 
     CheckSpecialColumns();
 

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -464,6 +464,7 @@ struct TUserTable : public TThrRefBase {
     TIncrementalBackupConfig IncrementalBackupConfig;
     bool IsBackup = false;
     ui32 UniqueIndexKeySize = 0;
+    NKikimrSchemeOp::EIndexType IndexImplType = NKikimrSchemeOp::EIndexType::EIndexTypeInvalid;
 
     TMap<TPathId, TTableIndex> Indexes;
 

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -114,6 +114,7 @@ void TSchemeShard::PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuil
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                 // no specialized index description
                 Y_ASSERT(std::holds_alternative<std::monostate>(info.SpecializedIndexDescription));
                 break;
@@ -123,6 +124,8 @@ void TSchemeShard::PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuil
                 break;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
                 *serializableRepresentation.MutableFulltextIndexDescription() =
                     std::get<NKikimrSchemeOp::TFulltextIndexDescription>(info.SpecializedIndexDescription);
                 break;

--- a/ydb/core/tx/schemeshard/index/build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__create.cpp
@@ -13,6 +13,7 @@ namespace NKikimr::NSchemeShard {
 static constexpr ui32 DefaultMaxShardsInFlight = 32;
 
 using namespace NTabletFlatExecutor;
+using NKikimrSchemeOp::EIndexType;
 
 class TSchemeShard::TIndexBuilder::TTxCreate: public TSchemeShard::TIndexBuilder::TTxSimple<TEvIndexBuilder::TEvCreateRequest, TEvIndexBuilder::TEvCreateResponse> {
 public:
@@ -331,33 +332,21 @@ private:
             break;
         }
         case Ydb::Table::TableIndex::TypeCase::kGlobalFulltextPlainIndex: {
-            if (!Self->EnableFulltextIndex) {
-                explain = "Fulltext index support is disabled";
+            auto type = Self->EnableCompactFulltextIndex
+                ? EIndexType::EIndexTypeGlobalFulltextCompact
+                : EIndexType::EIndexTypeGlobalFulltextPlain;
+            if (!PrepareFulltext(buildInfo, type, index.global_fulltext_plain_index().fulltext_settings(), explain)) {
                 return false;
             }
-            buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildFulltext;
-            buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextPlain;
-            NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
-            *fulltextIndexDescription.MutableSettings() = index.global_fulltext_plain_index().fulltext_settings();
-            if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), explain)) {
-                return false;
-            }
-            buildInfo.SpecializedIndexDescription = fulltextIndexDescription;
             break;
         }
         case Ydb::Table::TableIndex::TypeCase::kGlobalFulltextRelevanceIndex: {
-            if (!Self->EnableFulltextIndex) {
-                explain = "Fulltext index support is disabled";
+            auto type = Self->EnableCompactFulltextIndex
+                ? EIndexType::EIndexTypeGlobalFulltextCompactRelevance
+                : EIndexType::EIndexTypeGlobalFulltextRelevance;
+            if (!PrepareFulltext(buildInfo, type, index.global_fulltext_relevance_index().fulltext_settings(), explain)) {
                 return false;
             }
-            buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildFulltext;
-            buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance;
-            NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
-            *fulltextIndexDescription.MutableSettings() = index.global_fulltext_relevance_index().fulltext_settings();
-            if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), explain)) {
-                return false;
-            }
-            buildInfo.SpecializedIndexDescription = fulltextIndexDescription;
             break;
         }
         case Ydb::Table::TableIndex::TypeCase::kGlobalJsonIndex: {
@@ -366,7 +355,9 @@ private:
                 return false;
             }
             buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildFulltext;
-            buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson;
+            buildInfo.IndexType = Self->EnableCompactFulltextIndex
+                ? NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact
+                : NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson;
             break;
         }
         case Ydb::Table::TableIndex::TypeCase::kLocalBloomFilterIndex:
@@ -386,6 +377,22 @@ private:
         if (!FillIndexTablePartitioning(buildInfo.ImplTableDescriptions, index, status, explain)) {
             return false;
         }
+        return true;
+    }
+
+    bool PrepareFulltext(TIndexBuildInfo& buildInfo, NKikimrSchemeOp::EIndexType indexType, const Ydb::Table::FulltextIndexSettings& settings, TString& explain) {
+        if (!Self->EnableFulltextIndex) {
+            explain = "Fulltext index support is disabled";
+            return false;
+        }
+        NKikimrSchemeOp::TFulltextIndexDescription fulltextIndexDescription;
+        *fulltextIndexDescription.MutableSettings() = settings;
+        buildInfo.IndexType = indexType;
+        buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildFulltext;
+        if (!NKikimr::NFulltext::ValidateSettings(fulltextIndexDescription.GetSettings(), explain)) {
+            return false;
+        }
+        buildInfo.SpecializedIndexDescription = fulltextIndexDescription;
         return true;
     }
 };

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -367,6 +367,36 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
     return propose;
 }
 
+THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildFulltextPropose(
+    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+{
+    Y_ENSURE(buildInfo.IsBuildFulltextCompact());
+
+    auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
+    propose->Record.SetFailOnExist(true);
+    NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
+    modifyScheme.SetInternal(true);
+
+    auto path = TPath::Init(buildInfo.TablePathId, ss);
+    const auto& tableInfo = ss->Tables.at(path->PathId);
+
+    modifyScheme.SetWorkingDir(path.Dive(buildInfo.IndexName).PathString());
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpInitiateBuildIndexImplTable);
+    auto& op = *modifyScheme.MutableCreateTable();
+
+    op = CalcFulltextCompactImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
+        NKikimrSchemeOp::TTableDescription(),
+        std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&buildInfo.SpecializedIndexDescription),
+        buildInfo.IndexType);
+
+    op.SetName(TString::Join(NTableIndex::ImplTable, NTableIndex::NKMeans::BuildSuffix0));
+
+    LOG_NOTICE_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX,
+        "CreateBuildPropose " << buildInfo.Id << " " << buildInfo.State << " " << propose->Record.ShortDebugString());
+
+    return propose;
+}
+
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
     TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
 {
@@ -1153,18 +1183,10 @@ private:
         ev->Record.SetId(ui64(BuildId));
 
         buildInfo.TablePathId.ToProto(ev->Record.MutablePathId());
-
-        if (buildInfo.TargetName.empty()) {
-            TPath implTable = GetBuildPath(Self, buildInfo, NTableIndex::ImplTable);
-            buildInfo.TargetName = implTable.PathString();
-
-            const auto& implTableInfo = Self->Tables.at(implTable.Base()->PathId);
-            FillBuildInfoColumns(buildInfo, NTableIndex::ExtractInfo(implTableInfo));
-        }
         ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
-        ev->Record.SetIndexName(buildInfo.TargetName);
-        ev->Record.SetDocsTableName(GetBuildPath(Self, buildInfo, NTableIndex::NFulltext::DocsTable).PathString());
-        if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson) {
+
+        if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson ||
+            buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact) {
             auto *settings = ev->Record.MutableSettings();
             for (auto& column: buildInfo.IndexColumns) {
                 settings->add_columns()->set_column(column);
@@ -1173,14 +1195,22 @@ private:
             *ev->Record.MutableSettings() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(
                 buildInfo.SpecializedIndexDescription).GetSettings();
         }
+
+        if (buildInfo.IsBuildFulltextRelevance()) {
+            ev->Record.SetDocsTableName(GetBuildPath(Self, buildInfo, NTableIndex::NFulltext::DocsTable).PathString());
+        }
+
         *ev->Record.MutableDataColumns() = {
             buildInfo.DataColumns.begin(), buildInfo.DataColumns.end()
         };
-        if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance) {
-            ev->Record.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance);
-        } else if (buildInfo.IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson) {
-            ev->Record.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::Json);
+
+        bool compact = buildInfo.IsBuildFulltextCompact();
+        if (buildInfo.TargetName.empty()) {
+            TPath implTable = GetBuildPath(Self, buildInfo, TString(NTableIndex::ImplTable) + (compact ? NTableIndex::NKMeans::BuildSuffix0 : ""));
+            buildInfo.TargetName = implTable.PathString();
         }
+        ev->Record.SetIndexName(buildInfo.TargetName);
+        ev->Record.SetIndexType(ConvertFulltextType(buildInfo.IndexType));
 
         auto shardId = FillScanRequestCommon(ev->Record, shardIdx, buildInfo);
 
@@ -1197,19 +1227,48 @@ private:
         ToTabletSend.emplace(shardId, std::move(ev));
     }
 
+    NKikimrTxDataShard::EFulltextIndexType ConvertFulltextType(NKikimrSchemeOp::EIndexType indexType) {
+        switch (indexType) {
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
+            return NKikimrTxDataShard::EFulltextIndexType::FulltextPlain;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            return NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance;
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            return NKikimrTxDataShard::EFulltextIndexType::Json;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            return NKikimrTxDataShard::EFulltextIndexType::FulltextCompact;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+            return NKikimrTxDataShard::EFulltextIndexType::FulltextCompactRelevance;
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+            return NKikimrTxDataShard::EFulltextIndexType::JsonCompact;
+        default:
+            Y_ENSURE(false, "Unreachable");
+        }
+    }
+
     void SendBuildFulltextDictRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
         auto ev = MakeHolder<TEvDataShard::TEvBuildFulltextDictRequest>();
         ev->Record.SetId(ui64(BuildId));
         ev->Record.SetDatabaseName(CanonizePath(Self->RootPathElements));
 
         auto path = GetBuildPath(Self, buildInfo, NTableIndex::ImplTable);
-        path->PathId.ToProto(ev->Record.MutablePathId());
-        ev->Record.SetReadShadowData(true);
 
-        ev->Record.SetIndexType(NKikimrTxDataShard::EFulltextIndexType::FulltextRelevance);
+        ev->Record.SetIndexType(ConvertFulltextType(buildInfo.IndexType));
 
-        path.Rise().Dive(NTableIndex::NFulltext::DictTable);
-        ev->Record.SetDictTableName(path.PathString());
+        if (buildInfo.IsBuildFulltextCompact()) {
+            ev->Record.SetPostingTableName(path.PathString());
+            path.Rise().Dive(TString(NTableIndex::ImplTable) + NTableIndex::NKMeans::BuildSuffix0);
+            path->PathId.ToProto(ev->Record.MutablePathId());
+            ev->Record.SetReadShadowData(false);
+        } else {
+            path->PathId.ToProto(ev->Record.MutablePathId());
+            ev->Record.SetReadShadowData(true);
+        }
+
+        if (buildInfo.IsBuildFulltextRelevance()) {
+            path.Rise().Dive(NTableIndex::NFulltext::DictTable);
+            ev->Record.SetDictTableName(path.PathString());
+        }
 
         const auto& shardStatus = buildInfo.Shards.at(shardIdx);
         if (shardStatus.Range.From.GetCells().size() > 1) {
@@ -2046,18 +2105,27 @@ private:
                 buildInfo.DoneShards.size() == buildInfo.Shards.size();
             if (done) {
                 LOG_D("FillFulltextIndex Posting Done");
-                if (buildInfo.IndexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance) {
+                if (buildInfo.IsBuildFulltextRelevance()) {
                     NIceDb::TNiceDb db{txc.DB};
-                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexStats;
                     buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexStats;
                     Self->PersistBuildIndexState(db, buildInfo);
+                    Progress(BuildId);
+                    done = false;
+                } else if (buildInfo.IsBuildFulltextCompact()) {
+                    ClearDoneShards(txc, buildInfo);
+                    NIceDb::TNiceDb db{txc.DB};
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexDictionary;
+                    Self->PersistBuildIndexState(db, buildInfo);
+                    Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+                    ChangeState(BuildId, TIndexBuildInfo::EState::LockBuild);
                     Progress(BuildId);
                     done = false;
                 }
             }
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexStats:
-            // Stage 2 for FulltextRelevance - build statistics table (DocCount & TotalDocLength)
+            // Stage 2 for FulltextRelevance/FulltextCompactRelevance - build statistics table (DocCount & TotalDocLength)
             if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Collect) {
                 LOG_D("FillFulltextIndex SendUploadStats " << buildInfo.DebugString());
                 buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
@@ -2076,6 +2144,7 @@ private:
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexDictionary:
             // Stage 3 for FulltextRelevance - build dictionary table
+            // And/or stage 2 for FulltextCompact - compact token table
             LOG_D("FillFulltextIndex Dictionary");
             if (NoShardsAdded(buildInfo)) {
                 AddAllShards(buildInfo);
@@ -2085,11 +2154,17 @@ private:
             if (done) {
                 LOG_D("FillFulltextIndex Dictionary Done");
                 NIceDb::TNiceDb db{txc.DB};
-                buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexBorders;
-                buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
+                if (buildInfo.IsBuildFulltextRelevance()) {
+                    buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Collect;
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::FulltextIndexBorders;
+                    done = false;
+                } else {
+                    buildInfo.SubState = TIndexBuildInfo::ESubState::None;
+                    Self->PersistBuildIndexShardStatusReset(db, buildInfo);
+                    done = true;
+                }
                 Self->PersistBuildIndexState(db, buildInfo);
                 Progress(BuildId);
-                done = false;
             }
             break;
         case TIndexBuildInfo::ESubState::FulltextIndexBorders:
@@ -2265,7 +2340,8 @@ public:
             } else if (!buildInfo.InitiateTxDone) {
                 Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.InitiateTxId)));
             } else {
-                if (buildInfo.IsBuildVectorIndex() && buildInfo.KMeans.NeedsAnotherLevel()) {
+                if (buildInfo.IsBuildVectorIndex() && buildInfo.KMeans.NeedsAnotherLevel() ||
+                    buildInfo.IsBuildFulltextCompact()) {
                     ChangeState(BuildId, TIndexBuildInfo::EState::CreateBuild);
                 } else {
                     ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
@@ -2322,11 +2398,15 @@ public:
             }
             break;
         case TIndexBuildInfo::EState::CreateBuild:
-            Y_ENSURE(buildInfo.IsBuildVectorIndex());
+            Y_ENSURE(buildInfo.IsBuildVectorIndex() || buildInfo.IsBuildFulltextCompact());
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
-                Send(Self->SelfId(), CreateBuildPropose(Self, buildInfo), 0, ui64(BuildId));
+                if (buildInfo.IsBuildFulltextCompact()) {
+                    Send(Self->SelfId(), CreateBuildFulltextPropose(Self, buildInfo), 0, ui64(BuildId));
+                } else {
+                    Send(Self->SelfId(), CreateBuildPropose(Self, buildInfo), 0, ui64(BuildId));
+                }
             } else if (!buildInfo.ApplyTxDone) {
                 Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
             } else {
@@ -2352,13 +2432,18 @@ public:
                 buildInfo.SubState == TIndexBuildInfo::ESubState::UniqIndexValidation ||
                 buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation ||
                 buildInfo.SubState == TIndexBuildInfo::ESubState::PrepareValidation ||
-                buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary);
+                buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary ||
+                buildInfo.IsBuildFulltextCompact());
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
                 TString tableName;
                 if (buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary) {
-                    tableName = NTableIndex::ImplTable;
+                    if (buildInfo.IsBuildFulltextCompact()) {
+                        tableName = TString::Join(NTableIndex::ImplTable, NTableIndex::NKMeans::BuildSuffix0);
+                    } else {
+                        tableName = NTableIndex::ImplTable;
+                    }
                 } else if (buildInfo.SubState == TIndexBuildInfo::ESubState::UniqIndexValidation ||
                     buildInfo.SubState == TIndexBuildInfo::ESubState::UniqConsistentValidation ||
                     buildInfo.SubState == TIndexBuildInfo::ESubState::PrepareValidation) {
@@ -2594,6 +2679,9 @@ public:
             case TIndexBuildInfo::EBuildKind::BuildColumns:
             case TIndexBuildInfo::EBuildKind::BuildFulltext:
                 if (buildInfo.SubState == TIndexBuildInfo::ESubState::FulltextIndexDictionary) {
+                    if (buildInfo.IsBuildFulltextCompact()) {
+                        return GetBuildPath(Self, buildInfo, TString::Join(NTableIndex::ImplTable, NTableIndex::NKMeans::BuildSuffix0));
+                    }
                     return GetBuildPath(Self, buildInfo, NTableIndex::ImplTable);
                 }
                 return TPath::Init(buildInfo.TablePathId, Self);
@@ -2626,7 +2714,8 @@ public:
         TPath path = GetShardsPath(buildInfo);
         if (!path.IsLocked()) { // lock is needed to prevent table shards from being split
             Y_ENSURE(buildInfo.IsBuildVectorIndex() && (buildInfo.KMeans.Level > 1 ||
-                buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::Filter));
+                buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::Filter) ||
+                buildInfo.IsBuildFulltextCompact());
             ChangeState(buildInfo.Id, TIndexBuildInfo::EState::LockBuild);
             Progress(buildInfo.Id);
             return false;

--- a/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index_tx_base.cpp
@@ -326,12 +326,15 @@ void TSchemeShard::TIndexBuilder::TTxBase::Fill(NKikimrIndexBuilder::TIndexBuild
             *index.mutable_global_vector_kmeans_tree_index() = Ydb::Table::GlobalVectorKMeansTreeIndex();
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextPlain:
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompact:
             *index.mutable_global_fulltext_plain_index() = Ydb::Table::GlobalFulltextPlainIndex();
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance:
             *index.mutable_global_fulltext_relevance_index() = Ydb::Table::GlobalFulltextRelevanceIndex();
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact:
             *index.mutable_global_json_index() = Ydb::Table::GlobalJsonIndex();
             break;
         default:

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -39,6 +39,7 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
             break;
@@ -47,6 +48,8 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             *index.MutableFulltextIndexDescription() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(SpecializedIndexDescription);
             break;
         default:

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -720,6 +720,19 @@ public:
         return BuildKind == EBuildKind::BuildFulltext;
     }
 
+    bool IsBuildFulltextRelevance() const {
+        return BuildKind == EBuildKind::BuildFulltext && (
+            IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextRelevance ||
+            IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance);
+    }
+
+    bool IsBuildFulltextCompact() const {
+        return BuildKind == EBuildKind::BuildFulltext && (
+            IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompact ||
+            IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalFulltextCompactRelevance ||
+            IndexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact);
+    }
+
     virtual bool IsBuildIndex() const {
         return IsBuildSecondaryIndex() || IsBuildSecondaryUniqueIndex() || IsBuildVectorIndex() || IsBuildFulltextIndex();
     }

--- a/ydb/core/tx/schemeshard/index/index_utils.cpp
+++ b/ydb/core/tx/schemeshard/index/index_utils.cpp
@@ -25,11 +25,14 @@ TIndexObjectCounts GetIndexObjectCounts(const NKikimrSchemeOp::TIndexCreationCon
             break;
         }
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain: {
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact: {
             res.IndexTableCount = 1;
             break;
         }
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance: {
             res.IndexTableCount = 4;
             break;
         }
@@ -419,6 +422,86 @@ auto CalcVectorKmeansTreeBuildOverlapTableDescImpl(
     return implTableDesc;
 }
 
+auto CalcFulltextCompactImplTableDescImpl(
+    const auto& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const NKikimrSchemeOp::TFulltextIndexDescription* indexDesc,
+    const NKikimrSchemeOp::EIndexType indexType)
+{
+    auto tableColumns = ExtractInfo(baseTable);
+    THashSet<TString> indexColumns;
+    Y_ENSURE(tableColumns.Keys.size() == 1);
+    for (const auto & keyColumn: tableColumns.Keys) {
+        indexColumns.insert(keyColumn);
+    }
+
+    TColumnTypes baseColumnTypes;
+    TString error;
+    Y_ENSURE(ExtractTypes(baseTable, baseColumnTypes, error), error);
+    NScheme::TTypeId tokenColumnType;
+    if (indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact) {
+        tokenColumnType = NScheme::NTypeIds::String;
+    } else {
+        Y_ENSURE(indexDesc->GetSettings().columns().size() == 1);
+        auto textColumnInfo = baseColumnTypes.at(indexDesc->GetSettings().columns().at(0).column());
+        tokenColumnType = textColumnInfo.GetTypeId();
+    }
+
+    auto idType = baseColumnTypes.at(tableColumns.Keys.at(0)).GetTypeId();
+
+    NKikimrSchemeOp::TTableDescription implTableDesc;
+    implTableDesc.SetName(NTableIndex::ImplTable);
+    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
+    {
+        auto tokenColumn = implTableDesc.AddColumns();
+        tokenColumn->SetName(NFulltext::TokenColumn);
+        tokenColumn->SetType(NScheme::TypeName(tokenColumnType));
+        tokenColumn->SetTypeId(tokenColumnType);
+        tokenColumn->SetNotNull(true);
+        implTableDesc.AddKeyColumnNames(NFulltext::TokenColumn);
+    }
+
+    {
+        auto col = implTableDesc.AddColumns();
+        col->SetName(NFulltext::MaxIdColumn);
+        col->SetType(NScheme::TypeName(idType));
+        col->SetTypeId(idType);
+        col->SetNotNull(true);
+        implTableDesc.AddKeyColumnNames(NFulltext::MaxIdColumn);
+    }
+
+    {
+        auto col = implTableDesc.AddColumns();
+        col->SetName(NFulltext::GenColumn);
+        col->SetType(NScheme::TypeName(NFulltext::GenType));
+        col->SetTypeId(NFulltext::GenType);
+        col->SetNotNull(true);
+        implTableDesc.AddKeyColumnNames(NFulltext::GenColumn);
+    }
+
+    {
+        auto col = implTableDesc.AddColumns();
+        col->SetName(NFulltext::AddedColumn);
+        col->SetType("Bool");
+        col->SetTypeId(Ydb::Type::BOOL);
+        col->SetNotNull(true);
+    }
+
+    {
+        auto col = implTableDesc.AddColumns();
+        col->SetName(NFulltext::SegmentColumn);
+        col->SetType("String");
+        col->SetTypeId(NScheme::NTypeIds::String);
+        col->SetNotNull(true);
+    }
+
+    implTableDesc.SetSystemColumnNamesAllowed(true);
+    implTableDesc.SetIndexImplType(indexType);
+
+    return implTableDesc;
+}
+
 auto CalcFulltextImplTableDescImpl(
     const auto& baseTable,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
@@ -429,6 +512,9 @@ auto CalcFulltextImplTableDescImpl(
 {
     auto tableColumns = ExtractInfo(baseTable);
     THashSet<TString> indexColumns;
+    Y_ENSURE(indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain ||
+        indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance ||
+        indexType == NKikimrSchemeOp::EIndexTypeGlobalJson);
     if (indexType != NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance) {
         indexColumns = indexDataColumns;
     }
@@ -717,6 +803,26 @@ NKikimrSchemeOp::TTableDescription CalcFulltextImplTableDesc(
     const NKikimrSchemeOp::EIndexType indexType)
 {
     return CalcFulltextImplTableDescImpl(baseTableDescr, baseTablePartitionConfig, indexDataColumns, indexTableDesc, indexDesc, indexType);
+}
+
+NKikimrSchemeOp::TTableDescription CalcFulltextCompactImplTableDesc(
+    const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const NKikimrSchemeOp::TFulltextIndexDescription* indexDesc,
+    const NKikimrSchemeOp::EIndexType indexType)
+{
+    return CalcFulltextCompactImplTableDescImpl(baseTableInfo, baseTablePartitionConfig, indexTableDesc, indexDesc, indexType);
+}
+
+NKikimrSchemeOp::TTableDescription CalcFulltextCompactImplTableDesc(
+    const NKikimrSchemeOp::TTableDescription& baseTableDescr,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const NKikimrSchemeOp::TFulltextIndexDescription* indexDesc,
+    const NKikimrSchemeOp::EIndexType indexType)
+{
+    return CalcFulltextCompactImplTableDescImpl(baseTableDescr, baseTablePartitionConfig, indexTableDesc, indexDesc, indexType);
 }
 
 NKikimrSchemeOp::TTableDescription CalcFulltextDocsImplTableDesc(

--- a/ydb/core/tx/schemeshard/index/index_utils.h
+++ b/ydb/core/tx/schemeshard/index/index_utils.h
@@ -93,6 +93,20 @@ NKikimrSchemeOp::TTableDescription CalcFulltextImplTableDesc(
     const NKikimrSchemeOp::TFulltextIndexDescription& indexDesc,
     const NKikimrSchemeOp::EIndexType indexType);
 
+NKikimrSchemeOp::TTableDescription CalcFulltextCompactImplTableDesc(
+    const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const NKikimrSchemeOp::TFulltextIndexDescription* indexDesc,
+    const NKikimrSchemeOp::EIndexType indexType);
+
+NKikimrSchemeOp::TTableDescription CalcFulltextCompactImplTableDesc(
+    const NKikimrSchemeOp::TTableDescription& baseTableDescr,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    const NKikimrSchemeOp::TFulltextIndexDescription* indexDesc,
+    const NKikimrSchemeOp::EIndexType indexType);
+
 NKikimrSchemeOp::TTableDescription CalcFulltextDocsImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
@@ -218,7 +232,9 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
             break;
         }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance: {
             // We have already checked this in IsCompatibleIndex
             Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
 
@@ -247,7 +263,8 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
 
             break;
         }
-        case NKikimrSchemeOp::EIndexTypeGlobalJson: {
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact: {
             Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
 
             if (!CheckSingleIntegerPrimaryKey(baseTableColumns, baseColumnTypes, "JSON", error)) {

--- a/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_build_index.cpp
@@ -72,13 +72,16 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             break;
         }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance: {
             if (!context.SS->EnableFulltextIndex) {
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Fulltext index support is disabled")};
             }
             break;
         }
-        case NKikimrSchemeOp::EIndexTypeGlobalJson: {
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact: {
             if (!context.SS->EnableJsonIndex) {
                 return {CreateReject(opId, NKikimrScheme::EStatus::StatusPreconditionFailed, "JSON index support is disabled")};
             }
@@ -184,6 +187,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
     };
 
     const auto indexType = GetIndexType(indexDesc);
+    bool compact = false;
     switch (indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
@@ -227,6 +231,10 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             }
             break;
         }
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            compact = true;
+            [[fallthrough]];
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain: {
             NKikimrSchemeOp::TTableDescription indexTableDesc;
@@ -234,12 +242,18 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 indexTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
             }
             const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
-            auto implTableDesc = CalcFulltextImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns,
-                indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType);
+            auto implTableDesc = compact
+                ? CalcFulltextCompactImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
+                    indexTableDesc, &indexDesc.GetFulltextIndexDescription(), indexType)
+                : CalcFulltextImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns,
+                    indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType);
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
             result.push_back(createImplTable(std::move(implTableDesc)));
             break;
         }
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+            compact = true;
+            [[fallthrough]];
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
             NKikimrSchemeOp::TTableDescription indexTableDesc, docsTableDesc, dictTableDesc, statsTableDesc;
             if (indexDesc.IndexImplTableDescriptionsSize() == 4) {
@@ -249,8 +263,11 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 indexTableDesc = indexDesc.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition);
             }
             const THashSet<TString> indexDataColumns{indexDesc.GetDataColumnNames().begin(), indexDesc.GetDataColumnNames().end()};
-            auto implTableDesc = CalcFulltextImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns,
-                indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType);
+            auto implTableDesc = compact
+                ? CalcFulltextCompactImplTableDesc(tableInfo, tableInfo->PartitionConfig(),
+                    indexTableDesc, &indexDesc.GetFulltextIndexDescription(), indexType)
+                : CalcFulltextImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns,
+                    indexTableDesc, indexDesc.GetFulltextIndexDescription(), indexType);
             implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
             result.push_back(createImplTable(std::move(implTableDesc)));
             result.push_back(createImplTable(CalcFulltextDocsImplTableDesc(tableInfo, tableInfo->PartitionConfig(), indexDataColumns, docsTableDesc)));

--- a/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/index/operation_create_indexed_table.cpp
@@ -156,7 +156,9 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 break;
             }
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-            case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance: {
                 if (!context.SS->EnableFulltextIndex) {
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "Fulltext index support is disabled")};
                 }
@@ -166,7 +168,8 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 }
                 break;
             }
-            case NKikimrSchemeOp::EIndexTypeGlobalJson: {
+            case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact: {
                 if (!context.SS->EnableJsonIndex) {
                     return {CreateReject(nextId, NKikimrScheme::EStatus::StatusPreconditionFailed, "JSON index support is disabled")};
                 }
@@ -324,6 +327,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
 
         const auto& implTableColumns = indexes.at(indexDescription.GetName());
         const auto indexType = GetIndexType(indexDescription);
+        bool compact = false;
         switch (indexType) {
             case NKikimrSchemeOp::EIndexTypeGlobal:
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
@@ -373,6 +377,10 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 }
                 break;
             }
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+                compact = true;
+                [[fallthrough]];
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain: {
                 NKikimrSchemeOp::TTableDescription userIndexDesc;
@@ -380,10 +388,16 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     userIndexDesc = indexDescription.GetIndexImplTableDescriptions(0);
                 }
                 const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
-                result.push_back(createIndexImplTable(CalcFulltextImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
-                    indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType)));
+                result.push_back(createIndexImplTable(compact
+                    ? CalcFulltextCompactImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
+                        userIndexDesc, &indexDescription.GetFulltextIndexDescription(), indexType)
+                    : CalcFulltextImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
+                        indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType)));
                 break;
             }
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+                compact = true;
+                [[fallthrough]];
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
                 NKikimrSchemeOp::TTableDescription userIndexDesc, docsTableDesc, dictTableDesc, statsTableDesc;
                 if (indexDescription.IndexImplTableDescriptionsSize() == 4) {
@@ -393,8 +407,11 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                     userIndexDesc = indexDescription.GetIndexImplTableDescriptions(NTableIndex::NFulltext::PostingTablePosition);
                 }
                 const THashSet<TString> indexDataColumns{indexDescription.GetDataColumnNames().begin(), indexDescription.GetDataColumnNames().end()};
-                result.push_back(createIndexImplTable(CalcFulltextImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
-                    indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType)));
+                result.push_back(createIndexImplTable(compact
+                    ? CalcFulltextCompactImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
+                        userIndexDesc, &indexDescription.GetFulltextIndexDescription(), indexType)
+                    : CalcFulltextImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(),
+                        indexDataColumns, userIndexDesc, indexDescription.GetFulltextIndexDescription(), indexType)));
                 result.push_back(createIndexImplTable(CalcFulltextDocsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), indexDataColumns, docsTableDesc)));
                 result.push_back(createIndexImplTable(CalcFulltextDictImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), dictTableDesc, indexDescription.GetFulltextIndexDescription())));
                 result.push_back(createIndexImplTable(CalcFulltextStatsImplTableDesc(baseTableDescription, baseTableDescription.GetPartitionConfig(), statsTableDesc)));

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -78,6 +78,7 @@ static std::optional<NKikimrSchemeOp::TModifyScheme> CreateIndexTask(NKikimr::NS
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
         case NKikimrSchemeOp::EIndexTypeLocalMinMax:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
@@ -88,6 +89,8 @@ static std::optional<NKikimrSchemeOp::TModifyScheme> CreateIndexTask(NKikimr::NS
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             *operation->MutableFulltextIndexDescription() =
                 std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexInfo->SpecializedIndexDescription);
             break;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -1067,6 +1067,7 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
                 case NKikimrSchemeOp::EIndexTypeGlobalAsync:
                 case NKikimrSchemeOp::EIndexTypeGlobalUnique:
                 case NKikimrSchemeOp::EIndexTypeGlobalJson:
+                case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                 case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                     // no specialized index description
                     Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
@@ -1077,6 +1078,8 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
                     break;
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+                case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+                case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
                     *operation->MutableFulltextIndexDescription() =
                         std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexInfo->SpecializedIndexDescription);
                     break;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_truncate_table.cpp
@@ -435,6 +435,9 @@ bool DfsOnTableChildrenTree(
                             case NKikimrSchemeOp::EIndexTypeGlobalJson:
                             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
                             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+                            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+                            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+                            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
                             case NKikimrSchemeOp::EIndexTypeGlobal:
                             case NKikimrSchemeOp::EIndexTypeGlobalUnique: {
                                 if (!DfsOnTableChildrenTree(opId, tx, context, childPathId, result, ESchemeObjectType::GenericIndex)) {

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
@@ -415,6 +415,14 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
 
     TSerializedCellVec splitKey = getSplitBoundary(rec.GetTableStats(), GetKeyColumnTypes(*tableInfo));
 
+    if ((tableInfo->TableDescription.GetIndexImplType() == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact ||
+        tableInfo->TableDescription.GetIndexImplType() == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance ||
+        tableInfo->TableDescription.GetIndexImplType() == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact) &&
+        splitKey.GetCells().size() > 1) {
+        // For now, only allow to split compact fulltext index table by __ydb_token
+        splitKey = TSerializedCellVec(splitKey.GetCells().Slice(0, 1));
+    }
+
     if (splitKey.GetBuffer().empty()) {
         LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxPartitionHistogram Failed to find proper split key for"

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5533,6 +5533,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     EnableAddUniqueIndex = appData->FeatureFlags.GetEnableAddUniqueIndex();
     EnableOnlineAddUniqueIndex = appData->FeatureFlags.GetEnableOnlineAddUniqueIndex();
     EnableFulltextIndex = appData->FeatureFlags.GetEnableFulltextIndex();
+    EnableCompactFulltextIndex = appData->FeatureFlags.GetEnableCompactFulltextIndex();
     EnableJsonIndex = appData->FeatureFlags.GetEnableJsonIndex();
     EnableResourcePoolsOnServerless = appData->FeatureFlags.GetEnableResourcePoolsOnServerless();
     EnableExternalDataSourcesOnServerless = appData->FeatureFlags.GetEnableExternalDataSourcesOnServerless();
@@ -8504,6 +8505,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TFeatureFlags& featu
     EnableInitialUniqueIndex = featureFlags.GetEnableUniqConstraint();
     EnableAddUniqueIndex = featureFlags.GetEnableAddUniqueIndex();
     EnableFulltextIndex = featureFlags.GetEnableFulltextIndex();
+    EnableCompactFulltextIndex = featureFlags.GetEnableCompactFulltextIndex();
     EnableJsonIndex = featureFlags.GetEnableJsonIndex();
     EnableExternalDataSourcesOnServerless = featureFlags.GetEnableExternalDataSourcesOnServerless();
     EnableShred = featureFlags.GetEnableDataErasure();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -417,6 +417,7 @@ public:
     bool EnableAddUniqueIndex = false;
     bool EnableOnlineAddUniqueIndex = false;
     bool EnableFulltextIndex = false;
+    bool EnableCompactFulltextIndex = false;
     bool EnableJsonIndex = false;
     bool EnableExternalDataSourcesOnServerless = false;
     bool EnableShred = false;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -816,6 +816,10 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         alterData->TableDescriptionFull->SetUniqueIndexKeySize(op.GetUniqueIndexKeySize());
     }
 
+    if (op.HasIndexImplType()) {
+        alterData->TableDescriptionFull->SetIndexImplType(op.GetIndexImplType());
+    }
+
     if (source) {
         // key columns reorder or deletion is not supported
         const TVector<ui32>& oldColIds = source->KeyColumnIds;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3018,6 +3018,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                 // no specialized index description
                 Y_ASSERT(description.empty());
@@ -3030,7 +3031,9 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
                 break;
             }
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-            case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance: {
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance: {
                 auto success = SpecializedIndexDescription
                     .emplace<NKikimrSchemeOp::TFulltextIndexDescription>()
                     .ParseFromString(description);
@@ -3114,6 +3117,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                 // no specialized index description
                 break;
@@ -3122,6 +3126,8 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
                 break;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
                 alterData->SpecializedIndexDescription = config.GetFulltextIndexDescription();
                 break;
             case NKikimrSchemeOp::EIndexTypeLocalBloomFilter:

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -209,7 +209,7 @@ TPathElement::EPathSubType TPathDescriber::CalcPathSubType(const TPath& path) {
                 case NKikimrSchemeOp::EIndexTypeLocalBloomNgramFilter:
                     return TPathElement::EPathSubType::EPathSubTypeLocalBloomNgramFilterIndex;
                 case NKikimrSchemeOp::EIndexTypeLocalMinMax:
-                    return TPathElement::EPathSubType::EPathSubTypeLocalMinMaxIndex;                
+                    return TPathElement::EPathSubType::EPathSubTypeLocalMinMaxIndex;
                 case NKikimrSchemeOp::EIndexTypeInvalid:
                 case NKikimrSchemeOp::EIndexTypeGlobal:
                 case NKikimrSchemeOp::EIndexTypeGlobalAsync:
@@ -218,6 +218,9 @@ TPathElement::EPathSubType TPathDescriber::CalcPathSubType(const TPath& path) {
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
                 case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
                 case NKikimrSchemeOp::EIndexTypeGlobalJson:
+                case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+                case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+                case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                     break;
             }
         }
@@ -245,8 +248,11 @@ TPathElement::EPathSubType TPathDescriber::CalcPathSubType(const TPath& path) {
                 return TPathElement::EPathSubType::EPathSubTypeVectorKmeansTreeIndexImplTable;
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
             case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
                 return TPathElement::EPathSubType::EPathSubTypeFulltextIndexImplTable;
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                 return TPathElement::EPathSubType::EPathSubTypeJsonIndexImplTable;
             default:
                 Y_DEBUG_ABORT_S(NTableIndex::InvalidIndexType(indexInfo->Type));
@@ -1538,6 +1544,7 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
         case NKikimrSchemeOp::EIndexTypeLocalMinMax:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
@@ -1547,6 +1554,8 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             *entry.MutableFulltextIndexDescription() = std::get<NKikimrSchemeOp::TFulltextIndexDescription>(indexInfo->SpecializedIndexDescription);
             break;
         case NKikimrSchemeOp::EIndexTypeLocalBloomFilter:

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -1833,6 +1833,7 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
             break;
         }
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
             FillGlobalIndexSettings(
                 *index->mutable_global_fulltext_plain_index()->mutable_settings(),
                 tableIndex.GetIndexImplTableDescriptions(0)
@@ -1842,6 +1843,7 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
 
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             FillGlobalIndexSettings(
                 *index->mutable_global_fulltext_relevance_index()->mutable_dict_table_settings(),
                 tableIndex.GetIndexImplTableDescriptions(NTableIndex::NFulltext::DictTablePosition)
@@ -1863,6 +1865,7 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
 
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalJsonCompact:
             FillGlobalIndexSettings(
                 *index->mutable_global_json_index()->mutable_settings(),
                 tableIndex.GetIndexImplTableDescriptions(0)

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -240,6 +240,7 @@ message FulltextIndexSettings {
     repeated ColumnAnalyzers columns = 2;
 }
 
+// Without EnableCompactFulltextIndex feature flag (old version):
 // Simplest possible layout without support for relevance.
 // Uses a single flat inverted index table (indexImplTable).
 // Supports a single column only.
@@ -263,6 +264,23 @@ message FulltextIndexSettings {
 //     │ "quick"      │ 1  │
 //     │ "quick"      │ 2  │
 //     └──────────────┴────┘
+//
+// With EnableCompactFulltextIndex feature flag (new version):
+// Compact fulltext index format with segmented storage.
+// Index table stores varint+delta-compressed binary segments (document ID lists)
+// instead of individual document IDs.
+// Example inverted index table (indexImplTable):
+//     ┌──────────────┬──────────────┬──────────────────┬─────────────┬───────────────┐
+//     │ __ydb_token  │ __ydb_max_id │ __ydb_generation | __ydb_added | __ydb_segment │
+//     ├──────────────┼──────────────┼──────────────────┼─────────────┼───────────────┤
+//     │ "The"        │ 2^64-1       │ 2^64-1           │ true        │ 1 2           │
+//     │ "blue"       │ 2^64-1       │ 2^64-1           │ true        │ 2             │
+//     │ "brown"      │ 2^64-1       │ 2^64-1           │ true        │ 1             │
+//     │ "fox"        │ 2^64-1       │ 2^64-1           │ true        │ 1             │
+//     │ "hare"       │ 2^64-1       │ 2^64-1           │ true        │ 2             │
+//     │ "quick"      │ 2^64-1       │ 2^64-1           │ true        │ 1 2           │
+//     └──────────────┴──────────────┴──────────────────┴─────────────┴───────────────┘
+
 message GlobalFulltextPlainIndex {
     GlobalIndexSettings settings = 1;
     FulltextIndexSettings fulltext_settings = 2;
@@ -277,6 +295,7 @@ message GlobalFulltextPlainIndex {
 //     │ 1  │ "A quick fox catches quick hare"      │
 //     │ 2  │ "The quick blue hare"                 │
 //     └────┴───────────────────────────────────────┘
+// Without EnableCompactFulltextIndex feature flag (old version):
 // Example inverted index table with term frequencies (indexImplTable):
 //     ┌──────────────┬────┬────────────┐
 //     │ __ydb_token  │ id │ __ydb_freq │
@@ -291,6 +310,20 @@ message GlobalFulltextPlainIndex {
 //     │ "quick"      │ 1  │ 2          │
 //     │ "quick"      │ 2  │ 1          │
 //     └──────────────┴────┴────────────┘
+// With EnableCompactFulltextIndex feature flag (new version):
+//     ┌──────────────┬──────────────┬──────────────────┬─────────────┬───────────────┐
+//     │ __ydb_token  │ __ydb_max_id │ __ydb_generation | __ydb_added | __ydb_segment │
+//     ├──────────────┼──────────────┼──────────────────┼─────────────┼───────────────┤
+//     │ "A"          │ 2^64-1       │ 2^64-1           │ true        │ 1:1           │
+//     │ "The"        │ 2^64-1       │ 2^64-1           │ true        │ 2:1           │
+//     │ "blue"       │ 2^64-1       │ 2^64-1           │ true        │ 2:1           │
+//     │ "catches"    │ 2^64-1       │ 2^64-1           │ true        │ 1:1           │
+//     │ "fox"        │ 2^64-1       │ 2^64-1           │ true        │ 1:1           │
+//     │ "hare"       │ 2^64-1       │ 2^64-1           │ true        │ 1:1 2:1       │
+//     │ "quick"      │ 2^64-1       │ 2^64-1           │ true        │ 1:2 2:1       │
+//     └──────────────┴──────────────┴──────────────────┴─────────────┴───────────────┘
+//
+// Other tables are the same for both compressed and uncompressed formats:
 // Term dictionary table (indexImplDictTable):
 //     ┌──────────────┬────────────┐
 //     │ __ydb_token  │ __ydb_freq │

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -790,10 +790,13 @@ NYdb::NTable::EIndexType ConvertIndexTypeToAPI(NKikimrSchemeOp::EIndexType index
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             return NYdb::NTable::EIndexType::GlobalVectorKMeansTree;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
             return NYdb::NTable::EIndexType::GlobalFulltextPlain;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
             return NYdb::NTable::EIndexType::GlobalFulltextRelevance;
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             return NYdb::NTable::EIndexType::GlobalJson;
         default:
             UNIT_FAIL("No conversion to API for this index type");
@@ -807,6 +810,7 @@ void TestRestoreTableWithIndex(
 ) {
     using namespace fmt::literals;
     TString query;
+    TString type;
     switch (indexType) {
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
@@ -845,28 +849,24 @@ void TestRestoreTableWithIndex(
             }
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain:
-            query = fmt::format(R"(CREATE TABLE `{table}` (
-                Key Uint64,
-                Group Uint32,
-                Value String,
-                PRIMARY KEY (Key),
-                INDEX {index} GLOBAL USING fulltext_plain
-                    ON (Value)
-                    WITH (tokenizer=standard, use_filter_lowercase=true, use_filter_length=true, filter_length_max=42)
-                ))", "table"_a = table, "index"_a = index);
-            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact:
+            type = type.empty() ? "fulltext_plain" : type;
+            [[fallthrough]];
         case NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance:
+        case NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance:
+            type = type.empty() ? "fulltext_relevance" : type;
             query = fmt::format(R"(CREATE TABLE `{table}` (
                 Key Uint64,
                 Group Uint32,
                 Value String,
                 PRIMARY KEY (Key),
-                INDEX {index} GLOBAL USING fulltext_relevance
+                INDEX {index} GLOBAL USING {type}
                     ON (Value)
                     WITH (tokenizer=standard, use_filter_lowercase=true, use_filter_length=true, filter_length_max=42)
-                ))", "table"_a = table, "index"_a = index);
+                ))", "table"_a = table, "index"_a = index, "type"_a = type);
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             query = fmt::format(R"(CREATE TABLE `{table}` (
                 Key Uint64,
                 Group Uint32,
@@ -2883,6 +2883,11 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
 
     void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false) {
         NKikimrConfig::TAppConfig appConfig;
+        if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact ||
+            indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance ||
+            indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact) {
+            appConfig.MutableFeatureFlags()->SetEnableCompactFulltextIndex(true);
+        }
         appConfig.MutableFeatureFlags()->SetEnableVectorIndex(true);
         appConfig.MutableFeatureFlags()->SetEnableAddUniqueIndex(true);
         appConfig.MutableFeatureFlags()->SetEnableFulltextIndex(true);
@@ -3392,6 +3397,9 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             case EIndexTypeGlobalFulltextPlain:
             case EIndexTypeGlobalFulltextRelevance:
             case EIndexTypeGlobalJson:
+            case EIndexTypeGlobalFulltextCompact:
+            case EIndexTypeGlobalFulltextCompactRelevance:
+            case EIndexTypeGlobalJsonCompact:
                 return TestTableWithIndexBackupRestore(Value);
             case EIndexTypeLocalBloomFilter:
             case EIndexTypeLocalBloomNgramFilter:
@@ -4403,6 +4411,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
 
     void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false) {
         TS3TestEnv testEnv;
+        if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact ||
+            indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance ||
+            indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact) {
+            testEnv.GetServer().GetRuntime()->GetAppData().FeatureFlags.SetEnableCompactFulltextIndex(true);
+        }
         constexpr const char* table = "/Root/table";
         constexpr const char* index = "value_idx";
 
@@ -4708,6 +4721,9 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             case EIndexTypeGlobalFulltextPlain:
             case EIndexTypeGlobalFulltextRelevance:
             case EIndexTypeGlobalJson:
+            case EIndexTypeGlobalFulltextCompact:
+            case EIndexTypeGlobalFulltextCompactRelevance:
+            case EIndexTypeGlobalJsonCompact:
                 TestTableWithIndexBackupRestore(Value);
                 break;
             case EIndexTypeLocalBloomFilter:


### PR DESCRIPTION
### Changelog

* Support a new "compact" fulltext index format which allows much more compact storage (10x-20x compared to the previous implementation) and faster searching (~4x). A new feature flag switches all newly built fulltext indexes to the new format: EnableCompactFulltextIndex.

### Changelog category

* New feature

### Description for reviewers

Part 2 of #42110 - feature flag and index build support (no update and search support yet).