### PR TITLE
Yet another attempt to fix unstable kernel ping UT.

### DIFF
--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -500,12 +500,20 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
         settings.PingPeriod = TDuration::MilliSeconds(200);
     };
 
-    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, GetKernelLivenessFlags(withRdma),
+    TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+        .RejectingTrafficTimeout = TDuration::Zero(),
+        .BandWidth = 0.0,
+        .Disconnect = false,
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr, GetKernelLivenessFlags(withRdma),
         {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
 
     auto* recipientPtr = new TRecipientActor;
     const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
     cluster.RegisterActor(new TSenderActor(recipient), 2);
+    const TActorId dropRecipientOnNode1 = cluster.RegisterActor(new TDropRecipientActor, 1);
+    const TActorId dropRecipientOnNode2 = cluster.RegisterActor(new TDropRecipientActor, 2);
 
     WaitForCondition(TDuration::Seconds(10), [&] {
         return recipientPtr->GetReceived() >= 1;
@@ -521,25 +529,36 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
         }, description);
     };
 
-    auto reconnectFromNode2 = [&](TStringBuf description) {
-        const TString handshakeBefore = GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone");
-        auto sessionStaysAliveOnEof = [&](ui32 fromNode, ui32 toNode) {
-            const ui64 numEventsInQueue = GetSessionCounter(cluster, fromNode, toNode, "NumEventsInQueue");
-            const ui64 outputCounter = GetSessionCounter(cluster, fromNode, toNode, "OutputCounter");
-            const ui64 lastConfirmed = GetSessionCounter(cluster, fromNode, toNode, "LastConfirmed");
-            return numEventsInQueue > 0 || outputCounter != lastConfirmed;
-        };
+    auto sessionStaysAliveOnEof = [&](ui32 fromNode, ui32 toNode) {
+        const ui64 numEventsInQueue = GetSessionCounter(cluster, fromNode, toNode, "NumEventsInQueue");
+        const ui64 outputCounter = GetSessionCounter(cluster, fromNode, toNode, "OutputCounter");
+        const ui64 lastConfirmed = GetSessionCounter(cluster, fromNode, toNode, "LastConfirmed");
+        return numEventsInQueue > 0 || outputCounter != lastConfirmed;
+    };
 
-        // Keep both session instances alive after the socket is closed. This matches the session lifetime predicate
-        // used on EOF; otherwise the peer may destroy its idle session before accepting the continuation request.
+    auto sendPendingTraffic = [&] {
+        cluster.RegisterActor(new TBurstSenderActor(dropRecipientOnNode1, 4096, 4096), 2);
+        cluster.RegisterActor(new TBurstSenderActor(dropRecipientOnNode2, 4096, 4096), 1);
         WaitForCondition(TDuration::Seconds(10), [&] {
             try {
                 return sessionStaysAliveOnEof(2, 1) && sessionStaysAliveOnEof(1, 2);
             } catch (const TPatternNotFound&) {
                 return false;
             }
-        }, "both sessions stay alive on EOF before forced reconnect");
+        }, "both sessions have pending traffic while proxy forwarding is frozen");
+    };
+
+    auto reconnectFromNode2 = [&](TStringBuf description) {
+        const TString handshakeBefore = GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone");
+        // TEvClosePeerSocket is meant to exercise same-session continuation. Freeze proxy forwarding before the
+        // close so the peer cannot observe EOF and destroy an idle session before node2 has requested reconnect.
+        // Pending traffic keeps both session instances alive; after unfreezing, continuation has a peer session to resume.
+        cluster.StartBlackhole(1);
+        cluster.StartBlackhole(2);
+        sendPendingTraffic();
         cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvClosePeerSocket);
+        cluster.StopBlackhole(1);
+        cluster.StopBlackhole(2);
         WaitForCondition(TDuration::Seconds(20), [&] {
             try {
                 return GetSessionTextMetric(cluster, 2, 1, "LastHandshakeDone") != handshakeBefore &&

--- a/ydb/library/actors/interconnect/ut/lib/interrupter.h
+++ b/ydb/library/actors/interconnect/ut/lib/interrupter.h
@@ -106,12 +106,14 @@ public:
     void StartBlackhole() {
         ManualRejectingTraffic.store(true, std::memory_order_release);
         ManualRejectingTrafficOverride.store(true, std::memory_order_release);
+        WaitForManualStateObservation(ManualRejectingTrafficGeneration.fetch_add(1, std::memory_order_acq_rel) + 1);
     }
 
     // Disable forced blackhole and resume normal mode (random reject mode if configured, otherwise pass-through).
     void StopBlackhole() {
         ManualRejectingTraffic.store(false, std::memory_order_release);
         ManualRejectingTrafficOverride.store(true, std::memory_order_release);
+        WaitForManualStateObservation(ManualRejectingTrafficGeneration.fetch_add(1, std::memory_order_acq_rel) + 1);
     }
 
     // Drop manual override and return to legacy random reject toggling (when timeout is configured).
@@ -137,6 +139,16 @@ private:
     bool DelayTraffic;
     std::atomic<bool> ManualRejectingTrafficOverride = false;
     std::atomic<bool> ManualRejectingTraffic = false;
+    std::atomic<ui64> ManualRejectingTrafficGeneration = 0;
+    std::atomic<ui64> ObservedManualRejectingTrafficGeneration = 0;
+
+    void WaitForManualStateObservation(ui64 generation) const {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (ObservedManualRejectingTrafficGeneration.load(std::memory_order_acquire) < generation) {
+            Y_ABORT_UNLESS(TInstant::Now() < deadline, "timeout waiting for traffic interrupter manual state observation");
+            NanoSleep(1'000'000); // 1 ms
+        }
+    }
 
     void UpdateRejectingState() {
         if (TDuration::Seconds(std::abs(RejectingStateTimer.Passed())) > CurrentRejectingTimeout) {
@@ -167,11 +179,13 @@ private:
         Events.resize(10);
 
         while (Running.load(std::memory_order_acquire)) {
+            const ui64 manualGeneration = ManualRejectingTrafficGeneration.load(std::memory_order_acquire);
             if (ManualRejectingTrafficOverride.load(std::memory_order_acquire)) {
                 RejectingTraffic = ManualRejectingTraffic.load(std::memory_order_acquire);
             } else if (RejectingTrafficTimeout != TDuration::Zero()) {
                 UpdateRejectingState();
             }
+            ObservedManualRejectingTrafficGeneration.store(manualGeneration, std::memory_order_release);
             if (Disconnect) {
                 RandomlyDisconnect();
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The fix removes the timing-based race from the reconnect test.

Before, the test tried to force same-session continuation by closing the socket while hoping the peer session was still alive. That was flaky: the peer could observe EOF first, destroy its idle session, and then the resume path would not be exercised.

Now the test uses the existing traffic interrupter:

Enable a manual blackhole on both proxy directions.
Send pending traffic in both directions, so both session instances satisfy the “stay alive on EOF” condition.
Send TEvClosePeerSocket from node 2.
Disable the blackhole and let reconnect/continuation proceed.
I also made StartBlackhole/StopBlackhole synchronous in the test utility: they wait until the interrupter thread has actually observed the requested manual state. This replaces the old Sleep(200ms) style barrier with an explicit acknowledgement and avoids adding another race.
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
