### PR TITLE
Fix TestJoinStreaming::test_streamlookup_watermarks

### DIFF
--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -1094,7 +1094,7 @@ class TestJoinStreaming(TestYdsBase):
             ;
             $enriched =
                 SELECT CAST(HOP_END() AS Uint64)/1000000ul as hopTime, uid, ListSort(AGGREGATE_LIST(ts)) AS tsList FROM $enriched
-                    GROUP BY HoppingWindow(event_time, 'PT5S', 'PT10S', "max" AS TimeLimit)
+                    GROUP BY HoppingWindow(event_time, 'PT5S', 'PT10S')
                             , uid
                 ;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix test_streamlookup_watermarks

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Error: yql/essentials/minikql/mkql_program_builder.cpp:5806: Runtime version (67) too old for MultiHoppingCore