### PR TITLE
Merged permissions into one ACE in each SDK grant expression

### DIFF
--- a/ydb/core/grpc_services/rpc_modify_permissions.cpp
+++ b/ydb/core/grpc_services/rpc_modify_permissions.cpp
@@ -65,24 +65,60 @@ private:
             switch (perm.action_case()) {
                 case Ydb::Scheme::PermissionsAction::kSet: {
                     acl.ClearAccessForSid(perm.set().subject());
+                    ui32 targetAccessMask = 0;
+                    std::optional<ui32> inheritanceType;
                     for (const auto& n : perm.set().permission_names()) {
                         auto aclAttrs = ConvertYdbPermissionNameToACLAttrs(n);
-                        acl.AddAccess(NACLib::EAccessType::Allow, aclAttrs.AccessMask, perm.set().subject(), aclAttrs.InheritanceType);
+                        targetAccessMask |= aclAttrs.AccessMask;
+                        if (inheritanceType && aclAttrs.InheritanceType != *inheritanceType) {
+                            throw NYql::TErrorException(NKikimrIssues::TIssuesIds::DEFAULT_ERROR)
+                                << "Distinct inheritance types in one permission action";
+                        }
+
+                        inheritanceType = aclAttrs.InheritanceType;
+                    }
+
+                    if (targetAccessMask) {
+                        acl.AddAccess(NACLib::EAccessType::Allow, targetAccessMask, perm.set().subject(), *inheritanceType);
                     }
                 }
                 break;
                 case Ydb::Scheme::PermissionsAction::kGrant:
                 {
+                    ui32 targetAccessMask = 0;
+                    std::optional<ui32> inheritanceType;
                     for (const auto& n : perm.grant().permission_names()) {
                         auto aclAttrs = ConvertYdbPermissionNameToACLAttrs(n);
-                        acl.AddAccess(NACLib::EAccessType::Allow, aclAttrs.AccessMask, perm.grant().subject(), aclAttrs.InheritanceType);
+                        targetAccessMask |= aclAttrs.AccessMask;
+                        if (inheritanceType && aclAttrs.InheritanceType != *inheritanceType) {
+                            throw NYql::TErrorException(NKikimrIssues::TIssuesIds::DEFAULT_ERROR)
+                                << "Distinct inheritance types in one permission action";
+                        }
+
+                        inheritanceType = aclAttrs.InheritanceType;
+                    }
+
+                    if (targetAccessMask) {
+                        acl.AddAccess(NACLib::EAccessType::Allow, targetAccessMask, perm.grant().subject(), *inheritanceType);
                     }
                 }
                 break;
                 case Ydb::Scheme::PermissionsAction::kRevoke: {
+                    ui32 targetAccessMask = 0;
+                    std::optional<ui32> inheritanceType;
                     for (const auto& n : perm.revoke().permission_names()) {
                         auto aclAttrs = ConvertYdbPermissionNameToACLAttrs(n);
-                        acl.RemoveAccess(NACLib::EAccessType::Allow, aclAttrs.AccessMask, perm.revoke().subject(), aclAttrs.InheritanceType);
+                        targetAccessMask |= aclAttrs.AccessMask;
+                        if (inheritanceType && aclAttrs.InheritanceType != *inheritanceType) {
+                            throw NYql::TErrorException(NKikimrIssues::TIssuesIds::DEFAULT_ERROR)
+                                << "Distinct inheritance types in one permission action";
+                        }
+
+                        inheritanceType = aclAttrs.InheritanceType;
+                    }
+
+                    if (targetAccessMask) {
+                        acl.RemoveAccess(NACLib::EAccessType::Allow, targetAccessMask, perm.revoke().subject(), *inheritanceType);
                     }
                 }
                 break;

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -539,10 +539,14 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
                 }
             }
 
-            auto permissionsSettings =
-                NYdb::NScheme::TModifyPermissionsSettings()
-                .AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", grantPermissions))
-                .AddRevokePermissions(NYdb::NScheme::TPermissions("user0@builtin", revokePermissions));
+            auto permissionsSettings = NYdb::NScheme::TModifyPermissionsSettings();
+            for (const auto& permission : grantPermissions) {
+                permissionsSettings.AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", {permission}));
+            }
+
+            for (const auto& permission : revokePermissions) {
+                permissionsSettings.AddRevokePermissions(NYdb::NScheme::TPermissions("user0@builtin", {permission}));
+            }
 
             auto schemeClient = kikimr.GetSchemeClient();
             auto result = schemeClient.ModifyPermissions("/Root/Test", permissionsSettings).ExtractValueSync();

