### PR TITLE
Yq 5065 finalization fix

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -2530,9 +2530,6 @@ private:
                 StartLeaseChecking(event.RunScriptActorId, event.LeaseGeneration);
             }
         } else {
-            // Do not re-trigger finalization from GetOperation: it is already handled by
-            // TKqpFinalizeScriptService after query completion. Re-triggering caused duplicate
-            // finalize requests and spurious EXEC_STATUS_ABORTED during S3 atomic commit.
             Reply();
         }
     }

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1688,6 +1688,13 @@ public:
                         return;
                     }
                     Response->WaitFinalizationOrRetry = true;
+                    Response->OperationStatus = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
+                    if (const auto executionStatus = executionsResult.ColumnParser("execution_status").GetOptionalInt32()) {
+                        Response->ExecutionStatus = static_cast<Ydb::Query::ExecStatus>(*executionStatus);
+                    }
+                    if (const auto issuesSerialized = executionsResult.ColumnParser("issues").GetOptionalJsonDocument()) {
+                        Response->OperationIssues = DeserializeIssues(*issuesSerialized);
+                    }
                     break;
             }
 
@@ -1820,7 +1827,13 @@ private:
         } else if (event.LeaseExpired) {
             StartLeaseChecking(event.RunScriptActorId, event.LeaseGeneration);
         } else if (const auto finalizationStatus = event.FinalizationStatus) {
-            StartScriptFinalization(*finalizationStatus, event.OperationStatus, event.ExecutionStatus, event.Issues, event.LeaseGeneration);
+            const bool finalizationInProgress = event.WaitFinalizationOrRetry && !event.LeaseExpired;
+            if (!finalizationInProgress && event.OperationStatus && event.ExecutionStatus) {
+                auto issues = event.OperationIssues ? *event.OperationIssues : event.Issues;
+                StartScriptFinalization(*finalizationStatus, *event.OperationStatus, *event.ExecutionStatus, std::move(issues), event.LeaseGeneration);
+            } else {
+                Reply();
+            }
         } else {
             Reply();
         }
@@ -2389,8 +2402,14 @@ public:
         if (Response->FinalizationStatus || LeaseStatus && *LeaseStatus == ELeaseState::WaitRetry) {
             Response->Ready = false;
             if (OperationStatus) {
-                Response->Issues.AddIssue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << (Response->FinalizationStatus ? "finalization" : "retry"));
+                NYql::TIssue issue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << (Response->FinalizationStatus ? "finalization" : "retry"));
+                issue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
+                Response->Issues.AddIssue(std::move(issue));
                 OperationStatus = std::nullopt;
+            }
+            if (Response->FinalizationStatus) {
+                // Keep polling until S3 external effects are applied (e.g. atomic multipart commit).
+                Response->Metadata.set_exec_status(Ydb::Query::EXEC_STATUS_RUNNING);
             }
         }
 
@@ -2510,13 +2529,10 @@ private:
             } else {
                 StartLeaseChecking(event.RunScriptActorId, event.LeaseGeneration);
             }
-        } else if (const auto finalizationStatus = event.FinalizationStatus) {
-            TMaybe<Ydb::Query::ExecStatus> execStatus;
-            if (Response->Get()->Ready) {
-                execStatus = Response->Get()->Metadata.exec_status();
-            }
-            StartScriptFinalization(*Response->Get()->FinalizationStatus, Response->Get()->Status, execStatus, Response->Get()->Issues, event.LeaseGeneration);
         } else {
+            // Do not re-trigger finalization from GetOperation: it is already handled by
+            // TKqpFinalizeScriptService after query completion. Re-triggering caused duplicate
+            // finalize requests and spurious EXEC_STATUS_ABORTED during S3 atomic commit.
             Reply();
         }
     }

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -455,6 +455,102 @@ struct TScriptExecutionsYdbSetup {
         }
     }
 
