### PR TITLE
Disable S3 export on Windows in export library

### DIFF
--- a/ydb/apps/ydbd/export/ya.make
+++ b/ydb/apps/ydbd/export/ya.make
@@ -4,6 +4,12 @@ SRCS(
     export.cpp
 )
 
+IF (OS_WINDOWS)
+    CFLAGS(
+        -DKIKIMR_DISABLE_S3_OPS
+    )
+ENDIF()
+
 PEERDIR(
     yql/essentials/public/types
     ydb/core/tx/columnshard/engines/scheme/defaults/protos


### PR DESCRIPTION
## Summary
- Add `KIKIMR_DISABLE_S3_OPS` to `ydb/apps/ydbd/export/ya.make` on Windows
- The regression became visible after [#40985](https://github.com/ydb-platform/ydb/pull/40985) (*kqp run and export*, May 22): `kqprun` started linking `ydb/apps/ydbd/export` as a standalone library
- The underlying issue was introduced earlier in [#39918](https://github.com/ydb-platform/ydb/pull/39918) (May 12), when `export.cpp` was extracted from `ydbd` into a separate module without copying the Windows flag from `ydb/apps/ydbd/ya.make`
- Without the flag, `export.cpp` references `TS3Export` vtable symbols (`CreateUploader`, `CreateBuffer`) that are not compiled into `datashard` on Windows, causing `lld-link` undefined symbol errors

