### PR TITLE
Fix vhost evloop contention failing partition tests

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/bootstrap/bootstrap.cpp
+++ b/ydb/core/nbs/cloud/blockstore/bootstrap/bootstrap.cpp
@@ -89,6 +89,9 @@ const NKikimrConfig::TNbsConfig& TNbsService::GetConfig() const
 
 void CreateNbsService(const NKikimrConfig::TNbsConfig& config)
 {
+    // Ensure existing NbsService (if any) is destroyed BEFORE a new one
+    // is constructed to prevent global vhost queue contention.
+    NbsService = nullptr;
     NbsService = std::make_shared<TNbsService>(config);
 }
 


### PR DESCRIPTION
Closes #41062
Closes #40867
Closes #37752
Closes #37684

Every second call of `CreateNbsService()` on a test chunk resulted in non-acquired vhost event loop
due to a construction/destruction contention, causing every second test case in a chunk fail.

Root cause: g_vhost_evloop contention during re-creating NbsService
```c++
// Original code
void CreateNbsService(const NKikimrConfig::TNbsConfig& config)
{
    NbsService = std::make_shared<TNbsService>(config);
}
```
Failure sequence
1. `CreateNbsService()`
   1. `std::make_shared<TNbsService>(config)` Acquires event loop
2. `CreateNbsService()`
   1. `std::make_shared<TNbsService>(config)` Re-acquires evloop (since it is aquired nothing happens)
   3. Destruction of old NbsService releases the event loop despite already not owning it semantically

