### PR TITLE
Fixed the commit lag for empty batches

### DIFF
--- a/ydb/core/transfer/transfer_writer.cpp
+++ b/ydb/core/transfer/transfer_writer.cpp
@@ -328,21 +328,23 @@ private:
             }
         }
 
-        if (!ProcessingError && (TableState->BatchSize() >= BatchSizeBytes || *LastWriteTime < TInstant::Now() - FlushInterval || RequiredFlush)) {
-            if (TableState->Flush()) {
-                SendStats(EWorkerOperation::WRITE);
-                LastWriteTime.reset();
-                return Become(&TThis::StateWrite);
+        if (ProcessingError) {
+            SendStats(EWorkerOperation::NONE);
+            return LogCritAndLeave(*ProcessingError);
+        } else {
+            if (TableState->BatchSize() == 0 && LastProcessedOffset) {
+                Send(Worker, new TEvWorker::TEvCommit(LastProcessedOffset.value() + 1));
+            } else if (TableState->BatchSize() >= BatchSizeBytes || *LastWriteTime < TInstant::Now() - FlushInterval || RequiredFlush) {
+                if (TableState->Flush()) {
+                    SendStats(EWorkerOperation::WRITE);
+                    LastWriteTime.reset();
+                    return Become(&TThis::StateWrite);
+                }
             }
         }
 
-        if (ProcessingError) {
-            SendStats(EWorkerOperation::NONE);
-            LogCritAndLeave(*ProcessingError);
-        } else {
-            PollSent = true;
-            Send(Worker, new TEvWorker::TEvPoll(true));
-        }
+        PollSent = true;
+        Send(Worker, new TEvWorker::TEvPoll(true));
     }
 
     void TryFlush() {

--- a/ydb/core/transfer/ut/functional/transfer_ut.cpp
+++ b/ydb/core/transfer/ut/functional/transfer_ut.cpp
@@ -486,6 +486,49 @@ Y_UNIT_TEST_SUITE(Transfer)
         CheckCommittedOffset(false);
     }
 
+    void CheckCommittedOffsetEmptyBatch(bool local)
+    {
+        MainTestCase testCase;
+
+        testCase.CreateTable(R"(
+                CREATE TABLE `%s` (
+                    Key Uint64 NOT NULL,
+                    Message Utf8,
+                    PRIMARY KEY (Key)
+                )  WITH (
+                    STORE = ROW
+                );
+            )");
+        testCase.CreateTopic(1);
+        testCase.CreateTransfer(R"(
+                $l = ($x) -> {
+                    $json = CAST($x._data AS JSON);
+                    return IF (JSON_EXISTS($json, "$.update"), [
+                        <|
+                            Key:CAST($x._offset AS Uint64),
+                            Message:CAST($x._data AS Utf8)
+                        |>
+                    ], []);
+                };
+        )", MainTestCase::CreateTransferSettings::WithLocalTopic(local));
+
+        testCase.Write({"Message-1"});
+
+        testCase.CheckCommittedOffset(0, 1);
+
+        testCase.DropTransfer();
+        testCase.DropTable();
+        testCase.DropTopic();
+    }
+
+    Y_UNIT_TEST(CheckCommittedOffsetEmptyBatch_Local) {
+        CheckCommittedOffsetEmptyBatch(true);
+    }
+
+    Y_UNIT_TEST(CheckCommittedOffsetEmptyBatch_Remote) {
+        CheckCommittedOffsetEmptyBatch(false);
+    }
+
     Y_UNIT_TEST(DropTransfer)
     {
         MainTestCase testCase;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Поправлена ошибка в трансфере. Если приходили сообщения , которые не надо было записывать в таблицу, то в топик не коммитились оффсеты, и рос лаг незакоммиченных сообщений в топике.

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->