+    void SetAtomicUploadFinalizationInProgress(const TString& executionId, i64 leaseGeneration = 1) {
+        const TString sql = R"(
+            DECLARE $database AS Utf8;
+            DECLARE $execution_id AS Utf8;
+            DECLARE $operation_status AS Int32;
+            DECLARE $execution_status AS Int32;
+            DECLARE $finalization_status AS Int32;
+            DECLARE $customer_supplied_id AS Utf8;
+            DECLARE $script_sinks AS JsonDocument;
+            DECLARE $lease_deadline AS Timestamp;
+            DECLARE $lease_state AS Int32;
+            DECLARE $lease_generation AS Int64;
+
+            UPDATE `.metadata/script_executions`
+            SET
+                operation_status = $operation_status,
+                execution_status = $execution_status,
+                finalization_status = $finalization_status,
+                customer_supplied_id = $customer_supplied_id,
+                script_sinks = $script_sinks,
+                end_ts = CurrentUtcTimestamp()
+            WHERE database = $database AND execution_id = $execution_id;
+
+            UPSERT INTO `.metadata/script_execution_leases` (
+                database, execution_id, lease_deadline, lease_generation, lease_state
+            ) VALUES (
+                $database, $execution_id, $lease_deadline, $lease_generation, $lease_state
+            );
+        )";
+
+        NYdb::TParamsBuilder params;
+        params
+            .AddParam("$database")
+                .Utf8(TestDatabase)
+                .Build()
+            .AddParam("$execution_id")
+                .Utf8(executionId)
+                .Build()
+            .AddParam("$operation_status")
+                .Int32(Ydb::StatusIds::SUCCESS)
+                .Build()
+            .AddParam("$execution_status")
+                .Int32(Ydb::Query::EXEC_STATUS_COMPLETED)
+                .Build()
+            .AddParam("$finalization_status")
+                .Int32(static_cast<i32>(EFinalizationStatus::FS_COMMIT))
+                .Build()
+            .AddParam("$customer_supplied_id")
+                .Utf8("test_job_id")
+                .Build()
+            .AddParam("$script_sinks")
+                .JsonDocument("[]")
+                .Build()
+            .AddParam("$lease_deadline")
+                .Timestamp(TInstant::Now() + TestLeaseDuration)
+                .Build()
+            .AddParam("$lease_state")
+                .Int32(static_cast<i32>(NPrivate::ELeaseState::ScriptFinalizing))
+                .Build()
+            .AddParam("$lease_generation")
+                .Int64(leaseGeneration)
+                .Build();
+
+        const auto result = TableClientSession->ExecuteDataQuery(
+            sql, NYdb::NTable::TTxControl::BeginTx().CommitTx(), params.Build()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    std::optional<i32> GetFinalizationStatus(const TString& executionId) {
+        const TString sql = R"(
+            DECLARE $database AS Utf8;
+            DECLARE $execution_id AS Utf8;
+
+            SELECT finalization_status
+            FROM `.metadata/script_executions`
+            WHERE database = $database AND execution_id = $execution_id;
+        )";
+
+        NYdb::TParamsBuilder params;
+        params
+            .AddParam("$database")
+                .Utf8(TestDatabase)
+                .Build()
+            .AddParam("$execution_id")
+                .Utf8(executionId)
+                .Build();
+
+        const auto result = TableClientSession->ExecuteDataQuery(
+            sql, NYdb::NTable::TTxControl::BeginTx().CommitTx(), params.Build()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+
+        NYdb::TResultSetParser parser(result.GetResultSet(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        return parser.ColumnParser("finalization_status").GetOptionalInt32();
+    }
+
 private:
     NKikimrKqp::TEvQueryRequest GetQueryRequest(const TString& query) {
         NKikimrKqp::TEvQueryRequest queryProto;
@@ -659,6 +755,48 @@ Y_UNIT_TEST_SUITE(ScriptExecutionsTest) {
         ydb.WaitOperationStatus(executionId, Ydb::StatusIds::UNAVAILABLE);
 
         ydb.CheckLeaseExistence(executionId, false, Ydb::StatusIds::UNAVAILABLE);
+    }
+
+    Y_UNIT_TEST(GetOperationDuringAtomicUploadFinalization) {
+        TScriptExecutionsYdbSetup ydb;
+
+        const TString executionId = ydb.CreateQueryInDb();
+        ydb.SetAtomicUploadFinalizationInProgress(executionId);
+        UNIT_ASSERT(ydb.GetFinalizationStatus(executionId));
+
+        for (size_t i = 0; i < 3; ++i) {
+            const auto response = ydb.GetScriptExecutionOperation(executionId);
+            const auto& ev = *response->Get();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(ev.Status, Ydb::StatusIds::SUCCESS, ev.Issues.ToString());
+            UNIT_ASSERT(!ev.Ready);
+            UNIT_ASSERT(ev.Metadata);
+
+            Ydb::Query::ExecuteScriptMetadata metadata;
+            ev.Metadata->UnpackTo(&metadata);
+            UNIT_ASSERT_C(
+                metadata.exec_status() == Ydb::Query::EXEC_STATUS_RUNNING,
+                Ydb::Query::ExecStatus_Name(metadata.exec_status()));
+            UNIT_ASSERT_STRING_CONTAINS(ev.Issues.ToString(), "wait finalization");
+            UNIT_ASSERT_STRING_CONTAINS(ev.Issues.ToString(), "Info:");
+            UNIT_ASSERT_C(
+                !ev.Issues.ToString().Contains("Finalization is not complete"),
+                ev.Issues.ToString());
+        }
+
+        UNIT_ASSERT(ydb.GetFinalizationStatus(executionId));
+
+        const auto leaseCheck = ydb.CheckLeaseStatus(executionId);
+        UNIT_ASSERT_VALUES_EQUAL(leaseCheck->Get()->Status, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(leaseCheck->Get()->WaitFinalizationOrRetry);
+        UNIT_ASSERT(leaseCheck->Get()->OperationStatus);
+        UNIT_ASSERT_VALUES_EQUAL(*leaseCheck->Get()->OperationStatus, Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT(leaseCheck->Get()->ExecutionStatus);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<i32>(*leaseCheck->Get()->ExecutionStatus),
+            static_cast<i32>(Ydb::Query::EXEC_STATUS_COMPLETED));
+
+        UNIT_ASSERT(ydb.GetFinalizationStatus(executionId));
     }
 
     Y_UNIT_TEST(BackgroundChecksStartAfterRestart) {


### PR DESCRIPTION
Fix spurious ABORTED status during S3 atomic upload finalization GetOperation with CheckLeaseState re-triggered StartScriptFinalization while finalization_status was already set, without exec_status. That produced "Finalization is not complete", forced EXEC_STATUS_ABORTED, and raced with TKqpFinalizeScriptService / S3 applicator (duplicate finalize, premature Forget).

- Do not start finalization from GetOperation; only report in-progress
  state (Ready=false, exec_status=RUNNING)
- Mark "wait finalization" issue as INFO
- Run StartScriptFinalization from lease check only for recovery, not
  while ScriptFinalizing lease is active
- Populate operation/execution status in lease check for ScriptFinalizing
