### PR TITLE
Fix overriding TDescribeReq options

### DIFF
--- a/ydb/core/tx/tx_proxy/describe.cpp
+++ b/ydb/core/tx/tx_proxy/describe.cpp
@@ -419,12 +419,10 @@ void TDescribeReq::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &
     if (UserToken != nullptr) {
         auto options = record.MutableOptions();
         if (entry.SecurityObject != nullptr) {
-            options->SetReturnBoundaries(false);
-            options->SetReturnRangeKey(false);
             ui32 access = NACLib::EAccessRights::SelectRow;
-            if (entry.SecurityObject->CheckAccess(access, *UserToken)) {
-                options->SetReturnBoundaries(true);
-                options->SetReturnRangeKey(true);
+            if (!entry.SecurityObject->CheckAccess(access, *UserToken)) {
+                options->SetReturnBoundaries(false);
+                options->SetReturnRangeKey(false);
             }
         }
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

tx_proxy incorrectly overrides TDescribeReq ReturnBoundaries and ReturnRangeKey `false` to `true` even if nobody requested it. It results in `viewer/json/describe` huge responses despite the handler uses `&boundaries=false` by default

- Fixup for c28586c3736da502ce58e08c5410768106e81ef4 (PR: https://nda.ya.ru/t/i-9tiGLP7fVbKd)
- This resolves https://nda.ya.ru/t/zU2mtWLu7epHua
- Part of https://github.com/ydb-platform/ydb-embedded-ui/issues/3988