### PR TITLE
Fix viewer allocation units without pool name

### DIFF
--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -7897,6 +7897,31 @@
             "text": "1\n"
         }
     },
+    "test.TestViewer.test_viewer_groups_allocation_units_without_pool_name": {
+        "FieldsAvailable": "000000100000100000100011111",
+        "FieldsRequired": "000000000000100000000000011",
+        "FoundGroups": 5,
+        "StorageGroups": [
+            {
+                "GroupId": "0"
+            },
+            {
+                "GroupId": "2181038080"
+            },
+            {
+                "GroupId": "2181038081"
+            },
+            {
+                "AllocationUnits": "34",
+                "GroupId": "2181038082"
+            },
+            {
+                "AllocationUnits": "54",
+                "GroupId": "2181038083"
+            }
+        ],
+        "TotalGroups": 5
+    },
     "test.TestViewer.test_viewer_groups_group_by_capacity_alert": [
         {
             "FieldsAvailable": "111110111111011111011110001",

--- a/ydb/core/viewer/tests/test.py
+++ b/ydb/core/viewer/tests/test.py
@@ -794,6 +794,12 @@ class TestViewer(object):
         }
 
     @classmethod
+    def test_viewer_groups_allocation_units_without_pool_name(cls):
+        return cls.get_viewer_normalized("/viewer/groups", {
+            'fields_required': 'AllocationUnits',
+        })
+
+    @classmethod
     def test_viewer_groups_with_invalid_database(cls):
         # Test that the endpoint doesn't crash when provided with an invalid database
         result = cls.call_viewer("/viewer/groups", {

--- a/ydb/core/viewer/viewer_groups.h
+++ b/ydb/core/viewer/viewer_groups.h
@@ -728,6 +728,7 @@ public:
         { EGroupFields::MaxNormalizedOccupancy, TFieldsType().set(+EGroupFields::NodeId) },
         { EGroupFields::MaxVDiskRawUsage, TFieldsType().set(+EGroupFields::NodeId) },
         { EGroupFields::CapacityAlert, TFieldsType().set(+EGroupFields::NodeId) },
+        { EGroupFields::AllocationUnits, TFieldsType().set(+EGroupFields::PoolName) },
     };
 
     bool FieldsNeeded(TFieldsType fields) const {


### PR DESCRIPTION
### What
- Make `AllocationUnits` internally depend on `PoolName` so storage pool metadata is loaded before collecting Hive stats.
- Add a canonical viewer test for requesting `AllocationUnits` without `PoolName`.

### Why
Fixes ydb-platform/ydb-embedded-ui#3972: allocation units were missing/zero when the UI hid the Pool Name column.

### Tests
- `./ya make --build relwithdebinfo -tA ydb/core/viewer -F '*test_viewer_groups_allocation_units_without_pool_name*' 2>&1 | tail`\n- `./ya make --build relwithdebinfo -tA ydb/core/viewer -F '*test_storage_groups*' 2>&1 | tail`\n\nNote: a full `./ya make --build relwithdebinfo -tA ydb/core/viewer 2>&1 | tail` run before adding the new test failed in unrelated tests with `Schemeshard not available` / missing `PathDescription`.