--- a/ydb/core/kqp/ut/scheme/kqp_acl_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_acl_ut.cpp
@@ -296,9 +296,10 @@ Y_UNIT_TEST_SUITE(KqpAcl) {
 
         {
             auto schemeClient = kikimr.GetSchemeClient();
-            NYdb::NScheme::TPermissions permissions("user0@builtin", {"ydb.deprecated.describe_schema", "ydb.deprecated.select_row"});
             AssertSuccessResult(schemeClient.ModifyPermissions("/Root/test_acl",
-                    NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions)
+                    NYdb::NScheme::TModifyPermissionsSettings()
+                        .AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", {"ydb.deprecated.describe_schema"}))
+                        .AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", {"ydb.deprecated.select_row"}))
                 ).ExtractValueSync()
             );
         }
@@ -405,9 +406,10 @@ Y_UNIT_TEST_SUITE(KqpAcl) {
 
         {
             auto schemeClient = kikimr.GetSchemeClient();
-            NYdb::NScheme::TPermissions permissions("user0@builtin", {"ydb.deprecated.erase_row", "ydb.deprecated.update_row"});
             AssertSuccessResult(schemeClient.ModifyPermissions("/Root/test_acl",
-                    NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions)
+                    NYdb::NScheme::TModifyPermissionsSettings()
+                        .AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", {"ydb.deprecated.erase_row"}))
+                        .AddGrantPermissions(NYdb::NScheme::TPermissions("user0@builtin", {"ydb.deprecated.update_row"}))
                 ).ExtractValueSync()
             );
         }
