### PR TITLE
YQ-4997 fixed MKQL allocator bound in Scan/Source/Sinks DQ actors (#31435)

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -38,6 +38,10 @@ TKqpScanComputeActor::TKqpScanComputeActor(TComputeActorSchedulingOptions cpuOpt
     YQL_ENSURE(Meta.GetTable().GetTableKind() != (ui32)ETableKind::SysView);
 }
 
+TKqpScanComputeActor::~TKqpScanComputeActor() {
+    FreeComputeCtxData();
+}
+
 void TKqpScanComputeActor::ProcessRlNoResourceAndDie() {
     const NYql::TIssue issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_RESOURCE_USAGE_LIMITED,
         "Throughput limit exceeded for query");

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -73,6 +73,8 @@ public:
         const NYql::NDq::TComputeRuntimeSettings& settings, const NYql::NDq::TComputeMemoryLimits& memoryLimits, NWilson::TTraceId traceId,
         TIntrusivePtr<NActors::TProtoArenaHolder> arena, EBlockTrackingMode mode);
 
+    ~TKqpScanComputeActor();
+
     STFUNC(StateFunc) {
         try {
             switch (ev->GetTypeRewrite()) {

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -255,6 +255,10 @@ public:
         Counters->WriteActorsCount->Inc();
     }
 
+    ~TKqpTableWriteActor() {
+        ClearMkqlData();
+    }
+
     void Bootstrap() {
         LogPrefix = TStringBuilder() << "SelfId: " << this->SelfId() << ", " << LogPrefix;
         try {
@@ -1244,11 +1248,8 @@ public:
     }
 
     void PassAway() override {
-        {
-            Y_ABORT_UNLESS(Alloc);
-            TGuard<NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
-            ShardedWriteController.Reset();
-        }
+        Y_ABORT_UNLESS(Alloc);
+        ClearMkqlData();
         Counters->WriteActorsCount->Dec();
         Send(PipeCacheId, new TEvPipeCache::TEvUnlink(0));
         TActorBootstrapped<TKqpTableWriteActor>::PassAway();
@@ -1317,6 +1318,13 @@ public:
     }
 
 private:
+    void ClearMkqlData() {
+        if (Alloc && ShardedWriteController) {
+            TGuard<NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ShardedWriteController.Reset();
+        }
+    }
+
     NActors::TActorId PipeCacheId = NKikimr::MakePipePerNodeCacheID(false);
 
     TString LogPrefix;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -136,12 +136,12 @@ struct IDqComputeActorAsyncInput {
     virtual void FillExtraStats(NDqProto::TDqTaskStats* /* stats */, bool /* finalized stats */, const NYql::NDq::TDqMeteringStats*) { }
 
     // The same signature as IActor::PassAway().
-    // It is guaranted that this method will be called with bound MKQL allocator.
+    // It is guaranteed that this method will be called with bound MKQL allocator.
     // So, it is the right place to destroy all internal UnboxedValues.
     virtual void PassAway() = 0;
 
-    // Do not destroy UnboxedValues inside destructor!!!
-    // It is called from actor system thread, and MKQL allocator is not bound in this case.
+    // You must also destroy all internal UnboxedValues inside destructor (same as in PassAway)
+    // But you should explicitly bind MKQL allocator here, because it is called from actor system thread.
     virtual ~IDqComputeActorAsyncInput() = default;
 };
 
@@ -202,6 +202,8 @@ struct IDqComputeActorAsyncOutput {
 
     virtual void PassAway() = 0; // The same signature as IActor::PassAway()
 
+    // You must also destroy all internal UnboxedValues inside destructor (same as in PassAway)
+    // But you should explicitly bind MKQL allocator here, because it is called from actor system thread.
     virtual ~IDqComputeActorAsyncOutput() = default;
 };
 

--- a/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
@@ -24,7 +24,8 @@ namespace NYql::NDq {
                 args.ReadRanges,
                 args.ComputeActorId,
                 credentialsFactory,
-                args.HolderFactory);
+                args.HolderFactory,
+                std::move(args.Alloc));
         };
 
         auto lookupActorFactory = [credentialsFactory, genericClient](Generic::TLookupSource&& lookupSource, IDqAsyncIoFactory::TLookupSourceArguments&& args) {

--- a/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
@@ -48,6 +48,7 @@ namespace NYql::NDq {
             Generic::TSource&& source,
             const NActors::TActorId& computeActorId,
             const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+            std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
             TVector<Generic::TPartition>&& partitions)
             : InputIndex_(inputIndex)
             , ComputeActorId_(computeActorId)
@@ -55,9 +56,17 @@ namespace NYql::NDq {
             , TokenProvider_(std::move(tokenProvider))
             , Partitions_(std::move(partitions))
             , HolderFactory_(holderFactory)
-            , Source_(source)
+            , Alloc_(std::move(alloc))
+            , Source_(std::move(source))
         {
             IngressStats_.Level = statsLevel;
+        }
+
+        ~TGenericReadActor() {
+            if (Alloc_) {
+                TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc_);
+                ClearMkqlData();
+            }
         }
 
         void Bootstrap() {
@@ -331,10 +340,6 @@ namespace NYql::NDq {
             // freeSpace -= size;
             LastReadSplitsResponse_ = std::nullopt;
 
-            // TODO: check it, because in S3 the generic cache clearing happens only when LastFileWasProcessed:
-            // https://a.yandex-team.ru/arcadia/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp?rev=r11543410#L2497
-            ArrowRowContainerCache_.Clear();
-
             // Request server for the next data block
             AwaitNextStreamItem<NConnector::IReadSplitsStreamIterator,
                                 TEvReadSplitsPart,
@@ -352,6 +357,7 @@ namespace NYql::NDq {
                                             << ": bytes " << IngressStats_.Bytes
                                             << ", rows " << IngressStats_.Rows
                                             << ", chunks " << IngressStats_.Chunks;
+            ClearMkqlData();
             TActorBootstrapped<TGenericReadActor>::PassAway();
         }
 
@@ -372,6 +378,11 @@ namespace NYql::NDq {
             return IngressStats_;
         }
 
+        // Should be called with bound MKQL alloc
+        void ClearMkqlData() {
+            ArrowRowContainerCache_.Clear();
+        }
+
     private:
         const ui64 InputIndex_;
         TDqAsyncStats IngressStats_;
@@ -388,6 +399,7 @@ namespace NYql::NDq {
 
         NKikimr::NMiniKQL::TPlainContainerCache ArrowRowContainerCache_;
         const NKikimr::NMiniKQL::THolderFactory& HolderFactory_;
+        const std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc_;
         Generic::TSource Source_;
     };
 
@@ -426,7 +438,8 @@ namespace NYql::NDq {
                            const TVector<TString>& readRanges,
                            const NActors::TActorId& computeActorId,
                            ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
-                           const NKikimr::NMiniKQL::THolderFactory& holderFactory)
+                           const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+                           std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc)
     {
         TVector<Generic::TPartition> partitions;
         ExtractPartitionsFromParams(partitions, taskParams, readRanges);
@@ -466,6 +479,7 @@ namespace NYql::NDq {
             std::move(source),
             computeActorId,
             holderFactory,
+            std::move(alloc),
             std::move(partitions));
 
         return {actor, actor};

--- a/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.h
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_read_actor.h
@@ -20,6 +20,7 @@ namespace NYql::NDq {
         const TVector<TString>& readRanges,
         const NActors::TActorId& computeActorId,
         ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
-        const NKikimr::NMiniKQL::THolderFactory& holderFactory);
+        const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
@@ -132,6 +132,7 @@ public:
         const TTxId& txId,
         ui64 taskId,
         const THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         NPq::NProto::TDqPqTopicSource&& sourceParams,
         NPq::NProto::TDqReadTaskParams&& readParams,
         NYdb::TDriver driver,
@@ -145,6 +146,7 @@ public:
         , Metrics(txId, taskId, counters)
         , BufferSize(bufferSize)
         , HolderFactory(holderFactory)
+        , Alloc(std::move(alloc))
         , Driver(std::move(driver))
         , CredentialsProviderFactory(std::move(credentialsProviderFactory))
         , PqGateway(pqGateway)
@@ -158,6 +160,13 @@ public:
 
         InitWatermarkTracker();
         IngressStats.Level = statsLevel;
+    }
+
+    ~TDqPqReadActor() {
+        if (Alloc) {
+            TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ClearMkqlData();
+        }
     }
 
     NYdb::NTopic::TTopicClientSettings GetTopicClientSettings() const {
@@ -245,7 +254,8 @@ private:
         if (ReadSession) {
             ReadSession->Close(TDuration::Zero());
             ReadSession.reset();
-            ReadyBuffer = std::queue<TReadyBatch>{}; // clear read buffer
+            TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ClearMkqlData();
         }
 
         Schedule(ReconnectPeriod, new TEvPrivate::TEvReconnectSession());
@@ -253,8 +263,7 @@ private:
 
     // IActor & IDqComputeActorAsyncInput
     void PassAway() override { // Is called from Compute Actor
-        std::queue<TReadyBatch> empty;
-        ReadyBuffer.swap(empty);
+        ClearMkqlData();
 
         if (ReadSession) {
             ReadSession->Close(TDuration::Zero());
@@ -463,6 +472,13 @@ private:
         ReadyBuffer.back().Watermark = watermark;
     }
 
+    // must be called with bound allocator
+    void ClearMkqlData() {
+        std::queue<TReadyBatch> empty;
+        ReadyBuffer.swap(empty);
+    }
+
+    // must be called (visited) with bound allocator
     struct TTopicEventProcessor {
         static TString ToString(const TPartitionKey& key) {
             return TStringBuilder{} << "[" << key.first << ", " << key.second << "]";
@@ -607,6 +623,7 @@ private:
     TMetrics Metrics;
     const i64 BufferSize;
     const THolderFactory& HolderFactory;
+    const std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     NYdb::TDriver Driver;
     std::shared_ptr<NYdb::ICredentialsProviderFactory> CredentialsProviderFactory;
     ITopicClient::TPtr TopicClient;
@@ -635,6 +652,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateDqPqReadActor(
     ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
     const NActors::TActorId& computeActorId,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const ::NMonitoring::TDynamicCounterPtr& counters,
     IPqGateway::TPtr pqGateway,
     i64 bufferSize
@@ -656,6 +674,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateDqPqReadActor(
         txId,
         taskId,
         holderFactory,
+        std::move(alloc),
         std::move(settings),
         std::move(readTaskParamsMsg),
         std::move(driver),
@@ -694,7 +713,8 @@ void RegisterDqPqReadActorFactory(TDqAsyncIoFactory& factory, NYdb::TDriver driv
                 credentialsFactory,
                 args.ComputeActorId,
                 args.HolderFactory,
-                counters,
+                std::move(args.Alloc),
+                counters ? counters : args.TaskCounters,
                 pqGateway,
                 PQReadDefaultFreeSpace);
         }

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.h
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.h
@@ -35,6 +35,7 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateDqPqReadActor(
     ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory,
     const NActors::TActorId& computeActorId,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const ::NMonitoring::TDynamicCounterPtr& counters,
     IPqGateway::TPtr pqGateway,
     i64 bufferSize = PQReadDefaultFreeSpace

--- a/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
@@ -70,7 +70,7 @@ namespace NYql::NDq {
                 NDB::registerFormats();
                 factory.RegisterSource<NS3::TSource>("S3Source",
                     [credentialsFactory, gateway, retryPolicy, cfg, counters, allowLocalFiles](NS3::TSource&& settings, IDqAsyncIoFactory::TSourceArguments&& args) {
-                        return CreateS3ReadActor(args.TypeEnv, args.HolderFactory, gateway,
+                        return CreateS3ReadActor(args.TypeEnv, args.HolderFactory, std::move(args.Alloc), gateway,
                             std::move(settings), args.InputIndex, args.StatsLevel, args.TxId, args.SecureParams,
                             args.TaskParams, args.ReadRanges, args.ComputeActorId, credentialsFactory, retryPolicy, cfg,
                             counters, args.TaskCounters, args.MemoryQuotaManager, allowLocalFiles);

--- a/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
@@ -41,6 +41,7 @@ public:
         const TTxId& txId,
         IHTTPGateway::TPtr gateway,
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const TString& url,
         const TS3Credentials& credentials,
         const TString& pattern,
@@ -64,6 +65,7 @@ public:
         : ReadActorFactoryCfg(readActorFactoryCfg)
         , Gateway(std::move(gateway))
         , HolderFactory(holderFactory)
+        , Alloc(std::move(alloc))
         , InputIndex(inputIndex)
         , TxId(txId)
         , ComputeActorId(computeActorId)
@@ -98,6 +100,13 @@ public:
             TaskQueueDataLimit->Add(ReadActorFactoryCfg.DataInflight);
         }
         IngressStats.Level = statsLevel;
+    }
+
+    ~TS3ReadActor() {
+        if (Alloc) {
+            TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ClearMkqlData();
+        }
     }
 
     void Bootstrap() {
@@ -440,15 +449,21 @@ private:
         }
         QueueTotalDataSize = 0;
 
-        ContainerCache.Clear();
+        ClearMkqlData();
         FileQueueEvents.Unsubscribe();
         TActorBootstrapped<TS3ReadActor>::PassAway();
+    }
+
+    // Should be called with bound MKQL alloc
+    void ClearMkqlData() {
+        ContainerCache.Clear();
     }
 
 private:
     const TS3ReadActorFactoryConfig ReadActorFactoryCfg;
     const IHTTPGateway::TPtr Gateway;
     const NKikimr::NMiniKQL::THolderFactory& HolderFactory;
+    const std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     NKikimr::NMiniKQL::TPlainContainerCache ContainerCache;
 
     const ui64 InputIndex;
@@ -507,6 +522,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateRawRead
     const TTxId& txId,
     IHTTPGateway::TPtr gateway,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const TString& url,
     const TS3Credentials& credentials,
     const TString& pattern,
@@ -534,6 +550,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateRawRead
         txId,
         std::move(gateway),
         holderFactory,
+        std::move(alloc),
         url,
         credentials,
         pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.h
@@ -18,6 +18,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateRawRead
     const TTxId& txId,
     IHTTPGateway::TPtr gateway,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     const TString& url,
     const TS3Credentials& credentials,
     const TString& pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -1292,6 +1292,7 @@ public:
         const TTxId& txId,
         IHTTPGateway::TPtr gateway,
         const THolderFactory& holderFactory,
+        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const TString& url,
         const TS3Credentials& credentials,
         const TString& pattern,
@@ -1319,6 +1320,7 @@ public:
     )   : ReadActorFactoryCfg(readActorFactoryCfg)
         , Gateway(std::move(gateway))
         , HolderFactory(holderFactory)
+        , Alloc(std::move(alloc))
         , InputIndex(inputIndex)
         , TxId(txId)
         , ComputeActorId(computeActorId)
@@ -1367,6 +1369,13 @@ public:
             RawInflightSize = TaskCounters->GetCounter("RawInflightSize");
         }
         IngressStats.Level = statsLevel;
+    }
+
+    ~TS3StreamReadActor() {
+        if (Alloc) {
+            TGuard<NKikimr::NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            ClearMkqlData();
+        }
     }
 
     void Bootstrap() {
@@ -1670,9 +1679,7 @@ private:
             LOG_T("TS3StreamReadActor", "PassAway FileQueue RemoveConfirmedEvents=" << FileQueueEvents.RemoveConfirmedEvents());
             FileQueueEvents.Unsubscribe();
 
-            ContainerCache.Clear();
-            ArrowTupleContainerCache.Clear();
-            ArrowRowContainerCache.Clear();
+            ClearMkqlData();
 
             MemoryQuotaManager->FreeQuota(ReadActorFactoryCfg.DataInflight);
         } else {
@@ -1879,9 +1886,17 @@ private:
         return RowsRemained && *RowsRemained == 0;
     }
 
+    // Should be called with bound MKQL alloc
+    void ClearMkqlData() {
+        ContainerCache.Clear();
+        ArrowTupleContainerCache.Clear();
+        ArrowRowContainerCache.Clear();
+    }
+
     const TS3ReadActorFactoryConfig ReadActorFactoryCfg;
     const IHTTPGateway::TPtr Gateway;
     const THolderFactory& HolderFactory;
+    const std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     TPlainContainerCache ContainerCache;
     TPlainContainerCache ArrowTupleContainerCache;
     TPlainContainerCache ArrowRowContainerCache;
@@ -2087,6 +2102,7 @@ NDB::FormatSettings::TimestampFormat ToTimestampFormat(const TString& formatName
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
     const TTypeEnvironment& typeEnv,
     const THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     IHTTPGateway::TPtr gateway,
     NS3::TSource&& params,
     ui64 inputIndex,
@@ -2296,7 +2312,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
             sizeLimit = FromString<ui64>(it->second);
         }
 
-        const auto actor = new TS3StreamReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, params.GetUrl(), credentials, pathPattern, pathPatternVariant,
+        const auto actor = new TS3StreamReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, std::move(alloc), params.GetUrl(), credentials, pathPattern, pathPatternVariant,
                                                   std::move(paths), addPathIndex, readSpec, computeActorId, retryPolicy,
                                                   cfg, counters, taskCounters, fileSizeLimit, sizeLimit, rowsLimitHint, memoryQuotaManager,
                                                   params.GetUseRuntimeListing(), fileQueueActor, fileQueueBatchSizeLimit, fileQueueBatchObjectCountLimit, fileQueueConsumersCountDelta,
@@ -2308,7 +2324,7 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateS3ReadActor(
         if (const auto it = settings.find("sizeLimit"); settings.cend() != it)
             sizeLimit = FromString<ui64>(it->second);
 
-        return CreateRawReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, params.GetUrl(), credentials, pathPattern, pathPatternVariant,
+        return CreateRawReadActor(inputIndex, statsLevel, txId, std::move(gateway), holderFactory, std::move(alloc), params.GetUrl(), credentials, pathPattern, pathPatternVariant,
                                             std::move(paths), addPathIndex, computeActorId, sizeLimit, retryPolicy,
                                             cfg, counters, taskCounters, fileSizeLimit, rowsLimitHint,
                                             params.GetUseRuntimeListing(), fileQueueActor, fileQueueBatchSizeLimit, fileQueueBatchObjectCountLimit, fileQueueConsumersCountDelta, allowLocalFiles);

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
@@ -35,6 +35,7 @@ NActors::IActor* CreateS3FileQueueActor(
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateS3ReadActor(
     const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
     const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
     IHTTPGateway::TPtr gateway,
     NS3::TSource&& params,
     ui64 inputIndex,

--- a/ydb/tests/fq/pq_async_io/ut_helpers.cpp
+++ b/ydb/tests/fq/pq_async_io/ut_helpers.cpp
@@ -110,6 +110,7 @@ void TPqIoTestFixture::InitSource(
             nullptr,
             actor.SelfId(),
             actor.GetHolderFactory(),
+            std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc>(&actor.Alloc, [](NKikimr::NMiniKQL::TScopedAlloc*) {}),
             MakeIntrusive<NMonitoring::TDynamicCounters>(),
             CreatePqNativeGateway(std::move(pqServices)),
             freeSpace);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


(cherry picked from commit d29fa22599bbd18d171eb68856cafc404843363d)

 Conflicts:
	ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
	ydb/library/yql/providers/generic/actors/yql_generic_read_actor.cpp
	ydb/library/yql/providers/pq/async_io/dq_pq_read_actor.cpp
	ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
	ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
	ydb/tests/fq/pq_async_io/ut/dq_pq_read_actor_ut.cpp




### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
