### PR TITLE
Cherry pick fix label persisting

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1368,6 +1368,10 @@ public:
             throw TInitializationException("YDB-CFG13") << errors.front();
         }
 
+        if (const auto it = Labels.find("empty_domain_during_node_registration"); it != Labels.end()) {
+            AddLabelToAppConfig(it->first, it->second);
+        }
+
         Logger.Out() << "configured" << Endl;
     }
 
@@ -1485,7 +1489,6 @@ public:
         TString domainName = DeduceNodeDomain(cf, AppConfig);
 
         Labels["empty_domain_during_node_registration"] = domainName.empty() ? "true" : "false";
-        AddLabelToAppConfig("empty_domain_during_node_registration", Labels["empty_domain_during_node_registration"]);
 
         if (!cf.NodeHost) {
             cf.NodeHost = Env.FQDNHostName();

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1484,6 +1484,9 @@ public:
 
         TString domainName = DeduceNodeDomain(cf, AppConfig);
 
+        Labels["empty_domain_during_node_registration"] = domainName.empty() ? "true" : "false";
+        AddLabelToAppConfig("empty_domain_during_node_registration", Labels["empty_domain_during_node_registration"]);
+
         if (!cf.NodeHost) {
             cf.NodeHost = Env.FQDNHostName();
         }

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1956,6 +1956,16 @@ void TKikimrRunner::InitializeActorSystem(
     }
 }
 
+void TKikimrRunner::RecordEmptyDomainSensor() {
+    const auto& labels = AppData->Labels;
+    const auto it = labels.find("empty_domain_during_node_registration");
+    if (it != labels.end() && it->second == "true") {
+        GetServiceCounters(AppData->Counters, "ydb")
+            ->GetSubgroup("subsystem", "nodeRegistration")
+            ->GetCounter("EmptyDomainName")->Inc();
+    }
+}
+
 TIntrusivePtr<TServiceInitializersList> TKikimrRunner::CreateServiceInitializersList(
     const TKikimrRunConfig& runConfig,
     const TBasicKikimrServicesMask& serviceMask) {
@@ -2501,6 +2511,7 @@ TIntrusivePtr<TKikimrRunner> TKikimrRunner::CreateKikimrRunner(
     runner->InitializeControlBoard(runConfig);
     runner->InitializeAppData(runConfig);
     runner->InitializeLogSettings(runConfig);
+    runner->RecordEmptyDomainSensor();
     TIntrusivePtr<TServiceInitializersList> sil(runner->CreateServiceInitializersList(runConfig, runConfig.ServicesMask));
     runner->InitializeActorSystem(runConfig, sil, runConfig.ServicesMask);
     runner->InitializeMonitoringLogin(runConfig);

--- a/ydb/core/driver_lib/run/run.h
+++ b/ydb/core/driver_lib/run/run.h
@@ -127,6 +127,8 @@ protected:
         TIntrusivePtr<TServiceInitializersList> serviceInitializers,
         const TBasicKikimrServicesMask& serviceMask = {});
 
+    void RecordEmptyDomainSensor();
+
     TIntrusivePtr<TServiceInitializersList> CreateServiceInitializersList(
         const TKikimrRunConfig& runConfig,
         const TBasicKikimrServicesMask& serviceMask = {});


### PR DESCRIPTION
## Summary

- **Fixed erasing registration node Labels in AppConfig** — registration node Labels
  are no longer wiped out in AppConfig.
- **Added monitoring of register node requests without domain** (backport of PR #40320 /
  #40410) — register node requests that omit the domain are now exposed in monitoring.