@@ -658,7 +660,8 @@ Y_UNIT_TEST_SUITE(KqpAcl) {
         AddConnectPermission(kikimr, UserName);
 
         for (const auto permission : {"ydb.deprecated.describe_schema", "ydb.deprecated.update_row"}) {
-            AddPermissions(kikimr, "/Root/test_acl", UserName, {"ydb.deprecated.describe_schema", "ydb.deprecated.update_row"});
+            AddPermissions(kikimr, "/Root/test_acl", UserName, {"ydb.deprecated.describe_schema"});
+            AddPermissions(kikimr, "/Root/test_acl", UserName, {"ydb.deprecated.update_row"});
 
             auto driverConfig = TDriverConfig()
                 .SetEndpoint(kikimr.GetEndpoint())

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -5992,6 +5992,116 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
     }
 
+    Y_UNIT_TEST(GrantMergesPermissionsIntoSingleAce) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        {
+            auto driver = TDriver(TDriverConfig()
+                .SetEndpoint(kikimr.GetEndpoint())
+                .SetDatabase("/Root")
+                .SetAuthToken("root@builtin"));
+            auto client = NQuery::TQueryClient(driver);
+            AssertSuccessResult(client.ExecuteQuery(R"(
+                CREATE TABLE `/Root/test_acl` (
+                    id Int64 NOT NULL,
+                    primary key (id)
+                );
+            )", NQuery::TTxControl::NoTx()).ExtractValueSync());
+            driver.Stop(true);
+        }
+
+        // Within a single request:
+        //  - one action grants {ydb.granular.update_row, ydb.granular.erase_row}: the names share the same
+        //    inheritance type and are merged into a single ACE whose mask (UpdateRow|EraseRow) collapses back
+        //    into the composite name "ydb.tables.modify";
+        //  - a separate action grants ydb.granular.update_row to the same subject: being a distinct action,
+        //    it produces its own ACE, so it is not folded into the merged one.
+        auto schemeClient = kikimr.GetSchemeClient();
+        AssertSuccessResult(schemeClient.ModifyPermissions("/Root/test_acl",
+                NYdb::NScheme::TModifyPermissionsSettings()
+                    .AddGrantPermissions(NYdb::NScheme::TPermissions("user1", {"ydb.granular.update_row", "ydb.granular.erase_row"}))
+                    .AddGrantPermissions(NYdb::NScheme::TPermissions("user1", {"ydb.granular.update_row"}))
+            ).ExtractValueSync()
+        );
+
+        CheckPermissions(session,
+            {
+                {.Path = "/Root/test_acl",
+                    .Permissions = {
+                                {"user1", {"ydb.tables.modify", "ydb.granular.update_row"}},
+                    }
+                },
+            }
+        );
+    }
+
+    Y_UNIT_TEST(DistinctInheritanceTypesInSingleGrant) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        {
+            auto driver = TDriver(TDriverConfig()
+                .SetEndpoint(kikimr.GetEndpoint())
+                .SetDatabase("/Root")
+                .SetAuthToken("root@builtin"));
+            auto client = NQuery::TQueryClient(driver);
+            AssertSuccessResult(client.ExecuteQuery(R"(
+                CREATE TABLE `/Root/test_acl` (
+                    id Int64 NOT NULL,
+                    primary key (id)
+                );
+            )", NQuery::TTxControl::NoTx()).ExtractValueSync());
+            driver.Stop(true);
+        }
+
+        auto schemeClient = kikimr.GetSchemeClient();
+        auto result = schemeClient.ModifyPermissions("/Root/test_acl",
+                NYdb::NScheme::TModifyPermissionsSettings()
+                    .AddGrantPermissions(NYdb::NScheme::TPermissions("user1", {"ydb.database.connect", "ydb.generic.read"}))
+            ).ExtractValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Distinct inheritance types in one permission action");
+
+        CheckPermissions(session,
+            {
+                {.Path = "/Root/test_acl",
+                    .Permissions = {
+                    }
+                },
+            }
+        );
+    }
+
+    Y_UNIT_TEST(DistinctInheritanceTypesInSingleRevoke) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        {
+            auto driver = TDriver(TDriverConfig()
+                .SetEndpoint(kikimr.GetEndpoint())
+                .SetDatabase("/Root")
+                .SetAuthToken("root@builtin"));
+            auto client = NQuery::TQueryClient(driver);
+            AssertSuccessResult(client.ExecuteQuery(R"(
+                CREATE TABLE `/Root/test_acl` (
+                    id Int64 NOT NULL,
+                    primary key (id)
+                );
+            )", NQuery::TTxControl::NoTx()).ExtractValueSync());
+            driver.Stop(true);
+        }
+
+        auto schemeClient = kikimr.GetSchemeClient();
+        auto result = schemeClient.ModifyPermissions("/Root/test_acl",
+                NYdb::NScheme::TModifyPermissionsSettings()
+                    .AddRevokePermissions(NYdb::NScheme::TPermissions("user1", {"ydb.database.connect", "ydb.generic.read"}))
+            ).ExtractValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Distinct inheritance types in one permission action");
+    }
 
     Y_UNIT_TEST(FamilyColumnTest) {
         TKikimrRunner kikimr;

--- a/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
@@ -1419,10 +1419,10 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
             edgeActor, TDuration::Seconds(5));
 
         UNIT_ASSERT_C(response, "Compile service did not respond in time");
-        UNIT_ASSERT_C(response->Get()->Record.HasStatus(), 
+        UNIT_ASSERT_C(response->Get()->Record.HasStatus(),
             "Response for tenant mismatch must have Status field");
         UNIT_ASSERT_EQUAL_C(response->Get()->Record.GetStatus(), Ydb::StatusIds::UNAVAILABLE,
-            "Tenant mismatch must return UNAVAILABLE status, got " 
+            "Tenant mismatch must return UNAVAILABLE status, got "
             << static_cast<int>(response->Get()->Record.GetStatus()));
         UNIT_ASSERT_C(response->Get()->Record.GetIssues().size() > 0,
             "Response must contain error message in Issues");
@@ -1442,13 +1442,14 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
             for (const auto& user : {"user1@builtin", "user2@builtin"}) {
                 TPermissions permissions(user,
                     {
-                        "ydb.database.connect",
                         "ydb.granular.describe_schema",
                         "ydb.granular.select_row",
                     }
                 );
                 auto result = schemeClient.ModifyPermissions("/Root",
-                    TModifyPermissionsSettings().AddGrantPermissions(permissions)
+                    TModifyPermissionsSettings()
+                        .AddGrantPermissions(TPermissions(user, {"ydb.database.connect"}))
+                        .AddGrantPermissions(permissions)
                 ).ExtractValueSync();
                 UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
             }

--- a/ydb/core/tx/tx_proxy/schemereq_ut.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq_ut.cpp
@@ -412,7 +412,10 @@ void CreateLocalGroup2(TTestEnv& env, const TString& database, const TString& na
 void SetPermissions(const TTestEnv& env, const TString& path, const TString& targetSid, const std::vector<std::string>& permissions) {
     auto client = CreateSchemeClient(env, env.RootToken);
     auto modify = NYdb::NScheme::TModifyPermissionsSettings();
-    auto status = client.ModifyPermissions(path, modify.AddSetPermissions({targetSid, permissions}))
+    for (const auto& permission : permissions) {
+        modify.AddGrantPermissions({targetSid, {permission}});
+    }
+    auto status = client.ModifyPermissions(path, modify)
         .ExtractValueSync();
     UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
 }

--- a/ydb/services/datastreams/datastreams_ut.cpp
+++ b/ydb/services/datastreams/datastreams_ut.cpp
@@ -100,10 +100,12 @@ public:
 
         {
             NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("user@builtin", {"ydb.database.connect", "ydb.generic.read", "ydb.generic.write"});
+            NYdb::NScheme::TPermissions permissions("user@builtin", {"ydb.generic.read", "ydb.generic.write"});
 
             auto result = schemeClient.ModifyPermissions("/Root",
-                NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions)
+                NYdb::NScheme::TModifyPermissionsSettings()
+                    .AddGrantPermissions(NYdb::NScheme::TPermissions("user@builtin", {"ydb.database.connect"}))
+                    .AddGrantPermissions(permissions)
             ).ExtractValueSync();
             Cerr << result.GetIssues().ToString() << "\n";
             UNIT_ASSERT(result.IsSuccess());

--- a/ydb/services/metadata/initializer/common.cpp
+++ b/ydb/services/metadata/initializer/common.cpp
@@ -17,10 +17,13 @@ TACLModifierConstructor TACLModifierConstructor::GetReadOnlyModifier(const TStri
     TACLModifierConstructor result(path, id);
     result->set_clear_permissions(true);
     result->set_interrupt_inheritance(true);
-    auto* permission = result->add_actions();
-    permission->mutable_grant()->set_subject(AppData()->AllAuthenticatedUsers ? AppData()->AllAuthenticatedUsers : "USERS");
-    permission->mutable_grant()->add_permission_names("ydb.tables.read");
-    permission->mutable_grant()->add_permission_names("ydb.deprecated.describe_schema");
+    const TString subject = AppData()->AllAuthenticatedUsers ? AppData()->AllAuthenticatedUsers : "USERS";
+    auto* readPermission = result->add_actions();
+    readPermission->mutable_grant()->set_subject(subject);
+    readPermission->mutable_grant()->add_permission_names("ydb.tables.read");
+    auto* describePermission = result->add_actions();
+    describePermission->mutable_grant()->set_subject(subject);
+    describePermission->mutable_grant()->add_permission_names("ydb.deprecated.describe_schema");
     return result;
 }
 


### PR DESCRIPTION
Example (Python SDK) explaining this change

```
driver.scheme_client.modify_permissions(
    "/Root/testdb",
    ydb.ModifyPermissionsSettings()
        # one grant action with two permissions -> one ACE
        .grant_permissions(
            "user1", ("ydb.granular.update_row", "ydb.granular.erase_row")
        )
        # separate grant action -> separate ACE
        .grant_permissions(
            "user2", ("ydb.granular.update_row",)
        )
)
```

**Expected result before that change**

Each permission forms a separate ACE in ACL:
user1 ['ydb.granular.update_row']
user1 ['ydb.granular.erase_row']
user2 ['ydb.granular.update_row']

**Expected result after that change**

Permissions from the first grant action merge into one ACE with bitmask equals `update_row | erase_row.` The second grant action forms a separate ACE.:
user1 ['ydb.granular.update_row' | 'ydb.granular.erase_row']
user2 ['ydb.granular.update_row']
